### PR TITLE
control_plane: refresh detached finalizer checkout

### DIFF
--- a/control_plane/control_plane/services/proposal_finalizer.py
+++ b/control_plane/control_plane/services/proposal_finalizer.py
@@ -355,8 +355,7 @@ def _git_dirty(repo_root: Path) -> bool:
 
 def _prepare_repo(repo_root: Path) -> str:
     _run_git(repo_root, "fetch", "origin")
-    _run_git(repo_root, "checkout", "master")
-    _run_git(repo_root, "pull", "--ff-only", "origin", "master")
+    _run_git(repo_root, "reset", "--hard", "refs/remotes/origin/master")
     return _run_git(repo_root, "rev-parse", "HEAD")
 
 

--- a/control_plane/control_plane/tests/test_proposal_finalizer.py
+++ b/control_plane/control_plane/tests/test_proposal_finalizer.py
@@ -619,3 +619,26 @@ def test_finalize_refreshes_repo_before_loading_proposal_files() -> None:
         assert result.commit_sha == "finalize123"
         promotion_result = json.loads((proposal_path / "promotion_result.json").read_text())
         assert promotion_result["merge_commit"] == "merge123"
+
+
+def test_prepare_repo_resets_detached_worktree_to_origin_master() -> None:
+    calls: list[tuple[str, ...]] = []
+    original_run_git = proposal_finalizer._run_git
+    try:
+        def fake_run_git(_root: Path, *args: str, env=None) -> str:
+            calls.append(args)
+            if args[:1] == ("rev-parse",):
+                return "finalize123"
+            return ""
+
+        proposal_finalizer._run_git = fake_run_git
+        commit_sha = proposal_finalizer._prepare_repo(Path('/tmp/repo'))
+    finally:
+        proposal_finalizer._run_git = original_run_git
+
+    assert commit_sha == "finalize123"
+    assert calls == [
+        ("fetch", "origin"),
+        ("reset", "--hard", "refs/remotes/origin/master"),
+        ("rev-parse", "HEAD"),
+    ]


### PR DESCRIPTION
## Summary
- refresh proposal finalizer service checkouts with HEAD is now at a01c18c control_plane: finalize prop_l1_terminal_hardsigmoid_block_v1 after merge of l1_prop_l1_terminal_hardsigmoid_block_v1_nangate45_r1 instead of Your branch is behind 'origin/master' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch) + Updating 7b922ee..a01c18c
Fast-forward
 .../analysis_report.md                              | 21 +++++++++++++++++----
 .../evaluation_requests.json                        | 11 +++++++----
 .../promotion_decision.json                         | 18 ++++++++++++------
 .../promotion_result.json                           |  8 ++++----
 4 files changed, 40 insertions(+), 18 deletions(-)
- avoid the evaluator detached-worktree failure where  is already checked out in 
- add focused regression coverage for the detached-worktree refresh sequence

## Validation
- ....                                                                     [100%]
=============================== warnings summary ===============================
control_plane/control_plane/models/base.py:20
  /workspaces/RTLGen/control_plane/control_plane/models/base.py:20: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base(metadata=metadata)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
4 passed, 1 warning in 0.20s
- manual merged-item finalizer repro for  succeeded and pushed closeout commit 

Closes #87.