### PR TITLE
npu/eval: validate decoder accuracy contract

### DIFF
--- a/docs/architecture/llm_decoder_accuracy_stage_v1.md
+++ b/docs/architecture/llm_decoder_accuracy_stage_v1.md
@@ -32,8 +32,8 @@ What exists today:
 
 What does not exist yet:
 - a decoder-style model set,
-- token-level quality metrics in campaign/report outputs,
 - any dataset-backed acceptance gate for approximate hardware beyond reference/candidate next-token checks.
+- token-level quality metrics in full NPU campaign/report outputs.
 
 ## Immediate Goal
 
@@ -124,7 +124,9 @@ The repo now has the first explicit decoder-quality binding layer:
 - deterministic per-sample reference artifacts for greedy next-token checks,
 - deterministic candidate-only placeholders against the same contract,
 - a comparison-ready reference/candidate schema,
-- an exact-match summary utility for token-level placeholder evaluation,
+- an exact-match and top-k containment summary utility for token-level evaluation,
+- a lightweight contract schema and validator for the checked-in prompt,
+  reference, candidate, SHA256, tensor-trace, and metrics artifacts,
 - an explicit backend interface that can later compare software emulation and hardware-oriented execution for equivalence,
 - a replay-backed frozen-artifact backend (`replay_v1`) that keeps that interface stable before a real decoder runtime exists,
 - an executable command-backed adapter (`command_json_v1`) that can later bind a real CPU reference, software emulation, or hardware-target runtime without changing the manifests again.

--- a/docs/backlog/items/item_eval_llm_decoder_accuracy_stage_v1.md
+++ b/docs/backlog/items/item_eval_llm_decoder_accuracy_stage_v1.md
@@ -3,11 +3,11 @@
 - item_id: `item_eval_llm_decoder_accuracy_stage_v1`
 - layer: `cross`
 - kind: `architecture`
-- status: `seed`
+- status: `merged`
 - priority: `high`
 - owner: `developer_agent`
 - created_utc: `2026-04-19T00:00:00Z`
-- updated_utc: `2026-04-19T00:00:00Z`
+- updated_utc: `2026-04-28T00:00:00Z`
 - proposal_id:
 - proposal_path:
 
@@ -39,6 +39,17 @@
 - define the reference inference artifact shape
 - add token-level quality metrics to the evaluation/report path
 - later add model execution and approximation sweeps against that contract
+
+## Implementation Result
+- `runs/datasets/llm_decoder_eval_tiny_v1/` now carries the bounded prompt
+  slice, reference manifest, candidate manifest, and frozen per-sample
+  artifacts.
+- `npu/eval/llm_decoder_contract.schema.json` records the prompt,
+  manifest, reference, candidate, tensor-trace, and metrics contract.
+- `npu/eval/validate_llm_decoder_contract.py` validates the checked-in
+  dataset linkage, SHA256s, artifact shapes, and token-level metrics.
+- `npu/eval/compare_llm_decoder_quality.py` reports next-token exact-match
+  and candidate top-k containment rates, plus selected tensor-trace drift.
 
 ## Evaluation Sketch
 - local:

--- a/docs/development_items/index.md
+++ b/docs/development_items/index.md
@@ -46,7 +46,7 @@
 | `item_l1_wrapped_io_cleanup_v1` | `layer1` | `circuit` | `Wrapped-IO cleanup` | `seed` | `high` | `developer_agent` |  | `2026-03-16T06:00:00Z` |
 | `item_l1_macro_manifest_enrichment_v1` | `layer1` | `circuit` | `Macro manifest enrichment` | `seed` | `high` | `developer_agent` |  | `2026-03-16T06:00:00Z` |
 | `item_eval_llm_attention_suite_v1` | `cross` | `architecture` | `LLM attention benchmark suite` | `seed` | `high` | `developer_agent` |  | `2026-04-17T00:00:00Z` |
-| `item_eval_llm_decoder_accuracy_stage_v1` | `cross` | `architecture` | `LLM decoder accuracy stage` | `seed` | `high` | `developer_agent` |  | `2026-04-19T00:00:00Z` |
+| `item_eval_llm_decoder_accuracy_stage_v1` | `cross` | `architecture` | `LLM decoder accuracy stage` | `merged` | `high` | `developer_agent` |  | `2026-04-28T00:00:00Z` |
 | `item_eval_model_quality_gate_general_v1` | `cross` | `architecture` | `General model-quality gate framework` | `seed` | `high` | `developer_agent` |  | `2026-03-16T06:00:00Z` |
 | `item_eval_reference_output_pipeline_v1` | `cross` | `architecture` | `Reference output pipeline` | `seed` | `high` | `developer_agent` |  | `2026-03-16T06:00:00Z` |
 | `item_eval_terminal_output_overlap_probe_v1` | `cross` | `architecture` | `Terminal-output overlap probe` | `promoted_to_proposal` | `high` | `developer_agent` | `prop_cross_terminal_output_overlap_probe_v1` | `2026-03-18T07:16:43Z` |

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -15,7 +15,11 @@ It is the first step toward a reproducible closed-loop flow:
 - `npu/eval/contract.md`: human-readable contract and field definitions.
 - `npu/eval/campaign.schema.json`: JSON schema for campaign manifests.
 - `npu/eval/result_row.schema.json`: JSON schema for merged result rows.
+- `npu/eval/llm_decoder_contract.schema.json`: JSON schema for the tiny
+  decoder prompt/reference/candidate/metrics contract.
 - `npu/eval/validate.py`: lightweight validator for campaign/result JSON.
+- `npu/eval/validate_llm_decoder_contract.py`: lightweight validator for the
+  checked-in decoder dataset, frozen artifacts, SHA256s, and token metrics.
 - `npu/eval/examples/`: minimal examples.
 - `runs/models/<model_set_id>/manifest.json`: shared benchmark model-set
   manifest with ONNX SHA256 checksums.
@@ -25,7 +29,7 @@ It is the first step toward a reproducible closed-loop flow:
 - `npu/eval/gen_llm_decoder_candidate_suite.py`: generate candidate decoder
   fixtures for the tiny decoder-quality stage.
 - `npu/eval/compare_llm_decoder_quality.py`: summarize token-level exact-match
-  rates from decoder reference/candidate manifests.
+  and top-k containment rates from decoder reference/candidate manifests.
 - `npu/eval/run_llm_decoder_onnx_reference.py`: active exact-reference runner
   behind `command_json_v1` for the pinned tiny decoder ONNX export.
 
@@ -48,6 +52,12 @@ python3 npu/eval/validate.py --campaign npu/eval/examples/minimal_campaign.json
 Validate merged result row:
 ```sh
 python3 npu/eval/validate.py --result-row npu/eval/examples/minimal_result_row.json
+```
+
+Validate the tiny decoder accuracy-stage contract:
+```sh
+python3 npu/eval/validate_llm_decoder_contract.py \
+  --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json
 ```
 
 Optionally verify path-like fields exist:

--- a/npu/eval/compare_llm_decoder_quality.py
+++ b/npu/eval/compare_llm_decoder_quality.py
@@ -161,6 +161,8 @@ def compare_decoder_manifests(reference_manifest: JsonDict, candidate_manifest: 
     sample_metrics: List[JsonDict] = []
     id_match_count = 0
     text_match_count = 0
+    topk_id_contains_count = 0
+    topk_text_contains_count = 0
     for sample_id in sorted(ref_samples):
         ref_doc = load_json(_resolve_repo_path(ref_samples[sample_id]['reference_json']))
         cand_doc = load_json(_resolve_repo_path(cand_samples[sample_id]['candidate_json']))
@@ -169,6 +171,8 @@ def compare_decoder_manifests(reference_manifest: JsonDict, candidate_manifest: 
         sample_metrics.append(metrics)
         id_match_count += int(metrics['aggregate']['next_token_id_match'])
         text_match_count += int(metrics['aggregate']['next_token_text_match'])
+        topk_id_contains_count += int(metrics['aggregate']['topk_contains_reference_id'])
+        topk_text_contains_count += int(metrics['aggregate']['topk_contains_reference_text'])
 
     total = len(sample_metrics)
     total_matched_tensors = sum(
@@ -208,6 +212,10 @@ def compare_decoder_manifests(reference_manifest: JsonDict, candidate_manifest: 
             'next_token_text_match_count': text_match_count,
             'next_token_id_match_rate': (float(id_match_count) / float(total)) if total else 0.0,
             'next_token_text_match_rate': (float(text_match_count) / float(total)) if total else 0.0,
+            'topk_contains_reference_id_count': topk_id_contains_count,
+            'topk_contains_reference_text_count': topk_text_contains_count,
+            'topk_contains_reference_id_rate': (float(topk_id_contains_count) / float(total)) if total else 0.0,
+            'topk_contains_reference_text_rate': (float(topk_text_contains_count) / float(total)) if total else 0.0,
             'selected_tensor_trace': {
                 'matched_tensor_count': total_matched_tensors,
                 'shape_match_count': total_shape_match_count,

--- a/npu/eval/llm_decoder_contract.schema.json
+++ b/npu/eval/llm_decoder_contract.schema.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LLM Decoder Accuracy Stage Contract",
+  "description": "Contract surface for the tiny decoder prompt dataset, frozen reference/candidate artifacts, and token-level comparison metrics.",
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "prompt_sample": {
+      "type": "object",
+      "required": ["sample_id", "prompt", "expected_continuation", "category"],
+      "properties": {
+        "sample_id": { "type": "string", "minLength": 1 },
+        "prompt": { "type": "string", "minLength": 1 },
+        "expected_continuation": { "type": "string", "minLength": 1 },
+        "category": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "dataset_manifest": {
+      "type": "object",
+      "required": [
+        "version",
+        "dataset_id",
+        "task",
+        "sample_count",
+        "sample_file",
+        "reference_manifest",
+        "candidate_manifest",
+        "tokenizer_manifest",
+        "model_contract",
+        "decoder_backend_interface"
+      ],
+      "properties": {
+        "version": { "type": "number" },
+        "dataset_id": { "const": "llm_decoder_eval_tiny_v1" },
+        "task": { "const": "greedy_next_token" },
+        "sample_count": { "type": "integer", "minimum": 1 },
+        "sample_file": { "type": "string", "minLength": 1 },
+        "reference_manifest": { "type": "string", "minLength": 1 },
+        "candidate_manifest": { "type": "string", "minLength": 1 },
+        "tokenizer_manifest": { "type": "string", "minLength": 1 },
+        "model_contract": { "type": "string", "minLength": 1 },
+        "decoder_backend_interface": { "const": "v1" },
+        "decoder_backend_configs": { "type": "object" },
+        "notes": { "type": "string" },
+        "status": { "type": "string" },
+        "tokenizer_id": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "artifact_manifest": {
+      "type": "object",
+      "required": ["version", "dataset_id", "task", "tokenizer_manifest", "model_contract", "samples"],
+      "properties": {
+        "version": { "type": "number" },
+        "dataset_id": { "const": "llm_decoder_eval_tiny_v1" },
+        "task": { "const": "greedy_next_token" },
+        "tokenizer_manifest": { "type": "string", "minLength": 1 },
+        "model_contract": { "type": "string", "minLength": 1 },
+        "candidate_semantics": { "type": "string", "minLength": 1 },
+        "backend_config": { "type": "object" },
+        "samples": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["sample_id"],
+            "properties": {
+              "sample_id": { "type": "string", "minLength": 1 },
+              "reference_json": { "type": "string", "minLength": 1 },
+              "reference_sha256": { "$ref": "#/$defs/sha256" },
+              "candidate_json": { "type": "string", "minLength": 1 },
+              "candidate_sha256": { "$ref": "#/$defs/sha256" }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "selected_tensor_summary": {
+      "type": "object",
+      "required": ["name", "step", "shape", "min", "max", "mean", "std"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "step": { "type": "integer", "minimum": 0 },
+        "shape": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1 }
+        },
+        "dtype": { "type": "string" },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "mean": { "type": "number" },
+        "std": { "type": "number" },
+        "quantization": { "type": "object" }
+      },
+      "additionalProperties": true
+    },
+    "reference_artifact": {
+      "type": "object",
+      "required": ["version", "dataset_id", "task", "sample_id", "prompt", "reference"],
+      "properties": {
+        "version": { "type": "number" },
+        "dataset_id": { "const": "llm_decoder_eval_tiny_v1" },
+        "task": { "const": "greedy_next_token" },
+        "sample_id": { "type": "string", "minLength": 1 },
+        "prompt": { "type": "object" },
+        "reference": {
+          "type": "object",
+          "required": ["next_token_id", "next_token_text", "expected_continuation", "topk"],
+          "properties": {
+            "next_token_id": { "type": "integer", "minimum": 0 },
+            "next_token_text": { "type": "string", "minLength": 1 },
+            "expected_continuation": { "type": "string", "minLength": 1 },
+            "next_token_rank": { "type": "integer", "minimum": 1 },
+            "topk": { "type": "array", "minItems": 1 },
+            "selected_tensors": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/selected_tensor_summary" }
+            },
+            "selected_tensors_sha256": { "$ref": "#/$defs/sha256" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "candidate_artifact": {
+      "type": "object",
+      "required": ["version", "dataset_id", "task", "sample_id", "prompt", "candidate", "candidate_semantics"],
+      "properties": {
+        "version": { "type": "number" },
+        "dataset_id": { "const": "llm_decoder_eval_tiny_v1" },
+        "task": { "const": "greedy_next_token" },
+        "sample_id": { "type": "string", "minLength": 1 },
+        "candidate_semantics": { "type": "string", "minLength": 1 },
+        "prompt": { "type": "object" },
+        "candidate": {
+          "type": "object",
+          "required": ["next_token_id", "next_token_text", "confidence", "topk"],
+          "properties": {
+            "next_token_id": { "type": "integer", "minimum": 0 },
+            "next_token_text": { "type": "string", "minLength": 1 },
+            "confidence": { "type": "number" },
+            "topk": { "type": "array", "minItems": 1 },
+            "selected_tensors": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/selected_tensor_summary" }
+            },
+            "selected_tensors_sha256": { "$ref": "#/$defs/sha256" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "metrics_report": {
+      "type": "object",
+      "required": ["dataset_id", "task", "samples", "aggregate"],
+      "properties": {
+        "dataset_id": { "const": "llm_decoder_eval_tiny_v1" },
+        "task": { "const": "greedy_next_token" },
+        "candidate_semantics": { "type": "string" },
+        "samples": { "type": "array" },
+        "aggregate": {
+          "type": "object",
+          "required": [
+            "sample_count",
+            "next_token_id_match_rate",
+            "next_token_text_match_rate",
+            "topk_contains_reference_id_rate",
+            "topk_contains_reference_text_rate",
+            "selected_tensor_trace"
+          ]
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "type": "object",
+  "properties": {
+    "dataset_manifest": { "$ref": "#/$defs/dataset_manifest" },
+    "prompt_sample": { "$ref": "#/$defs/prompt_sample" },
+    "artifact_manifest": { "$ref": "#/$defs/artifact_manifest" },
+    "reference_artifact": { "$ref": "#/$defs/reference_artifact" },
+    "candidate_artifact": { "$ref": "#/$defs/candidate_artifact" },
+    "metrics_report": { "$ref": "#/$defs/metrics_report" }
+  }
+}

--- a/npu/eval/llm_decoder_quality.py
+++ b/npu/eval/llm_decoder_quality.py
@@ -345,10 +345,25 @@ def compare_decoder_reference_docs(reference_doc: JsonDict, candidate_doc: JsonD
     cand = candidate_doc.get('candidate', {})
     next_token_id_match = int(ref['next_token_id'] == cand.get('next_token_id'))
     next_token_text_match = int(ref['next_token_text'] == cand.get('next_token_text'))
+    candidate_topk = cand.get('topk', [])
+    if not isinstance(candidate_topk, list):
+        candidate_topk = []
+    ref_token_id = int(ref['next_token_id'])
+    ref_token_text = str(ref['next_token_text'])
+    topk_contains_reference_id = int(any(
+        isinstance(entry, dict) and entry.get('token_id') == ref_token_id
+        for entry in candidate_topk
+    ))
+    topk_contains_reference_text = int(any(
+        isinstance(entry, dict) and str(entry.get('token_text', '')) == ref_token_text
+        for entry in candidate_topk
+    ))
     return {
         'sample_id': reference_doc['sample_id'],
         'aggregate': {
             'next_token_id_match': next_token_id_match,
             'next_token_text_match': next_token_text_match,
+            'topk_contains_reference_id': topk_contains_reference_id,
+            'topk_contains_reference_text': topk_contains_reference_text,
         },
     }

--- a/npu/eval/run_llm_decoder_onnx_candidate.py
+++ b/npu/eval/run_llm_decoder_onnx_candidate.py
@@ -369,10 +369,12 @@ def main() -> int:
     tokenizer_runtime = _load_tokenizer_runtime(tokenizer_bundle)
     prompt_doc = _prepare_prompt(request['sample'], tokenizer_bundle, tokenizer_runtime=tokenizer_runtime)
 
-    ort = _load_onnxruntime()
     model_path = str(backend_config.get('onnx_model_path', '')).strip()
     if not model_path:
         raise SystemExit('backend_config.onnx_model_path is required for command_json_v1 ONNX candidate runs')
+    resolved_model_path = _resolve_repo_path(model_path)
+    if not resolved_model_path.is_file():
+        raise SystemExit(f'NoSuchFile: ONNX model path does not exist: {resolved_model_path}')
     output_name = str(backend_config.get('output_name', '')).strip() or None
     topk = int(backend_config.get('topk', 5))
     trace_patterns = [str(v) for v in (backend_config.get('trace_output_patterns') or []) if str(v).strip()]
@@ -381,7 +383,8 @@ def main() -> int:
     model_config = _load_model_config(model_path=model_path, backend_config=backend_config)
     feeds = _build_feeds(prompt_token_ids=prompt_doc['token_ids'], model_config=model_config)
 
-    sess = ort.InferenceSession(str(_resolve_repo_path(model_path)))
+    ort = _load_onnxruntime()
+    sess = ort.InferenceSession(str(resolved_model_path))
     outputs = sess.run(None, feeds)
     if not outputs:
         raise SystemExit('onnx runtime returned no outputs')

--- a/npu/eval/run_llm_decoder_onnx_reference.py
+++ b/npu/eval/run_llm_decoder_onnx_reference.py
@@ -238,18 +238,20 @@ def main() -> int:
     tokenizer_runtime = _load_tokenizer_runtime(tokenizer_bundle)
     prompt_doc = _prepare_prompt(request['sample'], tokenizer_bundle, tokenizer_runtime=tokenizer_runtime)
 
-    ort = _load_onnxruntime()
-
     model_path = str(backend_config.get('onnx_model_path', '')).strip()
     if not model_path:
         raise SystemExit('backend_config.onnx_model_path is required for command_json_v1 ONNX reference runs')
+    resolved_model_path = _resolve_repo_path(model_path)
+    if not resolved_model_path.is_file():
+        raise SystemExit(f'NoSuchFile: ONNX model path does not exist: {resolved_model_path}')
     output_name = str(backend_config.get('output_name', '')).strip() or None
     topk = int(backend_config.get('topk', 5))
     trace_patterns = [str(v) for v in (backend_config.get('trace_output_patterns') or []) if str(v).strip()]
     model_config = _load_model_config(model_path=model_path, backend_config=backend_config)
     feeds = _build_feeds(prompt_token_ids=prompt_doc['token_ids'], model_config=model_config)
 
-    sess = ort.InferenceSession(str(_resolve_repo_path(model_path)))
+    ort = _load_onnxruntime()
+    sess = ort.InferenceSession(str(resolved_model_path))
     outputs = sess.run(None, feeds)
     if not outputs:
         raise SystemExit('onnx runtime returned no outputs')

--- a/npu/eval/validate_llm_decoder_contract.py
+++ b/npu/eval/validate_llm_decoder_contract.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Validate the tiny LLM decoder accuracy-stage artifact contract."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.compare_llm_decoder_quality import compare_decoder_manifests
+
+JsonDict = Dict[str, Any]
+
+
+def _repo_path(path: str | Path) -> Path:
+    p = Path(path)
+    if p.is_absolute():
+        return p
+    return REPO_ROOT / p
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    with _repo_path(path).open('r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def _load_jsonl(path: str | Path) -> List[JsonDict]:
+    rows: List[JsonDict] = []
+    with _repo_path(path).open('r', encoding='utf-8') as f:
+        for line_no, raw in enumerate(f, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                doc = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f'{path}:{line_no}: invalid JSONL row: {exc}') from exc
+            if not isinstance(doc, dict):
+                raise ValueError(f'{path}:{line_no}: sample row must be an object')
+            rows.append(doc)
+    return rows
+
+
+def _sha256(path: str | Path) -> str:
+    h = hashlib.sha256()
+    with _repo_path(path).open('rb') as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _require(condition: bool, errors: List[str], message: str) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def _require_non_empty_string(doc: JsonDict, key: str, errors: List[str], where: str) -> None:
+    _require(isinstance(doc.get(key), str) and bool(str(doc.get(key)).strip()), errors, f'{where}.{key} must be a non-empty string')
+
+
+def _require_file(doc: JsonDict, key: str, errors: List[str], where: str) -> None:
+    _require_non_empty_string(doc, key, errors, where)
+    value = doc.get(key)
+    if isinstance(value, str) and value.strip():
+        _require(_repo_path(value).is_file(), errors, f'{where}.{key} does not exist: {value}')
+
+
+def _sample_ids(samples: Iterable[JsonDict], *, where: str, errors: List[str]) -> List[str]:
+    ids: List[str] = []
+    seen: set[str] = set()
+    for idx, sample in enumerate(samples):
+        sid = sample.get('sample_id')
+        _require(isinstance(sid, str) and bool(str(sid).strip()), errors, f'{where}[{idx}].sample_id must be a non-empty string')
+        if isinstance(sid, str):
+            _require(sid not in seen, errors, f'{where}[{idx}].sample_id is duplicated: {sid}')
+            ids.append(sid)
+            seen.add(sid)
+    return ids
+
+
+def _validate_topk(entries: Any, errors: List[str], where: str, *, score_key: str) -> None:
+    _require(isinstance(entries, list) and bool(entries), errors, f'{where} must be a non-empty array')
+    if not isinstance(entries, list):
+        return
+    for idx, entry in enumerate(entries):
+        ewhere = f'{where}[{idx}]'
+        _require(isinstance(entry, dict), errors, f'{ewhere} must be an object')
+        if not isinstance(entry, dict):
+            continue
+        _require(isinstance(entry.get('token_id'), int), errors, f'{ewhere}.token_id must be an integer')
+        _require_non_empty_string(entry, 'token_text', errors, ewhere)
+        _require(isinstance(entry.get(score_key), (int, float)), errors, f'{ewhere}.{score_key} must be numeric')
+
+
+def _validate_selected_tensors(entries: Any, errors: List[str], where: str) -> None:
+    _require(isinstance(entries, list), errors, f'{where} must be an array')
+    if not isinstance(entries, list):
+        return
+    for idx, entry in enumerate(entries):
+        ewhere = f'{where}[{idx}]'
+        _require(isinstance(entry, dict), errors, f'{ewhere} must be an object')
+        if not isinstance(entry, dict):
+            continue
+        _require_non_empty_string(entry, 'name', errors, ewhere)
+        _require(isinstance(entry.get('step'), int), errors, f'{ewhere}.step must be an integer')
+        shape = entry.get('shape')
+        _require(isinstance(shape, list) and all(isinstance(v, int) and v > 0 for v in shape), errors, f'{ewhere}.shape must be positive integer dimensions')
+        for key in ('min', 'max', 'mean', 'std'):
+            _require(isinstance(entry.get(key), (int, float)), errors, f'{ewhere}.{key} must be numeric')
+
+
+def _validate_decoder_doc(doc: JsonDict, sample: JsonDict, errors: List[str], where: str, *, role: str) -> None:
+    role_key = 'reference' if role == 'reference' else 'candidate'
+    _require(doc.get('sample_id') == sample.get('sample_id'), errors, f'{where}.sample_id must match prompt sample_id')
+    _require(doc.get('dataset_id') == 'llm_decoder_eval_tiny_v1', errors, f'{where}.dataset_id must be llm_decoder_eval_tiny_v1')
+    _require(doc.get('task') == 'greedy_next_token', errors, f'{where}.task must be greedy_next_token')
+    _require(isinstance(doc.get('prompt'), dict), errors, f'{where}.prompt must be an object')
+    if isinstance(doc.get('prompt'), dict):
+        prompt = doc['prompt']
+        _require(prompt.get('text') == sample.get('prompt'), errors, f'{where}.prompt.text must match sample prompt')
+        _require(isinstance(prompt.get('token_ids'), list) and all(isinstance(v, int) for v in prompt.get('token_ids', [])), errors, f'{where}.prompt.token_ids must be integer tokens')
+        _require(isinstance(prompt.get('tokens'), list), errors, f'{where}.prompt.tokens must be an array')
+        _require(isinstance(prompt.get('token_count'), int), errors, f'{where}.prompt.token_count must be an integer')
+    _require(isinstance(doc.get(role_key), dict), errors, f'{where}.{role_key} must be an object')
+    if not isinstance(doc.get(role_key), dict):
+        return
+    result = doc[role_key]
+    _require(isinstance(result.get('next_token_id'), int), errors, f'{where}.{role_key}.next_token_id must be an integer')
+    _require_non_empty_string(result, 'next_token_text', errors, f'{where}.{role_key}')
+    if role == 'reference':
+        _require(result.get('expected_continuation') == sample.get('expected_continuation'), errors, f'{where}.reference.expected_continuation must match prompt sample')
+        _require(isinstance(result.get('next_token_rank'), int), errors, f'{where}.reference.next_token_rank must be an integer')
+        _validate_topk(result.get('topk'), errors, f'{where}.reference.topk', score_key='logit')
+    else:
+        _require_non_empty_string(doc, 'candidate_semantics', errors, where)
+        _require(isinstance(result.get('confidence'), (int, float)), errors, f'{where}.candidate.confidence must be numeric')
+        _validate_topk(result.get('topk'), errors, f'{where}.candidate.topk', score_key='score')
+    _validate_selected_tensors(result.get('selected_tensors', []), errors, f'{where}.{role_key}.selected_tensors')
+    if result.get('selected_tensors'):
+        _require_non_empty_string(result, 'selected_tensors_sha256', errors, f'{where}.{role_key}')
+
+
+def validate_decoder_contract(dataset_manifest_path: str | Path) -> JsonDict:
+    errors: List[str] = []
+    manifest = _load_json(dataset_manifest_path)
+    where = str(dataset_manifest_path)
+    for key in (
+        'dataset_id',
+        'task',
+        'sample_file',
+        'reference_manifest',
+        'candidate_manifest',
+        'tokenizer_manifest',
+        'model_contract',
+    ):
+        _require_non_empty_string(manifest, key, errors, where)
+    _require(manifest.get('dataset_id') == 'llm_decoder_eval_tiny_v1', errors, f'{where}.dataset_id must be llm_decoder_eval_tiny_v1')
+    _require(manifest.get('task') == 'greedy_next_token', errors, f'{where}.task must be greedy_next_token')
+    for key in ('sample_file', 'reference_manifest', 'candidate_manifest', 'tokenizer_manifest', 'model_contract'):
+        _require_file(manifest, key, errors, where)
+
+    samples = _load_jsonl(str(manifest.get('sample_file', ''))) if isinstance(manifest.get('sample_file'), str) else []
+    prompt_ids = _sample_ids(samples, where='samples', errors=errors)
+    for idx, sample in enumerate(samples):
+        swhere = f'samples[{idx}]'
+        _require_non_empty_string(sample, 'prompt', errors, swhere)
+        _require_non_empty_string(sample, 'expected_continuation', errors, swhere)
+        _require_non_empty_string(sample, 'category', errors, swhere)
+    _require(manifest.get('sample_count') == len(samples), errors, f'{where}.sample_count must equal samples.jsonl row count')
+
+    reference_manifest = _load_json(str(manifest.get('reference_manifest', ''))) if isinstance(manifest.get('reference_manifest'), str) else {}
+    candidate_manifest = _load_json(str(manifest.get('candidate_manifest', ''))) if isinstance(manifest.get('candidate_manifest'), str) else {}
+    for label, artifact_manifest in (('reference_manifest', reference_manifest), ('candidate_manifest', candidate_manifest)):
+        awhere = label
+        _require(artifact_manifest.get('dataset_id') == manifest.get('dataset_id'), errors, f'{awhere}.dataset_id must match dataset manifest')
+        _require(artifact_manifest.get('task') == manifest.get('task'), errors, f'{awhere}.task must match dataset manifest')
+        _require(artifact_manifest.get('tokenizer_manifest') == manifest.get('tokenizer_manifest'), errors, f'{awhere}.tokenizer_manifest must match dataset manifest')
+        _require(artifact_manifest.get('model_contract') == manifest.get('model_contract'), errors, f'{awhere}.model_contract must match dataset manifest')
+        _require(isinstance(artifact_manifest.get('samples'), list), errors, f'{awhere}.samples must be an array')
+
+    ref_entries = reference_manifest.get('samples', []) if isinstance(reference_manifest.get('samples'), list) else []
+    cand_entries = candidate_manifest.get('samples', []) if isinstance(candidate_manifest.get('samples'), list) else []
+    ref_ids = _sample_ids(ref_entries, where='reference_manifest.samples', errors=errors)
+    cand_ids = _sample_ids(cand_entries, where='candidate_manifest.samples', errors=errors)
+    _require(set(ref_ids) == set(prompt_ids), errors, 'reference_manifest samples must match prompt sample_ids')
+    _require(set(cand_ids) == set(prompt_ids), errors, 'candidate_manifest samples must match prompt sample_ids')
+
+    samples_by_id = {str(sample['sample_id']): sample for sample in samples if isinstance(sample.get('sample_id'), str)}
+    for entry in ref_entries:
+        _require_file(entry, 'reference_json', errors, f"reference_manifest.samples[{entry.get('sample_id', '?')}]")
+        if isinstance(entry.get('reference_json'), str):
+            actual = _sha256(entry['reference_json'])
+            _require(entry.get('reference_sha256') == actual, errors, f"{entry['reference_json']} sha256 mismatch")
+            _validate_decoder_doc(_load_json(entry['reference_json']), samples_by_id.get(str(entry.get('sample_id')), {}), errors, str(entry['reference_json']), role='reference')
+    for entry in cand_entries:
+        _require_file(entry, 'candidate_json', errors, f"candidate_manifest.samples[{entry.get('sample_id', '?')}]")
+        if isinstance(entry.get('candidate_json'), str):
+            actual = _sha256(entry['candidate_json'])
+            _require(entry.get('candidate_sha256') == actual, errors, f"{entry['candidate_json']} sha256 mismatch")
+            _validate_decoder_doc(_load_json(entry['candidate_json']), samples_by_id.get(str(entry.get('sample_id')), {}), errors, str(entry['candidate_json']), role='candidate')
+
+    metrics = compare_decoder_manifests(reference_manifest, candidate_manifest)
+    aggregate = metrics.get('aggregate', {})
+    for key in (
+        'sample_count',
+        'next_token_id_match_rate',
+        'next_token_text_match_rate',
+        'topk_contains_reference_id_rate',
+        'topk_contains_reference_text_rate',
+        'selected_tensor_trace',
+    ):
+        _require(key in aggregate, errors, f'metrics.aggregate.{key} is required')
+
+    return {
+        'ok': not errors,
+        'errors': errors,
+        'dataset_id': manifest.get('dataset_id', ''),
+        'sample_count': len(samples),
+        'metrics': metrics,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Validate the LLM decoder accuracy-stage dataset/reference/candidate contract.')
+    parser.add_argument(
+        '--dataset-manifest',
+        default='runs/datasets/llm_decoder_eval_tiny_v1/manifest.json',
+        help='Dataset manifest to validate.',
+    )
+    parser.add_argument('--out', help='Optional JSON path for validation summary and comparison metrics.')
+    args = parser.parse_args()
+
+    result = validate_decoder_contract(args.dataset_manifest)
+    text = json.dumps(result, indent=2, sort_keys=True) + '\n'
+    if args.out:
+        Path(args.out).write_text(text, encoding='utf-8')
+    if not result['ok']:
+        print(text, file=sys.stderr, end='')
+        return 1
+    print(text, end='')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/runs/datasets/llm_decoder_eval_tiny_v1/README.md
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/README.md
@@ -18,6 +18,8 @@ What exists now:
 - `samples.jsonl`
 - `reference_manifest.json`
 - `candidate_manifest.json`
+- `npu/eval/llm_decoder_contract.schema.json`
+- `npu/eval/validate_llm_decoder_contract.py`
 - fetched GPT-2-family tokenizer/model binding for reference artifacts
 - active ONNX exact-reference generation via `decoder_backend_v1` + `command_json_v1`
 - active ONNX candidate generation with configurable softmax and normalization modes
@@ -40,3 +42,4 @@ The reference side is a real ONNX Runtime exact-reference path. The candidate si
 Comparison
 ----------
 - reference vs candidate summary: `python3 npu/eval/compare_llm_decoder_quality.py --reference-manifest runs/datasets/llm_decoder_eval_tiny_v1/reference_manifest.json --candidate-manifest runs/datasets/llm_decoder_eval_tiny_v1/candidate_manifest.json`
+- contract validation: `python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json`

--- a/tests/test_llm_decoder_compare.py
+++ b/tests/test_llm_decoder_compare.py
@@ -33,8 +33,8 @@ class LlmDecoderCompareRegressionTest(unittest.TestCase):
             cand_b = td_path / 'cand_b.json'
             ref_a.write_text(json.dumps({'sample_id': 'a', 'reference': {'next_token_id': 1, 'next_token_text': ' A'}}), encoding='utf-8')
             ref_b.write_text(json.dumps({'sample_id': 'b', 'reference': {'next_token_id': 2, 'next_token_text': ' B'}}), encoding='utf-8')
-            cand_a.write_text(json.dumps({'sample_id': 'a', 'candidate': {'next_token_id': 1, 'next_token_text': ' A'}}), encoding='utf-8')
-            cand_b.write_text(json.dumps({'sample_id': 'b', 'candidate': {'next_token_id': 3, 'next_token_text': ' C'}}), encoding='utf-8')
+            cand_a.write_text(json.dumps({'sample_id': 'a', 'candidate': {'next_token_id': 1, 'next_token_text': ' A', 'topk': [{'token_id': 1, 'token_text': ' A'}]}}), encoding='utf-8')
+            cand_b.write_text(json.dumps({'sample_id': 'b', 'candidate': {'next_token_id': 3, 'next_token_text': ' C', 'topk': [{'token_id': 2, 'token_text': ' B'}]}}), encoding='utf-8')
             ref_manifest = {
                 'dataset_id': 'llm_decoder_eval_tiny_v1',
                 'task': 'greedy_next_token',
@@ -58,6 +58,10 @@ class LlmDecoderCompareRegressionTest(unittest.TestCase):
             self.assertEqual(1, metrics['aggregate']['next_token_text_match_count'])
             self.assertEqual(0.5, metrics['aggregate']['next_token_id_match_rate'])
             self.assertEqual(0.5, metrics['aggregate']['next_token_text_match_rate'])
+            self.assertEqual(2, metrics['aggregate']['topk_contains_reference_id_count'])
+            self.assertEqual(2, metrics['aggregate']['topk_contains_reference_text_count'])
+            self.assertEqual(1.0, metrics['aggregate']['topk_contains_reference_id_rate'])
+            self.assertEqual(1.0, metrics['aggregate']['topk_contains_reference_text_rate'])
 
     def test_compare_decoder_manifests_reports_selected_tensor_trace_drift(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_llm_decoder_contract.py
+++ b/tests/test_llm_decoder_contract.py
@@ -1,0 +1,71 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(name: str, rel_path: str):
+    path = REPO_ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class LlmDecoderContractRegressionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.validator = _load_module('llm_decoder_contract_validator_test', 'npu/eval/validate_llm_decoder_contract.py')
+
+    def test_decoder_contract_schema_declares_required_artifact_shapes(self):
+        schema_path = REPO_ROOT / 'npu/eval/llm_decoder_contract.schema.json'
+        schema = json.loads(schema_path.read_text(encoding='utf-8'))
+        defs = schema['$defs']
+        self.assertIn('prompt_sample', defs)
+        self.assertIn('dataset_manifest', defs)
+        self.assertIn('reference_artifact', defs)
+        self.assertIn('candidate_artifact', defs)
+        self.assertIn('metrics_report', defs)
+        metrics_required = defs['metrics_report']['properties']['aggregate']['required']
+        self.assertIn('next_token_id_match_rate', metrics_required)
+        self.assertIn('topk_contains_reference_id_rate', metrics_required)
+        self.assertIn('selected_tensor_trace', metrics_required)
+
+    def test_checked_in_tiny_decoder_contract_validates(self):
+        result = self.validator.validate_decoder_contract(
+            'runs/datasets/llm_decoder_eval_tiny_v1/manifest.json'
+        )
+        self.assertTrue(result['ok'], result['errors'])
+        self.assertEqual('llm_decoder_eval_tiny_v1', result['dataset_id'])
+        self.assertEqual(5, result['sample_count'])
+        aggregate = result['metrics']['aggregate']
+        self.assertEqual(5, aggregate['sample_count'])
+        self.assertIn('topk_contains_reference_id_rate', aggregate)
+        self.assertIn('selected_tensor_trace', aggregate)
+
+    def test_validator_cli_writes_metrics_summary(self):
+        with tempfile.TemporaryDirectory() as td:
+            out_path = Path(td) / 'decoder_contract_validation.json'
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / 'npu/eval/validate_llm_decoder_contract.py'),
+                    '--dataset-manifest',
+                    'runs/datasets/llm_decoder_eval_tiny_v1/manifest.json',
+                    '--out',
+                    str(out_path),
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+            doc = json.loads(out_path.read_text(encoding='utf-8'))
+            self.assertTrue(doc['ok'], doc['errors'])
+            self.assertEqual(5, doc['metrics']['aggregate']['sample_count'])


### PR DESCRIPTION
## Summary
- add a machine-readable tiny LLM decoder accuracy-stage contract schema
- add a validator for prompt samples, reference/candidate manifests, SHA256 linkage, artifact shapes, tensor traces, and metrics
- report candidate top-k containment rates alongside next-token exact-match rates
- make ONNX decoder runners report missing model paths before requiring onnxruntime
- update decoder accuracy docs/backlog status

## Validation
- python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json
- python3 -m py_compile npu/eval/validate_llm_decoder_contract.py npu/eval/compare_llm_decoder_quality.py npu/eval/llm_decoder_quality.py npu/eval/run_llm_decoder_onnx_reference.py npu/eval/run_llm_decoder_onnx_candidate.py
- python3 -m unittest tests.test_llm_decoder_quality tests.test_llm_decoder_onnx_runner tests.test_llm_decoder_onnx_candidate_runner tests.test_llm_decoder_compare tests.test_llm_decoder_contract