### PR TITLE
Add decoder quantization outline report

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -954,6 +954,47 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
     }
 
 
+def _decoder_quantization_outline_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    fp_sweep = f"{base}/decoder_quality_sweep__l2_decoder_fp_probability_format_sweep_v1.json"
+    distribution_sweep = f"{base}/decoder_quality_sweep__l2_decoder_distribution_robustness_v1.json"
+    q8_norm_frontier = f"{base}/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json"
+    outline_out = f"{base}/decoder_quantization_outline__{item_id}.json"
+    outline_report = f"{base}/decoder_quantization_outline__{item_id}.md"
+    commands = [
+        {
+            "name": "estimate_decoder_quantization_outline",
+            "run": (
+                "python3 npu/eval/estimate_llm_decoder_quantization_outline.py "
+                f"--fp-sweep {fp_sweep} "
+                f"--distribution-sweep {distribution_sweep} "
+                f"--q8-norm-frontier {q8_norm_frontier} "
+                f"--out {outline_out} "
+                f"--out-md {outline_report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            "fp_format_sweep": fp_sweep,
+            "distribution_robustness_sweep": distribution_sweep,
+            "q8_normalization_frontier": q8_norm_frontier,
+            "quantization_outline_out": outline_out,
+            "quantization_outline_report": outline_report,
+            "quantization_outline_scope": (
+                "multi-dimensional decoder quantization interpretation over existing fp-format, "
+                "distribution robustness, and measured q8 normalization frontier evidence; dimensions "
+                "are grouped to avoid cross-category ranking"
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            outline_out,
+            outline_report,
+        ],
+    }
+
+
 def _with_fresh_outputs(*, campaign: dict[str, Any], item_id: str) -> dict[str, Any]:
     cloned = json.loads(json.dumps(campaign))
     outputs = dict(cloned.get("outputs") or {})
@@ -1060,8 +1101,11 @@ def _build_payload(
         "decoder_survivor_cost_proxy",
         "decoder_pwl_frontier_detail",
         "decoder_q8_normalization_frontier",
+        "decoder_quantization_outline",
     }:
-        if abstraction_layer_name == "decoder_q8_normalization_frontier":
+        if abstraction_layer_name == "decoder_quantization_outline":
+            decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_q8_normalization_frontier":
             decoder_evidence = _decoder_q8_normalization_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pwl_frontier_detail":
             decoder_evidence = _decoder_pwl_frontier_detail_evidence(item_id=item_id)

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -689,6 +689,50 @@ def test_generate_l2_campaign_task_adds_decoder_q8_normalization_frontier_eviden
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_quantization_outline_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_quantization_outline_v1",
+                    proposal_id="prop_l2_decoder_quantization_outline_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_quantization_outline_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_quantization_outline",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert work_item.command_manifest[0]["name"] == "estimate_decoder_quantization_outline"
+            assert "estimate_llm_decoder_quantization_outline.py" in work_item.command_manifest[0]["run"]
+            assert "--fp-sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_fp_probability_format_sweep_v1.json" in work_item.command_manifest[0]["run"]
+            assert "--distribution-sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_distribution_robustness_v1.json" in work_item.command_manifest[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["quantization_outline_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.json"
+            )
+            assert "avoid cross-category ranking" in decoder_inputs["quantization_outline_scope"]
+            assert decoder_inputs["quantization_outline_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_quantization_outline",
+            }
+
+
 def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/npu/eval/estimate_llm_decoder_quantization_outline.py
+++ b/npu/eval/estimate_llm_decoder_quantization_outline.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Summarize decoder quantization sweeps by comparable dimensions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+DEFAULT_FP_SWEEP = Path("runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_fp_probability_format_sweep_v1.json")
+DEFAULT_DISTRIBUTION_SWEEP = Path(
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_distribution_robustness_v1.json"
+)
+DEFAULT_Q8_NORM_FRONTIER = Path(
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json"
+)
+
+DIMENSION_LABELS = {
+    "logit_format": "Logit Format",
+    "softmax_input_format": "Softmax Input Format",
+    "softmax_weight_format": "Softmax Weight Format",
+    "normalization_reciprocal_format": "Normalization Reciprocal Format",
+    "probability_output_format": "Probability Output Format",
+    "approximate_pwl_probability_path": "Approximate PWL Probability Path",
+    "reference": "Reference",
+    "other": "Other",
+}
+
+
+def _load_json(path: Path) -> JsonDict:
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _quality(row: JsonDict) -> JsonDict:
+    sample_count = _as_int(row.get("sample_count"))
+    next_rate = _as_float(row.get("next_token_id_match_rate"))
+    topk_rate = _as_float(row.get("topk_contains_reference_id_rate"))
+    next_matches = round(next_rate * sample_count)
+    topk_matches = round(topk_rate * sample_count)
+    exact_safe = sample_count > 0 and next_matches == sample_count and topk_matches == sample_count
+    topk_safe = sample_count > 0 and topk_matches == sample_count
+    if exact_safe:
+        gate = "exact_safe"
+    elif topk_safe:
+        gate = "topk_safe_only"
+    else:
+        gate = "blocked"
+    return {
+        "sample_count": sample_count,
+        "next_token_matches": next_matches,
+        "topk_matches": topk_matches,
+        "next_token_match_rate": next_rate,
+        "topk_contains_reference_rate": topk_rate,
+        "next_token_mismatch_sample_ids": row.get("next_token_mismatch_sample_ids") or [],
+        "topk_miss_sample_ids": row.get("topk_miss_sample_ids") or [],
+        "gate": gate,
+        "exact_safe": exact_safe,
+        "topk_safe": topk_safe,
+    }
+
+
+def _dimension(row: JsonDict) -> str:
+    template = str(row.get("template") or "")
+    if template == "candidate_onnx_softmax_exact":
+        return "reference"
+    if template.startswith("grid_logits_") or _as_int(row.get("logit_quant_bits")):
+        return "logit_format"
+    if template.startswith("grid_softmax_input_"):
+        return "softmax_input_format"
+    if template.startswith("grid_softmax_weight_"):
+        return "softmax_weight_format"
+    if template.startswith("grid_norm_recip_"):
+        return "normalization_reciprocal_format"
+    if template.startswith("grid_prob_") or _as_int(row.get("probability_quant_bits")):
+        return "probability_output_format"
+    if template.startswith("grid_approx_pwl_"):
+        return "approximate_pwl_probability_path"
+    return "other"
+
+
+def _format_descriptor(row: JsonDict) -> str:
+    parts: list[str] = []
+    for key, label in (
+        ("logit_quant_bits", "logit_q"),
+        ("logit_float_format", "logit"),
+        ("softmax_input_quant_bits", "input_q"),
+        ("softmax_input_float_format", "input"),
+        ("softmax_weight_quant_bits", "weight_q"),
+        ("softmax_weight_float_format", "weight"),
+        ("normalization_reciprocal_bits", "recip_q"),
+        ("normalization_reciprocal_float_format", "recip"),
+        ("probability_quant_bits", "prob_q"),
+        ("probability_float_format", "prob"),
+    ):
+        value = row.get(key)
+        if value in (None, "", 0):
+            continue
+        if key.endswith("_quant_bits") or key == "normalization_reciprocal_bits":
+            parts.append(f"{label}{value}")
+        else:
+            parts.append(f"{label}={value}")
+    mode = str(row.get("normalization_mode") or "").strip()
+    if mode and mode != "exact":
+        parts.append(f"norm={mode}")
+    return ", ".join(parts) or "reference"
+
+
+def _row_record(row: JsonDict, *, source: str) -> JsonDict:
+    return {
+        "source": source,
+        "template": str(row.get("template") or ""),
+        "dimension": _dimension(row),
+        "format_descriptor": _format_descriptor(row),
+        "candidate_semantics": row.get("candidate_semantics", ""),
+        "quality": _quality(row),
+    }
+
+
+def _dimension_summary(rows: list[JsonDict]) -> JsonDict:
+    exact_safe = [row for row in rows if row["quality"]["exact_safe"]]
+    topk_only = [row for row in rows if row["quality"]["topk_safe"] and not row["quality"]["exact_safe"]]
+    blocked = [row for row in rows if not row["quality"]["topk_safe"]]
+    return {
+        "row_count": len(rows),
+        "exact_safe_count": len(exact_safe),
+        "topk_safe_only_count": len(topk_only),
+        "blocked_count": len(blocked),
+        "exact_safe_templates": [row["template"] for row in exact_safe],
+        "topk_safe_only_templates": [row["template"] for row in topk_only],
+        "blocked_templates": [row["template"] for row in blocked],
+    }
+
+
+def _group_dimensions(rows: list[JsonDict]) -> list[JsonDict]:
+    grouped: dict[str, list[JsonDict]] = {}
+    for row in rows:
+        grouped.setdefault(str(row["dimension"]), []).append(row)
+    out: list[JsonDict] = []
+    for name, items in grouped.items():
+        items = sorted(
+            items,
+            key=lambda row: (
+                row["quality"]["gate"] != "exact_safe",
+                row["quality"]["gate"] != "topk_safe_only",
+                row["source"],
+                row["template"],
+            ),
+        )
+        out.append(
+            {
+                "dimension": name,
+                "label": DIMENSION_LABELS.get(name, name),
+                "comparison_scope": "within_dimension_only",
+                "summary": _dimension_summary(items),
+                "rows": items,
+            }
+        )
+    out.sort(key=lambda row: (row["dimension"] in {"reference", "other"}, row["label"]))
+    return out
+
+
+def _q8_norm_summary(path: Path | None) -> JsonDict | None:
+    if path is None or not path.exists():
+        return None
+    payload = _load_json(path)
+    rows = payload.get("ranked_rows")
+    if not isinstance(rows, list):
+        return None
+    measured = [
+        row
+        for row in rows
+        if isinstance(row, dict)
+        and isinstance(row.get("normalization"), dict)
+        and str(row["normalization"].get("rank_source") or "").startswith("measured_q8_")
+    ]
+    return {
+        "source": str(path),
+        "decision": payload.get("decision", {}),
+        "measured_rows": [
+            {
+                "template": row.get("template"),
+                "rank": row.get("rank"),
+                "rank_source": row["normalization"].get("rank_source"),
+                "ppa_metrics": row["normalization"].get("ppa_metrics"),
+            }
+            for row in measured
+        ],
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Quantization Outline",
+        "",
+        f"- fp_sweep: `{payload['source_artifacts']['fp_format_sweep']}`",
+        f"- distribution_sweep: `{payload['source_artifacts']['distribution_robustness_sweep']}`",
+        f"- q8_norm_frontier: `{payload['source_artifacts']['q8_norm_frontier'] or ''}`",
+        "",
+        "## Interpretation",
+        "",
+    ]
+    for item in payload["interpretation"]:
+        lines.append(f"- {item}")
+    lines.extend(["", "## Comparable Dimensions", ""])
+    for dimension in payload["dimensions"]:
+        lines.append(f"### {dimension['label']}")
+        lines.append("")
+        summary = dimension["summary"]
+        lines.append(
+            "- scope: `{}`; rows: {}; exact-safe: {}; top-k-only: {}; blocked: {}".format(
+                dimension["comparison_scope"],
+                summary["row_count"],
+                summary["exact_safe_count"],
+                summary["topk_safe_only_count"],
+                summary["blocked_count"],
+            )
+        )
+        lines.append("")
+        lines.append("| source | template | descriptor | gate | next-token | top-k | misses |")
+        lines.append("|---|---|---|---|---:|---:|---|")
+        for row in dimension["rows"]:
+            quality = row["quality"]
+            misses = ", ".join(quality["next_token_mismatch_sample_ids"] or quality["topk_miss_sample_ids"]) or ""
+            lines.append(
+                "| `{source}` | `{template}` | {descriptor} | `{gate}` | {next}/{samples} | {topk}/{samples} | {misses} |".format(
+                    source=row["source"],
+                    template=row["template"],
+                    descriptor=row["format_descriptor"],
+                    gate=quality["gate"],
+                    next=quality["next_token_matches"],
+                    topk=quality["topk_matches"],
+                    samples=quality["sample_count"],
+                    misses=misses,
+                )
+            )
+        lines.append("")
+    if payload.get("q8_norm_frontier"):
+        lines.extend(["## Measured Q8 Normalization PPA", ""])
+        for row in payload["q8_norm_frontier"]["measured_rows"]:
+            metrics = row.get("ppa_metrics") or {}
+            lines.append(
+                "- `{}` rank {} via `{}`: critical_path_ns={}, die_area={}, total_power_mw={}".format(
+                    row.get("template"),
+                    row.get("rank"),
+                    row.get("rank_source"),
+                    metrics.get("critical_path_ns"),
+                    metrics.get("die_area"),
+                    metrics.get("total_power_mw"),
+                )
+            )
+    lines.extend(["", "## Next Step", ""])
+    for item in payload["next_step"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def build_report(
+    *,
+    fp_sweep_path: Path = DEFAULT_FP_SWEEP,
+    distribution_sweep_path: Path = DEFAULT_DISTRIBUTION_SWEEP,
+    q8_norm_frontier_path: Path | None = DEFAULT_Q8_NORM_FRONTIER,
+) -> JsonDict:
+    fp_sweep = _load_json(fp_sweep_path)
+    distribution_sweep = _load_json(distribution_sweep_path)
+    records: list[JsonDict] = []
+    for source, sweep in (("fp_format", fp_sweep), ("distribution", distribution_sweep)):
+        rows = sweep.get("templates")
+        if not isinstance(rows, list):
+            raise SystemExit(f"{source} sweep JSON must contain templates list")
+        records.extend(_row_record(row, source=source) for row in rows if isinstance(row, dict))
+    q8_norm = _q8_norm_summary(q8_norm_frontier_path)
+    return {
+        "version": 0.1,
+        "source_artifacts": {
+            "fp_format_sweep": str(fp_sweep_path),
+            "distribution_robustness_sweep": str(distribution_sweep_path),
+            "q8_norm_frontier": str(q8_norm_frontier_path) if q8_norm_frontier_path is not None else None,
+        },
+        "scope_note": (
+            "This report groups decoder quantization evidence by comparable dimension. It must not be read "
+            "as one global ranking across logits, normalization, probability storage, and approximate PWL paths."
+        ),
+        "interpretation": [
+            "bf16/fp16 probability and reciprocal software paths preserve next-token and top-k on the current fp-format and distribution sweeps.",
+            "fixed q8 probability output storage is blocked on the distribution robustness sweep, while q8/q6 logit quantization remains exact-safe there.",
+            "fp8 probability storage is not a current frontier candidate: e5m2 drops samples and e4m3 is blocked in both sweeps.",
+            "q8 reciprocal normalization now has measured integrated PPA; bf16 reciprocal normalization still needs a measurable datapath before PPA comparison.",
+        ],
+        "dimensions": _group_dimensions(records),
+        "q8_norm_frontier": q8_norm,
+        "next_step": [
+            "Keep q8 reciprocal as the immediate measured hardware frontier.",
+            "Use issue #297 to add and measure a bf16 reciprocal normalization datapath before claiming q8-versus-bf16 PPA superiority.",
+            "Broaden distribution coverage before treating these exact-safe rows as generally robust across weights and prompts.",
+        ],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--fp-sweep", default=str(DEFAULT_FP_SWEEP), help="decoder fp-format sweep JSON")
+    ap.add_argument("--distribution-sweep", default=str(DEFAULT_DISTRIBUTION_SWEEP), help="decoder distribution sweep JSON")
+    ap.add_argument("--q8-norm-frontier", default=str(DEFAULT_Q8_NORM_FRONTIER), help="q8 normalization frontier JSON")
+    ap.add_argument("--out", required=True, help="output JSON path")
+    ap.add_argument("--out-md", required=True, help="output Markdown path")
+    args = ap.parse_args()
+    report = build_report(
+        fp_sweep_path=Path(args.fp_sweep),
+        distribution_sweep_path=Path(args.distribution_sweep),
+        q8_norm_frontier_path=Path(args.q8_norm_frontier) if args.q8_norm_frontier else None,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    _write_markdown(out_md, report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.json
@@ -1,0 +1,861 @@
+{
+  "dimensions": [
+    {
+      "comparison_scope": "within_dimension_only",
+      "dimension": "approximate_pwl_probability_path",
+      "label": "Approximate PWL Probability Path",
+      "rows": [
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_bf16_w_bf16_norm_recip_bf16_prob_fp",
+          "dimension": "approximate_pwl_probability_path",
+          "format_descriptor": "input=bf16, weight=bf16, recip=bf16, norm=reciprocal_float",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 12,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 12,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "distribution",
+          "template": "grid_approx_pwl_bf16_path"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q6_w_q6_norm_recip_q10_prob_fp",
+          "dimension": "approximate_pwl_probability_path",
+          "format_descriptor": "input_q6, weight_q6, recip_q10, norm=reciprocal_quantized",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 12,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 12,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "distribution",
+          "template": "grid_approx_pwl_in_q6_w_q6_norm_recip_q10"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_exact_prob_fp",
+          "dimension": "approximate_pwl_probability_path",
+          "format_descriptor": "input_q8, weight_q8",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 12,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 12,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "distribution",
+          "template": "grid_approx_pwl_in_q8_w_q8_norm_exact"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_bf16_w_bf16_norm_recip_bf16_prob_fp",
+          "dimension": "approximate_pwl_probability_path",
+          "format_descriptor": "input=bf16, weight=bf16, recip=bf16, norm=reciprocal_float",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_approx_pwl_bf16_path"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_fp16_w_fp16_norm_recip_fp16_prob_fp",
+          "dimension": "approximate_pwl_probability_path",
+          "format_descriptor": "input=fp16, weight=fp16, recip=fp16, norm=reciprocal_float",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_approx_pwl_fp16_path"
+        }
+      ],
+      "summary": {
+        "blocked_count": 0,
+        "blocked_templates": [],
+        "exact_safe_count": 5,
+        "exact_safe_templates": [
+          "grid_approx_pwl_bf16_path",
+          "grid_approx_pwl_in_q6_w_q6_norm_recip_q10",
+          "grid_approx_pwl_in_q8_w_q8_norm_exact",
+          "grid_approx_pwl_bf16_path",
+          "grid_approx_pwl_fp16_path"
+        ],
+        "row_count": 5,
+        "topk_safe_only_count": 0,
+        "topk_safe_only_templates": []
+      }
+    },
+    {
+      "comparison_scope": "within_dimension_only",
+      "dimension": "logit_format",
+      "label": "Logit Format",
+      "rows": [
+        {
+          "candidate_semantics": "onnx_logits_q6_softmax_exact_norm_exact_prob_fp",
+          "dimension": "logit_format",
+          "format_descriptor": "logit_q6",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 12,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 12,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "distribution",
+          "template": "grid_logits_q6"
+        },
+        {
+          "candidate_semantics": "onnx_logits_q8_softmax_exact_norm_exact_prob_fp",
+          "dimension": "logit_format",
+          "format_descriptor": "logit_q8",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 12,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 12,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "distribution",
+          "template": "grid_logits_q8"
+        },
+        {
+          "candidate_semantics": "onnx_logits_bf16_softmax_exact_norm_exact_prob_fp",
+          "dimension": "logit_format",
+          "format_descriptor": "logit=bf16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_logits_bf16"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp16_softmax_exact_norm_exact_prob_fp",
+          "dimension": "logit_format",
+          "format_descriptor": "logit=fp16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_logits_fp16"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp8_e4m3_softmax_exact_norm_exact_prob_fp",
+          "dimension": "logit_format",
+          "format_descriptor": "logit=fp8_e4m3",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_logits_fp8_e4m3"
+        },
+        {
+          "candidate_semantics": "onnx_logits_q4_softmax_exact_norm_exact_prob_fp",
+          "dimension": "logit_format",
+          "format_descriptor": "logit_q4",
+          "quality": {
+            "exact_safe": false,
+            "gate": "topk_safe_only",
+            "next_token_match_rate": 0.9166666666666666,
+            "next_token_matches": 11,
+            "next_token_mismatch_sample_ids": [
+              "dist_math_symbolic"
+            ],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 12,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "distribution",
+          "template": "grid_logits_q4"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp8_e5m2_softmax_exact_norm_exact_prob_fp",
+          "dimension": "logit_format",
+          "format_descriptor": "logit=fp8_e5m2",
+          "quality": {
+            "exact_safe": false,
+            "gate": "topk_safe_only",
+            "next_token_match_rate": 0.8,
+            "next_token_matches": 4,
+            "next_token_mismatch_sample_ids": [
+              "math_two_plus_two"
+            ],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_logits_fp8_e5m2"
+        }
+      ],
+      "summary": {
+        "blocked_count": 0,
+        "blocked_templates": [],
+        "exact_safe_count": 5,
+        "exact_safe_templates": [
+          "grid_logits_q6",
+          "grid_logits_q8",
+          "grid_logits_bf16",
+          "grid_logits_fp16",
+          "grid_logits_fp8_e4m3"
+        ],
+        "row_count": 7,
+        "topk_safe_only_count": 2,
+        "topk_safe_only_templates": [
+          "grid_logits_q4",
+          "grid_logits_fp8_e5m2"
+        ]
+      }
+    },
+    {
+      "comparison_scope": "within_dimension_only",
+      "dimension": "normalization_reciprocal_format",
+      "label": "Normalization Reciprocal Format",
+      "rows": [
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_recip_bf16_prob_fp",
+          "dimension": "normalization_reciprocal_format",
+          "format_descriptor": "recip=bf16, norm=reciprocal_float",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_norm_recip_bf16"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_recip_fp16_prob_fp",
+          "dimension": "normalization_reciprocal_format",
+          "format_descriptor": "recip=fp16, norm=reciprocal_float",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_norm_recip_fp16"
+        }
+      ],
+      "summary": {
+        "blocked_count": 0,
+        "blocked_templates": [],
+        "exact_safe_count": 2,
+        "exact_safe_templates": [
+          "grid_norm_recip_bf16",
+          "grid_norm_recip_fp16"
+        ],
+        "row_count": 2,
+        "topk_safe_only_count": 0,
+        "topk_safe_only_templates": []
+      }
+    },
+    {
+      "comparison_scope": "within_dimension_only",
+      "dimension": "probability_output_format",
+      "label": "Probability Output Format",
+      "rows": [
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_bf16",
+          "dimension": "probability_output_format",
+          "format_descriptor": "prob=bf16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 12,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 12,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "distribution",
+          "template": "grid_prob_bf16"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp16",
+          "dimension": "probability_output_format",
+          "format_descriptor": "prob=fp16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 12,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 12,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "distribution",
+          "template": "grid_prob_fp16"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_bf16",
+          "dimension": "probability_output_format",
+          "format_descriptor": "prob=bf16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_prob_bf16"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp16",
+          "dimension": "probability_output_format",
+          "format_descriptor": "prob=fp16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_prob_fp16"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp8_e4m3",
+          "dimension": "probability_output_format",
+          "format_descriptor": "prob=fp8_e4m3",
+          "quality": {
+            "exact_safe": false,
+            "gate": "blocked",
+            "next_token_match_rate": 0.0,
+            "next_token_matches": 0,
+            "next_token_mismatch_sample_ids": [
+              "dist_ambiguous_article",
+              "dist_code_like",
+              "dist_commonsense_color",
+              "dist_dialogue",
+              "dist_geo_capital_short",
+              "dist_list_continuation",
+              "dist_long_context",
+              "dist_math_symbolic",
+              "dist_punctuation",
+              "dist_quote_midphrase",
+              "dist_repetition",
+              "dist_weekday_calendar"
+            ],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 0.0,
+            "topk_matches": 0,
+            "topk_miss_sample_ids": [
+              "dist_ambiguous_article",
+              "dist_code_like",
+              "dist_commonsense_color",
+              "dist_dialogue",
+              "dist_geo_capital_short",
+              "dist_list_continuation",
+              "dist_long_context",
+              "dist_math_symbolic",
+              "dist_punctuation",
+              "dist_quote_midphrase",
+              "dist_repetition",
+              "dist_weekday_calendar"
+            ],
+            "topk_safe": false
+          },
+          "source": "distribution",
+          "template": "grid_prob_fp8_e4m3"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp8_e5m2",
+          "dimension": "probability_output_format",
+          "format_descriptor": "prob=fp8_e5m2",
+          "quality": {
+            "exact_safe": false,
+            "gate": "blocked",
+            "next_token_match_rate": 0.8333333333333334,
+            "next_token_matches": 10,
+            "next_token_mismatch_sample_ids": [
+              "dist_math_symbolic",
+              "dist_punctuation"
+            ],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 0.8333333333333334,
+            "topk_matches": 10,
+            "topk_miss_sample_ids": [
+              "dist_math_symbolic",
+              "dist_punctuation"
+            ],
+            "topk_safe": false
+          },
+          "source": "distribution",
+          "template": "grid_prob_fp8_e5m2"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_q8",
+          "dimension": "probability_output_format",
+          "format_descriptor": "prob_q8",
+          "quality": {
+            "exact_safe": false,
+            "gate": "blocked",
+            "next_token_match_rate": 0.0,
+            "next_token_matches": 0,
+            "next_token_mismatch_sample_ids": [
+              "dist_ambiguous_article",
+              "dist_code_like",
+              "dist_commonsense_color",
+              "dist_dialogue",
+              "dist_geo_capital_short",
+              "dist_list_continuation",
+              "dist_long_context",
+              "dist_math_symbolic",
+              "dist_punctuation",
+              "dist_quote_midphrase",
+              "dist_repetition",
+              "dist_weekday_calendar"
+            ],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 0.0,
+            "topk_matches": 0,
+            "topk_miss_sample_ids": [
+              "dist_ambiguous_article",
+              "dist_code_like",
+              "dist_commonsense_color",
+              "dist_dialogue",
+              "dist_geo_capital_short",
+              "dist_list_continuation",
+              "dist_long_context",
+              "dist_math_symbolic",
+              "dist_punctuation",
+              "dist_quote_midphrase",
+              "dist_repetition",
+              "dist_weekday_calendar"
+            ],
+            "topk_safe": false
+          },
+          "source": "distribution",
+          "template": "grid_prob_q8"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp8_e4m3",
+          "dimension": "probability_output_format",
+          "format_descriptor": "prob=fp8_e4m3",
+          "quality": {
+            "exact_safe": false,
+            "gate": "blocked",
+            "next_token_match_rate": 0.0,
+            "next_token_matches": 0,
+            "next_token_mismatch_sample_ids": [
+              "color_banana",
+              "geo_france_capital",
+              "math_two_plus_two",
+              "quote_complete",
+              "weekday_after_monday"
+            ],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 0.0,
+            "topk_matches": 0,
+            "topk_miss_sample_ids": [
+              "color_banana",
+              "geo_france_capital",
+              "math_two_plus_two",
+              "quote_complete",
+              "weekday_after_monday"
+            ],
+            "topk_safe": false
+          },
+          "source": "fp_format",
+          "template": "grid_prob_fp8_e4m3"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp8_e5m2",
+          "dimension": "probability_output_format",
+          "format_descriptor": "prob=fp8_e5m2",
+          "quality": {
+            "exact_safe": false,
+            "gate": "blocked",
+            "next_token_match_rate": 0.8,
+            "next_token_matches": 4,
+            "next_token_mismatch_sample_ids": [
+              "math_two_plus_two"
+            ],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 0.8,
+            "topk_matches": 4,
+            "topk_miss_sample_ids": [
+              "math_two_plus_two"
+            ],
+            "topk_safe": false
+          },
+          "source": "fp_format",
+          "template": "grid_prob_fp8_e5m2"
+        }
+      ],
+      "summary": {
+        "blocked_count": 5,
+        "blocked_templates": [
+          "grid_prob_fp8_e4m3",
+          "grid_prob_fp8_e5m2",
+          "grid_prob_q8",
+          "grid_prob_fp8_e4m3",
+          "grid_prob_fp8_e5m2"
+        ],
+        "exact_safe_count": 4,
+        "exact_safe_templates": [
+          "grid_prob_bf16",
+          "grid_prob_fp16",
+          "grid_prob_bf16",
+          "grid_prob_fp16"
+        ],
+        "row_count": 9,
+        "topk_safe_only_count": 0,
+        "topk_safe_only_templates": []
+      }
+    },
+    {
+      "comparison_scope": "within_dimension_only",
+      "dimension": "softmax_input_format",
+      "label": "Softmax Input Format",
+      "rows": [
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_in_bf16_norm_exact_prob_fp",
+          "dimension": "softmax_input_format",
+          "format_descriptor": "input=bf16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_softmax_input_bf16"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_in_fp16_norm_exact_prob_fp",
+          "dimension": "softmax_input_format",
+          "format_descriptor": "input=fp16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_softmax_input_fp16"
+        }
+      ],
+      "summary": {
+        "blocked_count": 0,
+        "blocked_templates": [],
+        "exact_safe_count": 2,
+        "exact_safe_templates": [
+          "grid_softmax_input_bf16",
+          "grid_softmax_input_fp16"
+        ],
+        "row_count": 2,
+        "topk_safe_only_count": 0,
+        "topk_safe_only_templates": []
+      }
+    },
+    {
+      "comparison_scope": "within_dimension_only",
+      "dimension": "softmax_weight_format",
+      "label": "Softmax Weight Format",
+      "rows": [
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_w_bf16_norm_exact_prob_fp",
+          "dimension": "softmax_weight_format",
+          "format_descriptor": "weight=bf16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_softmax_weight_bf16"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_w_fp16_norm_exact_prob_fp",
+          "dimension": "softmax_weight_format",
+          "format_descriptor": "weight=fp16",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "grid_softmax_weight_fp16"
+        }
+      ],
+      "summary": {
+        "blocked_count": 0,
+        "blocked_templates": [],
+        "exact_safe_count": 2,
+        "exact_safe_templates": [
+          "grid_softmax_weight_bf16",
+          "grid_softmax_weight_fp16"
+        ],
+        "row_count": 2,
+        "topk_safe_only_count": 0,
+        "topk_safe_only_templates": []
+      }
+    },
+    {
+      "comparison_scope": "within_dimension_only",
+      "dimension": "reference",
+      "label": "Reference",
+      "rows": [
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
+          "dimension": "reference",
+          "format_descriptor": "reference",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 12,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 12,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 12,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "distribution",
+          "template": "candidate_onnx_softmax_exact"
+        },
+        {
+          "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
+          "dimension": "reference",
+          "format_descriptor": "reference",
+          "quality": {
+            "exact_safe": true,
+            "gate": "exact_safe",
+            "next_token_match_rate": 1.0,
+            "next_token_matches": 5,
+            "next_token_mismatch_sample_ids": [],
+            "sample_count": 5,
+            "topk_contains_reference_rate": 1.0,
+            "topk_matches": 5,
+            "topk_miss_sample_ids": [],
+            "topk_safe": true
+          },
+          "source": "fp_format",
+          "template": "candidate_onnx_softmax_exact"
+        }
+      ],
+      "summary": {
+        "blocked_count": 0,
+        "blocked_templates": [],
+        "exact_safe_count": 2,
+        "exact_safe_templates": [
+          "candidate_onnx_softmax_exact",
+          "candidate_onnx_softmax_exact"
+        ],
+        "row_count": 2,
+        "topk_safe_only_count": 0,
+        "topk_safe_only_templates": []
+      }
+    }
+  ],
+  "interpretation": [
+    "bf16/fp16 probability and reciprocal software paths preserve next-token and top-k on the current fp-format and distribution sweeps.",
+    "fixed q8 probability output storage is blocked on the distribution robustness sweep, while q8/q6 logit quantization remains exact-safe there.",
+    "fp8 probability storage is not a current frontier candidate: e5m2 drops samples and e4m3 is blocked in both sweeps.",
+    "q8 reciprocal normalization now has measured integrated PPA; bf16 reciprocal normalization still needs a measurable datapath before PPA comparison."
+  ],
+  "next_step": [
+    "Keep q8 reciprocal as the immediate measured hardware frontier.",
+    "Use issue #297 to add and measure a bf16 reciprocal normalization datapath before claiming q8-versus-bf16 PPA superiority.",
+    "Broaden distribution coverage before treating these exact-safe rows as generally robust across weights and prompts."
+  ],
+  "q8_norm_frontier": {
+    "decision": {
+      "decision": "q8_reciprocal_candidate_survived",
+      "reason": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact is included as measured baseline PPA; bf16 reciprocal normalization remains an unmeasured hardware gap.",
+      "selected_candidate": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
+    },
+    "measured_rows": [
+      {
+        "ppa_metrics": {
+          "critical_path_ns": 5.6126,
+          "die_area": 39776.3136,
+          "total_power_mw": 0.00463
+        },
+        "rank": 1,
+        "rank_source": "measured_q8_reciprocal_datapath_ppa",
+        "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
+      },
+      {
+        "ppa_metrics": {
+          "critical_path_ns": 5.7554,
+          "die_area": 52118.607025,
+          "total_power_mw": 0.014
+        },
+        "rank": 2,
+        "rank_source": "measured_q8_reciprocal_datapath_ppa",
+        "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q12"
+      },
+      {
+        "ppa_metrics": {
+          "critical_path_ns": 5.7617,
+          "die_area": 52360.880625,
+          "total_power_mw": 0.00637
+        },
+        "rank": 3,
+        "rank_source": "measured_q8_reciprocal_datapath_ppa",
+        "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q14"
+      },
+      {
+        "ppa_metrics": {
+          "critical_path_ns": 5.814,
+          "die_area": 45315.765625,
+          "total_power_mw": 0.0321
+        },
+        "rank": 4,
+        "rank_source": "measured_q8_reciprocal_datapath_ppa",
+        "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q16"
+      },
+      {
+        "ppa_metrics": {
+          "critical_path_ns": 20.2712,
+          "die_area": 105898.1764,
+          "total_power_mw": 1.11
+        },
+        "rank": 5,
+        "rank_source": "measured_q8_exact_datapath_ppa",
+        "template": "grid_approx_pwl_in_q8_w_q8_norm_exact"
+      }
+    ],
+    "source": "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json"
+  },
+  "scope_note": "This report groups decoder quantization evidence by comparable dimension. It must not be read as one global ranking across logits, normalization, probability storage, and approximate PWL paths.",
+  "source_artifacts": {
+    "distribution_robustness_sweep": "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_distribution_robustness_v1.json",
+    "fp_format_sweep": "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_fp_probability_format_sweep_v1.json",
+    "q8_norm_frontier": "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json"
+  },
+  "version": 0.1
+}

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.md
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.md
@@ -1,0 +1,106 @@
+# Decoder Quantization Outline
+
+- fp_sweep: `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_fp_probability_format_sweep_v1.json`
+- distribution_sweep: `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_distribution_robustness_v1.json`
+- q8_norm_frontier: `runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json`
+
+## Interpretation
+
+- bf16/fp16 probability and reciprocal software paths preserve next-token and top-k on the current fp-format and distribution sweeps.
+- fixed q8 probability output storage is blocked on the distribution robustness sweep, while q8/q6 logit quantization remains exact-safe there.
+- fp8 probability storage is not a current frontier candidate: e5m2 drops samples and e4m3 is blocked in both sweeps.
+- q8 reciprocal normalization now has measured integrated PPA; bf16 reciprocal normalization still needs a measurable datapath before PPA comparison.
+
+## Comparable Dimensions
+
+### Approximate PWL Probability Path
+
+- scope: `within_dimension_only`; rows: 5; exact-safe: 5; top-k-only: 0; blocked: 0
+
+| source | template | descriptor | gate | next-token | top-k | misses |
+|---|---|---|---|---:|---:|---|
+| `distribution` | `grid_approx_pwl_bf16_path` | input=bf16, weight=bf16, recip=bf16, norm=reciprocal_float | `exact_safe` | 12/12 | 12/12 |  |
+| `distribution` | `grid_approx_pwl_in_q6_w_q6_norm_recip_q10` | input_q6, weight_q6, recip_q10, norm=reciprocal_quantized | `exact_safe` | 12/12 | 12/12 |  |
+| `distribution` | `grid_approx_pwl_in_q8_w_q8_norm_exact` | input_q8, weight_q8 | `exact_safe` | 12/12 | 12/12 |  |
+| `fp_format` | `grid_approx_pwl_bf16_path` | input=bf16, weight=bf16, recip=bf16, norm=reciprocal_float | `exact_safe` | 5/5 | 5/5 |  |
+| `fp_format` | `grid_approx_pwl_fp16_path` | input=fp16, weight=fp16, recip=fp16, norm=reciprocal_float | `exact_safe` | 5/5 | 5/5 |  |
+
+### Logit Format
+
+- scope: `within_dimension_only`; rows: 7; exact-safe: 5; top-k-only: 2; blocked: 0
+
+| source | template | descriptor | gate | next-token | top-k | misses |
+|---|---|---|---|---:|---:|---|
+| `distribution` | `grid_logits_q6` | logit_q6 | `exact_safe` | 12/12 | 12/12 |  |
+| `distribution` | `grid_logits_q8` | logit_q8 | `exact_safe` | 12/12 | 12/12 |  |
+| `fp_format` | `grid_logits_bf16` | logit=bf16 | `exact_safe` | 5/5 | 5/5 |  |
+| `fp_format` | `grid_logits_fp16` | logit=fp16 | `exact_safe` | 5/5 | 5/5 |  |
+| `fp_format` | `grid_logits_fp8_e4m3` | logit=fp8_e4m3 | `exact_safe` | 5/5 | 5/5 |  |
+| `distribution` | `grid_logits_q4` | logit_q4 | `topk_safe_only` | 11/12 | 12/12 | dist_math_symbolic |
+| `fp_format` | `grid_logits_fp8_e5m2` | logit=fp8_e5m2 | `topk_safe_only` | 4/5 | 5/5 | math_two_plus_two |
+
+### Normalization Reciprocal Format
+
+- scope: `within_dimension_only`; rows: 2; exact-safe: 2; top-k-only: 0; blocked: 0
+
+| source | template | descriptor | gate | next-token | top-k | misses |
+|---|---|---|---|---:|---:|---|
+| `fp_format` | `grid_norm_recip_bf16` | recip=bf16, norm=reciprocal_float | `exact_safe` | 5/5 | 5/5 |  |
+| `fp_format` | `grid_norm_recip_fp16` | recip=fp16, norm=reciprocal_float | `exact_safe` | 5/5 | 5/5 |  |
+
+### Probability Output Format
+
+- scope: `within_dimension_only`; rows: 9; exact-safe: 4; top-k-only: 0; blocked: 5
+
+| source | template | descriptor | gate | next-token | top-k | misses |
+|---|---|---|---|---:|---:|---|
+| `distribution` | `grid_prob_bf16` | prob=bf16 | `exact_safe` | 12/12 | 12/12 |  |
+| `distribution` | `grid_prob_fp16` | prob=fp16 | `exact_safe` | 12/12 | 12/12 |  |
+| `fp_format` | `grid_prob_bf16` | prob=bf16 | `exact_safe` | 5/5 | 5/5 |  |
+| `fp_format` | `grid_prob_fp16` | prob=fp16 | `exact_safe` | 5/5 | 5/5 |  |
+| `distribution` | `grid_prob_fp8_e4m3` | prob=fp8_e4m3 | `blocked` | 0/12 | 0/12 | dist_ambiguous_article, dist_code_like, dist_commonsense_color, dist_dialogue, dist_geo_capital_short, dist_list_continuation, dist_long_context, dist_math_symbolic, dist_punctuation, dist_quote_midphrase, dist_repetition, dist_weekday_calendar |
+| `distribution` | `grid_prob_fp8_e5m2` | prob=fp8_e5m2 | `blocked` | 10/12 | 10/12 | dist_math_symbolic, dist_punctuation |
+| `distribution` | `grid_prob_q8` | prob_q8 | `blocked` | 0/12 | 0/12 | dist_ambiguous_article, dist_code_like, dist_commonsense_color, dist_dialogue, dist_geo_capital_short, dist_list_continuation, dist_long_context, dist_math_symbolic, dist_punctuation, dist_quote_midphrase, dist_repetition, dist_weekday_calendar |
+| `fp_format` | `grid_prob_fp8_e4m3` | prob=fp8_e4m3 | `blocked` | 0/5 | 0/5 | color_banana, geo_france_capital, math_two_plus_two, quote_complete, weekday_after_monday |
+| `fp_format` | `grid_prob_fp8_e5m2` | prob=fp8_e5m2 | `blocked` | 4/5 | 4/5 | math_two_plus_two |
+
+### Softmax Input Format
+
+- scope: `within_dimension_only`; rows: 2; exact-safe: 2; top-k-only: 0; blocked: 0
+
+| source | template | descriptor | gate | next-token | top-k | misses |
+|---|---|---|---|---:|---:|---|
+| `fp_format` | `grid_softmax_input_bf16` | input=bf16 | `exact_safe` | 5/5 | 5/5 |  |
+| `fp_format` | `grid_softmax_input_fp16` | input=fp16 | `exact_safe` | 5/5 | 5/5 |  |
+
+### Softmax Weight Format
+
+- scope: `within_dimension_only`; rows: 2; exact-safe: 2; top-k-only: 0; blocked: 0
+
+| source | template | descriptor | gate | next-token | top-k | misses |
+|---|---|---|---|---:|---:|---|
+| `fp_format` | `grid_softmax_weight_bf16` | weight=bf16 | `exact_safe` | 5/5 | 5/5 |  |
+| `fp_format` | `grid_softmax_weight_fp16` | weight=fp16 | `exact_safe` | 5/5 | 5/5 |  |
+
+### Reference
+
+- scope: `within_dimension_only`; rows: 2; exact-safe: 2; top-k-only: 0; blocked: 0
+
+| source | template | descriptor | gate | next-token | top-k | misses |
+|---|---|---|---|---:|---:|---|
+| `distribution` | `candidate_onnx_softmax_exact` | reference | `exact_safe` | 12/12 | 12/12 |  |
+| `fp_format` | `candidate_onnx_softmax_exact` | reference | `exact_safe` | 5/5 | 5/5 |  |
+
+## Measured Q8 Normalization PPA
+
+- `grid_approx_pwl_in_q8_w_q8_norm_recip_q10` rank 1 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.6126, die_area=39776.3136, total_power_mw=0.00463
+- `grid_approx_pwl_in_q8_w_q8_norm_recip_q12` rank 2 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.7554, die_area=52118.607025, total_power_mw=0.014
+- `grid_approx_pwl_in_q8_w_q8_norm_recip_q14` rank 3 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.7617, die_area=52360.880625, total_power_mw=0.00637
+- `grid_approx_pwl_in_q8_w_q8_norm_recip_q16` rank 4 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.814, die_area=45315.765625, total_power_mw=0.0321
+- `grid_approx_pwl_in_q8_w_q8_norm_exact` rank 5 via `measured_q8_exact_datapath_ppa`: critical_path_ns=20.2712, die_area=105898.1764, total_power_mw=1.11
+
+## Next Step
+
+- Keep q8 reciprocal as the immediate measured hardware frontier.
+- Use issue #297 to add and measure a bf16 reciprocal normalization datapath before claiming q8-versus-bf16 PPA superiority.
+- Broaden distribution coverage before treating these exact-safe rows as generally robust across weights and prompts.

--- a/tests/test_llm_decoder_quantization_outline.py
+++ b/tests/test_llm_decoder_quantization_outline.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from npu.eval.estimate_llm_decoder_quantization_outline import build_report
+
+
+def test_decoder_quantization_outline_groups_comparable_dimensions() -> None:
+    report = build_report(
+        fp_sweep_path=Path("runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_fp_probability_format_sweep_v1.json"),
+        distribution_sweep_path=Path("runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_distribution_robustness_v1.json"),
+        q8_norm_frontier_path=Path("runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json"),
+    )
+
+    by_dimension = {row["dimension"]: row for row in report["dimensions"]}
+    assert by_dimension["logit_format"]["comparison_scope"] == "within_dimension_only"
+    assert "grid_logits_bf16" in by_dimension["logit_format"]["summary"]["exact_safe_templates"]
+    assert "grid_logits_q4" in by_dimension["logit_format"]["summary"]["topk_safe_only_templates"]
+    assert "grid_prob_q8" in by_dimension["probability_output_format"]["summary"]["blocked_templates"]
+    assert "grid_prob_bf16" in by_dimension["probability_output_format"]["summary"]["exact_safe_templates"]
+    assert "grid_approx_pwl_bf16_path" in by_dimension["approximate_pwl_probability_path"]["summary"]["exact_safe_templates"]
+    assert report["q8_norm_frontier"]["decision"]["selected_candidate"] == "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
+    assert any(
+        row["template"] == "grid_approx_pwl_in_q8_w_q8_norm_exact"
+        for row in report["q8_norm_frontier"]["measured_rows"]
+    )


### PR DESCRIPTION
## Summary
- add a decoder quantization outline estimator that groups existing fp-format and distribution robustness sweeps by comparable dimension
- generate JSON/Markdown outline artifacts for the current tiny decoder evidence
- add a control-plane L2 abstraction hook for future quantization-outline jobs

## Verification
- PYTHONPATH=.:control_plane control_plane/.venv/bin/pytest -q tests/test_llm_decoder_quantization_outline.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 npu/eval/estimate_llm_decoder_quantization_outline.py --fp-sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_fp_probability_format_sweep_v1.json --distribution-sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_distribution_robustness_v1.json --q8-norm-frontier runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json --out runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.json --out-md runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.md