### PR TITLE
Use repo-local control-plane venv for daemons

### DIFF
--- a/control_plane/pyproject.toml
+++ b/control_plane/pyproject.toml
@@ -22,6 +22,11 @@ api = [
 test = [
   "pytest>=8.0",
 ]
+eval = [
+  "numpy>=1.24",
+  "onnxruntime>=1.17",
+  "tokenizers>=0.15",
+]
 
 [project.scripts]
 rtlgen-control-plane = "control_plane.cli.main:main"

--- a/control_plane/scripts/bootstrap_venv.sh
+++ b/control_plane/scripts/bootstrap_venv.sh
@@ -8,7 +8,7 @@ python3 -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
 
 python -m pip install --upgrade pip
-python -m pip install -e "$ROOT_DIR[test]"
+python -m pip install -e "$ROOT_DIR[test,eval]"
 python -m pip install "psycopg[binary]>=3.2"
 python -m pip install "PyYAML>=6.0"
 

--- a/control_plane/scripts/dispatch_ready_items_service.sh
+++ b/control_plane/scripts/dispatch_ready_items_service.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 
 : "${RTLCP_DATABASE_URL:?RTLCP_DATABASE_URL is required}"
 

--- a/control_plane/scripts/poll_github_service.sh
+++ b/control_plane/scripts/poll_github_service.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 
 : "${RTLCP_DATABASE_URL:?RTLCP_DATABASE_URL is required}"
 

--- a/control_plane/scripts/process_completions_service.sh
+++ b/control_plane/scripts/process_completions_service.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 
 : "${RTLCP_DATABASE_URL:?RTLCP_DATABASE_URL is required}"
 

--- a/control_plane/scripts/refresh_blocked_dependents_service.sh
+++ b/control_plane/scripts/refresh_blocked_dependents_service.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 
 : "${RTLCP_DATABASE_URL:?RTLCP_DATABASE_URL is required}"
 

--- a/control_plane/scripts/report_failure_issues_service.sh
+++ b/control_plane/scripts/report_failure_issues_service.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 
 : "${RTLCP_DATABASE_URL:?RTLCP_DATABASE_URL is required}"
 

--- a/control_plane/scripts/restart_local_control_plane_daemons.sh
+++ b/control_plane/scripts/restart_local_control_plane_daemons.sh
@@ -2,13 +2,12 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 DEFAULT_DATABASE_URL="postgresql+psycopg://rtlgen:rtlgen@localhost:5432/rtlgen_control_plane"
 DEFAULT_REPO_SLUG="yhmtmt/RTLGen"
 
 ACTION="${1:-restart}"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 RUNTIME_DIR="${RTLCP_RUNTIME_DIR:-${REPO_ROOT}/control_plane/runtime_logs/daemons}"
 WORKER_LOG_ROOT="${RTLCP_LOG_ROOT:-${REPO_ROOT}/control_plane/runtime_logs/worker_jobs}"
 

--- a/control_plane/scripts/run_api_service.sh
+++ b/control_plane/scripts/run_api_service.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 
 HOST="${RTLCP_HOST:-0.0.0.0}"
 PORT="${RTLCP_PORT:-8080}"

--- a/control_plane/scripts/run_dev_resolver_service.sh
+++ b/control_plane/scripts/run_dev_resolver_service.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 POLL_SECONDS="${RTLCP_RESOLVER_POLL_SECONDS:-60}"
 
 : "${RTLCP_DATABASE_URL:?RTLCP_DATABASE_URL is required}"

--- a/control_plane/scripts/run_eval_resolver_service.sh
+++ b/control_plane/scripts/run_eval_resolver_service.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 POLL_SECONDS="${RTLCP_RESOLVER_POLL_SECONDS:-60}"
 
 : "${RTLCP_DATABASE_URL:?RTLCP_DATABASE_URL is required}"

--- a/control_plane/scripts/run_worker_daemon_service.sh
+++ b/control_plane/scripts/run_worker_daemon_service.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_VENV_PATH="/workspaces/RTLGen/control_plane/.venv"
 REPO_ROOT="${RTLGEN_SERVICE_REPO:-${REPO_ROOT:-${DEFAULT_SERVICE_REPO}}}"
-VENV_PATH="${VENV_PATH:-${DEFAULT_VENV_PATH}}"
+VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 
 : "${RTLCP_DATABASE_URL:?RTLCP_DATABASE_URL is required}"
 


### PR DESCRIPTION
## Summary
- make control-plane daemon service scripts default to `${REPO_ROOT}/control_plane/.venv` instead of the developer checkout at `/workspaces/RTLGen`
- add an `eval` optional dependency group for LLM decoder reference/candidate runtime dependencies
- bootstrap control-plane venvs with `test,eval` extras so evaluator checkouts include `tokenizers` and `onnxruntime`

## Validation
- bash -n on updated control_plane/scripts/*.sh entrypoints
- PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q tests/test_llm_decoder_quality.py control_plane/control_plane/tests/test_l2_task_generator.py

## Context
The q8 normalization distribution robustness r2 retry still failed on the remote evaluator at reference generation. PR #311 made decoder backend commands checkout-portable, but the remote daemon still needs a repo-local venv with the LLM eval runtime deps. These scripts should make the evaluator refresh deterministic.