### PR TITLE
control_plane: attach decoder evidence in l2 generator

### DIFF
--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -130,10 +130,14 @@ def main(argv: list[str] | None = None) -> int:
     generate_l2_parser.add_argument("--proposal-id")
     generate_l2_parser.add_argument("--proposal-path")
     generate_l2_parser.add_argument("--evaluation-mode")
+    generate_l2_parser.add_argument("--abstraction-layer")
     generate_l2_parser.add_argument("--expected-direction")
     generate_l2_parser.add_argument("--expected-reason")
     generate_l2_parser.add_argument("--comparison-role")
     generate_l2_parser.add_argument("--paired-baseline-item-id")
+    generate_l2_parser.add_argument("--depends-on-item-id", action="append", default=[])
+    generate_l2_parser.add_argument("--requires-merged-inputs", action="store_true")
+    generate_l2_parser.add_argument("--requires-materialized-refs", action="store_true")
     generate_l2_parser.add_argument("--no-run-physical", action="store_true")
     generate_l2_parser.add_argument("--no-auto-dispatch", action="store_true")
     generate_l2_parser.add_argument("--dispatch-machine-key")
@@ -578,6 +582,7 @@ def main(argv: list[str] | None = None) -> int:
             ("--proposal-id", args.proposal_id),
             ("--proposal-path", args.proposal_path),
             ("--evaluation-mode", args.evaluation_mode),
+            ("--abstraction-layer", args.abstraction_layer),
             ("--expected-direction", args.expected_direction),
             ("--expected-reason", args.expected_reason),
             ("--comparison-role", args.comparison_role),
@@ -590,6 +595,12 @@ def main(argv: list[str] | None = None) -> int:
             argv2.append("--no-run-physical")
         if args.no_auto_dispatch:
             argv2.append("--no-auto-dispatch")
+        for item_id in args.depends_on_item_id or []:
+            argv2.extend(["--depends-on-item-id", str(item_id)])
+        if args.requires_merged_inputs:
+            argv2.append("--requires-merged-inputs")
+        if args.requires_materialized_refs:
+            argv2.append("--requires-materialized-refs")
         if args.dispatch_freshness_seconds is not None:
             argv2.extend(["--dispatch-freshness-seconds", str(args.dispatch_freshness_seconds)])
         return generate_l2_campaign_main(argv2)

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -415,6 +415,93 @@ def _build_expected_outputs(
     return _uniq(expected)
 
 
+def _decoder_probability_path_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    validation_out = f"{base}/decoder_contract_validation__{item_id}.json"
+    quality_out = f"{base}/decoder_quality_compare__{item_id}.json"
+    missing_model_check_out = f"{base}/missing_model_check__{item_id}.json"
+    missing_model_check_cmd = f"""python3 - <<'PY2'
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+out = Path('{missing_model_check_out}')
+out.parent.mkdir(parents=True, exist_ok=True)
+with tempfile.TemporaryDirectory() as td:
+    td_path = Path(td)
+    vocab_json = td_path / 'vocab.json'
+    model_config = td_path / 'config.json'
+    tokenizer_manifest = td_path / 'tokenizer_manifest.json'
+    vocab_json.write_text(json.dumps({{'tokens': ['The', ' capital', ' of', ' France', ' is', ' Paris']}}), encoding='utf-8')
+    model_config.write_text(json.dumps({{'n_layer': 2, 'n_head': 2, 'n_embd': 128}}), encoding='utf-8')
+    tokenizer_manifest.write_text(json.dumps({{
+        'tokenizer_id': 'llm_decoder_space_prefix_v1',
+        'kind': 'space_prefix_words',
+        'vocab_json': str(vocab_json),
+    }}), encoding='utf-8')
+    request = {{
+        'role': 'reference',
+        'backend_config': {{
+            'backend_id': 'command_json_v1',
+            'onnx_model_path': str(td_path / 'missing.onnx'),
+            'model_config_path': str(model_config),
+            'input_name': 'input_ids',
+        }},
+        'sample': {{
+            'sample_id': 'geo_france_capital',
+            'prompt': 'The capital of France is',
+            'expected_continuation': ' Paris',
+        }},
+        'paths': {{'tokenizer_manifest_path': str(tokenizer_manifest)}},
+    }}
+    proc = subprocess.run(
+        [sys.executable, 'npu/eval/run_llm_decoder_onnx_reference.py'],
+        input=json.dumps(request),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    result = {{
+        'ok': proc.returncode != 0 and 'NoSuchFile' in proc.stderr,
+        'returncode': proc.returncode,
+        'stderr_contains_NoSuchFile': 'NoSuchFile' in proc.stderr,
+        'stderr_tail': proc.stderr[-1000:],
+    }}
+    out.write_text(json.dumps(result, indent=2, sort_keys=True) + '\\n', encoding='utf-8')
+    if not result['ok']:
+        print(json.dumps(result, indent=2, sort_keys=True), file=sys.stderr)
+        raise SystemExit(1)
+PY2"""
+    return {
+        "inputs": {
+            "dataset_manifest": f"{base}/manifest.json",
+            "reference_manifest": f"{base}/reference_manifest.json",
+            "candidate_manifest": f"{base}/candidate_manifest.json",
+            "baseline_quality_out": f"{base}/decoder_quality_compare__l2_decoder_contract_eval_confirm_v1.json",
+            "validation_out": validation_out,
+            "quality_out": quality_out,
+            "missing_model_check_out": missing_model_check_out,
+        },
+        "commands": [
+            {
+                "name": "validate_decoder_contract",
+                "run": f"python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest {base}/manifest.json --out {validation_out}",
+            },
+            {
+                "name": "compare_decoder_quality",
+                "run": f"python3 npu/eval/compare_llm_decoder_quality.py --reference-manifest {base}/reference_manifest.json --candidate-manifest {base}/candidate_manifest.json --out {quality_out}",
+            },
+            {
+                "name": "check_decoder_missing_model_error",
+                "run": missing_model_check_cmd,
+            },
+        ],
+        "expected_outputs": [validation_out, quality_out, missing_model_check_out],
+    }
+
+
 def _with_fresh_outputs(*, campaign: dict[str, Any], item_id: str) -> dict[str, Any]:
     cloned = json.loads(json.dumps(campaign))
     outputs = dict(cloned.get("outputs") or {})
@@ -501,6 +588,20 @@ def _build_payload(
             "run": "python3 scripts/validate_runs.py --skip_eval_queue",
         }
     )
+    task_inputs: dict[str, Any] = {
+        **inputs,
+        "generated_campaign": {
+            "base_campaign_path": campaign_path,
+            "path": generated_campaign_path,
+            "clean_outputs": True,
+            "outputs": generated_outputs,
+        },
+    }
+    if str(abstraction_layer or "").strip() == "decoder_probability_path":
+        decoder_evidence = _decoder_probability_path_evidence(item_id=item_id)
+        commands = [*decoder_evidence["commands"], *commands]
+        expected_outputs = _uniq([*expected_outputs, *decoder_evidence["expected_outputs"]])
+        task_inputs["decoder_contract"] = decoder_evidence["inputs"]
 
     payload = {
         "version": 0.1,
@@ -516,15 +617,7 @@ def _build_payload(
         "task": {
             "objective": objective,
             "source_mode": "src_verilog",
-            "inputs": {
-                **inputs,
-                "generated_campaign": {
-                    "base_campaign_path": campaign_path,
-                    "path": generated_campaign_path,
-                    "clean_outputs": True,
-                    "outputs": generated_outputs,
-                },
-            },
+            "inputs": task_inputs,
             "commands": commands,
             "expected_outputs": expected_outputs,
             "acceptance": [

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -204,6 +204,72 @@ def test_generate_l2_campaign_task_creates_ready_work_item() -> None:
             assert "--run_physical" in payload["task"]["commands"][2]["run"]
 
 
+def test_generate_l2_campaign_task_adds_decoder_probability_path_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_exact_probability_path_v1",
+                    proposal_id="prop_l2_decoder_exact_probability_path_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_exact_probability_path_v1/proposal.json",
+                    evaluation_mode="paired_comparison",
+                    abstraction_layer="decoder_probability_path",
+                    expected_direction="better_than_historical",
+                    comparison_role="candidate",
+                    paired_baseline_item_id="l2_decoder_contract_eval_confirm_v1",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:3] == [
+                "validate_decoder_contract",
+                "compare_decoder_quality",
+                "check_decoder_missing_model_error",
+            ]
+            assert command_names == [
+                "validate_decoder_contract",
+                "compare_decoder_quality",
+                "check_decoder_missing_model_error",
+                "fetch_models",
+                "validate_campaign",
+                "run_campaign",
+                "report_campaign",
+                "validate_runs",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs == {
+                "dataset_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/manifest.json",
+                "reference_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/reference_manifest.json",
+                "candidate_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/candidate_manifest.json",
+                "baseline_quality_out": "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_compare__l2_decoder_contract_eval_confirm_v1.json",
+                "validation_out": "runs/datasets/llm_decoder_eval_tiny_v1/decoder_contract_validation__l2_decoder_exact_probability_path_v1.json",
+                "quality_out": "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_compare__l2_decoder_exact_probability_path_v1.json",
+                "missing_model_check_out": "runs/datasets/llm_decoder_eval_tiny_v1/missing_model_check__l2_decoder_exact_probability_path_v1.json",
+            }
+            assert decoder_inputs["validation_out"] in work_item.expected_outputs
+            assert decoder_inputs["quality_out"] in work_item.expected_outputs
+            assert decoder_inputs["missing_model_check_out"] in work_item.expected_outputs
+            assert "NoSuchFile" in work_item.command_manifest[2]["run"]
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_probability_path",
+            }
+
+
 def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/developer_agent_loop.md
+++ b/docs/developer_agent_loop.md
@@ -246,6 +246,12 @@ self-contained before dispatch, including `proposal.json` and
 `evaluation_requests.json` with the queued item ids, so the artifact PR can
 package the exact review context referenced by `reviewer_first_read`.
 
+For decoder-quality proposals, set `abstraction_layer` to
+`decoder_probability_path`. The Layer 2 generator will then attach the decoder
+contract validation, quality comparison, and missing-model negative-path
+commands before the normal campaign commands. Do not rely on an after-dispatch
+DB patch for these evidence files.
+
 Ordering rule:
 - `measurement_only` items may usually queue immediately
 - `paired_comparison` items that consume a prior baseline should default to


### PR DESCRIPTION
## Summary
- add automatic decoder contract, quality comparison, and missing-model evidence commands for Layer 2 items with abstraction_layer=decoder_probability_path
- forward missing Layer 2 metadata flags through the aggregate control-plane CLI
- document the decoder_probability_path queue-generation rule for developer agents

## Tests
- PYTHONPATH=/tmp/rtlgen-decoder-evidence-gen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- PYTHONPATH=/tmp/rtlgen-decoder-evidence-gen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m control_plane.cli.main generate-l2-campaign --help | rg -- '--abstraction-layer|--depends-on-item-id|--requires-merged-inputs|--requires-materialized-refs'
- python3 scripts/validate_runs.py --skip_eval_queue

Note: broader l2_result_consumer/review_publisher tests currently fail on finalized master due existing paired-comparison fixture assumptions, unrelated to this generator change.