### PR TITLE
npu: use relative rtlgen path in nm1 sigmoid config

### DIFF
--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm1_sigmoidcmp/README.md
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm1_sigmoidcmp/README.md
@@ -8,5 +8,5 @@ sigmoid support in the fixed `nm1` vec path.
 - compute.gemm.num_modules: `1`
 - compute.vec.ops: `add`, `mul`, `relu`, `sigmoid`
 - compute.vec.activation_source: `rtlgen_cpp`
-- compute.gemm.rtlgen_cpp.binary_path: `/workspaces/RTLGen/build/rtlgen`
-- compute.vec.rtlgen_cpp.binary_path: `/workspaces/RTLGen/build/rtlgen`
+- compute.gemm.rtlgen_cpp.binary_path: `build/rtlgen`
+- compute.vec.rtlgen_cpp.binary_path: `build/rtlgen`

--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm1_sigmoidcmp/config_nm1_sigmoid.json
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm1_sigmoidcmp/config_nm1_sigmoid.json
@@ -43,7 +43,7 @@
         "subnormals": "preserve"
       },
       "rtlgen_cpp": {
-        "binary_path": "/workspaces/RTLGen/build/rtlgen",
+        "binary_path": "build/rtlgen",
         "module_name": "gemm_mac_fp16_ieee",
         "total_width": 16,
         "mantissa_width": 10
@@ -61,7 +61,7 @@
       ],
       "activation_source": "rtlgen_cpp",
       "rtlgen_cpp": {
-        "binary_path": "/workspaces/RTLGen/build/rtlgen",
+        "binary_path": "build/rtlgen",
         "module_prefix": "vec_act"
       }
     }


### PR DESCRIPTION
## Summary
- replace hardcoded /workspaces/RTLGen/build/rtlgen paths in the nm1 sigmoid config
- use build/rtlgen so worker temp checkouts resolve the freshly built binary correctly
- update the design README to match the config

## Why
The r7 evaluator failure was not a gen.py logic failure. The worker built rtlgen successfully in its temp checkout, but the config pinned binary_path to /workspaces/RTLGen/build/rtlgen, which does not exist in the worker worktree.

## Validation
- inspected the failed worker logs for l1_prop_l1_npu_nm1_sigmoid_vec_enable_v1_r7
- verified build_generator produced rtlgen in the temp checkout
- verified the config now uses relative build/rtlgen paths

Refs #64