### PR TITLE
Add decoder probability template sweep

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -502,6 +502,40 @@ PY2"""
     }
 
 
+def _decoder_probability_sweep_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    path_evidence = _decoder_probability_path_evidence(item_id=item_id)
+    sweep_dir = f"{base}/candidate_sweeps/{item_id}"
+    sweep_out = f"{base}/decoder_quality_sweep__{item_id}.json"
+    sweep_command = {
+        "name": "sweep_decoder_candidate_quality",
+        "run": (
+            "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
+            f"--dataset-manifest {base}/manifest.json "
+            "--template candidate_onnx_softmax_exact "
+            "--template candidate_onnx_softmax_approx "
+            f"--out-dir {sweep_dir} "
+            f"--out {sweep_out}"
+        ),
+    }
+    inputs = dict(path_evidence["inputs"])
+    inputs.update(
+        {
+            "candidate_sweep_dir": sweep_dir,
+            "candidate_sweep_out": sweep_out,
+            "candidate_sweep_templates": [
+                "candidate_onnx_softmax_exact",
+                "candidate_onnx_softmax_approx",
+            ],
+        }
+    )
+    return {
+        "inputs": inputs,
+        "commands": [*path_evidence["commands"], sweep_command],
+        "expected_outputs": [*path_evidence["expected_outputs"], sweep_out],
+    }
+
+
 def _with_fresh_outputs(*, campaign: dict[str, Any], item_id: str) -> dict[str, Any]:
     cloned = json.loads(json.dumps(campaign))
     outputs = dict(cloned.get("outputs") or {})
@@ -597,8 +631,12 @@ def _build_payload(
             "outputs": generated_outputs,
         },
     }
-    if str(abstraction_layer or "").strip() == "decoder_probability_path":
-        decoder_evidence = _decoder_probability_path_evidence(item_id=item_id)
+    abstraction_layer_name = str(abstraction_layer or "").strip()
+    if abstraction_layer_name in {"decoder_probability_path", "decoder_probability_sweep"}:
+        if abstraction_layer_name == "decoder_probability_sweep":
+            decoder_evidence = _decoder_probability_sweep_evidence(item_id=item_id)
+        else:
+            decoder_evidence = _decoder_probability_path_evidence(item_id=item_id)
         commands = [*decoder_evidence["commands"], *commands]
         expected_outputs = _uniq([*expected_outputs, *decoder_evidence["expected_outputs"]])
         task_inputs["decoder_contract"] = decoder_evidence["inputs"]

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -270,6 +270,62 @@ def test_generate_l2_campaign_task_adds_decoder_probability_path_evidence() -> N
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_probability_sweep_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_probability_sweep_v1",
+                    proposal_id="prop_l2_decoder_probability_sweep_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_probability_sweep_v1/proposal.json",
+                    evaluation_mode="broad_ranking",
+                    abstraction_layer="decoder_probability_sweep",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:4] == [
+                "validate_decoder_contract",
+                "compare_decoder_quality",
+                "check_decoder_missing_model_error",
+                "sweep_decoder_candidate_quality",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["candidate_sweep_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_quality_sweep__l2_decoder_probability_sweep_v1.json"
+            )
+            assert decoder_inputs["candidate_sweep_dir"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "candidate_sweeps/l2_decoder_probability_sweep_v1"
+            )
+            assert decoder_inputs["candidate_sweep_templates"] == [
+                "candidate_onnx_softmax_exact",
+                "candidate_onnx_softmax_approx",
+            ]
+            assert decoder_inputs["candidate_sweep_out"] in work_item.expected_outputs
+            assert "--template candidate_onnx_softmax_exact" in work_item.command_manifest[3]["run"]
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_probability_sweep",
+            }
+
+
 def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llm_decoder_accuracy_stage_v1.md
+++ b/docs/architecture/llm_decoder_accuracy_stage_v1.md
@@ -126,6 +126,9 @@ The repo now has the first explicit decoder-quality binding layer:
 - deterministic candidate-only placeholders against the same contract,
 - a comparison-ready reference/candidate schema,
 - an exact-match and top-k containment summary utility for token-level evaluation,
+- a candidate-quality sweep utility that can compare exact and bounded
+  approximation backend templates without replacing the active exact candidate
+  manifest,
 - a lightweight contract schema and validator for the checked-in prompt,
   reference, candidate, SHA256, tensor-trace, and metrics artifacts,
 - an explicit backend interface that can later compare software emulation and hardware-oriented execution for equivalence,

--- a/docs/proposals/prop_l2_decoder_probability_sweep_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_probability_sweep_v1/design_brief.md
@@ -1,0 +1,49 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_probability_sweep_v1`
+- `title`: `LLM decoder probability-template sweep`
+
+## Problem
+The exact decoder probability path restored `llm_decoder_eval_tiny_v1` quality
+to `1.0` exact/top-k, while the earlier approximate path recorded `0.8`.
+Approximation work should not resume from graph-pressure evidence alone. The
+next step is a dataset-backed sweep that compares exact and bounded approximate
+probability templates without replacing the active exact candidate.
+
+## Hypothesis
+A sidecar sweep over decoder backend templates can identify whether the current
+bounded approximation envelope preserves quality, and can provide the artifact
+shape needed for later approximation-specific proposals.
+
+## Evaluation Scope
+- direct comparison set:
+  - `candidate_onnx_softmax_exact`
+  - `candidate_onnx_softmax_approx`
+  - `llm_decoder_eval_tiny_v1`
+- evaluation mode:
+  - `broad_ranking`
+- expected result:
+  - record candidate-template quality ranking, not promote hardware
+- excluded first-stage comparisons:
+  - RTL approximation implementation
+  - mapper scheduling changes
+  - tokenizer/model/prompt-set changes
+
+## Knowledge Inputs
+- `runs/datasets/llm_decoder_eval_tiny_v1/manifest.json`
+- `runs/models/llm_decoder_tiny_v1/model_contract.json`
+- `npu/eval/sweep_llm_decoder_candidate_quality.py`
+- `docs/architecture/llm_decoder_accuracy_stage_v1.md`
+
+## Candidate Direction
+If the approximate template fails quality, continue with exact probability as
+the active candidate and defer approximate datapath work. If it preserves
+quality, use the sweep output to define a narrower approximation proposal.
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-04-29T00:00:00Z
+- note: dataset-backed probability-template sweep approved after practical
+  graph proxy evidence did not justify softmax datapath work.

--- a/docs/proposals/prop_l2_decoder_probability_sweep_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_probability_sweep_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_probability_sweep_v1",
+  "source_commit": "c4b2c6f0cc4c5ede747550d42dc6e126e2653503",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_probability_sweep_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a dataset-backed decoder probability-template sweep over exact and bounded approximate candidate backends.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "broad_ranking",
+      "abstraction_layer": "decoder_probability_sweep",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_exact_probability_path_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The sweep should identify whether any bounded approximation template preserves decoder quality before approximate probability-path hardware work is reopened."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_probability_sweep_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_probability_sweep_v1/implementation_summary.md
@@ -1,0 +1,38 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_probability_sweep_v1`
+- `title`: `LLM decoder probability-template sweep`
+
+## Scope
+- added `npu/eval/sweep_llm_decoder_candidate_quality.py`
+- added `decoder_probability_sweep` evidence wiring in the L2 task generator
+- added generator coverage for the new evidence hook
+- documented the decoder-quality sweep path
+- added proposal metadata for an evaluator-run sweep
+- did not change RTL, mapper logic, simulator logic, tokenizer assets, prompt
+  samples, or the active exact candidate manifest
+
+## Files Changed
+- `npu/eval/sweep_llm_decoder_candidate_quality.py`
+- `control_plane/control_plane/services/l2_task_generator.py`
+- `control_plane/control_plane/tests/test_l2_task_generator.py`
+- `npu/eval/README.md`
+- `docs/architecture/llm_decoder_accuracy_stage_v1.md`
+- `docs/proposals/prop_l2_decoder_probability_sweep_v1/`
+
+## Local Validation
+- `python3 -m py_compile npu/eval/sweep_llm_decoder_candidate_quality.py`
+- `python3 npu/eval/sweep_llm_decoder_candidate_quality.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json --template candidate_onnx_softmax_exact --template candidate_onnx_softmax_approx --out-dir /tmp/decoder_candidate_sweep --out /tmp/decoder_candidate_sweep.json`
+- `PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+
+## Evaluation Request
+- item: `l2_decoder_probability_sweep_v1`
+- task type: `l2_campaign`
+- evaluation mode: `broad_ranking`
+- abstraction layer: `decoder_probability_sweep`
+
+## Risks
+- The tiny prompt set remains a narrow quality gate.
+- Sweep evidence is still software-emulated probability-path evidence.

--- a/docs/proposals/prop_l2_decoder_probability_sweep_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_probability_sweep_v1/promotion_decision.json
@@ -1,0 +1,12 @@
+{
+  "proposal_id": "prop_l2_decoder_probability_sweep_v1",
+  "candidate_id": "l2_decoder_probability_sweep_v1",
+  "decision": "pending",
+  "reason": "Awaiting proposal-backed decoder probability-template sweep evidence.",
+  "evidence_refs": [
+    "docs/proposals/prop_l2_decoder_probability_sweep_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/manifest.json"
+  ],
+  "next_action": "run l2_decoder_probability_sweep_v1 and inspect exact-vs-approx template quality",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_probability_sweep_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_probability_sweep_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_probability_sweep_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_probability_sweep_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_probability_sweep_v1/proposal.json
@@ -1,0 +1,56 @@
+{
+  "proposal_id": "prop_l2_decoder_probability_sweep_v1",
+  "created_utc": "2026-04-29T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "LLM decoder probability-template sweep",
+  "hypothesis": "The decoder-quality gate should compare exact and bounded approximate probability-path templates side by side before any approximate softmax or normalization hardware proposal is reopened.",
+  "direct_comparison": {
+    "primary_question": "Which decoder probability-path backend template preserves next-token and top-k quality on llm_decoder_eval_tiny_v1?",
+    "include": [
+      "llm_decoder_eval_tiny_v1 reference manifest",
+      "candidate_onnx_softmax_exact backend template",
+      "candidate_onnx_softmax_approx backend template",
+      "next-token exact-match and top-k containment rates",
+      "selected present.* tensor shape and drift summaries"
+    ],
+    "exclude": [
+      "changing the active exact candidate manifest",
+      "claiming hardware approximation acceptance",
+      "new RTL or mapper changes"
+    ],
+    "follow_on_broad_sweep": [
+      "only reopen narrower approximation knobs after the sweep output identifies a quality-preserving candidate envelope"
+    ]
+  },
+  "expected_benefit": [
+    "keeps dataset-backed decoder quality ahead of approximate softmax architecture work",
+    "lets exact and approximate candidate templates be evaluated without mutating the active candidate manifest",
+    "records the first reusable decoder probability-template sweep artifact"
+  ],
+  "risks": [
+    "the tiny prompt set is too small to prove broader language-model quality",
+    "the approximate template may remain below exact quality, which means architecture work should stay deferred",
+    "this is still software-emulated probability-path evidence, not RTL-backed decoder execution"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_probability_sweep_v1",
+      "task_type": "l2_campaign",
+      "objective": "decoder_probability_sweep",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json"
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_exact_probability_path_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_compare__l2_decoder_exact_probability_path_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llm_decoder_accuracy_stage_v1.md",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "runs/models/llm_decoder_tiny_v1/model_contract.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/manifest.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_probability_sweep_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_probability_sweep_v1/quality_gate.md
@@ -1,0 +1,36 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_probability_sweep_v1`
+- `title`: `LLM decoder probability-template sweep`
+
+## Why This Gate Is Required
+The proposal adds a new dataset-backed decoder-quality sweep path. The gate
+checks that the sweep runs locally and that generated evaluator jobs include the
+new evidence command and expected output.
+
+## Reference
+- proposal: `docs/proposals/prop_l2_decoder_probability_sweep_v1/proposal.json`
+- sweep tool: `npu/eval/sweep_llm_decoder_candidate_quality.py`
+- dataset: `runs/datasets/llm_decoder_eval_tiny_v1/manifest.json`
+
+## Checks
+- sweep syntax:
+  - threshold: `python3 -m py_compile` passes
+- local sweep:
+  - threshold: exact and approximate template quality summaries are emitted
+- task generator:
+  - threshold: `decoder_probability_sweep` adds the sweep command and output
+- run index validation:
+  - threshold: `scripts/validate_runs.py --skip_eval_queue` passes
+
+## Local Commands
+- `python3 -m py_compile npu/eval/sweep_llm_decoder_candidate_quality.py`
+- `python3 npu/eval/sweep_llm_decoder_candidate_quality.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json --template candidate_onnx_softmax_exact --template candidate_onnx_softmax_approx --out-dir /tmp/decoder_candidate_sweep --out /tmp/decoder_candidate_sweep.json`
+- `PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+
+## Result
+- status: local-pass
+- note: local sweep, task-generator, and run-index checks passed; remote
+  evaluator execution remains pending.

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -30,6 +30,10 @@ It is the first step toward a reproducible closed-loop flow:
   fixtures for the tiny decoder-quality stage.
 - `npu/eval/compare_llm_decoder_quality.py`: summarize token-level exact-match
   and top-k containment rates from decoder reference/candidate manifests.
+- `npu/eval/sweep_llm_decoder_candidate_quality.py`: generate alternate
+  candidate fixtures from decoder backend templates and summarize each
+  candidate's token-level quality without changing the active candidate
+  manifest.
 - `npu/eval/run_llm_decoder_onnx_reference.py`: active exact-reference runner
   behind `command_json_v1` for the pinned tiny decoder ONNX export.
 
@@ -58,6 +62,16 @@ Validate the tiny decoder accuracy-stage contract:
 ```sh
 python3 npu/eval/validate_llm_decoder_contract.py \
   --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json
+```
+
+Run a bounded decoder candidate-quality sweep:
+```sh
+python3 npu/eval/sweep_llm_decoder_candidate_quality.py \
+  --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json \
+  --template candidate_onnx_softmax_exact \
+  --template candidate_onnx_softmax_approx \
+  --out-dir /tmp/decoder_candidate_sweep \
+  --out /tmp/decoder_candidate_sweep.json
 ```
 
 Optionally verify path-like fields exist:

--- a/npu/eval/sweep_llm_decoder_candidate_quality.py
+++ b/npu/eval/sweep_llm_decoder_candidate_quality.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Run decoder-quality comparisons for candidate backend templates."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.compare_llm_decoder_quality import compare_decoder_manifests
+from npu.eval.llm_decoder_quality import (
+    build_decoder_candidate_doc,
+    load_json,
+    load_jsonl,
+    load_tokenizer_bundle,
+)
+
+
+JsonDict = Dict[str, Any]
+
+
+def _sha256_bytes(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _resolve_repo_path(path: str | Path) -> Path:
+    p = Path(path)
+    if p.is_absolute():
+        return p
+    return REPO_ROOT / p
+
+
+def _portable_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _candidate_templates(model_contract: JsonDict, requested: List[str]) -> Dict[str, JsonDict]:
+    templates = model_contract.get("backend_templates", {}) or {}
+    if not isinstance(templates, dict):
+        raise ValueError("model_contract.backend_templates must be an object")
+    names = requested or sorted(name for name in templates if str(name).startswith("candidate_"))
+    out: Dict[str, JsonDict] = {}
+    for name in names:
+        if name not in templates:
+            raise ValueError(f"candidate backend template not found: {name}")
+        cfg = dict(templates[name])
+        cfg["role"] = "candidate"
+        cfg["interface"] = "decoder_backend_v1"
+        out[name] = cfg
+    if not out:
+        raise ValueError("no candidate backend templates selected")
+    return out
+
+
+def _generate_candidate_manifest(
+    *,
+    dataset_manifest: JsonDict,
+    dataset_manifest_path: Path,
+    tokenizer_manifest: JsonDict,
+    tokenizer_manifest_path: Path,
+    tokenizer_bundle: JsonDict,
+    model_contract: JsonDict,
+    model_contract_path: Path,
+    samples: List[JsonDict],
+    backend_config: JsonDict,
+    out_dir: Path,
+) -> JsonDict:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    vocab = dict(tokenizer_bundle["vocab"])
+    manifest_samples: List[JsonDict] = []
+    candidate_semantics = ""
+    for sample in samples:
+        doc = build_decoder_candidate_doc(
+            dataset_manifest=dataset_manifest,
+            sample=sample,
+            tokenizer_manifest=tokenizer_manifest,
+            vocab=vocab,
+            model_contract=model_contract,
+            dataset_manifest_path=_portable_path(dataset_manifest_path),
+            tokenizer_manifest_path=_portable_path(tokenizer_manifest_path),
+            model_contract_path=_portable_path(model_contract_path),
+            backend_config=backend_config,
+            tokenizer_bundle=tokenizer_bundle,
+        )
+        candidate_semantics = str(doc.get("candidate_semantics", candidate_semantics))
+        out_path = out_dir / f"{sample['sample_id']}.json"
+        raw = (json.dumps(doc, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        out_path.write_bytes(raw)
+        manifest_samples.append(
+            {
+                "sample_id": sample["sample_id"],
+                "candidate_json": _portable_path(out_path),
+                "candidate_sha256": _sha256_bytes(raw),
+            }
+        )
+
+    return {
+        "version": 0.1,
+        "dataset_id": dataset_manifest["dataset_id"],
+        "task": dataset_manifest["task"],
+        "tokenizer_manifest": _portable_path(tokenizer_manifest_path),
+        "model_contract": _portable_path(model_contract_path),
+        "backend_config": backend_config,
+        "candidate_semantics": candidate_semantics,
+        "samples": manifest_samples,
+    }
+
+
+def _aggregate_row(template_name: str, manifest_path: Path, quality_path: Path, metrics: JsonDict) -> JsonDict:
+    aggregate = dict(metrics.get("aggregate", {}) or {})
+    tensor = dict(aggregate.get("selected_tensor_trace", {}) or {})
+    return {
+        "template": template_name,
+        "candidate_semantics": metrics.get("candidate_semantics", ""),
+        "candidate_manifest": _portable_path(manifest_path),
+        "quality_json": _portable_path(quality_path),
+        "sample_count": aggregate.get("sample_count"),
+        "next_token_id_match_rate": aggregate.get("next_token_id_match_rate"),
+        "next_token_text_match_rate": aggregate.get("next_token_text_match_rate"),
+        "topk_contains_reference_id_rate": aggregate.get("topk_contains_reference_id_rate"),
+        "topk_contains_reference_text_rate": aggregate.get("topk_contains_reference_text_rate"),
+        "selected_tensor_shape_match_rate": tensor.get("shape_match_rate"),
+        "selected_tensor_trace_sha256_match_rate": tensor.get("trace_sha256_match_rate"),
+        "selected_tensor_delta_rollups": tensor.get("delta_rollups", {}),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dataset-manifest", default="runs/datasets/llm_decoder_eval_tiny_v1/manifest.json")
+    ap.add_argument(
+        "--template",
+        action="append",
+        default=[],
+        help="Candidate backend template name. Defaults to all model_contract backend_templates starting with candidate_.",
+    )
+    ap.add_argument("--out-dir", default="runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/local")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    dataset_manifest_path = _resolve_repo_path(args.dataset_manifest)
+    dataset_manifest = load_json(dataset_manifest_path)
+    sample_file = _resolve_repo_path(dataset_manifest["sample_file"])
+    tokenizer_manifest_path = _resolve_repo_path(dataset_manifest["tokenizer_manifest"])
+    model_contract_path = _resolve_repo_path(dataset_manifest["model_contract"])
+    reference_manifest_path = _resolve_repo_path(dataset_manifest["reference_manifest"])
+    tokenizer_manifest = load_json(tokenizer_manifest_path)
+    model_contract = load_json(model_contract_path)
+    reference_manifest = load_json(reference_manifest_path)
+    tokenizer_bundle = load_tokenizer_bundle(tokenizer_manifest, manifest_path=tokenizer_manifest_path)
+    samples = load_jsonl(sample_file)
+    templates = _candidate_templates(model_contract, [str(v) for v in args.template])
+
+    out_dir = _resolve_repo_path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    results: List[JsonDict] = []
+    for template_name, backend_config in templates.items():
+        template_dir = out_dir / template_name
+        candidate_dir = template_dir / "candidate"
+        candidate_manifest = _generate_candidate_manifest(
+            dataset_manifest=dataset_manifest,
+            dataset_manifest_path=dataset_manifest_path,
+            tokenizer_manifest=tokenizer_manifest,
+            tokenizer_manifest_path=tokenizer_manifest_path,
+            tokenizer_bundle=tokenizer_bundle,
+            model_contract=model_contract,
+            model_contract_path=model_contract_path,
+            samples=samples,
+            backend_config=backend_config,
+            out_dir=candidate_dir,
+        )
+        manifest_path = template_dir / "candidate_manifest.json"
+        manifest_path.write_text(json.dumps(candidate_manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        metrics = compare_decoder_manifests(reference_manifest, candidate_manifest)
+        quality_path = template_dir / "quality.json"
+        quality_path.write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        results.append(_aggregate_row(template_name, manifest_path, quality_path, metrics))
+
+    best = sorted(
+        results,
+        key=lambda row: (
+            -float(row.get("next_token_id_match_rate") or 0.0),
+            -float(row.get("topk_contains_reference_id_rate") or 0.0),
+            str(row.get("template") or ""),
+        ),
+    )[0]
+    doc = {
+        "version": 0.1,
+        "dataset_id": dataset_manifest["dataset_id"],
+        "task": dataset_manifest["task"],
+        "reference_manifest": _portable_path(reference_manifest_path),
+        "template_count": len(results),
+        "templates": results,
+        "best_template": best,
+    }
+    text = json.dumps(doc, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        out_path = _resolve_repo_path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a decoder candidate-quality sweep utility for backend templates
- attach decoder_probability_sweep evidence generation to L2 campaign tasks
- add proposal/docs for l2_decoder_probability_sweep_v1

## Validation
- python3 -m py_compile npu/eval/sweep_llm_decoder_candidate_quality.py
- python3 scripts/validate_runs.py --skip_eval_queue
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- local sweep over candidate_onnx_softmax_exact and candidate_onnx_softmax_approx: exact=1.0 next-token/top-k, approx=0.8 next-token/top-k

## Known pre-existing test issue
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -q currently fails in existing paired-comparison fixtures unrelated to this sweep hook.