### PR TITLE
Use measured q8 exact PPA in normalization frontier

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -859,6 +859,10 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
     frontier_out = f"{base}/decoder_q8_norm_frontier__{item_id}.json"
     frontier_report = f"{base}/decoder_q8_norm_frontier__{item_id}.md"
     q8_recip_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json"
+    q8_exact_ppa = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json"
+    )
     rough_grid = "decoder_q8_normalization_frontier_v1"
     commands = [
         {
@@ -908,6 +912,7 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
                 "python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py "
                 f"--sweep {sweep_out} "
                 f"--q8-recip-ppa {q8_recip_ppa} "
+                f"--q8-exact-ppa {q8_exact_ppa} "
                 f"--out {frontier_out} "
                 f"--out-md {frontier_report}"
             ),
@@ -929,10 +934,11 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
             "frontier_out": frontier_out,
             "frontier_report": frontier_report,
             "q8_reciprocal_datapath_ppa": q8_recip_ppa,
+            "q8_exact_datapath_ppa": q8_exact_ppa,
             "candidate_sweep_scope": (
                 "focused q8 PWL normalization frontier over exact normalization and quantized reciprocal "
-                "normalization bit widths on the prompt-stress dataset, with q8 reciprocal ranking backed "
-                "by merged integrated datapath PPA when available"
+                "normalization bit widths on the prompt-stress dataset, with q8 exact and q8 reciprocal "
+                "ranking backed by merged integrated datapath PPA when available"
             ),
         },
         "commands": commands,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -669,8 +669,18 @@ def test_generate_l2_campaign_task_adds_decoder_q8_normalization_frontier_eviden
             assert "estimate_llm_decoder_q8_norm_frontier.py" in work_item.command_manifest[5]["run"]
             assert "--q8-recip-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json" in work_item.command_manifest[5]["run"]
             assert (
+                "--q8-exact-ppa control_plane/shadow_exports/l1_promotions/"
+                "l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json"
+                in work_item.command_manifest[5]["run"]
+            )
+            assert (
                 decoder_inputs["q8_reciprocal_datapath_ppa"]
                 == "control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json"
+            )
+            assert (
+                decoder_inputs["q8_exact_datapath_ppa"]
+                == "control_plane/shadow_exports/l1_promotions/"
+                "l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json"
             )
             assert decoder_inputs["frontier_out"] in work_item.expected_outputs
             assert decoder_inputs["frontier_report"] in work_item.expected_outputs

--- a/npu/eval/estimate_llm_decoder_q8_norm_frontier.py
+++ b/npu/eval/estimate_llm_decoder_q8_norm_frontier.py
@@ -16,23 +16,26 @@ BASELINE_Q8_EXACT = "grid_approx_pwl_in_q8_w_q8_norm_exact"
 BF16_ANCHOR = "grid_approx_pwl_bf16_path"
 Q8_PREFIX = "grid_approx_pwl_in_q8_w_q8_norm_recip_q"
 DEFAULT_Q8_RECIP_PPA = Path("control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json")
+DEFAULT_Q8_EXACT_PPA = Path(
+    "control_plane/shadow_exports/l1_promotions/l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json"
+)
 METRIC_KEYS = ("critical_path_ns", "die_area", "total_power_mw")
 
 COST_MODEL = {
-    "name": "decoder_q8_normalization_ppa_frontier_v2",
-    "source": "rtlgen_openroad_q8_reciprocal_datapath_metrics",
+    "name": "decoder_q8_normalization_ppa_frontier_v3",
+    "source": "rtlgen_openroad_q8_exact_and_reciprocal_datapath_metrics",
     "unit": "nangate45_physical_metrics",
-    "calibration_status": "q8_reciprocal_integrated_datapath_measured",
+    "calibration_status": "q8_exact_and_reciprocal_integrated_datapaths_measured",
     "ppa_balance": (
-        "Measured q8 reciprocal candidates are ranked lexicographically by critical path, "
-        "then area, then power. Exact q8 and bf16 reciprocal normalization remain unmeasured "
-        "hardware gaps and are not compared as accepted PPA."
+        "Measured q8 exact and q8 reciprocal candidates are ranked lexicographically by critical path, "
+        "then area, then power. The bf16 reciprocal normalization path remains an unmeasured "
+        "hardware gap and is not compared as accepted PPA."
     ),
     "intended_use": (
-        "Replace the q8 reciprocal normalization heuristic with merged RTLGen/OpenROAD "
-        "datapath evidence while preserving quality gates from the decoder sweep."
+        "Replace the q8 normalization heuristic with merged RTLGen/OpenROAD datapath "
+        "evidence while preserving quality gates from the decoder sweep."
     ),
-    "rtlgen_calibration_proposal": "prop_l1_decoder_q8_recip_norm_datapath_v1",
+    "rtlgen_calibration_proposal": "prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1",
     "fallback_source": "hand_written_planning_proxy_used_only_when_ppa_artifact_is_absent",
 }
 
@@ -102,6 +105,33 @@ def _load_q8_recip_ppa(path: Path | None) -> dict[int, JsonDict]:
     return rows
 
 
+def _load_q8_exact_ppa(path: Path | None) -> JsonDict | None:
+    if path is None or not path.exists():
+        return None
+    payload = _load_json(path)
+    proposals = payload.get("proposals")
+    if not isinstance(proposals, list):
+        raise SystemExit(f"q8 exact PPA artifact must contain proposals list: {path}")
+    for proposal in proposals:
+        if not isinstance(proposal, dict):
+            continue
+        metrics_ref = proposal.get("metrics_ref")
+        if not isinstance(metrics_ref, dict):
+            continue
+        metrics = _metric_summary(proposal)
+        if str(metrics_ref.get("status") or "") != "ok":
+            continue
+        if any(metrics[key] is None for key in METRIC_KEYS):
+            continue
+        return {
+            "platform": metrics_ref.get("platform"),
+            "metrics_ref": metrics_ref,
+            "metrics": metrics,
+            "selection_reason": proposal.get("selection_reason"),
+        }
+    return None
+
+
 def _quality(row: JsonDict) -> JsonDict:
     sample_count = _as_int(row.get("sample_count"))
     next_rate = _as_float(row.get("next_token_id_match_rate"))
@@ -143,7 +173,7 @@ def _heuristic_normalization_cost(row: JsonDict) -> float:
     return 40.0
 
 
-def _normalization_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict]) -> JsonDict:
+def _normalization_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict], q8_exact_ppa: JsonDict | None) -> JsonDict:
     mode = str(row.get("normalization_mode") or "exact").strip()
     bits = _as_int(row.get("normalization_reciprocal_bits"), 0)
     heuristic_cost = _heuristic_normalization_cost(row)
@@ -182,7 +212,22 @@ def _normalization_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict]) -
         )
         return record
     if mode == "exact":
-        record["calibration_status"] = "unmeasured_exact_normalization_datapath"
+        template = str(row.get("template") or "")
+        if template == BASELINE_Q8_EXACT and q8_exact_ppa is not None:
+            metrics = q8_exact_ppa["metrics"]
+            record.update(
+                {
+                    "ppa_metrics": metrics,
+                    "metrics_ref": q8_exact_ppa["metrics_ref"],
+                    "rank_source": "measured_q8_exact_datapath_ppa",
+                    "rank_key": [0] + [float(metrics[key]) for key in METRIC_KEYS],
+                    "calibration_status": "integrated_q8_exact_datapath_measured",
+                }
+            )
+            return record
+        record["calibration_status"] = "missing_integrated_q8_exact_datapath_ppa"
+        record["rank_source"] = "heuristic_fallback_missing_q8_exact_ppa"
+        record["rank_key"] = [1, round(heuristic_cost, 6)]
     elif mode == "reciprocal_float":
         record["calibration_status"] = "unmeasured_float_reciprocal_datapath"
     else:
@@ -190,10 +235,10 @@ def _normalization_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict]) -
     return record
 
 
-def _row_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict]) -> JsonDict:
+def _row_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict], q8_exact_ppa: JsonDict | None) -> JsonDict:
     template = str(row.get("template") or "")
     quality = _quality(row)
-    normalization = _normalization_record(row, q8_recip_ppa=q8_recip_ppa)
+    normalization = _normalization_record(row, q8_recip_ppa=q8_recip_ppa, q8_exact_ppa=q8_exact_ppa)
     if template == BF16_ANCHOR:
         role = "bf16_primary_anchor"
     elif template == BASELINE_Q8_EXACT:
@@ -274,13 +319,23 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
     path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
 
 
-def build_report(*, sweep_path: Path, q8_recip_ppa_path: Path | None = DEFAULT_Q8_RECIP_PPA) -> JsonDict:
+def build_report(
+    *,
+    sweep_path: Path,
+    q8_recip_ppa_path: Path | None = DEFAULT_Q8_RECIP_PPA,
+    q8_exact_ppa_path: Path | None = DEFAULT_Q8_EXACT_PPA,
+) -> JsonDict:
     sweep = _load_json(sweep_path)
     q8_recip_ppa = _load_q8_recip_ppa(q8_recip_ppa_path)
+    q8_exact_ppa = _load_q8_exact_ppa(q8_exact_ppa_path)
     rows = sweep.get("templates")
     if not isinstance(rows, list):
         raise SystemExit("sweep JSON must contain a templates list")
-    records = [_row_record(row, q8_recip_ppa=q8_recip_ppa) for row in rows if isinstance(row, dict)]
+    records = [
+        _row_record(row, q8_recip_ppa=q8_recip_ppa, q8_exact_ppa=q8_exact_ppa)
+        for row in rows
+        if isinstance(row, dict)
+    ]
     interesting = [
         row
         for row in records
@@ -309,7 +364,7 @@ def build_report(*, sweep_path: Path, q8_recip_ppa_path: Path | None = DEFAULT_Q
             "reason": (
                 f"{selected['template']} preserved the exact prompt-stress gate and has the best "
                 f"{selected['normalization']['rank_source']} among exact-safe q8 reciprocal candidates. "
-                "q8 exact and bf16 reciprocal normalization remain unmeasured hardware gaps."
+                "q8 exact is included as measured baseline PPA; bf16 reciprocal normalization remains an unmeasured hardware gap."
             ),
         }
     else:
@@ -340,20 +395,22 @@ def build_report(*, sweep_path: Path, q8_recip_ppa_path: Path | None = DEFAULT_Q
             "scope_note": (
                 "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization "
                 "precision as a replacement for q8 exact normalization. q8 reciprocal rows use merged "
-                "RTLGen/OpenROAD integrated datapath metrics when the PPA artifact is available; exact "
-                "q8 and bf16 normalization paths remain unmeasured."
+                "RTLGen/OpenROAD integrated datapath metrics when the PPA artifact is available; q8 exact "
+                "uses the measured row-wise int8 softmax baseline when available; bf16 normalization remains unmeasured."
             ),
         },
         "source_artifacts": {
             "q8_reciprocal_datapath_ppa": str(q8_recip_ppa_path) if q8_recip_ppa_path is not None else None,
             "q8_reciprocal_ppa_bits": sorted(q8_recip_ppa),
+            "q8_exact_datapath_ppa": str(q8_exact_ppa_path) if q8_exact_ppa_path is not None else None,
+            "q8_exact_ppa_available": q8_exact_ppa is not None,
         },
         "cost_model": COST_MODEL,
         "decision": decision,
         "ranked_rows": ranked,
         "next_step": [
-            "Measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.",
-            "Measure or model q8 exact normalization only if it remains a candidate beyond the reciprocal path.",
+            "Implement and measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.",
+            "Use the measured q8 exact baseline as the current reference point for q8 reciprocal normalization tradeoffs.",
         ],
     }
 
@@ -362,12 +419,14 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Summarize q8 PWL normalization frontier quality/PPA tradeoffs")
     ap.add_argument("--sweep", required=True, help="q8 normalization frontier sweep JSON")
     ap.add_argument("--q8-recip-ppa", default=str(DEFAULT_Q8_RECIP_PPA), help="merged q8 reciprocal datapath promotion JSON")
+    ap.add_argument("--q8-exact-ppa", default=str(DEFAULT_Q8_EXACT_PPA), help="merged q8 exact datapath promotion JSON")
     ap.add_argument("--out", required=True, help="output JSON path")
     ap.add_argument("--out-md", required=True, help="output Markdown report path")
     args = ap.parse_args()
     report = build_report(
         sweep_path=Path(args.sweep),
         q8_recip_ppa_path=Path(args.q8_recip_ppa) if args.q8_recip_ppa else None,
+        q8_exact_ppa_path=Path(args.q8_exact_ppa) if args.q8_exact_ppa else None,
     )
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json
@@ -1,27 +1,27 @@
 {
   "cost_model": {
-    "calibration_status": "q8_reciprocal_integrated_datapath_measured",
+    "calibration_status": "q8_exact_and_reciprocal_integrated_datapaths_measured",
     "fallback_source": "hand_written_planning_proxy_used_only_when_ppa_artifact_is_absent",
-    "intended_use": "Replace the q8 reciprocal normalization heuristic with merged RTLGen/OpenROAD datapath evidence while preserving quality gates from the decoder sweep.",
-    "name": "decoder_q8_normalization_ppa_frontier_v2",
-    "ppa_balance": "Measured q8 reciprocal candidates are ranked lexicographically by critical path, then area, then power. Exact q8 and bf16 reciprocal normalization remain unmeasured hardware gaps and are not compared as accepted PPA.",
-    "rtlgen_calibration_proposal": "prop_l1_decoder_q8_recip_norm_datapath_v1",
-    "source": "rtlgen_openroad_q8_reciprocal_datapath_metrics",
+    "intended_use": "Replace the q8 normalization heuristic with merged RTLGen/OpenROAD datapath evidence while preserving quality gates from the decoder sweep.",
+    "name": "decoder_q8_normalization_ppa_frontier_v3",
+    "ppa_balance": "Measured q8 exact and q8 reciprocal candidates are ranked lexicographically by critical path, then area, then power. The bf16 reciprocal normalization path remains an unmeasured hardware gap and is not compared as accepted PPA.",
+    "rtlgen_calibration_proposal": "prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1",
+    "source": "rtlgen_openroad_q8_exact_and_reciprocal_datapath_metrics",
     "unit": "nangate45_physical_metrics"
   },
   "decision": {
     "decision": "q8_reciprocal_candidate_survived",
-    "reason": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact and bf16 reciprocal normalization remain unmeasured hardware gaps.",
+    "reason": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact is included as measured baseline PPA; bf16 reciprocal normalization remains an unmeasured hardware gap.",
     "selected_candidate": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
   },
   "frontier_scope": {
     "quality_gate": "candidate must match next-token and top-k for every prompt-stress sample",
     "rough_grid": "decoder_q8_normalization_frontier_v1",
-    "scope_note": "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization precision as a replacement for q8 exact normalization. q8 reciprocal rows use merged RTLGen/OpenROAD integrated datapath metrics when the PPA artifact is available; exact q8 and bf16 normalization paths remain unmeasured."
+    "scope_note": "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization precision as a replacement for q8 exact normalization. q8 reciprocal rows use merged RTLGen/OpenROAD integrated datapath metrics when the PPA artifact is available; q8 exact uses the measured row-wise int8 softmax baseline when available; bf16 normalization remains unmeasured."
   },
   "next_step": [
-    "Measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.",
-    "Measure or model q8 exact normalization only if it remains a candidate beyond the reciprocal path."
+    "Implement and measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.",
+    "Use the measured q8 exact baseline as the current reference point for q8 reciprocal normalization tradeoffs."
   ],
   "ranked_rows": [
     {
@@ -241,6 +241,60 @@
       "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q16"
     },
     {
+      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_exact_prob_fp",
+      "frontier_rank_key": [
+        0,
+        20.2712,
+        105898.1764,
+        1.11
+      ],
+      "normalization": {
+        "calibration_status": "integrated_q8_exact_datapath_measured",
+        "heuristic_fallback_unit": "heuristic_planning_units",
+        "heuristic_fallback_units": 52.0,
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_wrapper/softmax_rowwise_int8_r8_acc24_wrapper/metrics.csv",
+          "param_hash": "49828ffb",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_wrapper/softmax_rowwise_int8_r8_acc24_wrapper/work/49828ffb/result.json",
+          "status": "ok",
+          "tag": "softmax_rowwise_ng45_v1_9dd950f2"
+        },
+        "mode": "exact",
+        "ppa_metrics": {
+          "critical_path_ns": 20.2712,
+          "die_area": 105898.1764,
+          "total_power_mw": 1.11
+        },
+        "rank_key": [
+          0,
+          20.2712,
+          105898.1764,
+          1.11
+        ],
+        "rank_source": "measured_q8_exact_datapath_ppa",
+        "reciprocal_bits": 0,
+        "reciprocal_float_format": "",
+        "unit": "nangate45_physical_metrics"
+      },
+      "quality": {
+        "exact_safe": true,
+        "gate": "exact_safe_survivor",
+        "next_token_match_rate": 1.0,
+        "next_token_matches": 24,
+        "next_token_mismatch_sample_ids": [],
+        "sample_count": 24,
+        "topk_contains_reference_rate": 1.0,
+        "topk_matches": 24,
+        "topk_miss_sample_ids": [],
+        "topk_safe": true
+      },
+      "rank": 5,
+      "role": "q8_exact_normalization_baseline",
+      "template": "grid_approx_pwl_in_q8_w_q8_norm_exact"
+    },
+    {
       "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_bf16_w_bf16_norm_recip_bf16_prob_fp",
       "frontier_rank_key": [
         2,
@@ -274,50 +328,14 @@
         "topk_miss_sample_ids": [],
         "topk_safe": true
       },
-      "rank": 5,
+      "rank": 6,
       "role": "bf16_primary_anchor",
       "template": "grid_approx_pwl_bf16_path"
-    },
-    {
-      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_exact_prob_fp",
-      "frontier_rank_key": [
-        2,
-        52.0
-      ],
-      "normalization": {
-        "calibration_status": "unmeasured_exact_normalization_datapath",
-        "heuristic_fallback_unit": "heuristic_planning_units",
-        "heuristic_fallback_units": 52.0,
-        "metrics_ref": null,
-        "mode": "exact",
-        "ppa_metrics": null,
-        "rank_key": [
-          2,
-          52.0
-        ],
-        "rank_source": "unmeasured_gap",
-        "reciprocal_bits": 0,
-        "reciprocal_float_format": "",
-        "unit": "nangate45_physical_metrics"
-      },
-      "quality": {
-        "exact_safe": true,
-        "gate": "exact_safe_survivor",
-        "next_token_match_rate": 1.0,
-        "next_token_matches": 24,
-        "next_token_mismatch_sample_ids": [],
-        "sample_count": 24,
-        "topk_contains_reference_rate": 1.0,
-        "topk_matches": 24,
-        "topk_miss_sample_ids": [],
-        "topk_safe": true
-      },
-      "rank": 6,
-      "role": "q8_exact_normalization_baseline",
-      "template": "grid_approx_pwl_in_q8_w_q8_norm_exact"
     }
   ],
   "source_artifacts": {
+    "q8_exact_datapath_ppa": "control_plane/shadow_exports/l1_promotions/l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json",
+    "q8_exact_ppa_available": true,
     "q8_reciprocal_datapath_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json",
     "q8_reciprocal_ppa_bits": [
       10,

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.md
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.md
@@ -3,16 +3,16 @@
 - source_sweep: `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_normalization_frontier_v1.json`
 - decision: `q8_reciprocal_candidate_survived`
 - selected_candidate: `grid_approx_pwl_in_q8_w_q8_norm_recip_q10`
-- reason: grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact and bf16 reciprocal normalization remain unmeasured hardware gaps.
-- cost_model_source: `rtlgen_openroad_q8_reciprocal_datapath_metrics`
+- reason: grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact is included as measured baseline PPA; bf16 reciprocal normalization remains an unmeasured hardware gap.
+- cost_model_source: `rtlgen_openroad_q8_exact_and_reciprocal_datapath_metrics`
 - cost_model_unit: `nangate45_physical_metrics`
-- rtlgen_calibration_proposal: `prop_l1_decoder_q8_recip_norm_datapath_v1`
+- rtlgen_calibration_proposal: `prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1`
 
 ## Cost Model Provenance
 
-Measured q8 reciprocal candidates are ranked lexicographically by critical path, then area, then power. Exact q8 and bf16 reciprocal normalization remain unmeasured hardware gaps and are not compared as accepted PPA.
+Measured q8 exact and q8 reciprocal candidates are ranked lexicographically by critical path, then area, then power. The bf16 reciprocal normalization path remains an unmeasured hardware gap and is not compared as accepted PPA.
 
-Replace the q8 reciprocal normalization heuristic with merged RTLGen/OpenROAD datapath evidence while preserving quality gates from the decoder sweep.
+Replace the q8 normalization heuristic with merged RTLGen/OpenROAD datapath evidence while preserving quality gates from the decoder sweep.
 
 ## Quality And Normalization PPA
 
@@ -22,8 +22,8 @@ Replace the q8 reciprocal normalization heuristic with merged RTLGen/OpenROAD da
 | `grid_approx_pwl_in_q8_w_q8_norm_recip_q12` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 12 | `measured_q8_reciprocal_datapath_ppa` | 5.7554 | 52118.607025 | 0.014 |
 | `grid_approx_pwl_in_q8_w_q8_norm_recip_q14` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 14 | `measured_q8_reciprocal_datapath_ppa` | 5.7617 | 52360.880625 | 0.00637 |
 | `grid_approx_pwl_in_q8_w_q8_norm_recip_q16` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 16 | `measured_q8_reciprocal_datapath_ppa` | 5.814 | 45315.765625 | 0.0321 |
+| `grid_approx_pwl_in_q8_w_q8_norm_exact` | `q8_exact_normalization_baseline` | `exact_safe_survivor` | 24/24 | 24/24 | `exact` |  | `measured_q8_exact_datapath_ppa` | 20.2712 | 105898.1764 | 1.11 |
 | `grid_approx_pwl_bf16_path` | `bf16_primary_anchor` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_float` |  | `unmeasured_gap` |  |  |  |
-| `grid_approx_pwl_in_q8_w_q8_norm_exact` | `q8_exact_normalization_baseline` | `exact_safe_survivor` | 24/24 | 24/24 | `exact` |  | `unmeasured_gap` |  |  |  |
 
 ## Blocked Rows
 
@@ -31,5 +31,5 @@ Replace the q8 reciprocal normalization heuristic with merged RTLGen/OpenROAD da
 
 ## Next Step
 
-- Measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.
-- Measure or model q8 exact normalization only if it remains a candidate beyond the reciprocal path.
+- Implement and measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.
+- Use the measured q8 exact baseline as the current reference point for q8 reciprocal normalization tradeoffs.

--- a/tests/fixtures/q8_exact_norm_datapath_ppa.json
+++ b/tests/fixtures/q8_exact_norm_datapath_ppa.json
@@ -1,0 +1,18 @@
+{
+  "version": 0.1,
+  "proposals": [
+    {
+      "metrics_ref": {
+        "metrics_csv": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_wrapper/metrics.csv",
+        "platform": "nangate45",
+        "status": "ok",
+        "result_path": "runs/designs/activations/softmax_rowwise_int8_r8_acc24_wrapper/work/49828ffb/result.json"
+      },
+      "metric_summary": {
+        "critical_path_ns": 20.2712,
+        "die_area": 105898.1764,
+        "total_power_mw": 1.11
+      }
+    }
+  ]
+}

--- a/tests/test_llm_decoder_q8_norm_frontier.py
+++ b/tests/test_llm_decoder_q8_norm_frontier.py
@@ -28,15 +28,16 @@ def test_q8_normalization_frontier_report_selects_lowest_cost_exact_safe_recipro
     report = build_report(
         sweep_path=Path("tests/fixtures/decoder_q8_norm_frontier_sweep.json"),
         q8_recip_ppa_path=Path("tests/fixtures/q8_recip_norm_datapath_ppa.json"),
+        q8_exact_ppa_path=Path("tests/fixtures/q8_exact_norm_datapath_ppa.json"),
     )
 
     assert report["decision"]["decision"] == "q8_reciprocal_candidate_survived"
     assert report["decision"]["selected_candidate"] == "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
-    assert report["cost_model"]["source"] == "rtlgen_openroad_q8_reciprocal_datapath_metrics"
+    assert report["cost_model"]["source"] == "rtlgen_openroad_q8_exact_and_reciprocal_datapath_metrics"
     assert report["cost_model"]["unit"] == "nangate45_physical_metrics"
     assert (
         report["cost_model"]["rtlgen_calibration_proposal"]
-        == "prop_l1_decoder_q8_recip_norm_datapath_v1"
+        == "prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1"
     )
     by_template = {row["template"]: row for row in report["ranked_rows"]}
     assert by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["quality"]["exact_safe"]
@@ -49,4 +50,11 @@ def test_q8_normalization_frontier_report_selects_lowest_cost_exact_safe_recipro
         by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["normalization"]["ppa_metrics"]["critical_path_ns"]
         < by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q12"]["normalization"]["ppa_metrics"]["critical_path_ns"]
     )
-    assert by_template["grid_approx_pwl_in_q8_w_q8_norm_exact"]["normalization"]["ppa_metrics"] is None
+    assert (
+        by_template["grid_approx_pwl_in_q8_w_q8_norm_exact"]["normalization"]["calibration_status"]
+        == "integrated_q8_exact_datapath_measured"
+    )
+    assert (
+        by_template["grid_approx_pwl_in_q8_w_q8_norm_exact"]["normalization"]["ppa_metrics"]["critical_path_ns"]
+        == 20.2712
+    )


### PR DESCRIPTION
## Summary
- load the measured q8 exact row-wise int8 softmax promotion artifact into the q8 normalization frontier estimator
- pass the q8 exact PPA artifact through the L2 task generator manifest and command
- regenerate the decoder q8 normalization frontier report so q8 exact is a measured baseline while bf16 remains an unmeasured implementation gap

## Verification
- PYTHONPATH=.:control_plane control_plane/.venv/bin/pytest -q tests/test_llm_decoder_q8_norm_frontier.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py --sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_normalization_frontier_v1.json --q8-recip-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json --q8-exact-ppa control_plane/shadow_exports/l1_promotions/l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json --out runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json --out-md runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.md