### PR TITLE
Add decoder probability sensitivity grid

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -536,6 +536,41 @@ def _decoder_probability_sweep_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_probability_sensitivity_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    path_evidence = _decoder_probability_path_evidence(item_id=item_id)
+    sweep_dir = f"{base}/candidate_sweeps/{item_id}"
+    sweep_out = f"{base}/decoder_quality_sweep__{item_id}.json"
+    rough_grid = "decoder_probability_broad_v1"
+    sweep_command = {
+        "name": "sweep_decoder_candidate_quality",
+        "run": (
+            "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
+            f"--dataset-manifest {base}/manifest.json "
+            f"--rough-grid {rough_grid} "
+            f"--out-dir {sweep_dir} "
+            f"--out {sweep_out}"
+        ),
+    }
+    inputs = dict(path_evidence["inputs"])
+    inputs.update(
+        {
+            "candidate_sweep_dir": sweep_dir,
+            "candidate_sweep_out": sweep_out,
+            "candidate_sweep_grid": rough_grid,
+            "candidate_sweep_scope": (
+                "coarse distribution-dependent sensitivity map for the pinned tiny decoder "
+                "benchmark; not general approximation acceptance evidence"
+            ),
+        }
+    )
+    return {
+        "inputs": inputs,
+        "commands": [*path_evidence["commands"], sweep_command],
+        "expected_outputs": [*path_evidence["expected_outputs"], sweep_out],
+    }
+
+
 def _with_fresh_outputs(*, campaign: dict[str, Any], item_id: str) -> dict[str, Any]:
     cloned = json.loads(json.dumps(campaign))
     outputs = dict(cloned.get("outputs") or {})
@@ -632,8 +667,14 @@ def _build_payload(
         },
     }
     abstraction_layer_name = str(abstraction_layer or "").strip()
-    if abstraction_layer_name in {"decoder_probability_path", "decoder_probability_sweep"}:
-        if abstraction_layer_name == "decoder_probability_sweep":
+    if abstraction_layer_name in {
+        "decoder_probability_path",
+        "decoder_probability_sweep",
+        "decoder_probability_sensitivity",
+    }:
+        if abstraction_layer_name == "decoder_probability_sensitivity":
+            decoder_evidence = _decoder_probability_sensitivity_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_probability_sweep":
             decoder_evidence = _decoder_probability_sweep_evidence(item_id=item_id)
         else:
             decoder_evidence = _decoder_probability_path_evidence(item_id=item_id)

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -326,6 +326,60 @@ def test_generate_l2_campaign_task_adds_decoder_probability_sweep_evidence() -> 
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_probability_sensitivity_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_probability_sensitivity_v1",
+                    proposal_id="prop_l2_decoder_probability_sensitivity_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_probability_sensitivity_v1/proposal.json",
+                    evaluation_mode="broad_ranking",
+                    abstraction_layer="decoder_probability_sensitivity",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:4] == [
+                "validate_decoder_contract",
+                "compare_decoder_quality",
+                "check_decoder_missing_model_error",
+                "sweep_decoder_candidate_quality",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["candidate_sweep_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_quality_sweep__l2_decoder_probability_sensitivity_v1.json"
+            )
+            assert decoder_inputs["candidate_sweep_dir"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "candidate_sweeps/l2_decoder_probability_sensitivity_v1"
+            )
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_probability_broad_v1"
+            assert "distribution-dependent sensitivity map" in decoder_inputs["candidate_sweep_scope"]
+            assert "--rough-grid decoder_probability_broad_v1" in work_item.command_manifest[3]["run"]
+            assert decoder_inputs["candidate_sweep_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_probability_sensitivity",
+            }
+
+
 def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/design_brief.md
@@ -1,0 +1,41 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_probability_sensitivity_v1`
+- `title`: `LLM decoder probability sensitivity map`
+
+## Problem
+The current exact-vs-approx sweep showed that the active q4 PWL plus reciprocal
+candidate drops decoder quality to `0.8`, but that single point is not enough to
+understand the approximation space. Probability-path approximation behavior is
+deeply dependent on model weights, prompt distribution, and logit margins.
+
+## Hypothesis
+A rough grid over several probability-path approximation families can identify
+where quality cliffs begin without overfitting the next decision to one narrow
+benchmark setup.
+
+## Evaluation Scope
+- rough grid:
+  - exact path with coarse logit and probability quantization probes
+  - PWL softmax with float, q8, q6, and q4 input/weight probes
+  - reciprocal normalization probes
+  - final probability quantization stress probes
+- evaluation mode:
+  - `broad_ranking`
+- excluded:
+  - RTL changes
+  - mapper changes
+  - promotion of approximate softmax hardware
+
+## Caveat
+Passing this benchmark is not general acceptance evidence. The result is a
+local map for the pinned `llm_decoder_eval_tiny_v1` model, tokenizer, and prompt
+set. A later broad dataset/model expansion is required before any hardware
+approximation is promoted.
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-04-29T00:00:00Z
+- note: proceed as a broad outline map, not a narrow parameter optimization.

--- a/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_probability_sensitivity_v1",
+  "source_commit": "d3231acda1b9f0bb403bb2c381c300421b179965",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_probability_sensitivity_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a broad rough decoder probability-path sensitivity map over coarse exact, PWL, reciprocal, and probability quantization points.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "broad_ranking",
+      "abstraction_layer": "decoder_probability_sensitivity",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_probability_sweep_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The map is expected to identify rough quality cliffs and candidate-safe regions for the pinned tiny benchmark, while explicitly avoiding general approximation acceptance claims."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/implementation_summary.md
@@ -1,0 +1,18 @@
+# Implementation Summary
+
+- Extend `npu/eval/sweep_llm_decoder_candidate_quality.py` with
+  `--rough-grid decoder_probability_broad_v1`.
+- Generate coarse candidate backend configs from existing exact and approximate
+  decoder templates instead of checking in many permanent model-contract
+  templates.
+- Record per-template quality, tensor drift rollups, and sample IDs where
+  next-token or top-k matching fails.
+- Add `decoder_probability_sensitivity` evidence generation to the L2 task
+  generator.
+
+## Local Preview
+
+The local preview over the pinned tiny decoder benchmark produced a mixed map:
+several exact/q8/q6/PWL points preserved `1.0`, while q4 and final probability
+quantization points exposed quality cliffs. This preview is used only to confirm
+the artifact shape before evaluator execution.

--- a/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/promotion_decision.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_probability_sensitivity_v1",
+  "decision": "pending_evaluation",
+  "reason": "Await evaluator broad-ranking evidence for the rough decoder probability sensitivity map."
+}

--- a/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/promotion_result.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_probability_sensitivity_v1",
+  "status": "pending",
+  "result_refs": []
+}

--- a/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/proposal.json
@@ -1,0 +1,57 @@
+{
+  "proposal_id": "prop_l2_decoder_probability_sensitivity_v1",
+  "created_utc": "2026-04-29T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "LLM decoder probability sensitivity map",
+  "hypothesis": "A broad, rough decoder probability-path sensitivity map should be recorded before optimizing a specific approximation knob, because approximation quality depends strongly on model weights, prompts, logits, and input distribution.",
+  "direct_comparison": {
+    "primary_question": "Which coarse probability-path approximation families preserve next-token and top-k quality on the pinned tiny decoder benchmark, and where do cliffs appear?",
+    "include": [
+      "exact softmax and normalization reference candidate",
+      "coarse logit quantization points",
+      "coarse PWL softmax quantization points",
+      "reciprocal-normalization precision points",
+      "final probability quantization stress points",
+      "per-sample next-token and top-k miss lists"
+    ],
+    "exclude": [
+      "claiming general LLM accuracy acceptance",
+      "tuning a narrow approximation optimum for this benchmark only",
+      "new RTL or mapper changes"
+    ],
+    "follow_on_broad_sweep": [
+      "expand prompts, model families, and logit-margin regimes before any hardware approximation is promoted"
+    ]
+  },
+  "expected_benefit": [
+    "maps the coarse outline of the decoder probability approximation space",
+    "separates obvious quality cliffs from potentially safe approximation families",
+    "keeps the distribution-dependence caveat explicit in the evaluation artifact"
+  ],
+  "risks": [
+    "the tiny prompt/model setup is too narrow to predict broader LLM behavior",
+    "points that pass this benchmark may fail on different weight or prompt distributions",
+    "the sweep is software-emulated probability-path evidence, not RTL-backed decoder execution"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_probability_sensitivity_v1",
+      "task_type": "l2_campaign",
+      "objective": "decoder_probability_sensitivity",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json"
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_probability_sweep_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_probability_sweep_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llm_decoder_accuracy_stage_v1.md",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "runs/models/llm_decoder_tiny_v1/model_contract.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/manifest.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_probability_sensitivity_v1/quality_gate.md
@@ -1,0 +1,17 @@
+# Quality Gate
+
+## Required Checks
+
+- `python3 -m py_compile npu/eval/sweep_llm_decoder_candidate_quality.py`
+- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+- Local rough-grid smoke:
+  - `python3 npu/eval/sweep_llm_decoder_candidate_quality.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json --rough-grid decoder_probability_broad_v1 --out-dir /tmp/decoder_probability_broad_grid --out /tmp/decoder_probability_broad_grid.json`
+
+## Acceptance
+
+- The evaluator result must include `decoder_quality_sweep__l2_decoder_probability_sensitivity_v1.json`.
+- The artifact must include `scope_note` stating the distribution-dependence
+  limitation.
+- The result must list per-template next-token/top-k rates and sample-level miss
+  IDs.

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -74,6 +74,15 @@ python3 npu/eval/sweep_llm_decoder_candidate_quality.py \
   --out /tmp/decoder_candidate_sweep.json
 ```
 
+Run a rough decoder probability sensitivity grid:
+```sh
+python3 npu/eval/sweep_llm_decoder_candidate_quality.py \
+  --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest.json \
+  --rough-grid decoder_probability_broad_v1 \
+  --out-dir /tmp/decoder_probability_broad_grid \
+  --out /tmp/decoder_probability_broad_grid.json
+```
+
 Optionally verify path-like fields exist:
 ```sh
 python3 npu/eval/validate.py --campaign <campaign.json> --check_paths

--- a/npu/eval/sweep_llm_decoder_candidate_quality.py
+++ b/npu/eval/sweep_llm_decoder_candidate_quality.py
@@ -62,6 +62,133 @@ def _candidate_templates(model_contract: JsonDict, requested: List[str]) -> Dict
     return out
 
 
+def _candidate_template(model_contract: JsonDict, name: str) -> JsonDict:
+    templates = model_contract.get("backend_templates", {}) or {}
+    if not isinstance(templates, dict):
+        raise ValueError("model_contract.backend_templates must be an object")
+    if name not in templates:
+        raise ValueError(f"candidate backend template not found: {name}")
+    cfg = dict(templates[name])
+    cfg["role"] = "candidate"
+    cfg["interface"] = "decoder_backend_v1"
+    return cfg
+
+
+def _named_grid_point(base: JsonDict, name: str, **updates: Any) -> tuple[str, JsonDict]:
+    cfg = dict(base)
+    cfg.pop("candidate_semantics", None)
+    for key, value in updates.items():
+        if value is None:
+            cfg.pop(key, None)
+        else:
+            cfg[key] = value
+    return name, cfg
+
+
+def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str, JsonDict]:
+    if grid_name != "decoder_probability_broad_v1":
+        raise ValueError(f"unsupported rough grid: {grid_name}")
+    exact = _candidate_template(model_contract, "candidate_onnx_softmax_exact")
+    approx = _candidate_template(model_contract, "candidate_onnx_softmax_approx")
+    points = [
+        ("candidate_onnx_softmax_exact", exact),
+        _named_grid_point(exact, "grid_exact_logits_q8", logit_quant_bits=8),
+        _named_grid_point(exact, "grid_exact_logits_q6", logit_quant_bits=6),
+        _named_grid_point(exact, "grid_exact_logits_q4", logit_quant_bits=4),
+        _named_grid_point(exact, "grid_exact_prob_q8", probability_quant_bits=8),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_float_norm_exact",
+            softmax_input_quant_bits=None,
+            softmax_weight_quant_bits=None,
+            normalization_mode="exact",
+            normalization_reciprocal_bits=None,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_in_q8_w_fp_norm_exact",
+            softmax_input_quant_bits=8,
+            softmax_weight_quant_bits=None,
+            normalization_mode="exact",
+            normalization_reciprocal_bits=None,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_in_fp_w_q8_norm_exact",
+            softmax_input_quant_bits=None,
+            softmax_weight_quant_bits=8,
+            normalization_mode="exact",
+            normalization_reciprocal_bits=None,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_in_q8_w_q8_norm_exact",
+            softmax_input_quant_bits=8,
+            softmax_weight_quant_bits=8,
+            normalization_mode="exact",
+            normalization_reciprocal_bits=None,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_in_q6_w_q6_norm_exact",
+            softmax_input_quant_bits=6,
+            softmax_weight_quant_bits=6,
+            normalization_mode="exact",
+            normalization_reciprocal_bits=None,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_in_q4_w_q4_norm_exact",
+            softmax_input_quant_bits=4,
+            softmax_weight_quant_bits=4,
+            normalization_mode="exact",
+            normalization_reciprocal_bits=None,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_float_norm_recip_q10",
+            softmax_input_quant_bits=None,
+            softmax_weight_quant_bits=None,
+            normalization_mode="reciprocal_quantized",
+            normalization_reciprocal_bits=10,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_in_q8_w_q8_norm_recip_q12",
+            softmax_input_quant_bits=8,
+            softmax_weight_quant_bits=8,
+            normalization_mode="reciprocal_quantized",
+            normalization_reciprocal_bits=12,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_in_q6_w_q6_norm_recip_q10",
+            softmax_input_quant_bits=6,
+            softmax_weight_quant_bits=6,
+            normalization_mode="reciprocal_quantized",
+            normalization_reciprocal_bits=10,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_in_q4_w_q4_norm_recip_q8",
+            softmax_input_quant_bits=4,
+            softmax_weight_quant_bits=4,
+            normalization_mode="reciprocal_quantized",
+            normalization_reciprocal_bits=8,
+        ),
+        _named_grid_point(
+            approx,
+            "grid_approx_pwl_in_q8_w_q8_norm_recip_q12_prob_q8",
+            softmax_input_quant_bits=8,
+            softmax_weight_quant_bits=8,
+            normalization_mode="reciprocal_quantized",
+            normalization_reciprocal_bits=12,
+            probability_quant_bits=8,
+        ),
+    ]
+    return {name: cfg for name, cfg in points}
+
+
 def _generate_candidate_manifest(
     *,
     dataset_manifest: JsonDict,
@@ -116,19 +243,38 @@ def _generate_candidate_manifest(
     }
 
 
-def _aggregate_row(template_name: str, manifest_path: Path, quality_path: Path, metrics: JsonDict) -> JsonDict:
+def _aggregate_row(template_name: str, manifest_path: Path, quality_path: Path, backend_config: JsonDict, metrics: JsonDict) -> JsonDict:
     aggregate = dict(metrics.get("aggregate", {}) or {})
     tensor = dict(aggregate.get("selected_tensor_trace", {}) or {})
+    mismatch_sample_ids = [
+        str(sample.get("sample_id", ""))
+        for sample in metrics.get("samples", []) or []
+        if not int((sample.get("aggregate", {}) or {}).get("next_token_id_match", 0))
+    ]
+    topk_miss_sample_ids = [
+        str(sample.get("sample_id", ""))
+        for sample in metrics.get("samples", []) or []
+        if not int((sample.get("aggregate", {}) or {}).get("topk_contains_reference_id", 0))
+    ]
     return {
         "template": template_name,
         "candidate_semantics": metrics.get("candidate_semantics", ""),
         "candidate_manifest": _portable_path(manifest_path),
         "quality_json": _portable_path(quality_path),
+        "logit_quant_bits": backend_config.get("logit_quant_bits", 0),
+        "softmax_mode": backend_config.get("softmax_mode", "exact"),
+        "softmax_input_quant_bits": backend_config.get("softmax_input_quant_bits", 0),
+        "softmax_weight_quant_bits": backend_config.get("softmax_weight_quant_bits", 0),
+        "normalization_mode": backend_config.get("normalization_mode", "exact"),
+        "normalization_reciprocal_bits": backend_config.get("normalization_reciprocal_bits", 0),
+        "probability_quant_bits": backend_config.get("probability_quant_bits", 0),
         "sample_count": aggregate.get("sample_count"),
         "next_token_id_match_rate": aggregate.get("next_token_id_match_rate"),
         "next_token_text_match_rate": aggregate.get("next_token_text_match_rate"),
         "topk_contains_reference_id_rate": aggregate.get("topk_contains_reference_id_rate"),
         "topk_contains_reference_text_rate": aggregate.get("topk_contains_reference_text_rate"),
+        "next_token_mismatch_sample_ids": mismatch_sample_ids,
+        "topk_miss_sample_ids": topk_miss_sample_ids,
         "selected_tensor_shape_match_rate": tensor.get("shape_match_rate"),
         "selected_tensor_trace_sha256_match_rate": tensor.get("trace_sha256_match_rate"),
         "selected_tensor_delta_rollups": tensor.get("delta_rollups", {}),
@@ -143,6 +289,11 @@ def main() -> int:
         action="append",
         default=[],
         help="Candidate backend template name. Defaults to all model_contract backend_templates starting with candidate_.",
+    )
+    ap.add_argument(
+        "--rough-grid",
+        default="",
+        help="Generate a built-in rough approximation grid, e.g. decoder_probability_broad_v1.",
     )
     ap.add_argument("--out-dir", default="runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/local")
     ap.add_argument("--out", default="")
@@ -159,7 +310,12 @@ def main() -> int:
     reference_manifest = load_json(reference_manifest_path)
     tokenizer_bundle = load_tokenizer_bundle(tokenizer_manifest, manifest_path=tokenizer_manifest_path)
     samples = load_jsonl(sample_file)
-    templates = _candidate_templates(model_contract, [str(v) for v in args.template])
+    if args.rough_grid:
+        if args.template:
+            raise ValueError("--template cannot be combined with --rough-grid")
+        templates = _rough_grid_templates(model_contract, str(args.rough_grid))
+    else:
+        templates = _candidate_templates(model_contract, [str(v) for v in args.template])
 
     out_dir = _resolve_repo_path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -184,7 +340,7 @@ def main() -> int:
         metrics = compare_decoder_manifests(reference_manifest, candidate_manifest)
         quality_path = template_dir / "quality.json"
         quality_path.write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        results.append(_aggregate_row(template_name, manifest_path, quality_path, metrics))
+        results.append(_aggregate_row(template_name, manifest_path, quality_path, backend_config, metrics))
 
     best = sorted(
         results,
@@ -199,6 +355,12 @@ def main() -> int:
         "dataset_id": dataset_manifest["dataset_id"],
         "task": dataset_manifest["task"],
         "reference_manifest": _portable_path(reference_manifest_path),
+        "rough_grid": str(args.rough_grid),
+        "scope_note": (
+            "Approximation sensitivity is distribution-dependent. This sweep is a coarse map for the pinned "
+            "llm_decoder_eval_tiny_v1 prompt/model/tokenizer setup and must not be treated as general "
+            "acceptance evidence without broader datasets."
+        ),
         "template_count": len(results),
         "templates": results,
         "best_template": best,


### PR DESCRIPTION
## Summary
- add a rough decoder probability sensitivity grid to the decoder candidate sweep tool
- wire a decoder_probability_sensitivity L2 evidence path
- add proposal docs for l2_decoder_probability_sensitivity_v1

## Notes
- the grid is intentionally broad and rough, not a narrow parameter optimizer
- output includes a scope note that approximation quality is distribution-dependent and specific to the pinned tiny decoder setup

## Validation
- python3 -m py_compile npu/eval/sweep_llm_decoder_candidate_quality.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- local rough-grid smoke: 16 templates, best exact candidate at 1.0 next-token/top-k, scope_note present