### PR TITLE
Plan RTLGen calibration for decoder normalization costs

### DIFF
--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/README.md
@@ -1,0 +1,11 @@
+# Decoder Normalization Arithmetic Calibration
+
+This workspace tracks the first RTLGen-backed calibration step for the decoder
+normalization cost proxy. The current proxy is a hand-written planning model.
+It is useful for choosing what to measure next, but it is not a literature
+model and it is not measured Nangate45 PPA.
+
+The requested L1 work measures multiplier and adder primitives that bound the
+q8 reciprocal-normalization path. Divider and bf16 reciprocal blocks are
+explicit follow-ups because RTLGen does not currently expose standalone config
+support for them.

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending L1 measurement results.

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/design_brief.md
@@ -1,0 +1,43 @@
+# Design Brief
+
+- `proposal_id`: `prop_l1_decoder_normalization_arithmetic_calibration_v1`
+- `title`: `Decoder normalization arithmetic calibration`
+- `layer`: `l1`
+- `kind`: `circuit`
+
+## Context
+
+The decoder q8 normalization frontier selected
+`grid_approx_pwl_in_q8_w_q8_norm_recip_q10` because it preserved the
+prompt-stress exact next-token and top-k gate while scoring lower than exact
+normalization in the planning proxy. That score is a hand-written heuristic,
+not a research-derived or physically calibrated model.
+
+RTLGen exists to close this gap. The next step is to measure the integer
+arithmetic primitives that the q8 reciprocal path depends on before fitting any
+calibrated normalization-cost model.
+
+## Calibration Scope
+
+Run two L1 OpenROAD measurement-only sweeps on Nangate45:
+
+- `l1_decoder_norm_q8_recip_mult_calibration_v1`: unsigned multiplier wrappers
+  for 8/16/32-bit datapath envelopes.
+- `l1_decoder_norm_accumulator_adder_calibration_v1`: unsigned 16/32/64-bit
+  adders for normalization sum and accumulator envelopes.
+
+This scope intentionally does not claim full decoder-softmax PPA. It measures
+available RTLGen primitive blocks and records the unsupported blocks as gaps:
+
+- exact normalization still needs a divider or reciprocal-generation block;
+- bf16 reciprocal normalization still needs a bf16-compatible reciprocal and
+  multiply integration point;
+- table lookup, rounding, control, and row-level softmax integration remain
+  outside this primitive calibration job.
+
+## Expected Use
+
+The merged metrics should replace the current uncalibrated multiplier/adder
+terms in the decoder planning scripts. If the measurements contradict the q10
+heuristic ordering, the next q8 frontier decision should be updated before any
+architecture promotion.

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+The calibration is evaluable when both requested L1 items have merged
+lightweight `metrics.csv` outputs and those outputs contain at least one
+`status=ok` Nangate45 row per requested wrapper.
+
+The first analysis must separate measured primitive timing, power, and area
+from the existing heuristic planning units. It must also state which decoder
+normalization blocks remain unmeasured.

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/evaluation_requests.json
@@ -1,0 +1,22 @@
+{
+  "proposal_id": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
+  "source_commit": "59f95c15052629122aa78fafe9e549367de32cbd",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_norm_q8_recip_mult_calibration_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for unsigned multiplier wrappers that bound q8 reciprocal-normalization multiply paths.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "status": "pending"
+    },
+    {
+      "item_id": "l1_decoder_norm_accumulator_adder_calibration_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for unsigned prefix-adder wrappers that bound q8 normalization-sum and accumulator paths.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/implementation_summary.md
@@ -1,0 +1,11 @@
+# Implementation Summary
+
+Pending evaluator work.
+
+The developer-side change for this proposal is documentation and control-plane
+setup:
+
+- the decoder cost-estimator reports now mark cost units as uncalibrated
+  heuristic planning units;
+- this proposal records the L1 measurements needed to start calibrating those
+  terms with RTLGen/OpenROAD evidence.

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Await L1 multiplier and adder calibration measurements before revising the decoder normalization cost model.",
+  "evidence_refs": [],
+  "next_action": "run first L1 calibration items",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/promotion_gate.md
@@ -1,0 +1,9 @@
+# Promotion Gate
+
+Promotion requires merged L1 evidence and an explicit statement of how the
+measured multiplier and adder trends affect the q8 reciprocal-normalization
+frontier.
+
+Do not promote a full decoder normalization architecture from this proposal
+alone. Exact divide, bf16 reciprocal, table lookup, rounding, and integration
+overheads remain outside this primitive calibration scope.

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
+  "created_utc": "2026-04-29T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "l1",
+  "kind": "circuit",
+  "title": "Decoder normalization arithmetic calibration",
+  "hypothesis": "The q8 reciprocal-normalization frontier should be grounded by RTLGen/OpenROAD measurements of the integer multiplier and accumulator/adder primitives before the heuristic normalization score is used for architecture selection.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 timing, power, and area trends do RTLGen-generated multiplier and adder primitives show for the arithmetic that underlies q8 reciprocal normalization?",
+    "include": [
+      "unsigned 8/16/32-bit multiplier wrappers that bound q8 reciprocal multiply datapaths",
+      "unsigned 16/32/64-bit prefix-adder wrappers that bound q8 weight accumulation and normalization-sum datapaths",
+      "Nangate45 OpenROAD measurements with lightweight metrics.csv outputs",
+      "explicit separation of measured primitive PPA from the current decoder heuristic planning units"
+    ],
+    "exclude": [
+      "claiming full decoder-softmax PPA",
+      "claiming exact divide or bf16 reciprocal PPA before those RTL blocks exist",
+      "changing decoder quality thresholds or mapper behavior"
+    ],
+    "follow_on_broad_sweep": [
+      "add a bounded reciprocal/divider RTL block if exact normalization remains a candidate",
+      "fit a calibrated decoder normalization cost model only after primitive measurements are merged",
+      "rerun q8 normalization frontier ranking using the calibrated terms"
+    ]
+  },
+  "expected_benefit": [
+    "turns the q8 q10 reciprocal choice into a measurable hardware hypothesis instead of a hand-written scalar assumption",
+    "starts the performance, power, and area decomposition with blocks RTLGen can synthesize today",
+    "keeps unsupported exact-divide and bf16 reciprocal costs visible as gaps"
+  ],
+  "risks": [
+    "primitive arithmetic measurements do not include control, table lookup, rounding, or full softmax integration overhead",
+    "the current RTLGen generator has multiplier and adder support but no standalone reciprocal/divider block",
+    "single-sweep Nangate45 points may need utilization or seed sensitivity follow-up before model fitting"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_norm_q8_recip_mult_calibration_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "measurement_only",
+      "objective": "Measure Nangate45 PPA for unsigned multiplier wrappers that bound q8 reciprocal-normalization multiply paths.",
+      "sweep_path": "runs/campaigns/multipliers/ppg_cpa_widths_4_32/sweeps/nangate45_highutil.json",
+      "abstraction_layer": "circuit_block"
+    },
+    {
+      "item_id": "l1_decoder_norm_accumulator_adder_calibration_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "measurement_only",
+      "objective": "Measure Nangate45 PPA for unsigned prefix-adder wrappers that bound q8 normalization-sum and accumulator paths.",
+      "sweep_path": "runs/campaigns/prefix_adders/sweeps/nangate45_highutil.json",
+      "abstraction_layer": "circuit_block"
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_q8_normalization_frontier_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json",
+    "runs/designs/multipliers/mult16u_normal_koggestone_wrapper/metrics.csv",
+    "runs/designs/prefix_adders/adder_koggestone_16u_wrapper/metrics.csv"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_survivor_cost.py",
+    "npu/eval/estimate_llm_decoder_pwl_frontier.py",
+    "npu/eval/estimate_llm_decoder_q8_norm_frontier.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ],
+  "abstraction_layer": "circuit_block"
+}

--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/quality_gate.md
@@ -1,0 +1,7 @@
+# Quality Gate
+
+This L1 proposal does not rerun model-quality gates. It inherits quality context
+from the q8 normalization frontier and only calibrates arithmetic cost terms.
+
+Any later calibrated ranking must continue to require exact next-token and
+top-k preservation on the prompt-stress suite before comparing hardware costs.

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -160,6 +160,14 @@ The cost proxy gates rows on exact prompt-stress quality and then scores rough
 softmax/probability-path terms. Treat it as a planning rank for the next RTL or
 OpenROAD step, not as measured PPA.
 
+The decoder cost proxy and the later PWL/q8-normalization detail scores are
+hand-written planning heuristics. They are not derived from a paper and they do
+not independently balance performance, power, and area. Their role is to choose
+which exact-safe architecture point should be physically calibrated next. Use
+RTLGen/OpenROAD Layer 1 evidence, such as
+`prop_l1_decoder_normalization_arithmetic_calibration_v1`, before making a
+hardware acceptance claim.
+
 Break down the exact-safe PWL frontier after the survivor cost proxy:
 ```sh
 python3 npu/eval/estimate_llm_decoder_pwl_frontier.py \
@@ -191,7 +199,10 @@ python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py \
 This frontier tests q8 PWL exact normalization against q8 PWL quantized
 reciprocal normalization at q10/q12/q14/q16, with the bf16 reciprocal PWL row
 kept as the current anchor. A reciprocal row is only a candidate if it preserves
-the full prompt-stress next-token and top-k gate.
+the full prompt-stress next-token and top-k gate. The reported normalization
+cost is an uncalibrated planning unit; follow it with RTLGen/OpenROAD
+calibration of the integer multiplier and accumulator/adder path before treating
+q10 as physically better than wider reciprocal options.
 
 Optionally verify path-like fields exist:
 ```sh

--- a/npu/eval/estimate_llm_decoder_pwl_frontier.py
+++ b/npu/eval/estimate_llm_decoder_pwl_frontier.py
@@ -16,6 +16,23 @@ FRONTIER_TEMPLATES = (
     "grid_approx_pwl_in_q8_w_q8_norm_exact",
 )
 
+COST_MODEL = {
+    "name": "decoder_pwl_frontier_detail_planning_proxy_v1",
+    "source": "hand_written_planning_proxy_not_literature_backed",
+    "unit": "heuristic_planning_units",
+    "calibration_status": "uncalibrated",
+    "ppa_balance": (
+        "The detail score is a decomposition aid, not an independent timing, power, and "
+        "area model. It folds datapath width, table size, and normalization risk into one "
+        "planning scalar."
+    ),
+    "intended_use": (
+        "Identify which PWL decoder block should receive RTLGen/OpenROAD calibration next; "
+        "do not use the score as hardware acceptance evidence."
+    ),
+    "rtlgen_calibration_proposal": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
+}
+
 
 def _load_json(path: Path) -> JsonDict:
     with path.open("r", encoding="utf-8") as f:
@@ -90,6 +107,8 @@ def _normalization_model(row: JsonDict) -> JsonDict:
             "mode": "exact",
             "implementation": "sum_plus_exact_divide",
             "relative_cost_units": 52.0,
+            "unit": COST_MODEL["unit"],
+            "calibration_status": COST_MODEL["calibration_status"],
             "integration_risk": "high",
             "risk_reason": "Exact normalization preserves quality but carries a divider-like path that can dominate the otherwise smaller q8 PWL datapath.",
         }
@@ -98,6 +117,8 @@ def _normalization_model(row: JsonDict) -> JsonDict:
             "mode": "reciprocal_float",
             "implementation": "bf16_reciprocal_multiply",
             "relative_cost_units": 22.0,
+            "unit": COST_MODEL["unit"],
+            "calibration_status": COST_MODEL["calibration_status"],
             "integration_risk": "medium",
             "risk_reason": "The reciprocal path is cheaper in this planning model, but it requires a bf16-compatible reciprocal/multiply integration point.",
         }
@@ -105,6 +126,8 @@ def _normalization_model(row: JsonDict) -> JsonDict:
         "mode": mode or "unknown",
         "implementation": "unclassified",
         "relative_cost_units": 36.0,
+        "unit": COST_MODEL["unit"],
+        "calibration_status": COST_MODEL["calibration_status"],
         "integration_risk": "unknown",
         "risk_reason": "The normalization path is outside the current two-candidate frontier model.",
     }
@@ -206,6 +229,15 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         f"- decision: `{payload['frontier_decision']['decision']}`",
         f"- primary_candidate: `{payload['frontier_decision']['primary_candidate']}`",
         f"- alternate_candidate: `{payload['frontier_decision']['alternate_candidate']}`",
+        f"- cost_model_source: `{payload['cost_model']['source']}`",
+        f"- cost_model_unit: `{payload['cost_model']['unit']}`",
+        f"- rtlgen_calibration_proposal: `{payload['cost_model']['rtlgen_calibration_proposal']}`",
+        "",
+        "## Cost Model Provenance",
+        "",
+        payload["cost_model"]["ppa_balance"],
+        "",
+        payload["cost_model"]["intended_use"],
         "",
         "## Frontier Breakdown",
         "",
@@ -267,9 +299,11 @@ def build_report(*, sweep_path: Path, cost_proxy_path: Path | None = None) -> Js
             "quality_gate": "both candidates must pass exact next-token and top-k on every prompt-stress sample",
             "scope_note": (
                 "This is a focused planning breakdown for the two exact-safe PWL candidates. "
-                "It is not RTL, OpenROAD PPA, or final hardware acceptance."
+                "It is not RTL, OpenROAD PPA, or final hardware acceptance. The detail "
+                "scores are uncalibrated heuristic planning units."
             ),
         },
+        "cost_model": COST_MODEL,
         "frontier_decision": {
             "decision": "deepen_primary_keep_alternate",
             "primary_candidate": primary,

--- a/npu/eval/estimate_llm_decoder_q8_norm_frontier.py
+++ b/npu/eval/estimate_llm_decoder_q8_norm_frontier.py
@@ -15,6 +15,22 @@ BASELINE_Q8_EXACT = "grid_approx_pwl_in_q8_w_q8_norm_exact"
 BF16_ANCHOR = "grid_approx_pwl_bf16_path"
 Q8_PREFIX = "grid_approx_pwl_in_q8_w_q8_norm_recip_q"
 
+COST_MODEL = {
+    "name": "decoder_q8_normalization_planning_proxy_v1",
+    "source": "hand_written_planning_proxy_not_literature_backed",
+    "unit": "heuristic_planning_units",
+    "calibration_status": "uncalibrated",
+    "ppa_balance": (
+        "The score is a single planning scalar. It does not independently balance timing, "
+        "power, and area, and it must not be read as Nangate45 PPA."
+    ),
+    "intended_use": (
+        "Choose the next RTLGen/OpenROAD calibration target after quality-gated decoder "
+        "sweeps; do not use it as hardware acceptance evidence."
+    ),
+    "rtlgen_calibration_proposal": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
+}
+
 
 def _load_json(path: Path) -> JsonDict:
     with path.open("r", encoding="utf-8") as f:
@@ -101,6 +117,8 @@ def _row_record(row: JsonDict) -> JsonDict:
             "reciprocal_bits": row.get("normalization_reciprocal_bits", 0),
             "reciprocal_float_format": row.get("normalization_reciprocal_float_format", ""),
             "relative_cost_units": round(norm_cost, 3),
+            "unit": COST_MODEL["unit"],
+            "calibration_status": COST_MODEL["calibration_status"],
         },
         "frontier_score": round(norm_cost + (0.0 if quality["exact_safe"] else 1000.0), 3),
     }
@@ -114,6 +132,15 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         f"- decision: `{payload['decision']['decision']}`",
         f"- selected_candidate: `{payload['decision']['selected_candidate'] or ''}`",
         f"- reason: {payload['decision']['reason']}",
+        f"- cost_model_source: `{payload['cost_model']['source']}`",
+        f"- cost_model_unit: `{payload['cost_model']['unit']}`",
+        f"- rtlgen_calibration_proposal: `{payload['cost_model']['rtlgen_calibration_proposal']}`",
+        "",
+        "## Cost Model Provenance",
+        "",
+        payload["cost_model"]["ppa_balance"],
+        "",
+        payload["cost_model"]["intended_use"],
         "",
         "## Quality And Normalization Cost",
         "",
@@ -218,9 +245,11 @@ def build_report(*, sweep_path: Path) -> JsonDict:
             "quality_gate": "candidate must match next-token and top-k for every prompt-stress sample",
             "scope_note": (
                 "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization "
-                "precision as a replacement for q8 exact normalization; it is not RTL or OpenROAD PPA."
+                "precision as a replacement for q8 exact normalization; it is not RTL or OpenROAD PPA. "
+                "The normalization cost values are uncalibrated heuristic planning units."
             ),
         },
+        "cost_model": COST_MODEL,
         "decision": decision,
         "ranked_rows": ranked,
         "next_step": [

--- a/npu/eval/estimate_llm_decoder_survivor_cost.py
+++ b/npu/eval/estimate_llm_decoder_survivor_cost.py
@@ -11,6 +11,24 @@ from typing import Any
 
 JsonDict = dict[str, Any]
 
+COST_MODEL = {
+    "name": "decoder_survivor_relative_softmax_cost_v1",
+    "source": "hand_written_planning_proxy_not_literature_backed",
+    "unit": "heuristic_planning_units",
+    "calibration_status": "uncalibrated",
+    "ppa_balance": (
+        "The ranking score is a single planning scalar. It is not derived from papers or "
+        "calibrated physical data, and it does not independently optimize timing, power, "
+        "and area."
+    ),
+    "intended_use": (
+        "Rank exact-safe decoder survivors well enough to choose the next RTLGen/OpenROAD "
+        "calibration target; do not use it as hardware acceptance evidence."
+    ),
+    "quality_gate": "eligible rows must match next-token and top-k on every prompt-stress sample",
+    "rtlgen_calibration_proposal": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
+}
+
 
 def _load_json(path: Path) -> JsonDict:
     with path.open("r", encoding="utf-8") as f:
@@ -89,6 +107,8 @@ def _cost_proxy(row: JsonDict) -> JsonDict:
 
     return {
         "relative_cost_units": round(relative_cost_units, 3),
+        "unit": COST_MODEL["unit"],
+        "calibration_status": COST_MODEL["calibration_status"],
         "softmax_path": softmax_path,
         "softmax_eval_cost": round(exp_or_pwl_cost, 3),
         "normalization_cost": round(normalization_cost, 3),
@@ -170,10 +190,17 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         f"- source_sweep: `{payload['source_sweep']}`",
         f"- recommendation: `{payload['recommendation']['template']}`",
         f"- reason: {payload['recommendation']['reason']}",
+        f"- cost_model_source: `{payload['cost_model']['source']}`",
+        f"- cost_model_unit: `{payload['cost_model']['unit']}`",
+        f"- rtlgen_calibration_proposal: `{payload['cost_model']['rtlgen_calibration_proposal']}`",
         "",
         "## Cost Model",
         "",
         payload["cost_model"]["scope_note"],
+        "",
+        payload["cost_model"]["ppa_balance"],
+        "",
+        payload["cost_model"]["intended_use"],
         "",
         "| rank | template | gate | next-token | top-k | relative cost | softmax path |",
         "|---:|---|---|---:|---:|---:|---|",
@@ -239,13 +266,13 @@ def build_report(*, sweep_path: Path) -> JsonDict:
         "version": 0.1,
         "source_sweep": str(sweep_path),
         "cost_model": {
-            "name": "decoder_survivor_relative_softmax_cost_v1",
+            **COST_MODEL,
             "scope_note": (
                 "This is a relative planning proxy for decoder softmax/probability-path implementation cost. "
                 "It weights exact exp paths above PWL paths and lower-width datapaths below fp-style datapaths. "
-                "It is not RTL, OpenROAD PPA, or final hardware acceptance."
+                "It is not RTL, OpenROAD PPA, or final hardware acceptance. The cost values are "
+                "uncalibrated heuristic planning units."
             ),
-            "quality_gate": "eligible rows must match next-token and top-k on every prompt-stress sample",
         },
         "recommendation": recommendation,
         "ranked_candidates": ranked,

--- a/tests/test_llm_decoder_pwl_frontier.py
+++ b/tests/test_llm_decoder_pwl_frontier.py
@@ -18,6 +18,12 @@ def test_decoder_pwl_frontier_detail_keeps_bf16_primary_and_q8_alternate() -> No
     assert report["frontier_decision"]["primary_candidate"] == "grid_approx_pwl_bf16_path"
     assert report["frontier_decision"]["alternate_candidate"] == "grid_approx_pwl_in_q8_w_q8_norm_exact"
     assert report["frontier_decision"]["decision"] == "deepen_primary_keep_alternate"
+    assert report["cost_model"]["source"] == "hand_written_planning_proxy_not_literature_backed"
+    assert report["cost_model"]["unit"] == "heuristic_planning_units"
+    assert (
+        report["cost_model"]["rtlgen_calibration_proposal"]
+        == "prop_l1_decoder_normalization_arithmetic_calibration_v1"
+    )
 
     candidates = report["frontier_candidates"]
     assert {row["template"] for row in candidates} == {
@@ -39,6 +45,7 @@ def test_decoder_pwl_frontier_detail_keeps_bf16_primary_and_q8_alternate() -> No
     )
     assert q8["normalization_path"]["integration_risk"] == "high"
     assert bf16["normalization_path"]["integration_risk"] == "medium"
+    assert q8["normalization_path"]["calibration_status"] == "uncalibrated"
     assert q8["normalization_path"]["relative_cost_units"] > bf16["normalization_path"]["relative_cost_units"]
     assert bf16["previous_survivor_cost_proxy"]["rank"] == 1
     assert q8["previous_survivor_cost_proxy"]["rank"] == 2

--- a/tests/test_llm_decoder_q8_norm_frontier.py
+++ b/tests/test_llm_decoder_q8_norm_frontier.py
@@ -29,8 +29,15 @@ def test_q8_normalization_frontier_report_selects_lowest_cost_exact_safe_recipro
 
     assert report["decision"]["decision"] == "q8_reciprocal_candidate_survived"
     assert report["decision"]["selected_candidate"] == "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
+    assert report["cost_model"]["source"] == "hand_written_planning_proxy_not_literature_backed"
+    assert report["cost_model"]["unit"] == "heuristic_planning_units"
+    assert (
+        report["cost_model"]["rtlgen_calibration_proposal"]
+        == "prop_l1_decoder_normalization_arithmetic_calibration_v1"
+    )
     by_template = {row["template"]: row for row in report["ranked_rows"]}
     assert by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["quality"]["exact_safe"]
+    assert by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["normalization"]["calibration_status"] == "uncalibrated"
     assert by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q12"]["quality"]["exact_safe"]
     assert (
         by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["normalization"]["relative_cost_units"]

--- a/tests/test_llm_decoder_survivor_cost.py
+++ b/tests/test_llm_decoder_survivor_cost.py
@@ -15,6 +15,12 @@ def test_decoder_survivor_cost_proxy_prefers_exact_safe_pwl_frontier() -> None:
         "grid_approx_pwl_bf16_path",
         "grid_approx_pwl_in_q8_w_q8_norm_exact",
     }
+    assert report["cost_model"]["source"] == "hand_written_planning_proxy_not_literature_backed"
+    assert report["cost_model"]["unit"] == "heuristic_planning_units"
+    assert (
+        report["cost_model"]["rtlgen_calibration_proposal"]
+        == "prop_l1_decoder_normalization_arithmetic_calibration_v1"
+    )
     ranked = report["ranked_candidates"]
     by_template = {row["template"]: row for row in ranked}
 
@@ -26,6 +32,7 @@ def test_decoder_survivor_cost_proxy_prefers_exact_safe_pwl_frontier() -> None:
         by_template["grid_approx_pwl_in_q8_w_q8_norm_exact"]["cost_proxy"]["relative_cost_units"]
         < by_template["grid_prob_bf16"]["cost_proxy"]["relative_cost_units"]
     )
+    assert by_template["grid_approx_pwl_in_q8_w_q8_norm_exact"]["cost_proxy"]["calibration_status"] == "uncalibrated"
     assert (
         by_template["grid_approx_pwl_bf16_path"]["cost_proxy"]["relative_cost_units"]
         < by_template["grid_prob_bf16"]["cost_proxy"]["relative_cost_units"]


### PR DESCRIPTION
## Summary
- mark decoder cost proxy outputs as uncalibrated heuristic planning units, including source/provenance and RTLGen calibration proposal linkage
- document that the current heuristic is not literature-derived and does not independently balance timing, power, and area
- add L1 proposal workspace for Nangate45 multiplier and adder primitive calibration behind q8 reciprocal normalization

## Tests
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py tests/test_llm_decoder_q8_norm_frontier.py tests/test_llm_decoder_pwl_frontier.py tests/test_llm_decoder_survivor_cost.py
- python3 -m py_compile npu/eval/estimate_llm_decoder_q8_norm_frontier.py npu/eval/estimate_llm_decoder_pwl_frontier.py npu/eval/estimate_llm_decoder_survivor_cost.py
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py --sweep tests/fixtures/decoder_q8_norm_frontier_sweep.json --out /tmp/decoder_q8_norm_frontier_check.json --out-md /tmp/decoder_q8_norm_frontier_check.md
- python3 npu/eval/estimate_llm_decoder_survivor_cost.py --sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_survivor_prompt_stress_v1.json --out /tmp/decoder_survivor_cost_check.json --out-md /tmp/decoder_survivor_cost_check.md
- python3 npu/eval/estimate_llm_decoder_pwl_frontier.py --sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_survivor_prompt_stress_v1.json --cost-proxy runs/datasets/llm_decoder_eval_tiny_v1/decoder_survivor_cost_proxy__l2_decoder_survivor_cost_proxy_v1.json --out /tmp/decoder_pwl_frontier_check.json --out-md /tmp/decoder_pwl_frontier_check.md

## Notes
- A first pytest attempt without PYTHONPATH used an editable control_plane package from /workspaces/RTLGen and failed against a different checkout. The pinned PYTHONPATH run above tested this worktree and passed.