### PR TITLE
control_plane: harden run finalization failure handling

### DIFF
--- a/control_plane/control_plane/cli/generate_l1_sweep.py
+++ b/control_plane/control_plane/cli/generate_l1_sweep.py
@@ -29,6 +29,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--make-target")
     parser.add_argument("--evaluation-mode")
     parser.add_argument("--abstraction-layer")
+    parser.add_argument("--trial-count", type=int, default=1)
+    parser.add_argument("--seed-start", type=int, default=0)
+    parser.add_argument("--stop-after-failures", type=int)
     args = parser.parse_args(argv)
 
     engine = build_engine(args.database_url)
@@ -55,6 +58,9 @@ def main(argv: list[str] | None = None) -> int:
                 make_target=args.make_target,
                 evaluation_mode=args.evaluation_mode,
                 abstraction_layer=args.abstraction_layer,
+                trial_count=args.trial_count,
+                seed_start=args.seed_start,
+                stop_after_failures=args.stop_after_failures,
             ),
         )
     print(json.dumps(result.__dict__, indent=2, sort_keys=True))

--- a/control_plane/control_plane/migrations/versions/0003_expand_work_item_state_enum_width.py
+++ b/control_plane/control_plane/migrations/versions/0003_expand_work_item_state_enum_width.py
@@ -1,0 +1,68 @@
+"""expand work item state enum width for dispatch_pending"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0003_dispatch_pending_state"
+down_revision = "0002_multi_evaluator_assignment"
+branch_labels = None
+depends_on = None
+
+work_item_state_enum = sa.Enum(
+    "draft",
+    "dispatch_pending",
+    "ready",
+    "leased",
+    "running",
+    "artifact_sync",
+    "awaiting_review",
+    "merged",
+    "failed",
+    "blocked",
+    "superseded",
+    name="workitemstate",
+    native_enum=False,
+    length=32,
+)
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "work_items",
+        "state",
+        existing_type=sa.String(length=15),
+        type_=work_item_state_enum,
+        existing_nullable=False,
+        existing_server_default="draft",
+        postgresql_using="state::varchar(32)",
+    )
+
+
+def downgrade() -> None:
+    legacy_state_enum = sa.Enum(
+        "draft",
+        "ready",
+        "leased",
+        "running",
+        "artifact_sync",
+        "awaiting_review",
+        "merged",
+        "failed",
+        "blocked",
+        "superseded",
+        name="workitemstate",
+        native_enum=False,
+        length=15,
+    )
+    op.execute("UPDATE work_items SET state = 'ready' WHERE state = 'dispatch_pending'")
+    op.alter_column(
+        "work_items",
+        "state",
+        existing_type=work_item_state_enum,
+        type_=legacy_state_enum,
+        existing_nullable=False,
+        existing_server_default="draft",
+        postgresql_using="state::varchar(15)",
+    )

--- a/control_plane/control_plane/migrations/versions/0004_trial_metadata.py
+++ b/control_plane/control_plane/migrations/versions/0004_trial_metadata.py
@@ -1,0 +1,40 @@
+"""add trial metadata and failure fields"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0004_trial_metadata"
+down_revision = "0003_dispatch_pending_state"
+branch_labels = None
+depends_on = None
+
+json_type = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.add_column("work_items", sa.Column("trial_policy_json", json_type, nullable=False, server_default=sa.text("'{}'::jsonb")))
+    op.add_column("runs", sa.Column("trial_index", sa.Integer(), nullable=True))
+    op.add_column("runs", sa.Column("seed", sa.Integer(), nullable=True))
+    op.add_column("runs", sa.Column("trial_group_key", sa.String(length=255), nullable=True))
+    op.add_column("runs", sa.Column("flow_variant", sa.String(length=128), nullable=True))
+    op.add_column("runs", sa.Column("scheduler_variant", sa.String(length=128), nullable=True))
+    op.add_column("runs", sa.Column("failure_stage", sa.String(length=128), nullable=True))
+    op.add_column("runs", sa.Column("failure_category", sa.String(length=128), nullable=True))
+    op.add_column("runs", sa.Column("failure_signature", sa.String(length=255), nullable=True))
+    op.add_column("runs", sa.Column("runtime_seconds", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("runs", "runtime_seconds")
+    op.drop_column("runs", "failure_signature")
+    op.drop_column("runs", "failure_category")
+    op.drop_column("runs", "failure_stage")
+    op.drop_column("runs", "scheduler_variant")
+    op.drop_column("runs", "flow_variant")
+    op.drop_column("runs", "trial_group_key")
+    op.drop_column("runs", "seed")
+    op.drop_column("runs", "trial_index")
+    op.drop_column("work_items", "trial_policy_json")

--- a/control_plane/control_plane/models/enums.py
+++ b/control_plane/control_plane/models/enums.py
@@ -21,6 +21,7 @@ class FlowName(_StrEnum):
 
 class WorkItemState(_StrEnum):
     DRAFT = "draft"
+    DISPATCH_PENDING = "dispatch_pending"
     READY = "ready"
     LEASED = "leased"
     RUNNING = "running"

--- a/control_plane/control_plane/models/runs.py
+++ b/control_plane/control_plane/models/runs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Column, DateTime, Enum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import Column, DateTime, Enum, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from control_plane.models.base import Base, TimestampMixin, json_type, uuid_column
@@ -27,6 +27,15 @@ class Run(TimestampMixin, Base):
     container_image = Column(String(255))
     checkout_commit = Column(String(64))
     branch_name = Column(String(255))
+    trial_index = Column(Integer)
+    seed = Column(Integer)
+    trial_group_key = Column(String(255))
+    flow_variant = Column(String(128))
+    scheduler_variant = Column(String(128))
+    failure_stage = Column(String(128))
+    failure_category = Column(String(128))
+    failure_signature = Column(String(255))
+    runtime_seconds = Column(Float)
     status = Column(Enum(RunStatus, native_enum=False), nullable=False, default=RunStatus.STARTING)
     started_at = Column(DateTime(timezone=True))
     completed_at = Column(DateTime(timezone=True))

--- a/control_plane/control_plane/models/work_items.py
+++ b/control_plane/control_plane/models/work_items.py
@@ -25,7 +25,11 @@ class WorkItem(TimestampMixin, UpdatedAtMixin, Base):
     flow = Column(Enum(FlowName, native_enum=False), nullable=False)
     platform = Column(String(64), nullable=False)
     task_type = Column(String(64), nullable=False)
-    state = Column(Enum(WorkItemState, native_enum=False), nullable=False, default=WorkItemState.DRAFT)
+    state = Column(
+        Enum(WorkItemState, native_enum=False, length=32),
+        nullable=False,
+        default=WorkItemState.DRAFT,
+    )
     priority = Column(Integer, nullable=False)
     source_mode = Column(String(64))
     input_manifest = Column(json_type, nullable=False, default=dict)

--- a/control_plane/control_plane/models/work_items.py
+++ b/control_plane/control_plane/models/work_items.py
@@ -39,6 +39,7 @@ class WorkItem(TimestampMixin, UpdatedAtMixin, Base):
     queue_snapshot_path = Column(Text)
     source_commit = Column(String(64))
     assigned_machine_key = Column(String(255))
+    trial_policy_json = Column(json_type, nullable=False, default=dict)
 
     task_request = relationship("TaskRequest", back_populates="work_items")
     leases = relationship("WorkerLease", back_populates="work_item")

--- a/control_plane/control_plane/services/dependency_gate.py
+++ b/control_plane/control_plane/services/dependency_gate.py
@@ -115,7 +115,7 @@ def refresh_blocked_dependents(session: Session, *, repo_root: str | Path, depen
             continue
         gate = evaluate_work_item_dependencies(session, repo_root=root, work_item=work_item)
         if gate.satisfied:
-            work_item.state = WorkItemState.READY
+            work_item.state = WorkItemState.DISPATCH_PENDING
             work_item.queue_snapshot_path = None
             released.append(work_item.item_id)
     return released
@@ -128,7 +128,7 @@ def refresh_all_blocked_items(session: Session, *, repo_root: str | Path) -> lis
     for work_item in blocked_items:
         gate = evaluate_work_item_dependencies(session, repo_root=root, work_item=work_item)
         if gate.satisfied:
-            work_item.state = WorkItemState.READY
+            work_item.state = WorkItemState.DISPATCH_PENDING
             work_item.queue_snapshot_path = None
             released.append(work_item.item_id)
     return released

--- a/control_plane/control_plane/services/dispatcher_service.py
+++ b/control_plane/control_plane/services/dispatcher_service.py
@@ -73,8 +73,8 @@ def _is_machine_dispatchable(machine: WorkerMachine, *, freshness_seconds: int) 
 def _next_unassigned_item_for_machine(session: Session, machine: WorkerMachine) -> WorkItem | None:
     query = (
         session.query(WorkItem)
-        .filter(WorkItem.state == WorkItemState.READY)
         .filter(WorkItem.assigned_machine_key.is_(None))
+        .filter(WorkItem.state.in_([WorkItemState.DISPATCH_PENDING, WorkItemState.READY]))
         .filter(~WorkItem.leases.any(WorkerLease.status == LeaseStatus.ACTIVE))
         .order_by(WorkItem.priority.desc(), WorkItem.created_at.asc(), WorkItem.item_id.asc())
     )

--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import csv
+from collections import Counter
 from dataclasses import dataclass
 from datetime import timezone
 import hashlib
 import json
 from pathlib import Path
 import re
+import statistics
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -71,7 +73,11 @@ def _resolve_run(session: Session, request: Layer1ConsumeRequest) -> tuple[WorkI
         raise Layer1ResultConsumerError(f"work item not found: {request.item_id}")
     if not work_item.runs:
         raise Layer1ResultConsumerError(f"work item has no runs: {request.item_id}")
-    run = sorted(work_item.runs, key=lambda row: (row.attempt, row.created_at or utcnow()))[-1]
+    successful_runs = [row for row in work_item.runs if row.status == RunStatus.SUCCEEDED]
+    if successful_runs:
+        run = sorted(successful_runs, key=lambda row: (row.attempt, row.created_at or utcnow()))[-1]
+    else:
+        run = sorted(work_item.runs, key=lambda row: (row.attempt, row.created_at or utcnow()))[-1]
     return work_item, run
 
 
@@ -265,6 +271,180 @@ def _proposal_entry(*, metrics_csv: str, best_row: dict[str, Any], evaluation_re
     return proposal
 
 
+def _completed_trial_runs(work_item: WorkItem) -> list[Run]:
+    completed: list[Run] = []
+    for run in sorted(work_item.runs, key=lambda row: (row.attempt, row.created_at or utcnow())):
+        if run.status not in {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.CANCELED, RunStatus.TIMED_OUT}:
+            continue
+        payload = dict(run.result_payload or {}) if isinstance(run.result_payload, dict) else {}
+        if bool((payload.get("retry_decision") or {}).get("requeue")):
+            continue
+        completed.append(run)
+    return completed
+
+
+def _metrics_csvs_from_run(run: Run, *, work_item: WorkItem | None = None) -> list[str]:
+    payload = dict(run.result_payload or {}) if isinstance(run.result_payload, dict) else {}
+    queue_result = dict(payload.get("queue_result") or {})
+    result: list[str] = []
+    for ref in queue_result.get("metrics_rows") or []:
+        rel_path = str(ref).split(":", 1)[0].strip()
+        if not rel_path or rel_path == "runs/index.csv" or not rel_path.endswith("metrics.csv"):
+            continue
+        if rel_path not in result:
+            result.append(rel_path)
+    if result or work_item is None:
+        return result
+    for rel_path in work_item.expected_outputs or []:
+        rel_path = str(rel_path).strip()
+        if not rel_path or rel_path == "runs/index.csv" or not rel_path.endswith("metrics.csv"):
+            continue
+        if rel_path not in result:
+            result.append(rel_path)
+    return result
+
+
+def _best_trial_row(repo_root: Path, run: Run) -> tuple[str, dict[str, Any]] | None:
+    candidates: list[tuple[str, dict[str, Any]]] = []
+    for metrics_csv in _metrics_csvs_from_run(run, work_item=run.work_item):
+        best_row = _best_metrics_row(repo_root=repo_root, metrics_csv=metrics_csv)
+        if best_row is None:
+            continue
+        candidates.append((metrics_csv, best_row))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: _row_sort_key(item[1]))
+    return candidates[0]
+
+
+def _metric_summary(values: list[float]) -> dict[str, float] | None:
+    if not values:
+        return None
+    return {
+        "best": min(values),
+        "mean": float(statistics.fmean(values)),
+        "median": float(statistics.median(values)),
+        "max": max(values),
+    }
+
+
+def _trial_artifact_paths(item_id: str) -> dict[str, str]:
+    base = f"control_plane/shadow_exports/l1_trials/{item_id}"
+    return {
+        "summary_stats": f"{base}/summary_stats.json",
+        "failure_stats": f"{base}/failure_stats.json",
+        "trial_table": f"{base}/trial_table.csv",
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_trial_table(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "run_key", "attempt", "trial_index", "seed", "status", "metrics_csv",
+        "critical_path_ns", "die_area", "total_power_mw",
+        "failure_category", "failure_stage", "failure_signature",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key, "") for key in fieldnames})
+
+
+def _upsert_repo_artifact(session: Session, *, run: Run, kind: str, path: str, metadata: dict[str, Any], repo_root: Path) -> None:
+    artifact = session.query(Artifact).filter(Artifact.run_id == run.id, Artifact.kind == kind).one_or_none()
+    rel_path = str(path)
+    abs_path = repo_root / rel_path
+    sha = hashlib.sha256(abs_path.read_bytes()).hexdigest() if abs_path.exists() else None
+    if artifact is None:
+        artifact = Artifact(
+            run_id=run.id,
+            kind=kind,
+            storage_mode=ArtifactStorageMode.REPO,
+            path=rel_path,
+            sha256=sha,
+            metadata_=metadata,
+        )
+        session.add(artifact)
+    else:
+        artifact.storage_mode = ArtifactStorageMode.REPO
+        artifact.path = rel_path
+        artifact.sha256 = sha
+        artifact.metadata_ = metadata
+
+
+def _trial_aggregate_payloads(repo_root: Path, work_item: WorkItem) -> tuple[list[str], dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
+    completed = _completed_trial_runs(work_item)
+    metrics_csvs: list[str] = []
+    trial_rows: list[dict[str, Any]] = []
+    success_metric_values = {"critical_path_ns": [], "die_area": [], "total_power_mw": []}
+    failure_category = Counter()
+    failure_stage = Counter()
+    success_count = 0
+    for run in completed:
+        payload = dict(run.result_payload or {}) if isinstance(run.result_payload, dict) else {}
+        trial = dict(payload.get("trial") or {})
+        failure = dict(payload.get("failure_classification") or {})
+        run_metrics_csvs = _metrics_csvs_from_run(run, work_item=work_item) if run.status == RunStatus.SUCCEEDED else []
+        for metrics_csv in run_metrics_csvs:
+            if metrics_csv not in metrics_csvs:
+                metrics_csvs.append(metrics_csv)
+        best = _best_trial_row(repo_root, run) if run.status == RunStatus.SUCCEEDED else None
+        metrics_csv = ""
+        best_row = None
+        if best is not None:
+            metrics_csv, best_row = best
+            success_count += 1
+            for key in success_metric_values:
+                value = _safe_float(best_row.get(key))
+                if value is not None:
+                    success_metric_values[key].append(value)
+        else:
+            category = str(failure.get("category", "") or run.failure_category or "unknown").strip() or "unknown"
+            stage = str(failure.get("stage", "") or run.failure_stage or "unknown").strip() or "unknown"
+            failure_category[category] += 1
+            failure_stage[stage] += 1
+        trial_rows.append({
+            "run_key": run.run_key,
+            "attempt": run.attempt,
+            "trial_index": trial.get("trial_index", run.trial_index or ""),
+            "seed": trial.get("seed", run.seed or ""),
+            "status": run.status.value,
+            "metrics_csv": metrics_csv,
+            "critical_path_ns": _safe_float(best_row.get("critical_path_ns")) if best_row else "",
+            "die_area": _safe_float(best_row.get("die_area")) if best_row else "",
+            "total_power_mw": _safe_float(best_row.get("total_power_mw")) if best_row else "",
+            "failure_category": str(failure.get("category", "") or run.failure_category or "").strip(),
+            "failure_stage": str(failure.get("stage", "") or run.failure_stage or "").strip(),
+            "failure_signature": str(failure.get("signature", "") or run.failure_signature or "").strip(),
+        })
+
+    completed_trials = len(completed)
+    failure_count = completed_trials - success_count
+    summary_stats = {
+        "item_id": work_item.item_id,
+        "completed_trials": completed_trials,
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "success_rate": (float(success_count) / float(completed_trials)) if completed_trials else 0.0,
+        "metrics": {key: value for key, value in {metric: _metric_summary(values) for metric, values in success_metric_values.items()}.items() if value is not None},
+    }
+    failure_stats = {
+        "item_id": work_item.item_id,
+        "completed_trials": completed_trials,
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "by_category": dict(failure_category),
+        "by_stage": dict(failure_stage),
+    }
+    return metrics_csvs, summary_stats, failure_stats, trial_rows
+
+
 def _build_payload(*, work_item: WorkItem, run: Run, proposals: list[dict[str, Any]], evaluation_record: dict[str, Any]) -> dict[str, Any]:
     return {
         "version": 0.1,
@@ -282,6 +462,7 @@ def _build_payload(*, work_item: WorkItem, run: Run, proposals: list[dict[str, A
         "evaluation_record": evaluation_record,
         "proposal_assessment": None,
         "proposals": proposals,
+        "trial_summary": None,
     }
 
 
@@ -317,11 +498,7 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
     if run.status != RunStatus.SUCCEEDED:
         raise Layer1ResultConsumerError(f"run is not succeeded: {run.run_key} status={run.status.value}")
 
-    metrics_csvs = [
-        str(path)
-        for path in (work_item.expected_outputs or [])
-        if str(path).endswith("/metrics.csv") or str(path).endswith("metrics.csv")
-    ]
+    metrics_csvs, summary_stats, failure_stats, trial_rows = _trial_aggregate_payloads(repo_root, work_item)
     proposals: list[dict[str, Any]] = []
     evaluation_record: dict[str, Any] | None = None
     for metrics_csv in metrics_csvs:
@@ -348,12 +525,24 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
         proposals=proposals,
         evaluation_record=evaluation_record,
     )
+    payload["trial_summary"] = summary_stats
     target_rel = request.target_path or _default_target_path(item_id=work_item.item_id)
     target_path = _resolve_path(repo_root=repo_root, path_text=target_rel)
     target_path.parent.mkdir(parents=True, exist_ok=True)
     target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
+    trial_paths = _trial_artifact_paths(work_item.item_id)
+    summary_path = _resolve_path(repo_root=repo_root, path_text=trial_paths["summary_stats"])
+    failure_path = _resolve_path(repo_root=repo_root, path_text=trial_paths["failure_stats"])
+    trial_table_path = _resolve_path(repo_root=repo_root, path_text=trial_paths["trial_table"])
+    _write_json(summary_path, summary_stats)
+    _write_json(failure_path, failure_stats)
+    _write_trial_table(trial_table_path, trial_rows)
+
     _upsert_artifact(session, run=run, target_path=str(target_path.relative_to(repo_root)), payload=payload)
+    _upsert_repo_artifact(session, run=run, kind="summary_stats", path=str(summary_path.relative_to(repo_root)), metadata={"completed_trials": summary_stats["completed_trials"]}, repo_root=repo_root)
+    _upsert_repo_artifact(session, run=run, kind="failure_stats", path=str(failure_path.relative_to(repo_root)), metadata={"failure_count": failure_stats["failure_count"]}, repo_root=repo_root)
+    _upsert_repo_artifact(session, run=run, kind="trial_table", path=str(trial_table_path.relative_to(repo_root)), metadata={"row_count": len(trial_rows)}, repo_root=repo_root)
     work_item.state = WorkItemState.ARTIFACT_SYNC
     session.add(
         RunEvent(
@@ -363,6 +552,8 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
             event_payload={
                 "target_path": str(target_path.relative_to(repo_root)),
                 "proposal_count": len(proposals),
+                "completed_trials": summary_stats["completed_trials"],
+                "success_count": summary_stats["success_count"],
             },
         )
     )

--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -182,6 +182,45 @@ def _load_proposal(repo_root: Path, work_item: WorkItem) -> dict[str, Any] | Non
         return None
 
 
+def _inferred_l1_abstraction_layer(repo_root: Path, work_item: WorkItem) -> str:
+    input_manifest = dict(work_item.input_manifest or {})
+    configs = input_manifest.get("configs")
+    if isinstance(configs, list):
+        for config_text in configs:
+            config_path = _resolve_path(repo_root=repo_root, path_text=str(config_text))
+            if not config_path.exists():
+                continue
+            try:
+                cfg = _load_json(config_path)
+            except Exception:
+                continue
+            if "top_name" in cfg and "compute" in cfg:
+                return "architecture_block"
+            if any(key in cfg for key in ("multiplier", "multiplier_yosys", "adder")):
+                return "circuit_block"
+            operations = cfg.get("operations")
+            if isinstance(operations, list) and len(operations) == 1:
+                op_type = str((operations[0] or {}).get("type", "")).strip()
+                if op_type in {"activation", "softmax_rowwise"}:
+                    return "circuit_block"
+    expected_outputs = [str(path_text) for path_text in (work_item.expected_outputs or [])]
+    joined = "\n".join(expected_outputs)
+    if "runs/designs/npu_blocks/" in joined:
+        return "architecture_block"
+    if any(
+        marker in joined
+        for marker in (
+            "runs/designs/activations/",
+            "runs/designs/prefix_adders/",
+            "runs/designs/multipliers/",
+            "runs/designs/adders/",
+            "runs/designs/trials/",
+        )
+    ):
+        return "circuit_block"
+    return ""
+
+
 def _developer_loop_abstraction_layer(repo_root: Path, work_item: WorkItem) -> str:
     developer_loop = _developer_loop_payload(work_item)
     abstraction = developer_loop.get("abstraction")
@@ -189,10 +228,21 @@ def _developer_loop_abstraction_layer(repo_root: Path, work_item: WorkItem) -> s
         layer = str(abstraction.get("layer", "")).strip()
         if layer:
             return layer
+    evaluation = developer_loop.get("evaluation")
+    if isinstance(evaluation, dict):
+        layer = str(evaluation.get("abstraction_layer", "")).strip()
+        if layer:
+            return layer
     proposal = _load_proposal(repo_root, work_item)
     if isinstance(proposal, dict):
-        return str(proposal.get("abstraction_layer", "")).strip()
-    return ""
+        layer = str(proposal.get("abstraction_layer", "")).strip()
+        if layer:
+            return layer
+    payload = dict(work_item.task_request.request_payload or {})
+    layer = str(payload.get("abstraction_layer", "")).strip()
+    if layer:
+        return layer
+    return _inferred_l1_abstraction_layer(repo_root, work_item)
 
 
 def _effective_evaluation_record(*, repo_root: Path, work_item: WorkItem, best_row: dict[str, Any]) -> dict[str, Any]:
@@ -445,7 +495,7 @@ def _trial_aggregate_payloads(repo_root: Path, work_item: WorkItem) -> tuple[lis
     return metrics_csvs, summary_stats, failure_stats, trial_rows
 
 
-def _build_payload(*, work_item: WorkItem, run: Run, proposals: list[dict[str, Any]], evaluation_record: dict[str, Any]) -> dict[str, Any]:
+def _build_payload(*, work_item: WorkItem, run: Run, proposals: list[dict[str, Any]], evaluation_record: dict[str, Any], source_refs: dict[str, Any] | None = None) -> dict[str, Any]:
     return {
         "version": 0.1,
         "generated_utc": utcnow().astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -463,6 +513,7 @@ def _build_payload(*, work_item: WorkItem, run: Run, proposals: list[dict[str, A
         "proposal_assessment": None,
         "proposals": proposals,
         "trial_summary": None,
+        "source_refs": source_refs or {},
     }
 
 
@@ -519,11 +570,19 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
     if not proposals or evaluation_record is None:
         raise Layer1ResultConsumerError(f"no status=ok metrics rows found for work item: {work_item.item_id}")
 
+    trial_paths = _trial_artifact_paths(work_item.item_id)
+    source_refs = {
+        "trial_metrics_csvs": metrics_csvs,
+        "summary_stats_json": trial_paths["summary_stats"],
+        "failure_stats_json": trial_paths["failure_stats"],
+        "trial_table_csv": trial_paths["trial_table"],
+    }
     payload = _build_payload(
         work_item=work_item,
         run=run,
         proposals=proposals,
         evaluation_record=evaluation_record,
+        source_refs=source_refs,
     )
     payload["trial_summary"] = summary_stats
     target_rel = request.target_path or _default_target_path(item_id=work_item.item_id)
@@ -531,7 +590,6 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
     target_path.parent.mkdir(parents=True, exist_ok=True)
     target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
-    trial_paths = _trial_artifact_paths(work_item.item_id)
     summary_path = _resolve_path(repo_root=repo_root, path_text=trial_paths["summary_stats"])
     failure_path = _resolve_path(repo_root=repo_root, path_text=trial_paths["failure_stats"])
     trial_table_path = _resolve_path(repo_root=repo_root, path_text=trial_paths["trial_table"])

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -43,6 +43,9 @@ class Layer1SweepGenerateRequest:
     make_target: str | None = None
     evaluation_mode: str | None = None
     abstraction_layer: str | None = None
+    trial_count: int = 1
+    seed_start: int = 0
+    stop_after_failures: int | None = None
 
 
 @dataclass(frozen=True)
@@ -363,6 +366,20 @@ def _default_objective(*, platform: str, config_paths: list[str], sweep_path: st
     )
 
 
+def _effective_trial_policy(*, trial_count: int, seed_start: int, stop_after_failures: int | None) -> dict[str, int]:
+    effective_trial_count = max(int(trial_count), 1)
+    effective_seed_start = int(seed_start)
+    effective_stop_after_failures = stop_after_failures
+    if effective_stop_after_failures is None:
+        effective_stop_after_failures = effective_trial_count
+    effective_stop_after_failures = max(1, min(int(effective_stop_after_failures), effective_trial_count))
+    return {
+        "trial_count": effective_trial_count,
+        "seed_start": effective_seed_start,
+        "stop_after_failures": effective_stop_after_failures,
+    }
+
+
 def _effective_evaluation_mode(*, evaluation_mode: str | None, make_target: str | None) -> str:
     mode = str(evaluation_mode or "").strip()
     if mode:
@@ -389,6 +406,7 @@ def _build_payload(
     proposal_path: str | None,
     evaluation_mode: str,
     abstraction_layer: str | None,
+    trial_policy: dict[str, int],
 ) -> dict[str, Any]:
     payload = {
         "version": 0.1,
@@ -411,6 +429,7 @@ def _build_payload(
                 "macro_manifests": [],
                 "candidate_manifests": [],
                 "required_submodules": _required_l1_runtime_submodules(),
+                "out_root": out_root,
             },
             "commands": [
                 *command_manifest,
@@ -454,6 +473,7 @@ def _build_payload(
             "proposal_path": proposal_path or "",
             "evaluation": {
                 "mode": evaluation_mode,
+                "trial_policy": trial_policy,
             },
         }
         if abstraction_layer:
@@ -533,6 +553,11 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             make_target=request.make_target,
         ),
         abstraction_layer=effective_abstraction_layer,
+        trial_policy=_effective_trial_policy(
+            trial_count=request.trial_count,
+            seed_start=request.seed_start,
+            stop_after_failures=request.stop_after_failures,
+        ),
     )
 
     existing = session.query(WorkItem).filter(WorkItem.item_id == item_id).one_or_none()
@@ -568,6 +593,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             expected_outputs=payload["task"]["expected_outputs"],
             acceptance_rules=payload["task"]["acceptance"],
             source_commit=source_commit,
+            trial_policy_json=((payload.get("developer_loop") or {}).get("evaluation") or {}).get("trial_policy") or {},
         )
         session.add(work_item)
         session.commit()
@@ -599,6 +625,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
     existing.expected_outputs = payload["task"]["expected_outputs"]
     existing.acceptance_rules = payload["task"]["acceptance"]
     existing.source_commit = source_commit
+    existing.trial_policy_json = ((payload.get("developer_loop") or {}).get("evaluation") or {}).get("trial_policy") or {}
     session.commit()
     return Layer1TaskGenerateResult(
         item_id=item_id,

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -560,7 +560,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             flow=FlowName.OPENROAD,
             platform=request.platform,
             task_type="l1_sweep",
-            state=WorkItemState.READY,
+            state=WorkItemState.DISPATCH_PENDING,
             priority=request.priority,
             source_mode="config",
             input_manifest=payload["task"]["inputs"],

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -540,7 +540,7 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
         requires_merged_inputs=effective_requires_merged_inputs,
         requires_materialized_refs=effective_requires_materialized_refs,
     )
-    initial_state = WorkItemState.READY
+    initial_state = WorkItemState.DISPATCH_PENDING
     transient_work_item = WorkItem(
         work_item_key=f"l2_campaign:{item_id}",
         task_request_id="",

--- a/control_plane/control_plane/services/lease_service.py
+++ b/control_plane/control_plane/services/lease_service.py
@@ -220,7 +220,7 @@ def expire_stale_leases(session: Session) -> LeaseExpiryResult:
             RunStatus.TIMED_OUT,
         }
         if not latest_run_terminal and work_item.state in {WorkItemState.LEASED, WorkItemState.RUNNING}:
-            work_item.state = WorkItemState.READY
+            work_item.state = WorkItemState.DISPATCH_PENDING
             requeued_count += 1
     session.commit()
     return LeaseExpiryResult(expired_count=expired_count, requeued_count=requeued_count)

--- a/control_plane/control_plane/services/lease_service.py
+++ b/control_plane/control_plane/services/lease_service.py
@@ -135,16 +135,30 @@ def acquire_next_lease(
             raise
 
         now = utcnow()
-        lease = WorkerLease(
-            work_item_id=work_item.id,
-            machine_id=machine.id,
-            lease_token=make_id("lease"),
-            status=LeaseStatus.ACTIVE,
-            leased_at=now,
-            expires_at=now + timedelta(seconds=lease_seconds),
-            last_heartbeat_at=now,
+        lease = (
+            session.query(WorkerLease)
+            .filter(WorkerLease.work_item_id == work_item.id)
+            .order_by(WorkerLease.leased_at.desc(), WorkerLease.id.desc())
+            .first()
         )
-        session.add(lease)
+        if lease is None:
+            lease = WorkerLease(
+                work_item_id=work_item.id,
+                machine_id=machine.id,
+                lease_token=make_id("lease"),
+                status=LeaseStatus.ACTIVE,
+                leased_at=now,
+                expires_at=now + timedelta(seconds=lease_seconds),
+                last_heartbeat_at=now,
+            )
+            session.add(lease)
+        else:
+            lease.machine_id = machine.id
+            lease.lease_token = make_id("lease")
+            lease.status = LeaseStatus.ACTIVE
+            lease.leased_at = now
+            lease.expires_at = now + timedelta(seconds=lease_seconds)
+            lease.last_heartbeat_at = now
         work_item.state = WorkItemState.LEASED
         try:
             session.commit()

--- a/control_plane/control_plane/services/operator_status.py
+++ b/control_plane/control_plane/services/operator_status.py
@@ -244,6 +244,9 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
     awaiting_review = state_counts.get(WorkItemState.AWAITING_REVIEW.value, 0)
     if awaiting_review:
         attention_flags.append(f"awaiting_review={awaiting_review}")
+    dispatch_pending_items = state_counts.get(WorkItemState.DISPATCH_PENDING.value, 0)
+    if dispatch_pending_items:
+        attention_flags.append(f"dispatch_pending={dispatch_pending_items}")
     ready_items = state_counts.get(WorkItemState.READY.value, 0)
     if ready_items:
         attention_flags.append(f"ready={ready_items}")

--- a/control_plane/control_plane/services/queue_importer.py
+++ b/control_plane/control_plane/services/queue_importer.py
@@ -18,8 +18,9 @@ from control_plane.models.work_items import WorkItem
 
 _STATE_RANK = {
     WorkItemState.DRAFT: 0,
-    WorkItemState.READY: 1,
-    WorkItemState.LEASED: 2,
+    WorkItemState.DISPATCH_PENDING: 1,
+    WorkItemState.READY: 2,
+    WorkItemState.LEASED: 3,
     WorkItemState.RUNNING: 3,
     WorkItemState.ARTIFACT_SYNC: 4,
     WorkItemState.AWAITING_REVIEW: 5,
@@ -93,7 +94,7 @@ def _semantic_payload(payload: dict[str, Any]) -> dict[str, Any]:
 def _queue_state_to_work_item_state(queue_state: str) -> WorkItemState:
     if queue_state == "evaluated":
         return WorkItemState.AWAITING_REVIEW
-    return WorkItemState.READY
+    return WorkItemState.DISPATCH_PENDING
 
 
 def _merge_state(current: WorkItemState, imported: WorkItemState) -> WorkItemState:

--- a/control_plane/control_plane/services/run_service.py
+++ b/control_plane/control_plane/services/run_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import timezone
 from typing import Any
 
 from sqlalchemy.exc import IntegrityError
@@ -21,6 +22,14 @@ _TERMINAL_RUN_STATUSES = {
     RunStatus.CANCELED,
     RunStatus.TIMED_OUT,
 }
+
+
+def _coerce_utc(dt):
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
 
 
 class RunLifecycleError(RuntimeError):
@@ -85,6 +94,10 @@ def _get_active_lease(session: Session, lease_token: str) -> WorkerLease:
     return lease
 
 
+def _dispatchable_state_for(work_item) -> WorkItemState:
+    return WorkItemState.READY if getattr(work_item, "assigned_machine_key", None) else WorkItemState.DISPATCH_PENDING
+
+
 def start_run(
     session: Session,
     *,
@@ -95,6 +108,11 @@ def start_run(
     container_image: str | None = None,
     checkout_commit: str | None = None,
     branch_name: str | None = None,
+    trial_index: int | None = None,
+    seed: int | None = None,
+    trial_group_key: str | None = None,
+    flow_variant: str | None = None,
+    scheduler_variant: str | None = None,
 ) -> RunStartResult:
     lease = _get_active_lease(session, lease_token)
     work_item = lease.work_item
@@ -117,6 +135,11 @@ def start_run(
         container_image=container_image,
         checkout_commit=checkout_commit,
         branch_name=branch_name,
+        trial_index=trial_index,
+        seed=seed,
+        trial_group_key=trial_group_key,
+        flow_variant=flow_variant,
+        scheduler_variant=scheduler_variant,
         status=RunStatus.RUNNING,
         started_at=utcnow(),
     )
@@ -132,6 +155,9 @@ def start_run(
             "lease_token": lease_token,
             "attempt": attempt,
             "executor_type": executor_type,
+            "trial_index": trial_index,
+            "seed": seed,
+            "trial_group_key": trial_group_key,
         },
     )
     session.add(event)
@@ -250,6 +276,15 @@ def complete_run(
     run.completed_at = utcnow()
     run.result_summary = result_summary
     run.result_payload = result_payload
+    if run.started_at is not None and run.completed_at is not None:
+        started_at = _coerce_utc(run.started_at)
+        completed_at = _coerce_utc(run.completed_at)
+        run.runtime_seconds = max((completed_at - started_at).total_seconds(), 0.0)
+    failure = (result_payload or {}).get("failure_classification") if isinstance(result_payload, dict) else {}
+    if isinstance(failure, dict):
+        run.failure_stage = str(failure.get("stage", "") or "").strip() or None
+        run.failure_category = str(failure.get("category", "") or "").strip() or None
+        run.failure_signature = str(failure.get("signature", "") or failure.get("detail", "") or "").strip() or None
 
     work_item = run.work_item
     retry_decision = (result_payload or {}).get("retry_decision", {}) if isinstance(result_payload, dict) else {}
@@ -257,7 +292,7 @@ def complete_run(
     if run_status == RunStatus.SUCCEEDED:
         work_item.state = WorkItemState.ARTIFACT_SYNC
     elif requeue_for_retry:
-        work_item.state = WorkItemState.DISPATCH_PENDING
+        work_item.state = _dispatchable_state_for(work_item)
     else:
         work_item.state = WorkItemState.FAILED
 

--- a/control_plane/control_plane/services/run_service.py
+++ b/control_plane/control_plane/services/run_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timezone
+from hashlib import sha1
 from typing import Any
 
 from sqlalchemy.exc import IntegrityError
@@ -22,6 +23,20 @@ _TERMINAL_RUN_STATUSES = {
     RunStatus.CANCELED,
     RunStatus.TIMED_OUT,
 }
+
+
+def _bounded_text(value: object, *, max_len: int) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if len(text) <= max_len:
+        return text
+    digest = sha1(text.encode("utf-8")).hexdigest()[:12]
+    suffix = f"... [sha1:{digest}]"
+    keep = max_len - len(suffix)
+    if keep <= 0:
+        return suffix[:max_len]
+    return text[:keep] + suffix
 
 
 def _coerce_utc(dt):
@@ -282,9 +297,12 @@ def complete_run(
         run.runtime_seconds = max((completed_at - started_at).total_seconds(), 0.0)
     failure = (result_payload or {}).get("failure_classification") if isinstance(result_payload, dict) else {}
     if isinstance(failure, dict):
-        run.failure_stage = str(failure.get("stage", "") or "").strip() or None
-        run.failure_category = str(failure.get("category", "") or "").strip() or None
-        run.failure_signature = str(failure.get("signature", "") or failure.get("detail", "") or "").strip() or None
+        run.failure_stage = _bounded_text(failure.get("stage", ""), max_len=128)
+        run.failure_category = _bounded_text(failure.get("category", ""), max_len=128)
+        run.failure_signature = _bounded_text(
+            failure.get("signature", "") or failure.get("detail", ""),
+            max_len=255,
+        )
 
     work_item = run.work_item
     retry_decision = (result_payload or {}).get("retry_decision", {}) if isinstance(result_payload, dict) else {}

--- a/control_plane/control_plane/services/run_service.py
+++ b/control_plane/control_plane/services/run_service.py
@@ -257,7 +257,7 @@ def complete_run(
     if run_status == RunStatus.SUCCEEDED:
         work_item.state = WorkItemState.ARTIFACT_SYNC
     elif requeue_for_retry:
-        work_item.state = WorkItemState.READY
+        work_item.state = WorkItemState.DISPATCH_PENDING
     else:
         work_item.state = WorkItemState.FAILED
 

--- a/control_plane/control_plane/services/scheduler.py
+++ b/control_plane/control_plane/services/scheduler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from sqlalchemy import case, or_
+from sqlalchemy import case
 from sqlalchemy.orm import Session
 
 from control_plane.models.enums import FlowName, LeaseStatus, WorkItemState
@@ -35,10 +35,17 @@ def assign_work_item(session: Session, *, item_id: str, machine_key: str | None)
         machine = session.query(WorkerMachine).filter(WorkerMachine.machine_key == machine_key).one_or_none()
         if machine is None:
             raise NoEligibleWorkItem(f"worker machine not found: {machine_key}")
+    update_payload = {WorkItem.assigned_machine_key: machine_key}
+    if machine_key is None:
+        if work_item.state in {WorkItemState.READY, WorkItemState.DISPATCH_PENDING}:
+            update_payload[WorkItem.state] = WorkItemState.DISPATCH_PENDING
+    else:
+        if work_item.state in {WorkItemState.DRAFT, WorkItemState.DISPATCH_PENDING, WorkItemState.READY}:
+            update_payload[WorkItem.state] = WorkItemState.READY
     (
         session.query(WorkItem)
         .filter(WorkItem.id == work_item.id)
-        .update({WorkItem.assigned_machine_key: machine_key}, synchronize_session=False)
+        .update(update_payload, synchronize_session=False)
     )
     session.commit()
     session.refresh(work_item)
@@ -70,9 +77,7 @@ def select_next_work_item(
     )
 
     if machine_key:
-        query = query.filter(
-            or_(WorkItem.assigned_machine_key.is_(None), WorkItem.assigned_machine_key == machine_key)
-        )
+        query = query.filter(WorkItem.assigned_machine_key == machine_key)
     if effective.get("platform"):
         query = query.filter(WorkItem.platform == effective["platform"])
     if effective.get("flow"):

--- a/control_plane/control_plane/services/submission_bridge.py
+++ b/control_plane/control_plane/services/submission_bridge.py
@@ -81,6 +81,25 @@ def _canonical_evidence_files(*, repo_root: Path, work_item: WorkItem) -> list[s
     return files
 
 
+def _collect_existing_file_refs(*, repo_root: Path, value: Any, files: list[str], seen: set[str]) -> None:
+    if isinstance(value, dict):
+        for nested in value.values():
+            _collect_existing_file_refs(repo_root=repo_root, value=nested, files=files, seen=seen)
+        return
+    if isinstance(value, list):
+        for nested in value:
+            _collect_existing_file_refs(repo_root=repo_root, value=nested, files=files, seen=seen)
+        return
+    rel_path = str(value or "").strip()
+    if not rel_path or rel_path in seen:
+        return
+    candidate = repo_root / rel_path
+    if not candidate.exists() or not candidate.is_file():
+        return
+    seen.add(rel_path)
+    files.append(rel_path)
+
+
 def _review_linked_supporting_files(*, repo_root: Path, package_payload: dict[str, Any]) -> list[str]:
     review_artifact = package_payload.get("review_artifact")
     if not isinstance(review_artifact, dict):
@@ -91,36 +110,9 @@ def _review_linked_supporting_files(*, repo_root: Path, package_payload: dict[st
     source_refs = payload.get("source_refs")
     if not isinstance(source_refs, dict):
         return []
-    supporting_keys = (
-        "focused_candidate_schedule_yml",
-        "focused_candidate_descriptors_bin",
-        "focused_candidate_perf_trace_json",
-    )
     files: list[str] = []
     seen: set[str] = set()
-    for key in supporting_keys:
-        rel_path = str(source_refs.get(key, "")).strip()
-        if not rel_path or rel_path in seen:
-            continue
-        candidate = repo_root / rel_path
-        if not candidate.exists() or not candidate.is_file():
-            continue
-        seen.add(rel_path)
-        files.append(rel_path)
-    focused_model_artifacts = source_refs.get("focused_model_artifacts")
-    if isinstance(focused_model_artifacts, list):
-        for entry in focused_model_artifacts:
-            if not isinstance(entry, dict):
-                continue
-            for key in ("schedule_yml", "descriptors_bin", "perf_trace_json"):
-                rel_path = str(entry.get(key, "")).strip()
-                if not rel_path or rel_path in seen:
-                    continue
-                candidate = repo_root / rel_path
-                if not candidate.exists() or not candidate.is_file():
-                    continue
-                seen.add(rel_path)
-                files.append(rel_path)
+    _collect_existing_file_refs(repo_root=repo_root, value=source_refs, files=files, seen=seen)
     return files
 
 
@@ -203,13 +195,36 @@ def _worktree_root(item_id: str, requested: str | None) -> Path:
     return Path(tempfile.mkdtemp(prefix=f"rtlcp-submit-{item_id}-"))
 
 
-def _copy_into_worktree(*, repo_root: Path, worktree_path: Path, rel_path: str) -> None:
+def _copy_into_worktree(*, repo_root: Path, worktree_path: Path, rel_path: str, target_rel_path: str | None = None) -> None:
     src = repo_root / rel_path
-    dst = worktree_path / rel_path
+    dst = worktree_path / (target_rel_path or rel_path)
     if not src.exists():
         raise SubmissionPrepareError(f"review file missing: {rel_path}")
     dst.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dst)
+
+
+def _frozen_rel_path(*, item_id: str, run_key: str, rel_path: str) -> str:
+    return str(Path('control_plane') / 'shadow_exports' / 'frozen_review' / item_id / run_key / rel_path)
+
+
+def _freeze_file(*, repo_root: Path, item_id: str, run_key: str, rel_path: str) -> str:
+    frozen_rel = _frozen_rel_path(item_id=item_id, run_key=run_key, rel_path=rel_path)
+    src = repo_root / rel_path
+    dst = repo_root / frozen_rel
+    if not src.exists():
+        raise SubmissionPrepareError(f"review file missing: {rel_path}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    return frozen_rel
+
+
+def _freeze_text(*, repo_root: Path, item_id: str, run_key: str, rel_path: str, text: str) -> str:
+    frozen_rel = _frozen_rel_path(item_id=item_id, run_key=run_key, rel_path=rel_path)
+    dst = repo_root / frozen_rel
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(text, encoding='utf-8')
+    return frozen_rel
 
 
 def _staged_paths(worktree_path: Path) -> list[str]:
@@ -296,6 +311,23 @@ def prepare_submission_branch(session: Session, request: SubmissionPrepareReques
     files_to_copy.extend(evidence_files)
     files_to_copy.extend(supporting_files)
 
+    pr_body_rel = f"control_plane/shadow_exports/review/{work_item.item_id}/pr_body.md"
+    frozen_file_map: dict[str, str] = {}
+    for rel_path in files_to_copy:
+        frozen_file_map[rel_path] = _freeze_file(
+            repo_root=repo_root,
+            item_id=work_item.item_id,
+            run_key=run.run_key,
+            rel_path=rel_path,
+        )
+    frozen_file_map[pr_body_rel] = _freeze_text(
+        repo_root=repo_root,
+        item_id=work_item.item_id,
+        run_key=run.run_key,
+        rel_path=pr_body_rel,
+        text=pr_body_md,
+    )
+
     worktree_root = _worktree_root(work_item.item_id, request.worktree_root)
     worktree_path = worktree_root / "repo"
     submission_base_ref, submission_base_commit = _resolve_submission_base(repo_root, request.pr_base)
@@ -305,12 +337,19 @@ def prepare_submission_branch(session: Session, request: SubmissionPrepareReques
 
     try:
         for rel_path in files_to_copy:
-            _copy_into_worktree(repo_root=repo_root, worktree_path=worktree_path, rel_path=rel_path)
+            _copy_into_worktree(
+                repo_root=repo_root,
+                worktree_path=worktree_path,
+                rel_path=frozen_file_map[rel_path],
+                target_rel_path=rel_path,
+            )
 
-        pr_body_rel = f"control_plane/shadow_exports/review/{work_item.item_id}/pr_body.md"
-        pr_body_path = worktree_path / pr_body_rel
-        pr_body_path.parent.mkdir(parents=True, exist_ok=True)
-        pr_body_path.write_text(pr_body_md, encoding="utf-8")
+        _copy_into_worktree(
+            repo_root=repo_root,
+            worktree_path=worktree_path,
+            rel_path=frozen_file_map[pr_body_rel],
+            target_rel_path=pr_body_rel,
+        )
 
         _run_git(
             worktree_path,
@@ -361,6 +400,7 @@ def prepare_submission_branch(session: Session, request: SubmissionPrepareReques
         "review_artifact_path": review_rel or None,
         "evidence_paths": evidence_files,
         "supporting_paths": supporting_files,
+        "frozen_file_map": frozen_file_map,
         "pr_title": pr_title,
         "pr_body_path": pr_body_rel,
         "pr_create_command": (

--- a/control_plane/control_plane/services/submission_executor.py
+++ b/control_plane/control_plane/services/submission_executor.py
@@ -121,6 +121,18 @@ def _run_cmd_capture(args: list[str], *, cwd: Path) -> subprocess.CompletedProce
     return subprocess.run(args, cwd=str(cwd), check=False, text=True, capture_output=True)
 
 
+def _format_failed_command(proc: subprocess.CompletedProcess[str]) -> str:
+    stderr = (proc.stderr or "").strip()
+    stdout = (proc.stdout or "").strip()
+    details: list[str] = []
+    if stderr:
+        details.append(f"stderr={stderr}")
+    if stdout:
+        details.append(f"stdout={stdout}")
+    suffix = f": {'; '.join(details)}" if details else ""
+    return f"command {proc.args!r} failed with exit code {proc.returncode}{suffix}"
+
+
 def _repo_diff_paths(*, cwd: Path, base_ref: str) -> list[str]:
     output = _run_cmd(["git", "diff", "--name-only", f"{base_ref}...HEAD"], cwd=cwd)
     return [line.strip() for line in output.splitlines() if line.strip()]
@@ -319,24 +331,22 @@ def execute_submission(session: Session, request: SubmissionExecuteRequest) -> S
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
     _run_cmd(["git", "push", "--force-with-lease", "-u", "origin", branch_name], cwd=worktree_path)
-    pr_view_proc = _run_cmd_capture(
-        [
-            "gh",
-            "--repo",
-            request.repo,
-            "pr",
-            "view",
-            branch_name,
-            "--json",
-            "number,url,headRefName,baseRefName",
-        ],
-        cwd=worktree_path,
-    )
+    pr_view_args = [
+        "gh",
+        "--repo",
+        request.repo,
+        "pr",
+        "view",
+        branch_name,
+        "--json",
+        "number,url,headRefName,baseRefName",
+    ]
+    pr_view_proc = _run_cmd_capture(pr_view_args, cwd=worktree_path)
     if pr_view_proc.returncode == 0:
         pr_view = json.loads(pr_view_proc.stdout.strip())
         pr_url = str(pr_view.get("url", "")).strip()
     else:
-        pr_create_out = _run_cmd(
+        pr_create_proc = _run_cmd_capture(
             [
                 "gh",
                 "--repo",
@@ -355,27 +365,27 @@ def execute_submission(session: Session, request: SubmissionExecuteRequest) -> S
             ],
             cwd=worktree_path,
         )
-        pr_url = pr_create_out.strip().splitlines()[-1].strip()
-        if not pr_url:
-            raise SubmissionExecuteError("gh pr create did not return a PR URL")
-        pr_view_json = _run_cmd(
-            [
-                "gh",
-                "--repo",
-                request.repo,
-                "pr",
-                "view",
-                branch_name,
-                "--json",
-                "number,url,headRefName,baseRefName",
-            ],
-            cwd=worktree_path,
-        )
-        pr_view = json.loads(pr_view_json)
+        if pr_create_proc.returncode != 0:
+            pr_view_retry = _run_cmd_capture(pr_view_args, cwd=worktree_path)
+            if pr_view_retry.returncode == 0:
+                pr_view = json.loads(pr_view_retry.stdout.strip())
+                pr_url = str(pr_view.get("url", "")).strip()
+            else:
+                raise SubmissionExecuteError(
+                    f"gh pr create failed for branch {branch_name}: {_format_failed_command(pr_create_proc)}"
+                )
+        else:
+            pr_url = pr_create_proc.stdout.strip().splitlines()[-1].strip()
+            if not pr_url:
+                raise SubmissionExecuteError("gh pr create did not return a PR URL")
+            pr_view_json = _run_cmd(pr_view_args, cwd=worktree_path)
+            pr_view = json.loads(pr_view_json)
     try:
         pr_number = int(pr_view["number"])
     except Exception as exc:
-        raise SubmissionExecuteError(f"gh pr view did not return a valid PR number: {pr_view_json}") from exc
+        raise SubmissionExecuteError(
+            f"gh pr view did not return a valid PR number: {json.dumps(pr_view, sort_keys=True)}"
+        ) from exc
 
     reconcile = reconcile_github_link(
         session,

--- a/control_plane/control_plane/services/worker_daemon.py
+++ b/control_plane/control_plane/services/worker_daemon.py
@@ -94,7 +94,12 @@ def run_worker_daemon(
             with session_factory() as session:
                 expire_stale_leases(session)
 
-        batch = _run_parallel_batch(session_factory, config=config)
+        try:
+            batch = _run_parallel_batch(session_factory, config=config)
+        except Exception as exc:
+            logger(f"worker-daemon batch_error error={exc}")
+            batch = [WorkerLoopResult(status="worker_error", summary=str(exc))]
+
         results.extend(batch)
 
         batch_executed = sum(1 for result in batch if result.status != "no_work")

--- a/control_plane/control_plane/tests/test_dispatcher_service.py
+++ b/control_plane/control_plane/tests/test_dispatcher_service.py
@@ -42,7 +42,7 @@ def _seed_ready_item(session: Session, *, item_id: str, platform: str, priority:
             flow="openroad",
             platform=platform,
             task_type="l2_campaign",
-            state=WorkItemState.READY,
+            state=WorkItemState.DISPATCH_PENDING,
             priority=priority,
             input_manifest={},
             command_manifest=[],
@@ -71,6 +71,7 @@ def test_dispatch_ready_items_assigns_matching_unassigned_work() -> None:
         assert [row.item_id for row in results] == ["item_a", "item_b"]
         items = session.query(WorkItem).order_by(WorkItem.item_id.asc()).all()
         assert all(item.assigned_machine_key == "eval-a" for item in items)
+        assert all(item.state == WorkItemState.READY for item in items)
 
 
 def test_dispatch_ready_items_respects_slot_capacity_and_existing_assignment() -> None:
@@ -103,3 +104,4 @@ def test_dispatch_ready_items_respects_slot_capacity_and_existing_assignment() -
         }
         item_b = session.query(WorkItem).filter_by(item_id="item_b").one()
         assert item_b.assigned_machine_key is None
+        assert item_b.state == WorkItemState.DISPATCH_PENDING

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -278,6 +278,7 @@ def test_consume_l1_result_accepts_synth_only_metrics_row() -> None:
                     "item_id": "l1_test_sigmoid_prefilter",
                     "layer": "layer1",
                     "flow": "openroad",
+                    "developer_loop": {"evaluation": {"mode": "synth_prefilter"}},
                 },
                 source_commit="deadbeef",
             )
@@ -348,3 +349,169 @@ def test_consume_l1_result_accepts_synth_only_metrics_row() -> None:
             assert payload["proposals"][0]["metrics_ref"]["result_kind"] == "synth_prefilter"
             assert payload["proposals"][0]["selection_reason"] == "first status=ok synth-stage prefilter row; no physical metrics are recorded yet"
             assert "metric_summary" not in payload["proposals"][0]
+
+
+def test_consume_l1_result_writes_trial_aggregate_artifacts() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        metrics_trial_1 = "runs/designs/activations/trials/trial_001/softmax_rowwise_int8_r4_wrapper/metrics.csv"
+        metrics_trial_2 = "runs/designs/activations/trials/trial_002/softmax_rowwise_int8_r4_wrapper/metrics.csv"
+        _write_metrics(
+            repo_root / metrics_trial_1,
+            [{
+                "platform": "nangate45",
+                "status": "ok",
+                "param_hash": "trial1",
+                "tag": "trial_1",
+                "critical_path_ns": "12.0",
+                "die_area": "30000",
+                "total_power_mw": "0.18",
+                "result_path": "runs/trials/trial_001/result.json",
+            }],
+        )
+        _write_metrics(
+            repo_root / metrics_trial_2,
+            [{
+                "platform": "nangate45",
+                "status": "ok",
+                "param_hash": "trial2",
+                "tag": "trial_2",
+                "critical_path_ns": "11.0",
+                "die_area": "29000",
+                "total_power_mw": "0.17",
+                "result_path": "runs/trials/trial_002/result.json",
+            }],
+        )
+
+        with Session(engine) as session:
+            task_request = TaskRequest(
+                request_key="l1_sweep:test_trial_aggregate",
+                source="test",
+                requested_by="@tester",
+                title="Layer1 trial aggregate test",
+                description="test l1 trial aggregation",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": "l1_test_trial_aggregate",
+                    "layer": "layer1",
+                    "flow": "openroad",
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+
+            work_item = WorkItem(
+                work_item_key="l1_sweep:l1_test_trial_aggregate",
+                task_request_id=task_request.id,
+                item_id="l1_test_trial_aggregate",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l1_sweep",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="config",
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[metrics_trial_1, metrics_trial_2, "runs/index.csv"],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+                trial_policy_json={"trial_count": 3, "seed_start": 3, "stop_after_failures": 3},
+            )
+            session.add(work_item)
+            session.flush()
+
+            run_1 = Run(
+                run_key="l1_test_trial_aggregate_run_1",
+                work_item_id=work_item.id,
+                attempt=1,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                trial_index=1,
+                seed=3,
+                result_summary="trial 1 succeeded",
+                result_payload={
+                    "trial": {"trial_index": 1, "seed": 3},
+                    "queue_result": {"status": "ok", "metrics_rows": [f"{metrics_trial_1}:2"]},
+                },
+            )
+            run_2 = Run(
+                run_key="l1_test_trial_aggregate_run_2",
+                work_item_id=work_item.id,
+                attempt=2,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                trial_index=2,
+                seed=4,
+                result_summary="trial 2 succeeded",
+                result_payload={
+                    "trial": {"trial_index": 2, "seed": 4},
+                    "queue_result": {"status": "ok", "metrics_rows": [f"{metrics_trial_2}:2"]},
+                },
+            )
+            run_3 = Run(
+                run_key="l1_test_trial_aggregate_run_3",
+                work_item_id=work_item.id,
+                attempt=3,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.FAILED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                trial_index=3,
+                seed=5,
+                result_summary="trial 3 failed",
+                result_payload={
+                    "trial": {"trial_index": 3, "seed": 5},
+                    "failure_classification": {"category": "timing_unmet", "stage": "route", "signature": "slack<0"},
+                },
+                failure_category="timing_unmet",
+                failure_stage="route",
+                failure_signature="slack<0",
+            )
+            session.add_all([run_1, run_2, run_3])
+            session.commit()
+
+            result = consume_l1_result(
+                session,
+                Layer1ConsumeRequest(
+                    repo_root=str(repo_root),
+                    item_id=work_item.item_id,
+                ),
+            )
+
+            assert result.item_id == work_item.item_id
+            proposal_path = repo_root / "control_plane" / "shadow_exports" / "l1_promotions" / f"{work_item.item_id}.json"
+            payload = json.loads(proposal_path.read_text(encoding="utf-8"))
+            assert payload["trial_summary"]["completed_trials"] == 3
+            assert payload["trial_summary"]["success_count"] == 2
+            assert payload["trial_summary"]["failure_count"] == 1
+            assert payload["trial_summary"]["metrics"]["critical_path_ns"]["best"] == 11.0
+
+            summary_path = repo_root / "control_plane" / "shadow_exports" / "l1_trials" / work_item.item_id / "summary_stats.json"
+            failure_path = repo_root / "control_plane" / "shadow_exports" / "l1_trials" / work_item.item_id / "failure_stats.json"
+            trial_table_path = repo_root / "control_plane" / "shadow_exports" / "l1_trials" / work_item.item_id / "trial_table.csv"
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            failure_stats = json.loads(failure_path.read_text(encoding="utf-8"))
+            trial_table = trial_table_path.read_text(encoding="utf-8")
+            assert summary["success_rate"] == 2 / 3
+            assert failure_stats["by_category"] == {"timing_unmet": 1}
+            assert failure_stats["by_stage"] == {"route": 1}
+            assert "trial_index,seed,status" in trial_table
+            assert "l1_test_trial_aggregate_run_3" in trial_table
+
+            artifact_kinds = {artifact.kind for artifact in session.query(Artifact).all()}
+            assert {"promotion_proposal", "summary_stats", "failure_stats", "trial_table"} <= artifact_kinds

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -170,6 +170,9 @@ def test_consume_l1_result_writes_promotion_proposal() -> None:
             assert payload["proposal_count"] == 2
             assert payload["evaluation_record"]["evaluation_mode"] == "measurement_only"
             assert payload["evaluation_record"]["physical_metrics_present"] is True
+            assert payload["evaluation_record"]["abstraction_layer"] == "circuit_block"
+            assert payload["source_refs"]["summary_stats_json"].endswith(f"/{item_id}/summary_stats.json")
+            assert payload["source_refs"]["trial_table_csv"].endswith(f"/{item_id}/trial_table.csv")
             assert payload["proposals"][0]["metrics_ref"]["param_hash"] == "fast0001"
             assert (
                 payload["proposals"][0]["metrics_ref"]["result_path"]
@@ -500,6 +503,9 @@ def test_consume_l1_result_writes_trial_aggregate_artifacts() -> None:
             assert payload["trial_summary"]["success_count"] == 2
             assert payload["trial_summary"]["failure_count"] == 1
             assert payload["trial_summary"]["metrics"]["critical_path_ns"]["best"] == 11.0
+            assert payload["evaluation_record"]["abstraction_layer"] == "circuit_block"
+            assert payload["source_refs"]["trial_metrics_csvs"] == [metrics_trial_1, metrics_trial_2]
+            assert payload["source_refs"]["summary_stats_json"].endswith(f"/{work_item.item_id}/summary_stats.json")
 
             summary_path = repo_root / "control_plane" / "shadow_exports" / "l1_trials" / work_item.item_id / "summary_stats.json"
             failure_path = repo_root / "control_plane" / "shadow_exports" / "l1_trials" / work_item.item_id / "failure_stats.json"

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -153,7 +153,7 @@ def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
             work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
             assert result.status == "applied"
             assert work_item.task_type == "l1_sweep"
-            assert work_item.state == WorkItemState.READY
+            assert work_item.state == WorkItemState.DISPATCH_PENDING
             assert work_item.source_mode == "config"
             assert [command["name"] for command in work_item.command_manifest] == [
                 "build_generator",
@@ -209,6 +209,7 @@ def test_generate_l1_sweep_task_omits_runtime_submodules_when_image_provides_dep
                         item_id="l1_demo_softmax_image_deps",
                         title="Layer1 demo image deps",
                         requested_by="@tester",
+                        source_commit="abc123",
                     ),
                 )
 
@@ -239,6 +240,7 @@ def test_generate_l1_sweep_task_upserts_existing_item() -> None:
                     item_id="l1_demo_softmax",
                     title="Layer1 demo",
                     requested_by="@tester",
+                    source_commit="abc123",
                 ),
             )
             second = generate_l1_sweep_task(
@@ -252,6 +254,7 @@ def test_generate_l1_sweep_task_upserts_existing_item() -> None:
                     item_id="l1_demo_softmax",
                     title="Layer1 demo updated",
                     requested_by="@tester2",
+                    source_commit="def456",
                 ),
             )
 
@@ -266,7 +269,11 @@ def test_generate_l1_sweep_task_supports_integrated_npu_block_configs() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
         repo_root.mkdir()
-        config_path, sweep_path = _write_example_block_repo(repo_root)
+        config_path, sweep_path = _write_example_block_repo(
+            repo_root,
+            mode_compare=False,
+            synth_hierarchical=1,
+        )
         proposal_dir = repo_root / "docs" / "developer_loop" / "prop_l1_npu_nm1_sigmoid_vec_enable_v1"
         proposal_dir.mkdir(parents=True, exist_ok=True)
         (proposal_dir / "proposal.json").write_text(
@@ -295,7 +302,7 @@ def test_generate_l1_sweep_task_supports_integrated_npu_block_configs() -> None:
             work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
             assert result.status == "applied"
             assert work_item.task_type == "l1_sweep"
-            assert work_item.state == WorkItemState.READY
+            assert work_item.state == WorkItemState.DISPATCH_PENDING
             assert [command["name"] for command in work_item.command_manifest] == [
                 "build_generator",
                 "generate_block_rtl",

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -61,7 +61,7 @@ def seed_ready_items(session: Session) -> tuple[WorkItem, WorkItem]:
         flow="openroad",
         platform="sky130hd",
         task_type="l2_campaign",
-        state=WorkItemState.READY,
+        state=WorkItemState.DISPATCH_PENDING,
         priority=1,
         input_manifest={},
         command_manifest=[],
@@ -76,7 +76,7 @@ def seed_ready_items(session: Session) -> tuple[WorkItem, WorkItem]:
         flow="openroad",
         platform="nangate45",
         task_type="l2_campaign",
-        state=WorkItemState.READY,
+        state=WorkItemState.DISPATCH_PENDING,
         priority=5,
         input_manifest={},
         command_manifest=[],
@@ -91,6 +91,9 @@ def seed_ready_items(session: Session) -> tuple[WorkItem, WorkItem]:
 def test_acquire_next_lease_selects_matching_highest_priority_item() -> None:
     with make_session() as session:
         item_a, item_b = seed_ready_items(session)
+        from control_plane.services.lease_service import upsert_worker_machine
+        upsert_worker_machine(session, machine_key="machine-1")
+        assign_work_item(session, item_id=item_b.item_id, machine_key="machine-1")
         result = acquire_next_lease(
             session,
             machine_key="machine-1",
@@ -106,7 +109,10 @@ def test_acquire_next_lease_selects_matching_highest_priority_item() -> None:
 
 def test_heartbeat_updates_expiry_and_machine_progress() -> None:
     with make_session() as session:
-        seed_ready_items(session)
+        _, item_b = seed_ready_items(session)
+        from control_plane.services.lease_service import upsert_worker_machine
+        upsert_worker_machine(session, machine_key="machine-1")
+        assign_work_item(session, item_id=item_b.item_id, machine_key="machine-1")
         acquired = acquire_next_lease(
             session,
             machine_key="machine-1",
@@ -129,6 +135,9 @@ def test_heartbeat_updates_expiry_and_machine_progress() -> None:
 def test_expire_stale_leases_requeues_nonterminal_work() -> None:
     with make_session() as session:
         _, item_b = seed_ready_items(session)
+        from control_plane.services.lease_service import upsert_worker_machine
+        upsert_worker_machine(session, machine_key="machine-1")
+        assign_work_item(session, item_id=item_b.item_id, machine_key="machine-1")
         acquired = acquire_next_lease(
             session,
             machine_key="machine-1",
@@ -145,7 +154,7 @@ def test_expire_stale_leases_requeues_nonterminal_work() -> None:
         assert result.expired_count == 1
         assert result.requeued_count == 1
         assert lease.status == LeaseStatus.EXPIRED
-        assert item_b.state == WorkItemState.READY
+        assert item_b.state == WorkItemState.DISPATCH_PENDING
 
 
 def test_lease_routes_work_in_process() -> None:
@@ -153,13 +162,16 @@ def test_lease_routes_work_in_process() -> None:
         db_path = Path(td) / "cp.db"
         engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
         create_all(engine)
-        with Session(engine) as session:
-            seed_ready_items(session)
-
         old = os.environ.get("RTLCP_DATABASE_URL")
         os.environ["RTLCP_DATABASE_URL"] = f"sqlite+pysqlite:///{db_path}"
         try:
             app = create_app()
+            with Session(engine) as session:
+                from control_plane.services.lease_service import upsert_worker_machine
+                item_a, item_b = seed_ready_items(session)
+                upsert_worker_machine(session, machine_key="machine-1")
+                assign_work_item(session, item_id=item_b.item_id, machine_key="machine-1")
+
             status, _, body = app.handle(
                 "POST",
                 "/api/v1/leases/acquire-next",
@@ -214,7 +226,9 @@ def test_acquire_next_lease_does_not_take_item_assigned_to_other_machine() -> No
     with make_session() as session:
         item_a, item_b = seed_ready_items(session)
         from control_plane.services.lease_service import upsert_worker_machine
+        upsert_worker_machine(session, machine_key="machine-1")
         upsert_worker_machine(session, machine_key="machine-2")
+        assign_work_item(session, item_id=item_a.item_id, machine_key="machine-1")
         assign_work_item(session, item_id=item_b.item_id, machine_key="machine-2")
         result = acquire_next_lease(
             session,
@@ -223,3 +237,19 @@ def test_acquire_next_lease_does_not_take_item_assigned_to_other_machine() -> No
             lease_seconds=900,
         )
         assert result.item_id == item_a.item_id
+
+
+def test_acquire_next_lease_requires_assignment_for_machine() -> None:
+    with make_session() as session:
+        seed_ready_items(session)
+        try:
+            acquire_next_lease(
+                session,
+                machine_key="machine-1",
+                capabilities={"platform": "nangate45", "flow": "openroad"},
+                lease_seconds=900,
+            )
+        except Exception as exc:
+            assert exc.__class__.__name__ == "NoEligibleWorkItem"
+        else:
+            raise AssertionError("expected NoEligibleWorkItem")

--- a/control_plane/control_plane/tests/test_operator_submission.py
+++ b/control_plane/control_plane/tests/test_operator_submission.py
@@ -392,6 +392,114 @@ def test_operate_submission_runs_full_chain_and_reuses_manifest() -> None:
             assert artifact.path == f"control_plane/shadow_exports/review/{item_id}/operator_submission.json"
 
 
+def test_operate_submission_recovers_on_retry_after_pr_create_failure() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, _run_key = _seed_l1_reviewable(session, repo_root)
+            fake_bin = repo_root / "fake_bin"
+            log_path = repo_root / "fake_cmds.log"
+            state_path = fake_bin / "gh_state.json"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            real_git = shutil.which("git")
+            assert real_git is not None
+            _write(
+                fake_bin / "git",
+                "#!/usr/bin/env python3\n"
+                "import json, subprocess, sys\n"
+                f"log={json.dumps(str(log_path))}\n"
+                f"real_git={json.dumps(real_git)}\n"
+                "argv=sys.argv[1:]\n"
+                "with open(log, 'a', encoding='utf-8') as h:\n"
+                "    h.write(json.dumps({'tool':'git','argv':argv})+'\\n')\n"
+                "if argv[:4] == ['push', '--force-with-lease', '-u', 'origin'] or argv[:3] == ['push', '-u', 'origin']:\n"
+                "    sys.exit(0)\n"
+                "completed = subprocess.run([real_git, *argv])\n"
+                "sys.exit(completed.returncode)\n",
+            )
+            _write(
+                fake_bin / "gh",
+                "#!/usr/bin/env python3\n"
+                "import json, os, sys\n"
+                f"log={json.dumps(str(log_path))}\n"
+                f"state_path={json.dumps(str(state_path))}\n"
+                "argv=sys.argv[1:]\n"
+                "with open(log, 'a', encoding='utf-8') as h:\n"
+                "    h.write(json.dumps({'tool':'gh','argv':argv})+'\\n')\n"
+                "state = {}\n"
+                "if os.path.exists(state_path):\n"
+                "    state = json.loads(open(state_path, 'r', encoding='utf-8').read())\n"
+                "if argv[:4] == ['--repo','yhmtmt/RTLGen','pr','create']:\n"
+                "    attempt = int(state.get('create_attempts', 0)) + 1\n"
+                "    state['create_attempts'] = attempt\n"
+                "    if attempt >= 2:\n"
+                "        state['created'] = True\n"
+                "        open(state_path, 'w', encoding='utf-8').write(json.dumps(state))\n"
+                "        print('https://github.com/yhmtmt/RTLGen/pull/654')\n"
+                "        sys.exit(0)\n"
+                "    open(state_path, 'w', encoding='utf-8').write(json.dumps(state))\n"
+                "    print('temporary network loss', file=sys.stderr)\n"
+                "    sys.exit(1)\n"
+                "if argv[:4] == ['--repo','yhmtmt/RTLGen','pr','view']:\n"
+                "    branch=argv[4]\n"
+                "    if not state.get('created'):\n"
+                "        sys.exit(1)\n"
+                "    print(json.dumps({'number':654,'url':'https://github.com/yhmtmt/RTLGen/pull/654','headRefName':branch,'baseRefName':'master'}))\n"
+                "    sys.exit(0)\n"
+                "sys.exit(1)\n",
+            )
+            os.chmod(fake_bin / "git", 0o755)
+            os.chmod(fake_bin / "gh", 0o755)
+
+            old_path = os.environ.get("PATH", "")
+            os.environ["PATH"] = f"{fake_bin}:{old_path}"
+            try:
+                try:
+                    operate_submission(
+                        session,
+                        OperatorSubmissionRequest(
+                            repo_root=str(repo_root),
+                            repo="yhmtmt/RTLGen",
+                            item_id=item_id,
+                            evaluator_id="cpbot",
+                            session_id="s20260401t103000z",
+                            host="cp-host",
+                            worktree_root=str(repo_root / "tmp_submit"),
+                        ),
+                    )
+                except OperatorSubmissionError as exc:
+                    assert "gh pr create failed" in str(exc)
+                else:
+                    raise AssertionError("expected OperatorSubmissionError")
+
+                result = operate_submission(
+                    session,
+                    OperatorSubmissionRequest(
+                        repo_root=str(repo_root),
+                        repo="yhmtmt/RTLGen",
+                        item_id=item_id,
+                        evaluator_id="cpbot",
+                        session_id="s20260401t103100z",
+                        host="cp-host",
+                        worktree_root=str(repo_root / "tmp_submit"),
+                    ),
+                )
+            finally:
+                os.environ["PATH"] = old_path
+
+            assert result.pr_number == 654
+            assert result.submission_prepared is False
+            assert result.submission_prepared_reused is True
+
+            log_entries = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+            assert sum(1 for entry in log_entries if entry["tool"] == "gh" and entry["argv"][:4] == ["--repo", "yhmtmt/RTLGen", "pr", "create"]) == 2
+
+
 def test_operate_submission_rebuilds_manifest_when_latest_run_differs() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_run_service.py
+++ b/control_plane/control_plane/tests/test_run_service.py
@@ -27,6 +27,8 @@ from control_plane.services.run_service import (
     request_run_cancel,
     start_run,
 )
+from control_plane.workers import executor as executor_module
+from control_plane.services import worker_daemon as worker_daemon_module
 
 
 def make_session() -> Session:
@@ -218,3 +220,59 @@ def test_request_run_cancel_marks_active_run() -> None:
 
         again = request_run_cancel(session, run_key="run-cancel-1", requested_by="tester")
         assert again.event_id == result.event_id
+
+
+def test_complete_run_truncates_failure_signature() -> None:
+    with make_session() as session:
+        lease, work_item = seed_leased_work_item(session)
+        start_run(
+            session,
+            lease_token=lease.lease_token,
+            run_key="run-long-signature",
+            attempt=1,
+            executor_type="internal_worker",
+        )
+        long_detail = "db-error:" + ("x" * 600)
+        complete_run(
+            session,
+            run_key="run-long-signature",
+            status="failed",
+            result_summary="flow failed",
+            result_payload={
+                "failure_classification": {
+                    "category": "worker_error",
+                    "stage": "finalization",
+                    "detail": long_detail,
+                }
+            },
+        )
+        run = session.query(Run).filter_by(run_key="run-long-signature").one()
+        assert run.failure_signature is not None
+        assert len(run.failure_signature) <= 255
+        assert '[sha1:' in run.failure_signature
+        session.refresh(work_item)
+        assert work_item.state == WorkItemState.FAILED
+
+
+def test_worker_daemon_survives_run_worker_exception(monkeypatch) -> None:
+    class DummySessionFactory:
+        def __call__(self):
+            raise AssertionError('session_factory should not be used when run_worker is monkeypatched')
+
+    def boom(session_factory, *, config, max_items):
+        raise RuntimeError('simulated worker crash')
+
+    monkeypatch.setattr(worker_daemon_module, 'run_worker', boom)
+    result = worker_daemon_module.run_worker_daemon(
+        DummySessionFactory(),
+        config=worker_daemon_module.WorkerDaemonConfig(
+            worker=executor_module.WorkerConfig(repo_root='/tmp', machine_key='test-worker'),
+            max_polls=1,
+            stop_on_no_work=False,
+            run_scheduler_maintenance=False,
+        ),
+        log_fn=lambda _message: None,
+    )
+    assert len(result.results) == 1
+    assert result.results[0].status == 'worker_error'
+    assert 'simulated worker crash' in str(result.results[0].summary)

--- a/control_plane/control_plane/tests/test_submission_bridge.py
+++ b/control_plane/control_plane/tests/test_submission_bridge.py
@@ -283,6 +283,94 @@ def _seed_l1_reviewable(session: Session, repo_root: Path) -> tuple[str, str]:
     return work_item.item_id, run.run_key
 
 
+def _seed_l1_trial_reviewable(session: Session, repo_root: Path) -> tuple[str, str, str]:
+    metrics_rel = "runs/designs/activations/trials/trial_001/softmax_rowwise_int8_r4_wrapper/metrics.csv"
+    _write(
+        repo_root / metrics_rel,
+        (
+            "platform,status,param_hash,tag,critical_path_ns,die_area,total_power_mw,params_json,result_path\n"
+            'nangate45,ok,trial0001,tag_trial,12.1,30100,0.19,{"CLOCK_PERIOD": 6.0},'
+            "runs/designs/activations/trials/trial_001/softmax_rowwise_int8_r4_wrapper/work/trial0001/result.json\n"
+        ),
+    )
+    _write(
+        repo_root / "runs/index.csv",
+        (
+            "circuit_type,design,platform,status,critical_path_ns,die_area,total_power_mw,config_hash,param_hash,tag,result_path,params_json,metrics_path,design_path,sram_area_um2,sram_read_energy_pj,sram_write_energy_pj,sram_max_access_time_ns\n"
+            'activations,softmax_rowwise_int8_r4_wrapper,nangate45,ok,12.1,30100,0.19,cfgtrial,trial0001,tag_trial,runs/designs/activations/trials/trial_001/softmax_rowwise_int8_r4_wrapper/work/trial0001/result.json,"{""CLOCK_PERIOD"": 6.0}",runs/designs/activations/trials/trial_001/softmax_rowwise_int8_r4_wrapper/metrics.csv,runs/designs/activations/trials/trial_001/softmax_rowwise_int8_r4_wrapper,,,\n'
+        ),
+    )
+
+    payload = {
+        "item_id": "l1_submit_trial_demo",
+        "title": "Layer1 submit trial demo",
+        "layer": "layer1",
+        "flow": "openroad",
+        "handoff": {
+            "branch": "eval/l1_submit_trial_demo/<session_id>",
+            "pr_title": "eval: run layer1 submit trial demo",
+            "pr_body_fields": {
+                "evaluator_id": "control_plane",
+                "session_id": "<session_id>",
+                "host": "<host>",
+                "queue_item_id": "l1_submit_trial_demo",
+            },
+            "checklist": ["Commit lightweight metrics outputs only"],
+        },
+    }
+    task_request = TaskRequest(
+        request_key="l1_sweep:l1_submit_trial_demo",
+        source="test",
+        requested_by="@tester",
+        title="Layer1 submit trial demo",
+        description="test submission bridge with trial evidence refs",
+        layer=LayerName.LAYER1,
+        flow=FlowName.OPENROAD,
+        priority=1,
+        request_payload=payload,
+        source_commit="deadbeef",
+    )
+    session.add(task_request)
+    session.flush()
+
+    work_item = WorkItem(
+        work_item_key="l1_sweep:l1_submit_trial_demo",
+        task_request_id=task_request.id,
+        item_id="l1_submit_trial_demo",
+        layer=LayerName.LAYER1,
+        flow=FlowName.OPENROAD,
+        platform="nangate45",
+        task_type="l1_sweep",
+        state=WorkItemState.ARTIFACT_SYNC,
+        priority=1,
+        source_mode="config",
+        input_manifest={"configs": ["examples/config_softmax_rowwise_int8.json"]},
+        command_manifest=[],
+        expected_outputs=["runs/index.csv"],
+        acceptance_rules=[],
+        source_commit="deadbeef",
+    )
+    session.add(work_item)
+    session.flush()
+
+    run = Run(
+        run_key="l1_submit_trial_demo_run_1",
+        work_item_id=work_item.id,
+        attempt=1,
+        executor_type=ExecutorType.INTERNAL_WORKER,
+        status=RunStatus.SUCCEEDED,
+        started_at=utcnow(),
+        completed_at=utcnow(),
+        checkout_commit="deadbeef",
+        result_summary="4/4 commands succeeded",
+        result_payload={"queue_result": {"status": "ok", "metrics_rows": [f"{metrics_rel}:2"], "notes": []}},
+    )
+    session.add(run)
+    session.commit()
+    consume_l1_result(session, Layer1ConsumeRequest(repo_root=str(repo_root), item_id=work_item.item_id))
+    return work_item.item_id, run.run_key, metrics_rel
+
+
 def test_prepare_submission_branch_creates_commit_and_manifest() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -360,8 +448,43 @@ def test_prepare_submission_branch_includes_canonical_runs_evidence_for_real_ite
                 "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv",
                 "runs/index.csv",
             ]
+            frozen_map = manifest["frozen_file_map"]
+            assert frozen_map["runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv"].startswith(
+                f"control_plane/shadow_exports/frozen_review/{item_id}/{run_key}/"
+            )
+            assert (repo_root / frozen_map["runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv"]).exists()
+            assert (repo_root / frozen_map["runs/index.csv"]).exists()
             assert (Path(result.worktree_path) / "runs" / "designs" / "activations" / "softmax_rowwise_int8_r4_wrapper" / "metrics.csv").exists()
             assert (Path(result.worktree_path) / "runs" / "index.csv").exists()
+
+
+def test_prepare_submission_branch_stages_trial_metrics_from_source_refs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, run_key, metrics_rel = _seed_l1_trial_reviewable(session, repo_root)
+            result = prepare_submission_branch(
+                session,
+                SubmissionPrepareRequest(
+                    repo_root=str(repo_root),
+                    item_id=item_id,
+                    evaluator_id="cpbot",
+                    session_id="s20260310t080550z",
+                    host="cp-host",
+                    worktree_root=str(repo_root / "tmp_submit"),
+                ),
+            )
+
+            manifest = json.loads((repo_root / "control_plane" / "shadow_exports" / "review" / item_id / "submission_manifest.json").read_text())
+            assert manifest["evidence_paths"] == ["runs/index.csv"]
+            assert metrics_rel in manifest["supporting_paths"]
+            assert (repo_root / manifest["frozen_file_map"][metrics_rel]).exists()
+            assert (Path(result.worktree_path) / metrics_rel).exists()
 
 
 def test_prepare_submission_branch_uses_current_base_branch_instead_of_head() -> None:

--- a/control_plane/control_plane/tests/test_submission_executor.py
+++ b/control_plane/control_plane/tests/test_submission_executor.py
@@ -276,6 +276,54 @@ def _seed_l1_reviewable(session: Session, repo_root: Path) -> tuple[str, str]:
     return work_item.item_id, run.run_key
 
 
+def _make_partial_create_fake_bin(fake_bin: Path, log_path: Path) -> None:
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    state_path = fake_bin / "gh_state.json"
+    real_git = shutil.which("git")
+    assert real_git is not None
+    _write(
+        fake_bin / "git",
+        "#!/usr/bin/env python3\n"
+        "import json, subprocess, sys\n"
+        f"log={json.dumps(str(log_path))}\n"
+        f"real_git={json.dumps(real_git)}\n"
+        "argv=sys.argv[1:]\n"
+        "with open(log, 'a', encoding='utf-8') as h:\n"
+        "    h.write(json.dumps({'tool':'git','argv':argv})+'\\n')\n"
+        "if argv[:4] == ['push', '--force-with-lease', '-u', 'origin'] or argv[:3] == ['push', '-u', 'origin']:\n"
+        "    sys.exit(0)\n"
+        "completed = subprocess.run([real_git, *argv])\n"
+        "sys.exit(completed.returncode)\n",
+    )
+    _write(
+        fake_bin / "gh",
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        f"log={json.dumps(str(log_path))}\n"
+        f"state_path={json.dumps(str(state_path))}\n"
+        "argv=sys.argv[1:]\n"
+        "with open(log, 'a', encoding='utf-8') as h:\n"
+        "    h.write(json.dumps({'tool':'gh','argv':argv})+'\\n')\n"
+        "state = {}\n"
+        "if os.path.exists(state_path):\n"
+        "    state = json.loads(open(state_path, 'r', encoding='utf-8').read())\n"
+        "if argv[:4] == ['--repo','yhmtmt/RTLGen','pr','create']:\n"
+        "    state['created'] = True\n"
+        "    open(state_path, 'w', encoding='utf-8').write(json.dumps(state))\n"
+        "    print('network interrupted after create', file=sys.stderr)\n"
+        "    sys.exit(1)\n"
+        "if argv[:4] == ['--repo','yhmtmt/RTLGen','pr','view']:\n"
+        "    if not state.get('created'):\n"
+        "        sys.exit(1)\n"
+        "    branch=argv[4]\n"
+        "    print(json.dumps({'number':456,'url':'https://github.com/yhmtmt/RTLGen/pull/456','headRefName':branch,'baseRefName':'master'}))\n"
+        "    sys.exit(0)\n"
+        "sys.exit(1)\n",
+    )
+    os.chmod(fake_bin / "git", 0o755)
+    os.chmod(fake_bin / "gh", 0o755)
+
+
 def _make_fake_bin(fake_bin: Path, log_path: Path) -> None:
     fake_bin.mkdir(parents=True, exist_ok=True)
     state_path = fake_bin / "gh_state.json"
@@ -384,6 +432,61 @@ def test_execute_submission_pushes_and_reconciles() -> None:
             assert any(entry["tool"] == "git" and entry["argv"][:4] == ["push", "--force-with-lease", "-u", "origin"] for entry in log_entries)
             assert any(entry["tool"] == "gh" and entry["argv"][:4] == ["--repo", "yhmtmt/RTLGen", "pr", "create"] for entry in log_entries)
             assert any(entry["tool"] == "gh" and entry["argv"][:4] == ["--repo", "yhmtmt/RTLGen", "pr", "view"] for entry in log_entries)
+
+
+def test_execute_submission_recovers_when_pr_create_returns_error_after_pr_exists() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, run_key = _seed_l1_reviewable(session, repo_root)
+            prepare_submission_branch(
+                session,
+                SubmissionPrepareRequest(
+                    repo_root=str(repo_root),
+                    item_id=item_id,
+                    evaluator_id="cpbot",
+                    session_id="s20260401t101500z",
+                    host="cp-host",
+                    worktree_root=str(repo_root / "tmp_submit"),
+                ),
+            )
+
+            fake_bin = repo_root / "fake_bin"
+            log_path = repo_root / "fake_cmds.log"
+            _make_partial_create_fake_bin(fake_bin, log_path)
+            old_path = os.environ.get("PATH", "")
+            os.environ["PATH"] = f"{fake_bin}:{old_path}"
+            try:
+                result = execute_submission(
+                    session,
+                    SubmissionExecuteRequest(
+                        repo_root=str(repo_root),
+                        repo="yhmtmt/RTLGen",
+                        item_id=item_id,
+                        evaluator_id="cpbot",
+                        session_id="s20260401t101500z",
+                        host="cp-host",
+                    ),
+                )
+            finally:
+                os.environ["PATH"] = old_path
+
+            assert result.item_id == item_id
+            assert result.run_key == run_key
+            assert result.pr_number == 456
+            assert result.pr_url == "https://github.com/yhmtmt/RTLGen/pull/456"
+
+            link = session.query(GitHubLink).filter_by(pr_number=456).one()
+            assert link.state == GitHubLinkState.PR_OPEN
+
+            log_entries = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            assert any(entry["tool"] == "gh" and entry["argv"][:4] == ["--repo", "yhmtmt/RTLGen", "pr", "create"] for entry in log_entries)
+            assert sum(1 for entry in log_entries if entry["tool"] == "gh" and entry["argv"][:4] == ["--repo", "yhmtmt/RTLGen", "pr", "view"]) >= 2
 
 
 def test_execute_submission_reuses_existing_pr_on_rerun() -> None:

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -13,12 +13,14 @@ from sqlalchemy.orm import Session
 from control_plane.db import build_session_factory, create_all
 from control_plane.models.enums import WorkItemState
 from control_plane.models.run_events import RunEvent
+from control_plane.models.runs import Run
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
 from control_plane.services.completion_service import CompletionProcessResult, CompletionProcessingError
 from control_plane.services.lease_service import upsert_worker_machine
 from control_plane.services.scheduler import assign_work_item
 from control_plane.services.worker_daemon import WorkerDaemonConfig, run_worker_daemon
+from control_plane.workers.checkout import CheckoutInfo
 from control_plane.workers.executor import WorkerConfig
 
 
@@ -458,3 +460,131 @@ def test_worker_daemon_registers_machine_slot_capacity() -> None:
             machine = session.query(WorkerMachine).filter_by(machine_key="daemon-worker-capacity").one()
             assert machine.role == "evaluator"
             assert machine.slot_capacity == 3
+
+
+def test_worker_daemon_runs_all_l1_trials_before_immediate_completion() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            task = TaskRequest(
+                request_key="queue:daemon_item_l1_trials",
+                source="test",
+                requested_by="tester",
+                title="daemon_item_l1_trials title",
+                description="worker daemon l1 trial test",
+                layer="layer1",
+                flow="openroad",
+                priority=1,
+                request_payload={"item_id": "daemon_item_l1_trials"},
+            )
+            session.add(task)
+            session.flush()
+
+            out_root = "runs/designs/activations/trial_demo"
+            work_item = WorkItem(
+                work_item_key="queue:daemon_item_l1_trials",
+                task_request_id=task.id,
+                item_id="daemon_item_l1_trials",
+                layer="layer1",
+                flow="openroad",
+                platform="nangate45",
+                task_type="l1_sweep",
+                state=WorkItemState.READY,
+                priority=1,
+                source_mode="config",
+                input_manifest={"out_root": out_root},
+                command_manifest=[
+                    {"name": "build_generator", "run": "python3 -c \"print(\'build\')\""},
+                    {
+                        "name": "run_sweep",
+                        "run": (
+                            "python3 -c \"from pathlib import Path; import sys; args=sys.argv; "
+                            "out=Path(args[args.index('--out_root')+1]); "
+                            "p=out/'trial_wrapper'/'metrics.csv'; "
+                            "p.parent.mkdir(parents=True, exist_ok=True); "
+                            "p.write_text('platform,status,param_hash,tag,critical_path_ns,die_area,total_power_mw,result_path\\n' "
+                            "'nangate45,ok,trialhash,trialtag,1.0,2.0,3.0,runs/demo/result.json\\n', encoding='utf-8')\" "
+                            f"--out_root {out_root} --skip_existing"
+                        ),
+                    },
+                    {
+                        "name": "build_runs_index",
+                        "run": "python3 -c \"from pathlib import Path; p=Path('runs/index.csv'); p.parent.mkdir(parents=True, exist_ok=True); p.write_text('item_id,status\\n', encoding='utf-8')\"",
+                    },
+                ],
+                expected_outputs=[
+                    f"{out_root}/trial_wrapper/metrics.csv",
+                    "runs/index.csv",
+                ],
+                acceptance_rules=[],
+                trial_policy_json={"trial_count": 2, "seed_start": 7, "stop_after_failures": 2},
+            )
+            session.add(work_item)
+            session.commit()
+            upsert_worker_machine(session, machine_key="daemon-worker-l1-trials", capabilities={"platform": "nangate45", "flow": "openroad"})
+            assign_work_item(session, item_id="daemon_item_l1_trials", machine_key="daemon-worker-l1-trials")
+
+        session_factory = build_session_factory(engine)
+        checkout_info = CheckoutInfo(
+            repo_root=str(repo_root),
+            work_dir=str(repo_root),
+            head_sha=None,
+            git_dirty=False,
+            source_commit=None,
+            source_commit_matches=None,
+            source_commit_relation=None,
+            materialized_submodules=(),
+            checkout_mode="inplace",
+            cleanup_path=None,
+        )
+        with patch("control_plane.workers.executor.process_completed_items") as process_completed, patch(
+            "control_plane.workers.executor.prepare_checkout", return_value=checkout_info
+        ), patch("control_plane.workers.executor.cleanup_checkout"):
+            process_completed.return_value = [
+                CompletionProcessResult(
+                    item_id="daemon_item_l1_trials",
+                    run_key="synthetic",
+                    task_type="l1_sweep",
+                    consumed=True,
+                    submitted=False,
+                    work_item_state="artifact_sync",
+                    target_path="control_plane/shadow_exports/l1_promotions/daemon_item_l1_trials.json",
+                    pr_url=None,
+                    submission_error=None,
+                )
+            ]
+            result = run_worker_daemon(
+                session_factory,
+                config=WorkerDaemonConfig(
+                    worker=WorkerConfig(
+                        repo_root=str(repo_root),
+                        machine_key="daemon-worker-l1-trials",
+                        capabilities={"platform": "nangate45", "flow": "openroad"},
+                        capability_filter={"platform": "nangate45", "flow": "openroad"},
+                        heartbeat_seconds=1,
+                        auto_process_completions=True,
+                    ),
+                    poll_seconds=0,
+                    max_polls=3,
+                    stop_on_no_work=True,
+                ),
+            )
+
+        assert result.executed_items == 2
+        assert [row.status for row in result.results] == ["succeeded", "succeeded", "no_work"]
+        assert process_completed.call_count == 1
+
+        with Session(engine) as session:
+            runs = session.query(Run).filter(Run.work_item_id == work_item.id).order_by(Run.attempt.asc()).all()
+            assert [run.trial_index for run in runs] == [1, 2]
+            assert [run.seed for run in runs] == [7, 8]
+            work_item = session.query(WorkItem).filter(WorkItem.item_id == "daemon_item_l1_trials").one()
+            assert work_item.state == WorkItemState.ARTIFACT_SYNC
+            assert session.query(RunEvent).filter(RunEvent.event_type == "trial_scheduled").count() == 1
+            assert session.query(RunEvent).filter(RunEvent.event_type == "trial_set_completed").count() == 1

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -209,6 +209,59 @@ def test_worker_daemon_executes_two_items_with_concurrency() -> None:
         ]
 
 
+def test_worker_daemon_syncs_expected_outputs_before_immediate_completion() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            _seed_ready_work_item(session, item_id="daemon_item_sync_before_completion", repo_root=repo_root)
+
+        session_factory = build_session_factory(engine)
+
+        def _assert_synced(session, request):
+            metrics_path = repo_root / "runs" / "campaigns" / "daemon_item_sync_before_completion" / "metrics.csv"
+            report_path = repo_root / "runs" / "campaigns" / "daemon_item_sync_before_completion" / "report.md"
+            assert metrics_path.exists(), metrics_path
+            assert report_path.exists(), report_path
+            return [
+                CompletionProcessResult(
+                    item_id="daemon_item_sync_before_completion",
+                    run_key="synthetic",
+                    task_type="l2_campaign",
+                    consumed=True,
+                    submitted=False,
+                    work_item_state="artifact_sync",
+                    target_path="control_plane/shadow_exports/review/demo/evaluated.json",
+                    pr_url=None,
+                    submission_error=None,
+                )
+            ]
+
+        with patch("control_plane.workers.executor.process_completed_items", side_effect=_assert_synced) as process_completed:
+            result = run_worker_daemon(
+                session_factory,
+                config=WorkerDaemonConfig(
+                    worker=WorkerConfig(
+                        repo_root=str(repo_root),
+                        machine_key="daemon-worker-sync-before-completion",
+                        capabilities={"platform": "nangate45", "flow": "openroad"},
+                        capability_filter={"platform": "nangate45", "flow": "openroad"},
+                        heartbeat_seconds=1,
+                        auto_process_completions=True,
+                    ),
+                    poll_seconds=0,
+                    max_polls=1,
+                ),
+            )
+
+        assert result.executed_items == 1
+        assert process_completed.call_count == 1
+
+
 def test_worker_daemon_immediately_processes_completion_for_supported_items() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -17,11 +17,12 @@ from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
 from control_plane.services.completion_service import CompletionProcessResult, CompletionProcessingError
 from control_plane.services.lease_service import upsert_worker_machine
+from control_plane.services.scheduler import assign_work_item
 from control_plane.services.worker_daemon import WorkerDaemonConfig, run_worker_daemon
 from control_plane.workers.executor import WorkerConfig
 
 
-def _seed_ready_work_item(session: Session, *, item_id: str, repo_root: Path) -> None:
+def _seed_ready_work_item(session: Session, *, item_id: str, repo_root: Path, assigned_machine_key: str | None = None) -> None:
     task = TaskRequest(
         request_key=f"queue:{item_id}",
         source="test",
@@ -47,7 +48,7 @@ def _seed_ready_work_item(session: Session, *, item_id: str, repo_root: Path) ->
         flow="openroad",
         platform="nangate45",
         task_type="l2_campaign",
-        state=WorkItemState.READY,
+        state=WorkItemState.READY if assigned_machine_key else WorkItemState.DISPATCH_PENDING,
         priority=1,
         input_manifest={},
         command_manifest=[
@@ -77,6 +78,9 @@ def _seed_ready_work_item(session: Session, *, item_id: str, repo_root: Path) ->
     )
     session.add(work_item)
     session.commit()
+    if assigned_machine_key:
+        upsert_worker_machine(session, machine_key=assigned_machine_key, capabilities={"platform": "nangate45", "flow": "openroad"})
+        assign_work_item(session, item_id=item_id, machine_key=assigned_machine_key)
 
 
 def test_worker_daemon_executes_item_then_stops_on_no_work() -> None:
@@ -88,7 +92,7 @@ def test_worker_daemon_executes_item_then_stops_on_no_work() -> None:
         engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
         create_all(engine)
         with Session(engine) as session:
-            _seed_ready_work_item(session, item_id="daemon_item_success", repo_root=repo_root)
+            _seed_ready_work_item(session, item_id="daemon_item_success", repo_root=repo_root, assigned_machine_key="daemon-worker-1")
 
         session_factory = build_session_factory(engine)
         result = run_worker_daemon(
@@ -122,7 +126,7 @@ def test_worker_daemon_emits_positive_poll_logs() -> None:
         engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
         create_all(engine)
         with Session(engine) as session:
-            _seed_ready_work_item(session, item_id="daemon_item_log", repo_root=repo_root)
+            _seed_ready_work_item(session, item_id="daemon_item_log", repo_root=repo_root, assigned_machine_key="daemon-worker-log")
 
         messages: list[str] = []
         session_factory = build_session_factory(engine)
@@ -173,8 +177,8 @@ def test_worker_daemon_executes_two_items_with_concurrency() -> None:
         )
         create_all(engine)
         with Session(engine) as session:
-            _seed_ready_work_item(session, item_id="daemon_item_parallel_a", repo_root=repo_root)
-            _seed_ready_work_item(session, item_id="daemon_item_parallel_b", repo_root=repo_root)
+            _seed_ready_work_item(session, item_id="daemon_item_parallel_a", repo_root=repo_root, assigned_machine_key="daemon-worker-parallel")
+            _seed_ready_work_item(session, item_id="daemon_item_parallel_b", repo_root=repo_root, assigned_machine_key="daemon-worker-parallel")
             upsert_worker_machine(
                 session,
                 machine_key="daemon-worker-parallel",
@@ -218,7 +222,7 @@ def test_worker_daemon_syncs_expected_outputs_before_immediate_completion() -> N
         engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
         create_all(engine)
         with Session(engine) as session:
-            _seed_ready_work_item(session, item_id="daemon_item_sync_before_completion", repo_root=repo_root)
+            _seed_ready_work_item(session, item_id="daemon_item_sync_before_completion", repo_root=repo_root, assigned_machine_key="daemon-worker-sync-before-completion")
 
         session_factory = build_session_factory(engine)
 
@@ -271,7 +275,7 @@ def test_worker_daemon_immediately_processes_completion_for_supported_items() ->
         engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
         create_all(engine)
         with Session(engine) as session:
-            _seed_ready_work_item(session, item_id="daemon_item_immediate_completion", repo_root=repo_root)
+            _seed_ready_work_item(session, item_id="daemon_item_immediate_completion", repo_root=repo_root, assigned_machine_key="daemon-worker-immediate")
 
         session_factory = build_session_factory(engine)
         with patch("control_plane.workers.executor.process_completed_items") as process_completed:
@@ -331,7 +335,7 @@ def test_worker_daemon_records_immediate_completion_failure_without_poisoning_ru
         engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
         create_all(engine)
         with Session(engine) as session:
-            _seed_ready_work_item(session, item_id="daemon_item_completion_failure", repo_root=repo_root)
+            _seed_ready_work_item(session, item_id="daemon_item_completion_failure", repo_root=repo_root, assigned_machine_key="daemon-worker-immediate-fail")
 
         session_factory = build_session_factory(engine)
         with patch(
@@ -380,7 +384,7 @@ def test_worker_daemon_records_unexpected_immediate_completion_failure_without_p
         engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
         create_all(engine)
         with Session(engine) as session:
-            _seed_ready_work_item(session, item_id="daemon_item_completion_runtime_failure", repo_root=repo_root)
+            _seed_ready_work_item(session, item_id="daemon_item_completion_runtime_failure", repo_root=repo_root, assigned_machine_key="daemon-worker-immediate-runtime-fail")
 
         session_factory = build_session_factory(engine)
         with patch(

--- a/control_plane/control_plane/workers/executor.py
+++ b/control_plane/control_plane/workers/executor.py
@@ -167,6 +167,31 @@ def _log_dir(config: WorkerConfig, item_id: str, run_key: str) -> str:
 SUPPORTED_IMMEDIATE_COMPLETION_TASK_TYPES = {"l1_sweep", "l2_campaign"}
 
 
+def _sync_expected_outputs_to_repo(*, checkout_root: str, repo_root: str, expected_outputs: list[str]) -> None:
+    source_root = Path(checkout_root).resolve()
+    target_root = Path(repo_root).resolve()
+    if source_root == target_root:
+        return
+
+    rel_paths: set[str] = {str(path) for path in (expected_outputs or []) if str(path).strip()}
+    rel_paths.update(
+        artifact.path
+        for artifact in collect_linked_results_artifacts(
+            repo_root=str(source_root),
+            expected_outputs=expected_outputs or [],
+        )
+        if str(artifact.path).strip()
+    )
+
+    for rel_path in sorted(rel_paths):
+        source_path = (source_root / rel_path).resolve()
+        if not source_path.exists() or not source_path.is_file():
+            continue
+        target_path = (target_root / rel_path).resolve()
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, target_path)
+
+
 def _record_completion_result(
     *,
     session_factory: sessionmaker,
@@ -570,15 +595,21 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
                 for artifact in artifacts
             ],
         )
-    cleanup_checkout(checkout_info)
 
     if completed.status == "succeeded":
+        _sync_expected_outputs_to_repo(
+            checkout_root=checkout_info.work_dir,
+            repo_root=config.repo_root,
+            expected_outputs=work_item.expected_outputs or [],
+        )
         _process_completed_work_item(
             session_factory,
             config=config,
             work_item=work_item,
             run_key=run_key,
         )
+
+    cleanup_checkout(checkout_info)
 
     return WorkerLoopResult(
         status=completed.status,

--- a/control_plane/control_plane/workers/executor.py
+++ b/control_plane/control_plane/workers/executor.py
@@ -11,6 +11,7 @@ from typing import Any
 from sqlalchemy.orm import Session, sessionmaker
 
 from control_plane.ids import make_id
+from control_plane.models.enums import RunStatus, WorkItemState
 from control_plane.models.runs import Run
 from control_plane.models.work_items import WorkItem
 from control_plane.services.completion_service import (
@@ -128,9 +129,13 @@ def _classify_failure(
             category = "command_failure"
             retryable = False
 
+    stage = "checkout" if checkout_error is not None else ("worker" if worker_error is not None else (failed_command or "execution"))
+    signature = detail if isinstance(detail, str) else None
     requeue = retryable and attempt < max_retry_attempts
     return {
         "category": category,
+        "stage": stage,
+        "signature": signature,
         "retryable": retryable,
         "requeue": requeue,
         "attempt": attempt,
@@ -155,6 +160,133 @@ def _next_attempt(session: Session, work_item_id: str) -> int:
         .first()
     )
     return 1 if latest is None else int(latest.attempt) + 1
+
+
+def _trial_policy(work_item: WorkItem) -> dict[str, int]:
+    raw = dict(getattr(work_item, "trial_policy_json", {}) or {})
+    if str(work_item.task_type) != "l1_sweep":
+        return {"trial_count": 1, "seed_start": 0, "stop_after_failures": 1}
+    trial_count = max(int(raw.get("trial_count", 1) or 1), 1)
+    seed_start = int(raw.get("seed_start", 0) or 0)
+    stop_after_failures = raw.get("stop_after_failures", trial_count)
+    stop_after_failures = max(1, min(int(stop_after_failures or trial_count), trial_count))
+    return {
+        "trial_count": trial_count,
+        "seed_start": seed_start,
+        "stop_after_failures": stop_after_failures,
+    }
+
+
+def _completed_trial_runs(session: Session, work_item_id: str) -> list[Run]:
+    runs = (
+        session.query(Run)
+        .filter(Run.work_item_id == work_item_id)
+        .order_by(Run.attempt.asc(), Run.created_at.asc())
+        .all()
+    )
+    completed: list[Run] = []
+    for run in runs:
+        if run.status not in {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.CANCELED, RunStatus.TIMED_OUT}:
+            continue
+        payload = dict(run.result_payload or {}) if isinstance(run.result_payload, dict) else {}
+        retry = bool((payload.get("retry_decision") or {}).get("requeue"))
+        if retry:
+            continue
+        completed.append(run)
+    return completed
+
+
+def _next_trial_index(session: Session, work_item: WorkItem) -> int:
+    return len(_completed_trial_runs(session, work_item.id)) + 1
+
+
+def _trial_out_root(work_item: WorkItem, trial_index: int) -> str | None:
+    policy = _trial_policy(work_item)
+    if policy["trial_count"] <= 1:
+        return None
+    out_root = str((work_item.input_manifest or {}).get("out_root", "")).strip()
+    if not out_root:
+        return None
+    return f"{out_root}/trials/trial_{trial_index:03d}"
+
+
+def _active_expected_outputs(work_item: WorkItem, trial_index: int) -> list[str]:
+    expected_outputs = [str(path) for path in (work_item.expected_outputs or [])]
+    trial_out_root = _trial_out_root(work_item, trial_index)
+    out_root = str((work_item.input_manifest or {}).get("out_root", "")).strip()
+    if not trial_out_root or not out_root:
+        return expected_outputs
+    prefix = f"{out_root}/"
+    replacement = f"{trial_out_root}/"
+    result: list[str] = []
+    for rel_path in expected_outputs:
+        if rel_path == "runs/index.csv":
+            result.append(rel_path)
+        elif rel_path.startswith(prefix):
+            result.append(rel_path.replace(prefix, replacement, 1))
+        else:
+            result.append(rel_path)
+    return result
+
+
+def _active_command_manifest(work_item: WorkItem, trial_index: int) -> list[dict[str, str]]:
+    commands = [dict(row) for row in (work_item.command_manifest or [])]
+    trial_out_root = _trial_out_root(work_item, trial_index)
+    out_root = str((work_item.input_manifest or {}).get("out_root", "")).strip()
+    if not trial_out_root or not out_root:
+        return commands
+    token = f"--out_root {out_root}"
+    replacement = f"--out_root {trial_out_root}"
+    for command in commands:
+        run_text = str(command.get("run", ""))
+        if token in run_text:
+            command["run"] = run_text.replace(token, replacement)
+    return commands
+
+
+def _should_continue_trials(session: Session, work_item: WorkItem) -> bool:
+    policy = _trial_policy(work_item)
+    completed = _completed_trial_runs(session, work_item.id)
+    completed_count = len(completed)
+    success_count = sum(1 for run in completed if run.status == RunStatus.SUCCEEDED)
+    failure_count = completed_count - success_count
+    if completed_count >= policy["trial_count"]:
+        return False
+    if success_count == 0 and failure_count >= policy["stop_after_failures"]:
+        return False
+    return True
+
+
+def _promote_post_run_state(*, session_factory: sessionmaker, work_item_id: str, run_key: str) -> tuple[bool, bool]:
+    with session_factory() as session:
+        work_item = _load_work_item(session, work_item_id)
+        completed = _completed_trial_runs(session, work_item.id)
+        success_count = sum(1 for row in completed if row.status == RunStatus.SUCCEEDED)
+        continue_trials = _should_continue_trials(session, work_item)
+        if continue_trials:
+            work_item.state = WorkItemState.READY if work_item.assigned_machine_key else WorkItemState.DISPATCH_PENDING
+            next_trial_index = len(completed) + 1
+            next_seed = _trial_policy(work_item)["seed_start"] + next_trial_index - 1
+            session.commit()
+            append_run_event(
+                session,
+                run_key=run_key,
+                event_type="trial_scheduled",
+                event_payload={"next_trial_index": next_trial_index, "next_seed": next_seed},
+            )
+            return True, False
+        if success_count > 0:
+            if work_item.state != WorkItemState.ARTIFACT_SYNC:
+                work_item.state = WorkItemState.ARTIFACT_SYNC
+                session.commit()
+            append_run_event(
+                session,
+                run_key=run_key,
+                event_type="trial_set_completed",
+                event_payload={"success_count": success_count, "completed_trials": len(completed)},
+            )
+            return False, True
+        return False, False
 
 
 def _log_dir(config: WorkerConfig, item_id: str, run_key: str) -> str:
@@ -337,6 +469,8 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
     with session_factory() as session:
         work_item = _load_work_item(session, acquired.work_item_id)
         attempt = _next_attempt(session, work_item.id)
+        trial_index = _next_trial_index(session, work_item)
+        seed = _trial_policy(work_item)["seed_start"] + trial_index - 1
         run_key = f"{work_item.item_id}_{make_id('run')}"
 
     checkout_error: str | None = None
@@ -359,6 +493,9 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
             attempt=attempt,
             executor_type="internal_worker",
             checkout_commit=checkout_info.head_sha if checkout_info is not None else None,
+            trial_index=trial_index,
+            seed=seed,
+            trial_group_key=work_item.item_id,
         )
 
     if checkout_error is not None:
@@ -440,8 +577,10 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
     command_results = []
     worker_error: str | None = None
     try:
+        active_command_manifest = _active_command_manifest(work_item, trial_index)
+        active_expected_outputs = _active_expected_outputs(work_item, trial_index)
         command_results = run_command_manifest(
-            command_manifest=work_item.command_manifest or [],
+            command_manifest=active_command_manifest,
             work_dir=checkout_info.work_dir,
             log_dir=log_dir,
             timeout_seconds=config.command_timeout_seconds,
@@ -484,17 +623,17 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
 
     artifacts = collect_expected_output_artifacts(
         repo_root=checkout_info.work_dir,
-        expected_outputs=work_item.expected_outputs or [],
+        expected_outputs=active_expected_outputs,
     ) + collect_linked_results_artifacts(
         repo_root=checkout_info.work_dir,
-        expected_outputs=work_item.expected_outputs or [],
+        expected_outputs=active_expected_outputs,
     ) + collect_log_artifacts(
         repo_root=checkout_info.work_dir,
         command_results=command_results,
     )
     queue_result = build_queue_result_payload(
         repo_root=checkout_info.work_dir,
-        expected_outputs=work_item.expected_outputs or [],
+        expected_outputs=active_expected_outputs,
         command_results=command_results,
         success=success,
     )
@@ -504,6 +643,8 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
             "metrics_rows": queue_result.metrics_rows,
             "notes": queue_result.notes,
         },
+        "trial": {"trial_index": trial_index, "seed": seed, "trial_group_key": work_item.item_id},
+        "active_expected_outputs": active_expected_outputs,
         "checkout": {
             "repo_root": checkout_info.repo_root,
             "head_sha": checkout_info.head_sha,
@@ -550,7 +691,7 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
     if not success:
         queue_result = build_queue_result_payload(
             repo_root=checkout_info.work_dir,
-            expected_outputs=work_item.expected_outputs or [],
+            expected_outputs=active_expected_outputs,
             command_results=command_results,
             success=False,
         )
@@ -600,8 +741,15 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
         _sync_expected_outputs_to_repo(
             checkout_root=checkout_info.work_dir,
             repo_root=config.repo_root,
-            expected_outputs=work_item.expected_outputs or [],
+            expected_outputs=active_expected_outputs,
         )
+
+    continue_trials, ready_for_completion = _promote_post_run_state(
+        session_factory=session_factory,
+        work_item_id=work_item.id,
+        run_key=run_key,
+    )
+    if ready_for_completion:
         _process_completed_work_item(
             session_factory,
             config=config,


### PR DESCRIPTION
Fixes #175.

- truncate oversized failure fields before DB write
- stop a worker-daemon batch exception from killing the whole daemon
- add focused regressions for both paths