### PR TITLE
control_plane: delay awaiting_review until PR open

### DIFF
--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -326,7 +326,7 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
     target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
     _upsert_artifact(session, run=run, target_path=str(target_path.relative_to(repo_root)), payload=payload)
-    work_item.state = WorkItemState.AWAITING_REVIEW
+    work_item.state = WorkItemState.ARTIFACT_SYNC
     session.add(
         RunEvent(
             run_id=run.id,

--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -782,7 +782,7 @@ def consume_l2_result(session: Session, request: Layer2ConsumeRequest) -> Layer2
     target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
     _upsert_artifact(session, run=run, target_path=str(target_path.relative_to(repo_root)), payload=payload)
-    work_item.state = WorkItemState.AWAITING_REVIEW
+    work_item.state = WorkItemState.ARTIFACT_SYNC
     session.add(
         RunEvent(
             run_id=run.id,

--- a/control_plane/control_plane/services/operator_submission.py
+++ b/control_plane/control_plane/services/operator_submission.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from control_plane.clock import utcnow
 from control_plane.models.artifacts import Artifact
-from control_plane.models.enums import ArtifactStorageMode, GitHubLinkState
+from control_plane.models.enums import ArtifactStorageMode, GitHubLinkState, WorkItemState
 from control_plane.models.github_links import GitHubLink
 from control_plane.models.run_events import RunEvent
 from control_plane.models.runs import Run
@@ -193,7 +193,7 @@ def assess_submission_eligibility(
         latest_run = sorted(work_item.runs, key=lambda row: (row.attempt, row.created_at or utcnow()))[-1]
 
     reason: str | None = None
-    if work_item.state.value != "awaiting_review":
+    if work_item.state not in {WorkItemState.ARTIFACT_SYNC, WorkItemState.AWAITING_REVIEW}:
         reason = f"state={work_item.state.value}"
     elif latest_run is None:
         reason = "no_runs"

--- a/control_plane/control_plane/tests/test_completion_service.py
+++ b/control_plane/control_plane/tests/test_completion_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import tempfile
+from unittest.mock import patch
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -22,6 +23,7 @@ from control_plane.services.completion_service import (
     CompletionProcessingError,
     process_completed_items,
 )
+from control_plane.services.operator_submission import OperatorSubmissionError
 
 
 def _write(path: Path, text: str) -> None:
@@ -123,7 +125,7 @@ def test_process_completed_items_consumes_l1_item() -> None:
             assert results[0].item_id == item_id
             assert results[0].consumed is True
             assert results[0].submitted is False
-            assert results[0].work_item_state == "awaiting_review"
+            assert results[0].work_item_state == "artifact_sync"
             assert results[0].target_path
 
 
@@ -286,10 +288,42 @@ def test_process_completed_items_materializes_expected_output_artifacts_for_cano
             )
             assert len(results) == 1
             assert results[0].consumed is True
-            assert results[0].work_item_state == "awaiting_review"
+            assert results[0].work_item_state == "artifact_sync"
 
         assert (repo_root / metrics_rel).read_text(encoding="utf-8") == metrics_text
         assert (repo_root / index_rel).read_text(encoding="utf-8") == index_text
+
+
+def test_process_completed_items_submission_failure_keeps_artifact_sync() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id = _seed_l1_artifact_sync(session, repo_root)
+            with patch(
+                "control_plane.services.completion_service.operate_submission",
+                side_effect=OperatorSubmissionError("gh pr create failed"),
+            ):
+                try:
+                    process_completed_items(
+                        session,
+                        CompletionProcessRequest(
+                            repo_root=str(repo_root),
+                            item_id=item_id,
+                            submit=True,
+                            repo="yhmtmt/RTLGen",
+                            force=True,
+                        ),
+                    )
+                except CompletionProcessingError as exc:
+                    assert "gh pr create failed" in str(exc)
+                else:
+                    raise AssertionError("expected CompletionProcessingError")
+
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            assert work_item.state == WorkItemState.ARTIFACT_SYNC
 
 
 def test_process_completed_items_materializes_supporting_output_artifacts() -> None:

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -163,7 +163,7 @@ def test_consume_l1_result_writes_promotion_proposal() -> None:
             assert result.item_id == item_id
             assert result.run_key == run_key
             assert result.proposal_count == 2
-            assert result.work_item_state == "awaiting_review"
+            assert result.work_item_state == "artifact_sync"
 
             proposal_path = repo_root / "control_plane" / "shadow_exports" / "l1_promotions" / f"{item_id}.json"
             payload = json.loads(proposal_path.read_text(encoding="utf-8"))

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -486,7 +486,7 @@ def test_consume_l2_result_writes_decision_proposal() -> None:
             assert result.recommended_arch_id == "fp16_nm1_demo"
             assert result.recommended_macro_mode == "flat_nomacro"
             assert result.profile_count == 2
-            assert result.work_item_state == "awaiting_review"
+            assert result.work_item_state == "artifact_sync"
 
             proposal_path = repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json"
             payload = json.loads(proposal_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- keep consumed L1/L2 items in ARTIFACT_SYNC after proposal generation
- allow submission to proceed from ARTIFACT_SYNC as well as AWAITING_REVIEW
- add a regression test that submission failure leaves the item in ARTIFACT_SYNC instead of falsely appearing review-ready

## Why
Issue #71 showed that the control plane could mark an item as AWAITING_REVIEW before GitHub PR creation succeeded. That let DB state claim a review-ready PR existed when gh pr create had actually failed.

## Validation
Focused issue-71 regression slice passed:
- test_consume_l1_result_writes_promotion_proposal
- test_consume_l2_result_writes_decision_proposal
- test_process_completed_items_consumes_l1_item
- test_process_completed_items_materializes_expected_output_artifacts_for_canonical_l1
- test_process_completed_items_submit_blocks_shadow_only_item_without_force
- test_process_completed_items_submission_failure_keeps_artifact_sync

Note: broader submission/worktree tests in this branch still hit separate pre-existing git worktree/add failures unrelated to this state-transition change.

Closes #71