### PR TITLE
Include decoder sweep sidecars in submissions

### DIFF
--- a/control_plane/control_plane/services/submission_bridge.py
+++ b/control_plane/control_plane/services/submission_bridge.py
@@ -20,6 +20,7 @@ from control_plane.models.runs import Run
 from control_plane.models.work_items import WorkItem
 from control_plane.services.docs_paths import resolve_proposal_file
 from control_plane.services.review_publisher import ReviewPublishRequest, publish_review_package
+from control_plane.workers.artifact_stage import collect_linked_results_artifacts
 
 
 class SubmissionPrepareError(RuntimeError):
@@ -152,6 +153,21 @@ def _review_linked_supporting_files(*, repo_root: Path, package_payload: dict[st
         if isinstance(source_refs, dict):
             _collect_existing_file_refs(repo_root=repo_root, value=source_refs, files=files, seen=seen)
     _collect_proposal_files(repo_root=repo_root, package_payload=package_payload, files=files, seen=seen)
+    return files
+
+
+def _expected_output_supporting_files(*, repo_root: Path, work_item: WorkItem, existing: list[str]) -> list[str]:
+    seen = set(existing)
+    files: list[str] = []
+    for artifact in collect_linked_results_artifacts(
+        repo_root=str(repo_root),
+        expected_outputs=[str(path) for path in (work_item.expected_outputs or [])],
+    ):
+        rel_path = str(artifact.path).strip()
+        if not rel_path or rel_path in seen:
+            continue
+        seen.add(rel_path)
+        files.append(rel_path)
     return files
 
 
@@ -344,6 +360,13 @@ def prepare_submission_branch(session: Session, request: SubmissionPrepareReques
     review_rel = str(review_artifact.get("path", "")).strip() if isinstance(review_artifact, dict) else ""
     evidence_files = _canonical_evidence_files(repo_root=repo_root, work_item=work_item)
     supporting_files = _review_linked_supporting_files(repo_root=repo_root, package_payload=package_payload)
+    supporting_files.extend(
+        _expected_output_supporting_files(
+            repo_root=repo_root,
+            work_item=work_item,
+            existing=[*evidence_files, *supporting_files],
+        )
+    )
     files_to_copy = [snapshot_rel, package_rel]
     if review_rel:
         files_to_copy.append(review_rel)

--- a/control_plane/control_plane/tests/test_submission_bridge.py
+++ b/control_plane/control_plane/tests/test_submission_bridge.py
@@ -648,6 +648,68 @@ def test_prepare_submission_branch_stages_trial_metrics_from_source_refs() -> No
             assert (Path(result.worktree_path) / metrics_rel).exists()
 
 
+def test_prepare_submission_branch_stages_decoder_sweep_sidecars() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, _run_key = _seed_l2_reviewable(session, repo_root)
+            sweep_rel = "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_submit_demo.json"
+            exact_manifest_rel = (
+                "runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/l2_submit_demo/"
+                "candidate_onnx_softmax_exact/candidate_manifest.json"
+            )
+            exact_quality_rel = (
+                "runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/l2_submit_demo/"
+                "candidate_onnx_softmax_exact/quality.json"
+            )
+            exact_sample_rel = (
+                "runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/l2_submit_demo/"
+                "candidate_onnx_softmax_exact/candidate/sample_001.json"
+            )
+            _write(repo_root / exact_sample_rel, json.dumps({"sample_id": "sample_001"}) + "\n")
+            _write(repo_root / exact_quality_rel, json.dumps({"aggregate": {"next_token_id_match_rate": 1.0}}) + "\n")
+            _write(
+                repo_root / exact_manifest_rel,
+                json.dumps({"samples": [{"sample_id": "sample_001", "candidate_json": exact_sample_rel}]}) + "\n",
+            )
+            _write(
+                repo_root / sweep_rel,
+                json.dumps({"templates": [{"candidate_manifest": exact_manifest_rel, "quality_json": exact_quality_rel}]}) + "\n",
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), sweep_rel]
+            session.commit()
+
+            result = prepare_submission_branch(
+                session,
+                SubmissionPrepareRequest(
+                    repo_root=str(repo_root),
+                    item_id=item_id,
+                    evaluator_id="cpbot",
+                    session_id="s20260310t080600z",
+                    host="cp-host",
+                    worktree_root=str(repo_root / "tmp_submit"),
+                ),
+            )
+
+            manifest = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "review" / item_id / "submission_manifest.json").read_text()
+            )
+            assert sweep_rel in manifest["evidence_paths"]
+            assert exact_quality_rel in manifest["supporting_paths"]
+            assert exact_manifest_rel in manifest["supporting_paths"]
+            assert exact_sample_rel in manifest["supporting_paths"]
+            assert (Path(result.worktree_path) / sweep_rel).exists()
+            assert (Path(result.worktree_path) / exact_quality_rel).exists()
+            assert (Path(result.worktree_path) / exact_manifest_rel).exists()
+            assert (Path(result.worktree_path) / exact_sample_rel).exists()
+
+
 def test_prepare_submission_branch_uses_current_base_branch_instead_of_head() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- include linked expected-output sidecars when preparing submission manifests
- ensures decoder_quality_sweep JSON pulls candidate manifests, quality JSONs, and candidate sample JSONs into eval PRs
- add regression coverage in submission bridge tests

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_submission_bridge.py -q
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_submission_bridge.py::test_prepare_submission_branch_stages_decoder_sweep_sidecars control_plane/control_plane/tests/test_artifact_stage.py -q
- python3 scripts/validate_runs.py --skip_eval_queue