### PR TITLE
Fix L1 multi-config sweep generation

### DIFF
--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -78,6 +78,12 @@ def main(argv: list[str] | None = None) -> int:
     generate_l1_parser.add_argument("--mode", default="upsert")
     generate_l1_parser.add_argument("--proposal-id")
     generate_l1_parser.add_argument("--proposal-path")
+    generate_l1_parser.add_argument("--make-target")
+    generate_l1_parser.add_argument("--evaluation-mode")
+    generate_l1_parser.add_argument("--abstraction-layer")
+    generate_l1_parser.add_argument("--trial-count", type=int, default=1)
+    generate_l1_parser.add_argument("--seed-start", type=int, default=0)
+    generate_l1_parser.add_argument("--stop-after-failures", type=int)
     generate_l1_parser.add_argument("--no-auto-dispatch", action="store_true")
     generate_l1_parser.add_argument("--dispatch-machine-key")
     generate_l1_parser.add_argument("--dispatch-freshness-seconds", type=int, default=120)
@@ -495,6 +501,10 @@ def main(argv: list[str] | None = None) -> int:
             str(args.priority),
             "--mode",
             args.mode,
+            "--trial-count",
+            str(args.trial_count),
+            "--seed-start",
+            str(args.seed_start),
             "--configs",
             *args.configs,
         ]
@@ -505,6 +515,10 @@ def main(argv: list[str] | None = None) -> int:
             ("--source-commit", args.source_commit),
             ("--proposal-id", args.proposal_id),
             ("--proposal-path", args.proposal_path),
+            ("--make-target", args.make_target),
+            ("--evaluation-mode", args.evaluation_mode),
+            ("--abstraction-layer", args.abstraction_layer),
+            ("--stop-after-failures", args.stop_after_failures),
             ("--dispatch-machine-key", args.dispatch_machine_key),
         ]:
             if value is not None:

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -7,6 +7,7 @@ from datetime import timezone
 from hashlib import sha256
 import json
 import os
+import shlex
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -330,7 +331,7 @@ def _read_config_target(
                     "run": _with_oss_cad_path(
                         (
                         "python3 scripts/run_sweep.py "
-                        f"--configs {config_rel} "
+                        "--configs {config_paths} "
                         "--platform {platform} "
                         f"--sweep {{sweep_path}} "
                         f"--out_root {out_root} "
@@ -357,7 +358,7 @@ def _read_config_target(
                     "run": _with_oss_cad_path(
                         (
                         "python3 scripts/run_sweep.py "
-                        f"--configs {config_rel} "
+                        "--configs {config_paths} "
                         "--platform {platform} "
                         f"--sweep {{sweep_path}} "
                         f"--out_root {out_root} "
@@ -384,7 +385,7 @@ def _read_config_target(
                     "run": _with_oss_cad_path(
                         (
                         "python3 scripts/run_sweep.py "
-                        f"--configs {config_rel} "
+                        "--configs {config_paths} "
                         "--platform {platform} "
                         f"--sweep {{sweep_path}} "
                         f"--out_root {out_root} "
@@ -415,7 +416,7 @@ def _read_config_target(
                     "run": _with_oss_cad_path(
                         (
                         "python3 scripts/run_sweep.py "
-                        f"--configs {config_rel} "
+                        "--configs {config_paths} "
                         "--platform {platform} "
                         f"--sweep {{sweep_path}} "
                         f"--out_root {out_root} "
@@ -504,6 +505,10 @@ def _effective_trial_policy(*, trial_count: int, seed_start: int, stop_after_fai
         "seed_start": effective_seed_start,
         "stop_after_failures": effective_stop_after_failures,
     }
+
+
+def _config_args(config_paths: list[str]) -> str:
+    return " ".join(shlex.quote(path) for path in config_paths)
 
 
 def _expand_expected_outputs_for_trials(*, expected_outputs: list[str], trial_policy: dict[str, int]) -> list[str]:
@@ -661,8 +666,13 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             f"mixed Layer1 config kinds are not supported in one sweep item: {sorted(design_kinds)}"
         )
     command_manifest = list(targets[0].commands)
+    config_args = _config_args(config_paths)
     for command in command_manifest:
-        command["run"] = command["run"].format(platform=request.platform, sweep_path=sweep_path)
+        command["run"] = command["run"].format(
+            platform=request.platform,
+            sweep_path=sweep_path,
+            config_paths=config_args,
+        )
     expected_outputs = [target.expected_metrics_path for target in targets]
 
     item_id = request.item_id or _default_item_id(

--- a/control_plane/control_plane/tests/test_cli_generate_l1.py
+++ b/control_plane/control_plane/tests/test_cli_generate_l1.py
@@ -1,0 +1,52 @@
+"""Top-level CLI coverage for Layer 1 generation flags."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from control_plane.cli.main import main
+
+
+def test_top_level_generate_l1_forwards_extended_generation_flags() -> None:
+    with patch("control_plane.cli.main.generate_l1_sweep_main", return_value=0) as generate:
+        result = main(
+            [
+                "generate-l1-sweep",
+                "--database-url",
+                "sqlite+pysqlite:///:memory:",
+                "--repo-root",
+                "/repo",
+                "--sweep-path",
+                "sweep.json",
+                "--configs",
+                "a.json",
+                "b.json",
+                "--platform",
+                "nangate45",
+                "--out-root",
+                "runs/designs/demo",
+                "--make-target",
+                "1_1_yosys_canonicalize",
+                "--evaluation-mode",
+                "measurement_only",
+                "--abstraction-layer",
+                "circuit_block",
+                "--trial-count",
+                "3",
+                "--seed-start",
+                "100",
+                "--stop-after-failures",
+                "2",
+            ]
+        )
+
+    assert result == 0
+    forwarded = generate.call_args.args[0]
+    configs_index = forwarded.index("--configs")
+    assert forwarded[configs_index + 1 : configs_index + 3] == ["a.json", "b.json"]
+    assert forwarded[forwarded.index("--make-target") + 1] == "1_1_yosys_canonicalize"
+    assert forwarded[forwarded.index("--evaluation-mode") + 1] == "measurement_only"
+    assert forwarded[forwarded.index("--abstraction-layer") + 1] == "circuit_block"
+    assert forwarded[forwarded.index("--trial-count") + 1] == "3"
+    assert forwarded[forwarded.index("--seed-start") + 1] == "100"
+    assert forwarded[forwarded.index("--stop-after-failures") + 1] == "2"

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -71,6 +71,36 @@ def _write_example_repo(repo_root: Path) -> tuple[str, str]:
     )
 
 
+def _write_second_softmax_config(repo_root: Path) -> str:
+    config_path = repo_root / "examples" / "config_softmax_rowwise_int8_r8.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "operations": [
+                    {
+                        "type": "softmax_rowwise",
+                        "module_name": "softmax_rowwise_int8_r8",
+                        "operand": "logits",
+                        "options": {
+                            "impl": "shift_exp",
+                            "row_elems": 8,
+                            "max_shift": 7,
+                            "accum_bits": 16,
+                            "output_scale": 127,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
 def _init_git_repo(repo_root: Path) -> str:
     origin_root = repo_root.parent / "origin.git"
     subprocess.run(["git", "init", "--bare", str(origin_root)], check=True, capture_output=True, text=True)
@@ -233,6 +263,41 @@ def test_generate_l1_sweep_task_expands_expected_outputs_for_multi_trial_items()
                 "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/trials/trial_001/softmax_rowwise_int8_r4_wrapper/metrics.csv",
                 "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/trials/trial_002/softmax_rowwise_int8_r4_wrapper/metrics.csv",
                 "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/trials/trial_003/softmax_rowwise_int8_r4_wrapper/metrics.csv",
+            ]
+
+
+def test_generate_l1_sweep_task_run_sweep_command_includes_all_wrapper_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        second_config_path = _write_second_softmax_config(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path, second_config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    item_id="l1_demo_softmax_multi_config",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="circuit_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run_sweep = work_item.command_manifest[1]["run"]
+            assert f"--configs {config_path} {second_config_path} " in run_sweep
+            assert work_item.expected_outputs == [
+                "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv",
+                "runs/designs/activations/softmax_rowwise_int8_r8_wrapper/metrics.csv",
             ]
 
 


### PR DESCRIPTION
## Summary
- pass every requested wrapper config path into generated L1 run_sweep commands instead of only the first config
- expose the direct L1 generator's make-target, evaluation-mode, abstraction-layer, and trial flags through the top-level CLI
- add regression coverage for multi-config commands and top-level flag forwarding

## Tests
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py control_plane/control_plane/tests/test_cli_generate_l1.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_q8_norm_frontier.py tests/test_llm_decoder_pwl_frontier.py tests/test_llm_decoder_survivor_cost.py
- python3 -m py_compile control_plane/control_plane/services/l1_task_generator.py control_plane/control_plane/cli/main.py
- python3 scripts/validate_runs.py --skip_eval_queue

## Note
This came from reviewing PR #278: the work item listed multiple configs, but the generated command only ran the first one. #278 should not be merged as calibration evidence until the job is regenerated after this fix.