### PR TITLE
Add comparable ranking dimensions to dashboard

### DIFF
--- a/control_plane/control_plane/api/routes_operator_status.py
+++ b/control_plane/control_plane/api/routes_operator_status.py
@@ -288,12 +288,9 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
           <div class="table-wrap"><table id="run-index-families-table"></table></div>
         </div>
         <div class="panel">
-          <h2>Best Indexed Designs</h2>
-          <div class="table-wrap"><table id="run-index-best-designs-table"></table></div>
-        </div>
-        <div class="panel">
-          <h2>Family Leaders</h2>
-          <div class="table-wrap"><table id="run-index-family-leaders-table"></table></div>
+          <h2>Comparable Ranking Dimensions</h2>
+          <p class="meta">Each row is scoped to one family; speed, area, and power leaders are not cross-family ranks.</p>
+          <div class="table-wrap"><table id="run-index-comparable-rankings-table"></table></div>
         </div>
         <div class="panel">
           <h2>Failure Rates</h2>
@@ -377,8 +374,7 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
       states: document.getElementById("states-table"),
       runIndexSummary: document.getElementById("run-index-summary-table"),
       runIndexFamilies: document.getElementById("run-index-families-table"),
-      runIndexBestDesigns: document.getElementById("run-index-best-designs-table"),
-      runIndexFamilyLeaders: document.getElementById("run-index-family-leaders-table"),
+      runIndexComparableRankings: document.getElementById("run-index-comparable-rankings-table"),
       runIndexFailureRates: document.getElementById("run-index-failure-rates-table"),
       seedTrialVariance: document.getElementById("seed-trial-variance-table"),
       runIndexFailureHotspots: document.getElementById("run-index-failure-hotspots-table"),
@@ -403,6 +399,13 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
         .replace(/</g, \"&lt;\")
         .replace(/>/g, \"&gt;\")
         .replace(/\"/g, \"&quot;\");
+    }
+
+    function renderLeaderCell(leader, metricKey) {
+      if (!leader) return "";
+      const metric = leader[metricKey];
+      const metricText = metric === null || metric === undefined ? "" : ` <span class="meta">${escapeHtml(metric)}</span>`;
+      return `<span class='mono'>${escapeHtml(leader.design || "")}</span>${metricText}`;
     }
 
     function renderTable(target, columns, rows) {
@@ -727,20 +730,14 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
         { key: "design_count", label: "Designs" },
         { key: "ok_row_count", label: "OK" },
       ], payload.run_index_families || []);
-      renderTable(tables.runIndexBestDesigns, [
-        { key: "design", label: "Design", render: (value) => `<span class='mono'>${escapeHtml(value)}</span>` },
-        { key: "platform", label: "Platform" },
-        { key: "ok_row_count", label: "OK" },
-        { key: "best_critical_path_ns", label: "Best CP" },
-        { key: "best_die_area", label: "Best Area" },
-        { key: "best_total_power_mw", label: "Best Power" },
-      ], payload.run_index_best_designs || []);
-      renderTable(tables.runIndexFamilyLeaders, [
+      renderTable(tables.runIndexComparableRankings, [
         { key: "circuit_type", label: "Family" },
-        { key: "design", label: "Leader", render: (value) => `<span class='mono'>${escapeHtml(value)}</span>` },
-        { key: "platform", label: "Platform" },
-        { key: "best_critical_path_ns", label: "Best CP" },
-      ], payload.run_index_family_leaders || []);
+        { key: "design_count", label: "Designs" },
+        { key: "ok_row_count", label: "OK" },
+        { key: "speed_leader", label: "Speed Leader", render: (value) => renderLeaderCell(value, "critical_path_ns") },
+        { key: "area_leader", label: "Area Leader", render: (value) => renderLeaderCell(value, "die_area") },
+        { key: "power_leader", label: "Power Leader", render: (value) => renderLeaderCell(value, "total_power_mw") },
+      ], payload.run_index_comparable_rankings || []);
       renderTable(tables.runIndexFailureRates, [
         { key: "circuit_type", label: "Family" },
         { key: "fail_row_count", label: "Fails" },
@@ -906,6 +903,7 @@ def _status_payload(database_url: str, recent_limit: int) -> dict[str, object]:
         "run_index_families": status.run_index_families,
         "run_index_best_designs": status.run_index_best_designs,
         "run_index_family_leaders": status.run_index_family_leaders,
+        "run_index_comparable_rankings": status.run_index_comparable_rankings,
         "run_index_failure_rates": status.run_index_failure_rates,
         "seed_trial_variance": status.seed_trial_variance,
         "run_index_failure_hotspots": status.run_index_failure_hotspots,

--- a/control_plane/control_plane/services/operator_status.py
+++ b/control_plane/control_plane/services/operator_status.py
@@ -84,6 +84,7 @@ class OperatorStatusResult:
     run_index_families: list[dict[str, object]]
     run_index_best_designs: list[dict[str, object]]
     run_index_family_leaders: list[dict[str, object]]
+    run_index_comparable_rankings: list[dict[str, object]]
     run_index_failure_rates: list[dict[str, object]]
     seed_trial_variance: list[dict[str, object]]
     run_index_failure_hotspots: list[dict[str, object]]
@@ -384,6 +385,7 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
         run_index_families=run_index.families,
         run_index_best_designs=run_index.best_designs,
         run_index_family_leaders=run_index.family_leaders,
+        run_index_comparable_rankings=run_index.comparable_rankings,
         run_index_failure_rates=run_index.failure_rates,
         seed_trial_variance=seed_trial_variance,
         run_index_failure_hotspots=run_index.failure_hotspots,

--- a/control_plane/control_plane/services/run_index_query.py
+++ b/control_plane/control_plane/services/run_index_query.py
@@ -71,6 +71,7 @@ class RunIndexComparativeResult:
     families: list[dict[str, object]]
     best_designs: list[dict[str, object]]
     family_leaders: list[dict[str, object]]
+    comparable_rankings: list[dict[str, object]]
     failure_rates: list[dict[str, object]]
     design_variance: list[dict[str, object]]
     failure_hotspots: list[dict[str, object]]
@@ -166,6 +167,7 @@ def comparative_run_index(session: Session, *, limit: int) -> RunIndexComparativ
             families=[],
             best_designs=[],
             family_leaders=[],
+            comparable_rankings=[],
             failure_rates=[],
             design_variance=[],
             failure_hotspots=[],
@@ -331,6 +333,57 @@ def comparative_run_index(session: Session, *, limit: int) -> RunIndexComparativ
         )
     failure_rates.sort(key=lambda row: (-float(row["failure_rate"]), -int(row["row_count"]), str(row["circuit_type"])))
 
+    def best_family_metric(circuit_type: str, metric: str) -> dict[str, object] | None:
+        best: dict[str, object] | None = None
+        best_score: tuple[float, float, float, float, str] | None = None
+        for row in rows:
+            if str(row.circuit_type or "").strip() != circuit_type:
+                continue
+            if str(row.status or "").strip() != "ok":
+                continue
+            value = _comparable_critical_path(row.critical_path_ns) if metric == "critical_path_ns" else _safe_float_text(getattr(row, metric))
+            if value is None or value < 0:
+                continue
+            cp = _comparable_critical_path(row.critical_path_ns)
+            area = _safe_float_text(row.die_area)
+            power = _safe_float_text(row.total_power_mw)
+            tie_break = (
+                cp if cp is not None else float("inf"),
+                area if area is not None else float("inf"),
+                power if power is not None else float("inf"),
+                str(row.design or ""),
+            )
+            score = (float(value), *tie_break)
+            if best_score is None or score < best_score:
+                best_score = score
+                best = {
+                    "design": str(row.design or "").strip() or "unknown",
+                    "platform": str(row.platform or "").strip() or "unknown",
+                    "value": value,
+                    "critical_path_ns": cp,
+                    "die_area": area,
+                    "total_power_mw": power,
+                    "metrics_path": str(row.metrics_path or "").strip(),
+                }
+        return best
+
+    comparable_rankings = []
+    for bucket in family_buckets.values():
+        circuit_type = str(bucket["circuit_type"])
+        comparable_rankings.append(
+            {
+                "circuit_type": circuit_type,
+                "comparison_scope": "within_family_only",
+                "row_count": int(bucket["row_count"]),
+                "ok_row_count": int(bucket["ok_row_count"]),
+                "design_count": len(bucket["designs"]),
+                "speed_leader": best_family_metric(circuit_type, "critical_path_ns"),
+                "area_leader": best_family_metric(circuit_type, "die_area"),
+                "power_leader": best_family_metric(circuit_type, "total_power_mw"),
+            }
+        )
+    comparable_rankings.sort(key=lambda row: (-int(row["ok_row_count"]), -int(row["row_count"]), str(row["circuit_type"])))
+
     design_variance = []
     failure_hotspots = []
     for bucket in design_buckets.values():
@@ -395,6 +448,7 @@ def comparative_run_index(session: Session, *, limit: int) -> RunIndexComparativ
         families=families[:limit],
         best_designs=best_designs[:limit],
         family_leaders=family_leaders[:limit],
+        comparable_rankings=comparable_rankings[:limit],
         failure_rates=failure_rates[:limit],
         design_variance=design_variance[:limit],
         failure_hotspots=failure_hotspots[:limit],

--- a/control_plane/control_plane/tests/test_app_smoke.py
+++ b/control_plane/control_plane/tests/test_app_smoke.py
@@ -37,8 +37,7 @@ def test_dashboard_route() -> None:
     assert b'Pending Submission' in body
     assert b'Dispatch Pending' in body
     assert b'Run Index Summary' in body
-    assert b'Best Indexed Designs' in body
-    assert b'Family Leaders' in body
+    assert b'Comparable Ranking Dimensions' in body
     assert b'Failure Rates' in body
     assert b'Seed Trial Variance' in body
     assert b'Failure Hotspots' in body
@@ -77,6 +76,7 @@ def test_operator_status_route() -> None:
     assert isinstance(payload["run_index_families"], list)
     assert isinstance(payload["run_index_best_designs"], list)
     assert isinstance(payload["run_index_family_leaders"], list)
+    assert isinstance(payload["run_index_comparable_rankings"], list)
     assert isinstance(payload["run_index_failure_rates"], list)
     assert isinstance(payload["seed_trial_variance"], list)
     assert isinstance(payload["run_index_failure_hotspots"], list)

--- a/control_plane/control_plane/tests/test_operator_status.py
+++ b/control_plane/control_plane/tests/test_operator_status.py
@@ -270,7 +270,7 @@ def test_operator_status_summarizes_live_state() -> None:
 
         session_factory = build_session_factory(engine)
         with session_factory() as session:
-            status = load_operator_status(session, OperatorStatusRequest(recent_limit=5))
+            status = load_operator_status(session, OperatorStatusRequest(recent_limit=5, repo_root=td))
 
         assert status.health_summary["status"] == "attention"
         assert "stale_leases=1" in str(status.health_summary["message"])
@@ -314,6 +314,9 @@ def test_operator_status_summarizes_live_state() -> None:
         assert status.run_index_families[0]["circuit_type"] == "terminal"
         assert status.run_index_best_designs[0]["design"] == "sigmoid_demo"
         assert status.run_index_family_leaders[0]["design"] == "sigmoid_demo"
+        assert status.run_index_comparable_rankings[0]["circuit_type"] == "terminal"
+        assert status.run_index_comparable_rankings[0]["comparison_scope"] == "within_family_only"
+        assert status.run_index_comparable_rankings[0]["speed_leader"]["design"] == "sigmoid_demo"
         assert status.run_index_failure_rates[0]["circuit_type"] == "terminal"
         assert status.run_index_failure_rates[0]["fail_row_count"] == 1
         assert status.seed_trial_variance == []

--- a/control_plane/control_plane/tests/test_run_index_query.py
+++ b/control_plane/control_plane/tests/test_run_index_query.py
@@ -127,6 +127,13 @@ def test_comparative_run_index_reports_leaders_and_failure_rates() -> None:
     assert all(row["design"] != "comb_only_macro" for row in result.family_leaders)
     assert result.best_designs[0]["design"] == "sigmoid_fast"
     assert any(row["circuit_type"] == "terminal" and row["design"] == "sigmoid_fast" for row in result.family_leaders)
+    terminal_rankings = next(row for row in result.comparable_rankings if row["circuit_type"] == "terminal")
+    assert terminal_rankings["comparison_scope"] == "within_family_only"
+    assert terminal_rankings["speed_leader"]["design"] == "sigmoid_fast"
+    assert terminal_rankings["area_leader"]["design"] == "sigmoid_fast"
+    assert terminal_rankings["power_leader"]["design"] == "sigmoid_fast"
+    reduction_rankings = next(row for row in result.comparable_rankings if row["circuit_type"] == "reduction")
+    assert reduction_rankings["speed_leader"]["design"] == "softmax_rowwise"
     terminal_failure = next(row for row in result.failure_rates if row["circuit_type"] == "terminal")
     assert terminal_failure["fail_row_count"] == 1
     assert terminal_failure["row_count"] == 3


### PR DESCRIPTION
## Summary
- add family-scoped comparable ranking dimensions to the run-index comparative payload
- replace the dashboard's mixed global best/family-leader ranking panels with a comparable speed/area/power leader view
- keep legacy best-design and family-leader API fields for compatibility while exposing the new focused payload
- make the operator status test deterministic by pinning its temporary repo root

## Verification
- PYTHONPATH=control_plane control_plane/.venv/bin/pytest -q control_plane/control_plane/tests/test_run_index_query.py control_plane/control_plane/tests/test_operator_status.py control_plane/control_plane/tests/test_app_smoke.py