### PR TITLE
Add q8 bf16 norm distribution L2 job hook

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -863,6 +863,7 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
         "control_plane/shadow_exports/l1_promotions/"
         "l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json"
     )
+    bf16_recip_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_recip_norm_datapath_v1_r2.json"
     rough_grid = "decoder_q8_normalization_frontier_v1"
     commands = [
         {
@@ -913,6 +914,7 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
                 f"--sweep {sweep_out} "
                 f"--q8-recip-ppa {q8_recip_ppa} "
                 f"--q8-exact-ppa {q8_exact_ppa} "
+                f"--bf16-recip-ppa {bf16_recip_ppa} "
                 f"--out {frontier_out} "
                 f"--out-md {frontier_report}"
             ),
@@ -935,10 +937,123 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
             "frontier_report": frontier_report,
             "q8_reciprocal_datapath_ppa": q8_recip_ppa,
             "q8_exact_datapath_ppa": q8_exact_ppa,
+            "bf16_reciprocal_datapath_ppa": bf16_recip_ppa,
             "candidate_sweep_scope": (
                 "focused q8 PWL normalization frontier over exact normalization and quantized reciprocal "
                 "normalization bit widths on the prompt-stress dataset, with q8 exact and q8 reciprocal "
                 "ranking backed by merged integrated datapath PPA when available"
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            reference_manifest,
+            candidate_manifest,
+            validation_out,
+            quality_out,
+            sweep_out,
+            frontier_out,
+            frontier_report,
+        ],
+    }
+
+
+def _decoder_q8_normalization_distribution_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    dataset_manifest = f"{base}/manifest_distribution_v1.json"
+    reference_dir = f"{base}/reference_distribution_v1"
+    reference_manifest = f"{base}/reference_distribution_v1_manifest.json"
+    candidate_dir = f"{base}/candidate_distribution_v1"
+    candidate_manifest = f"{base}/candidate_distribution_v1_manifest.json"
+    validation_out = f"{base}/decoder_contract_validation__{item_id}.json"
+    quality_out = f"{base}/decoder_quality_compare__{item_id}.json"
+    sweep_dir = f"{base}/candidate_sweeps/{item_id}"
+    sweep_out = f"{base}/decoder_quality_sweep__{item_id}.json"
+    frontier_out = f"{base}/decoder_q8_norm_frontier__{item_id}.json"
+    frontier_report = f"{base}/decoder_q8_norm_frontier__{item_id}.md"
+    q8_recip_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json"
+    q8_exact_ppa = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json"
+    )
+    bf16_recip_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_recip_norm_datapath_v1_r2.json"
+    rough_grid = "decoder_q8_normalization_frontier_v1"
+    commands = [
+        {
+            "name": "generate_decoder_q8_norm_distribution_reference",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_reference_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {reference_dir} "
+                f"--out-manifest {reference_manifest}"
+            ),
+        },
+        {
+            "name": "generate_decoder_q8_norm_distribution_candidate",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_candidate_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {candidate_dir} "
+                f"--out-manifest {candidate_manifest}"
+            ),
+        },
+        {
+            "name": "validate_decoder_q8_norm_distribution_contract",
+            "run": f"python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest {dataset_manifest} --out {validation_out}",
+        },
+        {
+            "name": "compare_decoder_q8_norm_distribution_quality",
+            "run": (
+                "python3 npu/eval/compare_llm_decoder_quality.py "
+                f"--reference-manifest {reference_manifest} "
+                f"--candidate-manifest {candidate_manifest} "
+                f"--out {quality_out}"
+            ),
+        },
+        {
+            "name": "sweep_decoder_q8_norm_distribution_frontier",
+            "run": (
+                "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--rough-grid {rough_grid} "
+                f"--out-dir {sweep_dir} "
+                f"--out {sweep_out}"
+            ),
+        },
+        {
+            "name": "estimate_decoder_q8_norm_distribution_frontier",
+            "run": (
+                "python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py "
+                f"--sweep {sweep_out} "
+                f"--q8-recip-ppa {q8_recip_ppa} "
+                f"--q8-exact-ppa {q8_exact_ppa} "
+                f"--bf16-recip-ppa {bf16_recip_ppa} "
+                f"--out {frontier_out} "
+                f"--out-md {frontier_report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            "dataset_manifest": dataset_manifest,
+            "sample_file": f"{base}/samples_distribution_v1.jsonl",
+            "reference_manifest": reference_manifest,
+            "candidate_manifest": candidate_manifest,
+            "reference_dir": reference_dir,
+            "candidate_dir": candidate_dir,
+            "validation_out": validation_out,
+            "quality_out": quality_out,
+            "candidate_sweep_dir": sweep_dir,
+            "candidate_sweep_out": sweep_out,
+            "candidate_sweep_grid": rough_grid,
+            "frontier_out": frontier_out,
+            "frontier_report": frontier_report,
+            "q8_reciprocal_datapath_ppa": q8_recip_ppa,
+            "q8_exact_datapath_ppa": q8_exact_ppa,
+            "bf16_reciprocal_datapath_ppa": bf16_recip_ppa,
+            "candidate_sweep_scope": (
+                "broader distribution robustness check for the q8-vs-bf16 normalization frontier "
+                "over the distribution dataset, using the same q8 reciprocal bit-width grid and "
+                "measured q8/bf16 normalization datapath PPA artifacts"
             ),
         },
         "commands": commands,
@@ -1101,10 +1216,13 @@ def _build_payload(
         "decoder_survivor_cost_proxy",
         "decoder_pwl_frontier_detail",
         "decoder_q8_normalization_frontier",
+        "decoder_q8_normalization_distribution",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_q8_normalization_distribution":
+            decoder_evidence = _decoder_q8_normalization_distribution_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_q8_normalization_frontier":
             decoder_evidence = _decoder_q8_normalization_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pwl_frontier_detail":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -674,6 +674,11 @@ def test_generate_l2_campaign_task_adds_decoder_q8_normalization_frontier_eviden
                 in work_item.command_manifest[5]["run"]
             )
             assert (
+                "--bf16-recip-ppa control_plane/shadow_exports/l1_promotions/"
+                "l1_decoder_bf16_recip_norm_datapath_v1_r2.json"
+                in work_item.command_manifest[5]["run"]
+            )
+            assert (
                 decoder_inputs["q8_reciprocal_datapath_ppa"]
                 == "control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json"
             )
@@ -682,10 +687,75 @@ def test_generate_l2_campaign_task_adds_decoder_q8_normalization_frontier_eviden
                 == "control_plane/shadow_exports/l1_promotions/"
                 "l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json"
             )
+            assert (
+                decoder_inputs["bf16_reciprocal_datapath_ppa"]
+                == "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_recip_norm_datapath_v1_r2.json"
+            )
             assert decoder_inputs["frontier_out"] in work_item.expected_outputs
             assert decoder_inputs["frontier_report"] in work_item.expected_outputs
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "decoder_q8_normalization_frontier",
+            }
+
+
+def test_generate_l2_campaign_task_adds_decoder_q8_normalization_distribution_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_q8_norm_distribution_robustness_v1",
+                    proposal_id="prop_l2_decoder_q8_norm_distribution_robustness_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_q8_norm_distribution_robustness_v1/proposal.json",
+                    evaluation_mode="broad_ranking",
+                    abstraction_layer="decoder_q8_normalization_distribution",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:6] == [
+                "generate_decoder_q8_norm_distribution_reference",
+                "generate_decoder_q8_norm_distribution_candidate",
+                "validate_decoder_q8_norm_distribution_contract",
+                "compare_decoder_q8_norm_distribution_quality",
+                "sweep_decoder_q8_norm_distribution_frontier",
+                "estimate_decoder_q8_norm_distribution_frontier",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["dataset_manifest"] == "runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v1.json"
+            assert decoder_inputs["sample_file"] == "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v1.jsonl"
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_q8_normalization_frontier_v1"
+            assert "broader distribution robustness" in decoder_inputs["candidate_sweep_scope"]
+            assert "--rough-grid decoder_q8_normalization_frontier_v1" in work_item.command_manifest[4]["run"]
+            assert "estimate_llm_decoder_q8_norm_frontier.py" in work_item.command_manifest[5]["run"]
+            assert (
+                "--bf16-recip-ppa control_plane/shadow_exports/l1_promotions/"
+                "l1_decoder_bf16_recip_norm_datapath_v1_r2.json"
+                in work_item.command_manifest[5]["run"]
+            )
+            assert decoder_inputs["frontier_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_q8_norm_frontier__l2_decoder_q8_norm_distribution_robustness_v1.json"
+            )
+            assert decoder_inputs["frontier_out"] in work_item.expected_outputs
+            assert decoder_inputs["frontier_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_q8_normalization_distribution",
             }
 
 


### PR DESCRIPTION
## Summary
- add a decoder_q8_normalization_distribution L2 evidence hook using the distribution dataset
- run the existing q8 reciprocal normalization grid against broader distribution samples
- pass the bf16 reciprocal PPA artifact explicitly in q8 normalization frontier generation

## Validation
- PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_q8_norm_frontier.py tests/test_llm_decoder_quantization_outline.py
- python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py npu/eval/estimate_llm_decoder_q8_norm_frontier.py