### PR TITLE
Add decoder PWL survivor distribution check

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1275,6 +1275,107 @@ def _decoder_pwl_logit_sensitivity_ladder_evidence(*, item_id: str) -> dict[str,
     }
 
 
+def _decoder_pwl_survivor_distribution_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    dataset_manifest = f"{base}/manifest_distribution_v2.json"
+    sample_file = f"{base}/samples_distribution_v2.jsonl"
+    reference_dir = f"{base}/reference_distribution_v2"
+    reference_manifest = f"{base}/reference_distribution_v2_manifest.json"
+    candidate_dir = f"{base}/candidate_distribution_v2"
+    candidate_manifest = f"{base}/candidate_distribution_v2_manifest.json"
+    validation_out = f"{base}/decoder_contract_validation__{item_id}.json"
+    quality_out = f"{base}/decoder_quality_compare__{item_id}.json"
+    sweep_dir = f"{base}/candidate_sweeps/{item_id}"
+    sweep_out = f"{base}/decoder_quality_sweep__{item_id}.json"
+    summary_out = f"{base}/decoder_pwl_survivor_distribution__{item_id}.json"
+    summary_report = f"{base}/decoder_pwl_survivor_distribution__{item_id}.md"
+    rough_grid = "decoder_pwl_survivor_distribution_v1"
+    commands = [
+        {
+            "name": "generate_decoder_pwl_survivor_distribution_reference",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_reference_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {reference_dir} "
+                f"--out-manifest {reference_manifest}"
+            ),
+        },
+        {
+            "name": "generate_decoder_pwl_survivor_distribution_candidate",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_candidate_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {candidate_dir} "
+                f"--out-manifest {candidate_manifest}"
+            ),
+        },
+        {
+            "name": "validate_decoder_pwl_survivor_distribution_contract",
+            "run": f"python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest {dataset_manifest} --out {validation_out}",
+        },
+        {
+            "name": "compare_decoder_pwl_survivor_distribution_quality",
+            "run": (
+                "python3 npu/eval/compare_llm_decoder_quality.py "
+                f"--reference-manifest {reference_manifest} "
+                f"--candidate-manifest {candidate_manifest} "
+                f"--out {quality_out}"
+            ),
+        },
+        {
+            "name": "sweep_decoder_pwl_survivor_distribution",
+            "run": (
+                "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--rough-grid {rough_grid} "
+                f"--out-dir {sweep_dir} "
+                f"--out {sweep_out}"
+            ),
+        },
+        {
+            "name": "summarize_decoder_pwl_survivor_distribution",
+            "run": (
+                "python3 npu/eval/summarize_llm_decoder_pwl_survivor_distribution.py "
+                f"--sweep {sweep_out} "
+                f"--sample-file {sample_file} "
+                f"--out {summary_out} "
+                f"--out-md {summary_report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            "dataset_manifest": dataset_manifest,
+            "sample_file": sample_file,
+            "reference_dir": reference_dir,
+            "reference_manifest": reference_manifest,
+            "candidate_dir": candidate_dir,
+            "candidate_manifest": candidate_manifest,
+            "validation_out": validation_out,
+            "quality_out": quality_out,
+            "candidate_sweep_dir": sweep_dir,
+            "candidate_sweep_out": sweep_out,
+            "candidate_sweep_grid": rough_grid,
+            "survivor_distribution_out": summary_out,
+            "survivor_distribution_report": summary_report,
+            "survivor_distribution_scope": (
+                "expanded v2 broad prompt-regime check for q12/unquantized PWL survivors, "
+                "with fp16/bf16, q10, and q8 rows kept as precision controls before RTL/PPA promotion"
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            reference_manifest,
+            candidate_manifest,
+            validation_out,
+            quality_out,
+            sweep_out,
+            summary_out,
+            summary_report,
+        ],
+    }
+
+
 def _with_fresh_outputs(*, campaign: dict[str, Any], item_id: str) -> dict[str, Any]:
     cloned = json.loads(json.dumps(campaign))
     outputs = dict(cloned.get("outputs") or {})
@@ -1385,10 +1486,13 @@ def _build_payload(
         "decoder_q8_normalization_distribution_broad_v2",
         "decoder_pwl_failure_diagnosis",
         "decoder_pwl_logit_sensitivity_ladder",
+        "decoder_pwl_survivor_distribution",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_pwl_survivor_distribution":
+            decoder_evidence = _decoder_pwl_survivor_distribution_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pwl_logit_sensitivity_ladder":
             decoder_evidence = _decoder_pwl_logit_sensitivity_ladder_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pwl_failure_diagnosis":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -975,6 +975,66 @@ def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evi
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_pwl_survivor_distribution_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_pwl_survivor_distribution_v1",
+                    proposal_id="prop_l2_decoder_pwl_survivor_distribution_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/proposal.json",
+                    evaluation_mode="broad_ranking",
+                    abstraction_layer="decoder_pwl_survivor_distribution",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:6] == [
+                "generate_decoder_pwl_survivor_distribution_reference",
+                "generate_decoder_pwl_survivor_distribution_candidate",
+                "validate_decoder_pwl_survivor_distribution_contract",
+                "compare_decoder_pwl_survivor_distribution_quality",
+                "sweep_decoder_pwl_survivor_distribution",
+                "summarize_decoder_pwl_survivor_distribution",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["dataset_manifest"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json"
+            )
+            assert decoder_inputs["sample_file"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl"
+            )
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_pwl_survivor_distribution_v1"
+            assert "q12/unquantized PWL survivors" in decoder_inputs["survivor_distribution_scope"]
+            assert "--rough-grid decoder_pwl_survivor_distribution_v1" in work_item.command_manifest[4]["run"]
+            assert "summarize_llm_decoder_pwl_survivor_distribution.py" in work_item.command_manifest[5]["run"]
+            assert decoder_inputs["survivor_distribution_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_pwl_survivor_distribution__l2_decoder_pwl_survivor_distribution_v1.json"
+            )
+            assert decoder_inputs["survivor_distribution_out"] in work_item.expected_outputs
+            assert decoder_inputs["survivor_distribution_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_pwl_survivor_distribution",
+            }
+
+
 def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/README.md
@@ -1,0 +1,5 @@
+Proposal workspace for `prop_l2_decoder_pwl_survivor_distribution_v1`.
+
+This promotes the focused PWL/logit ladder result into an expanded v2 prompt
+distribution check before spending hardware calibration effort on q12 or
+fp16-style PWL decoder softmax candidates.

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/analysis_report.md
@@ -1,0 +1,9 @@
+# Analysis Report
+
+Pending evaluator results for `l2_decoder_pwl_survivor_distribution_v1`.
+
+The expected interpretation is:
+
+- exact-safe q12/unquantized PWL: promote survivor rows to RTL/PPA calibration
+- top-k-safe but not exact-safe q12 PWL: inspect category misses and margins
+- q12 PWL broad failure: return to PWL curve or precision design before hardware

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/design_brief.md
@@ -1,0 +1,23 @@
+# Decoder PWL Survivor Distribution
+
+- `proposal_id`: `prop_l2_decoder_pwl_survivor_distribution_v1`
+- `item_id`: `l2_decoder_pwl_survivor_distribution_v1`
+- abstraction: `decoder_pwl_survivor_distribution`
+
+The focused ladder isolated the failure boundary at softmax input/weight or
+logit precision under small margins. q12 PWL and unquantized PWL recovered the
+focus samples; q8 and bf16 did not.
+
+This job moves from six focus samples to the expanded v2 distribution set. It
+uses a trimmed grid that keeps:
+
+- exact q12/q10/q8 and fp16/bf16 controls
+- unquantized PWL exact normalization
+- PWL fp16/bf16 exact normalization
+- PWL q12/q10/q8 exact normalization
+
+Expected output:
+
+- `decoder_quality_sweep__l2_decoder_pwl_survivor_distribution_v1.json`
+- `decoder_pwl_survivor_distribution__l2_decoder_pwl_survivor_distribution_v1.json`
+- `decoder_pwl_survivor_distribution__l2_decoder_pwl_survivor_distribution_v1.md`

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+Queue `l2_decoder_pwl_survivor_distribution_v1` only after
+`l2_decoder_pwl_logit_ladder_v1` is merged and finalized.
+
+Required merged inputs:
+
+- `runs/datasets/llm_decoder_eval_tiny_v1/decoder_pwl_logit_ladder__l2_decoder_pwl_logit_ladder_v1.json`
+- `runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json`
+- `npu/eval/summarize_llm_decoder_pwl_survivor_distribution.py`

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_survivor_distribution_v1",
+  "source_commit": "24c640512fd80d206a1cc585a36645c00d87664f",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_pwl_survivor_distribution_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a broad distribution check for q12 and fp16-style PWL survivor candidates.",
+      "evaluation_mode": "broad_ranking",
+      "abstraction_layer": "decoder_pwl_survivor_distribution",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_pwl_logit_ladder_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Determine whether focused q12/unquantized PWL recovery survives the expanded v2 prompt distribution before RTL/PPA calibration."
+      },
+      "status": "draft"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/implementation_summary.md
@@ -1,0 +1,11 @@
+# Implementation Summary
+
+This proposal adds:
+
+- `decoder_pwl_survivor_distribution_v1` to the decoder candidate sweep grid
+- `summarize_llm_decoder_pwl_survivor_distribution.py` for category-level broad
+  distribution summaries
+- `decoder_pwl_survivor_distribution` control-plane evidence generation
+
+The implementation intentionally reuses `manifest_distribution_v2.json` to keep
+the next step comparable with the q8/bf16 broad-v2 result.

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/promotion_decision.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_survivor_distribution_v1",
+  "status": "pending_evaluation",
+  "next_action": "Wait for l2_decoder_pwl_survivor_distribution_v1 evaluator artifacts, then decide whether q12 or fp16-style PWL should receive RTL/PPA calibration."
+}

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/promotion_gate.md
@@ -1,0 +1,8 @@
+# Promotion Gate
+
+Promote only if the summary artifact shows a PWL survivor row with:
+
+- no top-k misses on the expanded v2 distribution set
+- no exact-token misses, or a clearly bounded margin-only pattern accepted for
+  follow-up calibration
+- no claim of hardware acceptance before RTL/PPA measurement

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/promotion_result.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_survivor_distribution_v1",
+  "status": "pending_evaluation",
+  "result": null
+}

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/proposal.json
@@ -1,0 +1,61 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_survivor_distribution_v1",
+  "created_utc": "2026-05-02T02:10:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Decoder PWL survivor broad distribution check",
+  "hypothesis": "The focused ladder showed q12 and unquantized PWL can recover the margin-sensitive failures that q8/bf16 PWL lose. Reusing the expanded v2 prompt distribution should show whether q12/fp16-style PWL behavior is broadly stable enough to justify RTL/PPA calibration.",
+  "direct_comparison": {
+    "primary_question": "Across the expanded v2 prompt-regime dataset, do q12/unquantized PWL survivor rows preserve exact next-token and top-k behavior while q10/q8/bf16 controls expose the precision boundary?",
+    "include": [
+      "expanded distribution v2 prompt set",
+      "exact-softmax q12/q10/q8 logit controls",
+      "exact-softmax fp16/bf16 input and weight controls",
+      "unquantized PWL exact-normalization row",
+      "PWL fp16/bf16 exact-normalization rows",
+      "PWL q12/q10/q8 input and weight rows"
+    ],
+    "exclude": [
+      "new RTL or OpenROAD measurements",
+      "new model or tokenizer bindings",
+      "accepting q12/fp16 PWL for hardware without a follow-up PPA calibration"
+    ]
+  },
+  "expected_benefit": [
+    "tests the focused q12 PWL recovery across a broader prompt distribution",
+    "keeps q10/q8/bf16 rows as lower-precision negative controls",
+    "separates broad quality risk from later hardware cost calibration"
+  ],
+  "risks": [
+    "the expanded v2 set is still a tiny-model exploratory dataset",
+    "exact next-token behavior remains margin-sensitive and should be interpreted with top-k context",
+    "a broad quality survivor may still be too expensive after RTL/PPA calibration"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_pwl_survivor_distribution_v1",
+      "task_type": "l2_campaign",
+      "objective": "decoder_pwl_survivor_distribution",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "broad_ranking",
+      "abstraction_layer": "decoder_pwl_survivor_distribution",
+      "depends_on_item_ids": [
+        "l2_decoder_pwl_logit_ladder_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_pwl_logit_ladder_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_pwl_logit_ladder__l2_decoder_pwl_logit_ladder_v1.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "npu/eval/summarize_llm_decoder_pwl_survivor_distribution.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/quality_gate.md
@@ -1,0 +1,12 @@
+# Quality Gate
+
+The evaluation should:
+
+- regenerate the expanded v2 distribution reference and candidate manifests
+- run the `decoder_pwl_survivor_distribution_v1` rough grid
+- report exact next-token and top-k preservation for every row
+- group exact-token misses by prompt category
+- identify whether q12/unquantized/fp16-style PWL rows are broad exact-safe
+
+Acceptance is a complete broad-distribution quality artifact. Hardware
+acceptance still requires a follow-up RTL/PPA calibration for any survivor.

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -187,6 +187,37 @@ This ladder keeps the two failing broad-v2 samples and nearby arithmetic/list
 controls together. It separates exact-softmax logit quantization, unquantized
 PWL, PWL input/weight precision, and normalization precision.
 
+Run the broad distribution check for the PWL survivor rows:
+```sh
+python3 npu/eval/gen_llm_decoder_reference_suite.py \
+  --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json \
+  --out-dir /tmp/reference_distribution_v2 \
+  --out-manifest /tmp/reference_distribution_v2_manifest.json
+python3 npu/eval/gen_llm_decoder_candidate_suite.py \
+  --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json \
+  --out-dir /tmp/candidate_distribution_v2 \
+  --out-manifest /tmp/candidate_distribution_v2_manifest.json
+jq '.reference_manifest="/tmp/reference_distribution_v2_manifest.json" |
+    .candidate_manifest="/tmp/candidate_distribution_v2_manifest.json"' \
+  runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json \
+  > /tmp/manifest_distribution_v2.json
+python3 npu/eval/sweep_llm_decoder_candidate_quality.py \
+  --dataset-manifest /tmp/manifest_distribution_v2.json \
+  --rough-grid decoder_pwl_survivor_distribution_v1 \
+  --out-dir /tmp/decoder_pwl_survivor_distribution_sweep \
+  --out /tmp/decoder_pwl_survivor_distribution_sweep.json
+python3 npu/eval/summarize_llm_decoder_pwl_survivor_distribution.py \
+  --sweep /tmp/decoder_pwl_survivor_distribution_sweep.json \
+  --sample-file runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl \
+  --out /tmp/decoder_pwl_survivor_distribution.json \
+  --out-md /tmp/decoder_pwl_survivor_distribution.md
+```
+
+This grid promotes the focused q12/unquantized PWL recovery to the expanded v2
+prompt distribution and keeps q10/q8/bf16 rows as precision controls. Passing
+this check is quality evidence for a later RTL/PPA calibration, not hardware
+acceptance by itself.
+
 Run the focused survivor prompt-stress grid:
 ```sh
 python3 npu/eval/gen_llm_decoder_reference_suite.py \

--- a/npu/eval/summarize_llm_decoder_pwl_survivor_distribution.py
+++ b/npu/eval/summarize_llm_decoder_pwl_survivor_distribution.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Summarize broad-distribution quality for decoder PWL survivor candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+PRIMARY_SURVIVORS = {
+    "grid_approx_pwl_float_norm_exact",
+    "grid_approx_pwl_in_q12_w_q12_norm_exact",
+}
+PRECISION_CONTROLS = {
+    "grid_approx_pwl_fp16_norm_exact",
+    "grid_approx_pwl_bf16_norm_exact",
+    "grid_approx_pwl_in_q10_w_q10_norm_exact",
+    "grid_approx_pwl_in_q8_w_q8_norm_exact",
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve(path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return _repo_root() / candidate
+
+
+def _portable(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(_repo_root()))
+    except ValueError:
+        return str(path)
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    with _resolve(path).open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _load_jsonl(path: str | Path) -> list[JsonDict]:
+    rows: list[JsonDict] = []
+    with _resolve(path).open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if not isinstance(payload, dict):
+                raise SystemExit(f"expected object at {path}:{line_no}")
+            rows.append(payload)
+    return rows
+
+
+def _as_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _sample_categories(sample_file: str | Path) -> dict[str, str]:
+    categories: dict[str, str] = {}
+    for row in _load_jsonl(sample_file):
+        sample_id = str(row.get("sample_id") or "").strip()
+        if sample_id:
+            categories[sample_id] = str(row.get("category") or "uncategorized")
+    return categories
+
+
+def _template_family(row: JsonDict) -> str:
+    template = str(row.get("template") or "")
+    if template == "candidate_onnx_softmax_exact":
+        return "exact_reference_proxy"
+    if str(row.get("softmax_mode") or "exact") == "approx_pwl":
+        return "pwl"
+    return "exact_softmax_variant"
+
+
+def _role(template: str) -> str:
+    if template in PRIMARY_SURVIVORS:
+        return "primary_survivor_candidate"
+    if template in PRECISION_CONTROLS:
+        return "precision_control"
+    if template.startswith("grid_exact_"):
+        return "exact_softmax_control"
+    return "reference_proxy" if template == "candidate_onnx_softmax_exact" else "other"
+
+
+def _category_counts(sample_ids: list[str], categories: dict[str, str]) -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    for sample_id in sample_ids:
+        counts[categories.get(sample_id, "uncategorized")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _row_summary(row: JsonDict, categories: dict[str, str]) -> JsonDict:
+    sample_count = _as_int(row.get("sample_count"))
+    next_rate = _as_float(row.get("next_token_id_match_rate"))
+    topk_rate = _as_float(row.get("topk_contains_reference_id_rate"))
+    next_matches = round(next_rate * sample_count)
+    topk_matches = round(topk_rate * sample_count)
+    next_misses = [str(v) for v in row.get("next_token_mismatch_sample_ids") or []]
+    topk_misses = [str(v) for v in row.get("topk_miss_sample_ids") or []]
+    distribution = row.get("distribution") if isinstance(row.get("distribution"), dict) else {}
+    exact_safe = sample_count > 0 and next_matches == sample_count and topk_matches == sample_count
+    topk_safe = sample_count > 0 and topk_matches == sample_count
+    template = str(row.get("template") or "")
+    return {
+        "template": template,
+        "role": _role(template),
+        "family": _template_family(row),
+        "sample_count": sample_count,
+        "next_token_matches": next_matches,
+        "topk_matches": topk_matches,
+        "next_token_match_rate": next_rate,
+        "topk_contains_reference_id_rate": topk_rate,
+        "next_token_mismatch_sample_ids": next_misses,
+        "topk_miss_sample_ids": topk_misses,
+        "next_token_miss_categories": _category_counts(next_misses, categories),
+        "topk_miss_categories": _category_counts(topk_misses, categories),
+        "exact_safe": exact_safe,
+        "topk_safe": topk_safe,
+        "gate": "exact_safe_survivor" if exact_safe else "topk_safe_not_exact" if topk_safe else "blocked_quality",
+        "softmax_mode": row.get("softmax_mode", "exact"),
+        "logit_quant_bits": row.get("logit_quant_bits", 0),
+        "softmax_input_quant_bits": row.get("softmax_input_quant_bits", 0),
+        "softmax_input_float_format": row.get("softmax_input_float_format", ""),
+        "softmax_weight_quant_bits": row.get("softmax_weight_quant_bits", 0),
+        "softmax_weight_float_format": row.get("softmax_weight_float_format", ""),
+        "normalization_mode": row.get("normalization_mode", "exact"),
+        "candidate_score_sum_min": distribution.get("candidate_score_sum_min"),
+        "candidate_top1_top2_score_margin_min": distribution.get("candidate_top1_top2_score_margin_min"),
+    }
+
+
+def _diagnosis(rows: list[JsonDict]) -> JsonDict:
+    by_template = {str(row["template"]): row for row in rows}
+    q12 = by_template.get("grid_approx_pwl_in_q12_w_q12_norm_exact")
+    float_pwl = by_template.get("grid_approx_pwl_float_norm_exact")
+    fp16_pwl = by_template.get("grid_approx_pwl_fp16_norm_exact")
+    q10 = by_template.get("grid_approx_pwl_in_q10_w_q10_norm_exact")
+    q8 = by_template.get("grid_approx_pwl_in_q8_w_q8_norm_exact")
+    exact_fp16 = by_template.get("grid_exact_softmax_fp16_path")
+
+    exact_safe_survivors = [
+        row["template"]
+        for row in (float_pwl, q12, fp16_pwl)
+        if row is not None and row["exact_safe"]
+    ]
+    all_rows_topk_safe = all(row["topk_safe"] for row in rows if row["family"] != "exact_reference_proxy")
+
+    if q12 and q12["exact_safe"] and float_pwl and float_pwl["exact_safe"]:
+        if fp16_pwl and fp16_pwl["exact_safe"]:
+            decision = "q12_and_fp16_pwl_broad_safe"
+            recommended = "Move q12 and fp16 PWL candidates into RTL/PPA calibration, with q10/q8 retained only as lower-cost risk controls."
+        else:
+            decision = "q12_pwl_broad_safe_fp16_borderline"
+            recommended = "Promote q12 PWL to RTL/PPA calibration and inspect fp16 PWL misses before treating it as a survivor."
+    elif q12 and q12["topk_safe"]:
+        decision = "q12_pwl_topk_safe_not_exact"
+        recommended = "Treat q12 PWL as rank-stable but margin-sensitive; inspect misses by category before hardware spend."
+    else:
+        decision = "pwl_survivors_not_broad_safe"
+        recommended = "Do not promote q12/fp16 PWL to hardware selection yet; return to curve or precision design."
+
+    controls = {
+        "q10_exact_safe": bool(q10 and q10["exact_safe"]),
+        "q8_exact_safe": bool(q8 and q8["exact_safe"]),
+        "exact_fp16_exact_safe": bool(exact_fp16 and exact_fp16["exact_safe"]),
+    }
+    return {
+        "decision": decision,
+        "exact_safe_survivors": exact_safe_survivors,
+        "all_rows_topk_safe": all_rows_topk_safe,
+        "recommended_next_step": recommended,
+        "controls": controls,
+        "summary": (
+            "This broad distribution check reuses the expanded v2 prompt set to test whether the focused "
+            "PWL/logit survivor rows remain exact-safe outside the six-sample ladder. q10/q8 and bf16 rows "
+            "remain in the grid as negative precision controls, while exact fp16/q12 rows keep logit-format "
+            "effects visible."
+        ),
+    }
+
+
+def _write_md(doc: JsonDict, path: Path) -> None:
+    lines = [
+        "# Decoder PWL Survivor Distribution",
+        "",
+        f"- source_sweep: `{doc['source_sweep']}`",
+        f"- sample_file: `{doc['sample_file']}`",
+        f"- decision: `{doc['diagnosis']['decision']}`",
+        f"- summary: {doc['diagnosis']['summary']}",
+        f"- recommended_next_step: {doc['diagnosis']['recommended_next_step']}",
+        "",
+        "## Template Summary",
+        "",
+        "| template | role | next-token | top-k | gate | miss categories |",
+        "|---|---|---:|---:|---|---|",
+    ]
+    for row in doc["template_summaries"]:
+        categories = ", ".join(f"{key}:{value}" for key, value in row["next_token_miss_categories"].items()) or "none"
+        lines.append(
+            "| `{template}` | `{role}` | {next}/{samples} | {topk}/{samples} | `{gate}` | {categories} |".format(
+                template=row["template"],
+                role=row["role"],
+                next=row["next_token_matches"],
+                topk=row["topk_matches"],
+                samples=row["sample_count"],
+                gate=row["gate"],
+                categories=categories,
+            )
+        )
+    lines.extend(["", "## Exact-Safe Survivors", ""])
+    survivors = doc["diagnosis"]["exact_safe_survivors"]
+    if survivors:
+        for template in survivors:
+            lines.append(f"- `{template}`")
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Miss Details", ""])
+    for row in doc["template_summaries"]:
+        if not row["next_token_mismatch_sample_ids"]:
+            continue
+        lines.append(f"### `{row['template']}`")
+        lines.append("")
+        for sample_id in row["next_token_mismatch_sample_ids"]:
+            category = doc["sample_categories"].get(sample_id, "uncategorized")
+            lines.append(f"- `{sample_id}` ({category})")
+        lines.append("")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sweep", required=True)
+    ap.add_argument("--sample-file", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    sweep_path = _resolve(args.sweep)
+    sweep = _load_json(sweep_path)
+    templates = sweep.get("templates")
+    if not isinstance(templates, list):
+        raise SystemExit("sweep JSON must contain templates list")
+    categories = _sample_categories(args.sample_file)
+    rows = [_row_summary(row, categories) for row in templates if isinstance(row, dict)]
+    doc = {
+        "version": 0.1,
+        "source_sweep": _portable(sweep_path),
+        "sample_file": _portable(_resolve(args.sample_file)),
+        "sample_count": len(categories),
+        "sample_categories": categories,
+        "template_summaries": rows,
+        "diagnosis": _diagnosis(rows),
+    }
+    out_path = _resolve(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_path = _resolve(args.out_md)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_md(doc, md_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/sweep_llm_decoder_candidate_quality.py
+++ b/npu/eval/sweep_llm_decoder_candidate_quality.py
@@ -93,6 +93,7 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
         "decoder_survivor_prompt_stress_v1",
         "decoder_q8_normalization_frontier_v1",
         "decoder_pwl_logit_sensitivity_ladder_v1",
+        "decoder_pwl_survivor_distribution_v1",
     }:
         raise ValueError(f"unsupported rough grid: {grid_name}")
     exact = _candidate_template(model_contract, "candidate_onnx_softmax_exact")
@@ -422,6 +423,84 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
             ),
         ]
         return {name: cfg for name, cfg in points}
+    if grid_name == "decoder_pwl_survivor_distribution_v1":
+        points = [
+            ("candidate_onnx_softmax_exact", exact),
+            _named_grid_point(exact, "grid_exact_logits_q12", logit_quant_bits=12),
+            _named_grid_point(exact, "grid_exact_logits_q10", logit_quant_bits=10),
+            _named_grid_point(exact, "grid_exact_logits_q8", logit_quant_bits=8),
+            _named_grid_point(
+                exact,
+                "grid_exact_softmax_fp16_path",
+                softmax_input_float_format="fp16",
+                softmax_weight_float_format="fp16",
+            ),
+            _named_grid_point(
+                exact,
+                "grid_exact_softmax_bf16_path",
+                softmax_input_float_format="bf16",
+                softmax_weight_float_format="bf16",
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_float_norm_exact",
+                softmax_input_quant_bits=None,
+                softmax_weight_quant_bits=None,
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_fp16_norm_exact",
+                softmax_input_quant_bits=None,
+                softmax_weight_quant_bits=None,
+                softmax_input_float_format="fp16",
+                softmax_weight_float_format="fp16",
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_bf16_norm_exact",
+                softmax_input_quant_bits=None,
+                softmax_weight_quant_bits=None,
+                softmax_input_float_format="bf16",
+                softmax_weight_float_format="bf16",
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_in_q12_w_q12_norm_exact",
+                softmax_input_quant_bits=12,
+                softmax_weight_quant_bits=12,
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_in_q10_w_q10_norm_exact",
+                softmax_input_quant_bits=10,
+                softmax_weight_quant_bits=10,
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_in_q8_w_q8_norm_exact",
+                softmax_input_quant_bits=8,
+                softmax_weight_quant_bits=8,
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+        ]
+        return {name: cfg for name, cfg in points}
     points = [
         ("candidate_onnx_softmax_exact", exact),
         _named_grid_point(exact, "grid_exact_logits_q8", logit_quant_bits=8),
@@ -636,7 +715,7 @@ def main() -> int:
             "Generate a built-in rough approximation grid, e.g. decoder_probability_broad_v1, "
             "decoder_probability_fp_formats_v1, decoder_distribution_robustness_v1, or "
             "decoder_survivor_prompt_stress_v1, decoder_q8_normalization_frontier_v1, "
-            "or decoder_pwl_logit_sensitivity_ladder_v1."
+            "decoder_pwl_logit_sensitivity_ladder_v1, or decoder_pwl_survivor_distribution_v1."
         ),
     )
     ap.add_argument("--out-dir", default="runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/local")


### PR DESCRIPTION
## Summary

Adds the next decoder PWL survivor distribution check after the focused PWL/logit ladder.

- adds `decoder_pwl_survivor_distribution_v1` rough grid over distribution-v2 prompts
- adds a category-level summarizer for q12/unquantized/fp16-style PWL survivor quality
- wires the new `decoder_pwl_survivor_distribution` abstraction into the L2 task generator
- documents the proposal and evaluator request shape

## Local validation

- `python3 -m py_compile npu/eval/sweep_llm_decoder_candidate_quality.py npu/eval/summarize_llm_decoder_pwl_survivor_distribution.py control_plane/control_plane/services/l2_task_generator.py`
- `PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py`
- local distribution-v2 generation + `decoder_pwl_survivor_distribution_v1` sweep + summarizer into `/tmp/rtlgen_pwl_survivor_distribution`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

## Smoke result

The local `/tmp` smoke result showed q12 PWL and unquantized PWL exact-safe on 48/48 distribution-v2 samples, fp16 PWL at 47/48, q10 at 47/48, and q8/bf16 at 46/48. All rows were top-k safe.
