### PR TITLE
[codex] Add q12 PWL softmax datapath setup

### DIFF
--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/README.md
@@ -1,0 +1,8 @@
+# q12 PWL Softmax Datapath
+
+Proposal workspace for `prop_l1_decoder_q12_pwl_softmax_datapath_v1`.
+
+This proposal promotes the q12 PWL decoder softmax survivor into a hardware
+datapath calibration point. It measures the row-wise PWL-exp plus exact
+normalization block in RTLGen/OpenROAD before making cost claims against q8
+shift-exp or reciprocal-normalization alternatives.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l1_decoder_q12_pwl_softmax_datapath_v1",
+  "created_utc": "2026-05-02T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "circuit_block",
+  "title": "Decoder q12 PWL softmax datapath calibration",
+  "hypothesis": "The q12 PWL decoder softmax survivor needs an integrated RTLGen/OpenROAD datapath measurement before its quality result can be compared against q8 exact, q8 reciprocal, or bf16 normalization hardware points.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 timing, power, and area does the q12 PWL-exp row-wise softmax datapath show for the decoder survivor candidate?",
+    "include": [
+      "row-wise signed q12 logits",
+      "PWL exp anchors matching the decoder software approximation at shifted logits 0, -2, -4, and -8",
+      "q12 PWL weights and q12 unsigned outputs",
+      "row_elems=8, input_frac_bits=8, weight_bits=12, accum_bits=28, output_scale=4095",
+      "exact normalization so the first measurement isolates PWL exp datapath cost from reciprocal approximation cost"
+    ],
+    "exclude": [
+      "full-vocabulary dynamic quantizer hardware",
+      "reciprocal-normalization approximation for the q12 PWL candidate",
+      "full decoder system PPA",
+      "new prompt-stress quality thresholds"
+    ],
+    "follow_on_broad_sweep": [
+      "compare measured q12 PWL datapath PPA against q8 exact/reciprocal and bf16 normalization datapath results on separate performance, power, and area axes",
+      "if exact normalization dominates area or timing, queue a q12 PWL reciprocal-normalization variant",
+      "if the datapath is competitive, add dynamic-quantizer or scale-metadata cost before claiming end-to-end decoder hardware benefit"
+    ]
+  },
+  "expected_benefit": [
+    "replaces the q12 PWL cost proxy with direct RTL/OpenROAD measurement",
+    "keeps the broad quality survivor connected to an emitted hardware datapath",
+    "makes performance, power, and area tradeoffs visible as separate dashboard dimensions"
+  ],
+  "risks": [
+    "this is a fixed-point datapath proxy and does not include the full dynamic symmetric quantization step used by the software sweep",
+    "the exact divider may dominate the first measurement and hide PWL-exp datapath differences",
+    "single-row block PPA still excludes memory, control, and full decoder integration effects",
+    "quality remains benchmark-distribution dependent until prompt and weight/input distribution stress is broadened"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_q12_pwl_softmax_datapath_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "measurement_only",
+      "objective": "Measure Nangate45 PPA for the integrated q12 PWL-exp row-wise softmax block with exact normalization.",
+      "sweep_path": "runs/campaigns/activations/softmax_rowwise_q12_pwl/sweeps/nangate45_highutil.json",
+      "config_paths": [
+        "runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28.json"
+      ],
+      "abstraction_layer": "circuit_block"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_pwl_survivor_distribution__l2_decoder_pwl_survivor_distribution_v1.md",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_normalization_frontier_v1.json",
+    "docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/analysis_report.md"
+  ],
+  "knowledge_refs": [
+    "src/rtlgen/rtl_operations.cpp",
+    "scripts/softmax_rowwise_ref.py",
+    "runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28.json"
+  ]
+}

--- a/runs/campaigns/activations/softmax_rowwise_q12_pwl/sweeps/nangate45_highutil.json
+++ b/runs/campaigns/activations/softmax_rowwise_q12_pwl/sweeps/nangate45_highutil.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "softmax_rowwise_q12_pwl_nangate45_highutil",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.5],
+    "CORE_UTILIZATION": [60, 50],
+    "PLACE_DENSITY": [0.68]
+  }
+}

--- a/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28.json
+++ b/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 12,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "softmax_rowwise_q12_pwl_r8_acc28",
+      "operand": "logits",
+      "options": {
+        "impl": "pwl_exp",
+        "row_elems": 8,
+        "input_frac_bits": 8,
+        "weight_bits": 12,
+        "accum_bits": 28,
+        "output_scale": 4095,
+        "normalization_mode": "exact"
+      }
+    }
+  ]
+}

--- a/scripts/softmax_rowwise_ref.py
+++ b/scripts/softmax_rowwise_ref.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import math
 from pathlib import Path
 
 
@@ -18,6 +19,8 @@ def _load_config(path: str) -> dict:
         "reciprocal_lut_bucket_shift": int(opts.get("reciprocal_lut_bucket_shift", 0)),
         "row_elems": int(opts.get("row_elems", 1)),
         "max_shift": int(opts.get("max_shift", 7)),
+        "input_frac_bits": int(opts.get("input_frac_bits", 0)),
+        "weight_bits": int(opts.get("weight_bits", 0)),
         "accum_bits": int(opts.get("accum_bits", 16)),
         "output_scale": int(opts.get("output_scale", 127)),
     }
@@ -72,6 +75,78 @@ def compute_shift_exp_row(
     return out
 
 
+def compute_pwl_exp_row(
+    logits,
+    *,
+    input_frac_bits: int = 0,
+    weight_bits: int = 8,
+    output_scale: int = 127,
+    normalization_mode: str = "exact",
+    reciprocal_bits: int = 0,
+    reciprocal_lut_bucket_shift: int = 0,
+):
+    if not logits:
+        return []
+    if input_frac_bits < 0:
+        raise ValueError("input_frac_bits must be non-negative")
+    if weight_bits <= 0:
+        raise ValueError("weight_bits must be positive")
+    max_val = max(int(v) for v in logits)
+    input_scale = 1 << input_frac_bits
+    def round_half_up(value: float) -> int:
+        return int(math.floor(value + 0.5))
+
+    anchors = [
+        (0, (1 << weight_bits) - 1),
+        (2 * input_scale, round_half_up(math.exp(-2.0) * ((1 << weight_bits) - 1))),
+        (4 * input_scale, round_half_up(math.exp(-4.0) * ((1 << weight_bits) - 1))),
+        (8 * input_scale, round_half_up(math.exp(-8.0) * ((1 << weight_bits) - 1))),
+    ]
+
+    def pwl_weight(delta: int) -> int:
+        if delta < 0:
+            delta = 0
+        if delta > anchors[-1][0]:
+            return 0
+        if delta == anchors[-1][0]:
+            return int(anchors[-1][1])
+        for (x0, y0), (x1, y1) in zip(anchors, anchors[1:]):
+            if delta <= x1:
+                seg_width = x1 - x0
+                interp = ((delta - x0) * (y0 - y1) + (seg_width // 2)) // seg_width
+                return max(0, int(y0 - interp))
+        return 0
+
+    weights = [pwl_weight(max_val - int(value)) for value in logits]
+    sum_weights = sum(weights)
+    if sum_weights <= 0:
+        return [0 for _ in logits]
+    out = []
+    reciprocal = None
+    if normalization_mode == "reciprocal_quantized":
+        if reciprocal_bits <= 0:
+            raise ValueError("reciprocal_bits must be positive for reciprocal_quantized")
+        if reciprocal_lut_bucket_shift > 0:
+            bucket = (sum_weights + ((1 << reciprocal_lut_bucket_shift) - 1)) >> reciprocal_lut_bucket_shift
+            approx_sum = max(1, bucket << reciprocal_lut_bucket_shift)
+        else:
+            approx_sum = sum_weights
+        reciprocal = ((output_scale << reciprocal_bits) + (approx_sum // 2)) // approx_sum
+    elif normalization_mode != "exact":
+        raise ValueError(f"unsupported normalization_mode: {normalization_mode}")
+    for weight in weights:
+        if reciprocal is None:
+            quantized = ((weight * output_scale) + (sum_weights // 2)) // sum_weights
+        else:
+            quantized = ((weight * reciprocal) + (1 << (reciprocal_bits - 1))) >> reciprocal_bits
+        if quantized < 0:
+            quantized = 0
+        if quantized > output_scale:
+            quantized = output_scale
+        out.append(int(quantized))
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Reference model for Layer-1 softmax_rowwise candidates.")
     ap.add_argument("--config", required=True, help="Path to softmax_rowwise config JSON")
@@ -84,8 +159,12 @@ def main() -> int:
     args = ap.parse_args()
 
     cfg = _load_config(args.config)
-    if cfg["impl"] != "shift_exp":
+    if cfg["impl"] not in {"shift_exp", "pwl_exp"}:
         raise SystemExit(f"unsupported impl: {cfg['impl']}")
+    weight_bits = cfg["weight_bits"]
+    if weight_bits == 0:
+        operands = json.loads(Path(args.config).read_text(encoding="utf-8")).get("operands", [])
+        weight_bits = int(operands[0].get("bit_width", 8)) if operands else 8
 
     rows = []
     for raw_row in args.row:
@@ -97,13 +176,25 @@ def main() -> int:
         rows.append(
             {
                 "input": values,
-                "output": compute_shift_exp_row(
-                    values,
-                    max_shift=cfg["max_shift"],
-                    output_scale=cfg["output_scale"],
-                    normalization_mode=cfg["normalization_mode"],
-                    reciprocal_bits=cfg["reciprocal_bits"],
-                    reciprocal_lut_bucket_shift=cfg["reciprocal_lut_bucket_shift"],
+                "output": (
+                    compute_shift_exp_row(
+                        values,
+                        max_shift=cfg["max_shift"],
+                        output_scale=cfg["output_scale"],
+                        normalization_mode=cfg["normalization_mode"],
+                        reciprocal_bits=cfg["reciprocal_bits"],
+                        reciprocal_lut_bucket_shift=cfg["reciprocal_lut_bucket_shift"],
+                    )
+                    if cfg["impl"] == "shift_exp"
+                    else compute_pwl_exp_row(
+                        values,
+                        input_frac_bits=cfg["input_frac_bits"],
+                        weight_bits=weight_bits,
+                        output_scale=cfg["output_scale"],
+                        normalization_mode=cfg["normalization_mode"],
+                        reciprocal_bits=cfg["reciprocal_bits"],
+                        reciprocal_lut_bucket_shift=cfg["reciprocal_lut_bucket_shift"],
+                    )
                 ),
             }
         )
@@ -118,6 +209,8 @@ def main() -> int:
                 "reciprocal_lut_bucket_shift": cfg["reciprocal_lut_bucket_shift"],
                 "row_elems": cfg["row_elems"],
                 "max_shift": cfg["max_shift"],
+                "input_frac_bits": cfg["input_frac_bits"],
+                "weight_bits": weight_bits,
                 "accum_bits": cfg["accum_bits"],
                 "output_scale": cfg["output_scale"],
                 "rows": rows,

--- a/src/rtlgen/config.cpp
+++ b/src/rtlgen/config.cpp
@@ -357,8 +357,13 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                     softmax.reciprocal_lut_bucket_shift = options.value("reciprocal_lut_bucket_shift", 0);
                     softmax.row_elems = options.value("row_elems", 1);
                     softmax.max_shift = options.value("max_shift", 7);
+                    softmax.input_frac_bits = options.value("input_frac_bits", 0);
+                    softmax.weight_bits = options.value("weight_bits", 0);
                     softmax.accum_bits = options.value("accum_bits", 16);
                     softmax.output_scale = options.value("output_scale", 127);
+                    if (softmax.impl != "shift_exp" && softmax.impl != "pwl_exp") {
+                        throw std::runtime_error("softmax_rowwise impl must be shift_exp or pwl_exp for " + softmax.module_name);
+                    }
                     if (softmax.normalization_mode != "exact" && softmax.normalization_mode != "reciprocal_quantized") {
                         throw std::runtime_error("softmax_rowwise normalization_mode must be exact or reciprocal_quantized for " + softmax.module_name);
                     }
@@ -374,11 +379,17 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                     if (softmax.max_shift < 0 || softmax.max_shift > 15) {
                         throw std::runtime_error("softmax_rowwise max_shift must be in [0, 15] for " + softmax.module_name);
                     }
+                    if (softmax.input_frac_bits < 0 || softmax.input_frac_bits > 16) {
+                        throw std::runtime_error("softmax_rowwise input_frac_bits must be in [0, 16] for " + softmax.module_name);
+                    }
+                    if (softmax.weight_bits < 0 || softmax.weight_bits > 24) {
+                        throw std::runtime_error("softmax_rowwise weight_bits must be in [0, 24] for " + softmax.module_name);
+                    }
                     if (softmax.accum_bits < 4 || softmax.accum_bits > 64) {
                         throw std::runtime_error("softmax_rowwise accum_bits must be in [4, 64] for " + softmax.module_name);
                     }
-                    if (softmax.output_scale <= 0 || softmax.output_scale > 255) {
-                        throw std::runtime_error("softmax_rowwise output_scale must be in [1, 255] for " + softmax.module_name);
+                    if (softmax.output_scale <= 0 || softmax.output_scale > 16777215) {
+                        throw std::runtime_error("softmax_rowwise output_scale must be in [1, 16777215] for " + softmax.module_name);
                     }
                     config.softmax_rowwise_operations.push_back(softmax);
                 } else if (type == "bf16_recip_norm") {

--- a/src/rtlgen/config.hpp
+++ b/src/rtlgen/config.hpp
@@ -202,6 +202,8 @@ struct SoftmaxRowwiseOperationConfig {
     int reciprocal_lut_bucket_shift{0};
     int row_elems{1};
     int max_shift{7};
+    int input_frac_bits{0};
+    int weight_bits{0};
     int accum_bits{16};
     int output_scale{127};
 };

--- a/src/rtlgen/rtl_operations.cpp
+++ b/src/rtlgen/rtl_operations.cpp
@@ -892,10 +892,10 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     if (operand.kind != "int") {
         throw std::runtime_error("softmax_rowwise currently supports only integer operands");
     }
-    if (operand.bit_width != 8) {
-        throw std::runtime_error("softmax_rowwise currently supports only 8-bit operands");
+    if (operand.bit_width < 2 || operand.bit_width > 24) {
+        throw std::runtime_error("softmax_rowwise operand bit_width must be in [2, 24]");
     }
-    if (config.impl != "shift_exp") {
+    if (config.impl != "shift_exp" && config.impl != "pwl_exp") {
         throw std::runtime_error("Unsupported softmax_rowwise impl: " + config.impl);
     }
     if (config.normalization_mode != "exact" && config.normalization_mode != "reciprocal_quantized") {
@@ -913,11 +913,19 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     if (config.max_shift < 0 || config.max_shift > 15) {
         throw std::runtime_error("softmax_rowwise max_shift must be in [0, 15]");
     }
+    if (config.input_frac_bits < 0 || config.input_frac_bits > 16) {
+        throw std::runtime_error("softmax_rowwise input_frac_bits must be in [0, 16]");
+    }
+    const int weight_bits = (config.weight_bits == 0) ? operand.bit_width : config.weight_bits;
+    if (weight_bits < 2 || weight_bits > 24) {
+        throw std::runtime_error("softmax_rowwise weight_bits must be in [2, 24]");
+    }
     if (config.accum_bits < 4 || config.accum_bits > 64) {
         throw std::runtime_error("softmax_rowwise accum_bits must be in [4, 64]");
     }
-    if (config.output_scale <= 0 || config.output_scale > 255) {
-        throw std::runtime_error("softmax_rowwise output_scale must be in [1, 255]");
+    const long long output_max = (1LL << operand.bit_width) - 1;
+    if (config.output_scale <= 0 || config.output_scale > output_max) {
+        throw std::runtime_error("softmax_rowwise output_scale exceeds the operand output range");
     }
 
     const int data_width = operand.bit_width;
@@ -928,11 +936,12 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
         ? static_cast<int>(std::ceil(std::log2(static_cast<double>(config.output_scale) * std::ldexp(1.0, config.reciprocal_bits) + 1.0)))
         : data_width;
     const int product_bits = config.accum_bits + reciprocal_value_bits;
+    const long long max_weight = (config.impl == "shift_exp") ? (1LL << config.max_shift) : ((1LL << weight_bits) - 1);
     const int max_sum_bits = static_cast<int>(
-        std::ceil(std::log2(static_cast<double>(config.row_elems * (1 << config.max_shift)) + 1.0))
+        std::ceil(std::log2(static_cast<double>(config.row_elems) * static_cast<double>(max_weight) + 1.0))
     );
     if (config.accum_bits < std::max(1, max_sum_bits)) {
-        throw std::runtime_error("softmax_rowwise accum_bits is too small for row_elems/max_shift envelope");
+        throw std::runtime_error("softmax_rowwise accum_bits is too small for the row_elems/weight envelope");
     }
 
     std::string filename = config.module_name + ".v";
@@ -946,18 +955,81 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     os << "  input  [" << (row_width - 1) << ":0] X,\n";
     os << "  output reg [" << (row_width - 1) << ":0] Y\n";
     os << ");\n\n";
-    os << "  // Row-wise normalized int8 softmax approximation.\n";
+    os << "  // Row-wise normalized integer softmax approximation.\n";
     os << "  // 1) find row max\n";
-    os << "  // 2) assign power-of-two weights from clamped distance to max\n";
-    os << "  // 3) normalize weights into Q0.7-style outputs\n";
+    os << "  // 2) assign approximation weights from distance to max\n";
+    os << "  // 3) normalize weights into unsigned integer outputs\n";
     os << "  localparam integer ROW_ELEMS = " << config.row_elems << ";\n";
     os << "  localparam integer DATA_W = " << data_width << ";\n";
     os << "  localparam integer ACCUM_BITS = " << config.accum_bits << ";\n";
     os << "  localparam integer PRODUCT_BITS = " << product_bits << ";\n";
     os << "  localparam integer MAX_SHIFT = " << config.max_shift << ";\n";
     os << "  localparam integer OUTPUT_SCALE = " << config.output_scale << ";\n\n";
+    if (config.impl == "pwl_exp") {
+        const int input_scale = 1 << config.input_frac_bits;
+        const int x2 = 2 * input_scale;
+        const int x4 = 4 * input_scale;
+        const int x8 = 8 * input_scale;
+        const int weight_scale = (1 << weight_bits) - 1;
+        auto scaled_exp = [&](double x) {
+            return static_cast<int>(std::llround(std::exp(x) * static_cast<double>(weight_scale)));
+        };
+        const int y0 = weight_scale;
+        const int y2 = scaled_exp(-2.0);
+        const int y4 = scaled_exp(-4.0);
+        const int y8 = scaled_exp(-8.0);
+        os << "  localparam integer INPUT_FRAC_BITS = " << config.input_frac_bits << ";\n";
+        os << "  localparam integer WEIGHT_BITS = " << weight_bits << ";\n";
+        os << "  localparam integer PWL_X2 = " << x2 << ";\n";
+        os << "  localparam integer PWL_X4 = " << x4 << ";\n";
+        os << "  localparam integer PWL_X8 = " << x8 << ";\n";
+        os << "  localparam integer PWL_Y0 = " << y0 << ";\n";
+        os << "  localparam integer PWL_Y2 = " << y2 << ";\n";
+        os << "  localparam integer PWL_Y4 = " << y4 << ";\n";
+        os << "  localparam integer PWL_Y8 = " << y8 << ";\n\n";
+        os << "  function [ACCUM_BITS-1:0] pwl_weight;\n";
+        os << "    input integer delta_in;\n";
+        os << "    integer clamped_delta;\n";
+        os << "    integer seg_x0;\n";
+        os << "    integer seg_width;\n";
+        os << "    integer y0;\n";
+        os << "    integer y1;\n";
+        os << "    integer ydiff;\n";
+        os << "    reg [63:0] interp_num;\n";
+        os << "    begin\n";
+        os << "      clamped_delta = delta_in;\n";
+        os << "      if (clamped_delta < 0)\n";
+        os << "        clamped_delta = 0;\n";
+        os << "      if (clamped_delta > PWL_X8) begin\n";
+        os << "        pwl_weight = {ACCUM_BITS{1'b0}};\n";
+        os << "      end else if (clamped_delta == PWL_X8) begin\n";
+        os << "        pwl_weight = PWL_Y8;\n";
+        os << "      end else begin\n";
+        os << "        if (clamped_delta <= PWL_X2) begin\n";
+        os << "          seg_x0 = 0;\n";
+        os << "          seg_width = PWL_X2;\n";
+        os << "          y0 = PWL_Y0;\n";
+        os << "          y1 = PWL_Y2;\n";
+        os << "        end else if (clamped_delta <= PWL_X4) begin\n";
+        os << "          seg_x0 = PWL_X2;\n";
+        os << "          seg_width = PWL_X4 - PWL_X2;\n";
+        os << "          y0 = PWL_Y2;\n";
+        os << "          y1 = PWL_Y4;\n";
+        os << "        end else begin\n";
+        os << "          seg_x0 = PWL_X4;\n";
+        os << "          seg_width = PWL_X8 - PWL_X4;\n";
+        os << "          y0 = PWL_Y4;\n";
+        os << "          y1 = PWL_Y8;\n";
+        os << "        end\n";
+        os << "        ydiff = y0 - y1;\n";
+        os << "        interp_num = ((clamped_delta - seg_x0) * ydiff) + (seg_width >> 1);\n";
+        os << "        pwl_weight = y0 - (interp_num / seg_width);\n";
+        os << "      end\n";
+        os << "    end\n";
+        os << "  endfunction\n\n";
+    }
     if (reciprocal_quantized) {
-        const int max_sum = config.row_elems * (1 << config.max_shift);
+        const int max_sum = static_cast<int>(config.row_elems * max_weight);
         const int bucket_shift = config.reciprocal_lut_bucket_shift;
         const int max_bucket = (max_sum + reciprocal_bucket_step - 1) >> bucket_shift;
         const long long scale = static_cast<long long>(config.output_scale) << config.reciprocal_bits;
@@ -1006,9 +1078,13 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
     os << "      delta = row_max - lane_val;\n";
     os << "      if (delta < 0)\n";
     os << "        delta = 0;\n";
-    os << "      if (delta > MAX_SHIFT)\n";
-    os << "        delta = MAX_SHIFT;\n";
-    os << "      weights[i] = ({{(ACCUM_BITS-1){1'b0}}, 1'b1} << (MAX_SHIFT - delta));\n";
+    if (config.impl == "shift_exp") {
+        os << "      if (delta > MAX_SHIFT)\n";
+        os << "        delta = MAX_SHIFT;\n";
+        os << "      weights[i] = ({{(ACCUM_BITS-1){1'b0}}, 1'b1} << (MAX_SHIFT - delta));\n";
+    } else {
+        os << "      weights[i] = pwl_weight(delta);\n";
+    }
     os << "      sum_weights = sum_weights + weights[i];\n";
     os << "    end\n\n";
     os << "    Y = {ROW_ELEMS*DATA_W{1'b0}};\n";

--- a/tests/softmax_rowwise_q12_pwl_tb.v
+++ b/tests/softmax_rowwise_q12_pwl_tb.v
@@ -1,0 +1,32 @@
+`timescale 1ns/1ps
+
+module softmax_rowwise_q12_pwl_tb;
+  reg  [47:0] X;
+  wire [47:0] Y;
+
+  softmax_rowwise_q12_pwl_r4 dut (.X(X), .Y(Y));
+
+  task check_row;
+    input [47:0] a;
+    input [47:0] exp;
+    begin
+      X = a;
+      #1;
+      if (Y !== exp) begin
+        $display(
+          "FAIL softmax_rowwise_q12_pwl: got=[%0d,%0d,%0d,%0d] expected=[%0d,%0d,%0d,%0d]",
+          Y[11:0], Y[23:12], Y[35:24], Y[47:36],
+          exp[11:0], exp[23:12], exp[35:24], exp[47:36]
+        );
+        $fatal;
+      end
+    end
+  endtask
+
+  initial begin
+    check_row({12'd0, 12'd0, 12'd0, 12'd0}, {12'd1024, 12'd1024, 12'd1024, 12'd1024});
+    check_row({12'h800, 12'hc00, 12'he00, 12'd0}, {12'd1, 12'd65, 12'd480, 12'd3549});
+    $display("All q12 PWL row-wise softmax tests passed.");
+    $finish;
+  end
+endmodule

--- a/tests/test_softmax_rowwise.sh
+++ b/tests/test_softmax_rowwise.sh
@@ -62,4 +62,45 @@ if got != expected:
 PY
 iverilog -g2012 -DSOFTMAX_RECIP_Q10_BUCKETED -s softmax_rowwise_tb -o sim_recip softmax_rowwise_int8_r4.v "$ROOT/tests/softmax_rowwise_tb.v"
 vvp sim_recip
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+cfg = {
+    "version": "1.1",
+    "operands": [{"name": "logits", "dimensions": 1, "bit_width": 12, "signed": True}],
+    "operations": [
+        {
+            "type": "softmax_rowwise",
+            "module_name": "softmax_rowwise_q12_pwl_r4",
+            "operand": "logits",
+            "options": {
+                "impl": "pwl_exp",
+                "row_elems": 4,
+                "input_frac_bits": 8,
+                "weight_bits": 12,
+                "accum_bits": 28,
+                "output_scale": 4095,
+                "normalization_mode": "exact",
+            },
+        }
+    ],
+}
+Path("config_q12_pwl.json").write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+PY
+"$ROOT/build/rtlgen" config_q12_pwl.json
+python3 "$ROOT/scripts/softmax_rowwise_ref.py" --config config_q12_pwl.json --row 0,0,0,0 --row 0,-512,-1024,-2048 > ref_q12_pwl.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+payload = json.loads(Path("ref_q12_pwl.json").read_text(encoding="utf-8"))
+expected = [[1024, 1024, 1024, 1024], [3549, 480, 65, 1]]
+got = [row["output"] for row in payload["rows"]]
+if got != expected:
+    raise SystemExit(f"q12 PWL reference mismatch got={got} expected={expected}")
+PY
+iverilog -g2012 -s softmax_rowwise_q12_pwl_tb -o sim_q12_pwl softmax_rowwise_q12_pwl_r4.v "$ROOT/tests/softmax_rowwise_q12_pwl_tb.v"
+vvp sim_q12_pwl
 popd >/dev/null


### PR DESCRIPTION
## Summary
- add `pwl_exp` support to `softmax_rowwise` so RTLGen can emit the q12 PWL decoder survivor datapath instead of reusing the q8 shift-exp block
- add the matching Python reference path plus q12 PWL RTL simulation coverage
- add the Nangate45 high-util sweep config and Layer-1 proposal for `l1_decoder_q12_pwl_softmax_datapath_v1`

## Context
The latest decoder PWL survivor result found q12 PWL exact normalization safe on the current tiny decoder benchmark. This PR creates the hardware-facing setup to measure that candidate directly. The proposal records the limitation that this is a fixed-point datapath proxy and does not include the full dynamic symmetric quantizer from the software sweep.

## Validation
- `cmake --build build --target rtlgen`
- `bash tests/test_softmax_rowwise.sh`
- generated and compiled `softmax_rowwise_q12_pwl_r8_acc28.v` with `iverilog -g2012`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
