### PR TITLE
Force regenerate config L1 sweep collateral

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -335,7 +335,7 @@ def _read_config_target(
                         "--platform {platform} "
                         f"--sweep {{sweep_path}} "
                         f"--out_root {out_root} "
-                        "--skip_existing"
+                        "--force_gen --skip_existing"
                         )
                     ),
                 },
@@ -362,7 +362,7 @@ def _read_config_target(
                         "--platform {platform} "
                         f"--sweep {{sweep_path}} "
                         f"--out_root {out_root} "
-                        "--skip_existing"
+                        "--force_gen --skip_existing"
                         )
                     ),
                 },
@@ -389,7 +389,7 @@ def _read_config_target(
                         "--platform {platform} "
                         f"--sweep {{sweep_path}} "
                         f"--out_root {out_root} "
-                        "--skip_existing"
+                        "--force_gen --skip_existing"
                         )
                     ),
                 },
@@ -420,7 +420,7 @@ def _read_config_target(
                         "--platform {platform} "
                         f"--sweep {{sweep_path}} "
                         f"--out_root {out_root} "
-                        "--skip_existing"
+                        "--force_gen --skip_existing"
                         )
                     ),
                 },

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -211,6 +211,7 @@ def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
                 "export PATH=/oss-cad-suite/bin:$PATH && "
                 "cmake -S . -B build && cmake --build build --target rtlgen"
             )
+            assert "--force_gen" in work_item.command_manifest[1]["run"]
             assert "--skip_existing" in work_item.command_manifest[1]["run"]
             assert work_item.command_manifest[1]["run"].startswith(
                 "export PATH=/oss-cad-suite/bin:$PATH && python3 scripts/run_sweep.py "


### PR DESCRIPTION
## Summary
- Add --force_gen to generated config-driven L1 run_sweep commands.
- Prevent stale /orfs design collateral from being reused when a config/module name is unchanged but RTLGen emission changed.
- Cover the generated command in the L1 task generator test.

## Validation
- PYTHONPATH=control_plane control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check