### PR TITLE
Suppress artifact-sync resolver false positives after submission

### DIFF
--- a/control_plane/control_plane/services/resolver_detection.py
+++ b/control_plane/control_plane/services/resolver_detection.py
@@ -28,6 +28,24 @@ _TERMINAL_EVENT_TYPES = {
     "run_timed_out",
 }
 
+_SUBMISSION_FAILURE_EVENT_TYPES = {
+    "submission_failed",
+    "submission_retry_failed",
+}
+
+_SUBMISSION_STABLE_SUCCESS_EVENT_TYPES = {
+    "completion_processed",
+    "operator_submission_completed",
+    "pr_linked",
+}
+
+_SUBMISSION_RECENT_PROGRESS_EVENT_TYPES = {
+    "artifact_synced",
+    "review_package_published",
+    "submission_executed",
+    "submission_prepared",
+}
+
 
 def _latest_run(session: Session, work_item_id: str) -> Run | None:
     return (
@@ -100,6 +118,73 @@ def _latest_event(session: Session, run_id: str) -> RunEvent | None:
         .order_by(RunEvent.event_time.desc(), RunEvent.id.desc())
         .first()
     )
+
+
+def _event_time_with_timezone(event: RunEvent, now: Any) -> Any:
+    event_time = event.event_time
+    if event_time is not None and event_time.tzinfo is None:
+        event_time = event_time.replace(tzinfo=now.tzinfo)
+    return event_time
+
+
+def _event_payload_dict(event: RunEvent) -> dict[str, Any]:
+    return event.event_payload if isinstance(event.event_payload, dict) else {}
+
+
+def _payload_has_submission_error(payload: dict[str, Any]) -> bool:
+    error = str(payload.get("submission_error") or payload.get("error") or "").strip()
+    return bool(error and error.lower() != "none")
+
+
+def _event_is_stable_submission_success(event: RunEvent) -> bool:
+    payload = _event_payload_dict(event)
+    if _payload_has_submission_error(payload):
+        return False
+    if event.event_type == "pr_linked":
+        return True
+    if event.event_type == "operator_submission_completed":
+        return bool(
+            payload.get("pr_number")
+            or payload.get("pr_url")
+            or payload.get("submission_executed") is True
+            or payload.get("review_published") is True
+        )
+    if event.event_type == "completion_processed":
+        return bool(
+            payload.get("submitted") is True
+            or payload.get("pr_url")
+            or str(payload.get("work_item_state", "")).strip() == WorkItemState.AWAITING_REVIEW.value
+        )
+    return False
+
+
+def _has_submission_progress_after_latest_failure(
+    session: Session,
+    *,
+    run_id: str,
+    now: Any,
+    stale_grace_seconds: int,
+) -> bool:
+    """Return true when artifact-sync state is lagging behind submission progress."""
+
+    events = (
+        session.query(RunEvent)
+        .filter(RunEvent.run_id == run_id)
+        .order_by(RunEvent.event_time.desc(), RunEvent.id.desc())
+        .all()
+    )
+    recent_threshold = max(int(stale_grace_seconds), 0)
+    for event in events:
+        payload = _event_payload_dict(event)
+        if event.event_type in _SUBMISSION_FAILURE_EVENT_TYPES or _payload_has_submission_error(payload):
+            return False
+        event_time = _event_time_with_timezone(event, now)
+        is_recent = event_time is not None and (now - event_time).total_seconds() < recent_threshold
+        if event.event_type in _SUBMISSION_STABLE_SUCCESS_EVENT_TYPES and _event_is_stable_submission_success(event):
+            return True
+        if is_recent and event.event_type in _SUBMISSION_RECENT_PROGRESS_EVENT_TYPES:
+            return True
+    return False
 
 
 def detect_orphaned_running_items(
@@ -192,6 +277,13 @@ def detect_blocked_submission_items(
         latest_event_time = latest_event.event_time if latest_event is not None else None
         if latest_event_time is not None and latest_event_time.tzinfo is None:
             latest_event_time = latest_event_time.replace(tzinfo=now.tzinfo)
+        if _has_submission_progress_after_latest_failure(
+            session,
+            run_id=run.id,
+            now=now,
+            stale_grace_seconds=stale_grace_seconds,
+        ):
+            continue
         if latest_event_time is not None and (now - latest_event_time).total_seconds() < stale_grace_seconds:
             submission_failure_reason = assess_submission_eligibility(
                 session,

--- a/control_plane/control_plane/tests/test_resolver_detection.py
+++ b/control_plane/control_plane/tests/test_resolver_detection.py
@@ -36,6 +36,7 @@ def _seed_artifact_sync_item(
     request_payload: dict | None = None,
     submission_failed_reason: str | None = None,
     latest_event_type: str | None = None,
+    latest_event_payload: dict | None = None,
     latest_event_age_seconds: int = 0,
 ) -> WorkItem:
     now = utcnow()
@@ -98,7 +99,7 @@ def _seed_artifact_sync_item(
                 run_id=run.id,
                 event_time=now - timedelta(seconds=latest_event_age_seconds),
                 event_type=latest_event_type,
-                event_payload={},
+                event_payload=latest_event_payload or {},
             )
         )
     session.commit()
@@ -392,6 +393,60 @@ def test_detect_blocked_submission_skips_recent_artifact_sync_without_submission
         detections = detect_blocked_submission_items(session, repo_root=repo_root, stale_grace_seconds=120)
 
     assert detections == []
+
+
+def test_detect_blocked_submission_skips_completed_submission_even_after_grace() -> None:
+    with make_session() as session, tempfile.TemporaryDirectory() as repo_root:
+        _seed_artifact_sync_item(
+            session,
+            item_id="blocked-submitted-item",
+            run_key="run-submitted",
+            latest_event_type="operator_submission_completed",
+            latest_event_payload={
+                "review_published": True,
+                "submission_executed": True,
+                "pr_number": 236,
+                "pr_url": "https://github.com/yhmtmt/RTLGen/pull/236",
+                "submission_error": None,
+            },
+            latest_event_age_seconds=600,
+        )
+
+        detections = detect_blocked_submission_items(session, repo_root=repo_root, stale_grace_seconds=120)
+
+    assert detections == []
+
+
+def test_detect_blocked_submission_reports_failure_after_submission_progress() -> None:
+    now = utcnow()
+    with make_session() as session, tempfile.TemporaryDirectory() as repo_root:
+        work_item = _seed_artifact_sync_item(
+            session,
+            item_id="blocked-submission-failure-item",
+            run_key="run-submission-failure",
+            latest_event_type="pr_linked",
+            latest_event_payload={
+                "pr_number": 236,
+                "pr_url": "https://github.com/yhmtmt/RTLGen/pull/236",
+            },
+            latest_event_age_seconds=600,
+        )
+        run = session.query(Run).filter(Run.work_item_id == work_item.id).one()
+        session.add(
+            RunEvent(
+                run_id=run.id,
+                event_time=now - timedelta(seconds=30),
+                event_type="submission_failed",
+                event_payload={"error": "gh pr create failed: exit code 4"},
+            )
+        )
+        session.commit()
+
+        detections = detect_blocked_submission_items(session, repo_root=repo_root, stale_grace_seconds=120)
+
+    assert len(detections) == 1
+    assert detections[0].fingerprint == "artifact_sync_blocked_submission:gh_pr_create_failed"
+
 
 def test_detect_blocked_submission_gh_pr_create_failed() -> None:
     with make_session() as session, tempfile.TemporaryDirectory() as repo_root:

--- a/docs/operations/resolver_daemons.md
+++ b/docs/operations/resolver_daemons.md
@@ -43,6 +43,8 @@ Implemented detection:
 - blocked submission items
   - `ARTIFACT_SYNC` item
   - concrete submission or eligibility failure evidence
+  - suppressed when run events already show successful submission or PR
+    publication progress and no newer submission failure
 
 Implemented safe automated actions:
 - `expire_stale_lease`


### PR DESCRIPTION
## Summary

- suppress blocked-submission resolver detections when run events already show successful submission or PR publication progress and no newer submission failure
- keep `gh pr create failed` detection active when a later failure event is present
- document the artifact-sync suppression rule in resolver operations docs

## Validation

- `PYTHONPATH=/tmp/rtlgen-resolver-grace/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_resolver_detection.py control_plane/control_plane/tests/test_resolver_dev_daemon.py -q`
- `python3 scripts/validate_runs.py --skip_eval_queue`
