### PR TITLE
Record q8 norm distribution robustness r2 request

### DIFF
--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_robustness_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_robustness_v1/evaluation_requests.json
@@ -1,11 +1,11 @@
 {
   "proposal_id": "prop_l2_decoder_q8_norm_distribution_robustness_v1",
-  "source_commit": "38f3558a17412144bc0437b898fad691b1c2f94b",
+  "source_commit": "96c0af1714a22162e5b92d3f1f7455ff7f56ae4a",
   "requested_items": [
     {
-      "item_id": "l2_decoder_q8_norm_distribution_robustness_v1",
+      "item_id": "l2_decoder_q8_norm_distribution_robustness_v1_r2",
       "task_type": "l2_campaign",
-      "objective": "Run the q8 reciprocal-normalization frontier grid on the broader distribution dataset, compare the measured bf16 reciprocal anchor against q8 exact and q8 reciprocal q10/q12/q14/q16 under distribution shift, and keep PPA ranking grounded in merged Nangate45 datapath metrics.",
+      "objective": "Run the q8 reciprocal-normalization frontier grid on the broader distribution dataset after fixing checkout-portable decoder backend command paths.",
       "evaluation_mode": "broad_ranking",
       "abstraction_layer": "decoder_q8_normalization_distribution",
       "comparison_role": "ranking",
@@ -18,9 +18,12 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "iterate",
-        "reason": "Broader distribution evidence should validate whether the measured bf16 timing advantage and q8 reciprocal tradeoff remain quality-safe beyond the prompt-stress setup."
+        "reason": "Retry should confirm the distribution robustness job now generates reference/candidate artifacts without stale checkout paths."
       },
-      "status": "pending"
+      "status": "pending",
+      "prior_item_ids": [
+        "l2_decoder_q8_norm_distribution_robustness_v1"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update the q8 normalization distribution robustness proposal request to the r2 retry item
- pin the request metadata to the checkout-portable decoder backend command fix source commit
- preserve the prior failed item as retry-base history

## Validation
- bookkeeping-only proposal update
- prior code validation is in PR #311