### PR TITLE
Add broad-ranking review wording confirmation proposal

### DIFF
--- a/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/design_brief.md
+++ b/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/design_brief.md
@@ -1,0 +1,12 @@
+# Design Brief
+
+- `proposal_id`: `prop_cp_broad_ranking_review_wording_confirm_v1`
+- scope: control-plane workflow validation
+- target behavior: broad-ranking review artifacts should report `ranking_recorded` and say focused baseline comparison is not required.
+
+## Direction Gate
+
+- status: approved
+- approved_by: operator
+- approved_utc: 2026-04-29T00:35:00Z
+- note: Confirm the daemon import-path restart fix by running a proposal-backed broad-ranking item.

--- a/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/evaluation_requests.json
+++ b/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/evaluation_requests.json
@@ -1,0 +1,24 @@
+{
+  "proposal_id": "prop_cp_broad_ranking_review_wording_confirm_v1",
+  "source_commit": "21d8757ea3dbac217773d79f262bc5421c47344f",
+  "requested_items": [
+    {
+      "item_id": "l2_broad_ranking_review_wording_confirm_v1",
+      "task_type": "l2_campaign",
+      "objective": "Confirm broad-ranking review packages do not report missing focused-comparison baselines.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_llm_attention_tail_v1/campaign.json",
+      "evaluation_mode": "broad_ranking",
+      "abstraction_layer": "layer2",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": false,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Workflow confirmation should publish ranking_recorded evidence and baseline-not-required wording."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/implementation_summary.md
+++ b/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/implementation_summary.md
@@ -1,0 +1,12 @@
+# Implementation Summary
+
+- changed files:
+  - proposal scaffold only
+- prerequisite fix:
+  - PR #246 added `control_plane/scripts/restart_local_control_plane_daemons.sh`
+  - live daemons were restarted with `PYTHONPATH=/workspaces/rtlgen-eval-clean/control_plane`
+- requested remote evaluation:
+  - `l2_broad_ranking_review_wording_confirm_v1`
+- expected outcome:
+  - generated review package contains `outcome: ranking_recorded`
+  - generated PR body does not contain `Focused comparison baseline could not be resolved from proposal baseline_refs.`

--- a/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/promotion_decision.json
+++ b/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_cp_broad_ranking_review_wording_confirm_v1",
+  "candidate_id": "l2_broad_ranking_review_wording_confirm_v1",
+  "decision": "iterate",
+  "reason": "Awaiting evaluator evidence.",
+  "evidence_refs": [],
+  "next_action": "run l2_broad_ranking_review_wording_confirm_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/promotion_result.json
+++ b/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_cp_broad_ranking_review_wording_confirm_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/proposal.json
+++ b/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/proposal.json
@@ -1,0 +1,48 @@
+{
+  "proposal_id": "prop_cp_broad_ranking_review_wording_confirm_v1",
+  "created_utc": "2026-04-29T00:35:00Z",
+  "created_by": "codex",
+  "layer": "layer2",
+  "kind": "workflow_validation",
+  "title": "Broad-ranking review wording confirmation",
+  "hypothesis": "After restarting daemons with the service checkout on PYTHONPATH, broad-ranking L2 review packages should record ranking evidence without reporting a missing focused-comparison baseline.",
+  "direct_comparison": {
+    "primary_question": "Does a broad-ranking confirmation job publish review wording that says focused baseline comparison is not required?",
+    "include": [
+      "broad_ranking evaluation mode",
+      "ranking comparison role",
+      "empty baseline_refs",
+      "operator review package and decision proposal wording"
+    ],
+    "exclude": [
+      "paired baseline comparison",
+      "architecture changes",
+      "new scheduler or mapper behavior"
+    ],
+    "follow_on_broad_sweep": []
+  },
+  "expected_benefit": [
+    "confirms the daemon import-path fix is active for evaluator-generated review artifacts",
+    "prevents future broad-ranking proposals from carrying misleading missing-baseline language",
+    "keeps workflow evidence aligned with the intended evaluation mode"
+  ],
+  "risks": [
+    "the campaign is reused only as a compact review-package generation vehicle",
+    "this does not measure a new architecture improvement"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_broad_ranking_review_wording_confirm_v1",
+      "task_type": "l2_campaign",
+      "objective": "review_wording_confirmation",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_llm_attention_tail_v1/campaign.json"
+    }
+  ],
+  "baseline_refs": [],
+  "knowledge_refs": [
+    "control_plane/control_plane/services/l2_result_consumer.py",
+    "control_plane/control_plane/tests/test_l2_result_consumer.py",
+    "control_plane/scripts/restart_local_control_plane_daemons.sh"
+  ]
+}

--- a/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/quality_gate.md
+++ b/docs/proposals/prop_cp_broad_ranking_review_wording_confirm_v1/quality_gate.md
@@ -1,0 +1,5 @@
+# Quality Gate
+
+- status: pass
+- rationale: this proposal changes documentation and dispatch metadata only. It does not change design, mapper, simulator, or physical flow behavior.
+- required check: run the broad-ranking confirmation item and inspect the generated review package wording.


### PR DESCRIPTION
## Summary
- add proposal scaffold for `prop_cp_broad_ranking_review_wording_confirm_v1`
- request `l2_broad_ranking_review_wording_confirm_v1` as a broad-ranking workflow confirmation item
- keep `baseline_refs` empty so the evaluator must use the baseline-not-required wording path

## Validation
- JSON syntax checks for proposal metadata
- `python3 scripts/validate_runs.py --skip_eval_queue`
