### PR TITLE
[codex] Add q12 PWL reciprocal normalization setup

### DIFF
--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/README.md
@@ -1,0 +1,7 @@
+# q12 PWL Reciprocal Normalization Datapath
+
+Proposal workspace for `prop_l1_decoder_q12_pwl_recip_norm_datapath_v1`.
+
+This proposal measures divider-free reciprocal-normalization variants of the
+q12 PWL decoder softmax datapath. It follows the exact-normalization result,
+where the divider dominated timing, area, and power.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/proposal.json
@@ -1,0 +1,72 @@
+{
+  "proposal_id": "prop_l1_decoder_q12_pwl_recip_norm_datapath_v1",
+  "created_utc": "2026-05-02T10:50:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "circuit_block",
+  "title": "Decoder q12 PWL reciprocal-normalization datapath",
+  "hypothesis": "The q12 PWL exact-normalization datapath was dominated by the exact divider, so a bucketed reciprocal-normalization sweep can expose the hardware cost of the PWL-exp path separately from divider cost.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 timing, power, and area does q12 PWL softmax show when exact normalization is replaced with a bucketed reciprocal lookup plus multiply/shift?",
+    "include": [
+      "row-wise signed q12 logits",
+      "PWL exp anchors matching the decoder software approximation at shifted logits 0, -2, -4, and -8",
+      "q12 PWL weights and q12 unsigned outputs",
+      "reciprocal_bits q10, q12, q14, and q16",
+      "reciprocal_lut_bucket_shift=8 to keep the q12 sum-range lookup hardware bounded",
+      "row_elems=8, input_frac_bits=8, weight_bits=12, accum_bits=28, output_scale=4095 held constant"
+    ],
+    "exclude": [
+      "full-vocabulary dynamic quantizer hardware",
+      "full decoder system PPA",
+      "new prompt-stress quality thresholds",
+      "claiming reciprocal-normalization quality equivalence before a software quality check"
+    ],
+    "follow_on_broad_sweep": [
+      "if one reciprocal precision is physically viable, run an L2 quality check for q12 PWL reciprocal normalization on the decoder distribution",
+      "if q10/q12/q14/q16 remain much heavier than q8 reciprocal and bf16 normalization, deprioritize q12 PWL hardware despite its exact-normalization quality",
+      "if reciprocal PPA is competitive, add dynamic-quantizer or scale-metadata cost before claiming end-to-end decoder hardware benefit"
+    ]
+  },
+  "expected_benefit": [
+    "separates PWL-exp datapath cost from exact divider cost",
+    "provides a direct hardware comparison against q8 reciprocal-normalization datapaths",
+    "keeps timing, power, and area axes separate for dashboard review"
+  ],
+  "risks": [
+    "bucketed reciprocal normalization changes numerical behavior relative to the exact q12 PWL survivor",
+    "reciprocal_lut_bucket_shift=8 is a hardware feasibility choice and needs later quality validation",
+    "single-row block PPA still excludes memory, control, and full decoder integration effects",
+    "quality remains benchmark-distribution dependent until prompt and weight/input distribution stress is broadened"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_q12_pwl_recip_norm_datapath_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "measurement_only",
+      "objective": "Measure Nangate45 PPA for q12 PWL-exp row-wise softmax blocks with q10/q12/q14/q16 bucketed reciprocal normalization.",
+      "sweep_path": "runs/campaigns/activations/softmax_rowwise_q12_pwl_recip_norm/sweeps/nangate45_highutil.json",
+      "config_paths": [
+        "runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q10_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q10_bucket8.json",
+        "runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q12_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q12_bucket8.json",
+        "runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q14_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q14_bucket8.json",
+        "runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q16_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q16_bucket8.json"
+      ],
+      "abstraction_layer": "circuit_block"
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/analysis_report.md",
+    "runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_wrapper/metrics.csv",
+    "docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/analysis_report.md",
+    "docs/proposals/prop_l1_decoder_bf16_recip_norm_datapath_v1/analysis_report.md"
+  ],
+  "knowledge_refs": [
+    "src/rtlgen/rtl_operations.cpp",
+    "scripts/softmax_rowwise_ref.py",
+    "tests/test_softmax_rowwise.sh",
+    "runs/campaigns/activations/softmax_rowwise_q12_pwl_recip_norm/sweeps/nangate45_highutil.json"
+  ]
+}

--- a/runs/campaigns/activations/softmax_rowwise_q12_pwl_recip_norm/sweeps/nangate45_highutil.json
+++ b/runs/campaigns/activations/softmax_rowwise_q12_pwl_recip_norm/sweeps/nangate45_highutil.json
@@ -1,0 +1,15 @@
+{
+  "tag_prefix": "softmax_rowwise_q12_pwl_recip_norm_nangate45_highutil",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      2.5
+    ],
+    "CORE_UTILIZATION": [
+      60,
+      50
+    ],
+    "PLACE_DENSITY": [
+      0.68
+    ]
+  }
+}

--- a/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q10_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q10_bucket8.json
+++ b/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q10_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q10_bucket8.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 12,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "softmax_rowwise_q12_pwl_r8_acc28_recip_q10_bucket8",
+      "operand": "logits",
+      "options": {
+        "impl": "pwl_exp",
+        "row_elems": 8,
+        "input_frac_bits": 8,
+        "weight_bits": 12,
+        "accum_bits": 28,
+        "output_scale": 4095,
+        "normalization_mode": "reciprocal_quantized",
+        "reciprocal_bits": 10,
+        "reciprocal_lut_bucket_shift": 8
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q12_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q12_bucket8.json
+++ b/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q12_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q12_bucket8.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 12,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "softmax_rowwise_q12_pwl_r8_acc28_recip_q12_bucket8",
+      "operand": "logits",
+      "options": {
+        "impl": "pwl_exp",
+        "row_elems": 8,
+        "input_frac_bits": 8,
+        "weight_bits": 12,
+        "accum_bits": 28,
+        "output_scale": 4095,
+        "normalization_mode": "reciprocal_quantized",
+        "reciprocal_bits": 12,
+        "reciprocal_lut_bucket_shift": 8
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q14_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q14_bucket8.json
+++ b/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q14_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q14_bucket8.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 12,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "softmax_rowwise_q12_pwl_r8_acc28_recip_q14_bucket8",
+      "operand": "logits",
+      "options": {
+        "impl": "pwl_exp",
+        "row_elems": 8,
+        "input_frac_bits": 8,
+        "weight_bits": 12,
+        "accum_bits": 28,
+        "output_scale": 4095,
+        "normalization_mode": "reciprocal_quantized",
+        "reciprocal_bits": 14,
+        "reciprocal_lut_bucket_shift": 8
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q16_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q16_bucket8.json
+++ b/runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q16_bucket8_wrapper/config_softmax_rowwise_q12_pwl_r8_acc28_recip_q16_bucket8.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 12,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "softmax_rowwise_q12_pwl_r8_acc28_recip_q16_bucket8",
+      "operand": "logits",
+      "options": {
+        "impl": "pwl_exp",
+        "row_elems": 8,
+        "input_frac_bits": 8,
+        "weight_bits": 12,
+        "accum_bits": 28,
+        "output_scale": 4095,
+        "normalization_mode": "reciprocal_quantized",
+        "reciprocal_bits": 16,
+        "reciprocal_lut_bucket_shift": 8
+      }
+    }
+  ]
+}

--- a/tests/softmax_rowwise_q12_pwl_tb.v
+++ b/tests/softmax_rowwise_q12_pwl_tb.v
@@ -6,6 +6,14 @@ module softmax_rowwise_q12_pwl_tb;
 
   softmax_rowwise_q12_pwl_r4 dut (.X(X), .Y(Y));
 
+`ifdef SOFTMAX_Q12_PWL_RECIP_Q12_BUCKET8
+  localparam [47:0] EXP_EQUAL = {12'd1024, 12'd1024, 12'd1024, 12'd1024};
+  localparam [47:0] EXP_LADDER = {12'd1, 12'd63, 12'd466, 12'd3447};
+`else
+  localparam [47:0] EXP_EQUAL = {12'd1024, 12'd1024, 12'd1024, 12'd1024};
+  localparam [47:0] EXP_LADDER = {12'd1, 12'd65, 12'd480, 12'd3549};
+`endif
+
   task check_row;
     input [47:0] a;
     input [47:0] exp;
@@ -24,8 +32,8 @@ module softmax_rowwise_q12_pwl_tb;
   endtask
 
   initial begin
-    check_row({12'd0, 12'd0, 12'd0, 12'd0}, {12'd1024, 12'd1024, 12'd1024, 12'd1024});
-    check_row({12'h800, 12'hc00, 12'he00, 12'd0}, {12'd1, 12'd65, 12'd480, 12'd3549});
+    check_row({12'd0, 12'd0, 12'd0, 12'd0}, EXP_EQUAL);
+    check_row({12'h800, 12'hc00, 12'he00, 12'd0}, EXP_LADDER);
     $display("All q12 PWL row-wise softmax tests passed.");
     $finish;
   end

--- a/tests/test_softmax_rowwise.sh
+++ b/tests/test_softmax_rowwise.sh
@@ -103,4 +103,34 @@ if got != expected:
 PY
 iverilog -g2012 -s softmax_rowwise_q12_pwl_tb -o sim_q12_pwl softmax_rowwise_q12_pwl_r4.v "$ROOT/tests/softmax_rowwise_q12_pwl_tb.v"
 vvp sim_q12_pwl
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+cfg = json.loads(Path("config_q12_pwl.json").read_text(encoding="utf-8"))
+opts = cfg["operations"][0]["options"]
+opts["normalization_mode"] = "reciprocal_quantized"
+opts["reciprocal_bits"] = 12
+opts["reciprocal_lut_bucket_shift"] = 8
+Path("config_q12_pwl_recip_q12_bucket8.json").write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+PY
+"$ROOT/build/rtlgen" config_q12_pwl_recip_q12_bucket8.json
+if grep -q " / sum_weights" softmax_rowwise_q12_pwl_r4.v; then
+  echo "q12 PWL reciprocal_quantized softmax emitted divider" >&2
+  exit 1
+fi
+python3 "$ROOT/scripts/softmax_rowwise_ref.py" --config config_q12_pwl_recip_q12_bucket8.json --row 0,0,0,0 --row 0,-512,-1024,-2048 > ref_q12_pwl_recip.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+payload = json.loads(Path("ref_q12_pwl_recip.json").read_text(encoding="utf-8"))
+expected = [[1024, 1024, 1024, 1024], [3447, 466, 63, 1]]
+got = [row["output"] for row in payload["rows"]]
+if got != expected:
+    raise SystemExit(f"q12 PWL reciprocal reference mismatch got={got} expected={expected}")
+PY
+iverilog -g2012 -DSOFTMAX_Q12_PWL_RECIP_Q12_BUCKET8 -s softmax_rowwise_q12_pwl_tb -o sim_q12_pwl_recip softmax_rowwise_q12_pwl_r4.v "$ROOT/tests/softmax_rowwise_q12_pwl_tb.v"
+vvp sim_q12_pwl_recip
 popd >/dev/null


### PR DESCRIPTION
## Summary
- add q12 PWL reciprocal-normalization configs for q10/q12/q14/q16 with bucketed denominator lookup
- add a Nangate45 high-util sweep and Layer-1 proposal for `l1_decoder_q12_pwl_recip_norm_datapath_v1`
- extend the softmax regression to cover q12 PWL reciprocal normalization and verify the generated RTL does not emit the exact divider

## Context
The q12 PWL exact-normalization datapath measured in PR #335 was dominated by the exact divider. This setup queues a divider-free reciprocal-normalization sweep so we can separate PWL-exp cost from divider cost before deciding whether q12 PWL remains a viable hardware frontier.

The bucket shift is set to 8. This is a hardware feasibility choice for the larger q12 sum envelope; quality equivalence to the exact q12 PWL survivor still needs a later Layer-2 check if the PPA is promising.

## Validation
- `cmake --build build --target rtlgen`
- `bash tests/test_softmax_rowwise.sh`
- generated and compiled all four q12 PWL reciprocal configs with `iverilog -g2012`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
