### PR TITLE
[codex] Record q12 PWL reciprocal evaluation request

### DIFF
--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/analysis_report.md
@@ -1,0 +1,22 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l1_decoder_q12_pwl_recip_norm_datapath_v1`
+- `candidate_id`: `l1_decoder_q12_pwl_recip_norm_datapath_v1`
+
+## Evaluations Consumed
+- pending: `l1_decoder_q12_pwl_recip_norm_datapath_v1`
+- source commit: `859e5fddd225b9a81e6b491a50267482c5020535`
+
+## Baseline Comparison
+- pending evaluator result
+
+## Result
+- pending evaluator result
+
+## Failures and Caveats
+- This candidate does not include full dynamic symmetric quantizer hardware.
+- This candidate has not yet passed Layer-2 reciprocal-normalization quality validation.
+
+## Recommendation
+- pending evaluator result

--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/design_brief.md
@@ -1,0 +1,54 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_q12_pwl_recip_norm_datapath_v1`
+- `title`: `Decoder q12 PWL reciprocal-normalization datapath`
+- `layer`: `layer1`
+- `kind`: `circuit_block`
+
+## Problem
+
+The q12 PWL exact-normalization datapath produced accepted physical metrics, but
+the result was dominated by a wide exact divider: roughly 58.7 ns, 480.9k um^2,
+and 29.1 mW at the selected timing row. That makes it hard to tell whether q12
+PWL exp is inherently too costly or whether exact normalization is the blocker.
+
+## Candidate Direction
+
+Measure q12 PWL row-wise softmax with `normalization_mode=reciprocal_quantized`
+using q10/q12/q14/q16 reciprocal precision. The denominator lookup uses
+`reciprocal_lut_bucket_shift=8` to keep the q12 sum envelope bounded in hardware.
+
+This is measurement-only. It does not claim quality equivalence to the q12 PWL
+exact-normalization survivor.
+
+## Evaluation Scope
+
+Run one L1 measurement-only sweep over four Nangate45 configs:
+
+- `softmax_rowwise_q12_pwl_r8_acc28_recip_q10_bucket8`
+- `softmax_rowwise_q12_pwl_r8_acc28_recip_q12_bucket8`
+- `softmax_rowwise_q12_pwl_r8_acc28_recip_q14_bucket8`
+- `softmax_rowwise_q12_pwl_r8_acc28_recip_q16_bucket8`
+
+All rows hold `row_elems=8`, `input_frac_bits=8`, `weight_bits=12`,
+`accum_bits=28`, `output_scale=4095`, and `reciprocal_lut_bucket_shift=8`.
+
+## Exclusions
+
+- Full-vocabulary dynamic quantizer hardware.
+- Full decoder memory/control/system PPA.
+- Prompt-stress or broad-distribution quality claims for reciprocal
+  normalization.
+
+## Knowledge Inputs
+- `docs/proposals/prop_l1_decoder_q12_pwl_softmax_datapath_v1/analysis_report.md`
+- `runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_wrapper/metrics.csv`
+- `docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/analysis_report.md`
+- `docs/proposals/prop_l1_decoder_bf16_recip_norm_datapath_v1/analysis_report.md`
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-05-02T10:55:00Z
+- note: Immediate follow-up to isolate exact-divider cost from q12 PWL-exp cost.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved_after_merge
+- approved_by: developer_agent
+- approved_utc: 2026-05-02T10:55:00Z
+- allowed_evaluations:
+  - `l1_decoder_q12_pwl_recip_norm_datapath_v1`: L1 measurement-only sweep for q10/q12/q14/q16 q12 PWL reciprocal-normalization softmax blocks.
+- note: The evaluator must run this from a commit containing the q12 PWL reciprocal configs and the reciprocal regression check.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/evaluation_requests.json
@@ -1,0 +1,14 @@
+{
+  "proposal_id": "prop_l1_decoder_q12_pwl_recip_norm_datapath_v1",
+  "source_commit": "859e5fddd225b9a81e6b491a50267482c5020535",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_q12_pwl_recip_norm_datapath_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for q12 PWL-exp row-wise softmax blocks with q10/q12/q14/q16 bucketed reciprocal normalization.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/implementation_summary.md
@@ -1,0 +1,36 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_q12_pwl_recip_norm_datapath_v1`
+- title: `Decoder q12 PWL reciprocal-normalization datapath`
+
+## Scope
+- Added q10/q12/q14/q16 q12 PWL reciprocal-normalization configs.
+- Added the Nangate45 high-util sweep metadata.
+- Extended the q12 PWL softmax regression to cover reciprocal normalization.
+- Did not add a Layer-2 quality check for reciprocal normalization yet.
+
+## Files Changed
+- `tests/softmax_rowwise_q12_pwl_tb.v`
+- `tests/test_softmax_rowwise.sh`
+- `runs/designs/activations/softmax_rowwise_q12_pwl_r8_acc28_recip_q*_bucket8_wrapper/`
+- `runs/campaigns/activations/softmax_rowwise_q12_pwl_recip_norm/sweeps/nangate45_highutil.json`
+- `docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/`
+
+## Local Validation
+- `cmake --build build --target rtlgen`
+- `bash tests/test_softmax_rowwise.sh`
+- generated and compiled all four q12 PWL reciprocal configs with `iverilog -g2012`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+- `git diff --check`
+
+## Evaluation Request
+- requested item: `l1_decoder_q12_pwl_recip_norm_datapath_v1`
+- task type: `l1_sweep`
+- mode: `measurement_only`
+- compare against q12 PWL exact normalization, q8 reciprocal normalization, and bf16 reciprocal normalization on separate PPA axes.
+
+## Risks
+- Reciprocal normalization changes numerical behavior relative to the exact q12 PWL survivor.
+- Bucket shift 8 is hardware-feasible but still needs later quality validation.
+- Single-row block PPA excludes full decoder memory/control cost.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l1_decoder_q12_pwl_recip_norm_datapath_v1",
+  "candidate_id": "l1_decoder_q12_pwl_recip_norm_datapath_v1",
+  "decision": "pending",
+  "reason": "Awaiting L1 PPA measurement for q12 PWL reciprocal normalization.",
+  "evidence_refs": [
+    "item:l1_decoder_q12_pwl_recip_norm_datapath_v1"
+  ],
+  "next_action": "Consume evaluator result, compare against q12 PWL exact normalization and q8/bf16 reciprocal baselines, then decide whether to run Layer-2 quality validation.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action: Promote only as measured Layer-1 PPA evidence until reciprocal-normalization quality is checked.
+- note: Do not use this proposal alone to claim the q12 PWL decoder candidate is quality-safe.

--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_decoder_q12_pwl_recip_norm_datapath_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/quality_gate.md
@@ -1,0 +1,28 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_q12_pwl_recip_norm_datapath_v1`
+- `title`: `Decoder q12 PWL reciprocal-normalization datapath`
+
+## Why This Gate Is Required
+- q12 PWL reciprocal normalization is a new approximation point relative to the exact q12 PWL survivor.
+- The first gate checks RTL/reference consistency only; decoder quality needs a later Layer-2 evaluation if PPA is promising.
+
+## Reference
+- baseline_ref: `tests/test_softmax_rowwise.sh`
+- reference_ref: `scripts/softmax_rowwise_ref.py`
+
+## Checks
+- existing q8 exact and q8 reciprocal tests pass unchanged
+- q12 PWL exact tests pass unchanged
+- q12 PWL q12 reciprocal bucket8 reference row `[0, -512, -1024, -2048]` emits `[3447, 466, 63, 1]`
+- generated q12 PWL reciprocal RTL emits no `/ sum_weights` divider
+
+## Local Commands
+- `cmake --build build --target rtlgen`
+- `bash tests/test_softmax_rowwise.sh`
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+
+## Result
+- status: passed_local
+- note: Local build, q8/q12 softmax regression, q12 reciprocal RTL compile, and runs validation passed before PR submission.


### PR DESCRIPTION
## Summary
- record the evaluation request metadata for `l1_decoder_q12_pwl_recip_norm_datapath_v1`
- fill the proposal gate/report placeholders with q12 PWL reciprocal-normalization context
- keep the request linked to setup commit `859e5fddd225b9a81e6b491a50267482c5020535`

## Context
The L1 q12 PWL reciprocal-normalization sweep has been queued and assigned to the remote evaluator. These files keep the developer-loop proposal linkage canonical in the repository for artifact sync and finalization.

## Validation
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
