### PR TITLE
Add artifact-sync submission progress confirmation proposal

### DIFF
--- a/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/design_brief.md
+++ b/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/design_brief.md
@@ -1,0 +1,12 @@
+# Design Brief
+
+- `proposal_id`: `prop_cp_artifact_sync_submission_progress_v1`
+- scope: control-plane workflow validation
+- target behavior: artifact-sync resolver should not open a blocked-submission case when recent run events already show review publication, submission preparation, PR creation, or completion processing without a newer submission failure.
+
+## Direction Gate
+
+- status: approved
+- approved_by: operator
+- approved_utc: 2026-04-28T08:50:00Z
+- note: Run one fresh normal workflow item after PR #240 and confirm resolver quietness.

--- a/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/evaluation_requests.json
+++ b/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_cp_artifact_sync_submission_progress_v1",
+  "source_commit": "8294a774e8c6145e497946277c4250675d9cf177",
+  "requested_items": [
+    {
+      "item_id": "l2_artifact_sync_submission_progress_confirm_v1",
+      "task_type": "l2_campaign",
+      "objective": "Confirm PR #240 prevents artifact_sync blocked-submission false positives once review/submission progress exists.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "decoder_probability_path",
+      "comparison_role": "workflow_confirmation",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": false,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Workflow confirmation only; resolver should remain quiet after submission progress events."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/implementation_summary.md
+++ b/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/implementation_summary.md
@@ -1,0 +1,6 @@
+# Implementation Summary
+
+- changed files: resolver detection and tests were merged in PR #240.
+- local validation before this proposal: focused resolver tests passed and `scripts/validate_runs.py --skip_eval_queue` passed.
+- requested remote evaluation: `l2_artifact_sync_submission_progress_confirm_v1`.
+- expected outcome: evaluator submits a review PR and no new `artifact_sync_blocked_submission` resolver case appears during the transition.

--- a/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/promotion_decision.json
+++ b/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_cp_artifact_sync_submission_progress_v1",
+  "candidate_id": "cp_artifact_sync_submission_progress_v1",
+  "decision": "iterate",
+  "reason": "Awaiting confirmation run evidence.",
+  "evidence_refs": [],
+  "next_action": "run l2_artifact_sync_submission_progress_confirm_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/promotion_result.json
+++ b/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_cp_artifact_sync_submission_progress_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/proposal.json
+++ b/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/proposal.json
@@ -1,0 +1,46 @@
+{
+  "proposal_id": "prop_cp_artifact_sync_submission_progress_v1",
+  "created_utc": "2026-04-28T08:50:00Z",
+  "created_by": "codex",
+  "layer": "control_plane",
+  "kind": "workflow_validation",
+  "title": "Confirm artifact-sync resolver ignores submitted runs with PR progress",
+  "hypothesis": "A normal proposal-backed Layer 2 submission that reaches review publication and PR creation should not create an artifact_sync blocked-submission resolver case while work-item state transitions are still settling.",
+  "direct_comparison": {
+    "primary_question": "Does the resolver remain quiet during the artifact_sync to submitted/awaiting-review transition after PR #240?",
+    "include": [
+      "fresh proposal linkage",
+      "normal Layer 2 generator path",
+      "artifact sync, review package publication, submission preparation, PR creation, and resolver polling"
+    ],
+    "exclude": [
+      "new decoder semantics",
+      "new mapper behavior",
+      "new physical-performance claims"
+    ],
+    "follow_on_broad_sweep": []
+  },
+  "expected_benefit": [
+    "proves the artifact-sync false-positive suppression remains active in a real workflow",
+    "keeps the resolver available for real submission failures such as gh pr create failures"
+  ],
+  "risks": [
+    "the confirmation item may still expose an unrelated submission or GitHub integration issue"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_artifact_sync_submission_progress_confirm_v1",
+      "type": "l2_campaign",
+      "purpose": "workflow confirmation after resolver suppression fix"
+    }
+  ],
+  "baseline_refs": [
+    "PR #240",
+    "PR #236"
+  ],
+  "knowledge_refs": [
+    "docs/operations/resolver_daemons.md",
+    "docs/developer_agent_loop.md"
+  ]
+}

--- a/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/quality_gate.md
+++ b/docs/proposals/prop_cp_artifact_sync_submission_progress_v1/quality_gate.md
@@ -1,0 +1,5 @@
+# Quality Gate
+
+- status: pass
+- rationale: this proposal validates control-plane resolver behavior and does not change decoder, mapper, quantization, or model semantics.
+- required check: use the existing decoder-probability-path evidence commands as workflow fixtures only.


### PR DESCRIPTION
## Summary

- add a fresh control-plane workflow proposal for confirming PR #240 in a normal evaluator submission path
- include the already-dispatched confirmation item metadata so submission eligibility can resolve the proposal from clean worktrees

## Validation

- `python3 scripts/validate_runs.py --skip_eval_queue`
