### PR TITLE
control_plane: harden run finalization failure handling

### DIFF
--- a/control_plane/control_plane/services/run_service.py
+++ b/control_plane/control_plane/services/run_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timezone
+from hashlib import sha1
 from typing import Any
 
 from sqlalchemy.exc import IntegrityError
@@ -22,6 +23,20 @@ _TERMINAL_RUN_STATUSES = {
     RunStatus.CANCELED,
     RunStatus.TIMED_OUT,
 }
+
+
+def _bounded_text(value: object, *, max_len: int) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if len(text) <= max_len:
+        return text
+    digest = sha1(text.encode("utf-8")).hexdigest()[:12]
+    suffix = f"... [sha1:{digest}]"
+    keep = max_len - len(suffix)
+    if keep <= 0:
+        return suffix[:max_len]
+    return text[:keep] + suffix
 
 
 def _coerce_utc(dt):
@@ -282,9 +297,12 @@ def complete_run(
         run.runtime_seconds = max((completed_at - started_at).total_seconds(), 0.0)
     failure = (result_payload or {}).get("failure_classification") if isinstance(result_payload, dict) else {}
     if isinstance(failure, dict):
-        run.failure_stage = str(failure.get("stage", "") or "").strip() or None
-        run.failure_category = str(failure.get("category", "") or "").strip() or None
-        run.failure_signature = str(failure.get("signature", "") or failure.get("detail", "") or "").strip() or None
+        run.failure_stage = _bounded_text(failure.get("stage", ""), max_len=128)
+        run.failure_category = _bounded_text(failure.get("category", ""), max_len=128)
+        run.failure_signature = _bounded_text(
+            failure.get("signature", "") or failure.get("detail", ""),
+            max_len=255,
+        )
 
     work_item = run.work_item
     retry_decision = (result_payload or {}).get("retry_decision", {}) if isinstance(result_payload, dict) else {}

--- a/control_plane/control_plane/services/worker_daemon.py
+++ b/control_plane/control_plane/services/worker_daemon.py
@@ -94,7 +94,12 @@ def run_worker_daemon(
             with session_factory() as session:
                 expire_stale_leases(session)
 
-        batch = _run_parallel_batch(session_factory, config=config)
+        try:
+            batch = _run_parallel_batch(session_factory, config=config)
+        except Exception as exc:
+            logger(f"worker-daemon batch_error error={exc}")
+            batch = [WorkerLoopResult(status="worker_error", summary=str(exc))]
+
         results.extend(batch)
 
         batch_executed = sum(1 for result in batch if result.status != "no_work")

--- a/control_plane/control_plane/tests/test_run_service.py
+++ b/control_plane/control_plane/tests/test_run_service.py
@@ -27,6 +27,8 @@ from control_plane.services.run_service import (
     request_run_cancel,
     start_run,
 )
+from control_plane.workers import executor as executor_module
+from control_plane.services import worker_daemon as worker_daemon_module
 
 
 def make_session() -> Session:
@@ -218,3 +220,59 @@ def test_request_run_cancel_marks_active_run() -> None:
 
         again = request_run_cancel(session, run_key="run-cancel-1", requested_by="tester")
         assert again.event_id == result.event_id
+
+
+def test_complete_run_truncates_failure_signature() -> None:
+    with make_session() as session:
+        lease, work_item = seed_leased_work_item(session)
+        start_run(
+            session,
+            lease_token=lease.lease_token,
+            run_key="run-long-signature",
+            attempt=1,
+            executor_type="internal_worker",
+        )
+        long_detail = "db-error:" + ("x" * 600)
+        complete_run(
+            session,
+            run_key="run-long-signature",
+            status="failed",
+            result_summary="flow failed",
+            result_payload={
+                "failure_classification": {
+                    "category": "worker_error",
+                    "stage": "finalization",
+                    "detail": long_detail,
+                }
+            },
+        )
+        run = session.query(Run).filter_by(run_key="run-long-signature").one()
+        assert run.failure_signature is not None
+        assert len(run.failure_signature) <= 255
+        assert '[sha1:' in run.failure_signature
+        session.refresh(work_item)
+        assert work_item.state == WorkItemState.FAILED
+
+
+def test_worker_daemon_survives_run_worker_exception(monkeypatch) -> None:
+    class DummySessionFactory:
+        def __call__(self):
+            raise AssertionError('session_factory should not be used when run_worker is monkeypatched')
+
+    def boom(session_factory, *, config, max_items):
+        raise RuntimeError('simulated worker crash')
+
+    monkeypatch.setattr(worker_daemon_module, 'run_worker', boom)
+    result = worker_daemon_module.run_worker_daemon(
+        DummySessionFactory(),
+        config=worker_daemon_module.WorkerDaemonConfig(
+            worker=executor_module.WorkerConfig(repo_root='/tmp', machine_key='test-worker'),
+            max_polls=1,
+            stop_on_no_work=False,
+            run_scheduler_maintenance=False,
+        ),
+        log_fn=lambda _message: None,
+    )
+    assert len(result.results) == 1
+    assert result.results[0].status == 'worker_error'
+    assert 'simulated worker crash' in str(result.results[0].summary)


### PR DESCRIPTION
Fixes #175.

- truncate oversized failure fields before DB write
- stop a worker-daemon batch exception from killing the whole daemon
- add focused regressions for both paths