### PR TITLE
Make decoder backend commands checkout-portable

### DIFF
--- a/npu/eval/decoder_backend.py
+++ b/npu/eval/decoder_backend.py
@@ -24,6 +24,88 @@ from npu.eval.llm_decoder_quality import (
 
 JsonDict = Dict[str, Any]
 
+_REPO_PATH_MARKERS = frozenset({'control_plane', 'docs', 'examples', 'npu', 'runs', 'scripts', 'tests'})
+
+
+def _path_has_tail(path: Path, tail: Sequence[str]) -> bool:
+    parts = path.parts
+    tail_tuple = tuple(tail)
+    return len(parts) >= len(tail_tuple) and tuple(parts[-len(tail_tuple):]) == tail_tuple
+
+
+def _repo_relative_path(path: Path) -> Path | None:
+    parts = path.parts
+    for idx, part in enumerate(parts):
+        if part in _REPO_PATH_MARKERS:
+            return Path(*parts[idx:])
+    return None
+
+
+def _preferred_python_executable() -> str:
+    for rel in (Path('control_plane/.venv/bin/python3'), Path('control_plane/.venv/bin/python')):
+        candidate = REPO_ROOT / rel
+        if candidate.exists():
+            return str(candidate)
+    return sys.executable
+
+
+def _is_decoder_runner_path(path_text: str) -> bool:
+    path = Path(path_text)
+    rel = _repo_relative_path(path) if path.is_absolute() else path
+    if rel is None:
+        return False
+    rel_text = rel.as_posix()
+    return rel_text in {
+        'npu/eval/run_llm_decoder_onnx_candidate.py',
+        'npu/eval/run_llm_decoder_onnx_reference.py',
+    }
+
+
+def _normalize_decoder_command(command: Any) -> Any:
+    if isinstance(command, str):
+        argv = shlex.split(command)
+    elif isinstance(command, list):
+        argv = [str(part) for part in command]
+    else:
+        return command
+    if not argv:
+        return command
+
+    normalized: list[str] = []
+    for idx, part in enumerate(argv):
+        path = Path(part)
+        if idx == 0 and path.is_absolute() and (
+            _path_has_tail(path, ('control_plane', '.venv', 'bin', 'python'))
+            or _path_has_tail(path, ('control_plane', '.venv', 'bin', 'python3'))
+        ):
+            normalized.append('python3')
+            continue
+        if path.is_absolute():
+            repo_rel = _repo_relative_path(path)
+            if repo_rel is not None:
+                normalized.append(repo_rel.as_posix())
+                continue
+        normalized.append(part)
+
+    if normalized == argv:
+        return command
+    return normalized
+
+
+def _execution_command_argv(argv: Sequence[str]) -> list[str]:
+    out = [str(part) for part in argv]
+    if len(out) >= 2 and out[0] in {'python', 'python3'} and _is_decoder_runner_path(out[1]):
+        out[0] = _preferred_python_executable()
+    for idx, part in enumerate(out):
+        path = Path(part)
+        if path.is_absolute():
+            repo_rel = _repo_relative_path(path)
+            if repo_rel is not None:
+                out[idx] = str(REPO_ROOT / repo_rel)
+        elif path.parts and path.parts[0] in _REPO_PATH_MARKERS:
+            out[idx] = str(REPO_ROOT / path)
+    return out
+
 
 @dataclass(frozen=True)
 class DecoderBackendContext:
@@ -266,6 +348,7 @@ class CommandJsonV1Backend:
         normalized['backend_id'] = self.backend_id
         normalized['role'] = role
         normalized['interface'] = 'decoder_backend_v1'
+        normalized['command'] = _normalize_decoder_command(normalized.get('command', []))
         return normalized
 
     def _default_prompt(self, *, context: DecoderBackendContext, sample: JsonDict) -> JsonDict:
@@ -308,6 +391,7 @@ class CommandJsonV1Backend:
 
     def _run_command(self, *, context: DecoderBackendContext, sample: JsonDict, normalized: JsonDict) -> JsonDict:
         argv = self._command_argv(normalized.get('command', []))
+        exec_argv = _execution_command_argv(argv)
         env = os.environ.copy()
         env_overrides = normalized.get('env', {}) or {}
         for key, value in dict(env_overrides).items():
@@ -327,7 +411,7 @@ class CommandJsonV1Backend:
             },
         }
         proc = subprocess.run(
-            argv,
+            exec_argv,
             input=json.dumps(request),
             text=True,
             capture_output=True,
@@ -438,4 +522,6 @@ def resolve_decoder_backend_config(dataset_manifest: JsonDict, model_contract: J
         config.update(dict(dataset_cfgs[role]))
     config['role'] = role
     config['interface'] = 'decoder_backend_v1'
+    if str(config.get('backend_id', '')) == 'command_json_v1':
+        config['command'] = _normalize_decoder_command(config.get('command', []))
     return config

--- a/runs/datasets/llm_decoder_eval_tiny_v1/manifest.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/manifest.json
@@ -6,7 +6,7 @@
       "backend_id": "command_json_v1",
       "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
       "command": [
-        "/workspaces/RTLGen/control_plane/.venv/bin/python",
+        "python3",
         "npu/eval/run_llm_decoder_onnx_candidate.py"
       ],
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
@@ -26,7 +26,7 @@
     "reference": {
       "backend_id": "command_json_v1",
       "command": [
-        "/workspaces/RTLGen/control_plane/.venv/bin/python",
+        "python3",
         "npu/eval/run_llm_decoder_onnx_reference.py"
       ],
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",

--- a/runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v1.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v1.json
@@ -6,7 +6,7 @@
       "backend_id": "command_json_v1",
       "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
       "command": [
-        "/workspaces/RTLGen/control_plane/.venv/bin/python",
+        "python3",
         "npu/eval/run_llm_decoder_onnx_candidate.py"
       ],
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
@@ -26,7 +26,7 @@
     "reference": {
       "backend_id": "command_json_v1",
       "command": [
-        "/workspaces/RTLGen/control_plane/.venv/bin/python",
+        "python3",
         "npu/eval/run_llm_decoder_onnx_reference.py"
       ],
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",

--- a/runs/datasets/llm_decoder_eval_tiny_v1/manifest_prompt_stress_v1.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/manifest_prompt_stress_v1.json
@@ -6,7 +6,7 @@
       "backend_id": "command_json_v1",
       "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
       "command": [
-        "/workspaces/RTLGen/control_plane/.venv/bin/python",
+        "python3",
         "npu/eval/run_llm_decoder_onnx_candidate.py"
       ],
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
@@ -26,7 +26,7 @@
     "reference": {
       "backend_id": "command_json_v1",
       "command": [
-        "/workspaces/RTLGen/control_plane/.venv/bin/python",
+        "python3",
         "npu/eval/run_llm_decoder_onnx_reference.py"
       ],
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",

--- a/runs/models/llm_decoder_tiny_v1/model_contract.json
+++ b/runs/models/llm_decoder_tiny_v1/model_contract.json
@@ -44,7 +44,7 @@
       "backend_id": "command_json_v1",
       "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_q4_w_q4_norm_recip_q10_prob_fp",
       "command": [
-        "/workspaces/RTLGen/control_plane/.venv/bin/python",
+        "python3",
         "npu/eval/run_llm_decoder_onnx_candidate.py"
       ],
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
@@ -67,7 +67,7 @@
     "candidate_onnx_softmax_exact": {
       "backend_id": "command_json_v1",
       "command": [
-        "/workspaces/RTLGen/control_plane/.venv/bin/python",
+        "python3",
         "npu/eval/run_llm_decoder_onnx_candidate.py"
       ],
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
@@ -87,7 +87,7 @@
     "reference_onnx": {
       "backend_id": "command_json_v1",
       "command": [
-        "/workspaces/RTLGen/control_plane/.venv/bin/python",
+        "python3",
         "npu/eval/run_llm_decoder_onnx_reference.py"
       ],
       "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",

--- a/runs/models/llm_decoder_tiny_v1/reference_onnx_binding.json
+++ b/runs/models/llm_decoder_tiny_v1/reference_onnx_binding.json
@@ -5,7 +5,7 @@
   "purpose": "exact_reference",
   "runtime": {
     "backend_id": "command_json_v1",
-    "runner": "/workspaces/RTLGen/control_plane/.venv/bin/python npu/eval/run_llm_decoder_onnx_reference.py",
+    "runner": "python3 npu/eval/run_llm_decoder_onnx_reference.py",
     "runtime_target": "cpu_reference",
     "library": "onnxruntime"
   },

--- a/tests/test_llm_decoder_quality.py
+++ b/tests/test_llm_decoder_quality.py
@@ -232,6 +232,45 @@ class LlmDecoderQualityRegressionTest(unittest.TestCase):
         self.assertNotIn('candidate_rule', cfg)
         self.assertEqual('decoder_backend_v1', cfg['interface'])
 
+    def test_backend_config_resolution_localizes_stale_repo_command_paths(self):
+        dataset_manifest = {
+            'decoder_backend_configs': {
+                'reference': {
+                    'backend_id': 'command_json_v1',
+                    'command': [
+                        '/workspaces/RTLGen/control_plane/.venv/bin/python',
+                        '/workspaces/RTLGen/npu/eval/run_llm_decoder_onnx_reference.py',
+                    ],
+                    'runtime_target': 'cpu_reference',
+                }
+            }
+        }
+        model_contract = {'backend_configs': {}}
+        cfg = self.decoder.resolve_decoder_backend_config(dataset_manifest, model_contract, role='reference')
+        self.assertEqual(['python3', 'npu/eval/run_llm_decoder_onnx_reference.py'], cfg['command'])
+
+    def test_backend_config_resolution_keeps_portable_command_paths(self):
+        dataset_manifest = {
+            'decoder_backend_configs': {
+                'reference': {
+                    'backend_id': 'command_json_v1',
+                    'command': ['python3', 'npu/eval/run_llm_decoder_onnx_reference.py'],
+                    'runtime_target': 'cpu_reference',
+                }
+            }
+        }
+        model_contract = {'backend_configs': {}}
+        cfg = self.decoder.resolve_decoder_backend_config(dataset_manifest, model_contract, role='reference')
+        self.assertEqual(['python3', 'npu/eval/run_llm_decoder_onnx_reference.py'], cfg['command'])
+
+    def test_command_backend_executes_portable_runner_with_checkout_python(self):
+        argv = self.backend_mod._execution_command_argv(
+            ['python3', 'npu/eval/run_llm_decoder_onnx_reference.py']
+        )
+        expected_python = REPO_ROOT / 'control_plane/.venv/bin/python3'
+        self.assertEqual(str(expected_python if expected_python.exists() else Path(sys.executable)), argv[0])
+        self.assertEqual(str(REPO_ROOT / 'npu/eval/run_llm_decoder_onnx_reference.py'), argv[1])
+
     def test_build_decoder_reference_doc_binds_backend_metadata(self):
         dataset_manifest = {
             'dataset_id': 'llm_decoder_eval_tiny_v1',
@@ -405,7 +444,7 @@ json.dump(out, sys.stdout)
             self.assertEqual('cpu_reference_v1', doc['backend']['equivalence_group'])
             self.assertEqual(' Paris', doc['reference']['next_token_text'])
             self.assertEqual('unit_test', doc['backend_runtime']['runner'])
-            self.assertEqual([sys.executable, str(runner)], doc['backend_invocation']['command'])
+            self.assertEqual(['python3', str(runner)], doc['backend_invocation']['command'])
 
     def test_command_json_backend_executes_candidate_runner(self):
         with tempfile.TemporaryDirectory() as td:
@@ -464,7 +503,7 @@ json.dump(out, sys.stdout)
             self.assertEqual(3, doc['candidate']['next_token_id'])
             self.assertEqual(' =', doc['candidate']['next_token_text'])
             self.assertEqual('external_command_stub', doc['candidate_semantics'])
-            self.assertEqual([sys.executable, str(runner)], doc['backend_invocation']['command'])
+            self.assertEqual(['python3', str(runner)], doc['backend_invocation']['command'])
 
     def test_replay_backend_rehydrates_reference_doc_from_manifest(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- normalize stale repo-root decoder backend command paths into portable python3/repo-relative forms
- execute portable decoder runner commands with the checkout-local control_plane venv when present, falling back to the active interpreter
- replace committed LLM decoder manifests/model bindings that embedded /workspaces/RTLGen interpreter paths

## Validation
- PYTHONPATH=/workspaces/RTLGen /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q tests/test_llm_decoder_quality.py tests/test_llm_decoder_onnx_runner.py tests/test_llm_decoder_onnx_candidate_runner.py
- PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_quality.py
- python3 -m py_compile npu/eval/decoder_backend.py npu/eval/gen_llm_decoder_reference_suite.py npu/eval/gen_llm_decoder_candidate_suite.py
- python3 npu/eval/gen_llm_decoder_reference_suite.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v1.json --out-dir /tmp/rtlgen-reference-distribution-portable --out-manifest /tmp/rtlgen-reference-distribution-portable-manifest.json
- python3 npu/eval/gen_llm_decoder_candidate_suite.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v1.json --out-dir /tmp/rtlgen-candidate-distribution-portable --out-manifest /tmp/rtlgen-candidate-distribution-portable-manifest.json
- python3 scripts/validate_runs.py --skip_eval_queue