### PR TITLE
Add decoder PWL failure diagnosis job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1116,6 +1116,53 @@ def _decoder_quantization_outline_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_pwl_failure_diagnosis_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    sweep = f"{base}/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json"
+    sample_file = f"{base}/samples_distribution_v2.jsonl"
+    diagnosis_out = f"{base}/decoder_pwl_failure_diagnosis__{item_id}.json"
+    diagnosis_report = f"{base}/decoder_pwl_failure_diagnosis__{item_id}.md"
+    commands = [
+        {
+            "name": "diagnose_decoder_pwl_failures",
+            "run": (
+                "python3 npu/eval/diagnose_llm_decoder_pwl_failures.py "
+                f"--sweep {sweep} "
+                f"--sample-file {sample_file} "
+                f"--out {diagnosis_out} "
+                f"--out-md {diagnosis_report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            "source_sweep": sweep,
+            "sample_file": sample_file,
+            "diagnosis_out": diagnosis_out,
+            "diagnosis_report": diagnosis_report,
+            "focus_samples": [
+                "dist2_arith_three_plus_five",
+                "dist2_sequence_months",
+            ],
+            "control_samples": [
+                "dist2_arith_two_plus_two",
+                "dist2_arith_six_times_two",
+                "dist2_sequence_numbers",
+                "dist2_sequence_weekdays",
+            ],
+            "diagnosis_scope": (
+                "focused per-sample diagnosis for the shared PWL exact-token misses found "
+                "in the broad v2 q8/bf16 normalization distribution result"
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            diagnosis_out,
+            diagnosis_report,
+        ],
+    }
+
+
 def _with_fresh_outputs(*, campaign: dict[str, Any], item_id: str) -> dict[str, Any]:
     cloned = json.loads(json.dumps(campaign))
     outputs = dict(cloned.get("outputs") or {})
@@ -1224,10 +1271,13 @@ def _build_payload(
         "decoder_q8_normalization_frontier",
         "decoder_q8_normalization_distribution",
         "decoder_q8_normalization_distribution_broad_v2",
+        "decoder_pwl_failure_diagnosis",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_pwl_failure_diagnosis":
+            decoder_evidence = _decoder_pwl_failure_diagnosis_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_q8_normalization_distribution_broad_v2":
             decoder_evidence = _decoder_q8_normalization_distribution_evidence(item_id=item_id, distribution_version="v2")
         elif abstraction_layer_name == "decoder_q8_normalization_distribution":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -864,6 +864,58 @@ def test_generate_l2_campaign_task_adds_decoder_quantization_outline_evidence() 
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_pwl_failure_diagnosis_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_pwl_failure_diagnosis_v1",
+                    proposal_id="prop_l2_decoder_pwl_failure_diagnosis_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/proposal.json",
+                    evaluation_mode="broad_ranking",
+                    abstraction_layer="decoder_pwl_failure_diagnosis",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert work_item.command_manifest[0]["name"] == "diagnose_decoder_pwl_failures"
+            assert "diagnose_llm_decoder_pwl_failures.py" in work_item.command_manifest[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["source_sweep"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json"
+            )
+            assert decoder_inputs["sample_file"] == "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl"
+            assert decoder_inputs["focus_samples"] == [
+                "dist2_arith_three_plus_five",
+                "dist2_sequence_months",
+            ]
+            assert decoder_inputs["diagnosis_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_pwl_failure_diagnosis__l2_decoder_pwl_failure_diagnosis_v1.json"
+            )
+            assert decoder_inputs["diagnosis_out"] in work_item.expected_outputs
+            assert decoder_inputs["diagnosis_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_pwl_failure_diagnosis",
+            }
+
+
 def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/README.md
@@ -1,0 +1,4 @@
+Proposal workspace for `prop_l2_decoder_pwl_failure_diagnosis_v1`.
+
+This follows the merged broad v2 q8/bf16 normalization distribution result by
+diagnosing the two shared exact-token misses before launching another sweep.

--- a/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/design_brief.md
@@ -1,0 +1,24 @@
+# Decoder PWL Failure Diagnosis
+
+- `proposal_id`: `prop_l2_decoder_pwl_failure_diagnosis_v1`
+- `item_id`: `l2_decoder_pwl_failure_diagnosis_v1`
+- abstraction: `decoder_pwl_failure_diagnosis`
+
+The broad v2 q8/bf16 normalization result found two shared exact-token misses:
+
+- `dist2_arith_three_plus_five`
+- `dist2_sequence_months`
+
+Every PWL row preserved top-k, and q8 exact-normalization missed the same two
+samples as q8 reciprocal and bf16 reciprocal. That points away from reciprocal
+bit width as the immediate blocker.
+
+This job reads the merged broad-v2 sweep and emits a focused JSON and Markdown
+diagnosis. It compares exact-reference proxy output against the bf16 PWL path,
+q8 PWL exact-normalization path, and q8 PWL reciprocal q10 path for the failing
+samples plus a small control set.
+
+Expected output:
+
+- `decoder_pwl_failure_diagnosis__l2_decoder_pwl_failure_diagnosis_v1.json`
+- `decoder_pwl_failure_diagnosis__l2_decoder_pwl_failure_diagnosis_v1.md`

--- a/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+Queue `l2_decoder_pwl_failure_diagnosis_v1` only after
+`l2_decoder_q8_norm_distribution_broad_v2` is merged and finalized.
+
+Required merged inputs:
+
+- `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json`
+- `runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl`

--- a/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_failure_diagnosis_v1",
+  "source_commit": "ff068d902c1b0c05b709dee1aff8c8bead0f52c6",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_pwl_failure_diagnosis_v1",
+      "task_type": "l2_campaign",
+      "objective": "Diagnose whether the broad v2 exact-token misses are PWL/logit-margin sensitivity or normalization precision.",
+      "evaluation_mode": "broad_ranking",
+      "abstraction_layer": "decoder_pwl_failure_diagnosis",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_q8_norm_distribution_broad_v2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Choose the next decoder frontier job from failure mechanism evidence instead of sweeping reciprocal precision blindly."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/implementation_summary.md
@@ -1,0 +1,9 @@
+# Implementation Summary
+
+- Added `npu/eval/diagnose_llm_decoder_pwl_failures.py` to read a decoder
+  quality sweep and emit focused JSON/Markdown diagnosis for shared PWL misses.
+- Added a Layer-2 task-generator abstraction,
+  `decoder_pwl_failure_diagnosis`, that binds the diagnostic command to the
+  merged broad-v2 sweep artifact.
+- Added task-generator unit coverage for diagnostic inputs, outputs, and
+  command manifest wiring.

--- a/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/proposal.json
@@ -1,0 +1,61 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_failure_diagnosis_v1",
+  "created_utc": "2026-05-01T14:20:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Decoder PWL broad-v2 failure diagnosis",
+  "hypothesis": "The broad v2 q8/bf16 normalization result shows the same two exact-token misses across bf16 reciprocal, q8 exact-normalization, and q8 reciprocal rows while preserving top-k. A focused per-sample diagnosis should distinguish shared PWL/logit-margin sensitivity from normalization precision before the next architectural sweep.",
+  "direct_comparison": {
+    "primary_question": "For the two broad-v2 shared PWL misses, are exact-token changes explained by the common PWL probability path and narrow margins, or by q8 reciprocal normalization precision?",
+    "include": [
+      "candidate_onnx_softmax_exact broad-v2 row as the exact reference proxy",
+      "grid_approx_pwl_bf16_path",
+      "grid_approx_pwl_in_q8_w_q8_norm_exact",
+      "grid_approx_pwl_in_q8_w_q8_norm_recip_q10",
+      "per-sample next-token, top-k rank, score-delta, and distribution summaries"
+    ],
+    "exclude": [
+      "new reference or candidate generation",
+      "new RTL generation or OpenROAD measurements",
+      "claiming model-family-wide robustness"
+    ]
+  },
+  "expected_benefit": [
+    "prevents over-attributing broad-v2 exact-token misses to reciprocal bit width",
+    "identifies whether the next frontier job should stress PWL/logit margins",
+    "keeps the architecture loop grounded in already-merged broad-v2 artifacts"
+  ],
+  "risks": [
+    "the diagnosis is limited to the pinned tiny decoder and broad-v2 samples",
+    "exact next-token changes may be acceptable if top-k is preserved, depending on the final product gate",
+    "software-emulated PWL behavior still needs later hardware trace equivalence"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_pwl_failure_diagnosis_v1",
+      "task_type": "l2_campaign",
+      "objective": "decoder_pwl_failure_diagnosis",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "broad_ranking",
+      "abstraction_layer": "decoder_pwl_failure_diagnosis",
+      "depends_on_item_ids": [
+        "l2_decoder_q8_norm_distribution_broad_v2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_norm_distribution_broad_v2.json"
+  ],
+  "knowledge_refs": [
+    "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl",
+    "npu/eval/diagnose_llm_decoder_pwl_failures.py",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_pwl_failure_diagnosis_v1/quality_gate.md
@@ -1,0 +1,15 @@
+# Quality Gate
+
+The evaluation should:
+
+- read the merged broad v2 sweep artifact
+- compare exact-reference proxy, bf16 PWL, q8 PWL exact-normalization, and q8
+  PWL reciprocal q10 rows
+- report the two shared exact-token miss samples with exact and candidate top-k
+  context
+- include control samples that remained exact-safe
+- conclude whether the likely blocker is shared PWL/logit-margin sensitivity,
+  normalization precision, or mixed evidence
+
+Acceptance is a complete diagnostic artifact. It does not need to choose the
+final decoder probability format.

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -143,6 +143,20 @@ This v2 check broadens the rough prompt categories before making a q8 reciprocal
 versus bf16 reciprocal normalization decision. It remains tied to the pinned
 tiny decoder model.
 
+Diagnose the shared broad-v2 PWL exact-token misses:
+```sh
+python3 npu/eval/diagnose_llm_decoder_pwl_failures.py \
+  --sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json \
+  --sample-file runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl \
+  --out /tmp/decoder_pwl_failure_diagnosis.json \
+  --out-md /tmp/decoder_pwl_failure_diagnosis.md
+```
+
+The diagnosis compares the exact softmax row against bf16 PWL, q8 PWL exact
+normalization, and q8 PWL reciprocal q10 rows. Use it to decide whether the next
+frontier job should target shared PWL/logit-margin sensitivity or normalization
+precision.
+
 Run the focused survivor prompt-stress grid:
 ```sh
 python3 npu/eval/gen_llm_decoder_reference_suite.py \

--- a/npu/eval/diagnose_llm_decoder_pwl_failures.py
+++ b/npu/eval/diagnose_llm_decoder_pwl_failures.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Diagnose per-sample PWL decoder frontier misses from a quality sweep."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+DEFAULT_TEMPLATES = [
+    "candidate_onnx_softmax_exact",
+    "grid_approx_pwl_bf16_path",
+    "grid_approx_pwl_in_q8_w_q8_norm_exact",
+    "grid_approx_pwl_in_q8_w_q8_norm_recip_q10",
+]
+DEFAULT_FOCUS_SAMPLES = [
+    "dist2_arith_three_plus_five",
+    "dist2_sequence_months",
+]
+DEFAULT_CONTROL_SAMPLES = [
+    "dist2_arith_two_plus_two",
+    "dist2_arith_six_times_two",
+    "dist2_sequence_numbers",
+    "dist2_sequence_weekdays",
+]
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve(path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return _repo_root() / candidate
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    with _resolve(path).open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _load_jsonl(path: str | Path) -> list[JsonDict]:
+    out: list[JsonDict] = []
+    with _resolve(path).open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if not isinstance(payload, dict):
+                raise SystemExit(f"expected object at {path}:{line_no}")
+            out.append(payload)
+    return out
+
+
+def _portable(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(_repo_root()))
+    except ValueError:
+        return str(path)
+
+
+def _samples_by_id(sample_file: str | Path) -> dict[str, JsonDict]:
+    return {str(sample["sample_id"]): sample for sample in _load_jsonl(sample_file)}
+
+
+def _sweep_rows_by_template(sweep: JsonDict) -> dict[str, JsonDict]:
+    rows = sweep.get("templates")
+    if not isinstance(rows, list):
+        raise SystemExit("sweep JSON must contain templates list")
+    return {str(row.get("template") or ""): row for row in rows if isinstance(row, dict)}
+
+
+def _quality_samples_by_id(quality_path: str | Path) -> dict[str, JsonDict]:
+    quality = _load_json(quality_path)
+    samples = quality.get("samples")
+    if not isinstance(samples, list):
+        raise SystemExit(f"quality JSON must contain samples list: {quality_path}")
+    return {str(sample.get("sample_id") or ""): sample for sample in samples if isinstance(sample, dict)}
+
+
+def _manifest_samples_by_id(manifest_path: str | Path) -> dict[str, JsonDict]:
+    manifest = _load_json(manifest_path)
+    samples = manifest.get("samples")
+    if not isinstance(samples, list):
+        raise SystemExit(f"candidate manifest must contain samples list: {manifest_path}")
+    return {str(sample.get("sample_id") or ""): sample for sample in samples if isinstance(sample, dict)}
+
+
+def _topk(doc: JsonDict) -> list[JsonDict]:
+    candidate = doc.get("candidate")
+    if not isinstance(candidate, dict):
+        return []
+    topk = candidate.get("topk")
+    return [dict(row) for row in topk] if isinstance(topk, list) else []
+
+
+def _next(doc: JsonDict) -> JsonDict:
+    candidate = doc.get("candidate")
+    if not isinstance(candidate, dict):
+        return {"token_id": None, "token_text": ""}
+    return {
+        "token_id": candidate.get("next_token_id"),
+        "token_text": candidate.get("next_token_text"),
+    }
+
+
+def _score_for(topk: list[JsonDict], token_id: Any) -> float | None:
+    for row in topk:
+        if row.get("token_id") == token_id:
+            try:
+                return float(row.get("score"))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _rank_for(topk: list[JsonDict], token_id: Any) -> int | None:
+    for index, row in enumerate(topk, start=1):
+        if row.get("token_id") == token_id:
+            return index
+    return None
+
+
+def _sample_summary(
+    *,
+    sample_id: str,
+    sample: JsonDict,
+    exact_doc: JsonDict,
+    row: JsonDict,
+    quality_sample: JsonDict,
+    candidate_doc: JsonDict,
+) -> JsonDict:
+    exact_topk = _topk(exact_doc)
+    candidate_topk = _topk(candidate_doc)
+    exact_next = _next(exact_doc)
+    candidate_next = _next(candidate_doc)
+    exact_id = exact_next.get("token_id")
+    candidate_id = candidate_next.get("token_id")
+    exact_score = _score_for(exact_topk, exact_id)
+    candidate_score = _score_for(candidate_topk, candidate_id)
+    exact_token_candidate_score = _score_for(candidate_topk, exact_id)
+    exact_candidate_delta = None
+    if candidate_score is not None and exact_token_candidate_score is not None:
+        exact_candidate_delta = candidate_score - exact_token_candidate_score
+    distribution = quality_sample.get("reference_distribution")
+    candidate_distribution = quality_sample.get("candidate_distribution")
+    return {
+        "sample_id": sample_id,
+        "category": sample.get("category"),
+        "prompt": sample.get("prompt"),
+        "expected_continuation": sample.get("expected_continuation"),
+        "aggregate": quality_sample.get("aggregate", {}),
+        "reference_margin": {
+            "top1_top2_logit_margin": (distribution or {}).get("top1_top2_logit_margin")
+            if isinstance(distribution, dict)
+            else None,
+            "topk_probability_mass": (distribution or {}).get("topk_probability_mass")
+            if isinstance(distribution, dict)
+            else None,
+        },
+        "candidate_margin": {
+            "top1_top2_score_margin": (candidate_distribution or {}).get("top1_top2_score_margin")
+            if isinstance(candidate_distribution, dict)
+            else None,
+            "score_sum": (candidate_distribution or {}).get("score_sum") if isinstance(candidate_distribution, dict) else None,
+            "topk_score_mass": (candidate_distribution or {}).get("topk_score_mass")
+            if isinstance(candidate_distribution, dict)
+            else None,
+        },
+        "exact_next": exact_next,
+        "candidate_next": candidate_next,
+        "exact_rank_in_candidate_topk": _rank_for(candidate_topk, exact_id),
+        "candidate_rank_in_exact_topk": _rank_for(exact_topk, candidate_id),
+        "candidate_score_minus_exact_token_score": exact_candidate_delta,
+        "exact_topk": exact_topk,
+        "candidate_topk": candidate_topk,
+        "stage_settings": {
+            "template": row.get("template"),
+            "candidate_semantics": row.get("candidate_semantics"),
+            "softmax_mode": row.get("softmax_mode"),
+            "softmax_input_quant_bits": row.get("softmax_input_quant_bits"),
+            "softmax_weight_quant_bits": row.get("softmax_weight_quant_bits"),
+            "softmax_input_float_format": row.get("softmax_input_float_format"),
+            "softmax_weight_float_format": row.get("softmax_weight_float_format"),
+            "normalization_mode": row.get("normalization_mode"),
+            "normalization_reciprocal_bits": row.get("normalization_reciprocal_bits"),
+            "normalization_reciprocal_float_format": row.get("normalization_reciprocal_float_format"),
+            "probability_float_format": row.get("probability_float_format"),
+            "probability_quant_bits": row.get("probability_quant_bits"),
+        },
+    }
+
+
+def _candidate_doc(manifest_sample: JsonDict) -> JsonDict:
+    candidate_json = str(manifest_sample.get("candidate_json") or "").strip()
+    if not candidate_json:
+        raise SystemExit(f"candidate manifest sample missing candidate_json: {manifest_sample}")
+    return _load_json(candidate_json)
+
+
+def _diagnosis(rows: list[JsonDict], focus_samples: list[str]) -> JsonDict:
+    non_exact = [row for row in rows if row["template"] != "candidate_onnx_softmax_exact"]
+    miss_sets = {
+        row["template"]: set(row.get("next_token_mismatch_sample_ids") or [])
+        for row in non_exact
+    }
+    common_misses = set(focus_samples)
+    for misses in miss_sets.values():
+        common_misses &= misses
+    all_topk_safe = all(not row.get("topk_miss_sample_ids") for row in non_exact)
+    q8_exact = next((row for row in non_exact if row["template"] == "grid_approx_pwl_in_q8_w_q8_norm_exact"), None)
+    q8_recip = next((row for row in non_exact if row["template"] == "grid_approx_pwl_in_q8_w_q8_norm_recip_q10"), None)
+    bf16 = next((row for row in non_exact if row["template"] == "grid_approx_pwl_bf16_path"), None)
+    same_miss_pattern = len({tuple(sorted(misses)) for misses in miss_sets.values()}) <= 1
+    if same_miss_pattern and all_topk_safe and q8_exact is not None:
+        cause = "shared_pwl_softmax_or_logit_margin_sensitivity"
+        conclusion = (
+            "The same exact-token misses appear across bf16 reciprocal, q8 exact normalization, "
+            "and q8 reciprocal q10. Normalization precision is unlikely to be the root cause."
+        )
+    elif q8_recip is not None and bf16 is not None and miss_sets.get(q8_recip["template"]) != miss_sets.get(bf16["template"]):
+        cause = "format_or_normalization_sensitive"
+        conclusion = "q8 reciprocal and bf16 rows differ on sample misses; keep format/normalization in scope."
+    else:
+        cause = "mixed_or_inconclusive"
+        conclusion = "The focused rows do not collapse to a single obvious failure mechanism."
+    return {
+        "cause": cause,
+        "summary": conclusion,
+        "all_topk_safe": all_topk_safe,
+        "same_miss_pattern": same_miss_pattern,
+        "common_next_token_misses": sorted(common_misses),
+        "recommended_next_step": (
+            "Run a focused PWL/logit sensitivity ladder on the failing arithmetic and sequence samples, "
+            "with exact top-k retained as the broad gate and exact next-token treated as a margin stress signal."
+        ),
+    }
+
+
+def _write_md(doc: JsonDict, path: Path) -> None:
+    lines = [
+        "# Decoder PWL Failure Diagnosis",
+        "",
+        f"- source_sweep: `{doc['source_sweep']}`",
+        f"- decision: `{doc['diagnosis']['cause']}`",
+        f"- summary: {doc['diagnosis']['summary']}",
+        f"- recommended_next_step: {doc['diagnosis']['recommended_next_step']}",
+        "",
+        "## Template Summary",
+        "",
+        "| template | next-token | top-k | misses |",
+        "|---|---:|---:|---|",
+    ]
+    for row in doc["template_summaries"]:
+        misses = ", ".join(row["next_token_mismatch_sample_ids"]) or "none"
+        lines.append(
+            f"| `{row['template']}` | {row['next_token_matches']}/{row['sample_count']} | "
+            f"{row['topk_matches']}/{row['sample_count']} | {misses} |"
+        )
+    lines.extend(["", "## Focus Samples", ""])
+    for sample in doc["focus_samples"]:
+        lines.append(f"### `{sample['sample_id']}`")
+        lines.append("")
+        lines.append(f"- category: `{sample.get('category')}`")
+        lines.append(f"- prompt: `{sample.get('prompt')}`")
+        exact_next = sample["exact_next"]
+        lines.append(f"- exact next: `{exact_next.get('token_text')}` ({exact_next.get('token_id')})")
+        for template in sample["templates"]:
+            candidate_next = template["candidate_next"]
+            aggregate = template.get("aggregate", {})
+            delta = template.get("candidate_score_minus_exact_token_score")
+            delta_text = "" if delta is None else f", candidate-minus-exact-score={delta:.6g}"
+            lines.append(
+                f"- `{template['template']}`: next `{candidate_next.get('token_text')}` "
+                f"({candidate_next.get('token_id')}), exact_rank_in_candidate_topk="
+                f"{template.get('exact_rank_in_candidate_topk')}, next_match="
+                f"{aggregate.get('next_token_id_match')}, topk_contains="
+                f"{aggregate.get('topk_contains_reference_id')}{delta_text}"
+            )
+        lines.append("")
+    lines.extend(["## Control Samples", ""])
+    for sample in doc["control_samples"]:
+        lines.append(f"- `{sample['sample_id']}` ({sample.get('category')}): exact `{sample['exact_next'].get('token_text')}`")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sweep", required=True)
+    parser.add_argument("--sample-file", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--out-md", required=True)
+    parser.add_argument("--template", action="append", default=[])
+    parser.add_argument("--focus-sample", action="append", default=[])
+    parser.add_argument("--control-sample", action="append", default=[])
+    args = parser.parse_args()
+
+    sweep_path = _resolve(args.sweep)
+    sweep = _load_json(sweep_path)
+    samples = _samples_by_id(args.sample_file)
+    rows_by_template = _sweep_rows_by_template(sweep)
+    templates = args.template or DEFAULT_TEMPLATES
+    focus_samples = args.focus_sample or DEFAULT_FOCUS_SAMPLES
+    control_samples = args.control_sample or DEFAULT_CONTROL_SAMPLES
+    missing_templates = [template for template in templates if template not in rows_by_template]
+    if missing_templates:
+        raise SystemExit(f"templates missing from sweep: {missing_templates}")
+    missing_samples = [sample_id for sample_id in [*focus_samples, *control_samples] if sample_id not in samples]
+    if missing_samples:
+        raise SystemExit(f"samples missing from sample file: {missing_samples}")
+
+    exact_row = rows_by_template["candidate_onnx_softmax_exact"]
+    exact_manifest = _manifest_samples_by_id(exact_row["candidate_manifest"])
+    quality_by_template = {
+        template: _quality_samples_by_id(rows_by_template[template]["quality_json"])
+        for template in templates
+    }
+    manifest_by_template = {
+        template: _manifest_samples_by_id(rows_by_template[template]["candidate_manifest"])
+        for template in templates
+    }
+
+    template_summaries: list[JsonDict] = []
+    selected_rows: list[JsonDict] = []
+    for template in templates:
+        row = rows_by_template[template]
+        sample_count = int(row.get("sample_count") or 0)
+        next_rate = float(row.get("next_token_id_match_rate") or 0.0)
+        topk_rate = float(row.get("topk_contains_reference_id_rate") or 0.0)
+        summary = {
+            "template": template,
+            "candidate_semantics": row.get("candidate_semantics"),
+            "sample_count": sample_count,
+            "next_token_matches": round(next_rate * sample_count),
+            "topk_matches": round(topk_rate * sample_count),
+            "next_token_match_rate": next_rate,
+            "topk_contains_reference_id_rate": topk_rate,
+            "next_token_mismatch_sample_ids": row.get("next_token_mismatch_sample_ids") or [],
+            "topk_miss_sample_ids": row.get("topk_miss_sample_ids") or [],
+        }
+        template_summaries.append(summary)
+        selected_rows.append({**row, **summary})
+
+    def build_sample(sample_id: str) -> JsonDict:
+        exact_doc = _candidate_doc(exact_manifest[sample_id])
+        exact_next = _next(exact_doc)
+        out: JsonDict = {
+            "sample_id": sample_id,
+            "category": samples[sample_id].get("category"),
+            "prompt": samples[sample_id].get("prompt"),
+            "expected_continuation": samples[sample_id].get("expected_continuation"),
+            "exact_next": exact_next,
+            "exact_topk": _topk(exact_doc),
+            "templates": [],
+        }
+        for template in templates:
+            if template == "candidate_onnx_softmax_exact":
+                continue
+            candidate_doc = _candidate_doc(manifest_by_template[template][sample_id])
+            quality_sample = quality_by_template[template][sample_id]
+            out["templates"].append(
+                {
+                    "template": template,
+                    **_sample_summary(
+                        sample_id=sample_id,
+                        sample=samples[sample_id],
+                        exact_doc=exact_doc,
+                        row=rows_by_template[template],
+                        quality_sample=quality_sample,
+                        candidate_doc=candidate_doc,
+                    ),
+                }
+            )
+        return out
+
+    doc: JsonDict = {
+        "version": 0.1,
+        "source_sweep": _portable(sweep_path),
+        "sample_file": _portable(_resolve(args.sample_file)),
+        "focus_sample_ids": focus_samples,
+        "control_sample_ids": control_samples,
+        "templates": templates,
+        "template_summaries": template_summaries,
+        "diagnosis": _diagnosis(selected_rows, focus_samples),
+        "focus_samples": [build_sample(sample_id) for sample_id in focus_samples],
+        "control_samples": [build_sample(sample_id) for sample_id in control_samples],
+    }
+    out_path = _resolve(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_path = _resolve(args.out_md)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_md(doc, md_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a focused decoder PWL failure diagnosis script for broad-v2 exact-token misses
- wire the new Layer 2 abstraction into the task generator with unit coverage
- add proposal docs and evaluator request scaffold for l2_decoder_pwl_failure_diagnosis_v1

## Validation
- python3 npu/eval/diagnose_llm_decoder_pwl_failures.py --sweep runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json --sample-file runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl --out /tmp/pwl_diag.json --out-md /tmp/pwl_diag.md
- python3 -m py_compile npu/eval/diagnose_llm_decoder_pwl_failures.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py
- PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check