### PR TITLE
Record q8 reciprocal datapath retry dispatch

### DIFF
--- a/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_decoder_q8_recip_norm_datapath_v1",
-  "source_commit": "94c53a105616f373580c801d6d09672e8a909448",
+  "source_commit": "c654b44f099764973ad2b63998cbc25d46e1d4e5",
   "requested_items": [
     {
       "item_id": "l1_decoder_q8_recip_norm_datapath_v1",
@@ -8,8 +8,17 @@
       "objective": "Measure Nangate45 PPA for integrated row-wise int8 q8 reciprocal-normalization softmax blocks at q10/q12/q14/q16.",
       "evaluation_mode": "measurement_only",
       "abstraction_layer": "circuit_block",
-      "status": "ready",
-      "notes": "Queued from merged commit 94c53a105616f373580c801d6d09672e8a909448; assigned to evaluator by the control-plane dispatcher."
+      "status": "artifact_sync_blocked",
+      "notes": "Queued from merged commit 94c53a105616f373580c801d6d09672e8a909448. Artifact sync found no status=ok metrics rows because the unbucketed reciprocal LUT exceeded Yosys memory prefilter limits."
+    },
+    {
+      "item_id": "l1_decoder_q8_recip_norm_datapath_v1_r2",
+      "task_type": "l1_sweep",
+      "objective": "Retry Nangate45 PPA measurement for bucketed integrated row-wise int8 q8 reciprocal-normalization softmax blocks at q10/q12/q14/q16.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "status": "assigned",
+      "notes": "Queued from merged commit c654b44f099764973ad2b63998cbc25d46e1d4e5 after PR #287; assigned to eval-daemon-f59743373362."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Mark the original q8 reciprocal datapath item as artifact-sync blocked due to the unbucketed LUT synthesis failure.
- Record the r2 retry item assigned from merged commit c654b44f099764973ad2b63998cbc25d46e1d4e5.

## Validation
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check