### PR TITLE
Allow bf16 reciprocal LUT synthesis

### DIFF
--- a/runs/campaigns/activations/bf16_recip_norm/sweeps/nangate45_highutil.json
+++ b/runs/campaigns/activations/bf16_recip_norm/sweeps/nangate45_highutil.json
@@ -3,6 +3,7 @@
   "flow_params": {
     "CLOCK_PERIOD": [2.5],
     "CORE_UTILIZATION": [60, 50],
-    "PLACE_DENSITY": [0.68]
+    "PLACE_DENSITY": [0.68],
+    "SYNTH_MEMORY_MAX_BITS": [32768]
   }
 }


### PR DESCRIPTION
## Summary
- raise SYNTH_MEMORY_MAX_BITS for the bf16 reciprocal-normalization L1 sweep so the inferred reciprocal LUT is accepted by Yosys/OpenROAD

## Context
The first r1 run reached artifact_sync but had no status=ok metrics because Yosys rejected the 1024-row reciprocal ROM with the default memory-size gate.

## Tests
- python3 -m json.tool runs/campaigns/activations/bf16_recip_norm/sweeps/nangate45_highutil.json