### PR TITLE
Calibrate decoder normalization primitive costs

### DIFF
--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/analysis_report.md
@@ -2,28 +2,37 @@
 
 ## Candidate
 - `proposal_id`: `prop_l1_decoder_normalization_arithmetic_calibration_v1`
+- `candidate_id`: `l1_decoder_norm_q8_recip_mult_calibration_v1_r2`
 - `candidate_id`: `l1_decoder_norm_accumulator_adder_calibration_v1_r2`
 
 ## Evaluations Consumed
-- `l1_decoder_norm_accumulator_adder_calibration_v1_r2`
-- `l1_decoder_norm_accumulator_adder_calibration_v1_r2_run_468c5ccfebeb29c6`
+- `l1_decoder_norm_q8_recip_mult_calibration_v1_r2`
+- review: PR #281
 - source commit: `ea6095808f683c26979575365f9a5c4249470a05`
+- `l1_decoder_norm_accumulator_adder_calibration_v1_r2`
 - review: PR #282
+- source commit: `ea6095808f683c26979575365f9a5c4249470a05`
 
-## Baseline Comparison
-- not applicable
+## Calibrated Primitive Evidence
+- multiplier artifact: `control_plane/shadow_exports/l1_promotions/l1_decoder_norm_q8_recip_mult_calibration_v1_r2.json`
+- adder artifact: `control_plane/shadow_exports/l1_promotions/l1_decoder_norm_accumulator_adder_calibration_v1_r2.json`
+- synthesis report: `runs/datasets/llm_decoder_eval_tiny_v1/decoder_norm_ppa_calibration__prop_l1_decoder_normalization_arithmetic_calibration_v1.md`
+- selected q8 reciprocal multiplier primitive: `mult16u_booth4_koggestone`, Nangate45, `critical_path_ns=0.1941`, `die_area=3487.493025`, `total_power_mw=0.00364`
+- selected q8 accumulator adder primitive: `adder_koggestone_64u`, Nangate45, `critical_path_ns=0.2225`, `die_area=3074.7025`, `total_power_mw=0.00104`
 
 ## Result
 - result: `promote`
-- confidence level: merged accepted evidence
-- estimated optimization room: accepted at current stage
-- architecture conclusion robustness: accepted for the current proposal scope
-- summary: Physical metrics recorded from an accepted status=ok Layer 1 row.
+- confidence level: merged accepted L1 evidence
+- architecture conclusion robustness: partial primitive-level calibration, not full datapath PPA
+- summary: The q8 reciprocal normalization path now has measured Nangate45 multiplier and accumulator/adder primitive evidence. The evidence replaces the previous hand-written planning proxy for those primitive terms, but does not yet calibrate the exact divider, bf16 reciprocal/multiply path, or integrated normalization datapath routing/control.
 
-## Failures and Caveats
-- no additional caveats recorded during automatic finalization
+## Interpretation
+- The q8 reciprocal q10/q12/q14/q16 rows all use the same current 16-bit multiplier envelope plus the same accumulator primitive in this synthesis.
+- Under that envelope, physical primitive PPA does not justify preferring q10 over q12/q14/q16. q10 remains a quality/minimum-precision decision from the prompt-stress sweep, not a measured PPA win over wider reciprocal settings.
+- The q8 exact-normalization row remains a hardware-acceptance gap because the exact divider/reciprocal datapath has not been measured.
+- The bf16 reciprocal PWL anchor remains a hardware-acceptance gap because the bf16 reciprocal and multiply/convert datapaths have not been measured.
 
 ## Recommendation
 - `promote`
-- reason: Accepted Layer 1 physical metrics were merged in PR #282 for the current candidate.
-- next_action: inspect the next dependent item
+- reason: Accepted Layer 1 physical metrics were merged for both the multiplier and accumulator/adder primitive jobs.
+- next_action: plan an integrated q8 reciprocal-normalization datapath measurement, and separately measure bf16 reciprocal/multiply primitives before making q8-versus-bf16 hardware decisions.

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -204,6 +204,24 @@ cost is an uncalibrated planning unit; follow it with RTLGen/OpenROAD
 calibration of the integer multiplier and accumulator/adder path before treating
 q10 as physically better than wider reciprocal options.
 
+After the corresponding Layer 1 multiplier and accumulator/adder calibration
+jobs merge, synthesize the measured primitive evidence into a decoder
+normalization report:
+```sh
+python3 npu/eval/calibrate_llm_decoder_normalization_cost.py \
+  --out /tmp/decoder_norm_ppa_calibration.json \
+  --out-md /tmp/decoder_norm_ppa_calibration.md
+```
+
+The calibration report keeps `critical_path_ns`, `die_area`, and
+`total_power_mw` as separate Nangate45 axes. It filters out rows from other
+platforms before composing decoder-normalization evidence, marks the q8 exact
+divider and bf16 reciprocal/multiply paths as unmeasured gaps, and records that
+q10/q12/q14/q16 share the same current 16-bit multiplier plus accumulator
+primitive envelope. Under that envelope, the physical primitive metrics do not
+make q10 cheaper than q12/q14/q16; q10 remains a quality/minimum-precision
+choice until an integrated datapath measurement says otherwise.
+
 Optionally verify path-like fields exist:
 ```sh
 python3 npu/eval/validate.py --campaign <campaign.json> --check_paths

--- a/npu/eval/calibrate_llm_decoder_normalization_cost.py
+++ b/npu/eval/calibrate_llm_decoder_normalization_cost.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Synthesize decoder-normalization cost evidence from merged L1 PPA rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+DEFAULT_SWEEP = Path("runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_normalization_frontier_v1.json")
+DEFAULT_MULT_PROMOTION = Path("control_plane/shadow_exports/l1_promotions/l1_decoder_norm_q8_recip_mult_calibration_v1_r2.json")
+DEFAULT_ADDER_PROMOTION = Path("control_plane/shadow_exports/l1_promotions/l1_decoder_norm_accumulator_adder_calibration_v1_r2.json")
+PROPOSAL_ID = "prop_l1_decoder_normalization_arithmetic_calibration_v1"
+Q8_PREFIX = "grid_approx_pwl_in_q8_w_q8_norm_recip_q"
+Q8_EXACT = "grid_approx_pwl_in_q8_w_q8_norm_exact"
+BF16_ANCHOR = "grid_approx_pwl_bf16_path"
+METRIC_KEYS = ("critical_path_ns", "die_area", "total_power_mw")
+
+
+def _load_json(path: Path) -> JsonDict:
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _block_id(metrics_ref: JsonDict) -> str:
+    metrics_csv = str(metrics_ref.get("metrics_csv") or "")
+    if not metrics_csv:
+        return "unknown"
+    return Path(metrics_csv).parent.name.removesuffix("_wrapper")
+
+
+def _parse_width(block_id: str) -> int | None:
+    match = re.search(r"(?:^|_)(?:mult|adder_)?(\d+)u(?:_|$)", block_id)
+    return int(match.group(1)) if match else None
+
+
+def _parse_topology(block_id: str) -> str:
+    if block_id.startswith("mult"):
+        match = re.match(r"mult\d+u_(.+)", block_id)
+        return match.group(1) if match else "unknown"
+    if block_id.startswith("adder_"):
+        match = re.match(r"adder_([^_]+)_", block_id)
+        return match.group(1) if match else "unknown"
+    return "unknown"
+
+
+def _primitive_family(block_id: str) -> str:
+    if block_id.startswith("mult"):
+        return "multiplier"
+    if block_id.startswith("adder"):
+        return "adder"
+    return "unknown"
+
+
+def _metric_summary(row: JsonDict) -> JsonDict:
+    summary = row.get("metric_summary")
+    if not isinstance(summary, dict):
+        return {key: None for key in METRIC_KEYS}
+    return {key: _as_float(summary.get(key)) for key in METRIC_KEYS}
+
+
+def _promotion_rows(path: Path) -> list[JsonDict]:
+    payload = _load_json(path)
+    proposals = payload.get("proposals")
+    if not isinstance(proposals, list):
+        raise SystemExit(f"promotion artifact must contain proposals list: {path}")
+    rows: list[JsonDict] = []
+    for proposal in proposals:
+        if not isinstance(proposal, dict):
+            continue
+        metrics_ref = proposal.get("metrics_ref")
+        if not isinstance(metrics_ref, dict):
+            continue
+        block_id = _block_id(metrics_ref)
+        metrics = _metric_summary(proposal)
+        rows.append(
+            {
+                "block_id": block_id,
+                "family": _primitive_family(block_id),
+                "width_bits": _parse_width(block_id),
+                "topology": _parse_topology(block_id),
+                "platform": metrics_ref.get("platform"),
+                "status": metrics_ref.get("status"),
+                "metrics_ref": metrics_ref,
+                "metrics": metrics,
+                "selection_reason": proposal.get("selection_reason"),
+            }
+        )
+    return rows
+
+
+def _quality(row: JsonDict) -> JsonDict:
+    sample_count = _as_int(row.get("sample_count"))
+    next_rate = _as_float(row.get("next_token_id_match_rate")) or 0.0
+    topk_rate = _as_float(row.get("topk_contains_reference_id_rate")) or 0.0
+    next_matches = round(next_rate * sample_count)
+    topk_matches = round(topk_rate * sample_count)
+    return {
+        "sample_count": sample_count,
+        "next_token_matches": next_matches,
+        "topk_matches": topk_matches,
+        "exact_safe": sample_count > 0 and next_matches == sample_count and topk_matches == sample_count,
+    }
+
+
+def _frontier_templates(sweep_path: Path) -> dict[str, JsonDict]:
+    sweep = _load_json(sweep_path)
+    rows = sweep.get("templates")
+    if not isinstance(rows, list):
+        raise SystemExit("sweep JSON must contain a templates list")
+    by_template: dict[str, JsonDict] = {}
+    for row in rows:
+        if isinstance(row, dict) and isinstance(row.get("template"), str):
+            template = row["template"]
+            if template in {Q8_EXACT, BF16_ANCHOR} or template.startswith(Q8_PREFIX):
+                by_template[template] = row
+    missing = [template for template in (Q8_EXACT, BF16_ANCHOR) if template not in by_template]
+    if missing:
+        raise SystemExit(f"missing required frontier rows: {', '.join(missing)}")
+    return by_template
+
+
+def _ok_nangate45(rows: list[JsonDict]) -> list[JsonDict]:
+    return [row for row in rows if row["status"] == "ok" and row["platform"] == "nangate45"]
+
+
+def _best_row(rows: list[JsonDict], *, family: str, width_bits: int) -> JsonDict:
+    matches = [
+        row
+        for row in _ok_nangate45(rows)
+        if row["family"] == family and row["width_bits"] == width_bits and all(row["metrics"][key] is not None for key in METRIC_KEYS)
+    ]
+    if not matches:
+        raise SystemExit(f"missing Nangate45 {family} {width_bits}u primitive evidence")
+    return min(matches, key=lambda row: tuple(float(row["metrics"][key]) for key in METRIC_KEYS) + (row["block_id"],))
+
+
+def _sum_metrics(rows: list[JsonDict]) -> JsonDict:
+    return {key: round(sum(float(row["metrics"][key]) for row in rows), 6) for key in METRIC_KEYS}
+
+
+def _reciprocal_bits(template: str) -> int:
+    match = re.search(r"_q(\d+)$", template)
+    return int(match.group(1)) if match else 0
+
+
+def _candidate_rows(
+    *,
+    templates: dict[str, JsonDict],
+    selected_mult16: JsonDict,
+    selected_adder64: JsonDict,
+) -> list[JsonDict]:
+    primitive_combo = [selected_mult16, selected_adder64]
+    primitive_sum = _sum_metrics(primitive_combo)
+    rows: list[JsonDict] = []
+    for template in sorted(templates):
+        source = templates[template]
+        if template.startswith(Q8_PREFIX):
+            rows.append(
+                {
+                    "template": template,
+                    "normalization_path": "q8_reciprocal_quantized",
+                    "reciprocal_bits": _reciprocal_bits(template),
+                    "quality": _quality(source),
+                    "calibration_status": "integer_reciprocal_primitives_calibrated_not_integrated_datapath",
+                    "primitive_envelope": {
+                        "multiplier_operand_envelope_bits": 16,
+                        "accumulator_adder_bits": 64,
+                        "note": (
+                            "q10/q12/q14/q16 all map to the same current 16-bit multiplier envelope "
+                            "and the same accumulator primitive. These L1 metrics therefore do not prove "
+                            "a physical PPA advantage for q10 over q12/q14/q16."
+                        ),
+                    },
+                    "selected_primitives": [row["block_id"] for row in primitive_combo],
+                    "primitive_sum_proxy": primitive_sum,
+                    "unmeasured_gaps": [
+                        "integrated normalization datapath routing/control",
+                        "pipeline/register placement around reciprocal multiply and accumulation",
+                    ],
+                }
+            )
+        elif template == Q8_EXACT:
+            rows.append(
+                {
+                    "template": template,
+                    "normalization_path": "q8_exact_normalization",
+                    "reciprocal_bits": 0,
+                    "quality": _quality(source),
+                    "calibration_status": "unmeasured_gap",
+                    "selected_primitives": [selected_adder64["block_id"]],
+                    "measured_partial_primitives": ["64-bit accumulator adder"],
+                    "unmeasured_gaps": ["integer exact divider/reciprocal datapath"],
+                }
+            )
+        elif template == BF16_ANCHOR:
+            rows.append(
+                {
+                    "template": template,
+                    "normalization_path": "bf16_reciprocal_pwl_anchor",
+                    "reciprocal_bits": 0,
+                    "quality": _quality(source),
+                    "calibration_status": "unmeasured_gap",
+                    "selected_primitives": [],
+                    "unmeasured_gaps": [
+                        "bf16 reciprocal path",
+                        "bf16 multiply/round/convert datapath",
+                        "integrated normalization datapath routing/control",
+                    ],
+                }
+            )
+    return rows
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    selected = payload["selected_primitives"]
+    rows = payload["candidate_calibration"]
+    lines = [
+        "# Decoder Normalization PPA Calibration",
+        "",
+        f"- calibration_status: `{payload['calibration_status']}`",
+        f"- platform: `{payload['platform']}`",
+        f"- source_sweep: `{payload['source_sweep']}`",
+        f"- proposal: `{payload['proposal_id']}`",
+        "",
+        "## Selected Primitive Evidence",
+        "",
+        "| role | block | critical_path_ns | die_area | total_power_mw | metrics_csv |",
+        "|---|---|---:|---:|---:|---|",
+    ]
+    for role, row in selected.items():
+        metrics = row["metrics"]
+        lines.append(
+            "| `{role}` | `{block}` | {cp:.6g} | {area:.6g} | {power:.6g} | `{csv}` |".format(
+                role=role,
+                block=row["block_id"],
+                cp=metrics["critical_path_ns"],
+                area=metrics["die_area"],
+                power=metrics["total_power_mw"],
+                csv=row["metrics_ref"]["metrics_csv"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Candidate Calibration",
+            "",
+            "| template | status | exact-safe | reciprocal bits | primitive critical_path_ns sum | primitive area sum | primitive power sum | gaps |",
+            "|---|---|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for row in rows:
+        primitive_sum = row.get("primitive_sum_proxy") or {}
+        quality = row["quality"]
+        lines.append(
+            "| `{template}` | `{status}` | {safe} | {bits} | {cp} | {area} | {power} | {gaps} |".format(
+                template=row["template"],
+                status=row["calibration_status"],
+                safe="yes" if quality["exact_safe"] else "no",
+                bits=row["reciprocal_bits"] or "",
+                cp=primitive_sum.get("critical_path_ns", ""),
+                area=primitive_sum.get("die_area", ""),
+                power=primitive_sum.get("total_power_mw", ""),
+                gaps=", ".join(f"`{gap}`" for gap in row.get("unmeasured_gaps", [])),
+            )
+        )
+    lines.extend(["", "## Interpretation", ""])
+    for item in payload["interpretation"]:
+        lines.append(f"- {item}")
+    lines.extend(["", "## Next Step", ""])
+    for item in payload["next_step"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def build_report(
+    *,
+    sweep_path: Path = DEFAULT_SWEEP,
+    mult_promotion_path: Path = DEFAULT_MULT_PROMOTION,
+    adder_promotion_path: Path = DEFAULT_ADDER_PROMOTION,
+) -> JsonDict:
+    mult_rows = _promotion_rows(mult_promotion_path)
+    adder_rows = _promotion_rows(adder_promotion_path)
+    templates = _frontier_templates(sweep_path)
+    selected_mult16 = _best_row(mult_rows, family="multiplier", width_bits=16)
+    selected_adder64 = _best_row(adder_rows, family="adder", width_bits=64)
+    candidate_rows = _candidate_rows(
+        templates=templates,
+        selected_mult16=selected_mult16,
+        selected_adder64=selected_adder64,
+    )
+    reciprocal_rows = [row for row in candidate_rows if row["template"].startswith(Q8_PREFIX)]
+    identical_recip_metrics = len({json.dumps(row.get("primitive_sum_proxy", {}), sort_keys=True) for row in reciprocal_rows}) <= 1
+    return {
+        "version": 0.1,
+        "proposal_id": PROPOSAL_ID,
+        "source_sweep": str(sweep_path),
+        "source_artifacts": {
+            "multiplier_promotion": str(mult_promotion_path),
+            "adder_promotion": str(adder_promotion_path),
+        },
+        "platform": "nangate45",
+        "calibration_status": "partial_integer_reciprocal_primitives_calibrated",
+        "scope": {
+            "measured": "integer reciprocal multiplier and accumulator/adder primitive PPA from merged L1 rows",
+            "not_measured": "full integrated normalization datapath, exact divider, bf16 reciprocal/multiply datapath",
+            "score_policy": "No weighted PPA score is emitted; delay, area, and power remain separate axes.",
+        },
+        "primitive_evidence": {
+            "multipliers": mult_rows,
+            "adders": adder_rows,
+        },
+        "selected_primitives": {
+            "q8_reciprocal_multiplier_16u": selected_mult16,
+            "q8_accumulator_adder_64u": selected_adder64,
+        },
+        "candidate_calibration": candidate_rows,
+        "interpretation": [
+            "The q8 reciprocal path now has measured Nangate45 multiplier and accumulator/adder primitive evidence.",
+            "The q8 exact-normalization row is still blocked for hardware acceptance by an unmeasured exact divider/reciprocal datapath.",
+            "The bf16 reciprocal PWL anchor is still blocked for hardware acceptance by unmeasured bf16 reciprocal and multiply/convert datapaths.",
+            (
+                "The q8 reciprocal q10/q12/q14/q16 rows share the same measured primitive envelope in this calibration. "
+                "Under that envelope, physical PPA does not justify preferring q10 over q12/q14/q16; q10 remains a "
+                "quality/minimum-precision choice from the prompt-stress sweep."
+            )
+            if identical_recip_metrics
+            else "The q8 reciprocal rows do not share identical primitive sums; inspect per-row primitive envelopes before ranking.",
+        ],
+        "next_step": [
+            "Use the calibrated primitive axes to plan an integrated q8 reciprocal-normalization datapath measurement.",
+            "Do not compare q8 reciprocal against bf16 as a hardware decision until bf16 reciprocal/multiply primitives are also measured.",
+        ],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Calibrate decoder normalization costs from merged L1 primitive PPA evidence")
+    ap.add_argument("--sweep", default=str(DEFAULT_SWEEP), help="q8 normalization frontier sweep JSON")
+    ap.add_argument("--mult-promotion", default=str(DEFAULT_MULT_PROMOTION), help="merged multiplier L1 promotion artifact")
+    ap.add_argument("--adder-promotion", default=str(DEFAULT_ADDER_PROMOTION), help="merged adder L1 promotion artifact")
+    ap.add_argument("--out", required=True, help="output JSON path")
+    ap.add_argument("--out-md", required=True, help="output Markdown report path")
+    args = ap.parse_args()
+    report = build_report(
+        sweep_path=Path(args.sweep),
+        mult_promotion_path=Path(args.mult_promotion),
+        adder_promotion_path=Path(args.adder_promotion),
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    _write_markdown(out_md, report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_norm_ppa_calibration__prop_l1_decoder_normalization_arithmetic_calibration_v1.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_norm_ppa_calibration__prop_l1_decoder_normalization_arithmetic_calibration_v1.json
@@ -1,0 +1,540 @@
+{
+  "calibration_status": "partial_integer_reciprocal_primitives_calibrated",
+  "candidate_calibration": [
+    {
+      "calibration_status": "unmeasured_gap",
+      "normalization_path": "bf16_reciprocal_pwl_anchor",
+      "quality": {
+        "exact_safe": true,
+        "next_token_matches": 24,
+        "sample_count": 24,
+        "topk_matches": 24
+      },
+      "reciprocal_bits": 0,
+      "selected_primitives": [],
+      "template": "grid_approx_pwl_bf16_path",
+      "unmeasured_gaps": [
+        "bf16 reciprocal path",
+        "bf16 multiply/round/convert datapath",
+        "integrated normalization datapath routing/control"
+      ]
+    },
+    {
+      "calibration_status": "unmeasured_gap",
+      "measured_partial_primitives": [
+        "64-bit accumulator adder"
+      ],
+      "normalization_path": "q8_exact_normalization",
+      "quality": {
+        "exact_safe": true,
+        "next_token_matches": 24,
+        "sample_count": 24,
+        "topk_matches": 24
+      },
+      "reciprocal_bits": 0,
+      "selected_primitives": [
+        "adder_koggestone_64u"
+      ],
+      "template": "grid_approx_pwl_in_q8_w_q8_norm_exact",
+      "unmeasured_gaps": [
+        "integer exact divider/reciprocal datapath"
+      ]
+    },
+    {
+      "calibration_status": "integer_reciprocal_primitives_calibrated_not_integrated_datapath",
+      "normalization_path": "q8_reciprocal_quantized",
+      "primitive_envelope": {
+        "accumulator_adder_bits": 64,
+        "multiplier_operand_envelope_bits": 16,
+        "note": "q10/q12/q14/q16 all map to the same current 16-bit multiplier envelope and the same accumulator primitive. These L1 metrics therefore do not prove a physical PPA advantage for q10 over q12/q14/q16."
+      },
+      "primitive_sum_proxy": {
+        "critical_path_ns": 0.4166,
+        "die_area": 6562.195525,
+        "total_power_mw": 0.00468
+      },
+      "quality": {
+        "exact_safe": true,
+        "next_token_matches": 24,
+        "sample_count": 24,
+        "topk_matches": 24
+      },
+      "reciprocal_bits": 10,
+      "selected_primitives": [
+        "mult16u_booth4_koggestone",
+        "adder_koggestone_64u"
+      ],
+      "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10",
+      "unmeasured_gaps": [
+        "integrated normalization datapath routing/control",
+        "pipeline/register placement around reciprocal multiply and accumulation"
+      ]
+    },
+    {
+      "calibration_status": "integer_reciprocal_primitives_calibrated_not_integrated_datapath",
+      "normalization_path": "q8_reciprocal_quantized",
+      "primitive_envelope": {
+        "accumulator_adder_bits": 64,
+        "multiplier_operand_envelope_bits": 16,
+        "note": "q10/q12/q14/q16 all map to the same current 16-bit multiplier envelope and the same accumulator primitive. These L1 metrics therefore do not prove a physical PPA advantage for q10 over q12/q14/q16."
+      },
+      "primitive_sum_proxy": {
+        "critical_path_ns": 0.4166,
+        "die_area": 6562.195525,
+        "total_power_mw": 0.00468
+      },
+      "quality": {
+        "exact_safe": true,
+        "next_token_matches": 24,
+        "sample_count": 24,
+        "topk_matches": 24
+      },
+      "reciprocal_bits": 12,
+      "selected_primitives": [
+        "mult16u_booth4_koggestone",
+        "adder_koggestone_64u"
+      ],
+      "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q12",
+      "unmeasured_gaps": [
+        "integrated normalization datapath routing/control",
+        "pipeline/register placement around reciprocal multiply and accumulation"
+      ]
+    },
+    {
+      "calibration_status": "integer_reciprocal_primitives_calibrated_not_integrated_datapath",
+      "normalization_path": "q8_reciprocal_quantized",
+      "primitive_envelope": {
+        "accumulator_adder_bits": 64,
+        "multiplier_operand_envelope_bits": 16,
+        "note": "q10/q12/q14/q16 all map to the same current 16-bit multiplier envelope and the same accumulator primitive. These L1 metrics therefore do not prove a physical PPA advantage for q10 over q12/q14/q16."
+      },
+      "primitive_sum_proxy": {
+        "critical_path_ns": 0.4166,
+        "die_area": 6562.195525,
+        "total_power_mw": 0.00468
+      },
+      "quality": {
+        "exact_safe": true,
+        "next_token_matches": 24,
+        "sample_count": 24,
+        "topk_matches": 24
+      },
+      "reciprocal_bits": 14,
+      "selected_primitives": [
+        "mult16u_booth4_koggestone",
+        "adder_koggestone_64u"
+      ],
+      "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q14",
+      "unmeasured_gaps": [
+        "integrated normalization datapath routing/control",
+        "pipeline/register placement around reciprocal multiply and accumulation"
+      ]
+    },
+    {
+      "calibration_status": "integer_reciprocal_primitives_calibrated_not_integrated_datapath",
+      "normalization_path": "q8_reciprocal_quantized",
+      "primitive_envelope": {
+        "accumulator_adder_bits": 64,
+        "multiplier_operand_envelope_bits": 16,
+        "note": "q10/q12/q14/q16 all map to the same current 16-bit multiplier envelope and the same accumulator primitive. These L1 metrics therefore do not prove a physical PPA advantage for q10 over q12/q14/q16."
+      },
+      "primitive_sum_proxy": {
+        "critical_path_ns": 0.4166,
+        "die_area": 6562.195525,
+        "total_power_mw": 0.00468
+      },
+      "quality": {
+        "exact_safe": true,
+        "next_token_matches": 24,
+        "sample_count": 24,
+        "topk_matches": 24
+      },
+      "reciprocal_bits": 16,
+      "selected_primitives": [
+        "mult16u_booth4_koggestone",
+        "adder_koggestone_64u"
+      ],
+      "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q16",
+      "unmeasured_gaps": [
+        "integrated normalization datapath routing/control",
+        "pipeline/register placement around reciprocal multiply and accumulation"
+      ]
+    }
+  ],
+  "interpretation": [
+    "The q8 reciprocal path now has measured Nangate45 multiplier and accumulator/adder primitive evidence.",
+    "The q8 exact-normalization row is still blocked for hardware acceptance by an unmeasured exact divider/reciprocal datapath.",
+    "The bf16 reciprocal PWL anchor is still blocked for hardware acceptance by unmeasured bf16 reciprocal and multiply/convert datapaths.",
+    "The q8 reciprocal q10/q12/q14/q16 rows share the same measured primitive envelope in this calibration. Under that envelope, physical PPA does not justify preferring q10 over q12/q14/q16; q10 remains a quality/minimum-precision choice from the prompt-stress sweep."
+  ],
+  "next_step": [
+    "Use the calibrated primitive axes to plan an integrated q8 reciprocal-normalization datapath measurement.",
+    "Do not compare q8 reciprocal against bf16 as a hardware decision until bf16 reciprocal/multiply primitives are also measured."
+  ],
+  "platform": "nangate45",
+  "primitive_evidence": {
+    "adders": [
+      {
+        "block_id": "adder_ripple_16u",
+        "family": "adder",
+        "metrics": {
+          "critical_path_ns": 0.1844,
+          "die_area": 679.6449,
+          "total_power_mw": 0.000197
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/prefix_adders/adder_ripple_16u_wrapper/metrics.csv",
+          "param_hash": "8fb1f207",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_ripple_16u_wrapper/work/8fb1f207/result.json",
+          "status": "ok",
+          "tag": "prefix_adders_nangate45_highutil_87b48795"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "ripple",
+        "width_bits": 16
+      },
+      {
+        "block_id": "adder_brentkung_16u",
+        "family": "adder",
+        "metrics": {
+          "critical_path_ns": 0.1861,
+          "die_area": 739.568025,
+          "total_power_mw": 0.000206
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/prefix_adders/adder_brentkung_16u_wrapper/metrics.csv",
+          "param_hash": "8fb1f207",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_brentkung_16u_wrapper/work/8fb1f207/result.json",
+          "status": "ok",
+          "tag": "prefix_adders_nangate45_highutil_87b48795"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "brentkung",
+        "width_bits": 16
+      },
+      {
+        "block_id": "adder_koggestone_16u",
+        "family": "adder",
+        "metrics": {
+          "critical_path_ns": 0.1836,
+          "die_area": 913.2484,
+          "total_power_mw": 0.000243
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/prefix_adders/adder_koggestone_16u_wrapper/metrics.csv",
+          "param_hash": "8fb1f207",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_koggestone_16u_wrapper/work/8fb1f207/result.json",
+          "status": "ok",
+          "tag": "prefix_adders_nangate45_highutil_87b48795"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "koggestone",
+        "width_bits": 16
+      },
+      {
+        "block_id": "adder_ripple_32u",
+        "family": "adder",
+        "metrics": {
+          "critical_path_ns": 1.1646604999999999,
+          "die_area": 115.928289,
+          "total_power_mw": 0.00023999999999999998
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/prefix_adders/adder_ripple_32u_wrapper/metrics.csv",
+          "param_hash": "cf19db5a",
+          "platform": "asap7",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_ripple_32u_wrapper/work/cf19db5a/result.json",
+          "status": "ok",
+          "tag": "prefix_adders_asap7_highutil_c51f6982"
+        },
+        "platform": "asap7",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "ripple",
+        "width_bits": 32
+      },
+      {
+        "block_id": "adder_brentkung_32u",
+        "family": "adder",
+        "metrics": {
+          "critical_path_ns": 0.1938,
+          "die_area": 1195.0849,
+          "total_power_mw": 0.000423
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/prefix_adders/adder_brentkung_32u_wrapper/metrics.csv",
+          "param_hash": "1d3bcf3d",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_brentkung_32u_wrapper/work/1d3bcf3d/result.json",
+          "status": "ok",
+          "tag": "prefix_adders_nangate45_highutil_da64be35"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "brentkung",
+        "width_bits": 32
+      },
+      {
+        "block_id": "adder_koggestone_32u",
+        "family": "adder",
+        "metrics": {
+          "critical_path_ns": 0.1975,
+          "die_area": 1605.204225,
+          "total_power_mw": 0.000532
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/prefix_adders/adder_koggestone_32u_wrapper/metrics.csv",
+          "param_hash": "1d3bcf3d",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_koggestone_32u_wrapper/work/1d3bcf3d/result.json",
+          "status": "ok",
+          "tag": "prefix_adders_nangate45_highutil_da64be35"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "koggestone",
+        "width_bits": 32
+      },
+      {
+        "block_id": "adder_ripple_64u",
+        "family": "adder",
+        "metrics": {
+          "critical_path_ns": 2.2664414,
+          "die_area": 207.446409,
+          "total_power_mw": 0.000544
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/prefix_adders/adder_ripple_64u_wrapper/metrics.csv",
+          "param_hash": "cf19db5a",
+          "platform": "asap7",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_ripple_64u_wrapper/work/cf19db5a/result.json",
+          "status": "ok",
+          "tag": "prefix_adders_asap7_highutil_c51f6982"
+        },
+        "platform": "asap7",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "ripple",
+        "width_bits": 64
+      },
+      {
+        "block_id": "adder_brentkung_64u",
+        "family": "adder",
+        "metrics": {
+          "critical_path_ns": 1.2620005,
+          "die_area": 203.975524,
+          "total_power_mw": 0.000602
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/prefix_adders/adder_brentkung_64u_wrapper/metrics.csv",
+          "param_hash": "cf19db5a",
+          "platform": "asap7",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_brentkung_64u_wrapper/work/cf19db5a/result.json",
+          "status": "ok",
+          "tag": "prefix_adders_asap7_highutil_c51f6982"
+        },
+        "platform": "asap7",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "brentkung",
+        "width_bits": 64
+      },
+      {
+        "block_id": "adder_koggestone_64u",
+        "family": "adder",
+        "metrics": {
+          "critical_path_ns": 0.2225,
+          "die_area": 3074.7025,
+          "total_power_mw": 0.00104
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/prefix_adders/adder_koggestone_64u_wrapper/metrics.csv",
+          "param_hash": "1d3bcf3d",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_koggestone_64u_wrapper/work/1d3bcf3d/result.json",
+          "status": "ok",
+          "tag": "prefix_adders_nangate45_highutil_da64be35"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "koggestone",
+        "width_bits": 64
+      }
+    ],
+    "multipliers": [
+      {
+        "block_id": "mult8u_normal_koggestone",
+        "family": "multiplier",
+        "metrics": {
+          "critical_path_ns": 0.1756,
+          "die_area": 1063.086025,
+          "total_power_mw": 0.000512
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/multipliers/mult8u_normal_koggestone_wrapper/metrics.csv",
+          "param_hash": "84032167",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/multipliers/mult8u_normal_koggestone_wrapper/work/84032167/result.json",
+          "status": "ok",
+          "tag": "mult_ppg_cpa_w4_32_nangate45_highutil_da64be35"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "normal_koggestone",
+        "width_bits": 8
+      },
+      {
+        "block_id": "mult16u_normal_koggestone",
+        "family": "multiplier",
+        "metrics": {
+          "critical_path_ns": 0.1943,
+          "die_area": 3495.765625,
+          "total_power_mw": 0.00382
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/multipliers/mult16u_normal_koggestone_wrapper/metrics.csv",
+          "param_hash": "84032167",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/multipliers/mult16u_normal_koggestone_wrapper/work/84032167/result.json",
+          "status": "ok",
+          "tag": "mult_ppg_cpa_w4_32_nangate45_highutil_da64be35"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "normal_koggestone",
+        "width_bits": 16
+      },
+      {
+        "block_id": "mult16u_booth4_koggestone",
+        "family": "multiplier",
+        "metrics": {
+          "critical_path_ns": 0.1941,
+          "die_area": 3487.493025,
+          "total_power_mw": 0.00364
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/multipliers/mult16u_booth4_koggestone_wrapper/metrics.csv",
+          "param_hash": "84032167",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/multipliers/mult16u_booth4_koggestone_wrapper/work/84032167/result.json",
+          "status": "ok",
+          "tag": "mult_ppg_cpa_w4_32_nangate45_highutil_da64be35"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "booth4_koggestone",
+        "width_bits": 16
+      },
+      {
+        "block_id": "mult32u_normal_koggestone",
+        "family": "multiplier",
+        "metrics": {
+          "critical_path_ns": 0.2407,
+          "die_area": 11997.916225,
+          "total_power_mw": 0.0302
+        },
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/multipliers/mult32u_normal_koggestone_wrapper/metrics.csv",
+          "param_hash": "84032167",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "/workspaces/RTLGen/runs/designs/multipliers/mult32u_normal_koggestone_wrapper/work/84032167/result.json",
+          "status": "ok",
+          "tag": "mult_ppg_cpa_w4_32_nangate45_highutil_da64be35"
+        },
+        "platform": "nangate45",
+        "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+        "status": "ok",
+        "topology": "normal_koggestone",
+        "width_bits": 32
+      }
+    ]
+  },
+  "proposal_id": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
+  "scope": {
+    "measured": "integer reciprocal multiplier and accumulator/adder primitive PPA from merged L1 rows",
+    "not_measured": "full integrated normalization datapath, exact divider, bf16 reciprocal/multiply datapath",
+    "score_policy": "No weighted PPA score is emitted; delay, area, and power remain separate axes."
+  },
+  "selected_primitives": {
+    "q8_accumulator_adder_64u": {
+      "block_id": "adder_koggestone_64u",
+      "family": "adder",
+      "metrics": {
+        "critical_path_ns": 0.2225,
+        "die_area": 3074.7025,
+        "total_power_mw": 0.00104
+      },
+      "metrics_ref": {
+        "metrics_csv": "runs/designs/prefix_adders/adder_koggestone_64u_wrapper/metrics.csv",
+        "param_hash": "1d3bcf3d",
+        "platform": "nangate45",
+        "result_kind": "physical_metrics",
+        "result_path": "/workspaces/RTLGen/runs/designs/prefix_adders/adder_koggestone_64u_wrapper/work/1d3bcf3d/result.json",
+        "status": "ok",
+        "tag": "prefix_adders_nangate45_highutil_da64be35"
+      },
+      "platform": "nangate45",
+      "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+      "status": "ok",
+      "topology": "koggestone",
+      "width_bits": 64
+    },
+    "q8_reciprocal_multiplier_16u": {
+      "block_id": "mult16u_booth4_koggestone",
+      "family": "multiplier",
+      "metrics": {
+        "critical_path_ns": 0.1941,
+        "die_area": 3487.493025,
+        "total_power_mw": 0.00364
+      },
+      "metrics_ref": {
+        "metrics_csv": "runs/designs/multipliers/mult16u_booth4_koggestone_wrapper/metrics.csv",
+        "param_hash": "84032167",
+        "platform": "nangate45",
+        "result_kind": "physical_metrics",
+        "result_path": "/workspaces/RTLGen/runs/designs/multipliers/mult16u_booth4_koggestone_wrapper/work/84032167/result.json",
+        "status": "ok",
+        "tag": "mult_ppg_cpa_w4_32_nangate45_highutil_da64be35"
+      },
+      "platform": "nangate45",
+      "selection_reason": "lowest critical_path_ns, then die_area, then total_power_mw among status=ok rows",
+      "status": "ok",
+      "topology": "booth4_koggestone",
+      "width_bits": 16
+    }
+  },
+  "source_artifacts": {
+    "adder_promotion": "control_plane/shadow_exports/l1_promotions/l1_decoder_norm_accumulator_adder_calibration_v1_r2.json",
+    "multiplier_promotion": "control_plane/shadow_exports/l1_promotions/l1_decoder_norm_q8_recip_mult_calibration_v1_r2.json"
+  },
+  "source_sweep": "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_normalization_frontier_v1.json",
+  "version": 0.1
+}

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_norm_ppa_calibration__prop_l1_decoder_normalization_arithmetic_calibration_v1.md
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_norm_ppa_calibration__prop_l1_decoder_normalization_arithmetic_calibration_v1.md
@@ -1,0 +1,36 @@
+# Decoder Normalization PPA Calibration
+
+- calibration_status: `partial_integer_reciprocal_primitives_calibrated`
+- platform: `nangate45`
+- source_sweep: `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_normalization_frontier_v1.json`
+- proposal: `prop_l1_decoder_normalization_arithmetic_calibration_v1`
+
+## Selected Primitive Evidence
+
+| role | block | critical_path_ns | die_area | total_power_mw | metrics_csv |
+|---|---|---:|---:|---:|---|
+| `q8_reciprocal_multiplier_16u` | `mult16u_booth4_koggestone` | 0.1941 | 3487.49 | 0.00364 | `runs/designs/multipliers/mult16u_booth4_koggestone_wrapper/metrics.csv` |
+| `q8_accumulator_adder_64u` | `adder_koggestone_64u` | 0.2225 | 3074.7 | 0.00104 | `runs/designs/prefix_adders/adder_koggestone_64u_wrapper/metrics.csv` |
+
+## Candidate Calibration
+
+| template | status | exact-safe | reciprocal bits | primitive critical_path_ns sum | primitive area sum | primitive power sum | gaps |
+|---|---|---:|---:|---:|---:|---:|---|
+| `grid_approx_pwl_bf16_path` | `unmeasured_gap` | yes |  |  |  |  | `bf16 reciprocal path`, `bf16 multiply/round/convert datapath`, `integrated normalization datapath routing/control` |
+| `grid_approx_pwl_in_q8_w_q8_norm_exact` | `unmeasured_gap` | yes |  |  |  |  | `integer exact divider/reciprocal datapath` |
+| `grid_approx_pwl_in_q8_w_q8_norm_recip_q10` | `integer_reciprocal_primitives_calibrated_not_integrated_datapath` | yes | 10 | 0.4166 | 6562.195525 | 0.00468 | `integrated normalization datapath routing/control`, `pipeline/register placement around reciprocal multiply and accumulation` |
+| `grid_approx_pwl_in_q8_w_q8_norm_recip_q12` | `integer_reciprocal_primitives_calibrated_not_integrated_datapath` | yes | 12 | 0.4166 | 6562.195525 | 0.00468 | `integrated normalization datapath routing/control`, `pipeline/register placement around reciprocal multiply and accumulation` |
+| `grid_approx_pwl_in_q8_w_q8_norm_recip_q14` | `integer_reciprocal_primitives_calibrated_not_integrated_datapath` | yes | 14 | 0.4166 | 6562.195525 | 0.00468 | `integrated normalization datapath routing/control`, `pipeline/register placement around reciprocal multiply and accumulation` |
+| `grid_approx_pwl_in_q8_w_q8_norm_recip_q16` | `integer_reciprocal_primitives_calibrated_not_integrated_datapath` | yes | 16 | 0.4166 | 6562.195525 | 0.00468 | `integrated normalization datapath routing/control`, `pipeline/register placement around reciprocal multiply and accumulation` |
+
+## Interpretation
+
+- The q8 reciprocal path now has measured Nangate45 multiplier and accumulator/adder primitive evidence.
+- The q8 exact-normalization row is still blocked for hardware acceptance by an unmeasured exact divider/reciprocal datapath.
+- The bf16 reciprocal PWL anchor is still blocked for hardware acceptance by unmeasured bf16 reciprocal and multiply/convert datapaths.
+- The q8 reciprocal q10/q12/q14/q16 rows share the same measured primitive envelope in this calibration. Under that envelope, physical PPA does not justify preferring q10 over q12/q14/q16; q10 remains a quality/minimum-precision choice from the prompt-stress sweep.
+
+## Next Step
+
+- Use the calibrated primitive axes to plan an integrated q8 reciprocal-normalization datapath measurement.
+- Do not compare q8 reciprocal against bf16 as a hardware decision until bf16 reciprocal/multiply primitives are also measured.

--- a/tests/test_llm_decoder_normalization_calibration.py
+++ b/tests/test_llm_decoder_normalization_calibration.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from npu.eval.calibrate_llm_decoder_normalization_cost import build_report
+
+
+def test_decoder_normalization_calibration_uses_nangate45_l1_primitives() -> None:
+    report = build_report()
+
+    assert report["calibration_status"] == "partial_integer_reciprocal_primitives_calibrated"
+    assert report["platform"] == "nangate45"
+    selected = report["selected_primitives"]
+    assert selected["q8_reciprocal_multiplier_16u"]["block_id"] == "mult16u_booth4_koggestone"
+    assert selected["q8_reciprocal_multiplier_16u"]["platform"] == "nangate45"
+    assert selected["q8_accumulator_adder_64u"]["block_id"] == "adder_koggestone_64u"
+    assert selected["q8_accumulator_adder_64u"]["platform"] == "nangate45"
+
+
+def test_decoder_normalization_calibration_keeps_reciprocal_ppa_tied_by_envelope() -> None:
+    report = build_report()
+    rows = {row["template"]: row for row in report["candidate_calibration"]}
+    reciprocal_templates = [
+        "grid_approx_pwl_in_q8_w_q8_norm_recip_q10",
+        "grid_approx_pwl_in_q8_w_q8_norm_recip_q12",
+        "grid_approx_pwl_in_q8_w_q8_norm_recip_q14",
+        "grid_approx_pwl_in_q8_w_q8_norm_recip_q16",
+    ]
+
+    reciprocal_sums = {tuple(sorted(rows[template]["primitive_sum_proxy"].items())) for template in reciprocal_templates}
+    assert len(reciprocal_sums) == 1
+    assert rows["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["calibration_status"].startswith(
+        "integer_reciprocal_primitives_calibrated"
+    )
+    assert "q10 remains a quality/minimum-precision choice" in "\n".join(report["interpretation"])
+
+
+def test_decoder_normalization_calibration_marks_unmeasured_divider_and_bf16_gaps() -> None:
+    report = build_report()
+    rows = {row["template"]: row for row in report["candidate_calibration"]}
+
+    q8_exact = rows["grid_approx_pwl_in_q8_w_q8_norm_exact"]
+    assert q8_exact["calibration_status"] == "unmeasured_gap"
+    assert "integer exact divider/reciprocal datapath" in q8_exact["unmeasured_gaps"]
+
+    bf16 = rows["grid_approx_pwl_bf16_path"]
+    assert bf16["calibration_status"] == "unmeasured_gap"
+    assert "bf16 reciprocal path" in bf16["unmeasured_gaps"]
+
+
+def test_decoder_normalization_calibration_script_sources_are_checked_in() -> None:
+    report = build_report()
+    for source in report["source_artifacts"].values():
+        assert Path(source).exists()


### PR DESCRIPTION
## Summary
- add a decoder-normalization calibration synthesizer that consumes merged L1 multiplier and adder promotion artifacts
- emit a checked-in PPA calibration report that keeps delay, area, and power separate and filters to Nangate45 evidence
- update the L1 normalization proposal analysis and eval README with the calibrated interpretation and remaining unmeasured gaps

## Tests
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_q8_norm_frontier.py tests/test_llm_decoder_normalization_calibration.py
- python3 -m py_compile npu/eval/calibrate_llm_decoder_normalization_cost.py
- python3 scripts/validate_runs.py --skip_eval_queue