### PR TITLE
Record q8 reciprocal datapath dispatch

### DIFF
--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_decoder_q8_recip_norm_datapath_v1",
-  "source_commit": "git-sha",
+  "source_commit": "94c53a105616f373580c801d6d09672e8a909448",
   "requested_items": [
     {
       "item_id": "l1_decoder_q8_recip_norm_datapath_v1",
@@ -8,8 +8,8 @@
       "objective": "Measure Nangate45 PPA for integrated row-wise int8 q8 reciprocal-normalization softmax blocks at q10/q12/q14/q16.",
       "evaluation_mode": "measurement_only",
       "abstraction_layer": "circuit_block",
-      "status": "pending",
-      "notes": "Queue only after this proposal branch merges so evaluator has reciprocal_quantized RTLGen support."
+      "status": "ready",
+      "notes": "Queued from merged commit 94c53a105616f373580c801d6d09672e8a909448; assigned to evaluator by the control-plane dispatcher."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- record the merged source commit used to queue l1_decoder_q8_recip_norm_datapath_v1
- mark the proposal evaluation request ready after control-plane dispatch

## Tests
- python3 scripts/validate_runs.py --skip_eval_queue