### PR TITLE
control_plane: make iterate finalization idempotent

### DIFF
--- a/control_plane/control_plane/services/proposal_finalizer.py
+++ b/control_plane/control_plane/services/proposal_finalizer.py
@@ -376,7 +376,7 @@ def _is_merged_status(status: str) -> bool:
 
 def _is_terminal_decision(decision: str) -> bool:
     normalized = str(decision or "").strip().lower()
-    return normalized in {"promote", "promoted", "reject", "rejected", "close", "closed", "superseded"}
+    return normalized in {"promote", "promoted", "iterate", "reject", "rejected", "close", "closed", "superseded"}
 
 
 def _mark_merged_requested_item(

--- a/control_plane/control_plane/tests/test_proposal_finalizer.py
+++ b/control_plane/control_plane/tests/test_proposal_finalizer.py
@@ -195,6 +195,10 @@ def test_finalize_accepts_directory_style_proposal_path() -> None:
         assert promotion_result["merge_commit"] == "facefeed"
 
 
+def test_iterate_decision_is_terminal_for_idempotent_finalize() -> None:
+    assert proposal_finalizer._is_terminal_decision("iterate")
+
+
 
 def test_finalize_after_merge_refreshes_central_runs_index() -> None:
     with tempfile.TemporaryDirectory() as td:

--- a/docs/proposals/prop_l2_decoder_fp_probability_format_sweep_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_fp_probability_format_sweep_v1/evaluation_requests.json
@@ -23,8 +23,8 @@
       "status": "merged",
       "merged_pr_number": 264,
       "merge_commit": "8c7ed15a23431933e876a59ca6ba9be2f6594889",
-      "merged_utc": "2026-04-29T05:29:44.564391Z",
-      "notes": "Merged via PR #264 and merge 8c7ed15a23431933e876a59ca6ba9be2f6594889 at 2026-04-29T05:27:39Z. Merged via PR #264 and merge 8c7ed15a23431933e876a59ca6ba9be2f6594889 at 2026-04-29T05:29:44.564391Z."
+      "merged_utc": "2026-04-29T05:27:39Z",
+      "notes": "Merged via PR #264 and merge 8c7ed15a23431933e876a59ca6ba9be2f6594889 at 2026-04-29T05:27:39Z."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_fp_probability_format_sweep_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_fp_probability_format_sweep_v1/promotion_result.json
@@ -6,5 +6,5 @@
   "decision": "iterate",
   "pr_number": 264,
   "merge_commit": "8c7ed15a23431933e876a59ca6ba9be2f6594889",
-  "merged_utc": "2026-04-29T05:29:44.564391Z"
+  "merged_utc": "2026-04-29T05:27:39Z"
 }


### PR DESCRIPTION
## Summary
- Treat `iterate` as a terminal proposal finalization decision so repeated GitHub reconciliation skips already-finalized iterate proposals.
- Clean the duplicate merge note/timestamp produced when #264 was finalized once manually and then finalized again by `poll-github`.

## Verification
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_proposal_finalizer.py -q -k iterate_decision_is_terminal_for_idempotent_finalize`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile control_plane/control_plane/services/proposal_finalizer.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`

Note: the full `test_proposal_finalizer.py` file still has a pre-existing failure in `test_finalize_refreshes_repo_before_loading_proposal_files` on current master; this change does not touch that path.