### PR TITLE
control_plane: enforce strict proposal packaging

### DIFF
--- a/control_plane/control_plane/services/docs_paths.py
+++ b/control_plane/control_plane/services/docs_paths.py
@@ -30,26 +30,32 @@ def proposal_dir_candidates(repo_root: Path, proposal_path: str | None = None, p
     proposal_id_text = str(proposal_id or "").strip()
 
     if proposal_path_text:
-        resolved = _resolve_path(repo_root, proposal_path_text)
-        if resolved.name == 'proposal.json':
-            candidates.append(resolved.parent)
-        else:
-            candidates.append(resolved)
-
-        rel_text = proposal_path_text
-        if rel_text.startswith('docs/developer_loop/'):
-            mapped = rel_text.replace('docs/developer_loop/', 'docs/proposals/', 1)
-            mapped_path = _resolve_path(repo_root, mapped)
-            candidates.append(mapped_path.parent if mapped_path.name == 'proposal.json' else mapped_path)
-        elif rel_text.startswith('docs/proposals/'):
-            mapped = rel_text.replace('docs/proposals/', 'docs/developer_loop/', 1)
-            mapped_path = _resolve_path(repo_root, mapped)
-            candidates.append(mapped_path.parent if mapped_path.name == 'proposal.json' else mapped_path)
+        candidates.extend(_proposal_path_candidates(repo_root, proposal_path_text))
 
     if proposal_id_text:
         candidates.append(repo_root / 'docs' / 'proposals' / proposal_id_text)
         candidates.append(repo_root / 'docs' / 'developer_loop' / proposal_id_text)
 
+    return _dedupe_paths(candidates)
+
+
+def _proposal_path_candidates(repo_root: Path, proposal_path_text: str) -> list[Path]:
+    candidates: list[Path] = []
+    resolved = _resolve_path(repo_root, proposal_path_text)
+    if resolved.name == 'proposal.json':
+        candidates.append(resolved.parent)
+    else:
+        candidates.append(resolved)
+
+    rel_text = proposal_path_text
+    if rel_text.startswith('docs/developer_loop/'):
+        mapped = rel_text.replace('docs/developer_loop/', 'docs/proposals/', 1)
+        mapped_path = _resolve_path(repo_root, mapped)
+        candidates.append(mapped_path.parent if mapped_path.name == 'proposal.json' else mapped_path)
+    elif rel_text.startswith('docs/proposals/'):
+        mapped = rel_text.replace('docs/proposals/', 'docs/developer_loop/', 1)
+        mapped_path = _resolve_path(repo_root, mapped)
+        candidates.append(mapped_path.parent if mapped_path.name == 'proposal.json' else mapped_path)
     return _dedupe_paths(candidates)
 
 
@@ -68,10 +74,18 @@ def resolve_proposal_dir(repo_root: Path, proposal_path: str | None = None, prop
 
 
 def resolve_proposal_file(repo_root: Path, proposal_path: str | None = None, proposal_id: str | None = None) -> Path | None:
-    for candidate in proposal_dir_candidates(repo_root, proposal_path=proposal_path, proposal_id=proposal_id):
+    proposal_path_text = str(proposal_path or "").strip()
+    if proposal_path_text:
+        candidates = _proposal_path_candidates(repo_root, proposal_path_text)
+    else:
+        candidates = proposal_dir_candidates(repo_root, proposal_id=proposal_id)
+
+    for candidate in candidates:
         proposal_file = candidate if candidate.name == 'proposal.json' else candidate / 'proposal.json'
         if proposal_file.exists():
             return proposal_file.resolve()
+    if proposal_path_text:
+        return None
     proposal_dir = resolve_proposal_dir(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
     if proposal_dir is None:
         return None

--- a/control_plane/control_plane/services/submission_bridge.py
+++ b/control_plane/control_plane/services/submission_bridge.py
@@ -124,6 +124,8 @@ def _collect_proposal_files(*, repo_root: Path, package_payload: dict[str, Any],
     proposal_path = str(developer_loop.get("proposal_path", "")).strip() or None
     proposal_file = resolve_proposal_file(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
     if proposal_file is None or not proposal_file.exists() or proposal_file.name != "proposal.json":
+        if proposal_id or proposal_path:
+            raise SubmissionPrepareError("developer_loop proposal linkage does not resolve to a proposal")
         return
     proposal_dir = proposal_file.parent
     for candidate in sorted(path for path in proposal_dir.rglob("*") if path.is_file()):

--- a/control_plane/control_plane/tests/test_docs_paths.py
+++ b/control_plane/control_plane/tests/test_docs_paths.py
@@ -33,6 +33,36 @@ def test_resolve_proposal_maps_legacy_path_to_canonical_when_legacy_is_missing(t
     assert proposal_file == (canonical_dir / "proposal.json").resolve()
 
 
+def test_resolve_proposal_path_requires_specific_proposal_directory(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    canonical_dir = repo_root / "docs" / "proposals" / "prop_demo_v3"
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "proposal.json").write_text('{"proposal_id":"prop_demo_v3"}\n', encoding="utf-8")
+
+    proposal_file = resolve_proposal_file(
+        repo_root,
+        proposal_path="docs/proposals",
+        proposal_id="prop_demo_v3",
+    )
+
+    assert proposal_file is None
+
+
+def test_resolve_proposal_path_does_not_fallback_from_stale_path_to_id(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    canonical_dir = repo_root / "docs" / "proposals" / "prop_demo_v4"
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "proposal.json").write_text('{"proposal_id":"prop_demo_v4"}\n', encoding="utf-8")
+
+    proposal_file = resolve_proposal_file(
+        repo_root,
+        proposal_path="docs/proposals/prop_missing",
+        proposal_id="prop_demo_v4",
+    )
+
+    assert proposal_file is None
+
+
 def test_canonicalize_proposal_path_returns_canonical_relative_file(tmp_path: Path) -> None:
     repo_root = tmp_path
     canonical_dir = repo_root / "docs" / "proposals" / "prop_demo_v3"

--- a/control_plane/control_plane/tests/test_submission_bridge.py
+++ b/control_plane/control_plane/tests/test_submission_bridge.py
@@ -470,7 +470,7 @@ def test_prepare_submission_branch_creates_commit_and_manifest() -> None:
             assert artifact.path == f"control_plane/shadow_exports/review/{item_id}/submission_manifest.json"
 
 
-def test_prepare_submission_branch_packages_only_resolved_proposal_file_parent() -> None:
+def test_prepare_submission_branch_packages_only_specific_proposal_file_parent() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
         repo_root.mkdir()
@@ -487,7 +487,7 @@ def test_prepare_submission_branch_packages_only_resolved_proposal_file_parent()
 
             work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
             payload = json.loads(json.dumps(work_item.task_request.request_payload))
-            payload["developer_loop"]["proposal_path"] = "docs/proposals"
+            payload["developer_loop"]["proposal_path"] = "docs/proposals/prop_l2_submit_demo"
             work_item.task_request.request_payload = payload
             session.commit()
 
@@ -511,6 +511,76 @@ def test_prepare_submission_branch_packages_only_resolved_proposal_file_parent()
             assert "docs/proposals/prop_unrelated/proposal.json" not in manifest["supporting_paths"]
             assert (Path(result.worktree_path) / "docs/proposals/prop_l2_submit_demo/proposal.json").exists()
             assert not (Path(result.worktree_path) / "docs/proposals/prop_unrelated/proposal.json").exists()
+
+
+def test_prepare_submission_branch_rejects_broad_proposal_path() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, _run_key = _seed_l2_reviewable(session, repo_root)
+
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = json.loads(json.dumps(work_item.task_request.request_payload))
+            payload["developer_loop"]["proposal_path"] = "docs/proposals"
+            work_item.task_request.request_payload = payload
+            session.commit()
+
+            try:
+                prepare_submission_branch(
+                    session,
+                    SubmissionPrepareRequest(
+                        repo_root=str(repo_root),
+                        item_id=item_id,
+                        evaluator_id="cpbot",
+                        session_id="s20260310t080011z",
+                        host="cp-host",
+                        worktree_root=str(repo_root / "tmp_submit"),
+                    ),
+                )
+            except SubmissionPrepareError as exc:
+                assert "proposal linkage" in str(exc)
+            else:
+                raise AssertionError("expected SubmissionPrepareError")
+
+
+def test_prepare_submission_branch_rejects_stale_proposal_path() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, _run_key = _seed_l2_reviewable(session, repo_root)
+
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = json.loads(json.dumps(work_item.task_request.request_payload))
+            payload["developer_loop"]["proposal_path"] = "docs/proposals/prop_missing"
+            work_item.task_request.request_payload = payload
+            session.commit()
+
+            try:
+                prepare_submission_branch(
+                    session,
+                    SubmissionPrepareRequest(
+                        repo_root=str(repo_root),
+                        item_id=item_id,
+                        evaluator_id="cpbot",
+                        session_id="s20260310t080012z",
+                        host="cp-host",
+                        worktree_root=str(repo_root / "tmp_submit"),
+                    ),
+                )
+            except SubmissionPrepareError as exc:
+                assert "proposal linkage" in str(exc)
+            else:
+                raise AssertionError("expected SubmissionPrepareError")
 
 
 def test_prepare_submission_branch_includes_canonical_runs_evidence_for_real_item() -> None:


### PR DESCRIPTION
## Summary
- make proposal file resolution strict when developer_loop.proposal_path is present
- reject unresolved proposal linkage during submission branch preparation instead of silently omitting proposal artifacts
- add resolver and submission-bridge regression coverage for specific, broad, and stale proposal paths

## Tests
- PYTHONPATH=/tmp/rtlgen-doc-agent-instructions/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_docs_paths.py control_plane/control_plane/tests/test_submission_bridge.py
- /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile control_plane/control_plane/services/docs_paths.py control_plane/control_plane/services/submission_bridge.py

## Notes
- Adjacent operator/status suites were also sampled, but they currently fail on unrelated fixture/fake-gh behavior outside this patch path.