### PR TITLE
Fix decoder backend venv path in temp worktrees

### DIFF
--- a/npu/eval/decoder_backend.py
+++ b/npu/eval/decoder_backend.py
@@ -98,6 +98,11 @@ def _execution_command_argv(argv: Sequence[str]) -> list[str]:
         out[0] = _preferred_python_executable()
     for idx, part in enumerate(out):
         path = Path(part)
+        if idx == 0 and path.is_absolute() and (
+            _path_has_tail(path, ('control_plane', '.venv', 'bin', 'python'))
+            or _path_has_tail(path, ('control_plane', '.venv', 'bin', 'python3'))
+        ):
+            continue
         if path.is_absolute():
             repo_rel = _repo_relative_path(path)
             if repo_rel is not None:

--- a/tests/test_llm_decoder_quality.py
+++ b/tests/test_llm_decoder_quality.py
@@ -271,6 +271,27 @@ class LlmDecoderQualityRegressionTest(unittest.TestCase):
         self.assertEqual(str(expected_python if expected_python.exists() else Path(sys.executable)), argv[0])
         self.assertEqual(str(REPO_ROOT / 'npu/eval/run_llm_decoder_onnx_reference.py'), argv[1])
 
+    def test_command_backend_preserves_external_venv_python_for_temp_worktree(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_repo_root = self.backend_mod.REPO_ROOT
+            old_executable = self.backend_mod.sys.executable
+            external_python = '/workspaces/rtlgen-eval-clean/control_plane/.venv/bin/python3'
+            try:
+                self.backend_mod.REPO_ROOT = Path(tmpdir) / 'repo'
+                self.backend_mod.sys.executable = external_python
+                argv = self.backend_mod._execution_command_argv(
+                    ['python3', 'npu/eval/run_llm_decoder_onnx_reference.py']
+                )
+            finally:
+                self.backend_mod.REPO_ROOT = old_repo_root
+                self.backend_mod.sys.executable = old_executable
+
+        self.assertEqual(external_python, argv[0])
+        self.assertEqual(
+            str(Path(tmpdir) / 'repo/npu/eval/run_llm_decoder_onnx_reference.py'),
+            argv[1],
+        )
+
     def test_build_decoder_reference_doc_binds_backend_metadata(self):
         dataset_manifest = {
             'dataset_id': 'llm_decoder_eval_tiny_v1',


### PR DESCRIPTION
## Summary
- preserve the selected control-plane venv Python when executing decoder backend runner commands
- keep runner script paths rewritten into the active checkout/worktree
- add a regression test for temp worker worktrees using an external service venv

## Verification
- /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest tests/test_llm_decoder_quality.py
- /workspaces/rtlgen-eval-clean/control_plane/.venv/bin/python3 -m pytest tests/test_llm_decoder_quality.py

Fixes the root cause observed in issue #315: the r3 worker temp checkout rewrote the external venv executable to /tmp/rtlcp-worktree-.../repo/control_plane/.venv/bin/python3.