### PR TITLE
control_plane: refresh LLM tail broad ranking result

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_llm_attention_tail_v1_nangate45_r1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_llm_attention_tail_v1_nangate45_r1.json
@@ -1,6 +1,6 @@
 {
   "version": 0.1,
-  "generated_utc": "2026-04-26T12:27:54.612170Z",
+  "generated_utc": "2026-04-28T00:20:24.982698Z",
   "item_id": "l2_llm_attention_tail_v1_nangate45_r1",
   "run_key": "l2_llm_attention_tail_v1_nangate45_r1_run_be2fd33c8cfd917e",
   "layer": "layer2",
@@ -8,7 +8,7 @@
   "platform": "nangate45",
   "task_type": "l2_campaign",
   "source_commit": "e0010e569dcbf4f4da47802bfed745545e49e563",
-  "review_metadata_source_commit": "813d7a7166e961da4105e4c326b6ab14120356db",
+  "review_metadata_source_commit": "2dab8b8995edea8d62e5c3f49e64c73979398202",
   "objective": "Collect repeated attention-tail scheduler evidence for LLM architecture planning.",
   "input_manifest": {
     "sweeps": [
@@ -63,18 +63,19 @@
     "abstraction_layer": "layer2",
     "expected_direction": "collect_evidence",
     "expected_reason": "Measure per-token latency, throughput, softmax occupancy, stall buckets, and overlap/backpressure before launching softmax architecture proposals.",
-    "summary": "Focused comparison baseline could not be resolved from proposal baseline_refs.",
-    "outcome": "unavailable",
+    "summary": "Broad ranking evidence was recorded for this proposal; focused baseline comparison is not required for this evaluation mode.",
+    "outcome": "ranking_recorded",
     "expectation_status": "unspecified"
   },
   "proposal_assessment": {
     "proposal_id": "prop_l2_llm_attention_tail_v1",
     "title": "LLM attention tail measurement gate",
+    "kind": "architecture",
     "primary_question": "Which current architecture point best supports LLM attention-tail scheduling evidence?",
     "evaluation_mode": "broad_ranking",
     "comparison_role": "ranking",
-    "outcome": "unavailable",
-    "summary": "Focused comparison baseline could not be resolved from proposal baseline_refs.",
+    "outcome": "ranking_recorded",
+    "summary": "Broad ranking evidence was recorded for this proposal; focused baseline comparison is not required for this evaluation mode.",
     "baseline_ref": null,
     "baseline_item_id": null,
     "matched_row_count": 0,

--- a/docs/proposals/prop_l2_llm_attention_tail_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_llm_attention_tail_v1/analysis_report.md
@@ -13,20 +13,20 @@
 ## Baseline Comparison
 - baseline_ref: `None`
 - baseline_item_id: `None`
-- outcome: `unavailable`
-- summary: Focused comparison baseline could not be resolved from proposal baseline_refs.
+- outcome: `ranking_recorded`
+- summary: Broad ranking evidence was recorded for this proposal; focused baseline comparison is not required for this evaluation mode.
 
 ## Result
 - result: `iterate`
 - confidence level: merged accepted evidence
 - estimated optimization room: pending follow-on comparison
 - architecture conclusion robustness: staged evidence
-- summary: Focused comparison baseline could not be resolved from proposal baseline_refs.
+- summary: Broad ranking evidence was recorded for this proposal; focused baseline comparison is not required for this evaluation mode.
 
 ## Failures and Caveats
-- paired baseline comparison payload was unavailable at consume time
+- no additional caveats recorded during automatic finalization
 
 ## Recommendation
 - `iterate`
-- reason: Focused comparison baseline could not be resolved from proposal baseline_refs.
+- reason: Broad ranking evidence was recorded for this proposal; focused baseline comparison is not required for this evaluation mode.
 - next_action: inspect follow-on work after l2_llm_attention_tail_v1_nangate45_r1

--- a/docs/proposals/prop_l2_llm_attention_tail_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_llm_attention_tail_v1/promotion_decision.json
@@ -2,7 +2,7 @@
   "proposal_id": "prop_l2_llm_attention_tail_v1",
   "candidate_id": "l2_llm_attention_tail_v1_nangate45_r1",
   "decision": "iterate",
-  "reason": "Focused comparison baseline could not be resolved from proposal baseline_refs.",
+  "reason": "Broad ranking evidence was recorded for this proposal; focused baseline comparison is not required for this evaluation mode.",
   "evidence_refs": [
     "item:l2_llm_attention_tail_v1_nangate45_r1",
     "run:l2_llm_attention_tail_v1_nangate45_r1_run_be2fd33c8cfd917e",


### PR DESCRIPTION
## Summary
- re-consume the merged LLM attention-tail L2 result after PR #224
- replace the misleading missing-baseline result with `ranking_recorded` broad-ranking evidence
- update the proposal analysis and promotion decision reason to reflect that broad ranking does not require baseline refs

## Verification
- `consume-l2-result` succeeded for `l2_llm_attention_tail_v1_nangate45_r1`
- `finalize-after-merge --no-git-publish` regenerated the proposal decision/report
- JSON validation passed for the touched decision files
- `git diff --check` passed