### PR TITLE
Add compressor assignment selection and legacy CT path

### DIFF
--- a/examples/about_config.md
+++ b/examples/about_config.md
@@ -92,9 +92,17 @@ Pipelining is not yet implemented; `pipeline_depth` must be `1`.
 
 ## Multiplier Configuration
 
-Multiplier entries support all of the fields from the legacy `multiplier` object: `module_name`, `ppg_algorithm`, `compressor_structure`, `cpa_structure`, and `pipeline_depth`. When using the `operations` array, set `"type": "multiplier"`, reference the operand supplying both inputs, and place the implementation options inside an `options` object.
+Multiplier entries support all of the fields from the legacy `multiplier` object: `module_name`, `ppg_algorithm`, `compressor_structure`, `compressor_library`, `compressor_assignment`, `cpa_structure`, and `pipeline_depth`. When using the `operations` array, set `"type": "multiplier"`, reference the operand supplying both inputs, and place the implementation options inside an `options` object.
 
-Currently, `compressor_structure` and `pipeline_depth` are fixed to `AdderTree` and `1`. The `AdderTree` is optimized using ILP as described in [UFO-MAC: A Unified Framework for Optimization of High-Performance Multipliers and Multiply-Accumulators](https://arxiv.org/abs/2408.06935). See [Compressor Tree Memo](doc/compressor_tree/memo_about_compressor_tree.md) for details.
+Currently, `compressor_structure` and `pipeline_depth` are fixed to `AdderTree` and `1`. The `AdderTree` is optimized using ILP as described in [UFO-MAC: A Unified Framework for Optimization of High-Performance Multipliers and Multiply-Accumulators](https://arxiv.org/abs/2408.06935). The `compressor_library` option selects which compressor cells can be used during ILP assignment:
+- `fa_ha` (default): 3:2 and 2:2 only
+- `fa_ha_c42`: 3:2, 2:2, and 4:2
+See [Compressor Tree Memo](doc/compressor_tree/memo_about_compressor_tree.md) for details.
+
+The `compressor_assignment` option selects the ILP formulation:
+- `legacy_fa_ha` (default): prior FA/HA-count-based ILP (3:2/2:2 only).
+- `direct_ilp`: direct compressor assignment ILP (supports `fa_ha_c42`).
+Note: the current direct ILP solver fails to find solutions for 16-bit and wider multipliers; use `legacy_fa_ha` for practical widths until the solver is fixed. See [Compressor Tree Memo](doc/compressor_tree/memo_about_compressor_tree.md) for evaluation notes.
 
 Supported partial product generators (`ppg_algorithm`):
 

--- a/main.cpp
+++ b/main.cpp
@@ -188,11 +188,19 @@ int main(int argc, char** argv) {
             Operand lhs = makeOperandValue(operandDef);
             Operand rhs = lhs;
             CTType ctype = get_compressor_type(mult.compressor_structure);
+            CompressorLibrary library = get_compressor_library(mult.compressor_library);
+            CompressorAssignment assignment = get_compressor_assignment(mult.compressor_assignment);
             CPAType cptype = get_cpa_type(mult.cpa_structure);
             PPType ptype = get_ppg_algorithm(mult.ppg_algorithm);
             MultiplierGenerator generator;
             std::cout << "[INFO] Generating multiplier " << mult.module_name << "\n";
-            generator.build(lhs, rhs, ctype, ptype, cptype, mult.module_name);
+            bool enable_c42 = (library == FA_HA_C42);
+            bool use_direct_ilp = (assignment == DirectILP);
+            if (!use_direct_ilp && enable_c42) {
+                std::cout << "[WARN] legacy_fa_ha ignores compressor_library fa_ha_c42; forcing fa_ha.\n";
+                enable_c42 = false;
+            }
+            generator.build(lhs, rhs, ctype, ptype, cptype, mult.module_name, enable_c42, use_direct_ilp);
         }
 
         for (auto yosys : config.yosys_multipliers) {

--- a/scripts/generate_multiplier_configs.py
+++ b/scripts/generate_multiplier_configs.py
@@ -29,6 +29,8 @@ def generate_configs(max_bit_width):
                             "module_name": f"{algorithm.lower()}_multiplier_{cpa_structure.lower()}_{bit_width}{signed_suffix}",
                             "ppg_algorithm": algorithm,
                             "compressor_structure": "AdderTree",
+                            "compressor_library": "fa_ha",
+                            "compressor_assignment": "legacy_fa_ha",
                             "cpa_structure": cpa_structure,
                             "pipeline_depth": 1
                         }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -152,6 +152,8 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
             multiplier.operand = operandName;
             multiplier.ppg_algorithm = node.at("ppg_algorithm").get<std::string>();
             multiplier.compressor_structure = node.at("compressor_structure").get<std::string>();
+            multiplier.compressor_library = node.value("compressor_library", "fa_ha");
+            multiplier.compressor_assignment = node.value("compressor_assignment", "legacy_fa_ha");
             multiplier.cpa_structure = node.at("cpa_structure").get<std::string>();
             multiplier.pipeline_depth = node.value("pipeline_depth", 1);
             config.multipliers.push_back(multiplier);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -69,7 +69,15 @@ enum CTType{
     CSATree   // 3:2 FA and 2:2 HA
 };
 
+enum CompressorLibrary{
+    FA_HA,     // 3:2 and 2:2 only
+    FA_HA_C42  // 3:2, 2:2, and 4:2
+};
 
+enum CompressorAssignment{
+    LegacyFAHA, // legacy FA/HA-count-based ILP
+    DirectILP   // direct compressor assignment ILP
+};
 // Operand configuration
 struct OperandConfig {
     int bit_width;
@@ -82,6 +90,8 @@ struct MultiplierConfig {
     std::string operand;
     std::string ppg_algorithm;
     std::string compressor_structure;
+    std::string compressor_library{"fa_ha"};
+    std::string compressor_assignment{"legacy_fa_ha"};
     std::string cpa_structure;
     int pipeline_depth;
 };
@@ -201,6 +211,18 @@ inline CTType get_compressor_type(const std::string& structure) {
     if (structure == "AdderTree") return AdderTree;
     if (structure == "CSATree") return CSATree;
     throw std::invalid_argument("Unknown compressor structure: " + structure);
+}
+
+inline CompressorLibrary get_compressor_library(const std::string& library) {
+    if (library == "fa_ha") return FA_HA;
+    if (library == "fa_ha_c42") return FA_HA_C42;
+    throw std::invalid_argument("Unknown compressor library: " + library);
+}
+
+inline CompressorAssignment get_compressor_assignment(const std::string& assignment) {
+    if (assignment == "legacy_fa_ha") return LegacyFAHA;
+    if (assignment == "direct_ilp") return DirectILP;
+    throw std::invalid_argument("Unknown compressor assignment: " + assignment);
 }
 
 // get_cpa_type cpa_structure to enum


### PR DESCRIPTION
PR Description Draft

  Overview
  This PR introduces a selectable compressor assignment strategy for
  multiplier CSA trees, restores the legacy FA/HA-count-based ILP path
  alongside the direct ILP, and documents current solver limitations.

  What’s included

  - Added compressor_assignment to multiplier configs with legacy_fa_ha
    (default) and direct_ilp.
  - Restored legacy FA/HA assignment allocation and wiring while keeping
    the direct ILP path for 4:2 experimentation.
  - Main driver now selects assignment strategy and warns when fa_ha_c42
    is requested with legacy.
  - Tests extended with an 8-bit direct ILP sanity case.
  - Documentation updated to explain the new knob and to note that direct
    ILP currently fails for >=16-bit widths.

  Why
  The direct compressor-assignment ILP differs from the legacy method and
  currently fails for practical widths. Keeping both solver paths
  selectable allows evaluation without losing the previously working
  flow.

  Notes / Follow-ups

  - Direct ILP failures for >=16-bit are documented; evaluations should
    remain on legacy_fa_ha until fixed.
  - 4:2 mix results should be interpreted with caution (4:2 modeled as
    two 3:2 levels).

  Files touched
  src/multiplier.cpp, src/multiplier.hpp, src/config.cpp, src/config.hpp,
  main.cpp, tests/test_multiplier.cpp, scripts/
  generate_multiplier_configs.py, examples/about_config.md, doc/
  compressor_tree/memo_about_compressor_tree.md.