### PR TITLE
Bucket q8 reciprocal softmax LUT

### DIFF
--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/design_brief.md
@@ -25,11 +25,13 @@ Add a divider-free `softmax_rowwise` normalization mode:
 
 - `normalization_mode: reciprocal_quantized`
 - `reciprocal_bits: 10/12/14/16`
+- `reciprocal_lut_bucket_shift: 4`
 
 The emitted RTL uses a denominator-indexed reciprocal lookup table and a
 multiply/shift normalization path. This keeps the architecture aligned with the
 decoder q8 reciprocal frontier and gives OpenROAD an integrated block to
-measure.
+measure. The first retry uses a bucketed reciprocal lookup to avoid Yosys
+inferring a memory larger than the OpenROAD synth prefilter allows.
 
 ## Evaluation Scope
 
@@ -41,7 +43,8 @@ Run one L1 measurement-only sweep over four Nangate45 configs:
 - `softmax_rowwise_int8_r8_acc24_recip_q16`
 
 All rows keep `row_elems=8`, `max_shift=7`, `accum_bits=24`, and
-`output_scale=127` so the only intended variable is reciprocal precision.
+`output_scale=127` so the primary variable is reciprocal precision. The
+reciprocal denominator bucket size is held constant across rows.
 
 ## Exclusions
 

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/implementation_summary.md
@@ -8,8 +8,8 @@
 - Added `normalization_mode` and `reciprocal_bits` options to RTLGen
   `softmax_rowwise`.
 - Preserved the existing exact divider mode as the default.
-- Added `reciprocal_quantized` emission using a denominator-indexed reciprocal
-  lookup and multiply/shift normalization path.
+- Added `reciprocal_quantized` emission using a bucketed denominator-indexed
+  reciprocal lookup and multiply/shift normalization path.
 - Added q10/q12/q14/q16 row-wise int8 r8 acc24 configs for L1 measurement.
 
 ## Files Changed
@@ -36,5 +36,7 @@
 
 ## Risks
 - The reciprocal lookup table may dominate area for this row envelope.
+- The bucketed denominator lookup changes numerical behavior relative to the
+  earlier exact reciprocal software quality rows.
 - This remains a row-wise block measurement, not full decoder-system PPA.
 - bf16 reciprocal/multiply datapaths remain unmeasured.

--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/proposal.json
@@ -12,6 +12,7 @@
     "include": [
       "row-wise int8 shift-exp softmax with reciprocal_quantized normalization",
       "reciprocal_bits q10, q12, q14, and q16",
+      "reciprocal_lut_bucket_shift fixed at 4 to keep the LUT under synth prefilter memory limits",
       "row_elems=8, max_shift=7, accum_bits=24, output_scale=127 held constant",
       "divider-free RTL emission using reciprocal lookup plus multiply/shift"
     ],
@@ -31,6 +32,7 @@
     "keeps performance, power, and area axes separate for architecture discussion"
   ],
   "risks": [
+    "bucketed reciprocal lookup adds approximation error beyond the software q10/q12/q14/q16 quality rows",
     "reciprocal lookup table area may dominate and make row_elems/max_shift choices interaction-sensitive",
     "single-row block PPA still excludes decoder control and memory effects",
     "q8 reciprocal quality remains benchmark-distribution dependent"

--- a/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q10_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q10.json
+++ b/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q10_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q10.json
@@ -17,6 +17,7 @@
         "impl": "shift_exp",
         "normalization_mode": "reciprocal_quantized",
         "reciprocal_bits": 10,
+        "reciprocal_lut_bucket_shift": 4,
         "row_elems": 8,
         "max_shift": 7,
         "accum_bits": 24,

--- a/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q12_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q12.json
+++ b/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q12_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q12.json
@@ -17,6 +17,7 @@
         "impl": "shift_exp",
         "normalization_mode": "reciprocal_quantized",
         "reciprocal_bits": 12,
+        "reciprocal_lut_bucket_shift": 4,
         "row_elems": 8,
         "max_shift": 7,
         "accum_bits": 24,

--- a/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q14_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q14.json
+++ b/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q14_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q14.json
@@ -17,6 +17,7 @@
         "impl": "shift_exp",
         "normalization_mode": "reciprocal_quantized",
         "reciprocal_bits": 14,
+        "reciprocal_lut_bucket_shift": 4,
         "row_elems": 8,
         "max_shift": 7,
         "accum_bits": 24,

--- a/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q16_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q16.json
+++ b/runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q16_wrapper/config_softmax_rowwise_int8_r8_acc24_recip_q16.json
@@ -17,6 +17,7 @@
         "impl": "shift_exp",
         "normalization_mode": "reciprocal_quantized",
         "reciprocal_bits": 16,
+        "reciprocal_lut_bucket_shift": 4,
         "row_elems": 8,
         "max_shift": 7,
         "accum_bits": 24,

--- a/scripts/softmax_rowwise_ref.py
+++ b/scripts/softmax_rowwise_ref.py
@@ -15,6 +15,7 @@ def _load_config(path: str) -> dict:
         "impl": str(opts.get("impl", "shift_exp")),
         "normalization_mode": str(opts.get("normalization_mode", "exact")),
         "reciprocal_bits": int(opts.get("reciprocal_bits", 0)),
+        "reciprocal_lut_bucket_shift": int(opts.get("reciprocal_lut_bucket_shift", 0)),
         "row_elems": int(opts.get("row_elems", 1)),
         "max_shift": int(opts.get("max_shift", 7)),
         "accum_bits": int(opts.get("accum_bits", 16)),
@@ -29,6 +30,7 @@ def compute_shift_exp_row(
     output_scale: int = 127,
     normalization_mode: str = "exact",
     reciprocal_bits: int = 0,
+    reciprocal_lut_bucket_shift: int = 0,
 ):
     if not logits:
         return []
@@ -49,7 +51,12 @@ def compute_shift_exp_row(
     if normalization_mode == "reciprocal_quantized":
         if reciprocal_bits <= 0:
             raise ValueError("reciprocal_bits must be positive for reciprocal_quantized")
-        reciprocal = ((output_scale << reciprocal_bits) + (sum_weights // 2)) // sum_weights
+        if reciprocal_lut_bucket_shift > 0:
+            bucket = (sum_weights + ((1 << reciprocal_lut_bucket_shift) - 1)) >> reciprocal_lut_bucket_shift
+            approx_sum = max(1, bucket << reciprocal_lut_bucket_shift)
+        else:
+            approx_sum = sum_weights
+        reciprocal = ((output_scale << reciprocal_bits) + (approx_sum // 2)) // approx_sum
     elif normalization_mode != "exact":
         raise ValueError(f"unsupported normalization_mode: {normalization_mode}")
     for weight in weights:
@@ -96,6 +103,7 @@ def main() -> int:
                     output_scale=cfg["output_scale"],
                     normalization_mode=cfg["normalization_mode"],
                     reciprocal_bits=cfg["reciprocal_bits"],
+                    reciprocal_lut_bucket_shift=cfg["reciprocal_lut_bucket_shift"],
                 ),
             }
         )
@@ -107,6 +115,7 @@ def main() -> int:
                 "impl": cfg["impl"],
                 "normalization_mode": cfg["normalization_mode"],
                 "reciprocal_bits": cfg["reciprocal_bits"],
+                "reciprocal_lut_bucket_shift": cfg["reciprocal_lut_bucket_shift"],
                 "row_elems": cfg["row_elems"],
                 "max_shift": cfg["max_shift"],
                 "accum_bits": cfg["accum_bits"],

--- a/src/rtlgen/config.cpp
+++ b/src/rtlgen/config.cpp
@@ -353,6 +353,7 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                     softmax.impl = options.value("impl", "shift_exp");
                     softmax.normalization_mode = options.value("normalization_mode", "exact");
                     softmax.reciprocal_bits = options.value("reciprocal_bits", 0);
+                    softmax.reciprocal_lut_bucket_shift = options.value("reciprocal_lut_bucket_shift", 0);
                     softmax.row_elems = options.value("row_elems", 1);
                     softmax.max_shift = options.value("max_shift", 7);
                     softmax.accum_bits = options.value("accum_bits", 16);
@@ -362,6 +363,9 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                     }
                     if (softmax.normalization_mode == "reciprocal_quantized" && (softmax.reciprocal_bits < 1 || softmax.reciprocal_bits > 24)) {
                         throw std::runtime_error("softmax_rowwise reciprocal_bits must be in [1, 24] for " + softmax.module_name);
+                    }
+                    if (softmax.reciprocal_lut_bucket_shift < 0 || softmax.reciprocal_lut_bucket_shift > 12) {
+                        throw std::runtime_error("softmax_rowwise reciprocal_lut_bucket_shift must be in [0, 12] for " + softmax.module_name);
                     }
                     if (softmax.row_elems <= 0) {
                         throw std::runtime_error("softmax_rowwise row_elems must be positive for " + softmax.module_name);

--- a/src/rtlgen/config.hpp
+++ b/src/rtlgen/config.hpp
@@ -199,6 +199,7 @@ struct SoftmaxRowwiseOperationConfig {
     std::string impl{"shift_exp"};
     std::string normalization_mode{"exact"};
     int reciprocal_bits{0};
+    int reciprocal_lut_bucket_shift{0};
     int row_elems{1};
     int max_shift{7};
     int accum_bits{16};

--- a/src/rtlgen/rtl_operations.cpp
+++ b/src/rtlgen/rtl_operations.cpp
@@ -903,6 +903,9 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     if (config.normalization_mode == "reciprocal_quantized" && (config.reciprocal_bits < 1 || config.reciprocal_bits > 24)) {
         throw std::runtime_error("softmax_rowwise reciprocal_bits must be in [1, 24]");
     }
+    if (config.reciprocal_lut_bucket_shift < 0 || config.reciprocal_lut_bucket_shift > 12) {
+        throw std::runtime_error("softmax_rowwise reciprocal_lut_bucket_shift must be in [0, 12]");
+    }
     if (config.row_elems <= 0) {
         throw std::runtime_error("softmax_rowwise row_elems must be positive");
     }
@@ -919,6 +922,7 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     const int data_width = operand.bit_width;
     const int row_width = config.row_elems * data_width;
     const bool reciprocal_quantized = config.normalization_mode == "reciprocal_quantized";
+    const int reciprocal_bucket_step = reciprocal_quantized ? (1 << config.reciprocal_lut_bucket_shift) : 1;
     const int reciprocal_value_bits = reciprocal_quantized
         ? static_cast<int>(std::ceil(std::log2(static_cast<double>(config.output_scale) * std::ldexp(1.0, config.reciprocal_bits) + 1.0)))
         : data_width;
@@ -953,17 +957,21 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     os << "  localparam integer OUTPUT_SCALE = " << config.output_scale << ";\n\n";
     if (reciprocal_quantized) {
         const int max_sum = config.row_elems * (1 << config.max_shift);
+        const int bucket_shift = config.reciprocal_lut_bucket_shift;
+        const int max_bucket = (max_sum + reciprocal_bucket_step - 1) >> bucket_shift;
         const long long scale = static_cast<long long>(config.output_scale) << config.reciprocal_bits;
         os << "  localparam integer RECIP_BITS = " << config.reciprocal_bits << ";\n";
         os << "  localparam integer RECIP_VALUE_BITS = " << reciprocal_value_bits << ";\n\n";
+        os << "  localparam integer RECIP_BUCKET_SHIFT = " << bucket_shift << ";\n\n";
         os << "  function [RECIP_VALUE_BITS-1:0] recip_lut;\n";
-        os << "    input [ACCUM_BITS-1:0] denom;\n";
+        os << "    input [ACCUM_BITS-1:0] bucket;\n";
         os << "    begin\n";
-        os << "      case (denom)\n";
+        os << "      case (bucket)\n";
         os << "        " << config.accum_bits << "'d0: recip_lut = {RECIP_VALUE_BITS{1'b0}};\n";
-        for (int denom = 1; denom <= max_sum; ++denom) {
+        for (int bucket = 1; bucket <= max_bucket; ++bucket) {
+            const int denom = bucket << bucket_shift;
             const long long recip = (scale + (denom / 2)) / denom;
-            os << "        " << config.accum_bits << "'d" << denom
+            os << "        " << config.accum_bits << "'d" << bucket
                << ": recip_lut = " << reciprocal_value_bits << "'d" << recip << ";\n";
         }
         os << "        default: recip_lut = {RECIP_VALUE_BITS{1'b0}};\n";
@@ -981,6 +989,7 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     os << "  reg [PRODUCT_BITS-1:0] scaled_out;\n";
     if (reciprocal_quantized) {
         os << "  reg [RECIP_VALUE_BITS-1:0] reciprocal;\n";
+        os << "  reg [ACCUM_BITS-1:0] reciprocal_bucket;\n";
     }
     os << "  reg [DATA_W-1:0] lane_out;\n\n";
     os << "  always @* begin\n";
@@ -1003,7 +1012,13 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     os << "    end\n\n";
     os << "    Y = {ROW_ELEMS*DATA_W{1'b0}};\n";
     if (reciprocal_quantized) {
-        os << "    reciprocal = recip_lut(sum_weights);\n";
+        if (config.reciprocal_lut_bucket_shift > 0) {
+            os << "    reciprocal_bucket = (sum_weights + " << config.accum_bits << "'d" << (reciprocal_bucket_step - 1)
+               << ") >> RECIP_BUCKET_SHIFT;\n";
+        } else {
+            os << "    reciprocal_bucket = sum_weights;\n";
+        }
+        os << "    reciprocal = recip_lut(reciprocal_bucket);\n";
     }
     os << "    for (i = 0; i < ROW_ELEMS; i = i + 1) begin\n";
     if (reciprocal_quantized) {

--- a/tests/softmax_rowwise_tb.v
+++ b/tests/softmax_rowwise_tb.v
@@ -6,6 +6,14 @@ module softmax_rowwise_tb;
 
   softmax_rowwise_int8_r4 dut (.X(X), .Y(Y));
 
+`ifdef SOFTMAX_RECIP_Q10_BUCKETED
+  localparam [31:0] EXP_ROW1 = {8'd6, 8'd6, 8'd6, 8'd102};
+  localparam [31:0] EXP_ROW2 = {8'd113, 8'd7, 8'd1, 8'd1};
+`else
+  localparam [31:0] EXP_ROW1 = {8'd7, 8'd7, 8'd7, 8'd107};
+  localparam [31:0] EXP_ROW2 = {8'd118, 8'd7, 8'd1, 8'd1};
+`endif
+
   task check_row;
     input [31:0] a;
     input [31:0] exp;
@@ -26,8 +34,8 @@ module softmax_rowwise_tb;
 
   initial begin
     check_row({8'd0, 8'd0, 8'd0, 8'd0}, {8'd32, 8'd32, 8'd32, 8'd32});
-    check_row({8'd0, 8'd0, 8'd0, 8'd4}, {8'd7, 8'd7, 8'd7, 8'd107});
-    check_row({8'd8, 8'd4, 8'd0, 8'hfc}, {8'd118, 8'd7, 8'd1, 8'd1});
+    check_row({8'd0, 8'd0, 8'd0, 8'd4}, EXP_ROW1);
+    check_row({8'd8, 8'd4, 8'd0, 8'hfc}, EXP_ROW2);
     $display("All row-wise softmax tests passed.");
     $finish;
   end

--- a/tests/test_softmax_rowwise.sh
+++ b/tests/test_softmax_rowwise.sh
@@ -42,6 +42,7 @@ cfg = json.loads(Path("config.json").read_text(encoding="utf-8"))
 opts = cfg["operations"][0]["options"]
 opts["normalization_mode"] = "reciprocal_quantized"
 opts["reciprocal_bits"] = 10
+opts["reciprocal_lut_bucket_shift"] = 4
 Path("config_recip_q10.json").write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
 PY
 "$ROOT/build/rtlgen" config_recip_q10.json
@@ -55,10 +56,10 @@ import json
 from pathlib import Path
 
 got = json.loads(Path("ref_recip.json").read_text(encoding="utf-8"))["rows"][0]["output"]
-expected = [1, 1, 7, 118]
+expected = [1, 1, 7, 113]
 if got != expected:
     raise SystemExit(f"reciprocal reference mismatch got={got} expected={expected}")
 PY
-iverilog -g2012 -s softmax_rowwise_tb -o sim_recip softmax_rowwise_int8_r4.v "$ROOT/tests/softmax_rowwise_tb.v"
+iverilog -g2012 -DSOFTMAX_RECIP_Q10_BUCKETED -s softmax_rowwise_tb -o sim_recip softmax_rowwise_int8_r4.v "$ROOT/tests/softmax_rowwise_tb.v"
 vvp sim_recip
 popd >/dev/null


### PR DESCRIPTION
## Summary
- Add reciprocal_lut_bucket_shift for row-wise softmax reciprocal_quantized mode.
- Generate a bucket-indexed reciprocal LUT to avoid Yosys memory-size rejection while keeping divider-free normalization.
- Update q10/q12/q14/q16 reciprocal configs, reference model, tests, and proposal docs.

## Validation
- cmake --build build -j2
- bash tests/test_softmax_rowwise.sh
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check
- Local q10 Nangate45 repro produced status=ok metrics for CORE_UTILIZATION=60 with critical_path_ns=5.6238.