### PR TITLE
Record q8 norm distribution robustness r4 request

### DIFF
--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_robustness_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_robustness_v1/evaluation_requests.json
@@ -1,11 +1,11 @@
 {
   "proposal_id": "prop_l2_decoder_q8_norm_distribution_robustness_v1",
-  "source_commit": "bb5a21e64574b237e3146139d4a6d673870ef558",
+  "source_commit": "44bb1f281fd62b048e8936e12ae0906b47e77bf7",
   "requested_items": [
     {
-      "item_id": "l2_decoder_q8_norm_distribution_robustness_v1_r3",
+      "item_id": "l2_decoder_q8_norm_distribution_robustness_v1_r4",
       "task_type": "l2_campaign",
-      "objective": "Run the q8 reciprocal-normalization frontier grid on the broader distribution dataset after refreshing the remote evaluator repo-local venv with decoder eval dependencies.",
+      "objective": "Run the q8 reciprocal-normalization frontier grid on the broader distribution dataset after preserving the external service venv Python in worker temp checkouts.",
       "evaluation_mode": "broad_ranking",
       "abstraction_layer": "decoder_q8_normalization_distribution",
       "comparison_role": "ranking",
@@ -18,12 +18,13 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "iterate",
-        "reason": "Retry should confirm the remote evaluator refresh plus checkout-portable decoder commands allow reference/candidate artifact generation to complete."
+        "reason": "Retry should confirm the worker temp-checkout venv path fix allows reference/candidate artifact generation to complete."
       },
       "status": "pending",
       "prior_item_ids": [
         "l2_decoder_q8_norm_distribution_robustness_v1",
-        "l2_decoder_q8_norm_distribution_robustness_v1_r2"
+        "l2_decoder_q8_norm_distribution_robustness_v1_r2",
+        "l2_decoder_q8_norm_distribution_robustness_v1_r3"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- update the q8 normalization distribution robustness proposal request to r4
- include base, r2, and r3 attempts as retry history
- pin request metadata to the decoder backend temp-worktree venv fix

## Validation
- proposal bookkeeping only
- r4 work item generated but not dispatched until this bookkeeping lands