### PR TITLE
control_plane: handle L2 broad ranking without baseline

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -669,6 +669,41 @@ def _build_proposal_assessment(
             ),
             {},
         )
+    if evaluation_mode == "broad_ranking":
+        summary = (
+            "Broad ranking evidence was recorded for this proposal; focused baseline comparison is not required "
+            "for this evaluation mode."
+        )
+        assessment = {
+            "proposal_id": str(context.get("proposal_id", "")).strip(),
+            "title": str(context.get("title", "")).strip(),
+            "kind": str(context.get("kind", "")).strip(),
+            "primary_question": str(context.get("primary_question", "")).strip(),
+            "evaluation_mode": evaluation_mode,
+            "comparison_role": comparison_role,
+            "outcome": "ranking_recorded",
+            "summary": summary,
+            "baseline_ref": None,
+            "baseline_item_id": None,
+            "matched_row_count": 0,
+            "matched_rows": [],
+        }
+        return (
+            assessment,
+            _build_evaluation_record(
+                work_item=work_item,
+                proposal=proposal,
+                repo_root=repo_root,
+                evaluation_mode=evaluation_mode,
+                comparison_role=comparison_role,
+                baseline_ref=None,
+                baseline_item_id=None,
+                outcome="ranking_recorded",
+                expectation_outcome="ranking_recorded",
+                summary=summary,
+            ),
+            {},
+        )
     comparison = _developer_loop_comparison(repo_root, work_item)
     baseline_ref, baseline_rows, baseline_report, assessment_meta, source_refs = _resolve_baseline_summary(
         session,

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -645,6 +645,75 @@ def test_consume_l2_result_measurement_only_omits_proposal_assessment() -> None:
             assert decision_payload["evaluation_record"]["expectation_status"] == "not_applicable"
 
 
+def test_consume_l2_result_broad_ranking_does_not_require_baseline_refs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "developer_loop" / "prop_l2_demo_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_demo_v1",
+                        "kind": "architecture",
+                        "title": "Demo broad ranking",
+                        "direct_comparison": {
+                            "primary_question": "Which current architecture point ranks best?",
+                        },
+                        "baseline_refs": [],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_broad_ranking",
+                campaign_dir_rel="runs/campaigns/npu/broad_ranking_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/developer_loop/prop_l2_demo_v1",
+                comparison={"role": "ranking"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "broad_ranking",
+                "expected_direction": "unknown",
+                "expected_reason": "This item ranks current architecture points without a paired baseline.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "full_architecture",
+            }
+            work_item.task_request.request_payload = payload
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            evaluation_record = decision_payload["evaluation_record"]
+            assert assessment["evaluation_mode"] == "broad_ranking"
+            assert assessment["comparison_role"] == "ranking"
+            assert assessment["outcome"] == "ranking_recorded"
+            assert assessment["baseline_ref"] is None
+            assert evaluation_record["evaluation_mode"] == "broad_ranking"
+            assert evaluation_record["comparison_role"] == "ranking"
+            assert evaluation_record["abstraction_layer"] == "full_architecture"
+            assert "baseline comparison is not required" in evaluation_record["summary"]
+
+
 def test_consume_l2_result_multimodel_measurement_exports_model_artifacts() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- treat L2 `broad_ranking` as a non-baseline evaluation mode in result consumption
- emit a ranking proposal assessment/evaluation record instead of falling through to focused baseline resolution
- add regression coverage for empty `baseline_refs` broad-ranking proposals

## Tests
- PYTHONPATH=/tmp/rtlgen-doc-agent-instructions/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_broad_ranking_does_not_require_baseline_refs control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_measurement_only_omits_proposal_assessment
- /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile control_plane/control_plane/services/l2_result_consumer.py
- git diff --check

## Notes
- Full `test_l2_result_consumer.py` is not green on current master due existing paired-comparison fixture failures unrelated to this change.