### PR TITLE
devcontainer: harden evaluator service startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,8 +22,8 @@
     "RTLCP_SUBMIT": "${localEnv:RTLCP_SUBMIT}",
     "RTLCP_AUTOSTART_WORKER_DAEMON": "${localEnv:RTLCP_AUTOSTART_WORKER_DAEMON}",
     "RTLCP_AUTOSTART_API": "${localEnv:RTLCP_AUTOSTART_API}",
-    "RTLCP_HOST": "${localEnv:RTLCP_HOST}",
-    "RTLCP_PORT": "${localEnv:RTLCP_PORT}"
+    "RTLCP_HOST": "0.0.0.0",
+    "RTLCP_PORT": "8080"
   },
   "postStartCommand": "/workspaces/RTLGen/.devcontainer/start_control_plane_services.sh",
   "settings": {

--- a/control_plane/scripts/ensure_service_repo.sh
+++ b/control_plane/scripts/ensure_service_repo.sh
@@ -10,11 +10,18 @@ if [[ "${SERVICE_REPO_ROOT}" == "${REPO_ROOT}" ]]; then
   exit 0
 fi
 
+git -C "${REPO_ROOT}" worktree prune
+
 if git -C "${SERVICE_REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 0
 fi
 
 mkdir -p "$(dirname "${SERVICE_REPO_ROOT}")"
+
+if git -C "${REPO_ROOT}" worktree list --porcelain | grep -Fx "worktree ${SERVICE_REPO_ROOT}" >/dev/null 2>&1; then
+  git -C "${REPO_ROOT}" worktree remove --force "${SERVICE_REPO_ROOT}" >/dev/null 2>&1 || true
+  git -C "${REPO_ROOT}" worktree prune
+fi
 
 if [[ -e "${SERVICE_REPO_ROOT}" ]]; then
   if [[ -d "${SERVICE_REPO_ROOT}" ]] && [[ -z "$(ls -A "${SERVICE_REPO_ROOT}" 2>/dev/null)" ]]; then


### PR DESCRIPTION
## Summary
- prune and repair stale service worktree registrations before recreating /workspaces/rtlgen-eval-clean
- stop injecting empty RTLCP_HOST/RTLCP_PORT values by using explicit evaluator API defaults

## Validation
- rebuilt the devcontainer
- verified worker, completions, and api autostart successfully
- confirmed the rebuilt container has RTLCP_HOST=0.0.0.0 and RTLCP_PORT=8080