### PR TITLE
Record q8 norm broad distribution v2 request

### DIFF
--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/analysis_report.md
@@ -1,0 +1,26 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_q8_norm_distribution_broad_v2`
+- `candidate_id`: `l2_decoder_q8_norm_distribution_broad_v2`
+
+## Evaluations Consumed
+- pending: `l2_decoder_q8_norm_distribution_broad_v2`
+- baseline: `l2_decoder_q8_norm_distribution_robustness_v1_r4`
+
+## Baseline Comparison
+The baseline r4 result used the 12-sample distribution v1 set and found no
+blocked q8 reciprocal or bf16 reciprocal rows. This follow-on job expands the
+rough distribution set to 48 samples before treating the measured PPA ranking as
+architecture guidance.
+
+## Result
+Pending evaluator result.
+
+## Failures And Caveats
+- The expanded dataset is still tied to the tiny decoder model.
+- The result should identify distribution-sensitive rows and sample categories,
+  not claim model-family robustness.
+
+## Recommendation
+Pending evaluator result.

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_q8_norm_distribution_broad_v2",
-  "source_commit": "20cbb10a0226e60d1751a48970976bfc3fd8e09b",
+  "source_commit": "8a7d004b41de3f4d45f1d714a668fa03543469d4",
   "requested_items": [
     {
       "item_id": "l2_decoder_q8_norm_distribution_broad_v2",
@@ -17,7 +17,7 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "iterate",
-        "reason": "The current 12-sample result should be broadened before choosing q8 reciprocal versus bf16 reciprocal normalization."
+        "reason": "Broaden the distribution screen before choosing q8 reciprocal versus bf16 reciprocal normalization."
       },
       "status": "pending"
     }

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l2_decoder_q8_norm_distribution_broad_v2",
+  "candidate_id": "l2_decoder_q8_norm_distribution_broad_v2",
+  "decision": "pending",
+  "reason": "Await the expanded 48-sample q8/bf16 normalization distribution result.",
+  "evidence_refs": [
+    "item:l2_decoder_q8_norm_distribution_broad_v2"
+  ],
+  "next_action": "Review the v2 frontier artifact and decide whether to broaden model/input coverage again or focus on the first distribution-sensitive normalization row.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_q8_norm_distribution_broad_v2",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}


### PR DESCRIPTION
## Summary
- record the pending `l2_decoder_q8_norm_distribution_broad_v2` evaluator request against merged source commit `8a7d004b`
- add the standard proposal analysis/promotion placeholders with proposal-specific text

## Validation
- `jq empty docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/evaluation_requests.json docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/promotion_decision.json docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/promotion_result.json`