### PR TITLE
[codex] Clarify developer-loop proposal artifact linkage

### DIFF
--- a/docs/developer_agent_loop.md
+++ b/docs/developer_agent_loop.md
@@ -240,6 +240,12 @@ Required metadata per work item:
   - `requires_merged_inputs`
   - `requires_materialized_refs`
 
+`proposal_path` must resolve to the proposal's `proposal.json`, normally
+`docs/proposals/<proposal_id>/proposal.json`. Keep the proposal workspace
+self-contained before dispatch, including `proposal.json` and
+`evaluation_requests.json` with the queued item ids, so the artifact PR can
+package the exact review context referenced by `reviewer_first_read`.
+
 Ordering rule:
 - `measurement_only` items may usually queue immediately
 - `paired_comparison` items that consume a prior baseline should default to

--- a/docs/developer_agent_orchestration.md
+++ b/docs/developer_agent_orchestration.md
@@ -213,6 +213,13 @@ If approved, notebook developer agent:
 2. records the created item ids in the proposal directory
 3. includes `proposal_id` and `proposal_path` in the queued work item payload
 
+Use a repo-relative `proposal_path` that resolves to the proposal's
+`proposal.json`, preferably
+`docs/proposals/<proposal_id>/proposal.json`. Do not use broad parent
+directories. The generated artifact PR is expected to contain the proposal
+workspace files named by `reviewer_first_read`; at minimum keep
+`proposal.json` and `evaluation_requests.json` materialized before dispatch.
+
 Recommended file:
 ```text
 docs/proposals/<proposal_id>/evaluation_requests.json

--- a/docs/developer_agent_review.md
+++ b/docs/developer_agent_review.md
@@ -36,6 +36,11 @@ Every developer-loop evaluation item should carry:
 - `proposal_id`
 - `proposal_path`
 
+`proposal_path` should identify the exact proposal file in repo-relative form,
+normally `docs/proposals/<proposal_id>/proposal.json`. Directory paths are only
+acceptable when the control-plane tooling canonicalizes them to that exact
+file; broad ancestors such as `docs/proposals/` are invalid.
+
 These must be visible in:
 
 - queued payload
@@ -43,8 +48,11 @@ These must be visible in:
 - `review_package.json`
 - PR body
 
-If proposal linkage is missing, the review is incomplete and should be treated
-as lower-confidence.
+The artifact PR must also include the proposal workspace files referenced by
+`reviewer_first_read`, especially `proposal.json` and
+`evaluation_requests.json`. If proposal linkage is missing, does not resolve, or
+points to files absent from the PR branch, the evidence package is incomplete;
+fix packaging before reviewing or merging the PR.
 
 ## Review Questions
 

--- a/docs/workflows/developer_loop.md
+++ b/docs/workflows/developer_loop.md
@@ -79,3 +79,22 @@ Current core proposal files:
 
 These files are repeated across proposals by design, but their schema should be
 kept tight and consistent.
+
+## Evaluation proposal linkage contract
+
+Every developer-loop work item that may enter `artifact_sync` must carry
+`developer_loop.proposal_id` and `developer_loop.proposal_path` in its queued
+payload. `proposal_path` is a repo-relative pointer to the proposal's
+`proposal.json`; use `docs/proposals/<proposal_id>/proposal.json` when writing
+payloads directly. Do not queue a broad ancestor such as `docs/proposals/`.
+
+Before dispatch, the proposal workspace must contain at least:
+
+- `proposal.json`
+- `evaluation_requests.json`
+
+`evaluation_requests.json` should name the item ids being queued. When evidence
+is exported, the artifact PR must be self-contained: the PR body's
+`reviewer_first_read` paths must exist in that PR branch, including the
+proposal scaffold. The submission path resolves `proposal_path` to a single
+`proposal.json` and packages files from that proposal directory.


### PR DESCRIPTION
## Summary
- document that developer-loop queued payloads must carry resolvable `developer_loop.proposal_id` and `developer_loop.proposal_path`
- state that `proposal_path` should resolve to the exact `proposal.json`, not a broad proposal ancestor
- require artifact PRs to include the proposal scaffold files referenced by `reviewer_first_read`

## Why
PR #219 fixed submission packaging so proposal scaffolds are included automatically, but the developer-agent instructions did not clearly describe the required linkage and packaging contract. This makes the next queued job less likely to repeat the missing proposal artifact failure.

## Validation
- `git diff --check`