### PR TITLE
Record bf16 reciprocal normalization L1 request

### DIFF
--- a/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_decoder_normalization_arithmetic_calibration_v1",
-  "source_commit": "ea6095808f683c26979575365f9a5c4249470a05",
+  "source_commit": "beb0ca3cb6f0129820f3d7617787fec12e1e8a78",
   "requested_items": [
     {
       "item_id": "l1_decoder_norm_q8_recip_mult_calibration_v1_r2",
@@ -31,6 +31,14 @@
       "merged_pr_number": 282,
       "merge_commit": "3dca7765d27c3c679d966396fc42b52305a81631",
       "merged_utc": "2026-04-29T09:18:58.855526Z"
+    },
+    {
+      "item_id": "l1_decoder_bf16_recip_norm_datapath_v1_r1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the row-8 bf16 reciprocal-normalization datapath added in PR #300, so the decoder q8-vs-bf16 normalization frontier can replace the remaining bf16 heuristic gap.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "status": "pending"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- record the queued bf16 reciprocal-normalization L1 sweep under the decoder normalization calibration proposal

## Tests
- not run; proposal bookkeeping only