### PR TITLE
[codex] Record q12 PWL softmax evaluation request

### DIFF
--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/analysis_report.md
@@ -1,0 +1,22 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l1_decoder_q12_pwl_softmax_datapath_v1`
+- `candidate_id`: `softmax_rowwise_q12_pwl_r8_acc28`
+
+## Evaluations Consumed
+- pending: `l1_decoder_q12_pwl_softmax_datapath_v1`
+- source commit: `180842b289eacc28b747bd5c58c959bec9b9d0e8`
+
+## Baseline Comparison
+- pending evaluator result
+
+## Result
+- pending evaluator result
+
+## Failures and Caveats
+- This candidate does not include full dynamic symmetric quantizer hardware.
+- The first measurement uses exact normalization, so divider cost may dominate.
+
+## Recommendation
+- pending evaluator result

--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/design_brief.md
@@ -1,0 +1,57 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_q12_pwl_softmax_datapath_v1`
+- `title`: `Decoder q12 PWL softmax datapath calibration`
+- `layer`: `layer1`
+- `kind`: `circuit_block`
+
+## Problem
+
+The decoder PWL survivor distribution found q12 PWL exact normalization safe on
+the current tiny decoder benchmark, but the existing RTLGen row-wise softmax
+block only measured the older q8 shift-exp approximation. A cost comparison
+against q8 exact, q8 reciprocal, or bf16 normalization needs a hardware point
+that actually emits the q12 PWL-exp datapath.
+
+## Candidate Direction
+
+Add a `softmax_rowwise` `impl=pwl_exp` mode with fixed-point q12 logits,
+q12 PWL weights, and exact normalization. The PWL anchors match the decoder
+software approximation at shifted logits 0, -2, -4, and -8.
+
+This first hardware point intentionally excludes the full dynamic symmetric
+quantizer used by the software sweep. It is a row-wise datapath PPA proxy, not
+an end-to-end decoder-softmax implementation.
+
+## Evaluation Scope
+
+Run one L1 measurement-only Nangate45 sweep:
+
+- `softmax_rowwise_q12_pwl_r8_acc28`
+- `row_elems=8`
+- `input_frac_bits=8`
+- `weight_bits=12`
+- `output_scale=4095`
+- `normalization_mode=exact`
+
+The result should be compared against existing q8 reciprocal and bf16
+normalization datapath results on separate timing, power, and area axes.
+
+## Exclusions
+
+- Full-vocabulary dynamic quantizer hardware.
+- q12 PWL reciprocal-normalization approximation.
+- Full decoder memory/control/system PPA.
+- New prompt-stress quality thresholds.
+
+## Knowledge Inputs
+- `runs/datasets/llm_decoder_eval_tiny_v1/decoder_pwl_survivor_distribution__l2_decoder_pwl_survivor_distribution_v1.md`
+- `docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/analysis_report.md`
+- `docs/proposals/prop_l1_decoder_bf16_recip_norm_datapath_v1/analysis_report.md`
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-05-02T05:45:00Z
+- note: Immediate frontier follow-up after q12 PWL survived the broad decoder distribution check.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved_after_merge
+- approved_by: developer_agent
+- approved_utc: 2026-05-02T05:45:00Z
+- allowed_evaluations:
+  - `l1_decoder_q12_pwl_softmax_datapath_v1`: L1 measurement-only sweep for the q12 PWL-exp row-wise softmax datapath with exact normalization.
+- note: The evaluator must run this from a commit containing `softmax_rowwise` `impl=pwl_exp` support.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/evaluation_requests.json
@@ -1,0 +1,14 @@
+{
+  "proposal_id": "prop_l1_decoder_q12_pwl_softmax_datapath_v1",
+  "source_commit": "180842b289eacc28b747bd5c58c959bec9b9d0e8",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_q12_pwl_softmax_datapath_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the integrated q12 PWL-exp row-wise softmax block with exact normalization.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/implementation_summary.md
@@ -1,0 +1,40 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_q12_pwl_softmax_datapath_v1`
+- title: `Decoder q12 PWL softmax datapath calibration`
+
+## Scope
+- Added `impl=pwl_exp` support to RTLGen `softmax_rowwise`.
+- Added q12 fixed-point input/weight controls for the row-wise softmax emitter.
+- Added a matching Python reference path and RTL simulation coverage.
+- Added the q12 PWL row-8 config and Nangate45 high-util sweep metadata.
+- Did not add full dynamic symmetric quantizer hardware.
+
+## Files Changed
+- `src/rtlgen/config.hpp`
+- `src/rtlgen/config.cpp`
+- `src/rtlgen/rtl_operations.cpp`
+- `scripts/softmax_rowwise_ref.py`
+- `tests/test_softmax_rowwise.sh`
+- `tests/softmax_rowwise_q12_pwl_tb.v`
+- `runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28.json`
+- `runs/campaigns/activations/softmax_rowwise_q12_pwl/sweeps/nangate45_highutil.json`
+
+## Local Validation
+- `cmake --build build --target rtlgen`
+- `bash tests/test_softmax_rowwise.sh`
+- generated and compiled `softmax_rowwise_q12_pwl_r8_acc28.v` with `iverilog -g2012`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+- `git diff --check`
+
+## Evaluation Request
+- requested item: `l1_decoder_q12_pwl_softmax_datapath_v1`
+- task type: `l1_sweep`
+- mode: `measurement_only`
+- compare against q8 reciprocal and bf16 normalization datapath measurements using separate timing, power, and area axes.
+
+## Risks
+- The exact divider may dominate the first measurement.
+- This is a fixed-point datapath proxy and excludes dynamic quantizer cost.
+- The current quality evidence is benchmark-distribution dependent.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l1_decoder_q12_pwl_softmax_datapath_v1",
+  "candidate_id": "softmax_rowwise_q12_pwl_r8_acc28",
+  "decision": "pending",
+  "reason": "Awaiting L1 PPA measurement for l1_decoder_q12_pwl_softmax_datapath_v1.",
+  "evidence_refs": [
+    "item:l1_decoder_q12_pwl_softmax_datapath_v1"
+  ],
+  "next_action": "Consume evaluator result, compare q12 PWL PPA against q8 reciprocal and bf16 normalization datapath results, then decide whether to queue reciprocal q12 PWL or dynamic-quantizer calibration.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action: Promote only after measured PPA is compared against q8 reciprocal and bf16 normalization datapath baselines.
+- note: Do not claim end-to-end decoder benefit until dynamic quantizer or scale-metadata cost is accounted for.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_decoder_q12_pwl_softmax_datapath_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/quality_gate.md
@@ -1,0 +1,28 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_q12_pwl_softmax_datapath_v1`
+- `title`: `Decoder q12 PWL softmax datapath calibration`
+
+## Why This Gate Is Required
+- `softmax_rowwise` now supports a second approximation implementation.
+- q8 shift-exp and reciprocal-normalization behavior must remain unchanged.
+- q12 PWL reference outputs must match generated RTL for checked rows.
+
+## Reference
+- baseline_ref: `tests/test_softmax_rowwise.sh`
+- reference_ref: `scripts/softmax_rowwise_ref.py`
+
+## Checks
+- existing q8 exact and q8 reciprocal tests pass unchanged
+- q12 PWL reference row `[0, -512, -1024, -2048]` emits `[3549, 480, 65, 1]`
+- q12 PWL generated RTL simulation matches the Python reference rows
+
+## Local Commands
+- `cmake --build build --target rtlgen`
+- `bash tests/test_softmax_rowwise.sh`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+
+## Result
+- status: passed_local
+- note: Local build, q8/q12 softmax regression, q12 RTL compile, and runs validation passed before PR submission.


### PR DESCRIPTION
## Summary
- record the evaluation request metadata for `l1_decoder_q12_pwl_softmax_datapath_v1`
- fill the proposal gate/report placeholders with q12 PWL-specific context
- keep the request linked to setup commit `180842b289eacc28b747bd5c58c959bec9b9d0e8`

## Context
The L1 q12 PWL softmax datapath work item has been queued and assigned to the remote evaluator. These files keep the developer-loop proposal linkage canonical in the repository for later artifact sync and finalization.

## Validation
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
