### PR TITLE
control_plane: harden L2 result submission packaging

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -783,6 +783,7 @@ def _build_proposal_assessment(
 
 def _build_payload(
     *,
+    repo_root: Path,
     work_item: WorkItem,
     run: Run,
     best_point: dict[str, Any],
@@ -908,6 +909,7 @@ def consume_l2_result(session: Session, request: Layer2ConsumeRequest) -> Layer2
             objective_profiles = _profile_recommendations(_load_csv(objective_sweep_path))
 
     payload = _build_payload(
+        repo_root=repo_root,
         work_item=work_item,
         run=run,
         best_point=best_point,

--- a/control_plane/control_plane/services/submission_bridge.py
+++ b/control_plane/control_plane/services/submission_bridge.py
@@ -18,7 +18,7 @@ from control_plane.models.enums import ArtifactStorageMode
 from control_plane.models.run_events import RunEvent
 from control_plane.models.runs import Run
 from control_plane.models.work_items import WorkItem
-from control_plane.services.docs_paths import resolve_proposal_dir
+from control_plane.services.docs_paths import resolve_proposal_file
 from control_plane.services.review_publisher import ReviewPublishRequest, publish_review_package
 
 
@@ -122,9 +122,10 @@ def _collect_proposal_files(*, repo_root: Path, package_payload: dict[str, Any],
         return
     proposal_id = str(developer_loop.get("proposal_id", "")).strip() or None
     proposal_path = str(developer_loop.get("proposal_path", "")).strip() or None
-    proposal_dir = resolve_proposal_dir(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
-    if proposal_dir is None or not proposal_dir.exists() or not proposal_dir.is_dir():
+    proposal_file = resolve_proposal_file(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
+    if proposal_file is None or not proposal_file.exists() or proposal_file.name != "proposal.json":
         return
+    proposal_dir = proposal_file.parent
     for candidate in sorted(path for path in proposal_dir.rglob("*") if path.is_file()):
         try:
             rel_path = str(candidate.resolve().relative_to(repo_root.resolve()))

--- a/control_plane/control_plane/services/submission_bridge.py
+++ b/control_plane/control_plane/services/submission_bridge.py
@@ -18,6 +18,7 @@ from control_plane.models.enums import ArtifactStorageMode
 from control_plane.models.run_events import RunEvent
 from control_plane.models.runs import Run
 from control_plane.models.work_items import WorkItem
+from control_plane.services.docs_paths import resolve_proposal_dir
 from control_plane.services.review_publisher import ReviewPublishRequest, publish_review_package
 
 
@@ -115,19 +116,39 @@ def _collect_existing_file_refs(*, repo_root: Path, value: Any, files: list[str]
     files.append(rel_path)
 
 
+def _collect_proposal_files(*, repo_root: Path, package_payload: dict[str, Any], files: list[str], seen: set[str]) -> None:
+    developer_loop = package_payload.get("developer_loop")
+    if not isinstance(developer_loop, dict):
+        return
+    proposal_id = str(developer_loop.get("proposal_id", "")).strip() or None
+    proposal_path = str(developer_loop.get("proposal_path", "")).strip() or None
+    proposal_dir = resolve_proposal_dir(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
+    if proposal_dir is None or not proposal_dir.exists() or not proposal_dir.is_dir():
+        return
+    for candidate in sorted(path for path in proposal_dir.rglob("*") if path.is_file()):
+        try:
+            rel_path = str(candidate.resolve().relative_to(repo_root.resolve()))
+        except ValueError:
+            continue
+        if rel_path in seen:
+            continue
+        seen.add(rel_path)
+        files.append(rel_path)
+
+
 def _review_linked_supporting_files(*, repo_root: Path, package_payload: dict[str, Any]) -> list[str]:
-    review_artifact = package_payload.get("review_artifact")
-    if not isinstance(review_artifact, dict):
-        return []
-    payload = review_artifact.get("payload")
-    if not isinstance(payload, dict):
-        return []
-    source_refs = payload.get("source_refs")
-    if not isinstance(source_refs, dict):
-        return []
     files: list[str] = []
     seen: set[str] = set()
-    _collect_existing_file_refs(repo_root=repo_root, value=source_refs, files=files, seen=seen)
+    review_artifact = package_payload.get("review_artifact")
+    if not isinstance(review_artifact, dict):
+        _collect_proposal_files(repo_root=repo_root, package_payload=package_payload, files=files, seen=seen)
+        return files
+    payload = review_artifact.get("payload")
+    if isinstance(payload, dict):
+        source_refs = payload.get("source_refs")
+        if isinstance(source_refs, dict):
+            _collect_existing_file_refs(repo_root=repo_root, value=source_refs, files=files, seen=seen)
+    _collect_proposal_files(repo_root=repo_root, package_payload=package_payload, files=files, seen=seen)
     return files
 
 

--- a/control_plane/control_plane/tests/test_submission_bridge.py
+++ b/control_plane/control_plane/tests/test_submission_bridge.py
@@ -62,6 +62,40 @@ def _seed_l2_reviewable(session: Session, repo_root: Path) -> tuple[str, str]:
     design_metrics_rel = "control_plane/shadow_exports/designs/demo_nm1/metrics.csv"
     schedule_rel = "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml"
     relu_schedule_rel = "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/relu_model/schedule.yml"
+    proposal_dir_rel = "docs/proposals/prop_l2_submit_demo"
+    proposal_rel = f"{proposal_dir_rel}/proposal.json"
+    _write(
+        repo_root / proposal_rel,
+        json.dumps(
+            {
+                "proposal_id": "prop_l2_submit_demo",
+                "title": "Layer2 submit demo proposal",
+                "kind": "architecture",
+                "direct_comparison": {
+                    "primary_question": "Does the layer2 submission package include proposal context?",
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+    _write(
+        repo_root / proposal_dir_rel / "evaluation_requests.json",
+        json.dumps(
+            {
+                "proposal_id": "prop_l2_submit_demo",
+                "requested_items": [
+                    {
+                        "item_id": "l2_submit_demo",
+                        "task_type": "l2_campaign",
+                        "evaluation_mode": "measurement_only",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+    )
     _write(
         repo_root / design_metrics_rel,
         (
@@ -124,6 +158,8 @@ def _seed_l2_reviewable(session: Session, repo_root: Path) -> tuple[str, str]:
         "layer": "layer2",
         "flow": "openroad",
         "developer_loop": {
+            "proposal_id": "prop_l2_submit_demo",
+            "proposal_path": proposal_rel,
             "evaluation": {"mode": "measurement_only"},
             "comparison": {"role": "baseline"},
         },
@@ -408,6 +444,8 @@ def test_prepare_submission_branch_creates_commit_and_manifest() -> None:
             assert manifest["evidence_paths"] == []
             assert "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml" in manifest["supporting_paths"]
             assert "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/relu_model/schedule.yml" in manifest["supporting_paths"]
+            assert "docs/proposals/prop_l2_submit_demo/proposal.json" in manifest["supporting_paths"]
+            assert "docs/proposals/prop_l2_submit_demo/evaluation_requests.json" in manifest["supporting_paths"]
             assert "gh pr create --draft" in manifest["pr_create_command"]
             assert (
                 Path(result.worktree_path)
@@ -416,6 +454,14 @@ def test_prepare_submission_branch_creates_commit_and_manifest() -> None:
             assert (
                 Path(result.worktree_path)
                 / "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/relu_model/schedule.yml"
+            ).exists()
+            assert (
+                Path(result.worktree_path)
+                / "docs/proposals/prop_l2_submit_demo/proposal.json"
+            ).exists()
+            assert (
+                Path(result.worktree_path)
+                / "docs/proposals/prop_l2_submit_demo/evaluation_requests.json"
             ).exists()
 
             branch_head = _git(repo_root, "rev-parse", result.branch_name)

--- a/control_plane/control_plane/tests/test_submission_bridge.py
+++ b/control_plane/control_plane/tests/test_submission_bridge.py
@@ -470,6 +470,49 @@ def test_prepare_submission_branch_creates_commit_and_manifest() -> None:
             assert artifact.path == f"control_plane/shadow_exports/review/{item_id}/submission_manifest.json"
 
 
+def test_prepare_submission_branch_packages_only_resolved_proposal_file_parent() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, _run_key = _seed_l2_reviewable(session, repo_root)
+            _write(
+                repo_root / "docs/proposals/prop_unrelated/proposal.json",
+                json.dumps({"proposal_id": "prop_unrelated", "title": "Unrelated proposal"}, indent=2) + "\n",
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = json.loads(json.dumps(work_item.task_request.request_payload))
+            payload["developer_loop"]["proposal_path"] = "docs/proposals"
+            work_item.task_request.request_payload = payload
+            session.commit()
+
+            result = prepare_submission_branch(
+                session,
+                SubmissionPrepareRequest(
+                    repo_root=str(repo_root),
+                    item_id=item_id,
+                    evaluator_id="cpbot",
+                    session_id="s20260310t080010z",
+                    host="cp-host",
+                    worktree_root=str(repo_root / "tmp_submit"),
+                ),
+            )
+
+            manifest = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "review" / item_id / "submission_manifest.json").read_text()
+            )
+            assert "docs/proposals/prop_l2_submit_demo/proposal.json" in manifest["supporting_paths"]
+            assert "docs/proposals/prop_l2_submit_demo/evaluation_requests.json" in manifest["supporting_paths"]
+            assert "docs/proposals/prop_unrelated/proposal.json" not in manifest["supporting_paths"]
+            assert (Path(result.worktree_path) / "docs/proposals/prop_l2_submit_demo/proposal.json").exists()
+            assert not (Path(result.worktree_path) / "docs/proposals/prop_unrelated/proposal.json").exists()
+
+
 def test_prepare_submission_branch_includes_canonical_runs_evidence_for_real_item() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- pass repo_root into the L2 decision payload builder so review metadata can call _repo_head(repo_root)
- package developer_loop proposal directories as supporting files when preparing submission branches
- require proposal packaging to resolve an actual proposal.json, preventing broad/stale proposal_path values from copying unrelated proposal directories
- prevents future artifact submissions from referencing proposal_path without including the proposal scaffold

## Validation
- PYTHONPATH=/tmp/rtlgen-l2-consumer-fix/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_submission_bridge.py
  - 7 passed
- /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile control_plane/control_plane/services/submission_bridge.py control_plane/control_plane/services/l2_result_consumer.py
- live consume-l2-result completed for l2_llm_attention_tail_v1_nangate45_r1 and produced control_plane/shadow_exports/l2_decisions/l2_llm_attention_tail_v1_nangate45_r1.json

Note: the full local control_plane/control_plane/tests/test_l2_result_consumer.py file still has unrelated paired-comparison expectation failures in this checkout.