### PR TITLE
Add q8 reciprocal softmax normalization datapath

### DIFF
--- a/docs/proposals/index.md
+++ b/docs/proposals/index.md
@@ -6,6 +6,7 @@ Canonical source of truth for new proposal workspaces lives under `docs/proposal
 |---|---|---|---|---|---|---|---|
 | `prop_cross_non_mlp_terminal_suite_v1` | `cross` | `architecture` | `` | Terminal-sensitive softmax suite | `promote` | `2026-03-18T11:05:00Z` | `docs/proposals/prop_cross_non_mlp_terminal_suite_v1` |
 | `prop_cross_terminal_output_overlap_probe_v1` | `cross` | `architecture` | `` | Terminal-output overlap probe | `promote` | `2026-03-18T07:17:51Z` | `docs/proposals/prop_cross_terminal_output_overlap_probe_v1` |
+| `prop_l1_decoder_q8_recip_norm_datapath_v1` | `layer1` | `circuit_block` | `circuit_block` | Decoder q8 reciprocal normalization datapath | `iterate` | `2026-04-29T10:47:54Z` | `docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1` |
 | `prop_l1_npu_nm1_hardsigmoid_vec_enable_v1` | `l1` | `circuit` | `architecture_block` | NPU nm1 hard-sigmoid vec enable | `promote` | `2026-03-25T03:30:00Z` | `docs/proposals/prop_l1_npu_nm1_hardsigmoid_vec_enable_v1` |
 | `prop_l1_npu_nm1_hardtanh_vec_enable_v1` | `l1` | `circuit` | `architecture_block` | NPU nm1 hard-tanh vec enable | `promote` | `2026-03-25T03:30:00Z` | `docs/proposals/prop_l1_npu_nm1_hardtanh_vec_enable_v1` |
 | `prop_l1_npu_nm1_leakyrelu_vec_enable_v1` | `l1` | `circuit` | `architecture_block` | NPU nm1 LeakyReLU vec enable | `promote` | `2026-03-27T04:00:00Z` | `docs/proposals/prop_l1_npu_nm1_leakyrelu_vec_enable_v1` |

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/README.md
@@ -1,0 +1,8 @@
+# q8 Reciprocal Normalization Datapath
+
+Proposal workspace for `prop_l1_decoder_q8_recip_norm_datapath_v1`.
+
+This proposal turns the q8 reciprocal-normalization frontier into an integrated
+RTLGen/OpenROAD measurement. The previous calibration measured multiplier and
+adder primitives only; this one measures divider-free row-wise int8 softmax
+normalization blocks using a quantized reciprocal lookup and multiply path.

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/analysis_report.md
@@ -1,0 +1,25 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l1_decoder_q8_recip_norm_datapath_v1`
+- `candidate_id`: `l1_decoder_q8_recip_norm_datapath_v1`
+
+## Evaluations Consumed
+- pending L1 measurement
+
+## Baseline Comparison
+- baseline primitive calibration: `prop_l1_decoder_normalization_arithmetic_calibration_v1`
+- baseline q8 frontier: `prop_l2_decoder_q8_normalization_frontier_v1`
+
+## Result
+- result: pending
+- confidence level: implementation prepared, remote physical measurement not yet consumed
+- architecture conclusion robustness: pending q10/q12/q14/q16 integrated PPA rows
+
+## Failures and Caveats
+- no remote evaluation evidence has been consumed yet
+- bf16 reciprocal/multiply datapaths remain outside this proposal
+
+## Recommendation
+- `iterate`
+- reason: Merge RTLGen support first, then queue the L1 measurement item from the merged commit.

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/design_brief.md
@@ -1,0 +1,63 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_q8_recip_norm_datapath_v1`
+- `title`: `Decoder q8 reciprocal normalization datapath`
+- `layer`: `layer1`
+- `kind`: `circuit_block`
+
+## Problem
+
+The decoder q8 normalization frontier selected q10 reciprocal normalization on
+quality and heuristic planning cost. PR #283 then calibrated the multiplier and
+adder primitive terms, but showed that q10/q12/q14/q16 are physically tied under
+the same primitive envelope. The missing evidence is the integrated
+normalization datapath: reciprocal generation, reciprocal multiply, rounding,
+and row-level softmax wiring.
+
+The current RTLGen row-wise int8 softmax block uses a Verilog `/ sum_weights`
+divider for exact normalization. That is not the q8 reciprocal architecture
+under investigation.
+
+## Candidate Direction
+
+Add a divider-free `softmax_rowwise` normalization mode:
+
+- `normalization_mode: reciprocal_quantized`
+- `reciprocal_bits: 10/12/14/16`
+
+The emitted RTL uses a denominator-indexed reciprocal lookup table and a
+multiply/shift normalization path. This keeps the architecture aligned with the
+decoder q8 reciprocal frontier and gives OpenROAD an integrated block to
+measure.
+
+## Evaluation Scope
+
+Run one L1 measurement-only sweep over four Nangate45 configs:
+
+- `softmax_rowwise_int8_r8_acc24_recip_q10`
+- `softmax_rowwise_int8_r8_acc24_recip_q12`
+- `softmax_rowwise_int8_r8_acc24_recip_q14`
+- `softmax_rowwise_int8_r8_acc24_recip_q16`
+
+All rows keep `row_elems=8`, `max_shift=7`, `accum_bits=24`, and
+`output_scale=127` so the only intended variable is reciprocal precision.
+
+## Exclusions
+
+- This does not measure bf16 reciprocal or multiply/convert datapaths.
+- This does not claim full decoder-softmax system PPA.
+- This does not change the Layer-2 prompt-stress quality gate.
+
+## Knowledge Inputs
+
+- `docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/analysis_report.md`
+- `runs/datasets/llm_decoder_eval_tiny_v1/decoder_norm_ppa_calibration__prop_l1_decoder_normalization_arithmetic_calibration_v1.md`
+- `docs/proposals/prop_l2_decoder_q8_normalization_frontier_v1/analysis_report.md`
+
+## Direction Gate
+
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-04-29T00:00:00Z
+- note: Immediate frontier follow-up after primitive calibration.

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved_after_merge
+- approved_by: developer_agent
+- approved_utc: 2026-04-29T00:00:00Z
+- allowed_evaluations:
+  - `l1_decoder_q8_recip_norm_datapath_v1`: L1 measurement-only sweep for q10/q12/q14/q16 integrated reciprocal-normalization softmax blocks.
+- note: The evaluator must run this from a commit containing `normalization_mode=reciprocal_quantized` support.

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/evaluation_requests.json
@@ -1,0 +1,15 @@
+{
+  "proposal_id": "prop_l1_decoder_q8_recip_norm_datapath_v1",
+  "source_commit": "git-sha",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_q8_recip_norm_datapath_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for integrated row-wise int8 q8 reciprocal-normalization softmax blocks at q10/q12/q14/q16.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "status": "pending",
+      "notes": "Queue only after this proposal branch merges so evaluator has reciprocal_quantized RTLGen support."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/implementation_summary.md
@@ -1,0 +1,40 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_q8_recip_norm_datapath_v1`
+- title: `Decoder q8 reciprocal normalization datapath`
+
+## Scope
+- Added `normalization_mode` and `reciprocal_bits` options to RTLGen
+  `softmax_rowwise`.
+- Preserved the existing exact divider mode as the default.
+- Added `reciprocal_quantized` emission using a denominator-indexed reciprocal
+  lookup and multiply/shift normalization path.
+- Added q10/q12/q14/q16 row-wise int8 r8 acc24 configs for L1 measurement.
+
+## Files Changed
+- `src/rtlgen/config.hpp`
+- `src/rtlgen/config.cpp`
+- `src/rtlgen/rtl_operations.cpp`
+- `scripts/softmax_rowwise_ref.py`
+- `tests/test_softmax_rowwise.sh`
+- `runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q*_wrapper/`
+- `runs/campaigns/activations/softmax_rowwise_int8_recip_norm/sweeps/nangate45_highutil.json`
+
+## Local Validation
+- `cmake --build build -j2`
+- `bash tests/test_softmax_rowwise.sh`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+- `./build/test_onnx && ./build/test_boolexp && ./build/test_adder && ./build/test_multiplier`
+- `python3 scripts/run_sweep.py ... --dry_run`
+
+## Evaluation Request
+- requested item: `l1_decoder_q8_recip_norm_datapath_v1`
+- task type: `l1_sweep`
+- mode: `measurement_only`
+- compare q10/q12/q14/q16 integrated reciprocal-normalization blocks on Nangate45.
+
+## Risks
+- The reciprocal lookup table may dominate area for this row envelope.
+- This remains a row-wise block measurement, not full decoder-system PPA.
+- bf16 reciprocal/multiply datapaths remain unmeasured.

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l1_decoder_q8_recip_norm_datapath_v1",
+  "candidate_id": "l1_decoder_q8_recip_norm_datapath_v1",
+  "decision": "iterate",
+  "reason": "RTLGen support and evaluation configs are prepared; merge this branch before dispatching the L1 measurement item so the evaluator has reciprocal_quantized softmax support.",
+  "evidence_refs": [
+    "docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/implementation_summary.md"
+  ],
+  "next_action": "Queue l1_decoder_q8_recip_norm_datapath_v1 from the merged commit.",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action: Promote only as integrated Layer-1 PPA evidence for q8 reciprocal normalization.
+- note: Do not use this proposal alone to choose q8 over bf16; bf16 reciprocal/multiply datapaths remain unmeasured.

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_decoder_q8_recip_norm_datapath_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/proposal.json
@@ -1,0 +1,59 @@
+{
+  "proposal_id": "prop_l1_decoder_q8_recip_norm_datapath_v1",
+  "created_utc": "2026-04-29T10:47:54Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "circuit_block",
+  "title": "Decoder q8 reciprocal normalization datapath",
+  "hypothesis": "A divider-free q8 reciprocal-normalization row-wise softmax datapath can be emitted by RTLGen and measured by OpenROAD so q10/q12/q14/q16 can be compared as integrated blocks instead of primitive-envelope ties.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 timing, power, and area does the integrated q8 reciprocal-normalization softmax datapath show for q10/q12/q14/q16?",
+    "include": [
+      "row-wise int8 shift-exp softmax with reciprocal_quantized normalization",
+      "reciprocal_bits q10, q12, q14, and q16",
+      "row_elems=8, max_shift=7, accum_bits=24, output_scale=127 held constant",
+      "divider-free RTL emission using reciprocal lookup plus multiply/shift"
+    ],
+    "exclude": [
+      "bf16 reciprocal or multiply/convert datapaths",
+      "full decoder system PPA",
+      "prompt-stress quality threshold changes"
+    ],
+    "follow_on_broad_sweep": [
+      "if one reciprocal precision has a clear integrated PPA advantage, rerank the q8 normalization frontier report with measured datapath axes",
+      "if q10/q12/q14/q16 remain tied or area-heavy, measure bf16 reciprocal/multiply primitives before choosing q8 over bf16"
+    ]
+  },
+  "expected_benefit": [
+    "turns the previous primitive-level tie into an integrated RTLGen/OpenROAD comparison",
+    "removes the Verilog divider from the q8 reciprocal datapath candidate",
+    "keeps performance, power, and area axes separate for architecture discussion"
+  ],
+  "risks": [
+    "reciprocal lookup table area may dominate and make row_elems/max_shift choices interaction-sensitive",
+    "single-row block PPA still excludes decoder control and memory effects",
+    "q8 reciprocal quality remains benchmark-distribution dependent"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_q8_recip_norm_datapath_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "measurement_only",
+      "objective": "Measure Nangate45 PPA for integrated row-wise int8 q8 reciprocal-normalization softmax blocks at q10/q12/q14/q16.",
+      "sweep_path": "runs/campaigns/activations/softmax_rowwise_int8_recip_norm/sweeps/nangate45_highutil.json",
+      "abstraction_layer": "circuit_block"
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/analysis_report.md",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_norm_ppa_calibration__prop_l1_decoder_normalization_arithmetic_calibration_v1.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json"
+  ],
+  "knowledge_refs": [
+    "src/rtlgen/rtl_operations.cpp",
+    "scripts/softmax_rowwise_ref.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/quality_gate.md
@@ -1,0 +1,25 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_q8_recip_norm_datapath_v1`
+- `title`: `Decoder q8 reciprocal normalization datapath`
+
+## Checks
+
+- RTLGen must continue to emit the existing exact row-wise int8 softmax block.
+- `normalization_mode=reciprocal_quantized` must emit no `/ sum_weights`
+  divider in the generated Verilog.
+- The q10 reciprocal reference and generated RTL must match the checked row
+  examples in `tests/test_softmax_rowwise.sh`.
+- The Layer-1 evaluation is measurement-only; it should not change decoder
+  prompt-stress quality decisions.
+
+## Local Commands
+
+- `cmake --build build -j2`
+- `bash tests/test_softmax_rowwise.sh`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+
+## Result
+- status: passed_local
+- note: Local build, softmax regression, dry-run sweep, and runs validation passed before PR submission.

--- a/runs/campaigns/activations/softmax_rowwise_int8_recip_norm/sweeps/nangate45_highutil.json
+++ b/runs/campaigns/activations/softmax_rowwise_int8_recip_norm/sweeps/nangate45_highutil.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "softmax_rowwise_int8_recip_norm_nangate45_highutil",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.5],
+    "CORE_UTILIZATION": [60, 50],
+    "PLACE_DENSITY": [0.68]
+  }
+}

--- a/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q10_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q10.json
+++ b/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q10_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q10.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 8,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "softmax_rowwise_int8_r8_acc24_recip_q10",
+      "operand": "logits",
+      "options": {
+        "impl": "shift_exp",
+        "normalization_mode": "reciprocal_quantized",
+        "reciprocal_bits": 10,
+        "row_elems": 8,
+        "max_shift": 7,
+        "accum_bits": 24,
+        "output_scale": 127
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q12_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q12.json
+++ b/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q12_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q12.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 8,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "softmax_rowwise_int8_r8_acc24_recip_q12",
+      "operand": "logits",
+      "options": {
+        "impl": "shift_exp",
+        "normalization_mode": "reciprocal_quantized",
+        "reciprocal_bits": 12,
+        "row_elems": 8,
+        "max_shift": 7,
+        "accum_bits": 24,
+        "output_scale": 127
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q14_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q14.json
+++ b/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q14_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q14.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 8,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "softmax_rowwise_int8_r8_acc24_recip_q14",
+      "operand": "logits",
+      "options": {
+        "impl": "shift_exp",
+        "normalization_mode": "reciprocal_quantized",
+        "reciprocal_bits": 14,
+        "row_elems": 8,
+        "max_shift": 7,
+        "accum_bits": 24,
+        "output_scale": 127
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q16_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q16.json
+++ b/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q16_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q16.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 8,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "softmax_rowwise_int8_r8_acc24_recip_q16",
+      "operand": "logits",
+      "options": {
+        "impl": "shift_exp",
+        "normalization_mode": "reciprocal_quantized",
+        "reciprocal_bits": 16,
+        "row_elems": 8,
+        "max_shift": 7,
+        "accum_bits": 24,
+        "output_scale": 127
+      }
+    }
+  ]
+}

--- a/scripts/softmax_rowwise_ref.py
+++ b/scripts/softmax_rowwise_ref.py
@@ -13,6 +13,8 @@ def _load_config(path: str) -> dict:
     return {
         "module_name": operations[0]["module_name"],
         "impl": str(opts.get("impl", "shift_exp")),
+        "normalization_mode": str(opts.get("normalization_mode", "exact")),
+        "reciprocal_bits": int(opts.get("reciprocal_bits", 0)),
         "row_elems": int(opts.get("row_elems", 1)),
         "max_shift": int(opts.get("max_shift", 7)),
         "accum_bits": int(opts.get("accum_bits", 16)),
@@ -20,7 +22,14 @@ def _load_config(path: str) -> dict:
     }
 
 
-def compute_shift_exp_row(logits, *, max_shift: int = 7, output_scale: int = 127):
+def compute_shift_exp_row(
+    logits,
+    *,
+    max_shift: int = 7,
+    output_scale: int = 127,
+    normalization_mode: str = "exact",
+    reciprocal_bits: int = 0,
+):
     if not logits:
         return []
     max_val = max(int(v) for v in logits)
@@ -36,8 +45,18 @@ def compute_shift_exp_row(logits, *, max_shift: int = 7, output_scale: int = 127
     if sum_weights <= 0:
         return [0 for _ in logits]
     out = []
+    reciprocal = None
+    if normalization_mode == "reciprocal_quantized":
+        if reciprocal_bits <= 0:
+            raise ValueError("reciprocal_bits must be positive for reciprocal_quantized")
+        reciprocal = ((output_scale << reciprocal_bits) + (sum_weights // 2)) // sum_weights
+    elif normalization_mode != "exact":
+        raise ValueError(f"unsupported normalization_mode: {normalization_mode}")
     for weight in weights:
-        quantized = ((weight * output_scale) + (sum_weights // 2)) // sum_weights
+        if reciprocal is None:
+            quantized = ((weight * output_scale) + (sum_weights // 2)) // sum_weights
+        else:
+            quantized = ((weight * reciprocal) + (1 << (reciprocal_bits - 1))) >> reciprocal_bits
         if quantized < 0:
             quantized = 0
         if quantized > output_scale:
@@ -75,6 +94,8 @@ def main() -> int:
                     values,
                     max_shift=cfg["max_shift"],
                     output_scale=cfg["output_scale"],
+                    normalization_mode=cfg["normalization_mode"],
+                    reciprocal_bits=cfg["reciprocal_bits"],
                 ),
             }
         )
@@ -84,6 +105,8 @@ def main() -> int:
             {
                 "module_name": cfg["module_name"],
                 "impl": cfg["impl"],
+                "normalization_mode": cfg["normalization_mode"],
+                "reciprocal_bits": cfg["reciprocal_bits"],
                 "row_elems": cfg["row_elems"],
                 "max_shift": cfg["max_shift"],
                 "accum_bits": cfg["accum_bits"],

--- a/src/rtlgen/config.cpp
+++ b/src/rtlgen/config.cpp
@@ -351,10 +351,18 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                     softmax.module_name = module_name;
                     softmax.operand = operand_name;
                     softmax.impl = options.value("impl", "shift_exp");
+                    softmax.normalization_mode = options.value("normalization_mode", "exact");
+                    softmax.reciprocal_bits = options.value("reciprocal_bits", 0);
                     softmax.row_elems = options.value("row_elems", 1);
                     softmax.max_shift = options.value("max_shift", 7);
                     softmax.accum_bits = options.value("accum_bits", 16);
                     softmax.output_scale = options.value("output_scale", 127);
+                    if (softmax.normalization_mode != "exact" && softmax.normalization_mode != "reciprocal_quantized") {
+                        throw std::runtime_error("softmax_rowwise normalization_mode must be exact or reciprocal_quantized for " + softmax.module_name);
+                    }
+                    if (softmax.normalization_mode == "reciprocal_quantized" && (softmax.reciprocal_bits < 1 || softmax.reciprocal_bits > 24)) {
+                        throw std::runtime_error("softmax_rowwise reciprocal_bits must be in [1, 24] for " + softmax.module_name);
+                    }
                     if (softmax.row_elems <= 0) {
                         throw std::runtime_error("softmax_rowwise row_elems must be positive for " + softmax.module_name);
                     }

--- a/src/rtlgen/config.hpp
+++ b/src/rtlgen/config.hpp
@@ -197,6 +197,8 @@ struct SoftmaxRowwiseOperationConfig {
     std::string module_name;
     std::string operand;
     std::string impl{"shift_exp"};
+    std::string normalization_mode{"exact"};
+    int reciprocal_bits{0};
     int row_elems{1};
     int max_shift{7};
     int accum_bits{16};

--- a/src/rtlgen/rtl_operations.cpp
+++ b/src/rtlgen/rtl_operations.cpp
@@ -897,6 +897,12 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     if (config.impl != "shift_exp") {
         throw std::runtime_error("Unsupported softmax_rowwise impl: " + config.impl);
     }
+    if (config.normalization_mode != "exact" && config.normalization_mode != "reciprocal_quantized") {
+        throw std::runtime_error("Unsupported softmax_rowwise normalization_mode: " + config.normalization_mode);
+    }
+    if (config.normalization_mode == "reciprocal_quantized" && (config.reciprocal_bits < 1 || config.reciprocal_bits > 24)) {
+        throw std::runtime_error("softmax_rowwise reciprocal_bits must be in [1, 24]");
+    }
     if (config.row_elems <= 0) {
         throw std::runtime_error("softmax_rowwise row_elems must be positive");
     }
@@ -912,7 +918,11 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
 
     const int data_width = operand.bit_width;
     const int row_width = config.row_elems * data_width;
-    const int product_bits = config.accum_bits + data_width;
+    const bool reciprocal_quantized = config.normalization_mode == "reciprocal_quantized";
+    const int reciprocal_value_bits = reciprocal_quantized
+        ? static_cast<int>(std::ceil(std::log2(static_cast<double>(config.output_scale) * std::ldexp(1.0, config.reciprocal_bits) + 1.0)))
+        : data_width;
+    const int product_bits = config.accum_bits + reciprocal_value_bits;
     const int max_sum_bits = static_cast<int>(
         std::ceil(std::log2(static_cast<double>(config.row_elems * (1 << config.max_shift)) + 1.0))
     );
@@ -941,6 +951,26 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     os << "  localparam integer PRODUCT_BITS = " << product_bits << ";\n";
     os << "  localparam integer MAX_SHIFT = " << config.max_shift << ";\n";
     os << "  localparam integer OUTPUT_SCALE = " << config.output_scale << ";\n\n";
+    if (reciprocal_quantized) {
+        const int max_sum = config.row_elems * (1 << config.max_shift);
+        const long long scale = static_cast<long long>(config.output_scale) << config.reciprocal_bits;
+        os << "  localparam integer RECIP_BITS = " << config.reciprocal_bits << ";\n";
+        os << "  localparam integer RECIP_VALUE_BITS = " << reciprocal_value_bits << ";\n\n";
+        os << "  function [RECIP_VALUE_BITS-1:0] recip_lut;\n";
+        os << "    input [ACCUM_BITS-1:0] denom;\n";
+        os << "    begin\n";
+        os << "      case (denom)\n";
+        os << "        " << config.accum_bits << "'d0: recip_lut = {RECIP_VALUE_BITS{1'b0}};\n";
+        for (int denom = 1; denom <= max_sum; ++denom) {
+            const long long recip = (scale + (denom / 2)) / denom;
+            os << "        " << config.accum_bits << "'d" << denom
+               << ": recip_lut = " << reciprocal_value_bits << "'d" << recip << ";\n";
+        }
+        os << "        default: recip_lut = {RECIP_VALUE_BITS{1'b0}};\n";
+        os << "      endcase\n";
+        os << "    end\n";
+        os << "  endfunction\n\n";
+    }
     os << "  integer i;\n";
     os << "  integer signed lane_val;\n";
     os << "  integer signed row_max;\n";
@@ -948,6 +978,10 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     os << "  reg [ACCUM_BITS-1:0] weights [0:ROW_ELEMS-1];\n";
     os << "  reg [ACCUM_BITS-1:0] sum_weights;\n";
     os << "  reg [PRODUCT_BITS-1:0] numer;\n";
+    os << "  reg [PRODUCT_BITS-1:0] scaled_out;\n";
+    if (reciprocal_quantized) {
+        os << "  reg [RECIP_VALUE_BITS-1:0] reciprocal;\n";
+    }
     os << "  reg [DATA_W-1:0] lane_out;\n\n";
     os << "  always @* begin\n";
     os << "    row_max = -(1 << (DATA_W - 1));\n";
@@ -968,14 +1002,24 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     os << "      sum_weights = sum_weights + weights[i];\n";
     os << "    end\n\n";
     os << "    Y = {ROW_ELEMS*DATA_W{1'b0}};\n";
+    if (reciprocal_quantized) {
+        os << "    reciprocal = recip_lut(sum_weights);\n";
+    }
     os << "    for (i = 0; i < ROW_ELEMS; i = i + 1) begin\n";
-    os << "      numer = (weights[i] * OUTPUT_SCALE) + (sum_weights >> 1);\n";
-    os << "      if (sum_weights != 0)\n";
-    os << "        lane_out = numer / sum_weights;\n";
+    if (reciprocal_quantized) {
+        os << "      numer = (weights[i] * reciprocal) + ({{(PRODUCT_BITS-1){1'b0}}, 1'b1} << (RECIP_BITS - 1));\n";
+        os << "      scaled_out = numer >> RECIP_BITS;\n";
+    } else {
+        os << "      numer = (weights[i] * OUTPUT_SCALE) + (sum_weights >> 1);\n";
+        os << "      if (sum_weights != 0)\n";
+        os << "        scaled_out = numer / sum_weights;\n";
+        os << "      else\n";
+        os << "        scaled_out = {PRODUCT_BITS{1'b0}};\n";
+    }
+    os << "      if (scaled_out > OUTPUT_SCALE)\n";
+    os << "        lane_out = " << data_width << "'d" << config.output_scale << ";\n";
     os << "      else\n";
-    os << "        lane_out = {DATA_W{1'b0}};\n";
-    os << "      if (lane_out > OUTPUT_SCALE)\n";
-    os << "        lane_out = OUTPUT_SCALE;\n";
+    os << "        lane_out = scaled_out[DATA_W-1:0];\n";
     os << "      Y[(i*DATA_W) +: DATA_W] = lane_out;\n";
     os << "    end\n";
     os << "  end\n";

--- a/tests/test_softmax_rowwise.sh
+++ b/tests/test_softmax_rowwise.sh
@@ -33,4 +33,32 @@ PY
 
 iverilog -g2012 -s softmax_rowwise_tb -o sim softmax_rowwise_int8_r4.v "$ROOT/tests/softmax_rowwise_tb.v"
 vvp sim
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+cfg = json.loads(Path("config.json").read_text(encoding="utf-8"))
+opts = cfg["operations"][0]["options"]
+opts["normalization_mode"] = "reciprocal_quantized"
+opts["reciprocal_bits"] = 10
+Path("config_recip_q10.json").write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+PY
+"$ROOT/build/rtlgen" config_recip_q10.json
+if grep -q " / sum_weights" softmax_rowwise_int8_r4.v; then
+  echo "reciprocal_quantized softmax emitted divider" >&2
+  exit 1
+fi
+python3 "$ROOT/scripts/softmax_rowwise_ref.py" --config config_recip_q10.json --row=-4,0,4,8 > ref_recip.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+got = json.loads(Path("ref_recip.json").read_text(encoding="utf-8"))["rows"][0]["output"]
+expected = [1, 1, 7, 118]
+if got != expected:
+    raise SystemExit(f"reciprocal reference mismatch got={got} expected={expected}")
+PY
+iverilog -g2012 -s softmax_rowwise_tb -o sim_recip softmax_rowwise_int8_r4.v "$ROOT/tests/softmax_rowwise_tb.v"
+vvp sim_recip
 popd >/dev/null


### PR DESCRIPTION
## Summary
- add divider-free reciprocal_quantized normalization mode to RTLGen softmax_rowwise
- add q10/q12/q14/q16 row-wise int8 r8 acc24 configs and a Nangate45 high-util sweep for L1 measurement
- create prop_l1_decoder_q8_recip_norm_datapath_v1 proposal workspace for the integrated datapath job

## Tests
- cmake --build build -j2
- bash tests/test_softmax_rowwise.sh
- python3 scripts/validate_runs.py --skip_eval_queue
- ./build/test_onnx && ./build/test_boolexp && ./build/test_adder && ./build/test_multiplier
- python3 scripts/run_sweep.py --configs runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q10_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q10.json runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q12_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q12.json runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q14_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q14.json runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q16_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q16.json --platform nangate45 --sweep runs/campaigns/activations/softmax_rowwise_int8_recip_norm/sweeps/nangate45_highutil.json --out_root /tmp/rtlgen_recip_norm_dry --dry_run