### PR TITLE
Add bf16 reciprocal normalization datapath

### DIFF
--- a/apps/rtlgen_main.cpp
+++ b/apps/rtlgen_main.cpp
@@ -192,7 +192,8 @@ int main(int argc, char** argv) {
               << config.cmvm_operations.size() << " CMVM block(s), "
               << config.fp_operations.size() << " FP op(s), "
               << config.activation_operations.size() << " activation(s), "
-              << config.softmax_rowwise_operations.size() << " row-wise softmax block(s)\n";
+              << config.softmax_rowwise_operations.size() << " row-wise softmax block(s), "
+              << config.bf16_recip_norm_operations.size() << " bf16 reciprocal-normalization block(s)\n";
 
     try {
         std::filesystem::path flopocoPath;
@@ -304,6 +305,15 @@ int main(int argc, char** argv) {
             std::cout << "[INFO] Generating row-wise softmax " << softmax.module_name << " ("
                       << softmax.impl << ", row_elems=" << softmax.row_elems << ")\n";
             emitSoftmaxRowwiseModule(softmax, operandDef);
+        }
+
+        for (const auto &norm : config.bf16_recip_norm_operations) {
+            OperandDefinition operandDef = resolveOperand(config, norm.operand);
+            std::cout << "[INFO] Generating bf16 reciprocal normalization " << norm.module_name
+                      << " (row_elems=" << norm.row_elems
+                      << ", q_frac_bits=" << norm.q_frac_bits
+                      << ", reciprocal_bits=" << norm.reciprocal_bits << ")\n";
+            emitBf16RecipNormModule(norm, operandDef);
         }
 
         for (const auto &fp : config.fp_operations) {

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -398,7 +398,7 @@ def _read_config_target(
     elif "operations" in cfg and len(cfg["operations"]) == 1:
         entry = cfg["operations"][0]
         op_type = entry.get("type")
-        if op_type not in {"activation", "softmax_rowwise"}:
+        if op_type not in {"activation", "softmax_rowwise", "bf16_recip_norm"}:
             raise Layer1TaskGenerationError(f"unsupported single-operation design type in {config_path}: {op_type}")
         module_name = entry["module_name"]
         wrapper = f"{module_name}_wrapper"

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -101,6 +101,45 @@ def _write_second_softmax_config(repo_root: Path) -> str:
     return str(config_path.relative_to(repo_root))
 
 
+def _write_bf16_recip_norm_config(repo_root: Path) -> str:
+    config_path = repo_root / "examples" / "config_bf16_recip_norm.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "operands": [
+                    {
+                        "name": "weights",
+                        "dimensions": 1,
+                        "bit_width": 16,
+                        "signed": False,
+                        "kind": "int",
+                    }
+                ],
+                "operations": [
+                    {
+                        "type": "bf16_recip_norm",
+                        "module_name": "bf16_recip_norm_r4",
+                        "operand": "weights",
+                        "options": {
+                            "row_elems": 4,
+                            "q_frac_bits": 10,
+                            "sum_bits": 24,
+                            "reciprocal_bits": 12,
+                            "reciprocal_lut_bucket_shift": 4,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
 def _init_git_repo(repo_root: Path) -> str:
     origin_root = repo_root.parent / "origin.git"
     subprocess.run(["git", "init", "--bare", str(origin_root)], check=True, capture_output=True, text=True)
@@ -299,6 +338,39 @@ def test_generate_l1_sweep_task_run_sweep_command_includes_all_wrapper_configs()
             assert work_item.expected_outputs == [
                 "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv",
                 "runs/designs/activations/softmax_rowwise_int8_r8_wrapper/metrics.csv",
+            ]
+
+
+def test_generate_l1_sweep_task_supports_bf16_recip_norm_wrapper_config() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _, sweep_path = _write_example_repo(repo_root)
+        config_path = _write_bf16_recip_norm_config(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    item_id="l1_demo_bf16_recip_norm",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="circuit_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert work_item.expected_outputs == [
+                "runs/designs/activations/bf16_recip_norm_r4_wrapper/metrics.csv",
             ]
 
 

--- a/examples/config_bf16_recip_norm.json
+++ b/examples/config_bf16_recip_norm.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "weights",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "bf16_recip_norm",
+      "module_name": "bf16_recip_norm_r4",
+      "operand": "weights",
+      "options": {
+        "row_elems": 4,
+        "q_frac_bits": 10,
+        "sum_bits": 24,
+        "reciprocal_bits": 12,
+        "reciprocal_lut_bucket_shift": 4
+      }
+    }
+  ]
+}

--- a/runs/campaigns/activations/bf16_recip_norm/sweeps/nangate45_highutil.json
+++ b/runs/campaigns/activations/bf16_recip_norm/sweeps/nangate45_highutil.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "bf16_recip_norm_nangate45_highutil",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.5],
+    "CORE_UTILIZATION": [60, 50],
+    "PLACE_DENSITY": [0.68]
+  }
+}

--- a/runs/designs/activations/bf16_recip_norm_r8_wrapper/README.md
+++ b/runs/designs/activations/bf16_recip_norm_r8_wrapper/README.md
@@ -1,0 +1,8 @@
+# bf16 Reciprocal Normalization r8
+
+This design is a Layer 1 PPA proxy for the missing bf16 normalization cost in the decoder frontier.
+
+The block accepts eight packed IEEE bf16 lanes. Positive finite lanes are converted to a fixed-point
+Q format, summed, multiplied by a bucketed reciprocal lookup, clamped to `[0, 1]`, and converted back
+to bf16. Negative values, subnormals, NaNs, and infinities are intentionally clamped because the block
+is meant to measure the reciprocal-normalization datapath rather than full IEEE exception handling.

--- a/runs/designs/activations/bf16_recip_norm_r8_wrapper/config_bf16_recip_norm_r8.json
+++ b/runs/designs/activations/bf16_recip_norm_r8_wrapper/config_bf16_recip_norm_r8.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "weights",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "bf16_recip_norm",
+      "module_name": "bf16_recip_norm_r8",
+      "operand": "weights",
+      "options": {
+        "row_elems": 8,
+        "q_frac_bits": 10,
+        "sum_bits": 24,
+        "reciprocal_bits": 12,
+        "reciprocal_lut_bucket_shift": 4
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -87,6 +87,9 @@ def identify_design(config):
     operand = _resolve_operand(config, entry.get("operand", ""))
     bit_width = int(_operand_signal_width(operand))
     op_type = entry["type"]
+    if op_type == "bf16_recip_norm":
+        fp_format = operand.get("fp_format", {})
+        bit_width = int(fp_format.get("total_width", operand.get("bit_width", 0)))
     if op_type == "activation":
         return {
             "kind": "scalar_unary",
@@ -96,11 +99,11 @@ def identify_design(config):
             "output_width": bit_width,
             "include_mg_cpa": False,
         }
-    if op_type == "softmax_rowwise":
+    if op_type in {"softmax_rowwise", "bf16_recip_norm"}:
         options = entry.get("options", {})
         row_elems = int(options.get("row_elems", 1))
         if row_elems <= 0:
-            raise ValueError("softmax_rowwise row_elems must be positive")
+            raise ValueError(f"{op_type} row_elems must be positive")
         row_width = bit_width * row_elems
         return {
             "kind": "vector_unary",

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -118,7 +118,7 @@ def read_design_names(config_path: Path) -> Tuple[str, str]:
         module_name = cfg["adder"]["module_name"]
     elif "operations" in cfg and len(cfg["operations"]) == 1:
         entry = cfg["operations"][0]
-        if entry["type"] not in ("activation", "softmax_rowwise"):
+        if entry["type"] not in ("activation", "softmax_rowwise", "bf16_recip_norm"):
             raise ValueError(f"Unsupported single-operation design type in {config_path}: {entry['type']}")
         module_name = entry["module_name"]
     else:

--- a/src/rtlgen/config.cpp
+++ b/src/rtlgen/config.cpp
@@ -59,6 +59,7 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
         config.fp_operations.clear();
         config.activation_operations.clear();
         config.softmax_rowwise_operations.clear();
+        config.bf16_recip_norm_operations.clear();
         config.onnx_model.reset();
 
         if (j.contains("operand")) {
@@ -380,6 +381,32 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                         throw std::runtime_error("softmax_rowwise output_scale must be in [1, 255] for " + softmax.module_name);
                     }
                     config.softmax_rowwise_operations.push_back(softmax);
+                } else if (type == "bf16_recip_norm") {
+                    const json &options = entry.contains("options") ? entry["options"] : entry;
+                    Bf16RecipNormOperationConfig norm;
+                    norm.module_name = module_name;
+                    norm.operand = operand_name;
+                    norm.row_elems = options.value("row_elems", 1);
+                    norm.q_frac_bits = options.value("q_frac_bits", 10);
+                    norm.sum_bits = options.value("sum_bits", 24);
+                    norm.reciprocal_bits = options.value("reciprocal_bits", 12);
+                    norm.reciprocal_lut_bucket_shift = options.value("reciprocal_lut_bucket_shift", 4);
+                    if (norm.row_elems <= 0 || norm.row_elems > 1024) {
+                        throw std::runtime_error("bf16_recip_norm row_elems must be in [1, 1024] for " + norm.module_name);
+                    }
+                    if (norm.q_frac_bits < 4 || norm.q_frac_bits > 20) {
+                        throw std::runtime_error("bf16_recip_norm q_frac_bits must be in [4, 20] for " + norm.module_name);
+                    }
+                    if (norm.sum_bits < 8 || norm.sum_bits > 64) {
+                        throw std::runtime_error("bf16_recip_norm sum_bits must be in [8, 64] for " + norm.module_name);
+                    }
+                    if (norm.reciprocal_bits < 4 || norm.reciprocal_bits > 24) {
+                        throw std::runtime_error("bf16_recip_norm reciprocal_bits must be in [4, 24] for " + norm.module_name);
+                    }
+                    if (norm.reciprocal_lut_bucket_shift < 0 || norm.reciprocal_lut_bucket_shift > 12) {
+                        throw std::runtime_error("bf16_recip_norm reciprocal_lut_bucket_shift must be in [0, 12] for " + norm.module_name);
+                    }
+                    config.bf16_recip_norm_operations.push_back(norm);
                 } else {
                     throw std::runtime_error("Unknown operation type: " + type);
                 }

--- a/src/rtlgen/config.hpp
+++ b/src/rtlgen/config.hpp
@@ -206,6 +206,16 @@ struct SoftmaxRowwiseOperationConfig {
     int output_scale{127};
 };
 
+struct Bf16RecipNormOperationConfig {
+    std::string module_name;
+    std::string operand;
+    int row_elems{1};
+    int q_frac_bits{10};
+    int sum_bits{24};
+    int reciprocal_bits{12};
+    int reciprocal_lut_bucket_shift{4};
+};
+
 struct CircuitConfig {
     OperandConfig operand;
     std::vector<OperandDefinition> operands;
@@ -218,6 +228,7 @@ struct CircuitConfig {
     std::vector<FpOperationConfig> fp_operations;
     std::vector<ActivationOperationConfig> activation_operations;
     std::vector<SoftmaxRowwiseOperationConfig> softmax_rowwise_operations;
+    std::vector<Bf16RecipNormOperationConfig> bf16_recip_norm_operations;
     std::optional<std::string> onnx_model; // Added ONNX model path
 };
 

--- a/src/rtlgen/rtl_operations.cpp
+++ b/src/rtlgen/rtl_operations.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <cmath>
+#include <iomanip>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -1036,6 +1037,185 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     os << "      else\n";
     os << "        lane_out = scaled_out[DATA_W-1:0];\n";
     os << "      Y[(i*DATA_W) +: DATA_W] = lane_out;\n";
+    os << "    end\n";
+    os << "  end\n";
+    os << "endmodule\n";
+}
+
+void emitBf16RecipNormModule(const Bf16RecipNormOperationConfig &config, const OperandDefinition &operand) {
+    if (operand.bit_width != 16) {
+        throw std::runtime_error("bf16_recip_norm expects a 16-bit packed bf16 operand");
+    }
+    if (operand.kind == "fp" && (!operand.fp_format.has_value() ||
+                                 operand.fp_format->total_width != 16 ||
+                                 operand.fp_format->mantissa_width != 7)) {
+        throw std::runtime_error("bf16_recip_norm fp operands must use bf16 {total_width=16, mantissa_width=7}");
+    }
+    if (config.row_elems <= 0 || config.row_elems > 1024) {
+        throw std::runtime_error("bf16_recip_norm row_elems must be in [1, 1024]");
+    }
+    if (config.q_frac_bits < 4 || config.q_frac_bits > 20) {
+        throw std::runtime_error("bf16_recip_norm q_frac_bits must be in [4, 20]");
+    }
+    if (config.sum_bits < 8 || config.sum_bits > 64) {
+        throw std::runtime_error("bf16_recip_norm sum_bits must be in [8, 64]");
+    }
+    if (config.reciprocal_bits < 4 || config.reciprocal_bits > 24) {
+        throw std::runtime_error("bf16_recip_norm reciprocal_bits must be in [4, 24]");
+    }
+    if (config.reciprocal_lut_bucket_shift < 0 || config.reciprocal_lut_bucket_shift > 12) {
+        throw std::runtime_error("bf16_recip_norm reciprocal_lut_bucket_shift must be in [0, 12]");
+    }
+
+    const int data_width = 16;
+    const int row_width = config.row_elems * data_width;
+    const unsigned long long q_one = 1ULL << config.q_frac_bits;
+    const unsigned long long max_sum = static_cast<unsigned long long>(config.row_elems) * q_one;
+    const unsigned long long bucket_step = 1ULL << config.reciprocal_lut_bucket_shift;
+    const unsigned long long max_bucket = (max_sum + bucket_step - 1ULL) / bucket_step;
+    if (max_sum >= (1ULL << std::min(config.sum_bits, 63))) {
+        throw std::runtime_error("bf16_recip_norm sum_bits is too small for row_elems/q_frac_bits envelope");
+    }
+    if (max_bucket > 16384ULL) {
+        throw std::runtime_error("bf16_recip_norm reciprocal LUT exceeds 16384 entries; increase reciprocal_lut_bucket_shift");
+    }
+    const int reciprocal_value_bits = config.reciprocal_bits + config.q_frac_bits + 1;
+    const int product_bits = config.sum_bits + reciprocal_value_bits;
+    const unsigned long long reciprocal_scale = 1ULL << (config.reciprocal_bits + config.q_frac_bits);
+
+    std::string filename = config.module_name + ".v";
+    std::ofstream os(filename);
+    if (!os) {
+        throw std::runtime_error("Failed to open " + filename + " for writing");
+    }
+
+    os << "`timescale 1ns/1ps\n\n";
+    os << "module " << config.module_name << "(\n";
+    os << "  input  [" << (row_width - 1) << ":0] X,\n";
+    os << "  output reg [" << (row_width - 1) << ":0] Y\n";
+    os << ");\n\n";
+    os << "  // Packed-bf16 row normalization proxy.\n";
+    os << "  // Positive bf16 lanes are converted to fixed-point, summed, multiplied by\n";
+    os << "  // a bucketed reciprocal, and converted back to bf16. Subnormals, negative\n";
+    os << "  // inputs, NaNs, and infinities are clamped for an L1 datapath cost proxy.\n";
+    os << "  localparam integer ROW_ELEMS = " << config.row_elems << ";\n";
+    os << "  localparam integer DATA_W = 16;\n";
+    os << "  localparam integer Q_FRAC_BITS = " << config.q_frac_bits << ";\n";
+    os << "  localparam integer SUM_BITS = " << config.sum_bits << ";\n";
+    os << "  localparam integer RECIP_BITS = " << config.reciprocal_bits << ";\n";
+    os << "  localparam integer RECIP_VALUE_BITS = " << reciprocal_value_bits << ";\n";
+    os << "  localparam integer RECIP_BUCKET_SHIFT = " << config.reciprocal_lut_bucket_shift << ";\n";
+    os << "  localparam integer PRODUCT_BITS = " << product_bits << ";\n";
+    os << "  localparam [SUM_BITS-1:0] Q_ONE = " << config.sum_bits << "'d" << q_one << ";\n\n";
+
+    os << "  function [SUM_BITS-1:0] bf16_to_q;\n";
+    os << "    input [15:0] x;\n";
+    os << "    integer exp_unbiased;\n";
+    os << "    integer shift;\n";
+    os << "    reg [7:0] mant;\n";
+    os << "    reg [SUM_BITS+8:0] raw;\n";
+    os << "    begin\n";
+    os << "      raw = {SUM_BITS+9{1'b0}};\n";
+    os << "      if (x[15] || x[14:7] == 8'd0) begin\n";
+    os << "        bf16_to_q = {SUM_BITS{1'b0}};\n";
+    os << "      end else if (x[14:7] > 8'd127) begin\n";
+    os << "        bf16_to_q = Q_ONE;\n";
+    os << "      end else begin\n";
+    os << "        mant = {1'b1, x[6:0]};\n";
+    os << "        exp_unbiased = x[14:7] - 127;\n";
+    os << "        shift = Q_FRAC_BITS + exp_unbiased - 7;\n";
+    os << "        if (shift >= 0)\n";
+    os << "          raw = {{(SUM_BITS+1){1'b0}}, mant} << shift;\n";
+    os << "        else\n";
+    os << "          raw = {{(SUM_BITS+1){1'b0}}, mant} >> (-shift);\n";
+    os << "        if (raw > Q_ONE)\n";
+    os << "          bf16_to_q = Q_ONE;\n";
+    os << "        else\n";
+    os << "          bf16_to_q = raw[SUM_BITS-1:0];\n";
+    os << "      end\n";
+    os << "    end\n";
+    os << "  endfunction\n\n";
+
+    os << "  function [15:0] q_to_bf16;\n";
+    os << "    input [SUM_BITS-1:0] q;\n";
+    os << "    integer msb;\n";
+    os << "    integer k;\n";
+    os << "    integer exp_val;\n";
+    os << "    reg [7:0] exp_bits;\n";
+    os << "    reg [7:0] sig;\n";
+    os << "    reg [SUM_BITS-1:0] norm;\n";
+    os << "    begin\n";
+    os << "      if (q == {SUM_BITS{1'b0}}) begin\n";
+    os << "        q_to_bf16 = 16'h0000;\n";
+    os << "      end else begin\n";
+    os << "        msb = 0;\n";
+    os << "        for (k = 0; k < SUM_BITS; k = k + 1) begin\n";
+    os << "          if (q[k]) msb = k;\n";
+    os << "        end\n";
+    os << "        exp_val = 127 + msb - Q_FRAC_BITS;\n";
+    os << "        if (exp_val <= 0) begin\n";
+    os << "          q_to_bf16 = 16'h0000;\n";
+    os << "        end else if (exp_val >= 255) begin\n";
+    os << "          q_to_bf16 = 16'h7f7f;\n";
+    os << "        end else begin\n";
+    os << "          if (msb >= 7)\n";
+    os << "            norm = q >> (msb - 7);\n";
+    os << "          else\n";
+    os << "            norm = q << (7 - msb);\n";
+    os << "          exp_bits = exp_val;\n";
+    os << "          sig = norm[7:0];\n";
+    os << "          q_to_bf16 = {1'b0, exp_bits, sig[6:0]};\n";
+    os << "        end\n";
+    os << "      end\n";
+    os << "    end\n";
+    os << "  endfunction\n\n";
+
+    os << "  function [RECIP_VALUE_BITS-1:0] recip_lut;\n";
+    os << "    input [SUM_BITS-1:0] bucket;\n";
+    os << "    begin\n";
+    os << "      case (bucket)\n";
+    os << "        " << config.sum_bits << "'d0: recip_lut = {RECIP_VALUE_BITS{1'b0}};\n";
+    for (unsigned long long bucket = 1; bucket <= max_bucket; ++bucket) {
+        const unsigned long long denom = bucket * bucket_step;
+        const unsigned long long recip = (reciprocal_scale + (denom / 2ULL)) / denom;
+        os << "        " << config.sum_bits << "'d" << bucket
+           << ": recip_lut = " << reciprocal_value_bits << "'d" << recip << ";\n";
+    }
+    os << "        default: recip_lut = {RECIP_VALUE_BITS{1'b0}};\n";
+    os << "      endcase\n";
+    os << "    end\n";
+    os << "  endfunction\n\n";
+
+    os << "  integer i;\n";
+    os << "  reg [SUM_BITS-1:0] q_values [0:ROW_ELEMS-1];\n";
+    os << "  reg [SUM_BITS-1:0] sum_values;\n";
+    os << "  reg [SUM_BITS-1:0] reciprocal_bucket;\n";
+    os << "  reg [RECIP_VALUE_BITS-1:0] reciprocal;\n";
+    os << "  reg [PRODUCT_BITS-1:0] product;\n";
+    os << "  reg [PRODUCT_BITS-1:0] rounded_product;\n";
+    os << "  reg [SUM_BITS-1:0] norm_q;\n\n";
+
+    os << "  always @* begin\n";
+    os << "    sum_values = {SUM_BITS{1'b0}};\n";
+    os << "    for (i = 0; i < ROW_ELEMS; i = i + 1) begin\n";
+    os << "      q_values[i] = bf16_to_q(X[(i*DATA_W) +: DATA_W]);\n";
+    os << "      sum_values = sum_values + q_values[i];\n";
+    os << "    end\n\n";
+    os << "    Y = {ROW_ELEMS*DATA_W{1'b0}};\n";
+    if (config.reciprocal_lut_bucket_shift > 0) {
+        os << "    reciprocal_bucket = (sum_values + " << config.sum_bits << "'d" << (bucket_step - 1ULL)
+           << ") >> RECIP_BUCKET_SHIFT;\n";
+    } else {
+        os << "    reciprocal_bucket = sum_values;\n";
+    }
+    os << "    reciprocal = recip_lut(reciprocal_bucket);\n\n";
+    os << "    for (i = 0; i < ROW_ELEMS; i = i + 1) begin\n";
+    os << "      product = q_values[i] * reciprocal;\n";
+    os << "      rounded_product = product + ({{(PRODUCT_BITS-1){1'b0}}, 1'b1} << (RECIP_BITS - 1));\n";
+    os << "      norm_q = rounded_product >> RECIP_BITS;\n";
+    os << "      if (norm_q > Q_ONE)\n";
+    os << "        norm_q = Q_ONE;\n";
+    os << "      Y[(i*DATA_W) +: DATA_W] = q_to_bf16(norm_q);\n";
     os << "    end\n";
     os << "  end\n";
     os << "endmodule\n";

--- a/src/rtlgen/rtl_operations.hpp
+++ b/src/rtlgen/rtl_operations.hpp
@@ -6,3 +6,4 @@ void emitMcmModule(const McmOperationConfig &config, const OperandDefinition &op
 void emitCmvmModule(const CmvmOperationConfig &config, const OperandDefinition &operand);
 void emitActivationModule(const ActivationOperationConfig &config, const OperandDefinition &operand);
 void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const OperandDefinition &operand);
+void emitBf16RecipNormModule(const Bf16RecipNormOperationConfig &config, const OperandDefinition &operand);

--- a/tests/bf16_recip_norm_tb.v
+++ b/tests/bf16_recip_norm_tb.v
@@ -1,0 +1,42 @@
+`timescale 1ns/1ps
+
+module bf16_recip_norm_tb;
+  reg  [63:0] X;
+  wire [63:0] Y;
+
+  bf16_recip_norm_r4 dut (.X(X), .Y(Y));
+
+  task check_row;
+    input [63:0] a;
+    input [63:0] exp;
+    begin
+      X = a;
+      #1;
+      if (Y !== exp) begin
+        $display(
+          "FAIL bf16_recip_norm: got=[%h,%h,%h,%h] expected=[%h,%h,%h,%h]",
+          Y[15:0], Y[31:16], Y[47:32], Y[63:48],
+          exp[15:0], exp[31:16], exp[47:32], exp[63:48]
+        );
+        $fatal;
+      end
+    end
+  endtask
+
+  initial begin
+    check_row(
+      {16'h3f80, 16'h3f80, 16'h3f80, 16'h3f80},
+      {16'h3e80, 16'h3e80, 16'h3e80, 16'h3e80}
+    );
+    check_row(
+      {16'h0000, 16'h0000, 16'h0000, 16'h3f80},
+      {16'h0000, 16'h0000, 16'h0000, 16'h3f80}
+    );
+    check_row(
+      {16'h0000, 16'h0000, 16'h0000, 16'h0000},
+      {16'h0000, 16'h0000, 16'h0000, 16'h0000}
+    );
+    $display("All bf16 reciprocal-normalization tests passed.");
+    $finish;
+  end
+endmodule

--- a/tests/test_bf16_recip_norm.sh
+++ b/tests/test_bf16_recip_norm.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+cp "$ROOT/examples/config_bf16_recip_norm.json" "$TMP/config.json"
+
+pushd "$TMP" >/dev/null
+"$ROOT/build/rtlgen" config.json
+
+grep -q "module bf16_recip_norm_r4" bf16_recip_norm_r4.v
+grep -q "function \\[RECIP_VALUE_BITS-1:0\\] recip_lut" bf16_recip_norm_r4.v
+if grep -q " / " bf16_recip_norm_r4.v; then
+  echo "bf16_recip_norm emitted a divider" >&2
+  exit 1
+fi
+
+iverilog -g2012 -s bf16_recip_norm_tb -o sim bf16_recip_norm_r4.v "$ROOT/tests/bf16_recip_norm_tb.v"
+vvp sim
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add a bf16 reciprocal-normalization vector op to RTLGen with fixed-point conversion, bucketed reciprocal LUT, and bf16 output conversion
- wire the op through single-operation wrapper/sweep generation and Layer 1 task generation
- add bf16 row-4 simulation coverage plus a row-8 Nangate45 L1 scaffold

## Tests
- cmake --build /workspaces/RTLGen/build -j2
- tests/test_bf16_recip_norm.sh
- bash tests/test_softmax_rowwise.sh
- PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/pytest -q control_plane/control_plane/tests/test_l1_task_generator.py