### PR TITLE
Stage decoder sweep sidecar artifacts

### DIFF
--- a/control_plane/control_plane/tests/test_artifact_stage.py
+++ b/control_plane/control_plane/tests/test_artifact_stage.py
@@ -1,0 +1,79 @@
+"""Artifact staging coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from control_plane.workers.artifact_stage import collect_linked_results_artifacts
+
+
+def _write_json(path: Path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_collect_linked_results_artifacts_includes_decoder_sweep_sidecars(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    base = repo_root / "runs" / "datasets" / "llm_decoder_eval_tiny_v1"
+    sweep_rel = "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__demo.json"
+    exact_manifest_rel = (
+        "runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/demo/"
+        "candidate_onnx_softmax_exact/candidate_manifest.json"
+    )
+    exact_quality_rel = (
+        "runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/demo/"
+        "candidate_onnx_softmax_exact/quality.json"
+    )
+    exact_sample_rel = (
+        "runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/demo/"
+        "candidate_onnx_softmax_exact/candidate/sample_001.json"
+    )
+    approx_manifest_rel = (
+        "runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/demo/"
+        "candidate_onnx_softmax_approx/candidate_manifest.json"
+    )
+    approx_quality_rel = (
+        "runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/demo/"
+        "candidate_onnx_softmax_approx/quality.json"
+    )
+    approx_sample_rel = (
+        "runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/demo/"
+        "candidate_onnx_softmax_approx/candidate/sample_001.json"
+    )
+
+    _write_json(repo_root / exact_sample_rel, {"sample_id": "sample_001", "token": "A"})
+    _write_json(repo_root / approx_sample_rel, {"sample_id": "sample_001", "token": "B"})
+    _write_json(repo_root / exact_quality_rel, {"aggregate": {"next_token_id_match_rate": 1.0}})
+    _write_json(repo_root / approx_quality_rel, {"aggregate": {"next_token_id_match_rate": 0.8}})
+    _write_json(
+        repo_root / exact_manifest_rel,
+        {"samples": [{"sample_id": "sample_001", "candidate_json": exact_sample_rel}]},
+    )
+    _write_json(
+        repo_root / approx_manifest_rel,
+        {"samples": [{"sample_id": "sample_001", "candidate_json": approx_sample_rel}]},
+    )
+    _write_json(
+        base / "decoder_quality_sweep__demo.json",
+        {
+            "templates": [
+                {"candidate_manifest": exact_manifest_rel, "quality_json": exact_quality_rel},
+                {"candidate_manifest": approx_manifest_rel, "quality_json": approx_quality_rel},
+            ]
+        },
+    )
+
+    artifacts = collect_linked_results_artifacts(repo_root=str(repo_root), expected_outputs=[sweep_rel])
+
+    assert [artifact.path for artifact in artifacts] == [
+        exact_quality_rel,
+        exact_manifest_rel,
+        exact_sample_rel,
+        approx_quality_rel,
+        approx_manifest_rel,
+        approx_sample_rel,
+    ]
+    assert all(artifact.kind == "supporting_output" for artifact in artifacts)
+    assert all(artifact.metadata["transport_policy"] == "inline_text_supporting" for artifact in artifacts)

--- a/control_plane/control_plane/workers/artifact_stage.py
+++ b/control_plane/control_plane/workers/artifact_stage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import json
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
@@ -114,10 +115,70 @@ def _results_linked_supporting_paths(*, repo_root: Path, expected_outputs: list[
     return paths
 
 
+def _repo_local_file(repo_root: Path, rel_path: str, seen: set[str]) -> str | None:
+    rel_path = str(rel_path or "").strip()
+    if not rel_path or rel_path in seen:
+        return None
+    candidate = (repo_root / rel_path).resolve()
+    try:
+        candidate.relative_to(repo_root)
+    except ValueError:
+        return None
+    if not candidate.exists() or not candidate.is_file():
+        return None
+    seen.add(rel_path)
+    return rel_path
+
+
+def _decoder_sweep_linked_supporting_paths(*, repo_root: Path, expected_outputs: list[str]) -> list[str]:
+    paths: list[str] = []
+    seen: set[str] = set()
+    for output in expected_outputs:
+        sweep_path = (repo_root / output).resolve()
+        if not sweep_path.name.startswith("decoder_quality_sweep__") or sweep_path.suffix.lower() != ".json":
+            continue
+        if not sweep_path.exists() or not sweep_path.is_file():
+            continue
+        try:
+            sweep_doc = json.loads(sweep_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        for row in sweep_doc.get("templates", []) or []:
+            if not isinstance(row, dict):
+                continue
+            for field in ("quality_json", "candidate_manifest"):
+                rel_path = _repo_local_file(repo_root, str(row.get(field, "")), seen)
+                if rel_path is not None:
+                    paths.append(rel_path)
+            manifest_rel = str(row.get("candidate_manifest", "")).strip()
+            manifest_path = (repo_root / manifest_rel).resolve()
+            try:
+                manifest_path.relative_to(repo_root)
+            except ValueError:
+                continue
+            if not manifest_path.exists() or not manifest_path.is_file():
+                continue
+            try:
+                manifest_doc = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            for sample in manifest_doc.get("samples", []) or []:
+                if not isinstance(sample, dict):
+                    continue
+                rel_path = _repo_local_file(repo_root, str(sample.get("candidate_json", "")), seen)
+                if rel_path is not None:
+                    paths.append(rel_path)
+    return paths
+
+
 def collect_linked_results_artifacts(*, repo_root: str, expected_outputs: list[str]) -> list[StagedArtifact]:
     repo_path = Path(repo_root).resolve()
     artifacts: list[StagedArtifact] = []
-    for rel_path in _results_linked_supporting_paths(repo_root=repo_path, expected_outputs=expected_outputs):
+    linked_paths = [
+        *_results_linked_supporting_paths(repo_root=repo_path, expected_outputs=expected_outputs),
+        *_decoder_sweep_linked_supporting_paths(repo_root=repo_path, expected_outputs=expected_outputs),
+    ]
+    for rel_path in linked_paths:
         path = (repo_path / rel_path).resolve()
         metadata = {
             "size_bytes": path.stat().st_size,


### PR DESCRIPTION
## Summary
- teach artifact staging to follow decoder_quality_sweep JSON sidecar links
- include generated per-template quality JSON, candidate manifests, and candidate sample JSONs as supporting outputs
- add focused artifact-stage coverage

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_artifact_stage.py control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue