### PR TITLE
Use measured q8 normalization PPA in frontier ranking

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -858,6 +858,7 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
     sweep_out = f"{base}/decoder_quality_sweep__{item_id}.json"
     frontier_out = f"{base}/decoder_q8_norm_frontier__{item_id}.json"
     frontier_report = f"{base}/decoder_q8_norm_frontier__{item_id}.md"
+    q8_recip_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json"
     rough_grid = "decoder_q8_normalization_frontier_v1"
     commands = [
         {
@@ -906,6 +907,7 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
             "run": (
                 "python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py "
                 f"--sweep {sweep_out} "
+                f"--q8-recip-ppa {q8_recip_ppa} "
                 f"--out {frontier_out} "
                 f"--out-md {frontier_report}"
             ),
@@ -926,9 +928,11 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
             "candidate_sweep_grid": rough_grid,
             "frontier_out": frontier_out,
             "frontier_report": frontier_report,
+            "q8_reciprocal_datapath_ppa": q8_recip_ppa,
             "candidate_sweep_scope": (
                 "focused q8 PWL normalization frontier over exact normalization and quantized reciprocal "
-                "normalization bit widths on the prompt-stress dataset"
+                "normalization bit widths on the prompt-stress dataset, with q8 reciprocal ranking backed "
+                "by merged integrated datapath PPA when available"
             ),
         },
         "commands": commands,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -667,6 +667,11 @@ def test_generate_l2_campaign_task_adds_decoder_q8_normalization_frontier_eviden
             assert "quantized reciprocal" in decoder_inputs["candidate_sweep_scope"]
             assert "--rough-grid decoder_q8_normalization_frontier_v1" in work_item.command_manifest[4]["run"]
             assert "estimate_llm_decoder_q8_norm_frontier.py" in work_item.command_manifest[5]["run"]
+            assert "--q8-recip-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json" in work_item.command_manifest[5]["run"]
+            assert (
+                decoder_inputs["q8_reciprocal_datapath_ppa"]
+                == "control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json"
+            )
             assert decoder_inputs["frontier_out"] in work_item.expected_outputs
             assert decoder_inputs["frontier_report"] in work_item.expected_outputs
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -192,6 +192,7 @@ python3 npu/eval/sweep_llm_decoder_candidate_quality.py \
   --out /tmp/decoder_q8_norm_frontier_sweep.json
 python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py \
   --sweep /tmp/decoder_q8_norm_frontier_sweep.json \
+  --q8-recip-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json \
   --out /tmp/decoder_q8_norm_frontier.json \
   --out-md /tmp/decoder_q8_norm_frontier.md
 ```
@@ -199,10 +200,11 @@ python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py \
 This frontier tests q8 PWL exact normalization against q8 PWL quantized
 reciprocal normalization at q10/q12/q14/q16, with the bf16 reciprocal PWL row
 kept as the current anchor. A reciprocal row is only a candidate if it preserves
-the full prompt-stress next-token and top-k gate. The reported normalization
-cost is an uncalibrated planning unit; follow it with RTLGen/OpenROAD
-calibration of the integer multiplier and accumulator/adder path before treating
-q10 as physically better than wider reciprocal options.
+the full prompt-stress next-token and top-k gate. When the merged q8 reciprocal
+datapath artifact is available, q10/q12/q14/q16 are ranked by measured
+Nangate45 critical path, then area, then power. q8 exact normalization and the
+bf16 reciprocal anchor remain unmeasured hardware gaps until their datapaths are
+costed separately.
 
 After the corresponding Layer 1 multiplier and accumulator/adder calibration
 jobs merge, synthesize the measured primitive evidence into a decoder

--- a/npu/eval/estimate_llm_decoder_q8_norm_frontier.py
+++ b/npu/eval/estimate_llm_decoder_q8_norm_frontier.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Summarize q8 PWL normalization frontier quality and cost tradeoffs."""
+"""Summarize q8 PWL normalization frontier quality and PPA tradeoffs."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -14,21 +15,25 @@ JsonDict = dict[str, Any]
 BASELINE_Q8_EXACT = "grid_approx_pwl_in_q8_w_q8_norm_exact"
 BF16_ANCHOR = "grid_approx_pwl_bf16_path"
 Q8_PREFIX = "grid_approx_pwl_in_q8_w_q8_norm_recip_q"
+DEFAULT_Q8_RECIP_PPA = Path("control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json")
+METRIC_KEYS = ("critical_path_ns", "die_area", "total_power_mw")
 
 COST_MODEL = {
-    "name": "decoder_q8_normalization_planning_proxy_v1",
-    "source": "hand_written_planning_proxy_not_literature_backed",
-    "unit": "heuristic_planning_units",
-    "calibration_status": "uncalibrated",
+    "name": "decoder_q8_normalization_ppa_frontier_v2",
+    "source": "rtlgen_openroad_q8_reciprocal_datapath_metrics",
+    "unit": "nangate45_physical_metrics",
+    "calibration_status": "q8_reciprocal_integrated_datapath_measured",
     "ppa_balance": (
-        "The score is a single planning scalar. It does not independently balance timing, "
-        "power, and area, and it must not be read as Nangate45 PPA."
+        "Measured q8 reciprocal candidates are ranked lexicographically by critical path, "
+        "then area, then power. Exact q8 and bf16 reciprocal normalization remain unmeasured "
+        "hardware gaps and are not compared as accepted PPA."
     ),
     "intended_use": (
-        "Choose the next RTLGen/OpenROAD calibration target after quality-gated decoder "
-        "sweeps; do not use it as hardware acceptance evidence."
+        "Replace the q8 reciprocal normalization heuristic with merged RTLGen/OpenROAD "
+        "datapath evidence while preserving quality gates from the decoder sweep."
     ),
-    "rtlgen_calibration_proposal": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
+    "rtlgen_calibration_proposal": "prop_l1_decoder_q8_recip_norm_datapath_v1",
+    "fallback_source": "hand_written_planning_proxy_used_only_when_ppa_artifact_is_absent",
 }
 
 
@@ -52,6 +57,49 @@ def _as_int(value: Any, default: int = 0) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _metric_summary(row: JsonDict) -> JsonDict:
+    summary = row.get("metric_summary")
+    if not isinstance(summary, dict):
+        return {key: None for key in METRIC_KEYS}
+    return {key: _as_float(summary.get(key), default=None) for key in METRIC_KEYS}
+
+
+def _recip_bits_from_metrics_ref(metrics_ref: JsonDict) -> int | None:
+    text = " ".join(str(metrics_ref.get(key) or "") for key in ("metrics_csv", "result_path", "tag"))
+    match = re.search(r"recip_q(\d+)", text)
+    return int(match.group(1)) if match else None
+
+
+def _load_q8_recip_ppa(path: Path | None) -> dict[int, JsonDict]:
+    if path is None or not path.exists():
+        return {}
+    payload = _load_json(path)
+    proposals = payload.get("proposals")
+    if not isinstance(proposals, list):
+        raise SystemExit(f"q8 reciprocal PPA artifact must contain proposals list: {path}")
+    rows: dict[int, JsonDict] = {}
+    for proposal in proposals:
+        if not isinstance(proposal, dict):
+            continue
+        metrics_ref = proposal.get("metrics_ref")
+        if not isinstance(metrics_ref, dict):
+            continue
+        bits = _recip_bits_from_metrics_ref(metrics_ref)
+        metrics = _metric_summary(proposal)
+        if bits is None or str(metrics_ref.get("status") or "") != "ok":
+            continue
+        if any(metrics[key] is None for key in METRIC_KEYS):
+            continue
+        rows[bits] = {
+            "reciprocal_bits": bits,
+            "platform": metrics_ref.get("platform"),
+            "metrics_ref": metrics_ref,
+            "metrics": metrics,
+            "selection_reason": proposal.get("selection_reason"),
+        }
+    return rows
 
 
 def _quality(row: JsonDict) -> JsonDict:
@@ -82,7 +130,7 @@ def _quality(row: JsonDict) -> JsonDict:
     }
 
 
-def _normalization_cost(row: JsonDict) -> float:
+def _heuristic_normalization_cost(row: JsonDict) -> float:
     mode = str(row.get("normalization_mode") or "").strip()
     if mode == "exact":
         return 52.0
@@ -95,10 +143,57 @@ def _normalization_cost(row: JsonDict) -> float:
     return 40.0
 
 
-def _row_record(row: JsonDict) -> JsonDict:
+def _normalization_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict]) -> JsonDict:
+    mode = str(row.get("normalization_mode") or "exact").strip()
+    bits = _as_int(row.get("normalization_reciprocal_bits"), 0)
+    heuristic_cost = _heuristic_normalization_cost(row)
+    record: JsonDict = {
+        "mode": mode,
+        "reciprocal_bits": bits,
+        "reciprocal_float_format": row.get("normalization_reciprocal_float_format", ""),
+        "heuristic_fallback_units": round(heuristic_cost, 3),
+        "heuristic_fallback_unit": "heuristic_planning_units",
+        "ppa_metrics": None,
+        "metrics_ref": None,
+        "rank_source": "unmeasured_gap",
+        "rank_key": [2, round(heuristic_cost, 6)],
+        "unit": COST_MODEL["unit"],
+    }
+    if mode == "reciprocal_quantized":
+        ppa = q8_recip_ppa.get(bits)
+        if ppa is not None:
+            metrics = ppa["metrics"]
+            record.update(
+                {
+                    "ppa_metrics": metrics,
+                    "metrics_ref": ppa["metrics_ref"],
+                    "rank_source": "measured_q8_reciprocal_datapath_ppa",
+                    "rank_key": [0] + [float(metrics[key]) for key in METRIC_KEYS],
+                    "calibration_status": "integrated_q8_reciprocal_datapath_measured",
+                }
+            )
+            return record
+        record.update(
+            {
+                "rank_source": "heuristic_fallback_missing_q8_reciprocal_ppa",
+                "rank_key": [1, round(heuristic_cost, 6)],
+                "calibration_status": "missing_integrated_q8_reciprocal_datapath_ppa",
+            }
+        )
+        return record
+    if mode == "exact":
+        record["calibration_status"] = "unmeasured_exact_normalization_datapath"
+    elif mode == "reciprocal_float":
+        record["calibration_status"] = "unmeasured_float_reciprocal_datapath"
+    else:
+        record["calibration_status"] = "unmeasured_normalization_datapath"
+    return record
+
+
+def _row_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict]) -> JsonDict:
     template = str(row.get("template") or "")
     quality = _quality(row)
-    norm_cost = _normalization_cost(row)
+    normalization = _normalization_record(row, q8_recip_ppa=q8_recip_ppa)
     if template == BF16_ANCHOR:
         role = "bf16_primary_anchor"
     elif template == BASELINE_Q8_EXACT:
@@ -112,15 +207,8 @@ def _row_record(row: JsonDict) -> JsonDict:
         "candidate_semantics": row.get("candidate_semantics"),
         "role": role,
         "quality": quality,
-        "normalization": {
-            "mode": row.get("normalization_mode", "exact"),
-            "reciprocal_bits": row.get("normalization_reciprocal_bits", 0),
-            "reciprocal_float_format": row.get("normalization_reciprocal_float_format", ""),
-            "relative_cost_units": round(norm_cost, 3),
-            "unit": COST_MODEL["unit"],
-            "calibration_status": COST_MODEL["calibration_status"],
-        },
-        "frontier_score": round(norm_cost + (0.0 if quality["exact_safe"] else 1000.0), 3),
+        "normalization": normalization,
+        "frontier_rank_key": normalization["rank_key"] if quality["exact_safe"] else [9, *normalization["rank_key"]],
     }
 
 
@@ -142,16 +230,17 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         "",
         payload["cost_model"]["intended_use"],
         "",
-        "## Quality And Normalization Cost",
+        "## Quality And Normalization PPA",
         "",
-        "| template | role | gate | next-token | top-k | norm mode | recip bits | norm cost |",
-        "|---|---|---|---:|---:|---|---:|---:|",
+        "| template | role | gate | next-token | top-k | norm mode | recip bits | rank source | critical_path_ns | die_area | total_power_mw |",
+        "|---|---|---|---:|---:|---|---:|---|---:|---:|---:|",
     ]
     for row in payload["ranked_rows"]:
         quality = row["quality"]
         norm = row["normalization"]
+        metrics = norm.get("ppa_metrics") or {}
         lines.append(
-            "| `{template}` | `{role}` | `{gate}` | {next}/{samples} | {topk}/{samples} | `{mode}` | {bits} | {cost:.3f} |".format(
+            "| `{template}` | `{role}` | `{gate}` | {next}/{samples} | {topk}/{samples} | `{mode}` | {bits} | `{rank_source}` | {cp} | {area} | {power} |".format(
                 template=row["template"],
                 role=row["role"],
                 gate=quality["gate"],
@@ -160,7 +249,10 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
                 samples=quality["sample_count"],
                 mode=norm["mode"],
                 bits=norm["reciprocal_bits"] or "",
-                cost=norm["relative_cost_units"],
+                rank_source=norm["rank_source"],
+                cp=metrics.get("critical_path_ns", ""),
+                area=metrics.get("die_area", ""),
+                power=metrics.get("total_power_mw", ""),
             )
         )
     lines.extend(["", "## Blocked Rows", ""])
@@ -182,12 +274,13 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
     path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
 
 
-def build_report(*, sweep_path: Path) -> JsonDict:
+def build_report(*, sweep_path: Path, q8_recip_ppa_path: Path | None = DEFAULT_Q8_RECIP_PPA) -> JsonDict:
     sweep = _load_json(sweep_path)
+    q8_recip_ppa = _load_q8_recip_ppa(q8_recip_ppa_path)
     rows = sweep.get("templates")
     if not isinstance(rows, list):
         raise SystemExit("sweep JSON must contain a templates list")
-    records = [_row_record(row) for row in rows if isinstance(row, dict)]
+    records = [_row_record(row, q8_recip_ppa=q8_recip_ppa) for row in rows if isinstance(row, dict)]
     interesting = [
         row
         for row in records
@@ -203,7 +296,7 @@ def build_report(*, sweep_path: Path) -> JsonDict:
     ]
     reciprocal_survivors.sort(
         key=lambda row: (
-            row["normalization"]["relative_cost_units"],
+            row["normalization"]["rank_key"],
             _as_int(row["normalization"]["reciprocal_bits"]),
             row["template"],
         )
@@ -214,8 +307,9 @@ def build_report(*, sweep_path: Path) -> JsonDict:
             "decision": "q8_reciprocal_candidate_survived",
             "selected_candidate": selected["template"],
             "reason": (
-                f"{selected['template']} preserved the exact prompt-stress gate with lower modeled "
-                "normalization cost than q8 exact normalization. It should be costed against the bf16 anchor next."
+                f"{selected['template']} preserved the exact prompt-stress gate and has the best "
+                f"{selected['normalization']['rank_source']} among exact-safe q8 reciprocal candidates. "
+                "q8 exact and bf16 reciprocal normalization remain unmeasured hardware gaps."
             ),
         }
     else:
@@ -231,7 +325,7 @@ def build_report(*, sweep_path: Path) -> JsonDict:
         interesting,
         key=lambda row: (
             not row["quality"]["exact_safe"],
-            row["frontier_score"],
+            row["frontier_rank_key"],
             row["template"],
         ),
     )
@@ -245,27 +339,36 @@ def build_report(*, sweep_path: Path) -> JsonDict:
             "quality_gate": "candidate must match next-token and top-k for every prompt-stress sample",
             "scope_note": (
                 "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization "
-                "precision as a replacement for q8 exact normalization; it is not RTL or OpenROAD PPA. "
-                "The normalization cost values are uncalibrated heuristic planning units."
+                "precision as a replacement for q8 exact normalization. q8 reciprocal rows use merged "
+                "RTLGen/OpenROAD integrated datapath metrics when the PPA artifact is available; exact "
+                "q8 and bf16 normalization paths remain unmeasured."
             ),
+        },
+        "source_artifacts": {
+            "q8_reciprocal_datapath_ppa": str(q8_recip_ppa_path) if q8_recip_ppa_path is not None else None,
+            "q8_reciprocal_ppa_bits": sorted(q8_recip_ppa),
         },
         "cost_model": COST_MODEL,
         "decision": decision,
         "ranked_rows": ranked,
         "next_step": [
-            "If a q8 reciprocal row survives, compare it against bf16 reciprocal PWL with an RTL/OpenROAD-oriented block estimate.",
-            "If no q8 reciprocal row survives, keep q8 exact normalization only as a quality baseline and move the implementation frontier to bf16 reciprocal PWL.",
+            "Measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.",
+            "Measure or model q8 exact normalization only if it remains a candidate beyond the reciprocal path.",
         ],
     }
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Summarize q8 PWL normalization frontier quality/cost tradeoffs")
+    ap = argparse.ArgumentParser(description="Summarize q8 PWL normalization frontier quality/PPA tradeoffs")
     ap.add_argument("--sweep", required=True, help="q8 normalization frontier sweep JSON")
+    ap.add_argument("--q8-recip-ppa", default=str(DEFAULT_Q8_RECIP_PPA), help="merged q8 reciprocal datapath promotion JSON")
     ap.add_argument("--out", required=True, help="output JSON path")
     ap.add_argument("--out-md", required=True, help="output Markdown report path")
     args = ap.parse_args()
-    report = build_report(sweep_path=Path(args.sweep))
+    report = build_report(
+        sweep_path=Path(args.sweep),
+        q8_recip_ppa_path=Path(args.q8_recip_ppa) if args.q8_recip_ppa else None,
+    )
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json
@@ -1,27 +1,66 @@
 {
+  "cost_model": {
+    "calibration_status": "q8_reciprocal_integrated_datapath_measured",
+    "fallback_source": "hand_written_planning_proxy_used_only_when_ppa_artifact_is_absent",
+    "intended_use": "Replace the q8 reciprocal normalization heuristic with merged RTLGen/OpenROAD datapath evidence while preserving quality gates from the decoder sweep.",
+    "name": "decoder_q8_normalization_ppa_frontier_v2",
+    "ppa_balance": "Measured q8 reciprocal candidates are ranked lexicographically by critical path, then area, then power. Exact q8 and bf16 reciprocal normalization remain unmeasured hardware gaps and are not compared as accepted PPA.",
+    "rtlgen_calibration_proposal": "prop_l1_decoder_q8_recip_norm_datapath_v1",
+    "source": "rtlgen_openroad_q8_reciprocal_datapath_metrics",
+    "unit": "nangate45_physical_metrics"
+  },
   "decision": {
     "decision": "q8_reciprocal_candidate_survived",
-    "reason": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate with lower modeled normalization cost than q8 exact normalization. It should be costed against the bf16 anchor next.",
+    "reason": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact and bf16 reciprocal normalization remain unmeasured hardware gaps.",
     "selected_candidate": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
   },
   "frontier_scope": {
     "quality_gate": "candidate must match next-token and top-k for every prompt-stress sample",
     "rough_grid": "decoder_q8_normalization_frontier_v1",
-    "scope_note": "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization precision as a replacement for q8 exact normalization; it is not RTL or OpenROAD PPA."
+    "scope_note": "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization precision as a replacement for q8 exact normalization. q8 reciprocal rows use merged RTLGen/OpenROAD integrated datapath metrics when the PPA artifact is available; exact q8 and bf16 normalization paths remain unmeasured."
   },
   "next_step": [
-    "If a q8 reciprocal row survives, compare it against bf16 reciprocal PWL with an RTL/OpenROAD-oriented block estimate.",
-    "If no q8 reciprocal row survives, keep q8 exact normalization only as a quality baseline and move the implementation frontier to bf16 reciprocal PWL."
+    "Measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.",
+    "Measure or model q8 exact normalization only if it remains a candidate beyond the reciprocal path."
   ],
   "ranked_rows": [
     {
       "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_recip_q10_prob_fp",
-      "frontier_score": 17.5,
+      "frontier_rank_key": [
+        0,
+        5.6126,
+        39776.3136,
+        0.00463
+      ],
       "normalization": {
+        "calibration_status": "integrated_q8_reciprocal_datapath_measured",
+        "heuristic_fallback_unit": "heuristic_planning_units",
+        "heuristic_fallback_units": 17.5,
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q10_wrapper/metrics.csv",
+          "param_hash": "44181f67",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q10_wrapper/work/44181f67/result.json",
+          "status": "ok",
+          "tag": "softmax_rowwise_int8_recip_norm_nangate45_highutil_87b48795"
+        },
         "mode": "reciprocal_quantized",
+        "ppa_metrics": {
+          "critical_path_ns": 5.6126,
+          "die_area": 39776.3136,
+          "total_power_mw": 0.00463
+        },
+        "rank_key": [
+          0,
+          5.6126,
+          39776.3136,
+          0.00463
+        ],
+        "rank_source": "measured_q8_reciprocal_datapath_ppa",
         "reciprocal_bits": 10,
         "reciprocal_float_format": "",
-        "relative_cost_units": 17.5
+        "unit": "nangate45_physical_metrics"
       },
       "quality": {
         "exact_safe": true,
@@ -41,12 +80,41 @@
     },
     {
       "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_recip_q12_prob_fp",
-      "frontier_score": 19.0,
+      "frontier_rank_key": [
+        0,
+        5.7554,
+        52118.607025,
+        0.014
+      ],
       "normalization": {
+        "calibration_status": "integrated_q8_reciprocal_datapath_measured",
+        "heuristic_fallback_unit": "heuristic_planning_units",
+        "heuristic_fallback_units": 19.0,
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q12_wrapper/metrics.csv",
+          "param_hash": "44181f67",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q12_wrapper/work/44181f67/result.json",
+          "status": "ok",
+          "tag": "softmax_rowwise_int8_recip_norm_nangate45_highutil_87b48795"
+        },
         "mode": "reciprocal_quantized",
+        "ppa_metrics": {
+          "critical_path_ns": 5.7554,
+          "die_area": 52118.607025,
+          "total_power_mw": 0.014
+        },
+        "rank_key": [
+          0,
+          5.7554,
+          52118.607025,
+          0.014
+        ],
+        "rank_source": "measured_q8_reciprocal_datapath_ppa",
         "reciprocal_bits": 12,
         "reciprocal_float_format": "",
-        "relative_cost_units": 19.0
+        "unit": "nangate45_physical_metrics"
       },
       "quality": {
         "exact_safe": true,
@@ -66,12 +134,41 @@
     },
     {
       "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_recip_q14_prob_fp",
-      "frontier_score": 20.5,
+      "frontier_rank_key": [
+        0,
+        5.7617,
+        52360.880625,
+        0.00637
+      ],
       "normalization": {
+        "calibration_status": "integrated_q8_reciprocal_datapath_measured",
+        "heuristic_fallback_unit": "heuristic_planning_units",
+        "heuristic_fallback_units": 20.5,
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q14_wrapper/metrics.csv",
+          "param_hash": "44181f67",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q14_wrapper/work/44181f67/result.json",
+          "status": "ok",
+          "tag": "softmax_rowwise_int8_recip_norm_nangate45_highutil_87b48795"
+        },
         "mode": "reciprocal_quantized",
+        "ppa_metrics": {
+          "critical_path_ns": 5.7617,
+          "die_area": 52360.880625,
+          "total_power_mw": 0.00637
+        },
+        "rank_key": [
+          0,
+          5.7617,
+          52360.880625,
+          0.00637
+        ],
+        "rank_source": "measured_q8_reciprocal_datapath_ppa",
         "reciprocal_bits": 14,
         "reciprocal_float_format": "",
-        "relative_cost_units": 20.5
+        "unit": "nangate45_physical_metrics"
       },
       "quality": {
         "exact_safe": true,
@@ -90,13 +187,42 @@
       "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q14"
     },
     {
-      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_bf16_w_bf16_norm_recip_bf16_prob_fp",
-      "frontier_score": 22.0,
+      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_recip_q16_prob_fp",
+      "frontier_rank_key": [
+        0,
+        5.814,
+        45315.765625,
+        0.0321
+      ],
       "normalization": {
-        "mode": "reciprocal_float",
-        "reciprocal_bits": 0,
-        "reciprocal_float_format": "bf16",
-        "relative_cost_units": 22.0
+        "calibration_status": "integrated_q8_reciprocal_datapath_measured",
+        "heuristic_fallback_unit": "heuristic_planning_units",
+        "heuristic_fallback_units": 22.0,
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q16_wrapper/metrics.csv",
+          "param_hash": "dc30190b",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q16_wrapper/work/dc30190b/result.json",
+          "status": "ok",
+          "tag": "softmax_rowwise_int8_recip_norm_nangate45_highutil_da64be35"
+        },
+        "mode": "reciprocal_quantized",
+        "ppa_metrics": {
+          "critical_path_ns": 5.814,
+          "die_area": 45315.765625,
+          "total_power_mw": 0.0321
+        },
+        "rank_key": [
+          0,
+          5.814,
+          45315.765625,
+          0.0321
+        ],
+        "rank_source": "measured_q8_reciprocal_datapath_ppa",
+        "reciprocal_bits": 16,
+        "reciprocal_float_format": "",
+        "unit": "nangate45_physical_metrics"
       },
       "quality": {
         "exact_safe": true,
@@ -111,17 +237,30 @@
         "topk_safe": true
       },
       "rank": 4,
-      "role": "bf16_primary_anchor",
-      "template": "grid_approx_pwl_bf16_path"
+      "role": "q8_reciprocal_candidate",
+      "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q16"
     },
     {
-      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_recip_q16_prob_fp",
-      "frontier_score": 22.0,
+      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_bf16_w_bf16_norm_recip_bf16_prob_fp",
+      "frontier_rank_key": [
+        2,
+        22.0
+      ],
       "normalization": {
-        "mode": "reciprocal_quantized",
-        "reciprocal_bits": 16,
-        "reciprocal_float_format": "",
-        "relative_cost_units": 22.0
+        "calibration_status": "unmeasured_float_reciprocal_datapath",
+        "heuristic_fallback_unit": "heuristic_planning_units",
+        "heuristic_fallback_units": 22.0,
+        "metrics_ref": null,
+        "mode": "reciprocal_float",
+        "ppa_metrics": null,
+        "rank_key": [
+          2,
+          22.0
+        ],
+        "rank_source": "unmeasured_gap",
+        "reciprocal_bits": 0,
+        "reciprocal_float_format": "bf16",
+        "unit": "nangate45_physical_metrics"
       },
       "quality": {
         "exact_safe": true,
@@ -136,17 +275,30 @@
         "topk_safe": true
       },
       "rank": 5,
-      "role": "q8_reciprocal_candidate",
-      "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q16"
+      "role": "bf16_primary_anchor",
+      "template": "grid_approx_pwl_bf16_path"
     },
     {
       "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_exact_prob_fp",
-      "frontier_score": 52.0,
+      "frontier_rank_key": [
+        2,
+        52.0
+      ],
       "normalization": {
+        "calibration_status": "unmeasured_exact_normalization_datapath",
+        "heuristic_fallback_unit": "heuristic_planning_units",
+        "heuristic_fallback_units": 52.0,
+        "metrics_ref": null,
         "mode": "exact",
+        "ppa_metrics": null,
+        "rank_key": [
+          2,
+          52.0
+        ],
+        "rank_source": "unmeasured_gap",
         "reciprocal_bits": 0,
         "reciprocal_float_format": "",
-        "relative_cost_units": 52.0
+        "unit": "nangate45_physical_metrics"
       },
       "quality": {
         "exact_safe": true,
@@ -165,6 +317,15 @@
       "template": "grid_approx_pwl_in_q8_w_q8_norm_exact"
     }
   ],
+  "source_artifacts": {
+    "q8_reciprocal_datapath_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json",
+    "q8_reciprocal_ppa_bits": [
+      10,
+      12,
+      14,
+      16
+    ]
+  },
   "source_sweep": "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_normalization_frontier_v1.json",
   "version": 0.1
 }

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.md
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.md
@@ -3,18 +3,27 @@
 - source_sweep: `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_normalization_frontier_v1.json`
 - decision: `q8_reciprocal_candidate_survived`
 - selected_candidate: `grid_approx_pwl_in_q8_w_q8_norm_recip_q10`
-- reason: grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate with lower modeled normalization cost than q8 exact normalization. It should be costed against the bf16 anchor next.
+- reason: grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact and bf16 reciprocal normalization remain unmeasured hardware gaps.
+- cost_model_source: `rtlgen_openroad_q8_reciprocal_datapath_metrics`
+- cost_model_unit: `nangate45_physical_metrics`
+- rtlgen_calibration_proposal: `prop_l1_decoder_q8_recip_norm_datapath_v1`
 
-## Quality And Normalization Cost
+## Cost Model Provenance
 
-| template | role | gate | next-token | top-k | norm mode | recip bits | norm cost |
-|---|---|---|---:|---:|---|---:|---:|
-| `grid_approx_pwl_in_q8_w_q8_norm_recip_q10` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 10 | 17.500 |
-| `grid_approx_pwl_in_q8_w_q8_norm_recip_q12` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 12 | 19.000 |
-| `grid_approx_pwl_in_q8_w_q8_norm_recip_q14` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 14 | 20.500 |
-| `grid_approx_pwl_bf16_path` | `bf16_primary_anchor` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_float` |  | 22.000 |
-| `grid_approx_pwl_in_q8_w_q8_norm_recip_q16` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 16 | 22.000 |
-| `grid_approx_pwl_in_q8_w_q8_norm_exact` | `q8_exact_normalization_baseline` | `exact_safe_survivor` | 24/24 | 24/24 | `exact` |  | 52.000 |
+Measured q8 reciprocal candidates are ranked lexicographically by critical path, then area, then power. Exact q8 and bf16 reciprocal normalization remain unmeasured hardware gaps and are not compared as accepted PPA.
+
+Replace the q8 reciprocal normalization heuristic with merged RTLGen/OpenROAD datapath evidence while preserving quality gates from the decoder sweep.
+
+## Quality And Normalization PPA
+
+| template | role | gate | next-token | top-k | norm mode | recip bits | rank source | critical_path_ns | die_area | total_power_mw |
+|---|---|---|---:|---:|---|---:|---|---:|---:|---:|
+| `grid_approx_pwl_in_q8_w_q8_norm_recip_q10` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 10 | `measured_q8_reciprocal_datapath_ppa` | 5.6126 | 39776.3136 | 0.00463 |
+| `grid_approx_pwl_in_q8_w_q8_norm_recip_q12` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 12 | `measured_q8_reciprocal_datapath_ppa` | 5.7554 | 52118.607025 | 0.014 |
+| `grid_approx_pwl_in_q8_w_q8_norm_recip_q14` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 14 | `measured_q8_reciprocal_datapath_ppa` | 5.7617 | 52360.880625 | 0.00637 |
+| `grid_approx_pwl_in_q8_w_q8_norm_recip_q16` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 16 | `measured_q8_reciprocal_datapath_ppa` | 5.814 | 45315.765625 | 0.0321 |
+| `grid_approx_pwl_bf16_path` | `bf16_primary_anchor` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_float` |  | `unmeasured_gap` |  |  |  |
+| `grid_approx_pwl_in_q8_w_q8_norm_exact` | `q8_exact_normalization_baseline` | `exact_safe_survivor` | 24/24 | 24/24 | `exact` |  | `unmeasured_gap` |  |  |  |
 
 ## Blocked Rows
 
@@ -22,5 +31,5 @@
 
 ## Next Step
 
-- If a q8 reciprocal row survives, compare it against bf16 reciprocal PWL with an RTL/OpenROAD-oriented block estimate.
-- If no q8 reciprocal row survives, keep q8 exact normalization only as a quality baseline and move the implementation frontier to bf16 reciprocal PWL.
+- Measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.
+- Measure or model q8 exact normalization only if it remains a candidate beyond the reciprocal path.

--- a/tests/fixtures/q8_recip_norm_datapath_ppa.json
+++ b/tests/fixtures/q8_recip_norm_datapath_ppa.json
@@ -1,0 +1,31 @@
+{
+  "version": 0.1,
+  "proposals": [
+    {
+      "metrics_ref": {
+        "metrics_csv": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q10_wrapper/metrics.csv",
+        "platform": "nangate45",
+        "status": "ok",
+        "result_path": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q10_wrapper/work/44181f67/result.json"
+      },
+      "metric_summary": {
+        "critical_path_ns": 5.6126,
+        "die_area": 39776.3136,
+        "total_power_mw": 0.00463
+      }
+    },
+    {
+      "metrics_ref": {
+        "metrics_csv": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q12_wrapper/metrics.csv",
+        "platform": "nangate45",
+        "status": "ok",
+        "result_path": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_recip_q12_wrapper/work/44181f67/result.json"
+      },
+      "metric_summary": {
+        "critical_path_ns": 5.7554,
+        "die_area": 52118.607025,
+        "total_power_mw": 0.014
+      }
+    }
+  ]
+}

--- a/tests/test_llm_decoder_q8_norm_frontier.py
+++ b/tests/test_llm_decoder_q8_norm_frontier.py
@@ -25,21 +25,28 @@ def test_q8_normalization_frontier_grid_contains_exact_reciprocal_and_bf16_ancho
 
 
 def test_q8_normalization_frontier_report_selects_lowest_cost_exact_safe_reciprocal() -> None:
-    report = build_report(sweep_path=Path("tests/fixtures/decoder_q8_norm_frontier_sweep.json"))
+    report = build_report(
+        sweep_path=Path("tests/fixtures/decoder_q8_norm_frontier_sweep.json"),
+        q8_recip_ppa_path=Path("tests/fixtures/q8_recip_norm_datapath_ppa.json"),
+    )
 
     assert report["decision"]["decision"] == "q8_reciprocal_candidate_survived"
     assert report["decision"]["selected_candidate"] == "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
-    assert report["cost_model"]["source"] == "hand_written_planning_proxy_not_literature_backed"
-    assert report["cost_model"]["unit"] == "heuristic_planning_units"
+    assert report["cost_model"]["source"] == "rtlgen_openroad_q8_reciprocal_datapath_metrics"
+    assert report["cost_model"]["unit"] == "nangate45_physical_metrics"
     assert (
         report["cost_model"]["rtlgen_calibration_proposal"]
-        == "prop_l1_decoder_normalization_arithmetic_calibration_v1"
+        == "prop_l1_decoder_q8_recip_norm_datapath_v1"
     )
     by_template = {row["template"]: row for row in report["ranked_rows"]}
     assert by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["quality"]["exact_safe"]
-    assert by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["normalization"]["calibration_status"] == "uncalibrated"
+    assert (
+        by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["normalization"]["calibration_status"]
+        == "integrated_q8_reciprocal_datapath_measured"
+    )
     assert by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q12"]["quality"]["exact_safe"]
     assert (
-        by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["normalization"]["relative_cost_units"]
-        < by_template["grid_approx_pwl_in_q8_w_q8_norm_exact"]["normalization"]["relative_cost_units"]
+        by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["normalization"]["ppa_metrics"]["critical_path_ns"]
+        < by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q12"]["normalization"]["ppa_metrics"]["critical_path_ns"]
     )
+    assert by_template["grid_approx_pwl_in_q8_w_q8_norm_exact"]["normalization"]["ppa_metrics"] is None


### PR DESCRIPTION
## Summary
- replace the q8 reciprocal normalization frontier heuristic with merged integrated Nangate45 PPA metrics from PR #292
- keep q8 exact normalization and bf16 reciprocal normalization explicit as unmeasured hardware gaps
- pass the q8 reciprocal PPA artifact through future L2 q8 normalization frontier jobs and refresh the tracked frontier report

## Verification
- PYTHONPATH=.:control_plane control_plane/.venv/bin/pytest -q tests/test_llm_decoder_q8_norm_frontier.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py --sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_normalization_frontier_v1.json --q8-recip-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json --out /tmp/decoder_q8_norm_frontier_ppa.json --out-md /tmp/decoder_q8_norm_frontier_ppa.md