### PR TITLE
Record q8 norm distribution robustness r3 request

### DIFF
--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_robustness_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_robustness_v1/evaluation_requests.json
@@ -1,11 +1,11 @@
 {
   "proposal_id": "prop_l2_decoder_q8_norm_distribution_robustness_v1",
-  "source_commit": "96c0af1714a22162e5b92d3f1f7455ff7f56ae4a",
+  "source_commit": "bb5a21e64574b237e3146139d4a6d673870ef558",
   "requested_items": [
     {
-      "item_id": "l2_decoder_q8_norm_distribution_robustness_v1_r2",
+      "item_id": "l2_decoder_q8_norm_distribution_robustness_v1_r3",
       "task_type": "l2_campaign",
-      "objective": "Run the q8 reciprocal-normalization frontier grid on the broader distribution dataset after fixing checkout-portable decoder backend command paths.",
+      "objective": "Run the q8 reciprocal-normalization frontier grid on the broader distribution dataset after refreshing the remote evaluator repo-local venv with decoder eval dependencies.",
       "evaluation_mode": "broad_ranking",
       "abstraction_layer": "decoder_q8_normalization_distribution",
       "comparison_role": "ranking",
@@ -18,11 +18,12 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "iterate",
-        "reason": "Retry should confirm the distribution robustness job now generates reference/candidate artifacts without stale checkout paths."
+        "reason": "Retry should confirm the remote evaluator refresh plus checkout-portable decoder commands allow reference/candidate artifact generation to complete."
       },
       "status": "pending",
       "prior_item_ids": [
-        "l2_decoder_q8_norm_distribution_robustness_v1"
+        "l2_decoder_q8_norm_distribution_robustness_v1",
+        "l2_decoder_q8_norm_distribution_robustness_v1_r2"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- update the q8 normalization distribution robustness proposal request to r3
- include the failed base and r2 item IDs as retry history
- pin the request metadata to the repo-local evaluator venv fix source commit

## Validation
- proposal bookkeeping only
- r3 work item is generated but not dispatched until this bookkeeping lands