### PR TITLE
control_plane: normalize evaluated export snapshots

### DIFF
--- a/control_plane/control_plane/services/queue_exporter.py
+++ b/control_plane/control_plane/services/queue_exporter.py
@@ -118,7 +118,20 @@ def _merge_result(run: Run, work_item: WorkItem) -> dict[str, Any]:
                 f"evaluated export for {work_item.item_id} requires non-empty queue_result.metrics_rows when status=ok"
             )
 
-    return queue_result
+    export_keys = (
+        "branch",
+        "completed_utc",
+        "evaluator_id",
+        "executor",
+        "host",
+        "identity_block",
+        "metrics_rows",
+        "queue_item_id",
+        "session_id",
+        "status",
+        "summary",
+    )
+    return {key: queue_result[key] for key in export_keys if key in queue_result}
 
 
 def export_queue_item(session: Session, request: QueueExportRequest) -> QueueExportResult:

--- a/control_plane/control_plane/services/reconciliation_service.py
+++ b/control_plane/control_plane/services/reconciliation_service.py
@@ -79,6 +79,62 @@ def _relative_repo_path(path_text: str, repo_root: Path) -> str:
         return str(path.resolve())
 
 
+def _portable_repo_path(path_text: str, repo_root: Path) -> str | None:
+    path_text = str(path_text).strip()
+    if not path_text:
+        return None
+    path = Path(path_text)
+    if not path.is_absolute():
+        return str(path)
+    try:
+        return str(path.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return None
+
+
+def _portable_metrics_result_path(row: dict[str, Any], repo_root: Path) -> str | None:
+    result_path = _portable_repo_path(row.get("result_path", ""), repo_root)
+    if result_path:
+        return result_path
+    work_result_json = _portable_repo_path(row.get("work_result_json", ""), repo_root)
+    if work_result_json:
+        return work_result_json
+    return None
+
+
+def _metrics_row_matches_ref(candidate: dict[str, Any], ref: dict[str, Any]) -> bool:
+    if str(candidate.get("platform", "")).strip() != str(ref.get("platform", "")).strip():
+        return False
+    if str(candidate.get("status", "")).strip() != str(ref.get("status", "")).strip():
+        return False
+
+    for key in ("param_hash", "tag", "run_id", "sample_id", "batch_id"):
+        wanted = str(ref.get(key, "")).strip()
+        if wanted and str(candidate.get(key, "")).strip() != wanted:
+            return False
+
+    sample_index = ref.get("sample_index", "")
+    if sample_index not in ("", None) and str(candidate.get("sample_index", "")).strip() != str(sample_index).strip():
+        return False
+
+    return True
+
+
+def _recover_metrics_result_path_from_csv(row: dict[str, Any], repo_root: Path) -> str | None:
+    metrics_csv = str(row.get("metrics_csv", "")).strip()
+    if not metrics_csv:
+        return None
+    path = (repo_root / metrics_csv).resolve()
+    if not path.exists():
+        return None
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for candidate in reader:
+            if _metrics_row_matches_ref(candidate, row):
+                return _portable_metrics_result_path(candidate, repo_root)
+    return None
+
+
 def _normalize_metrics_csv_refs(*, repo_root: Path, metrics_csv: str, allow_missing: bool = False) -> list[dict[str, Any]]:
     path = (repo_root / metrics_csv).resolve()
     if not path.exists():
@@ -109,9 +165,9 @@ def _normalize_metrics_csv_refs(*, repo_root: Path, metrics_csv: str, allow_miss
                     ref["sample_index"] = int(str(row.get("sample_index")).strip())
                 except ValueError:
                     ref["sample_index"] = str(row.get("sample_index")).strip()
-            result_path = str(row.get("result_path", "")).strip()
+            result_path = _portable_metrics_result_path(row, repo_root)
             if result_path:
-                ref["result_path"] = _relative_repo_path(result_path, repo_root)
+                ref["result_path"] = result_path
             rows.append(ref)
     return rows
 
@@ -128,8 +184,13 @@ def _normalize_metrics_rows(
         normalized: list[dict[str, Any]] = []
         for row in metrics_rows:
             new_row = dict(row)
-            if "result_path" in new_row and new_row["result_path"]:
-                new_row["result_path"] = _relative_repo_path(str(new_row["result_path"]), repo_root)
+            result_path = _portable_metrics_result_path(new_row, repo_root)
+            if not result_path:
+                result_path = _recover_metrics_result_path_from_csv(new_row, repo_root)
+            if result_path:
+                new_row["result_path"] = result_path
+            else:
+                new_row.pop("result_path", None)
             normalized.append(new_row)
         return normalized
 

--- a/control_plane/control_plane/tests/test_queue_exporter.py
+++ b/control_plane/control_plane/tests/test_queue_exporter.py
@@ -18,7 +18,7 @@ from control_plane.models.work_items import WorkItem
 from control_plane.services.queue_exporter import QueueExportRequest, export_queue_item
 from control_plane.services.queue_importer import QueueImportRequest, import_queue_item
 
-REPO_ROOT = Path("/workspaces/RTLGen")
+REPO_ROOT = Path(__file__).resolve().parents[3]
 REAL_QUEUE_ITEM = REPO_ROOT / "runs/eval_queue/openroad/queued/l2_e2e_softmax_macro_tail_v1.json"
 
 
@@ -72,6 +72,9 @@ def _seed_evaluated_result(session: Session, item_id: str) -> None:
                 "session_id": "s20260308t000000z",
                 "host": "cp-host",
                 "identity_block": "[role:evaluator][account:yhmtmt][session:s20260308t000000z][host:cp-host][item:l2_e2e_softmax_macro_tail_v1]",
+                "notes": [
+                    "validate_campaign: exit_code=0, duration_s=0.023",
+                ],
                 "metrics_rows": [
                     {
                         "metrics_csv": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv",
@@ -96,7 +99,10 @@ def test_export_queued_snapshot() -> None:
         with make_session() as session:
             import_queue_item(
                 session,
-                QueueImportRequest(repo_root=str(REPO_ROOT), queue_path=str(REAL_QUEUE_ITEM)),
+                QueueImportRequest(
+                    repo_root=str(REPO_ROOT),
+                    queue_path=str(REAL_QUEUE_ITEM.relative_to(REPO_ROOT)),
+                ),
             )
             result = export_queue_item(
                 session,
@@ -121,7 +127,10 @@ def test_export_evaluated_snapshot() -> None:
         with make_session() as session:
             import_queue_item(
                 session,
-                QueueImportRequest(repo_root=str(REPO_ROOT), queue_path=str(REAL_QUEUE_ITEM)),
+                QueueImportRequest(
+                    repo_root=str(REPO_ROOT),
+                    queue_path=str(REAL_QUEUE_ITEM.relative_to(REPO_ROOT)),
+                ),
             )
             _seed_evaluated_result(session, "l2_e2e_softmax_macro_tail_v1")
             result = export_queue_item(
@@ -139,6 +148,7 @@ def test_export_evaluated_snapshot() -> None:
             assert payload["result"]["status"] == "ok"
             assert payload["result"]["queue_item_id"] == "l2_e2e_softmax_macro_tail_v1"
             assert payload["result"]["metrics_rows"][0]["tag"] == "export_smoke"
+            assert "notes" not in payload["result"]
 
 
 def test_export_route_works_in_process() -> None:
@@ -150,7 +160,10 @@ def test_export_route_works_in_process() -> None:
         with Session(engine) as session:
             import_queue_item(
                 session,
-                QueueImportRequest(repo_root=str(REPO_ROOT), queue_path=str(REAL_QUEUE_ITEM)),
+                QueueImportRequest(
+                    repo_root=str(REPO_ROOT),
+                    queue_path=str(REAL_QUEUE_ITEM.relative_to(REPO_ROOT)),
+                ),
             )
             _seed_evaluated_result(session, "l2_e2e_softmax_macro_tail_v1")
 

--- a/control_plane/control_plane/tests/test_reconciliation_service.py
+++ b/control_plane/control_plane/tests/test_reconciliation_service.py
@@ -54,8 +54,8 @@ def _write_queue_item(repo_root: Path) -> Path:
                         f"p=Path('{metrics_path}'); "
                         "p.parent.mkdir(parents=True, exist_ok=True); "
                         "p.write_text("
-                        "'platform,status,param_hash,tag,result_path\\n"
-                        "nangate45,ok,deadbeef,demo_tag,runs/designs/demo_block/work/deadbeef/result.json\\n', "
+                        "'platform,status,param_hash,tag,result_path,work_result_json\\n"
+                        "nangate45,ok,deadbeef,demo_tag,/orfs/flow/logs/demo/3_3_place_gp.json,runs/designs/demo_block/work/deadbeef/result.json\\n', "
                         "encoding='utf-8')\""
                     ),
                 },
@@ -156,6 +156,7 @@ def test_sync_run_artifacts_roundtrips_internal_worker_run() -> None:
         assert payload["result"]["metrics_rows"][0]["param_hash"] == "deadbeef"
         assert payload["result"]["metrics_rows"][0]["tag"] == "demo_tag"
         assert payload["result"]["metrics_rows"][0]["result_path"] == "runs/designs/demo_block/work/deadbeef/result.json"
+        assert "notes" not in payload["result"]
 
         with Session(engine) as session:
             work_item = session.query(WorkItem).filter_by(item_id="cp009_item").one()
@@ -223,3 +224,76 @@ def test_sync_run_artifacts_allows_failed_terminal_run() -> None:
         )
         assert payload["result"]["status"] == "fail"
         assert payload["result"]["queue_item_id"] == "cp009_item"
+
+
+def test_sync_run_artifacts_recovers_portable_result_path_on_resync() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        queue_path = _write_queue_item(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            import_queue_item(
+                session,
+                QueueImportRequest(
+                    repo_root=str(repo_root),
+                    queue_path=str(queue_path.relative_to(repo_root)),
+                ),
+            )
+
+        session_factory = build_session_factory(engine)
+        worker_results = run_worker(
+            session_factory,
+            config=WorkerConfig(
+                repo_root=str(repo_root),
+                machine_key="cp009-worker",
+                capabilities={"platform": "nangate45", "flow": "openroad"},
+                capability_filter={"platform": "nangate45", "flow": "openroad"},
+                lease_seconds=60,
+                heartbeat_seconds=1,
+            ),
+            max_items=1,
+        )
+        assert worker_results[0].status == "succeeded"
+
+        with Session(engine) as session:
+            sync_run_artifacts(
+                session,
+                ArtifactSyncRequest(
+                    repo_root=str(repo_root),
+                    item_id="cp009_item",
+                    evaluator_id="cpbot",
+                    session_id="s20260308t120700z",
+                    host="cp-host",
+                    executor="@control_plane",
+                ),
+            )
+            run = session.query(Run).filter_by(run_key=worker_results[0].run_key).one()
+            payload = dict(run.result_payload or {})
+            queue_result = dict(payload.get("queue_result") or {})
+            metrics_rows = [dict(row) for row in queue_result.get("metrics_rows") or []]
+            metrics_rows[0]["result_path"] = "/orfs/flow/logs/demo/3_3_place_gp.json"
+            queue_result["metrics_rows"] = metrics_rows
+            payload["queue_result"] = queue_result
+            run.result_payload = payload
+            session.commit()
+
+        with Session(engine) as session:
+            sync_run_artifacts(
+                session,
+                ArtifactSyncRequest(
+                    repo_root=str(repo_root),
+                    item_id="cp009_item",
+                    evaluator_id="cpbot",
+                    session_id="s20260308t120701z",
+                    host="cp-host",
+                    executor="@control_plane",
+                ),
+            )
+
+        payload = json.loads(
+            (repo_root / "runs" / "eval_queue" / "openroad" / "evaluated" / "cp009_item.json").read_text(encoding="utf-8")
+        )
+        assert payload["result"]["metrics_rows"][0]["result_path"] == "runs/designs/demo_block/work/deadbeef/result.json"


### PR DESCRIPTION
Summary
- drop the extra notes field from evaluated queue exports so CP-010 snapshots match the legacy result shape
- normalize metrics row result_path values to repo-portable runs/designs/.../work/<hash>/result.json paths, including on re-sync
- make the queue exporter tests use the active checkout root instead of a hard-coded path

Validation
- PYTHONPATH=/tmp/rtlgen-cp010-fix/control_plane pytest control_plane/tests/test_queue_exporter.py control_plane/tests/test_reconciliation_service.py
- PYTHONPATH=/tmp/rtlgen-cp010-fix/control_plane pytest control_plane/tests/test_queue_exporter.py control_plane/tests/test_reconciliation_service.py control_plane/tests/test_worker_executor.py control_plane/tests/test_reconciliation.py
- the new and affected tests pass; test_worker_executor.py still has the same pre-existing detached-instance failures on baseline
- re-ran sync-artifacts against the completed shadow-run DB and confirmed the exported snapshot now matches the reference result shape and uses repo-portable result_path values
