### PR TITLE
docs: close artifact packaging probe backlog item

### DIFF
--- a/docs/backlog/index.md
+++ b/docs/backlog/index.md
@@ -4,7 +4,7 @@ Canonical source of truth for new intake work lives under `docs/backlog/`.
 
 | item_id | layer | kind | title | status | priority | proposal_id | source |
 |---|---|---|---|---|---|---|---|
-| `item_cp_artifact_sync_proposal_packaging_probe_v1` | `cross` | `architecture` | Artifact-sync proposal packaging probe | `seed` | `high` |  | `docs/backlog/items/item_cp_artifact_sync_proposal_packaging_probe_v1.md` |
+| `item_cp_artifact_sync_proposal_packaging_probe_v1` | `cross` | `architecture` | Artifact-sync proposal packaging probe | `merged` | `high` |  | `docs/backlog/items/item_cp_artifact_sync_proposal_packaging_probe_v1.md` |
 | `item_eval_non_mlp_terminal_suite_v1` | `cross` | `architecture` | Terminal-sensitive softmax suite | `merged` | `high` | `prop_cross_non_mlp_terminal_suite_v1` | `docs/backlog/items/item_eval_non_mlp_terminal_suite_v1.md` |
 | `item_eval_llm_attention_suite_v1` | `cross` | `architecture` | LLM attention benchmark suite | `seed` | `high` |  | `docs/backlog/items/item_eval_llm_attention_suite_v1.md` |
 | `item_eval_llm_decoder_accuracy_stage_v1` | `cross` | `architecture` | LLM decoder accuracy stage | `seed` | `high` |  | `docs/backlog/items/item_eval_llm_decoder_accuracy_stage_v1.md` |

--- a/docs/backlog/items/item_cp_artifact_sync_proposal_packaging_probe_v1.md
+++ b/docs/backlog/items/item_cp_artifact_sync_proposal_packaging_probe_v1.md
@@ -3,15 +3,15 @@
 - item_id: `item_cp_artifact_sync_proposal_packaging_probe_v1`
 - layer: `cross`
 - kind: `architecture`
-- status: `seed`
+- status: `merged`
 - priority: `high`
 - owner: `developer_agent`
 - created_utc: `2026-04-27T23:20:00Z`
-- updated_utc: `2026-04-27T23:20:00Z`
+- updated_utc: `2026-04-28T00:10:00Z`
 - proposal_id:
 - proposal_path:
 - triggered_by_proposal: `prop_l2_llm_attention_tail_v1`
-- triggering_evidence: `PR #219`, `PR #218`
+- triggering_evidence: `PR #219`, `PR #218`, `PR #222`
 
 ## Problem
 - PR #219 fixed artifact submission packaging so proposal workspace files are
@@ -84,6 +84,17 @@
   an operator CLI wrapper
 - whether the negative broad-path case should be exposed in dashboard status as
   a distinct resolver reason or kept under the existing proposal-linkage error
+
+## Result
+- implemented by `PR #222`
+- strict `resolve_proposal_file` behavior now rejects broad or stale
+  `developer_loop.proposal_path` values instead of falling back to
+  `developer_loop.proposal_id`
+- submission preparation now fails unresolved proposal linkage before artifact
+  PR export instead of silently omitting proposal artifacts
+- regression coverage:
+  - `control_plane/control_plane/tests/test_docs_paths.py`
+  - `control_plane/control_plane/tests/test_submission_bridge.py`
 
 ## Promotion Rule
 - promote when the probe can fail before PR export for bad proposal linkage and


### PR DESCRIPTION
## Summary
- mark the artifact-sync proposal packaging probe backlog item as merged
- record PR #222 as the implementation evidence
- keep the generated backlog index status aligned for that item only

## Tests
- git diff --check