### PR TITLE
Add broad v2 decoder q8 norm distribution job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -957,13 +957,17 @@ def _decoder_q8_normalization_frontier_evidence(*, item_id: str) -> dict[str, An
     }
 
 
-def _decoder_q8_normalization_distribution_evidence(*, item_id: str) -> dict[str, Any]:
+def _decoder_q8_normalization_distribution_evidence(*, item_id: str, distribution_version: str = "v1") -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_tiny_v1"
-    dataset_manifest = f"{base}/manifest_distribution_v1.json"
-    reference_dir = f"{base}/reference_distribution_v1"
-    reference_manifest = f"{base}/reference_distribution_v1_manifest.json"
-    candidate_dir = f"{base}/candidate_distribution_v1"
-    candidate_manifest = f"{base}/candidate_distribution_v1_manifest.json"
+    version = str(distribution_version or "v1").strip()
+    if version not in {"v1", "v2"}:
+        raise Layer2TaskGenerationError(f"unsupported q8 normalization distribution version: {version}")
+    dataset_manifest = f"{base}/manifest_distribution_{version}.json"
+    sample_file = f"{base}/samples_distribution_{version}.jsonl"
+    reference_dir = f"{base}/reference_distribution_{version}"
+    reference_manifest = f"{base}/reference_distribution_{version}_manifest.json"
+    candidate_dir = f"{base}/candidate_distribution_{version}"
+    candidate_manifest = f"{base}/candidate_distribution_{version}_manifest.json"
     validation_out = f"{base}/decoder_contract_validation__{item_id}.json"
     quality_out = f"{base}/decoder_quality_compare__{item_id}.json"
     sweep_dir = f"{base}/candidate_sweeps/{item_id}"
@@ -977,9 +981,11 @@ def _decoder_q8_normalization_distribution_evidence(*, item_id: str) -> dict[str
     )
     bf16_recip_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_recip_norm_datapath_v1_r2.json"
     rough_grid = "decoder_q8_normalization_frontier_v1"
+    command_suffix = "" if version == "v1" else f"_{version}"
+    scope_note = "broader distribution" if version == "v1" else "expanded v2 broad distribution"
     commands = [
         {
-            "name": "generate_decoder_q8_norm_distribution_reference",
+            "name": f"generate_decoder_q8_norm_distribution{command_suffix}_reference",
             "run": (
                 "python3 npu/eval/gen_llm_decoder_reference_suite.py "
                 f"--dataset-manifest {dataset_manifest} "
@@ -988,7 +994,7 @@ def _decoder_q8_normalization_distribution_evidence(*, item_id: str) -> dict[str
             ),
         },
         {
-            "name": "generate_decoder_q8_norm_distribution_candidate",
+            "name": f"generate_decoder_q8_norm_distribution{command_suffix}_candidate",
             "run": (
                 "python3 npu/eval/gen_llm_decoder_candidate_suite.py "
                 f"--dataset-manifest {dataset_manifest} "
@@ -997,11 +1003,11 @@ def _decoder_q8_normalization_distribution_evidence(*, item_id: str) -> dict[str
             ),
         },
         {
-            "name": "validate_decoder_q8_norm_distribution_contract",
+            "name": f"validate_decoder_q8_norm_distribution{command_suffix}_contract",
             "run": f"python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest {dataset_manifest} --out {validation_out}",
         },
         {
-            "name": "compare_decoder_q8_norm_distribution_quality",
+            "name": f"compare_decoder_q8_norm_distribution{command_suffix}_quality",
             "run": (
                 "python3 npu/eval/compare_llm_decoder_quality.py "
                 f"--reference-manifest {reference_manifest} "
@@ -1010,7 +1016,7 @@ def _decoder_q8_normalization_distribution_evidence(*, item_id: str) -> dict[str
             ),
         },
         {
-            "name": "sweep_decoder_q8_norm_distribution_frontier",
+            "name": f"sweep_decoder_q8_norm_distribution{command_suffix}_frontier",
             "run": (
                 "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
                 f"--dataset-manifest {dataset_manifest} "
@@ -1020,7 +1026,7 @@ def _decoder_q8_normalization_distribution_evidence(*, item_id: str) -> dict[str
             ),
         },
         {
-            "name": "estimate_decoder_q8_norm_distribution_frontier",
+            "name": f"estimate_decoder_q8_norm_distribution{command_suffix}_frontier",
             "run": (
                 "python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py "
                 f"--sweep {sweep_out} "
@@ -1035,7 +1041,7 @@ def _decoder_q8_normalization_distribution_evidence(*, item_id: str) -> dict[str
     return {
         "inputs": {
             "dataset_manifest": dataset_manifest,
-            "sample_file": f"{base}/samples_distribution_v1.jsonl",
+            "sample_file": sample_file,
             "reference_manifest": reference_manifest,
             "candidate_manifest": candidate_manifest,
             "reference_dir": reference_dir,
@@ -1051,8 +1057,8 @@ def _decoder_q8_normalization_distribution_evidence(*, item_id: str) -> dict[str
             "q8_exact_datapath_ppa": q8_exact_ppa,
             "bf16_reciprocal_datapath_ppa": bf16_recip_ppa,
             "candidate_sweep_scope": (
-                "broader distribution robustness check for the q8-vs-bf16 normalization frontier "
-                "over the distribution dataset, using the same q8 reciprocal bit-width grid and "
+                f"{scope_note} robustness check for the q8-vs-bf16 normalization frontier "
+                "using the same q8 reciprocal bit-width grid and "
                 "measured q8/bf16 normalization datapath PPA artifacts"
             ),
         },
@@ -1217,10 +1223,13 @@ def _build_payload(
         "decoder_pwl_frontier_detail",
         "decoder_q8_normalization_frontier",
         "decoder_q8_normalization_distribution",
+        "decoder_q8_normalization_distribution_broad_v2",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_q8_normalization_distribution_broad_v2":
+            decoder_evidence = _decoder_q8_normalization_distribution_evidence(item_id=item_id, distribution_version="v2")
         elif abstraction_layer_name == "decoder_q8_normalization_distribution":
             decoder_evidence = _decoder_q8_normalization_distribution_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_q8_normalization_frontier":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -759,6 +759,67 @@ def test_generate_l2_campaign_task_adds_decoder_q8_normalization_distribution_ev
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_q8_normalization_distribution_broad_v2_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_q8_norm_distribution_broad_v2",
+                    proposal_id="prop_l2_decoder_q8_norm_distribution_broad_v2",
+                    proposal_path="docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/proposal.json",
+                    evaluation_mode="broad_ranking",
+                    abstraction_layer="decoder_q8_normalization_distribution_broad_v2",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:6] == [
+                "generate_decoder_q8_norm_distribution_v2_reference",
+                "generate_decoder_q8_norm_distribution_v2_candidate",
+                "validate_decoder_q8_norm_distribution_v2_contract",
+                "compare_decoder_q8_norm_distribution_v2_quality",
+                "sweep_decoder_q8_norm_distribution_v2_frontier",
+                "estimate_decoder_q8_norm_distribution_v2_frontier",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["dataset_manifest"] == "runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json"
+            assert decoder_inputs["sample_file"] == "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl"
+            assert decoder_inputs["reference_manifest"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/reference_distribution_v2_manifest.json"
+            )
+            assert decoder_inputs["candidate_manifest"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/candidate_distribution_v2_manifest.json"
+            )
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_q8_normalization_frontier_v1"
+            assert "expanded v2 broad distribution" in decoder_inputs["candidate_sweep_scope"]
+            assert "--dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json" in (
+                work_item.command_manifest[4]["run"]
+            )
+            assert decoder_inputs["frontier_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_q8_norm_frontier__l2_decoder_q8_norm_distribution_broad_v2.json"
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_q8_normalization_distribution_broad_v2",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_quantization_outline_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/README.md
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/README.md
@@ -1,0 +1,5 @@
+Proposal workspace for `prop_l2_decoder_q8_norm_distribution_broad_v2`.
+
+This follows the merged r4 q8/bf16 normalization distribution result by
+expanding the prompt-regime sample set before treating the measured PPA frontier
+as architecture guidance.

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/design_brief.md
@@ -1,0 +1,21 @@
+# Decoder q8/bf16 Normalization Broad Distribution v2
+
+- `proposal_id`: `prop_l2_decoder_q8_norm_distribution_broad_v2`
+- `item_id`: `l2_decoder_q8_norm_distribution_broad_v2`
+- abstraction: `decoder_q8_normalization_distribution_broad_v2`
+
+The r4 distribution robustness job proved that the q8/bf16 normalization
+frontier can run with measured q8 exact, q8 reciprocal, and bf16 reciprocal PPA
+inputs. It did not prove distribution robustness: the dataset had 12 curated
+samples.
+
+This step expands the rough distribution to 48 samples across factual,
+commonsense, arithmetic, sequence, code-like, dialogue, punctuation, long-context,
+repetition, ambiguous, instruction, and symbolic categories. The goal is still
+outline mapping, not final model-quality proof.
+
+Expected output:
+
+- `decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json`
+- `decoder_q8_norm_frontier__l2_decoder_q8_norm_distribution_broad_v2.json`
+- `decoder_q8_norm_frontier__l2_decoder_q8_norm_distribution_broad_v2.md`

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+Queue `l2_decoder_q8_norm_distribution_broad_v2` only after the r4 result from
+`prop_l2_decoder_q8_norm_distribution_robustness_v1` is merged.
+
+Required merged input:
+
+- `runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_norm_distribution_robustness_v1_r4.json`

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_q8_norm_distribution_broad_v2",
+  "source_commit": "20cbb10a0226e60d1751a48970976bfc3fd8e09b",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_q8_norm_distribution_broad_v2",
+      "task_type": "l2_campaign",
+      "objective": "Run the q8/bf16 reciprocal-normalization frontier on the expanded 48-sample distribution v2 dataset.",
+      "evaluation_mode": "broad_ranking",
+      "abstraction_layer": "decoder_q8_normalization_distribution_broad_v2",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_q8_norm_distribution_robustness_v1_r4"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The current 12-sample result should be broadened before choosing q8 reciprocal versus bf16 reciprocal normalization."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/implementation_summary.md
@@ -1,0 +1,9 @@
+# Implementation Summary
+
+- Added `samples_distribution_v2.jsonl` with 48 rough prompt-regime samples.
+- Added `manifest_distribution_v2.json` using the same tiny decoder model,
+  tokenizer, and command backend binding as distribution v1.
+- Added a Layer-2 task-generator abstraction,
+  `decoder_q8_normalization_distribution_broad_v2`, so v1 artifacts remain
+  reproducible and v2 jobs have explicit output paths.
+- Added task-generator unit coverage for the v2 command manifest and inputs.

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/proposal.json
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l2_decoder_q8_norm_distribution_broad_v2",
+  "created_utc": "2026-05-01T13:50:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Decoder q8/bf16 normalization broad distribution v2",
+  "hypothesis": "The current q8/bf16 normalization frontier is measured with real Nangate45 datapath PPA, but the quality gate is still tied to a small 12-sample distribution set. Expanding the prompt regimes before narrowing the architecture decision should expose whether q8 reciprocal precision or bf16 reciprocal normalization is sensitive to distribution shifts.",
+  "direct_comparison": {
+    "primary_question": "Across an expanded 48-sample rough prompt distribution, do bf16 reciprocal normalization and q8 reciprocal q10/q12/q14/q16 preserve exact next-token and top-k behavior relative to the exact reference and q8 exact-normalization baseline?",
+    "include": [
+      "expanded distribution v2 reference and candidate regeneration",
+      "bf16 reciprocal PWL normalization anchor",
+      "q8 PWL exact-normalization baseline",
+      "q8 PWL reciprocal-normalization q10/q12/q14/q16 rows",
+      "merged measured q8 reciprocal, q8 exact, and bf16 reciprocal Nangate45 datapath PPA artifacts"
+    ],
+    "exclude": [
+      "new RTL generation or OpenROAD measurements",
+      "claiming model-family-wide robustness",
+      "changing mapper or NPU architecture points"
+    ]
+  },
+  "expected_benefit": [
+    "turns the current normalization result into a broader rough distribution screen",
+    "keeps ranking grounded in measured PPA while avoiding overfitting to one prompt slice",
+    "identifies sample categories that should drive the next focused stress set"
+  ],
+  "risks": [
+    "the dataset still uses the same tiny decoder model and tokenizer binding",
+    "48 curated prompts are still only a rough distribution outline",
+    "software-emulated quantization may miss hardware rounding edge cases"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_q8_norm_distribution_broad_v2",
+      "task_type": "l2_campaign",
+      "objective": "decoder_q8_normalization_distribution_broad_v2",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "broad_ranking",
+      "abstraction_layer": "decoder_q8_normalization_distribution_broad_v2",
+      "depends_on_item_ids": [
+        "l2_decoder_q8_norm_distribution_robustness_v1_r4"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_q8_norm_distribution_robustness_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_norm_distribution_robustness_v1_r4.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v1.json"
+  ],
+  "knowledge_refs": [
+    "runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "npu/eval/estimate_llm_decoder_q8_norm_frontier.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/quality_gate.md
@@ -1,0 +1,14 @@
+# Quality Gate
+
+The evaluation should:
+
+- regenerate reference and candidate artifacts from
+  `runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json`
+- run the existing `decoder_q8_normalization_frontier_v1` rough grid
+- report next-token and top-k preservation by row
+- rank exact-safe rows with measured Nangate45 datapath metrics where available
+- explicitly list any blocked rows and mismatch sample ids
+
+Acceptance for this exploratory step is not "choose final q8 or bf16." Acceptance
+is a complete broad-ranking artifact that tells us whether the current exact-safe
+frontier survives a larger rough prompt distribution.

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -123,6 +123,26 @@ The distribution grid records entropy, effective-vocabulary, score-sum, and
 top-1/top-2 margin rollups alongside rank metrics. Use it to select follow-up
 approximation families, not to make a general model-quality claim.
 
+Run the expanded q8/bf16 normalization broad distribution check:
+```sh
+python3 npu/eval/sweep_llm_decoder_candidate_quality.py \
+  --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json \
+  --rough-grid decoder_q8_normalization_frontier_v1 \
+  --out-dir /tmp/decoder_q8_norm_distribution_v2 \
+  --out /tmp/decoder_q8_norm_distribution_v2.json
+python3 npu/eval/estimate_llm_decoder_q8_norm_frontier.py \
+  --sweep /tmp/decoder_q8_norm_distribution_v2.json \
+  --q8-recip-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_q8_recip_norm_datapath_v1_r3.json \
+  --q8-exact-ppa control_plane/shadow_exports/l1_promotions/l1_prop_l1_softmax_rowwise_int8_r8_acc24_block_v1_nangate45_r1.json \
+  --bf16-recip-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_recip_norm_datapath_v1_r2.json \
+  --out /tmp/decoder_q8_norm_frontier_v2.json \
+  --out-md /tmp/decoder_q8_norm_frontier_v2.md
+```
+
+This v2 check broadens the rough prompt categories before making a q8 reciprocal
+versus bf16 reciprocal normalization decision. It remains tied to the pinned
+tiny decoder model.
+
 Run the focused survivor prompt-stress grid:
 ```sh
 python3 npu/eval/gen_llm_decoder_reference_suite.py \

--- a/runs/datasets/llm_decoder_eval_tiny_v1/README.md
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/README.md
@@ -30,6 +30,15 @@ What does not exist yet:
 - continuation/perplexity metrics
 - larger decoder prompt set
 
+Distribution variants
+---------------------
+- `manifest_distribution_v1.json` / `samples_distribution_v1.jsonl`: first
+  12-sample rough prompt-regime check.
+- `manifest_distribution_v2.json` / `samples_distribution_v2.jsonl`: expanded
+  48-sample rough prompt-regime check for q8/bf16 normalization robustness. It
+  still uses the same tiny decoder model and should be treated as exploration
+  guidance, not model-family proof.
+
 Current binding
 ---------------
 - tokenizer: `runs/tokenizers/llm_decoder_gpt2_bpe_stub_v1/manifest.json`

--- a/runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json
@@ -1,0 +1,55 @@
+{
+  "candidate_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/candidate_distribution_v2_manifest.json",
+  "dataset_id": "llm_decoder_eval_tiny_v1",
+  "decoder_backend_configs": {
+    "candidate": {
+      "backend_id": "command_json_v1",
+      "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
+      "command": [
+        "python3",
+        "npu/eval/run_llm_decoder_onnx_candidate.py"
+      ],
+      "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
+      "input_name": "input_ids",
+      "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
+      "normalization_mode": "exact",
+      "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
+      "output_name": "logits",
+      "runtime_target": "software_emulation",
+      "softmax_mode": "exact",
+      "topk": 5,
+      "trace_output_patterns": [
+        "present.*"
+      ],
+      "trace_tensor_quant_bits": 4
+    },
+    "reference": {
+      "backend_id": "command_json_v1",
+      "command": [
+        "python3",
+        "npu/eval/run_llm_decoder_onnx_reference.py"
+      ],
+      "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
+      "input_name": "input_ids",
+      "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
+      "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
+      "output_name": "logits",
+      "runtime_target": "cpu_reference",
+      "topk": 5,
+      "trace_output_patterns": [
+        "present.*"
+      ]
+    }
+  },
+  "decoder_backend_interface": "v1",
+  "model_contract": "runs/models/llm_decoder_tiny_v1/model_contract.json",
+  "notes": "Expanded rough prompt-regime sample set for q8/bf16 normalization distribution checks. This remains a tiny-model exploratory dataset, but broadens categories before making a q8-versus-bf16 normalization decision.",
+  "reference_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/reference_distribution_v2_manifest.json",
+  "sample_count": 48,
+  "sample_file": "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl",
+  "status": "distribution_robustness_manifest_v2",
+  "task": "greedy_next_token",
+  "tokenizer_id": "llm_decoder_gpt2_bpe_stub_v1",
+  "tokenizer_manifest": "runs/tokenizers/llm_decoder_gpt2_bpe_stub_v1/manifest.json",
+  "version": 0.2
+}

--- a/runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl
@@ -1,0 +1,48 @@
+{"sample_id":"dist2_geo_capital_france","prompt":"The capital of France is","expected_continuation":" Paris","category":"factual_geo"}
+{"sample_id":"dist2_geo_capital_japan","prompt":"The capital of Japan is","expected_continuation":" Tokyo","category":"factual_geo"}
+{"sample_id":"dist2_geo_capital_germany","prompt":"The capital of Germany is","expected_continuation":" Berlin","category":"factual_geo"}
+{"sample_id":"dist2_geo_capital_italy","prompt":"The capital of Italy is","expected_continuation":" Rome","category":"factual_geo"}
+{"sample_id":"dist2_color_banana","prompt":"A ripe banana is usually","expected_continuation":" yellow","category":"commonsense_color"}
+{"sample_id":"dist2_color_sky","prompt":"On a clear day, the sky is","expected_continuation":" blue","category":"commonsense_color"}
+{"sample_id":"dist2_color_grass","prompt":"Fresh grass is often","expected_continuation":" green","category":"commonsense_color"}
+{"sample_id":"dist2_color_snow","prompt":"Fresh snow is usually","expected_continuation":" white","category":"commonsense_color"}
+{"sample_id":"dist2_arith_two_plus_two","prompt":"2 + 2 =","expected_continuation":" 4","category":"arithmetic_short"}
+{"sample_id":"dist2_arith_three_plus_five","prompt":"3 + 5 =","expected_continuation":" 8","category":"arithmetic_short"}
+{"sample_id":"dist2_arith_ten_minus_one","prompt":"10 - 1 =","expected_continuation":" 9","category":"arithmetic_short"}
+{"sample_id":"dist2_arith_six_times_two","prompt":"6 * 2 =","expected_continuation":" 12","category":"arithmetic_short"}
+{"sample_id":"dist2_sequence_numbers","prompt":"one, two, three,","expected_continuation":" four","category":"list_continuation"}
+{"sample_id":"dist2_sequence_letters","prompt":"A, B, C,","expected_continuation":" D","category":"list_continuation"}
+{"sample_id":"dist2_sequence_weekdays","prompt":"Monday, Tuesday, Wednesday,","expected_continuation":" Thursday","category":"list_continuation"}
+{"sample_id":"dist2_sequence_months","prompt":"January, February, March,","expected_continuation":" April","category":"list_continuation"}
+{"sample_id":"dist2_code_python_return","prompt":"def add(a, b): return a","expected_continuation":" +","category":"code_like"}
+{"sample_id":"dist2_code_python_if","prompt":"if value > 0: print","expected_continuation":"(","category":"code_like"}
+{"sample_id":"dist2_code_json_key","prompt":"{\"enabled\":","expected_continuation":" true","category":"code_like"}
+{"sample_id":"dist2_code_comment","prompt":"// TODO: update the","expected_continuation":" test","category":"code_like"}
+{"sample_id":"dist2_dialogue_greeting","prompt":"User: hello\nAssistant:","expected_continuation":" Hi","category":"dialogue_short"}
+{"sample_id":"dist2_dialogue_thanks","prompt":"User: thanks\nAssistant:","expected_continuation":" You","category":"dialogue_short"}
+{"sample_id":"dist2_dialogue_question","prompt":"User: what time is it?\nAssistant:","expected_continuation":" It","category":"dialogue_short"}
+{"sample_id":"dist2_dialogue_yesno","prompt":"User: can you help?\nAssistant:","expected_continuation":" Yes","category":"dialogue_short"}
+{"sample_id":"dist2_punctuation_period","prompt":"The answer is yes","expected_continuation":".","category":"punctuation"}
+{"sample_id":"dist2_punctuation_comma","prompt":"First we measure latency","expected_continuation":",","category":"punctuation"}
+{"sample_id":"dist2_punctuation_colon","prompt":"The result was clear","expected_continuation":":","category":"punctuation"}
+{"sample_id":"dist2_punctuation_quote","prompt":"She said","expected_continuation":" \"","category":"punctuation"}
+{"sample_id":"dist2_long_lab","prompt":"In a small laboratory notebook, the engineer wrote down the measured latency and then checked whether the output token was","expected_continuation":" correct","category":"long_context"}
+{"sample_id":"dist2_long_story","prompt":"After walking through the old station for nearly an hour, Mira finally found the platform where the train would","expected_continuation":" arrive","category":"long_context"}
+{"sample_id":"dist2_long_design","prompt":"The hardware team compared area, timing, and power before deciding that the next experiment should","expected_continuation":" focus","category":"long_context"}
+{"sample_id":"dist2_long_report","prompt":"The report listed the failing samples first and then summarized the reason each approximation had","expected_continuation":" failed","category":"long_context"}
+{"sample_id":"dist2_repetition_ha","prompt":"ha ha ha ha","expected_continuation":" ha","category":"repetition"}
+{"sample_id":"dist2_repetition_test","prompt":"test test test","expected_continuation":" test","category":"repetition"}
+{"sample_id":"dist2_repetition_go","prompt":"go go go","expected_continuation":" go","category":"repetition"}
+{"sample_id":"dist2_repetition_tick","prompt":"tick tock tick","expected_continuation":" tock","category":"repetition"}
+{"sample_id":"dist2_ambiguous_article","prompt":"The old book was on","expected_continuation":" the","category":"ambiguous_short"}
+{"sample_id":"dist2_ambiguous_preposition","prompt":"The meeting starts at","expected_continuation":" noon","category":"ambiguous_short"}
+{"sample_id":"dist2_ambiguous_object","prompt":"Please put it in","expected_continuation":" the","category":"ambiguous_short"}
+{"sample_id":"dist2_ambiguous_common","prompt":"This is a test of","expected_continuation":" the","category":"ambiguous_short"}
+{"sample_id":"dist2_instruction_short","prompt":"Translate yes to Spanish:","expected_continuation":" si","category":"instruction_short"}
+{"sample_id":"dist2_instruction_label","prompt":"Sentiment: I love this.\nLabel:","expected_continuation":" positive","category":"instruction_short"}
+{"sample_id":"dist2_instruction_classify","prompt":"Animal: cat\nType:","expected_continuation":" mammal","category":"instruction_short"}
+{"sample_id":"dist2_instruction_complete","prompt":"Complete the phrase: bread and","expected_continuation":" butter","category":"instruction_short"}
+{"sample_id":"dist2_symbol_paren","prompt":"The expression (a + b","expected_continuation":")","category":"symbolic"}
+{"sample_id":"dist2_symbol_bracket","prompt":"items[0","expected_continuation":"]","category":"symbolic"}
+{"sample_id":"dist2_symbol_arrow","prompt":"input -> hidden","expected_continuation":" ->","category":"symbolic"}
+{"sample_id":"dist2_symbol_equals","prompt":"x = y","expected_continuation":" +","category":"symbolic"}


### PR DESCRIPTION
## Summary
- add a 48-sample distribution v2 dataset for rough q8/bf16 normalization robustness checks
- add the Layer-2 abstraction `decoder_q8_normalization_distribution_broad_v2` with v2-specific artifacts
- add proposal workspace and docs for the next evaluator job

## Validation
- `PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py`
- `python3 npu/eval/gen_llm_decoder_reference_suite.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json --out-dir /tmp/rtlgen_decoder_dist_v2_reference --out-manifest /tmp/rtlgen_decoder_dist_v2_reference_manifest.json`
- `python3 npu/eval/gen_llm_decoder_candidate_suite.py --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json --out-dir /tmp/rtlgen_decoder_dist_v2_candidate --out-manifest /tmp/rtlgen_decoder_dist_v2_candidate_manifest.json`
- `python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest /tmp/rtlgen_manifest_distribution_v2_generated.json --out /tmp/rtlgen_decoder_dist_v2_validation.json`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py`