### PR TITLE
npu/eval: switch decoder candidate to exact probability path

### DIFF
--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/README.md
@@ -1,0 +1,7 @@
+# LLM Decoder Exact Probability Path
+
+Proposal workspace for `prop_l2_decoder_exact_probability_path_v1`.
+
+This proposal turns the active tiny decoder candidate into an exact softmax plus
+exact normalization path so later approximation sweeps have a quality-preserving
+candidate reference.

--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/analysis_report.md
@@ -1,0 +1,25 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_exact_probability_path_v1`
+- `candidate_id`: `l2_decoder_exact_probability_path_v1`
+
+## Evaluations Consumed
+- local regenerated candidate artifacts only; evaluator item pending
+
+## Baseline Comparison
+- baseline: `l2_decoder_contract_eval_confirm_v1`
+- prior exact/top-k rates: `0.8`
+- local exact probability-path exact/top-k rates: `1.0`
+
+## Result
+- local win; evaluator confirmation pending
+
+## Failures and Caveats
+- exact probability math is a quality-preserving reference candidate, not a
+  hardware approximation acceptance
+- selected tensor trace hashes remain intentionally different because candidate
+  selected tensors are still quantized for inspection
+
+## Recommendation
+- submit paired evaluator item before promotion

--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/design_brief.md
@@ -1,0 +1,54 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_exact_probability_path_v1`
+- `title`: `LLM decoder exact probability-path candidate`
+
+## Problem
+- the evaluator-confirmed decoder gate currently records a valid but imperfect
+  active candidate: 4/5 next-token exact matches and 4/5 top-k containment
+- the miss happens before the repo has a stable quality-preserving candidate
+  reference for later approximation sweeps
+
+## Hypothesis
+- switching only the active candidate probability path from q4 PWL softmax plus
+  quantized reciprocal normalization to exact softmax plus exact normalization
+  should recover the token-quality miss while preserving the existing model,
+  tokenizer, selected tensor trace, and missing-model failure contracts
+
+## Evaluation Scope
+- direct comparison set:
+  - prior evaluator-confirmed q4 PWL candidate evidence from
+    `l2_decoder_contract_eval_confirm_v1`
+  - regenerated exact probability-path candidate artifacts for
+    `llm_decoder_eval_tiny_v1`
+- evaluation modes:
+  - first remote item should be `paired_comparison`
+  - expected result is `better_than_historical` against the 0.8 exact/top-k
+    rates from the prior candidate
+- dependency order:
+  - depends on `l2_decoder_contract_eval_confirm_v1` being merged and
+    materialized
+- excluded first-stage comparisons:
+  - no claim that the exact path is a final hardware approximation
+  - no model, tokenizer, or prompt-set change
+- follow-on broad sweep:
+  - reintroduce approximation knobs one at a time after this exact path is
+    established as the active quality reference
+
+## Knowledge Inputs
+- `docs/architecture/llm_decoder_accuracy_stage_v1.md`
+- `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_compare__l2_decoder_contract_eval_confirm_v1.json`
+- `runs/models/llm_decoder_tiny_v1/model_contract.json`
+
+## Candidate Direction
+- update the active candidate backend to use:
+  - `softmax_mode: exact`
+  - `normalization_mode: exact`
+  - same ONNX model, tokenizer, top-k setting, and selected tensor trace list
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-04-28T07:29:55Z
+- note: bounded quality-reference candidate for the ordinary decoder workflow

--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-04-28T07:29:55Z
+- allowed_evaluations:
+  - paired decoder-quality comparison against `l2_decoder_contract_eval_confirm_v1`
+- note: run after the exact probability-path candidate artifacts validate locally

--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/evaluation_requests.json
@@ -1,0 +1,22 @@
+{
+  "proposal_id": "prop_l2_decoder_exact_probability_path_v1",
+  "source_commit": "pending_merge_commit",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_exact_probability_path_v1",
+      "task_type": "l2_campaign",
+      "objective": "decoder_quality",
+      "evaluation_mode": "paired_comparison",
+      "abstraction_layer": "decoder_probability_path",
+      "comparison_role": "candidate",
+      "paired_baseline_item_id": "l2_decoder_contract_eval_confirm_v1",
+      "expected_direction": "better_than_historical",
+      "expected_reason": "Exact softmax plus exact normalization should improve over the prior 0.8 exact/top-k rates without changing the model or tokenizer contract.",
+      "depends_on_item_ids": [
+        "l2_decoder_contract_eval_confirm_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/implementation_summary.md
@@ -1,0 +1,41 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_exact_probability_path_v1`
+- exact probability-path candidate
+
+## Scope
+- switch the active decoder candidate backend to exact softmax and exact
+  normalization
+- regenerate candidate artifacts for `llm_decoder_eval_tiny_v1`
+- preserve the ONNX model, tokenizer, prompt set, top-k setting, and selected
+  tensor trace list
+
+## Files Changed
+- `runs/datasets/llm_decoder_eval_tiny_v1/manifest.json`
+- `runs/datasets/llm_decoder_eval_tiny_v1/candidate_manifest.json`
+- `runs/datasets/llm_decoder_eval_tiny_v1/candidate/*.json`
+- `runs/models/llm_decoder_tiny_v1/model_contract.json`
+- `docs/proposals/prop_l2_decoder_exact_probability_path_v1/*`
+
+## Local Validation
+- `python3 npu/eval/gen_llm_decoder_candidate_suite.py`
+- `python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json --out /tmp/decoder_exact_contract.json`
+- `python3 npu/eval/compare_llm_decoder_quality.py --reference-manifest runs/datasets/llm_decoder_eval_tiny_v1/reference_manifest.json --candidate-manifest runs/datasets/llm_decoder_eval_tiny_v1/candidate_manifest.json --out /tmp/decoder_exact_quality.json`
+- `python3 -m unittest tests.test_llm_decoder_quality tests.test_llm_decoder_onnx_runner tests.test_llm_decoder_onnx_candidate_runner tests.test_llm_decoder_compare tests.test_llm_decoder_contract`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+
+Result:
+- decoder contract: `ok=true`
+- sample count: `5`
+- next-token exact-match rate: `1.0`
+- top-k containment rate: `1.0`
+- selected tensor shape-match rate: `1.0`
+
+## Evaluation Request
+- request `l2_decoder_exact_probability_path_v1`
+- paired comparison against `l2_decoder_contract_eval_confirm_v1`
+
+## Risks
+- this candidate improves quality by using exact probability math; it is a
+  quality-preserving reference point, not a final hardware approximation

--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l2_decoder_exact_probability_path_v1",
+  "candidate_id": "l2_decoder_exact_probability_path_v1",
+  "decision": "pending",
+  "reason": "Awaiting evaluator evidence.",
+  "evidence_refs": [],
+  "next_action": "Run paired decoder-quality evaluation through the control-plane evaluator.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_exact_probability_path_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/proposal.json
@@ -1,0 +1,64 @@
+{
+  "proposal_id": "prop_l2_decoder_exact_probability_path_v1",
+  "created_utc": "2026-04-28T07:29:55Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "LLM decoder exact probability-path candidate",
+  "hypothesis": "Using exact softmax and exact normalization for the first active decoder candidate should recover the tiny decoder next-token and top-k containment misses while preserving the same ONNX model, tokenizer, selected-tensor trace contract, and missing-model failure behavior.",
+  "direct_comparison": {
+    "primary_question": "Does the exact probability-path candidate improve the llm_decoder_eval_tiny_v1 token-quality gate relative to the prior q4 PWL softmax plus quantized reciprocal candidate?",
+    "include": [
+      "llm_decoder_eval_tiny_v1 reference and candidate manifests",
+      "next-token exact-match and top-k containment rates",
+      "selected tensor shape/missing-tensor checks",
+      "missing ONNX model path failure check"
+    ],
+    "exclude": [
+      "claiming a hardware approximation is accepted",
+      "changing the tokenizer, prompt set, ONNX model, or selected tensor trace list",
+      "full NPU campaign PPA conclusions"
+    ],
+    "follow_on_broad_sweep": [
+      "reintroduce bounded approximation knobs only after the exact probability path is established as the quality-preserving candidate reference"
+    ]
+  },
+  "expected_benefit": [
+    "raise decoder next-token exact-match and top-k containment above the previous 0.8 rates",
+    "preserve tensor-shape contract coverage for all selected present.* tensors",
+    "keep the active candidate backend suitable as a reference point for later approximation sweeps"
+  ],
+  "risks": [
+    "exact probability math is not itself a hardware approximation win",
+    "the tiny prompt set is too small to prove broader language-model quality",
+    "selected tensor hashes remain intentionally different because candidate traces are still quantized for inspection"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "paired_comparison",
+      "abstraction_layer": "decoder_probability_path",
+      "objective": "decoder_quality",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_contract_eval_confirm_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "better_than_historical",
+        "reason": "The prior evaluator-confirmed q4 PWL/reciprocal candidate recorded 0.8 next-token exact-match and top-k containment; exact softmax plus exact normalization should recover the missed prompt without changing the model or tokenizer contract."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/review/l2_decoder_contract_eval_confirm_v1/review_package.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_compare__l2_decoder_contract_eval_confirm_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llm_decoder_accuracy_stage_v1.md",
+    "npu/eval/README.md",
+    "runs/models/llm_decoder_tiny_v1/model_contract.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_exact_probability_path_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_exact_probability_path_v1/quality_gate.md
@@ -1,0 +1,32 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_exact_probability_path_v1`
+- `title`: `LLM decoder exact probability-path candidate`
+
+## Why This Gate Is Required
+- this proposal changes the active decoder candidate semantics and therefore
+  must prove token-quality behavior rather than only structural validity
+
+## Reference
+- baseline_ref: `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_compare__l2_decoder_contract_eval_confirm_v1.json`
+- reference_ref: `runs/datasets/llm_decoder_eval_tiny_v1/reference_manifest.json`
+
+## Checks
+- metric: `next_token_id_match_rate`
+  - threshold: `> 0.8`
+- metric: `topk_contains_reference_id_rate`
+  - threshold: `> 0.8`
+- metric: `selected_tensor_trace.shape_match_rate`
+  - threshold: `1.0`
+- metric: `missing_model_check.ok`
+  - threshold: `true`
+
+## Local Commands
+- command: `python3 npu/eval/gen_llm_decoder_candidate_suite.py`
+- command: `python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json`
+- command: `python3 npu/eval/compare_llm_decoder_quality.py --reference-manifest runs/datasets/llm_decoder_eval_tiny_v1/reference_manifest.json --candidate-manifest runs/datasets/llm_decoder_eval_tiny_v1/candidate_manifest.json`
+
+## Result
+- status: local_pass
+- note: local regenerated candidate artifacts reach `1.0` next-token exact-match and top-k containment, with selected tensor shape-match rate still `1.0`; evaluator evidence is still required before promotion.

--- a/runs/datasets/llm_decoder_eval_tiny_v1/candidate/color_banana.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/candidate/color_banana.json
@@ -1,7 +1,7 @@
 {
   "backend": {
     "backend_id": "command_json_v1",
-    "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+    "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
     "command": [
       "/workspaces/RTLGen/control_plane/.venv/bin/python",
       "/workspaces/RTLGen/npu/eval/run_llm_decoder_onnx_candidate.py"
@@ -11,16 +11,13 @@
     "input_name": "input_ids",
     "interface": "decoder_backend_v1",
     "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
-    "normalization_mode": "reciprocal_quantized",
-    "normalization_reciprocal_bits": 10,
+    "normalization_mode": "exact",
     "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
     "output_name": "logits",
     "request_schema": "decoder_backend_command_v1",
     "role": "candidate",
     "runtime_target": "software_emulation",
-    "softmax_input_quant_bits": 4,
-    "softmax_mode": "approx_pwl",
-    "softmax_weight_quant_bits": 4,
+    "softmax_mode": "exact",
     "timeout_s": 30.0,
     "topk": 5,
     "trace_output_patterns": [
@@ -43,42 +40,16 @@
         "mode": "identity_logits"
       },
       "normalization": {
-        "exponent": -14,
-        "mantissa": 0.7293144278192604,
-        "mantissa_quantized": 0.729227761485826,
-        "mode": "normalize_reciprocal_quantized",
-        "reciprocal": 4.4513820057327903e-05,
-        "reciprocal_bits": 10,
-        "reciprocal_quantized": 4.450853036412512e-05,
-        "sum_weights": 22464.93333333631
+        "mode": "normalize_exact",
+        "sum_weights": 14164.30519656722
       },
       "probabilities": {
         "mode": "identity_probabilities"
       },
       "softmax": {
-        "anchors": [
-          -8.0,
-          -4.0,
-          -2.0,
-          0.0
-        ],
-        "input_quant": {
-          "bits": 4,
-          "levels": 7,
-          "max_abs": 2.1805217266082764,
-          "mode": "softmax_input_quant",
-          "scale": 0.31150310380118235
-        },
         "max_logit": 1.2921810150146484,
-        "mode": "softmax_approx_pwl",
-        "shifted_min": -2.1805217266082764,
-        "weight_quant": {
-          "bits": 4,
-          "levels": 15,
-          "max_value": 1.0,
-          "mode": "softmax_weight_quant",
-          "scale": 0.06666666666666667
-        }
+        "mode": "softmax_exact",
+        "shifted_min": -2.1805217266082764
       }
     },
     "library": "onnxruntime",
@@ -88,7 +59,7 @@
     "score_rank": 1
   },
   "candidate": {
-    "confidence": 4.450853036412512e-05,
+    "confidence": 7.06000037504384e-05,
     "next_token_id": 3221,
     "next_token_text": " usually",
     "selected_tensors": [
@@ -184,33 +155,33 @@
     "selected_tensors_sha256": "96ea7ab13e05b2f1aba8a1d39e52f86f6aab3f9cc373c76ae10d4efd2e072c20",
     "topk": [
       {
-        "score": 4.450853036412512e-05,
+        "score": 7.06000037504384e-05,
         "token_id": 3221,
         "token_text": " usually"
       },
       {
-        "score": 3.2639588933691755e-05,
-        "token_id": 25,
-        "token_text": ":"
+        "score": 4.3903120988729204e-05,
+        "token_id": 22851,
+        "token_text": "Starting"
       },
       {
-        "score": 3.2639588933691755e-05,
-        "token_id": 93,
-        "token_text": "~"
+        "score": 4.337091471875266e-05,
+        "token_id": 25339,
+        "token_text": " Grab"
       },
       {
-        "score": 3.2639588933691755e-05,
-        "token_id": 135,
-        "token_text": "\ufffd"
+        "score": 4.328972793231658e-05,
+        "token_id": 40170,
+        "token_text": " spraying"
       },
       {
-        "score": 3.2639588933691755e-05,
-        "token_id": 174,
-        "token_text": "\ufffd"
+        "score": 4.3125959194828916e-05,
+        "token_id": 49224,
+        "token_text": "hiba"
       }
     ]
   },
-  "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+  "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
   "dataset_id": "llm_decoder_eval_tiny_v1",
   "dataset_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/manifest.json",
   "decode_policy": {

--- a/runs/datasets/llm_decoder_eval_tiny_v1/candidate/geo_france_capital.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/candidate/geo_france_capital.json
@@ -1,7 +1,7 @@
 {
   "backend": {
     "backend_id": "command_json_v1",
-    "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+    "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
     "command": [
       "/workspaces/RTLGen/control_plane/.venv/bin/python",
       "/workspaces/RTLGen/npu/eval/run_llm_decoder_onnx_candidate.py"
@@ -11,16 +11,13 @@
     "input_name": "input_ids",
     "interface": "decoder_backend_v1",
     "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
-    "normalization_mode": "reciprocal_quantized",
-    "normalization_reciprocal_bits": 10,
+    "normalization_mode": "exact",
     "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
     "output_name": "logits",
     "request_schema": "decoder_backend_command_v1",
     "role": "candidate",
     "runtime_target": "software_emulation",
-    "softmax_input_quant_bits": 4,
-    "softmax_mode": "approx_pwl",
-    "softmax_weight_quant_bits": 4,
+    "softmax_mode": "exact",
     "timeout_s": 30.0,
     "topk": 5,
     "trace_output_patterns": [
@@ -43,42 +40,16 @@
         "mode": "identity_logits"
       },
       "normalization": {
-        "exponent": -14,
-        "mantissa": 0.7136054263745335,
-        "mantissa_quantized": 0.7135874877810362,
-        "mode": "normalize_reciprocal_quantized",
-        "reciprocal": 4.355501869961752e-05,
-        "reciprocal_bits": 10,
-        "reciprocal_quantized": 4.355392381476051e-05,
-        "sum_weights": 22959.46666666869
+        "mode": "normalize_exact",
+        "sum_weights": 15151.503728612011
       },
       "probabilities": {
         "mode": "identity_probabilities"
       },
       "softmax": {
-        "anchors": [
-          -8.0,
-          -4.0,
-          -2.0,
-          0.0
-        ],
-        "input_quant": {
-          "bits": 4,
-          "levels": 7,
-          "max_abs": 2.1048333644866943,
-          "mode": "softmax_input_quant",
-          "scale": 0.3006904806409563
-        },
         "max_logit": 1.225936770439148,
-        "mode": "softmax_approx_pwl",
-        "shifted_min": -2.1048333644866943,
-        "weight_quant": {
-          "bits": 4,
-          "levels": 15,
-          "max_value": 1.0,
-          "mode": "softmax_weight_quant",
-          "scale": 0.06666666666666667
-        }
+        "mode": "softmax_exact",
+        "shifted_min": -2.1048333644866943
       }
     },
     "library": "onnxruntime",
@@ -88,7 +59,7 @@
     "score_rank": 1
   },
   "candidate": {
-    "confidence": 4.355392381476051e-05,
+    "confidence": 6.60000497582036e-05,
     "next_token_id": 318,
     "next_token_text": " is",
     "selected_tensors": [
@@ -184,33 +155,33 @@
     "selected_tensors_sha256": "8ea01014a98f2362e44fc496e72c7e76a3dcff871626433b0d705091f4a221f4",
     "topk": [
       {
-        "score": 4.355392381476051e-05,
+        "score": 6.60000497582036e-05,
         "token_id": 318,
         "token_text": " is"
       },
       {
-        "score": 3.774673397279244e-05,
-        "token_id": 4813,
-        "token_text": " girls"
+        "score": 5.02692060706975e-05,
+        "token_id": 26015,
+        "token_text": " southeast"
       },
       {
-        "score": 3.774673397279244e-05,
-        "token_id": 5127,
-        "token_text": " supply"
+        "score": 4.9358157871579054e-05,
+        "token_id": 27339,
+        "token_text": "ensible"
       },
       {
-        "score": 3.774673397279244e-05,
-        "token_id": 9226,
-        "token_text": "aval"
+        "score": 4.838138141667124e-05,
+        "token_id": 28136,
+        "token_text": " unleashed"
       },
       {
-        "score": 3.774673397279244e-05,
-        "token_id": 18015,
-        "token_text": "je"
+        "score": 4.730830634994207e-05,
+        "token_id": 35835,
+        "token_text": " Insert"
       }
     ]
   },
-  "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+  "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
   "dataset_id": "llm_decoder_eval_tiny_v1",
   "dataset_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/manifest.json",
   "decode_policy": {

--- a/runs/datasets/llm_decoder_eval_tiny_v1/candidate/math_two_plus_two.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/candidate/math_two_plus_two.json
@@ -1,7 +1,7 @@
 {
   "backend": {
     "backend_id": "command_json_v1",
-    "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+    "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
     "command": [
       "/workspaces/RTLGen/control_plane/.venv/bin/python",
       "/workspaces/RTLGen/npu/eval/run_llm_decoder_onnx_candidate.py"
@@ -11,16 +11,13 @@
     "input_name": "input_ids",
     "interface": "decoder_backend_v1",
     "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
-    "normalization_mode": "reciprocal_quantized",
-    "normalization_reciprocal_bits": 10,
+    "normalization_mode": "exact",
     "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
     "output_name": "logits",
     "request_schema": "decoder_backend_command_v1",
     "role": "candidate",
     "runtime_target": "software_emulation",
-    "softmax_input_quant_bits": 4,
-    "softmax_mode": "approx_pwl",
-    "softmax_weight_quant_bits": 4,
+    "softmax_mode": "exact",
     "timeout_s": 30.0,
     "topk": 5,
     "trace_output_patterns": [
@@ -43,42 +40,16 @@
         "mode": "identity_logits"
       },
       "normalization": {
-        "exponent": -14,
-        "mantissa": 0.5346734980256334,
-        "mantissa_quantized": 0.5347018572825024,
-        "mode": "normalize_reciprocal_quantized",
-        "reciprocal": 3.26338804947286e-05,
-        "reciprocal_bits": 10,
-        "reciprocal_quantized": 3.2635611406402735e-05,
-        "sum_weights": 30643.000000000964
+        "mode": "normalize_exact",
+        "sum_weights": 20762.866109172992
       },
       "probabilities": {
         "mode": "identity_probabilities"
       },
       "softmax": {
-        "anchors": [
-          -8.0,
-          -4.0,
-          -2.0,
-          0.0
-        ],
-        "input_quant": {
-          "bits": 4,
-          "levels": 7,
-          "max_abs": 1.8285884261131287,
-          "mode": "softmax_input_quant",
-          "scale": 0.2612269180161612
-        },
         "max_logit": 0.9097363948822021,
-        "mode": "softmax_approx_pwl",
-        "shifted_min": -1.8285884261131287,
-        "weight_quant": {
-          "bits": 4,
-          "levels": 15,
-          "max_value": 1.0,
-          "mode": "softmax_weight_quant",
-          "scale": 0.06666666666666667
-        }
+        "mode": "softmax_exact",
+        "shifted_min": -1.8285884261131287
       }
     },
     "library": "onnxruntime",
@@ -88,9 +59,9 @@
     "score_rank": 1
   },
   "candidate": {
-    "confidence": 3.2635611406402735e-05,
-    "next_token_id": 796,
-    "next_token_text": " =",
+    "confidence": 4.8162907507177056e-05,
+    "next_token_id": 17673,
+    "next_token_text": " indigenous",
     "selected_tensors": [
       {
         "dtype": "float32",
@@ -184,33 +155,33 @@
     "selected_tensors_sha256": "af626710544fcf9e11b150ff4202a9603a6ba4d15f73c68497c144611bf7490c",
     "topk": [
       {
-        "score": 3.2635611406402735e-05,
-        "token_id": 796,
-        "token_text": " ="
+        "score": 4.8162907507177056e-05,
+        "token_id": 17673,
+        "token_text": " indigenous"
       },
       {
-        "score": 3.2635611406402735e-05,
-        "token_id": 4915,
-        "token_text": " amb"
+        "score": 4.7337269463737156e-05,
+        "token_id": 42919,
+        "token_text": " pamphlet"
       },
       {
-        "score": 3.2635611406402735e-05,
+        "score": 4.664407421670924e-05,
+        "token_id": 29570,
+        "token_text": " pioneer"
+      },
+      {
+        "score": 4.603049012387999e-05,
         "token_id": 5424,
         "token_text": " clim"
       },
       {
-        "score": 3.2635611406402735e-05,
-        "token_id": 6399,
-        "token_text": " subsequ"
-      },
-      {
-        "score": 3.2635611406402735e-05,
-        "token_id": 6883,
-        "token_text": "phy"
+        "score": 4.5233059387412494e-05,
+        "token_id": 796,
+        "token_text": " ="
       }
     ]
   },
-  "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+  "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
   "dataset_id": "llm_decoder_eval_tiny_v1",
   "dataset_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/manifest.json",
   "decode_policy": {

--- a/runs/datasets/llm_decoder_eval_tiny_v1/candidate/quote_complete.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/candidate/quote_complete.json
@@ -1,7 +1,7 @@
 {
   "backend": {
     "backend_id": "command_json_v1",
-    "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+    "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
     "command": [
       "/workspaces/RTLGen/control_plane/.venv/bin/python",
       "/workspaces/RTLGen/npu/eval/run_llm_decoder_onnx_candidate.py"
@@ -11,16 +11,13 @@
     "input_name": "input_ids",
     "interface": "decoder_backend_v1",
     "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
-    "normalization_mode": "reciprocal_quantized",
-    "normalization_reciprocal_bits": 10,
+    "normalization_mode": "exact",
     "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
     "output_name": "logits",
     "request_schema": "decoder_backend_command_v1",
     "role": "candidate",
     "runtime_target": "software_emulation",
-    "softmax_input_quant_bits": 4,
-    "softmax_mode": "approx_pwl",
-    "softmax_weight_quant_bits": 4,
+    "softmax_mode": "exact",
     "timeout_s": 30.0,
     "topk": 5,
     "trace_output_patterns": [
@@ -43,42 +40,16 @@
         "mode": "identity_logits"
       },
       "normalization": {
-        "exponent": -14,
-        "mantissa": 0.8704953917868966,
-        "mantissa_quantized": 0.8709677419354839,
-        "mode": "normalize_reciprocal_quantized",
-        "reciprocal": 5.31308222526182e-05,
-        "reciprocal_bits": 10,
-        "reciprocal_quantized": 5.3159652217741936e-05,
-        "sum_weights": 18821.466666662054
+        "mode": "normalize_exact",
+        "sum_weights": 12628.340811368442
       },
       "probabilities": {
         "mode": "identity_probabilities"
       },
       "softmax": {
-        "anchors": [
-          -8.0,
-          -4.0,
-          -2.0,
-          0.0
-        ],
-        "input_quant": {
-          "bits": 4,
-          "levels": 7,
-          "max_abs": 2.348286986351013,
-          "mode": "softmax_input_quant",
-          "scale": 0.33546956947871615
-        },
         "max_logit": 1.4084631204605103,
-        "mode": "softmax_approx_pwl",
-        "shifted_min": -2.348286986351013,
-        "weight_quant": {
-          "bits": 4,
-          "levels": 15,
-          "max_value": 1.0,
-          "mode": "softmax_weight_quant",
-          "scale": 0.06666666666666667
-        }
+        "mode": "softmax_exact",
+        "shifted_min": -2.348286986351013
       }
     },
     "library": "onnxruntime",
@@ -88,7 +59,7 @@
     "score_rank": 1
   },
   "candidate": {
-    "confidence": 5.3159652217741936e-05,
+    "confidence": 7.918696643820126e-05,
     "next_token_id": 262,
     "next_token_text": " the",
     "selected_tensors": [
@@ -184,33 +155,33 @@
     "selected_tensors_sha256": "efa7cfd398ac84eca7c276f7d352568c6fd5fad8afe46368d0c6933b6e105ea4",
     "topk": [
       {
-        "score": 5.3159652217741936e-05,
+        "score": 7.918696643820126e-05,
         "token_id": 262,
         "token_text": " the"
       },
       {
-        "score": 4.607169858870968e-05,
+        "score": 5.082516510306384e-05,
         "token_id": 17439,
         "token_text": "Frank"
       },
       {
-        "score": 4.607169858870968e-05,
+        "score": 4.969478084822274e-05,
         "token_id": 35393,
         "token_text": "Norm"
       },
       {
-        "score": 3.898374495967742e-05,
-        "token_id": 119,
-        "token_text": "\ufffd"
+        "score": 4.533717059482821e-05,
+        "token_id": 26440,
+        "token_text": "prus"
       },
       {
-        "score": 3.898374495967742e-05,
-        "token_id": 223,
-        "token_text": "\ufffd"
+        "score": 4.471599764284134e-05,
+        "token_id": 8509,
+        "token_text": " bread"
       }
     ]
   },
-  "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+  "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
   "dataset_id": "llm_decoder_eval_tiny_v1",
   "dataset_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/manifest.json",
   "decode_policy": {

--- a/runs/datasets/llm_decoder_eval_tiny_v1/candidate/weekday_after_monday.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/candidate/weekday_after_monday.json
@@ -1,7 +1,7 @@
 {
   "backend": {
     "backend_id": "command_json_v1",
-    "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+    "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
     "command": [
       "/workspaces/RTLGen/control_plane/.venv/bin/python",
       "/workspaces/RTLGen/npu/eval/run_llm_decoder_onnx_candidate.py"
@@ -11,16 +11,13 @@
     "input_name": "input_ids",
     "interface": "decoder_backend_v1",
     "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
-    "normalization_mode": "reciprocal_quantized",
-    "normalization_reciprocal_bits": 10,
+    "normalization_mode": "exact",
     "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
     "output_name": "logits",
     "request_schema": "decoder_backend_command_v1",
     "role": "candidate",
     "runtime_target": "software_emulation",
-    "softmax_input_quant_bits": 4,
-    "softmax_mode": "approx_pwl",
-    "softmax_weight_quant_bits": 4,
+    "softmax_mode": "exact",
     "timeout_s": 30.0,
     "topk": 5,
     "trace_output_patterns": [
@@ -43,42 +40,16 @@
         "mode": "identity_logits"
       },
       "normalization": {
-        "exponent": -14,
-        "mantissa": 0.6719986875025515,
-        "mantissa_quantized": 0.6715542521994134,
-        "mode": "normalize_reciprocal_quantized",
-        "reciprocal": 4.1015544891513155e-05,
-        "reciprocal_bits": 10,
-        "reciprocal_quantized": 4.0988418713343106e-05,
-        "sum_weights": 24381.000000000433
+        "mode": "normalize_exact",
+        "sum_weights": 16086.268392429887
       },
       "probabilities": {
         "mode": "identity_probabilities"
       },
       "softmax": {
-        "anchors": [
-          -8.0,
-          -4.0,
-          -2.0,
-          0.0
-        ],
-        "input_quant": {
-          "bits": 4,
-          "levels": 7,
-          "max_abs": 2.112213373184204,
-          "mode": "softmax_input_quant",
-          "scale": 0.30174476759774344
-        },
         "max_logit": 1.1656006574630737,
-        "mode": "softmax_approx_pwl",
-        "shifted_min": -2.112213373184204,
-        "weight_quant": {
-          "bits": 4,
-          "levels": 15,
-          "max_value": 1.0,
-          "mode": "softmax_weight_quant",
-          "scale": 0.06666666666666667
-        }
+        "mode": "softmax_exact",
+        "shifted_min": -2.112213373184204
       }
     },
     "library": "onnxruntime",
@@ -88,7 +59,7 @@
     "score_rank": 1
   },
   "candidate": {
-    "confidence": 4.0988418713343106e-05,
+    "confidence": 6.21648213000471e-05,
     "next_token_id": 318,
     "next_token_text": " is",
     "selected_tensors": [
@@ -184,33 +155,33 @@
     "selected_tensors_sha256": "0f15ffbba0f403cbb57fac89d5fdc09a2cfa0b16a0159642b0ee66e9e2cd4747",
     "topk": [
       {
-        "score": 4.0988418713343106e-05,
+        "score": 6.21648213000471e-05,
         "token_id": 318,
         "token_text": " is"
       },
       {
-        "score": 3.5523296218230695e-05,
-        "token_id": 2983,
-        "token_text": "icles"
+        "score": 4.8279787781861584e-05,
+        "token_id": 26015,
+        "token_text": " southeast"
       },
       {
-        "score": 3.5523296218230695e-05,
-        "token_id": 3070,
-        "token_text": "03"
+        "score": 4.824544602359402e-05,
+        "token_id": 30503,
+        "token_text": " commercials"
       },
       {
-        "score": 3.5523296218230695e-05,
-        "token_id": 3892,
-        "token_text": " straight"
+        "score": 4.730963823040076e-05,
+        "token_id": 35835,
+        "token_text": " Insert"
       },
       {
-        "score": 3.5523296218230695e-05,
-        "token_id": 4031,
-        "token_text": " aim"
+        "score": 4.6555695072249896e-05,
+        "token_id": 28136,
+        "token_text": " unleashed"
       }
     ]
   },
-  "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+  "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
   "dataset_id": "llm_decoder_eval_tiny_v1",
   "dataset_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/manifest.json",
   "decode_policy": {

--- a/runs/datasets/llm_decoder_eval_tiny_v1/candidate_manifest.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/candidate_manifest.json
@@ -1,7 +1,7 @@
 {
   "backend_config": {
     "backend_id": "command_json_v1",
-    "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+    "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
     "command": [
       "/workspaces/RTLGen/control_plane/.venv/bin/python",
       "/workspaces/RTLGen/npu/eval/run_llm_decoder_onnx_candidate.py"
@@ -10,48 +10,45 @@
     "input_name": "input_ids",
     "interface": "decoder_backend_v1",
     "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
-    "normalization_mode": "reciprocal_quantized",
-    "normalization_reciprocal_bits": 10,
+    "normalization_mode": "exact",
     "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
     "output_name": "logits",
     "role": "candidate",
     "runtime_target": "software_emulation",
-    "softmax_input_quant_bits": 4,
-    "softmax_mode": "approx_pwl",
-    "softmax_weight_quant_bits": 4,
+    "softmax_mode": "exact",
     "topk": 5,
     "trace_output_patterns": [
       "present.*"
     ],
     "trace_tensor_quant_bits": 4
   },
-  "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+  "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
   "dataset_id": "llm_decoder_eval_tiny_v1",
   "model_contract": "runs/models/llm_decoder_tiny_v1/model_contract.json",
   "samples": [
     {
       "candidate_json": "runs/datasets/llm_decoder_eval_tiny_v1/candidate/geo_france_capital.json",
-      "candidate_sha256": "a804dc939cfc4d146bcf8a1de310983ae1ff3c2d52cdf5128bf7acfc69760ab8",
+      "candidate_sha256": "8b01a5a4af5d9b3ff249e4600f688a9b0e24f174c99145ed07a998f0dd911204",
       "sample_id": "geo_france_capital"
     },
     {
       "candidate_json": "runs/datasets/llm_decoder_eval_tiny_v1/candidate/math_two_plus_two.json",
-      "candidate_sha256": "7272143d45bbbeedc6d36e2ee4eb6fc7247c12fdd57531d7dd1c7f2fc1200eae",
+      "candidate_sha256": "540c33dfba262884e099029bdfb4f631bb6ec761a3a78a6c2f13641a90a00822",
       "sample_id": "math_two_plus_two"
     },
     {
       "candidate_json": "runs/datasets/llm_decoder_eval_tiny_v1/candidate/quote_complete.json",
-      "candidate_sha256": "43bd88c3a84d7401f35f27505feaf555ab943cdb555f5c7419b2481eec8eac07",
+      "candidate_sha256": "45210157e056c51228a7162f8da4cd27a09a2b2b9a1e7d49514768ffdead9634",
       "sample_id": "quote_complete"
     },
     {
       "candidate_json": "runs/datasets/llm_decoder_eval_tiny_v1/candidate/weekday_after_monday.json",
-      "candidate_sha256": "b271dbbfdc3eb935c37e4618dc5f74ef2ad2fc30dca2ad0f698299502a400411",
+      "candidate_sha256": "cb02e3e02f69c2184e9b14f3c43014ee3f2592c6681ca9ec3427773ea6037041",
       "sample_id": "weekday_after_monday"
     },
     {
       "candidate_json": "runs/datasets/llm_decoder_eval_tiny_v1/candidate/color_banana.json",
-      "candidate_sha256": "970a4cbfccf43449e18b177484450226df87d917f74093c90fbb01555ed138de",
+      "candidate_sha256": "61ebbd193f771f948d7919d099409acdb84b5b25da5ca0b8a54aa8b07ed44f5d",
       "sample_id": "color_banana"
     }
   ],

--- a/runs/datasets/llm_decoder_eval_tiny_v1/manifest.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/manifest.json
@@ -4,7 +4,7 @@
   "decoder_backend_configs": {
     "candidate": {
       "backend_id": "command_json_v1",
-      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+      "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
       "command": [
         "/workspaces/RTLGen/control_plane/.venv/bin/python",
         "/workspaces/RTLGen/npu/eval/run_llm_decoder_onnx_candidate.py"
@@ -12,15 +12,12 @@
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
       "input_name": "input_ids",
       "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
-      "normalization_mode": "reciprocal_quantized",
-      "normalization_reciprocal_bits": 10,
+      "normalization_mode": "exact",
       "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
       "output_name": "logits",
       "runtime_target": "software_emulation",
-      "softmax_mode": "approx_pwl",
+      "softmax_mode": "exact",
       "topk": 5,
-      "softmax_input_quant_bits": 4,
-      "softmax_weight_quant_bits": 4,
       "trace_output_patterns": [
         "present.*"
       ],
@@ -46,7 +43,7 @@
   },
   "decoder_backend_interface": "v1",
   "model_contract": "runs/models/llm_decoder_tiny_v1/model_contract.json",
-  "notes": "Tiny curated decoder-eval prompt set for the first inference-quality gate. Bound to the fetched GPT-2-family tokenizer assets, an active ONNX exact-reference path, and an approximation-aware ONNX candidate backend with explicit softmax and normalization-path controls.",
+  "notes": "Tiny curated decoder-eval prompt set for the first inference-quality gate. Bound to the fetched GPT-2-family tokenizer assets, an active ONNX exact-reference path, and an exact probability-path candidate backend that preserves the decoder contract while later approximation sweeps are evaluated.",
   "reference_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/reference_manifest.json",
   "sample_count": 5,
   "sample_file": "runs/datasets/llm_decoder_eval_tiny_v1/samples.jsonl",

--- a/runs/models/llm_decoder_tiny_v1/model_contract.json
+++ b/runs/models/llm_decoder_tiny_v1/model_contract.json
@@ -2,7 +2,7 @@
   "backend_configs": {
     "candidate": {
       "backend_id": "command_json_v1",
-      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
+      "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
       "command": [
         "/workspaces/RTLGen/control_plane/.venv/bin/python",
         "/workspaces/RTLGen/npu/eval/run_llm_decoder_onnx_candidate.py"
@@ -10,15 +10,12 @@
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
       "input_name": "input_ids",
       "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
-      "normalization_mode": "reciprocal_quantized",
-      "normalization_reciprocal_bits": 10,
+      "normalization_mode": "exact",
       "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
       "output_name": "logits",
       "runtime_target": "software_emulation",
-      "softmax_mode": "approx_pwl",
+      "softmax_mode": "exact",
       "topk": 5,
-      "softmax_input_quant_bits": 4,
-      "softmax_weight_quant_bits": 4,
       "trace_output_patterns": [
         "present.*"
       ],
@@ -109,7 +106,7 @@
   "exact_reference_binding": "runs/models/llm_decoder_tiny_v1/reference_onnx_binding.json",
   "execution_backend": "decoder_backend_v1",
   "model_id": "llm_decoder_tiny_v1",
-  "notes": "Decoder ONNX and GPT-2-family tokenizer assets are fetched, hashed, and validated against the local ONNX Runtime exact-reference runner. The candidate side now supports both exact softmax/normalization and approximation-aware softmax/normalization paths, with the active backend using PWL softmax plus quantized reciprocal normalization.",
+  "notes": "Decoder ONNX and GPT-2-family tokenizer assets are fetched, hashed, and validated against the local ONNX Runtime exact-reference runner. The candidate side supports both exact softmax/normalization and approximation-aware softmax/normalization paths; the active backend now uses exact softmax plus exact normalization as the quality-preserving reference candidate before narrower approximation sweeps are reintroduced.",
   "status": "exact_reference_active",
   "task": "greedy_next_token",
   "tokenizer_id": "llm_decoder_gpt2_bpe_stub_v1",


### PR DESCRIPTION
## Summary
- add proposal workspace for prop_l2_decoder_exact_probability_path_v1
- switch active llm_decoder_eval_tiny_v1 candidate from q4 PWL/reciprocal probability path to exact softmax plus exact normalization
- regenerate candidate artifacts and manifest hashes

## Local validation
- python3 npu/eval/gen_llm_decoder_candidate_suite.py
- python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json --out /tmp/decoder_exact_contract.json
- python3 npu/eval/compare_llm_decoder_quality.py --reference-manifest runs/datasets/llm_decoder_eval_tiny_v1/reference_manifest.json --candidate-manifest runs/datasets/llm_decoder_eval_tiny_v1/candidate_manifest.json --out /tmp/decoder_exact_quality.json
- python3 -m unittest tests.test_llm_decoder_quality tests.test_llm_decoder_onnx_runner tests.test_llm_decoder_onnx_candidate_runner tests.test_llm_decoder_compare tests.test_llm_decoder_contract
- python3 scripts/validate_runs.py --skip_eval_queue

## Result
- next-token exact-match: 5/5, rate 1.0
- top-k containment: 5/5, rate 1.0
- selected tensor shape-match: 20/20, rate 1.0