### PR TITLE
Integrate bf16 norm PPA into decoder frontier

### DIFF
--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -193,6 +193,7 @@ python3 npu/eval/sweep_llm_decoder_candidate_quality.py \
 python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py \
   --sweep /tmp/decoder_q8_norm_frontier_sweep.json \
   --q8-recip-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json \
+  --bf16-recip-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_recip_norm_datapath_v1_r2.json \
   --out /tmp/decoder_q8_norm_frontier.json \
   --out-md /tmp/decoder_q8_norm_frontier.md
 ```
@@ -202,9 +203,10 @@ reciprocal normalization at q10/q12/q14/q16, with the bf16 reciprocal PWL row
 kept as the current anchor. A reciprocal row is only a candidate if it preserves
 the full prompt-stress next-token and top-k gate. When the merged q8 reciprocal
 datapath artifact is available, q10/q12/q14/q16 are ranked by measured
-Nangate45 critical path, then area, then power. q8 exact normalization and the
-bf16 reciprocal anchor remain unmeasured hardware gaps until their datapaths are
-costed separately.
+Nangate45 critical path, then area, then power. When the merged bf16 reciprocal
+datapath artifact is available, the bf16 anchor is ranked with the same measured
+metric ordering. q8 exact normalization uses the measured row-wise int8 softmax
+baseline when that artifact is available.
 
 After the corresponding Layer 1 multiplier and accumulator/adder calibration
 jobs merge, synthesize the measured primitive evidence into a decoder

--- a/npu/eval/estimate_llm_decoder_q8_norm_frontier.py
+++ b/npu/eval/estimate_llm_decoder_q8_norm_frontier.py
@@ -19,23 +19,29 @@ DEFAULT_Q8_RECIP_PPA = Path("control_plane/shadow_exports/l1_promotions/l1_decod
 DEFAULT_Q8_EXACT_PPA = Path(
     "control_plane/shadow_exports/l1_promotions/l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json"
 )
+DEFAULT_BF16_RECIP_PPA = Path("control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_recip_norm_datapath_v1_r2.json")
 METRIC_KEYS = ("critical_path_ns", "die_area", "total_power_mw")
 
 COST_MODEL = {
-    "name": "decoder_q8_normalization_ppa_frontier_v3",
-    "source": "rtlgen_openroad_q8_exact_and_reciprocal_datapath_metrics",
+    "name": "decoder_q8_normalization_ppa_frontier_v4",
+    "source": "rtlgen_openroad_q8_exact_q8_reciprocal_and_bf16_reciprocal_datapath_metrics",
     "unit": "nangate45_physical_metrics",
-    "calibration_status": "q8_exact_and_reciprocal_integrated_datapaths_measured",
+    "calibration_status": "q8_exact_q8_reciprocal_and_bf16_reciprocal_integrated_datapaths_measured",
     "ppa_balance": (
-        "Measured q8 exact and q8 reciprocal candidates are ranked lexicographically by critical path, "
-        "then area, then power. The bf16 reciprocal normalization path remains an unmeasured "
-        "hardware gap and is not compared as accepted PPA."
+        "Measured q8 exact, q8 reciprocal, and bf16 reciprocal candidates are ranked lexicographically "
+        "by critical path, then area, then power. These physical metrics are comparable only within "
+        "the current Nangate45 row-8 normalization datapath framing."
     ),
     "intended_use": (
         "Replace the q8 normalization heuristic with merged RTLGen/OpenROAD datapath "
-        "evidence while preserving quality gates from the decoder sweep."
+        "evidence and compare it with the measured bf16 reciprocal anchor while preserving "
+        "quality gates from the decoder sweep."
     ),
-    "rtlgen_calibration_proposal": "prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1",
+    "rtlgen_calibration_proposal": (
+        "prop_l1_decoder_q8_recip_norm_datapath_v1_and_"
+        "prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_and_"
+        "prop_l1_decoder_bf16_recip_norm_datapath_v1"
+    ),
     "fallback_source": "hand_written_planning_proxy_used_only_when_ppa_artifact_is_absent",
 }
 
@@ -132,6 +138,33 @@ def _load_q8_exact_ppa(path: Path | None) -> JsonDict | None:
     return None
 
 
+def _load_bf16_recip_ppa(path: Path | None) -> JsonDict | None:
+    if path is None or not path.exists():
+        return None
+    payload = _load_json(path)
+    proposals = payload.get("proposals")
+    if not isinstance(proposals, list):
+        raise SystemExit(f"bf16 reciprocal PPA artifact must contain proposals list: {path}")
+    for proposal in proposals:
+        if not isinstance(proposal, dict):
+            continue
+        metrics_ref = proposal.get("metrics_ref")
+        if not isinstance(metrics_ref, dict):
+            continue
+        metrics = _metric_summary(proposal)
+        if str(metrics_ref.get("status") or "") != "ok":
+            continue
+        if any(metrics[key] is None for key in METRIC_KEYS):
+            continue
+        return {
+            "platform": metrics_ref.get("platform"),
+            "metrics_ref": metrics_ref,
+            "metrics": metrics,
+            "selection_reason": proposal.get("selection_reason"),
+        }
+    return None
+
+
 def _quality(row: JsonDict) -> JsonDict:
     sample_count = _as_int(row.get("sample_count"))
     next_rate = _as_float(row.get("next_token_id_match_rate"))
@@ -173,7 +206,13 @@ def _heuristic_normalization_cost(row: JsonDict) -> float:
     return 40.0
 
 
-def _normalization_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict], q8_exact_ppa: JsonDict | None) -> JsonDict:
+def _normalization_record(
+    row: JsonDict,
+    *,
+    q8_recip_ppa: dict[int, JsonDict],
+    q8_exact_ppa: JsonDict | None,
+    bf16_recip_ppa: JsonDict | None,
+) -> JsonDict:
     mode = str(row.get("normalization_mode") or "exact").strip()
     bits = _as_int(row.get("normalization_reciprocal_bits"), 0)
     heuristic_cost = _heuristic_normalization_cost(row)
@@ -229,16 +268,46 @@ def _normalization_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict], q
         record["rank_source"] = "heuristic_fallback_missing_q8_exact_ppa"
         record["rank_key"] = [1, round(heuristic_cost, 6)]
     elif mode == "reciprocal_float":
-        record["calibration_status"] = "unmeasured_float_reciprocal_datapath"
+        fmt = str(row.get("normalization_reciprocal_float_format") or "").strip()
+        template = str(row.get("template") or "")
+        if template == BF16_ANCHOR and fmt == "bf16" and bf16_recip_ppa is not None:
+            metrics = bf16_recip_ppa["metrics"]
+            record.update(
+                {
+                    "ppa_metrics": metrics,
+                    "metrics_ref": bf16_recip_ppa["metrics_ref"],
+                    "rank_source": "measured_bf16_reciprocal_datapath_ppa",
+                    "rank_key": [0] + [float(metrics[key]) for key in METRIC_KEYS],
+                    "calibration_status": "integrated_bf16_reciprocal_datapath_measured",
+                }
+            )
+            return record
+        if fmt == "bf16":
+            record["calibration_status"] = "missing_integrated_bf16_reciprocal_datapath_ppa"
+            record["rank_source"] = "heuristic_fallback_missing_bf16_reciprocal_ppa"
+            record["rank_key"] = [1, round(heuristic_cost, 6)]
+        else:
+            record["calibration_status"] = "unmeasured_float_reciprocal_datapath"
     else:
         record["calibration_status"] = "unmeasured_normalization_datapath"
     return record
 
 
-def _row_record(row: JsonDict, *, q8_recip_ppa: dict[int, JsonDict], q8_exact_ppa: JsonDict | None) -> JsonDict:
+def _row_record(
+    row: JsonDict,
+    *,
+    q8_recip_ppa: dict[int, JsonDict],
+    q8_exact_ppa: JsonDict | None,
+    bf16_recip_ppa: JsonDict | None,
+) -> JsonDict:
     template = str(row.get("template") or "")
     quality = _quality(row)
-    normalization = _normalization_record(row, q8_recip_ppa=q8_recip_ppa, q8_exact_ppa=q8_exact_ppa)
+    normalization = _normalization_record(
+        row,
+        q8_recip_ppa=q8_recip_ppa,
+        q8_exact_ppa=q8_exact_ppa,
+        bf16_recip_ppa=bf16_recip_ppa,
+    )
     if template == BF16_ANCHOR:
         role = "bf16_primary_anchor"
     elif template == BASELINE_Q8_EXACT:
@@ -324,15 +393,22 @@ def build_report(
     sweep_path: Path,
     q8_recip_ppa_path: Path | None = DEFAULT_Q8_RECIP_PPA,
     q8_exact_ppa_path: Path | None = DEFAULT_Q8_EXACT_PPA,
+    bf16_recip_ppa_path: Path | None = DEFAULT_BF16_RECIP_PPA,
 ) -> JsonDict:
     sweep = _load_json(sweep_path)
     q8_recip_ppa = _load_q8_recip_ppa(q8_recip_ppa_path)
     q8_exact_ppa = _load_q8_exact_ppa(q8_exact_ppa_path)
+    bf16_recip_ppa = _load_bf16_recip_ppa(bf16_recip_ppa_path)
     rows = sweep.get("templates")
     if not isinstance(rows, list):
         raise SystemExit("sweep JSON must contain a templates list")
     records = [
-        _row_record(row, q8_recip_ppa=q8_recip_ppa, q8_exact_ppa=q8_exact_ppa)
+        _row_record(
+            row,
+            q8_recip_ppa=q8_recip_ppa,
+            q8_exact_ppa=q8_exact_ppa,
+            bf16_recip_ppa=bf16_recip_ppa,
+        )
         for row in rows
         if isinstance(row, dict)
     ]
@@ -344,6 +420,18 @@ def build_report(
     missing = [template for template in (BF16_ANCHOR, BASELINE_Q8_EXACT) if template not in {row["template"] for row in interesting}]
     if missing:
         raise SystemExit(f"missing required frontier rows: {', '.join(missing)}")
+    measured_survivors = [
+        row
+        for row in interesting
+        if row["quality"]["exact_safe"] and str(row["normalization"].get("rank_source") or "").startswith("measured_")
+    ]
+    measured_survivors.sort(
+        key=lambda row: (
+            row["normalization"]["rank_key"],
+            _as_int(row["normalization"]["reciprocal_bits"]),
+            row["template"],
+        )
+    )
     reciprocal_survivors = [
         row
         for row in interesting
@@ -356,15 +444,18 @@ def build_report(
             row["template"],
         )
     )
-    if reciprocal_survivors:
-        selected = reciprocal_survivors[0]
+    if measured_survivors:
+        selected = measured_survivors[0]
+        q8_note = ""
+        if selected["role"] != "q8_reciprocal_candidate" and reciprocal_survivors:
+            q8_note = f" The best exact-safe q8 reciprocal row remains {reciprocal_survivors[0]['template']}."
         decision = {
-            "decision": "q8_reciprocal_candidate_survived",
+            "decision": "measured_frontier_candidate_selected",
             "selected_candidate": selected["template"],
             "reason": (
                 f"{selected['template']} preserved the exact prompt-stress gate and has the best "
-                f"{selected['normalization']['rank_source']} among exact-safe q8 reciprocal candidates. "
-                "q8 exact is included as measured baseline PPA; bf16 reciprocal normalization remains an unmeasured hardware gap."
+                f"{selected['normalization']['rank_source']} among exact-safe measured normalization candidates."
+                f"{q8_note}"
             ),
         }
     else:
@@ -396,7 +487,8 @@ def build_report(
                 "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization "
                 "precision as a replacement for q8 exact normalization. q8 reciprocal rows use merged "
                 "RTLGen/OpenROAD integrated datapath metrics when the PPA artifact is available; q8 exact "
-                "uses the measured row-wise int8 softmax baseline when available; bf16 normalization remains unmeasured."
+                "uses the measured row-wise int8 softmax baseline when available; bf16 reciprocal normalization "
+                "uses the measured row-8 bf16 reciprocal datapath when available."
             ),
         },
         "source_artifacts": {
@@ -404,13 +496,15 @@ def build_report(
             "q8_reciprocal_ppa_bits": sorted(q8_recip_ppa),
             "q8_exact_datapath_ppa": str(q8_exact_ppa_path) if q8_exact_ppa_path is not None else None,
             "q8_exact_ppa_available": q8_exact_ppa is not None,
+            "bf16_reciprocal_datapath_ppa": str(bf16_recip_ppa_path) if bf16_recip_ppa_path is not None else None,
+            "bf16_reciprocal_ppa_available": bf16_recip_ppa is not None,
         },
         "cost_model": COST_MODEL,
         "decision": decision,
         "ranked_rows": ranked,
         "next_step": [
-            "Implement and measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.",
-            "Use the measured q8 exact baseline as the current reference point for q8 reciprocal normalization tradeoffs.",
+            "Treat the bf16 and q8 reciprocal measurements as current row-8 Nangate45 datapath evidence, not distribution-robust architecture proof.",
+            "Broaden weight/input distribution coverage before making a final q8-versus-bf16 normalization decision.",
         ],
     }
 
@@ -420,6 +514,7 @@ def main() -> int:
     ap.add_argument("--sweep", required=True, help="q8 normalization frontier sweep JSON")
     ap.add_argument("--q8-recip-ppa", default=str(DEFAULT_Q8_RECIP_PPA), help="merged q8 reciprocal datapath promotion JSON")
     ap.add_argument("--q8-exact-ppa", default=str(DEFAULT_Q8_EXACT_PPA), help="merged q8 exact datapath promotion JSON")
+    ap.add_argument("--bf16-recip-ppa", default=str(DEFAULT_BF16_RECIP_PPA), help="merged bf16 reciprocal datapath promotion JSON")
     ap.add_argument("--out", required=True, help="output JSON path")
     ap.add_argument("--out-md", required=True, help="output Markdown report path")
     args = ap.parse_args()
@@ -427,6 +522,7 @@ def main() -> int:
         sweep_path=Path(args.sweep),
         q8_recip_ppa_path=Path(args.q8_recip_ppa) if args.q8_recip_ppa else None,
         q8_exact_ppa_path=Path(args.q8_exact_ppa) if args.q8_exact_ppa else None,
+        bf16_recip_ppa_path=Path(args.bf16_recip_ppa) if args.bf16_recip_ppa else None,
     )
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/npu/eval/estimate_llm_decoder_quantization_outline.py
+++ b/npu/eval/estimate_llm_decoder_quantization_outline.py
@@ -193,7 +193,7 @@ def _q8_norm_summary(path: Path | None) -> JsonDict | None:
         for row in rows
         if isinstance(row, dict)
         and isinstance(row.get("normalization"), dict)
-        and str(row["normalization"].get("rank_source") or "").startswith("measured_q8_")
+        and str(row["normalization"].get("rank_source") or "").startswith("measured_")
     ]
     return {
         "source": str(path),
@@ -306,13 +306,12 @@ def build_report(
             "bf16/fp16 probability and reciprocal software paths preserve next-token and top-k on the current fp-format and distribution sweeps.",
             "fixed q8 probability output storage is blocked on the distribution robustness sweep, while q8/q6 logit quantization remains exact-safe there.",
             "fp8 probability storage is not a current frontier candidate: e5m2 drops samples and e4m3 is blocked in both sweeps.",
-            "q8 reciprocal normalization now has measured integrated PPA; bf16 reciprocal normalization still needs a measurable datapath before PPA comparison.",
+            "q8 reciprocal and bf16 reciprocal normalization now have measured integrated PPA for the current row-8 Nangate45 datapath framing.",
         ],
         "dimensions": _group_dimensions(records),
         "q8_norm_frontier": q8_norm,
         "next_step": [
-            "Keep q8 reciprocal as the immediate measured hardware frontier.",
-            "Use issue #297 to add and measure a bf16 reciprocal normalization datapath before claiming q8-versus-bf16 PPA superiority.",
+            "Use the measured q8 reciprocal and bf16 reciprocal datapaths as the immediate hardware frontier.",
             "Broaden distribution coverage before treating these exact-safe rows as generally robust across weights and prompts.",
         ],
     }

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json
@@ -1,29 +1,83 @@
 {
   "cost_model": {
-    "calibration_status": "q8_exact_and_reciprocal_integrated_datapaths_measured",
+    "calibration_status": "q8_exact_q8_reciprocal_and_bf16_reciprocal_integrated_datapaths_measured",
     "fallback_source": "hand_written_planning_proxy_used_only_when_ppa_artifact_is_absent",
-    "intended_use": "Replace the q8 normalization heuristic with merged RTLGen/OpenROAD datapath evidence while preserving quality gates from the decoder sweep.",
-    "name": "decoder_q8_normalization_ppa_frontier_v3",
-    "ppa_balance": "Measured q8 exact and q8 reciprocal candidates are ranked lexicographically by critical path, then area, then power. The bf16 reciprocal normalization path remains an unmeasured hardware gap and is not compared as accepted PPA.",
-    "rtlgen_calibration_proposal": "prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1",
-    "source": "rtlgen_openroad_q8_exact_and_reciprocal_datapath_metrics",
+    "intended_use": "Replace the q8 normalization heuristic with merged RTLGen/OpenROAD datapath evidence and compare it with the measured bf16 reciprocal anchor while preserving quality gates from the decoder sweep.",
+    "name": "decoder_q8_normalization_ppa_frontier_v4",
+    "ppa_balance": "Measured q8 exact, q8 reciprocal, and bf16 reciprocal candidates are ranked lexicographically by critical path, then area, then power. These physical metrics are comparable only within the current Nangate45 row-8 normalization datapath framing.",
+    "rtlgen_calibration_proposal": "prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_and_prop_l1_decoder_bf16_recip_norm_datapath_v1",
+    "source": "rtlgen_openroad_q8_exact_q8_reciprocal_and_bf16_reciprocal_datapath_metrics",
     "unit": "nangate45_physical_metrics"
   },
   "decision": {
-    "decision": "q8_reciprocal_candidate_survived",
-    "reason": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact is included as measured baseline PPA; bf16 reciprocal normalization remains an unmeasured hardware gap.",
-    "selected_candidate": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
+    "decision": "measured_frontier_candidate_selected",
+    "reason": "grid_approx_pwl_bf16_path preserved the exact prompt-stress gate and has the best measured_bf16_reciprocal_datapath_ppa among exact-safe measured normalization candidates. The best exact-safe q8 reciprocal row remains grid_approx_pwl_in_q8_w_q8_norm_recip_q10.",
+    "selected_candidate": "grid_approx_pwl_bf16_path"
   },
   "frontier_scope": {
     "quality_gate": "candidate must match next-token and top-k for every prompt-stress sample",
     "rough_grid": "decoder_q8_normalization_frontier_v1",
-    "scope_note": "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization precision as a replacement for q8 exact normalization. q8 reciprocal rows use merged RTLGen/OpenROAD integrated datapath metrics when the PPA artifact is available; q8 exact uses the measured row-wise int8 softmax baseline when available; bf16 normalization remains unmeasured."
+    "scope_note": "This is a focused q8 PWL normalization frontier. It tests reciprocal-normalization precision as a replacement for q8 exact normalization. q8 reciprocal rows use merged RTLGen/OpenROAD integrated datapath metrics when the PPA artifact is available; q8 exact uses the measured row-wise int8 softmax baseline when available; bf16 reciprocal normalization uses the measured row-8 bf16 reciprocal datapath when available."
   },
   "next_step": [
-    "Implement and measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.",
-    "Use the measured q8 exact baseline as the current reference point for q8 reciprocal normalization tradeoffs."
+    "Treat the bf16 and q8 reciprocal measurements as current row-8 Nangate45 datapath evidence, not distribution-robust architecture proof.",
+    "Broaden weight/input distribution coverage before making a final q8-versus-bf16 normalization decision."
   ],
   "ranked_rows": [
+    {
+      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_bf16_w_bf16_norm_recip_bf16_prob_fp",
+      "frontier_rank_key": [
+        0,
+        4.2869,
+        50690.271025,
+        0.00479
+      ],
+      "normalization": {
+        "calibration_status": "integrated_bf16_reciprocal_datapath_measured",
+        "heuristic_fallback_unit": "heuristic_planning_units",
+        "heuristic_fallback_units": 22.0,
+        "metrics_ref": {
+          "metrics_csv": "runs/designs/activations/bf16_recip_norm_r8_wrapper/metrics.csv",
+          "param_hash": "707ea19f",
+          "platform": "nangate45",
+          "result_kind": "physical_metrics",
+          "result_path": "runs/designs/activations/bf16_recip_norm_r8_wrapper/work/707ea19f/result.json",
+          "status": "ok",
+          "tag": "bf16_recip_norm_nangate45_highutil_2ae5d3c9"
+        },
+        "mode": "reciprocal_float",
+        "ppa_metrics": {
+          "critical_path_ns": 4.2869,
+          "die_area": 50690.271025,
+          "total_power_mw": 0.00479
+        },
+        "rank_key": [
+          0,
+          4.2869,
+          50690.271025,
+          0.00479
+        ],
+        "rank_source": "measured_bf16_reciprocal_datapath_ppa",
+        "reciprocal_bits": 0,
+        "reciprocal_float_format": "bf16",
+        "unit": "nangate45_physical_metrics"
+      },
+      "quality": {
+        "exact_safe": true,
+        "gate": "exact_safe_survivor",
+        "next_token_match_rate": 1.0,
+        "next_token_matches": 24,
+        "next_token_mismatch_sample_ids": [],
+        "sample_count": 24,
+        "topk_contains_reference_rate": 1.0,
+        "topk_matches": 24,
+        "topk_miss_sample_ids": [],
+        "topk_safe": true
+      },
+      "rank": 1,
+      "role": "bf16_primary_anchor",
+      "template": "grid_approx_pwl_bf16_path"
+    },
     {
       "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q8_w_q8_norm_recip_q10_prob_fp",
       "frontier_rank_key": [
@@ -74,7 +128,7 @@
         "topk_miss_sample_ids": [],
         "topk_safe": true
       },
-      "rank": 1,
+      "rank": 2,
       "role": "q8_reciprocal_candidate",
       "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
     },
@@ -128,7 +182,7 @@
         "topk_miss_sample_ids": [],
         "topk_safe": true
       },
-      "rank": 2,
+      "rank": 3,
       "role": "q8_reciprocal_candidate",
       "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q12"
     },
@@ -182,7 +236,7 @@
         "topk_miss_sample_ids": [],
         "topk_safe": true
       },
-      "rank": 3,
+      "rank": 4,
       "role": "q8_reciprocal_candidate",
       "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q14"
     },
@@ -236,7 +290,7 @@
         "topk_miss_sample_ids": [],
         "topk_safe": true
       },
-      "rank": 4,
+      "rank": 5,
       "role": "q8_reciprocal_candidate",
       "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q16"
     },
@@ -290,50 +344,14 @@
         "topk_miss_sample_ids": [],
         "topk_safe": true
       },
-      "rank": 5,
+      "rank": 6,
       "role": "q8_exact_normalization_baseline",
       "template": "grid_approx_pwl_in_q8_w_q8_norm_exact"
-    },
-    {
-      "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_bf16_w_bf16_norm_recip_bf16_prob_fp",
-      "frontier_rank_key": [
-        2,
-        22.0
-      ],
-      "normalization": {
-        "calibration_status": "unmeasured_float_reciprocal_datapath",
-        "heuristic_fallback_unit": "heuristic_planning_units",
-        "heuristic_fallback_units": 22.0,
-        "metrics_ref": null,
-        "mode": "reciprocal_float",
-        "ppa_metrics": null,
-        "rank_key": [
-          2,
-          22.0
-        ],
-        "rank_source": "unmeasured_gap",
-        "reciprocal_bits": 0,
-        "reciprocal_float_format": "bf16",
-        "unit": "nangate45_physical_metrics"
-      },
-      "quality": {
-        "exact_safe": true,
-        "gate": "exact_safe_survivor",
-        "next_token_match_rate": 1.0,
-        "next_token_matches": 24,
-        "next_token_mismatch_sample_ids": [],
-        "sample_count": 24,
-        "topk_contains_reference_rate": 1.0,
-        "topk_matches": 24,
-        "topk_miss_sample_ids": [],
-        "topk_safe": true
-      },
-      "rank": 6,
-      "role": "bf16_primary_anchor",
-      "template": "grid_approx_pwl_bf16_path"
     }
   ],
   "source_artifacts": {
+    "bf16_reciprocal_datapath_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_recip_norm_datapath_v1_r2.json",
+    "bf16_reciprocal_ppa_available": true,
     "q8_exact_datapath_ppa": "control_plane/shadow_exports/l1_promotions/l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json",
     "q8_exact_ppa_available": true,
     "q8_reciprocal_datapath_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json",

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.md
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.md
@@ -1,29 +1,29 @@
 # Decoder q8 Normalization Frontier
 
 - source_sweep: `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_normalization_frontier_v1.json`
-- decision: `q8_reciprocal_candidate_survived`
-- selected_candidate: `grid_approx_pwl_in_q8_w_q8_norm_recip_q10`
-- reason: grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact is included as measured baseline PPA; bf16 reciprocal normalization remains an unmeasured hardware gap.
-- cost_model_source: `rtlgen_openroad_q8_exact_and_reciprocal_datapath_metrics`
+- decision: `measured_frontier_candidate_selected`
+- selected_candidate: `grid_approx_pwl_bf16_path`
+- reason: grid_approx_pwl_bf16_path preserved the exact prompt-stress gate and has the best measured_bf16_reciprocal_datapath_ppa among exact-safe measured normalization candidates. The best exact-safe q8 reciprocal row remains grid_approx_pwl_in_q8_w_q8_norm_recip_q10.
+- cost_model_source: `rtlgen_openroad_q8_exact_q8_reciprocal_and_bf16_reciprocal_datapath_metrics`
 - cost_model_unit: `nangate45_physical_metrics`
-- rtlgen_calibration_proposal: `prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1`
+- rtlgen_calibration_proposal: `prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_and_prop_l1_decoder_bf16_recip_norm_datapath_v1`
 
 ## Cost Model Provenance
 
-Measured q8 exact and q8 reciprocal candidates are ranked lexicographically by critical path, then area, then power. The bf16 reciprocal normalization path remains an unmeasured hardware gap and is not compared as accepted PPA.
+Measured q8 exact, q8 reciprocal, and bf16 reciprocal candidates are ranked lexicographically by critical path, then area, then power. These physical metrics are comparable only within the current Nangate45 row-8 normalization datapath framing.
 
-Replace the q8 normalization heuristic with merged RTLGen/OpenROAD datapath evidence while preserving quality gates from the decoder sweep.
+Replace the q8 normalization heuristic with merged RTLGen/OpenROAD datapath evidence and compare it with the measured bf16 reciprocal anchor while preserving quality gates from the decoder sweep.
 
 ## Quality And Normalization PPA
 
 | template | role | gate | next-token | top-k | norm mode | recip bits | rank source | critical_path_ns | die_area | total_power_mw |
 |---|---|---|---:|---:|---|---:|---|---:|---:|---:|
+| `grid_approx_pwl_bf16_path` | `bf16_primary_anchor` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_float` |  | `measured_bf16_reciprocal_datapath_ppa` | 4.2869 | 50690.271025 | 0.00479 |
 | `grid_approx_pwl_in_q8_w_q8_norm_recip_q10` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 10 | `measured_q8_reciprocal_datapath_ppa` | 5.6126 | 39776.3136 | 0.00463 |
 | `grid_approx_pwl_in_q8_w_q8_norm_recip_q12` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 12 | `measured_q8_reciprocal_datapath_ppa` | 5.7554 | 52118.607025 | 0.014 |
 | `grid_approx_pwl_in_q8_w_q8_norm_recip_q14` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 14 | `measured_q8_reciprocal_datapath_ppa` | 5.7617 | 52360.880625 | 0.00637 |
 | `grid_approx_pwl_in_q8_w_q8_norm_recip_q16` | `q8_reciprocal_candidate` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_quantized` | 16 | `measured_q8_reciprocal_datapath_ppa` | 5.814 | 45315.765625 | 0.0321 |
 | `grid_approx_pwl_in_q8_w_q8_norm_exact` | `q8_exact_normalization_baseline` | `exact_safe_survivor` | 24/24 | 24/24 | `exact` |  | `measured_q8_exact_datapath_ppa` | 20.2712 | 105898.1764 | 1.11 |
-| `grid_approx_pwl_bf16_path` | `bf16_primary_anchor` | `exact_safe_survivor` | 24/24 | 24/24 | `reciprocal_float` |  | `unmeasured_gap` |  |  |  |
 
 ## Blocked Rows
 
@@ -31,5 +31,5 @@ Replace the q8 normalization heuristic with merged RTLGen/OpenROAD datapath evid
 
 ## Next Step
 
-- Implement and measure bf16 reciprocal/multiply normalization before making a q8-versus-bf16 hardware decision.
-- Use the measured q8 exact baseline as the current reference point for q8 reciprocal normalization tradeoffs.
+- Treat the bf16 and q8 reciprocal measurements as current row-8 Nangate45 datapath evidence, not distribution-robust architecture proof.
+- Broaden weight/input distribution coverage before making a final q8-versus-bf16 normalization decision.

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.json
@@ -784,27 +784,36 @@
     "bf16/fp16 probability and reciprocal software paths preserve next-token and top-k on the current fp-format and distribution sweeps.",
     "fixed q8 probability output storage is blocked on the distribution robustness sweep, while q8/q6 logit quantization remains exact-safe there.",
     "fp8 probability storage is not a current frontier candidate: e5m2 drops samples and e4m3 is blocked in both sweeps.",
-    "q8 reciprocal normalization now has measured integrated PPA; bf16 reciprocal normalization still needs a measurable datapath before PPA comparison."
+    "q8 reciprocal and bf16 reciprocal normalization now have measured integrated PPA for the current row-8 Nangate45 datapath framing."
   ],
   "next_step": [
-    "Keep q8 reciprocal as the immediate measured hardware frontier.",
-    "Use issue #297 to add and measure a bf16 reciprocal normalization datapath before claiming q8-versus-bf16 PPA superiority.",
+    "Use the measured q8 reciprocal and bf16 reciprocal datapaths as the immediate hardware frontier.",
     "Broaden distribution coverage before treating these exact-safe rows as generally robust across weights and prompts."
   ],
   "q8_norm_frontier": {
     "decision": {
-      "decision": "q8_reciprocal_candidate_survived",
-      "reason": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10 preserved the exact prompt-stress gate and has the best measured_q8_reciprocal_datapath_ppa among exact-safe q8 reciprocal candidates. q8 exact is included as measured baseline PPA; bf16 reciprocal normalization remains an unmeasured hardware gap.",
-      "selected_candidate": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
+      "decision": "measured_frontier_candidate_selected",
+      "reason": "grid_approx_pwl_bf16_path preserved the exact prompt-stress gate and has the best measured_bf16_reciprocal_datapath_ppa among exact-safe measured normalization candidates. The best exact-safe q8 reciprocal row remains grid_approx_pwl_in_q8_w_q8_norm_recip_q10.",
+      "selected_candidate": "grid_approx_pwl_bf16_path"
     },
     "measured_rows": [
+      {
+        "ppa_metrics": {
+          "critical_path_ns": 4.2869,
+          "die_area": 50690.271025,
+          "total_power_mw": 0.00479
+        },
+        "rank": 1,
+        "rank_source": "measured_bf16_reciprocal_datapath_ppa",
+        "template": "grid_approx_pwl_bf16_path"
+      },
       {
         "ppa_metrics": {
           "critical_path_ns": 5.6126,
           "die_area": 39776.3136,
           "total_power_mw": 0.00463
         },
-        "rank": 1,
+        "rank": 2,
         "rank_source": "measured_q8_reciprocal_datapath_ppa",
         "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
       },
@@ -814,7 +823,7 @@
           "die_area": 52118.607025,
           "total_power_mw": 0.014
         },
-        "rank": 2,
+        "rank": 3,
         "rank_source": "measured_q8_reciprocal_datapath_ppa",
         "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q12"
       },
@@ -824,7 +833,7 @@
           "die_area": 52360.880625,
           "total_power_mw": 0.00637
         },
-        "rank": 3,
+        "rank": 4,
         "rank_source": "measured_q8_reciprocal_datapath_ppa",
         "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q14"
       },
@@ -834,7 +843,7 @@
           "die_area": 45315.765625,
           "total_power_mw": 0.0321
         },
-        "rank": 4,
+        "rank": 5,
         "rank_source": "measured_q8_reciprocal_datapath_ppa",
         "template": "grid_approx_pwl_in_q8_w_q8_norm_recip_q16"
       },
@@ -844,7 +853,7 @@
           "die_area": 105898.1764,
           "total_power_mw": 1.11
         },
-        "rank": 5,
+        "rank": 6,
         "rank_source": "measured_q8_exact_datapath_ppa",
         "template": "grid_approx_pwl_in_q8_w_q8_norm_exact"
       }

--- a/runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.md
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/decoder_quantization_outline__l2_decoder_quantization_outline_v1.md
@@ -9,7 +9,7 @@
 - bf16/fp16 probability and reciprocal software paths preserve next-token and top-k on the current fp-format and distribution sweeps.
 - fixed q8 probability output storage is blocked on the distribution robustness sweep, while q8/q6 logit quantization remains exact-safe there.
 - fp8 probability storage is not a current frontier candidate: e5m2 drops samples and e4m3 is blocked in both sweeps.
-- q8 reciprocal normalization now has measured integrated PPA; bf16 reciprocal normalization still needs a measurable datapath before PPA comparison.
+- q8 reciprocal and bf16 reciprocal normalization now have measured integrated PPA for the current row-8 Nangate45 datapath framing.
 
 ## Comparable Dimensions
 
@@ -93,14 +93,14 @@
 
 ## Measured Q8 Normalization PPA
 
-- `grid_approx_pwl_in_q8_w_q8_norm_recip_q10` rank 1 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.6126, die_area=39776.3136, total_power_mw=0.00463
-- `grid_approx_pwl_in_q8_w_q8_norm_recip_q12` rank 2 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.7554, die_area=52118.607025, total_power_mw=0.014
-- `grid_approx_pwl_in_q8_w_q8_norm_recip_q14` rank 3 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.7617, die_area=52360.880625, total_power_mw=0.00637
-- `grid_approx_pwl_in_q8_w_q8_norm_recip_q16` rank 4 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.814, die_area=45315.765625, total_power_mw=0.0321
-- `grid_approx_pwl_in_q8_w_q8_norm_exact` rank 5 via `measured_q8_exact_datapath_ppa`: critical_path_ns=20.2712, die_area=105898.1764, total_power_mw=1.11
+- `grid_approx_pwl_bf16_path` rank 1 via `measured_bf16_reciprocal_datapath_ppa`: critical_path_ns=4.2869, die_area=50690.271025, total_power_mw=0.00479
+- `grid_approx_pwl_in_q8_w_q8_norm_recip_q10` rank 2 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.6126, die_area=39776.3136, total_power_mw=0.00463
+- `grid_approx_pwl_in_q8_w_q8_norm_recip_q12` rank 3 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.7554, die_area=52118.607025, total_power_mw=0.014
+- `grid_approx_pwl_in_q8_w_q8_norm_recip_q14` rank 4 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.7617, die_area=52360.880625, total_power_mw=0.00637
+- `grid_approx_pwl_in_q8_w_q8_norm_recip_q16` rank 5 via `measured_q8_reciprocal_datapath_ppa`: critical_path_ns=5.814, die_area=45315.765625, total_power_mw=0.0321
+- `grid_approx_pwl_in_q8_w_q8_norm_exact` rank 6 via `measured_q8_exact_datapath_ppa`: critical_path_ns=20.2712, die_area=105898.1764, total_power_mw=1.11
 
 ## Next Step
 
-- Keep q8 reciprocal as the immediate measured hardware frontier.
-- Use issue #297 to add and measure a bf16 reciprocal normalization datapath before claiming q8-versus-bf16 PPA superiority.
+- Use the measured q8 reciprocal and bf16 reciprocal datapaths as the immediate hardware frontier.
 - Broaden distribution coverage before treating these exact-safe rows as generally robust across weights and prompts.

--- a/tests/fixtures/bf16_recip_norm_datapath_ppa.json
+++ b/tests/fixtures/bf16_recip_norm_datapath_ppa.json
@@ -1,0 +1,18 @@
+{
+  "version": 0.1,
+  "proposals": [
+    {
+      "metrics_ref": {
+        "metrics_csv": "runs/designs/activations/bf16_recip_norm_r8_wrapper/metrics.csv",
+        "platform": "nangate45",
+        "status": "ok",
+        "result_path": "runs/designs/activations/bf16_recip_norm_r8_wrapper/work/707ea19f/result.json"
+      },
+      "metric_summary": {
+        "critical_path_ns": 4.2869,
+        "die_area": 50690.271025,
+        "total_power_mw": 0.00479
+      }
+    }
+  ]
+}

--- a/tests/test_llm_decoder_q8_norm_frontier.py
+++ b/tests/test_llm_decoder_q8_norm_frontier.py
@@ -29,17 +29,30 @@ def test_q8_normalization_frontier_report_selects_lowest_cost_exact_safe_recipro
         sweep_path=Path("tests/fixtures/decoder_q8_norm_frontier_sweep.json"),
         q8_recip_ppa_path=Path("tests/fixtures/q8_recip_norm_datapath_ppa.json"),
         q8_exact_ppa_path=Path("tests/fixtures/q8_exact_norm_datapath_ppa.json"),
+        bf16_recip_ppa_path=Path("tests/fixtures/bf16_recip_norm_datapath_ppa.json"),
     )
 
-    assert report["decision"]["decision"] == "q8_reciprocal_candidate_survived"
-    assert report["decision"]["selected_candidate"] == "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
-    assert report["cost_model"]["source"] == "rtlgen_openroad_q8_exact_and_reciprocal_datapath_metrics"
+    assert report["decision"]["decision"] == "measured_frontier_candidate_selected"
+    assert report["decision"]["selected_candidate"] == "grid_approx_pwl_bf16_path"
+    assert (
+        report["cost_model"]["source"]
+        == "rtlgen_openroad_q8_exact_q8_reciprocal_and_bf16_reciprocal_datapath_metrics"
+    )
     assert report["cost_model"]["unit"] == "nangate45_physical_metrics"
     assert (
         report["cost_model"]["rtlgen_calibration_proposal"]
-        == "prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1"
+        == "prop_l1_decoder_q8_recip_norm_datapath_v1_and_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_and_prop_l1_decoder_bf16_recip_norm_datapath_v1"
     )
     by_template = {row["template"]: row for row in report["ranked_rows"]}
+    assert by_template["grid_approx_pwl_bf16_path"]["rank"] == 1
+    assert (
+        by_template["grid_approx_pwl_bf16_path"]["normalization"]["calibration_status"]
+        == "integrated_bf16_reciprocal_datapath_measured"
+    )
+    assert (
+        by_template["grid_approx_pwl_bf16_path"]["normalization"]["ppa_metrics"]["critical_path_ns"]
+        == 4.2869
+    )
     assert by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["quality"]["exact_safe"]
     assert (
         by_template["grid_approx_pwl_in_q8_w_q8_norm_recip_q10"]["normalization"]["calibration_status"]

--- a/tests/test_llm_decoder_quantization_outline.py
+++ b/tests/test_llm_decoder_quantization_outline.py
@@ -17,7 +17,12 @@ def test_decoder_quantization_outline_groups_comparable_dimensions() -> None:
     assert "grid_prob_q8" in by_dimension["probability_output_format"]["summary"]["blocked_templates"]
     assert "grid_prob_bf16" in by_dimension["probability_output_format"]["summary"]["exact_safe_templates"]
     assert "grid_approx_pwl_bf16_path" in by_dimension["approximate_pwl_probability_path"]["summary"]["exact_safe_templates"]
-    assert report["q8_norm_frontier"]["decision"]["selected_candidate"] == "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"
+    assert report["q8_norm_frontier"]["decision"]["selected_candidate"] == "grid_approx_pwl_bf16_path"
+    assert any(
+        row["template"] == "grid_approx_pwl_bf16_path"
+        and row["rank_source"] == "measured_bf16_reciprocal_datapath_ppa"
+        for row in report["q8_norm_frontier"]["measured_rows"]
+    )
     assert any(
         row["template"] == "grid_approx_pwl_in_q8_w_q8_norm_exact"
         for row in report["q8_norm_frontier"]["measured_rows"]


### PR DESCRIPTION
## Summary
- add the merged bf16 reciprocal normalization PPA artifact as an estimator input
- rank bf16, q8 reciprocal, and q8 exact normalization rows from measured Nangate45 metrics
- regenerate the q8 normalization frontier and quantization outline reports

## Validation
- PYTHONPATH=/workspaces/RTLGen /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q tests/test_llm_decoder_q8_norm_frontier.py tests/test_llm_decoder_quantization_outline.py
- python3 -m py_compile npu/eval/estimate_llm_decoder_q8_norm_frontier.py npu/eval/estimate_llm_decoder_quantization_outline.py