### PR TITLE
[codex] Add decoder PWL bitwidth boundary job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1376,6 +1376,107 @@ def _decoder_pwl_survivor_distribution_evidence(*, item_id: str) -> dict[str, An
     }
 
 
+def _decoder_pwl_bitwidth_boundary_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    dataset_manifest = f"{base}/manifest_distribution_v2.json"
+    sample_file = f"{base}/samples_distribution_v2.jsonl"
+    reference_dir = f"{base}/reference_distribution_v2"
+    reference_manifest = f"{base}/reference_distribution_v2_manifest.json"
+    candidate_dir = f"{base}/candidate_distribution_v2"
+    candidate_manifest = f"{base}/candidate_distribution_v2_manifest.json"
+    validation_out = f"{base}/decoder_contract_validation__{item_id}.json"
+    quality_out = f"{base}/decoder_quality_compare__{item_id}.json"
+    sweep_dir = f"{base}/candidate_sweeps/{item_id}"
+    sweep_out = f"{base}/decoder_quality_sweep__{item_id}.json"
+    boundary_out = f"{base}/decoder_pwl_bitwidth_boundary__{item_id}.json"
+    boundary_report = f"{base}/decoder_pwl_bitwidth_boundary__{item_id}.md"
+    rough_grid = "decoder_pwl_bitwidth_boundary_v1"
+    commands = [
+        {
+            "name": "generate_decoder_pwl_bitwidth_boundary_reference",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_reference_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {reference_dir} "
+                f"--out-manifest {reference_manifest}"
+            ),
+        },
+        {
+            "name": "generate_decoder_pwl_bitwidth_boundary_candidate",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_candidate_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {candidate_dir} "
+                f"--out-manifest {candidate_manifest}"
+            ),
+        },
+        {
+            "name": "validate_decoder_pwl_bitwidth_boundary_contract",
+            "run": f"python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest {dataset_manifest} --out {validation_out}",
+        },
+        {
+            "name": "compare_decoder_pwl_bitwidth_boundary_quality",
+            "run": (
+                "python3 npu/eval/compare_llm_decoder_quality.py "
+                f"--reference-manifest {reference_manifest} "
+                f"--candidate-manifest {candidate_manifest} "
+                f"--out {quality_out}"
+            ),
+        },
+        {
+            "name": "sweep_decoder_pwl_bitwidth_boundary",
+            "run": (
+                "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--rough-grid {rough_grid} "
+                f"--out-dir {sweep_dir} "
+                f"--out {sweep_out}"
+            ),
+        },
+        {
+            "name": "summarize_decoder_pwl_bitwidth_boundary",
+            "run": (
+                "python3 npu/eval/summarize_llm_decoder_pwl_bitwidth_boundary.py "
+                f"--sweep {sweep_out} "
+                f"--sample-file {sample_file} "
+                f"--out {boundary_out} "
+                f"--out-md {boundary_report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            "dataset_manifest": dataset_manifest,
+            "sample_file": sample_file,
+            "reference_dir": reference_dir,
+            "reference_manifest": reference_manifest,
+            "candidate_dir": candidate_dir,
+            "candidate_manifest": candidate_manifest,
+            "validation_out": validation_out,
+            "quality_out": quality_out,
+            "candidate_sweep_dir": sweep_dir,
+            "candidate_sweep_out": sweep_out,
+            "candidate_sweep_grid": rough_grid,
+            "bitwidth_boundary_out": boundary_out,
+            "bitwidth_boundary_report": boundary_report,
+            "bitwidth_boundary_scope": (
+                "expanded v2 prompt-distribution check for the lowest exact-safe integer PWL "
+                "softmax input/weight bit width after q12 proved broad-safe but expensive in PPA"
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            reference_manifest,
+            candidate_manifest,
+            validation_out,
+            quality_out,
+            sweep_out,
+            boundary_out,
+            boundary_report,
+        ],
+    }
+
+
 def _with_fresh_outputs(*, campaign: dict[str, Any], item_id: str) -> dict[str, Any]:
     cloned = json.loads(json.dumps(campaign))
     outputs = dict(cloned.get("outputs") or {})
@@ -1487,10 +1588,13 @@ def _build_payload(
         "decoder_pwl_failure_diagnosis",
         "decoder_pwl_logit_sensitivity_ladder",
         "decoder_pwl_survivor_distribution",
+        "decoder_pwl_bitwidth_boundary",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_pwl_bitwidth_boundary":
+            decoder_evidence = _decoder_pwl_bitwidth_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pwl_survivor_distribution":
             decoder_evidence = _decoder_pwl_survivor_distribution_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pwl_logit_sensitivity_ladder":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1035,6 +1035,66 @@ def test_generate_l2_campaign_task_adds_decoder_pwl_survivor_distribution_eviden
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_pwl_bitwidth_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_pwl_bitwidth_boundary_v1",
+                    proposal_id="prop_l2_decoder_pwl_bitwidth_boundary_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_pwl_bitwidth_boundary",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:6] == [
+                "generate_decoder_pwl_bitwidth_boundary_reference",
+                "generate_decoder_pwl_bitwidth_boundary_candidate",
+                "validate_decoder_pwl_bitwidth_boundary_contract",
+                "compare_decoder_pwl_bitwidth_boundary_quality",
+                "sweep_decoder_pwl_bitwidth_boundary",
+                "summarize_decoder_pwl_bitwidth_boundary",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["dataset_manifest"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json"
+            )
+            assert decoder_inputs["sample_file"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl"
+            )
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_pwl_bitwidth_boundary_v1"
+            assert "lowest exact-safe integer PWL" in decoder_inputs["bitwidth_boundary_scope"]
+            assert "--rough-grid decoder_pwl_bitwidth_boundary_v1" in work_item.command_manifest[4]["run"]
+            assert "summarize_llm_decoder_pwl_bitwidth_boundary.py" in work_item.command_manifest[5]["run"]
+            assert decoder_inputs["bitwidth_boundary_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_pwl_bitwidth_boundary__l2_decoder_pwl_bitwidth_boundary_v1.json"
+            )
+            assert decoder_inputs["bitwidth_boundary_out"] in work_item.expected_outputs
+            assert decoder_inputs["bitwidth_boundary_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_pwl_bitwidth_boundary",
+            }
+
+
 def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/README.md
@@ -1,0 +1,8 @@
+# Decoder PWL Integer Bit-Width Boundary
+
+Proposal workspace for `prop_l2_decoder_pwl_bitwidth_boundary_v1`.
+
+This job narrows the integer PWL precision boundary after q12 proved exact-safe
+on the expanded v2 prompt distribution but expensive in Layer 1 PPA. It checks
+whether q11 preserves exact next-token/top-k behavior before scheduling another
+hardware calibration point.

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending evaluator result.

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/design_brief.md
@@ -1,0 +1,23 @@
+# Decoder PWL Integer Bit-Width Boundary
+
+- `proposal_id`: `prop_l2_decoder_pwl_bitwidth_boundary_v1`
+- `item_id`: `l2_decoder_pwl_bitwidth_boundary_v1`
+- abstraction: `decoder_pwl_bitwidth_boundary`
+
+Current evidence puts the measured hardware frontier at bf16/q8 reciprocal PWL
+for PPA, while q12 PWL is the integer exact-safe quality point. The q12 datapath
+cost is high enough that the immediate frontier should check the missing
+integer boundary before more PPA work.
+
+This Layer 2 job runs the expanded v2 prompt distribution with:
+
+- exact-softmax q10/q11/q12/q13 logit controls
+- PWL q10/q11/q12/q13 exact-normalization rows
+- unquantized PWL exact-normalization control
+- bf16 reciprocal PWL anchor
+
+Expected output:
+
+- `decoder_quality_sweep__l2_decoder_pwl_bitwidth_boundary_v1.json`
+- `decoder_pwl_bitwidth_boundary__l2_decoder_pwl_bitwidth_boundary_v1.json`
+- `decoder_pwl_bitwidth_boundary__l2_decoder_pwl_bitwidth_boundary_v1.md`

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+Queue `l2_decoder_pwl_bitwidth_boundary_v1` after the q12 survivor distribution
+and q12 PWL datapath PPA inputs are merged.
+
+Required inputs:
+
+- `runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json`
+- `runs/datasets/llm_decoder_eval_tiny_v1/decoder_pwl_survivor_distribution__l2_decoder_pwl_survivor_distribution_v1.json`
+- `docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/analysis_report.md`

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/implementation_summary.md
@@ -1,0 +1,7 @@
+# Implementation Summary
+
+- Added the `decoder_pwl_bitwidth_boundary_v1` rough grid with q10/q11/q12/q13
+  exact-logit and PWL exact-normalization rows.
+- Added `summarize_llm_decoder_pwl_bitwidth_boundary.py` to report the minimum
+  exact-safe and top-k-safe integer PWL bit widths.
+- Registered `decoder_pwl_bitwidth_boundary` in the Layer 2 task generator.

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/promotion_decision.json
@@ -1,0 +1,10 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_bitwidth_boundary_v1",
+  "status": "pending_evaluation",
+  "decision": "iterate",
+  "candidate_id": "l2_decoder_pwl_bitwidth_boundary_v1",
+  "reason": "Awaiting Layer 2 bit-width boundary evidence.",
+  "evidence_refs": [],
+  "next_action": "run l2_decoder_pwl_bitwidth_boundary_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/promotion_gate.md
@@ -1,0 +1,6 @@
+# Promotion Gate
+
+- promote to Layer 1 only if q11 is exact-safe on the expanded v2 distribution
+- otherwise keep q12 as the known integer exact-safe floor and prefer the
+  measured bf16/q8 reciprocal frontier unless exact next-token behavior is
+  mandatory

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/promotion_result.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_bitwidth_boundary_v1",
+  "decision": "iterate",
+  "status": "pending_evaluation"
+}

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/proposal.json
@@ -1,0 +1,64 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_bitwidth_boundary_v1",
+  "created_utc": "2026-05-03T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_pwl_bitwidth_boundary",
+  "title": "Decoder PWL integer bit-width boundary",
+  "hypothesis": "q12 PWL is exact-safe on the expanded v2 distribution but its measured Nangate45 datapath cost is much higher than the bf16/q8 reciprocal frontier. A narrow q10/q11/q12/q13 distribution check can identify whether q11 is an exact-safe integer floor before spending another Layer 1 PPA run.",
+  "direct_comparison": {
+    "primary_question": "Across the expanded v2 prompt distribution, is q11 PWL exact-normalization enough to preserve exact next-token and top-k behavior, or does q12 remain the lowest exact-safe integer PWL bit width?",
+    "include": [
+      "q10, q11, q12, and q13 exact-logit controls",
+      "q10, q11, q12, and q13 PWL exact-normalization rows",
+      "unquantized PWL exact-normalization control",
+      "bf16 reciprocal PWL hardware-frontier anchor"
+    ],
+    "exclude": [
+      "new RTL/OpenROAD measurement",
+      "choosing a final q8-versus-bf16 architecture point",
+      "claiming robustness beyond the tiny decoder model and expanded v2 prompt set"
+    ]
+  },
+  "expected_benefit": [
+    "narrows the integer precision floor between the q10 miss and q12 exact-safe survivor",
+    "avoids spending remote PPA time on q12 if q11 already recovers exact behavior",
+    "keeps the bf16 reciprocal anchor visible as the current measured hardware frontier"
+  ],
+  "risks": [
+    "the expanded v2 set is still tied to one tiny decoder model and tokenizer binding",
+    "exact next-token behavior can be dominated by very small logit margins",
+    "software-emulated q11 behavior still needs RTL confirmation before hardware conclusions"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_pwl_bitwidth_boundary_v1",
+      "task_type": "l2_campaign",
+      "objective": "decoder_pwl_bitwidth_boundary",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_pwl_bitwidth_boundary",
+      "depends_on_item_ids": [
+        "l2_decoder_pwl_survivor_distribution_v1",
+        "l1_decoder_q12_pwl_recip_norm_datapath_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_pwl_survivor_distribution_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_pwl_survivor_distribution__l2_decoder_pwl_survivor_distribution_v1.json",
+    "docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/analysis_report.md",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_norm_distribution_broad_v2.json"
+  ],
+  "knowledge_refs": [
+    "runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "npu/eval/summarize_llm_decoder_pwl_bitwidth_boundary.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/quality_gate.md
@@ -1,0 +1,10 @@
+# Quality Gate
+
+Acceptance for this exploratory job is a completed summary identifying:
+
+- lowest exact-safe integer PWL bit width among q10/q11/q12/q13
+- lowest top-k-safe integer PWL bit width
+- miss categories for any non-exact rows
+- whether q11 is worth a follow-on Layer 1 PPA calibration
+
+The result must not be interpreted as model-family-wide robustness.

--- a/npu/eval/summarize_llm_decoder_pwl_bitwidth_boundary.py
+++ b/npu/eval/summarize_llm_decoder_pwl_bitwidth_boundary.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Summarize the decoder PWL integer bit-width boundary on a distribution sweep."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve(path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return _repo_root() / candidate
+
+
+def _portable(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(_repo_root()))
+    except ValueError:
+        return str(path)
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    with _resolve(path).open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _load_jsonl(path: str | Path) -> list[JsonDict]:
+    rows: list[JsonDict] = []
+    with _resolve(path).open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if not isinstance(payload, dict):
+                raise SystemExit(f"expected object at {path}:{line_no}")
+            rows.append(payload)
+    return rows
+
+
+def _as_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _sample_categories(sample_file: str | Path) -> dict[str, str]:
+    categories: dict[str, str] = {}
+    for row in _load_jsonl(sample_file):
+        sample_id = str(row.get("sample_id") or "").strip()
+        if sample_id:
+            categories[sample_id] = str(row.get("category") or "uncategorized")
+    return categories
+
+
+def _category_counts(sample_ids: list[str], categories: dict[str, str]) -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    for sample_id in sample_ids:
+        counts[categories.get(sample_id, "uncategorized")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _bits_from_template(template: str) -> int | None:
+    match = re.search(r"_in_q(\d+)_w_q\1_", template)
+    if match:
+        return int(match.group(1))
+    match = re.search(r"_logits_q(\d+)$", template)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _family(row: JsonDict) -> str:
+    template = str(row.get("template") or "")
+    if template == "candidate_onnx_softmax_exact":
+        return "reference"
+    if template == "grid_approx_pwl_float_norm_exact":
+        return "unquantized_pwl_control"
+    if template == "grid_approx_pwl_bf16_path":
+        return "bf16_hardware_anchor"
+    if template.startswith("grid_exact_logits_q"):
+        return "exact_softmax_logit_control"
+    if template.startswith("grid_approx_pwl_in_q"):
+        return "pwl_integer_boundary"
+    return "other"
+
+
+def _row_summary(row: JsonDict, categories: dict[str, str]) -> JsonDict:
+    sample_count = _as_int(row.get("sample_count"))
+    next_rate = _as_float(row.get("next_token_id_match_rate"))
+    topk_rate = _as_float(row.get("topk_contains_reference_id_rate"))
+    next_matches = round(next_rate * sample_count)
+    topk_matches = round(topk_rate * sample_count)
+    next_misses = [str(v) for v in row.get("next_token_mismatch_sample_ids") or []]
+    topk_misses = [str(v) for v in row.get("topk_miss_sample_ids") or []]
+    exact_safe = sample_count > 0 and next_matches == sample_count and topk_matches == sample_count
+    topk_safe = sample_count > 0 and topk_matches == sample_count
+    template = str(row.get("template") or "")
+    return {
+        "template": template,
+        "family": _family(row),
+        "bit_width": _bits_from_template(template),
+        "sample_count": sample_count,
+        "next_token_matches": next_matches,
+        "topk_matches": topk_matches,
+        "next_token_match_rate": next_rate,
+        "topk_contains_reference_id_rate": topk_rate,
+        "next_token_mismatch_sample_ids": next_misses,
+        "topk_miss_sample_ids": topk_misses,
+        "next_token_miss_categories": _category_counts(next_misses, categories),
+        "topk_miss_categories": _category_counts(topk_misses, categories),
+        "exact_safe": exact_safe,
+        "topk_safe": topk_safe,
+        "gate": "exact_safe" if exact_safe else "topk_safe_only" if topk_safe else "blocked",
+        "softmax_input_quant_bits": row.get("softmax_input_quant_bits", 0),
+        "softmax_weight_quant_bits": row.get("softmax_weight_quant_bits", 0),
+        "softmax_input_float_format": row.get("softmax_input_float_format", ""),
+        "softmax_weight_float_format": row.get("softmax_weight_float_format", ""),
+        "normalization_mode": row.get("normalization_mode", "exact"),
+        "normalization_reciprocal_float_format": row.get("normalization_reciprocal_float_format", ""),
+    }
+
+
+def _diagnosis(rows: list[JsonDict]) -> JsonDict:
+    integer_rows = [row for row in rows if row["family"] == "pwl_integer_boundary"]
+    exact_safe = sorted((row for row in integer_rows if row["exact_safe"]), key=lambda row: row["bit_width"] or 99)
+    topk_safe = sorted((row for row in integer_rows if row["topk_safe"]), key=lambda row: row["bit_width"] or 99)
+    minimum_exact = exact_safe[0] if exact_safe else None
+    minimum_topk = topk_safe[0] if topk_safe else None
+    q12 = next((row for row in integer_rows if row["bit_width"] == 12), None)
+    q11 = next((row for row in integer_rows if row["bit_width"] == 11), None)
+    q10 = next((row for row in integer_rows if row["bit_width"] == 10), None)
+    bf16 = next((row for row in rows if row["template"] == "grid_approx_pwl_bf16_path"), None)
+
+    if minimum_exact is not None and minimum_exact["bit_width"] is not None and minimum_exact["bit_width"] < 12:
+        decision = "sub_q12_integer_pwl_survivor"
+        recommended = (
+            f"Promote q{minimum_exact['bit_width']} PWL to the next PPA calibration before spending more q12 hardware effort."
+        )
+    elif q12 is not None and q12["exact_safe"]:
+        decision = "q12_remains_integer_exact_floor"
+        recommended = "Keep q12 as the integer exact-safe floor and prefer bf16/q8 top-k frontier unless exact next-token is required."
+    elif minimum_topk is not None:
+        decision = "integer_pwl_topk_only"
+        recommended = "Treat integer PWL as rank-stable but not exact-safe; do not schedule another integer PPA run yet."
+    else:
+        decision = "integer_pwl_boundary_blocked"
+        recommended = "Return to curve/logit precision design before hardware calibration."
+
+    return {
+        "decision": decision,
+        "minimum_exact_safe_template": minimum_exact["template"] if minimum_exact else None,
+        "minimum_exact_safe_bits": minimum_exact["bit_width"] if minimum_exact else None,
+        "minimum_topk_safe_template": minimum_topk["template"] if minimum_topk else None,
+        "minimum_topk_safe_bits": minimum_topk["bit_width"] if minimum_topk else None,
+        "q10_exact_safe": bool(q10 and q10["exact_safe"]),
+        "q11_exact_safe": bool(q11 and q11["exact_safe"]),
+        "q12_exact_safe": bool(q12 and q12["exact_safe"]),
+        "bf16_gate": bf16["gate"] if bf16 else "missing",
+        "recommended_next_step": recommended,
+        "summary": (
+            "The boundary sweep narrows the integer PWL precision floor after q12 proved exact-safe "
+            "but expensive. It compares q10/q11/q12/q13 PWL exact-normalization rows against the "
+            "unquantized PWL control and the measured bf16 reciprocal hardware anchor on the same "
+            "expanded v2 prompt distribution."
+        ),
+    }
+
+
+def _write_md(doc: JsonDict, path: Path) -> None:
+    lines = [
+        "# Decoder PWL Bit-Width Boundary",
+        "",
+        f"- source_sweep: `{doc['source_sweep']}`",
+        f"- sample_file: `{doc['sample_file']}`",
+        f"- decision: `{doc['diagnosis']['decision']}`",
+        f"- minimum_exact_safe_bits: `{doc['diagnosis']['minimum_exact_safe_bits']}`",
+        f"- minimum_topk_safe_bits: `{doc['diagnosis']['minimum_topk_safe_bits']}`",
+        f"- summary: {doc['diagnosis']['summary']}",
+        f"- recommended_next_step: {doc['diagnosis']['recommended_next_step']}",
+        "",
+        "## Template Summary",
+        "",
+        "| template | family | bits | next-token | top-k | gate | miss categories |",
+        "|---|---|---:|---:|---:|---|---|",
+    ]
+    for row in doc["template_summaries"]:
+        categories = ", ".join(f"{key}:{value}" for key, value in row["next_token_miss_categories"].items()) or "none"
+        lines.append(
+            "| `{template}` | `{family}` | {bits} | {next}/{samples} | {topk}/{samples} | `{gate}` | {categories} |".format(
+                template=row["template"],
+                family=row["family"],
+                bits=row["bit_width"] if row["bit_width"] is not None else "",
+                next=row["next_token_matches"],
+                topk=row["topk_matches"],
+                samples=row["sample_count"],
+                gate=row["gate"],
+                categories=categories,
+            )
+        )
+    lines.extend(["", "## Exact-Safe Integer Rows", ""])
+    survivors = [
+        row for row in doc["template_summaries"] if row["family"] == "pwl_integer_boundary" and row["exact_safe"]
+    ]
+    if survivors:
+        for row in sorted(survivors, key=lambda item: item["bit_width"] or 99):
+            lines.append(f"- q{row['bit_width']}: `{row['template']}`")
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Miss Details", ""])
+    for row in doc["template_summaries"]:
+        if not row["next_token_mismatch_sample_ids"]:
+            continue
+        lines.append(f"### `{row['template']}`")
+        lines.append("")
+        for sample_id in row["next_token_mismatch_sample_ids"]:
+            category = doc["sample_categories"].get(sample_id, "uncategorized")
+            lines.append(f"- `{sample_id}` ({category})")
+        lines.append("")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sweep", required=True)
+    ap.add_argument("--sample-file", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    sweep_path = _resolve(args.sweep)
+    sweep = _load_json(sweep_path)
+    templates = sweep.get("templates")
+    if not isinstance(templates, list):
+        raise SystemExit("sweep JSON must contain templates list")
+    categories = _sample_categories(args.sample_file)
+    rows = [_row_summary(row, categories) for row in templates if isinstance(row, dict)]
+    doc = {
+        "version": 0.1,
+        "source_sweep": _portable(sweep_path),
+        "sample_file": _portable(_resolve(args.sample_file)),
+        "sample_count": len(categories),
+        "sample_categories": categories,
+        "template_summaries": rows,
+        "diagnosis": _diagnosis(rows),
+    }
+    out_path = _resolve(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_path = _resolve(args.out_md)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_md(doc, md_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/sweep_llm_decoder_candidate_quality.py
+++ b/npu/eval/sweep_llm_decoder_candidate_quality.py
@@ -94,6 +94,7 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
         "decoder_q8_normalization_frontier_v1",
         "decoder_pwl_logit_sensitivity_ladder_v1",
         "decoder_pwl_survivor_distribution_v1",
+        "decoder_pwl_bitwidth_boundary_v1",
     }:
         raise ValueError(f"unsupported rough grid: {grid_name}")
     exact = _candidate_template(model_contract, "candidate_onnx_softmax_exact")
@@ -501,6 +502,71 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
             ),
         ]
         return {name: cfg for name, cfg in points}
+    if grid_name == "decoder_pwl_bitwidth_boundary_v1":
+        points = [
+            ("candidate_onnx_softmax_exact", exact),
+            _named_grid_point(exact, "grid_exact_logits_q13", logit_quant_bits=13),
+            _named_grid_point(exact, "grid_exact_logits_q12", logit_quant_bits=12),
+            _named_grid_point(exact, "grid_exact_logits_q11", logit_quant_bits=11),
+            _named_grid_point(exact, "grid_exact_logits_q10", logit_quant_bits=10),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_float_norm_exact",
+                softmax_input_quant_bits=None,
+                softmax_weight_quant_bits=None,
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_in_q13_w_q13_norm_exact",
+                softmax_input_quant_bits=13,
+                softmax_weight_quant_bits=13,
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_in_q12_w_q12_norm_exact",
+                softmax_input_quant_bits=12,
+                softmax_weight_quant_bits=12,
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_in_q11_w_q11_norm_exact",
+                softmax_input_quant_bits=11,
+                softmax_weight_quant_bits=11,
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_in_q10_w_q10_norm_exact",
+                softmax_input_quant_bits=10,
+                softmax_weight_quant_bits=10,
+                normalization_mode="exact",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_bf16_path",
+                softmax_input_quant_bits=None,
+                softmax_weight_quant_bits=None,
+                softmax_input_float_format="bf16",
+                softmax_weight_float_format="bf16",
+                normalization_mode="reciprocal_float",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format="bf16",
+            ),
+        ]
+        return {name: cfg for name, cfg in points}
     points = [
         ("candidate_onnx_softmax_exact", exact),
         _named_grid_point(exact, "grid_exact_logits_q8", logit_quant_bits=8),
@@ -715,7 +781,8 @@ def main() -> int:
             "Generate a built-in rough approximation grid, e.g. decoder_probability_broad_v1, "
             "decoder_probability_fp_formats_v1, decoder_distribution_robustness_v1, or "
             "decoder_survivor_prompt_stress_v1, decoder_q8_normalization_frontier_v1, "
-            "decoder_pwl_logit_sensitivity_ladder_v1, or decoder_pwl_survivor_distribution_v1."
+            "decoder_pwl_logit_sensitivity_ladder_v1, decoder_pwl_survivor_distribution_v1, "
+            "or decoder_pwl_bitwidth_boundary_v1."
         ),
     )
     ap.add_argument("--out-dir", default="runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/local")

--- a/tests/test_llm_decoder_q8_norm_frontier.py
+++ b/tests/test_llm_decoder_q8_norm_frontier.py
@@ -24,6 +24,29 @@ def test_q8_normalization_frontier_grid_contains_exact_reciprocal_and_bf16_ancho
     assert grid["grid_approx_pwl_bf16_path"]["normalization_reciprocal_float_format"] == "bf16"
 
 
+def test_pwl_bitwidth_boundary_grid_narrows_integer_precision_floor() -> None:
+    model_contract = load_json(Path("runs/models/llm_decoder_tiny_v1/model_contract.json"))
+    grid = _rough_grid_templates(model_contract, "decoder_pwl_bitwidth_boundary_v1")
+
+    assert set(grid) == {
+        "candidate_onnx_softmax_exact",
+        "grid_exact_logits_q13",
+        "grid_exact_logits_q12",
+        "grid_exact_logits_q11",
+        "grid_exact_logits_q10",
+        "grid_approx_pwl_float_norm_exact",
+        "grid_approx_pwl_in_q13_w_q13_norm_exact",
+        "grid_approx_pwl_in_q12_w_q12_norm_exact",
+        "grid_approx_pwl_in_q11_w_q11_norm_exact",
+        "grid_approx_pwl_in_q10_w_q10_norm_exact",
+        "grid_approx_pwl_bf16_path",
+    }
+    assert grid["grid_approx_pwl_in_q11_w_q11_norm_exact"]["softmax_input_quant_bits"] == 11
+    assert grid["grid_approx_pwl_in_q11_w_q11_norm_exact"]["softmax_weight_quant_bits"] == 11
+    assert grid["grid_approx_pwl_in_q11_w_q11_norm_exact"]["normalization_mode"] == "exact"
+    assert grid["grid_approx_pwl_bf16_path"]["normalization_reciprocal_float_format"] == "bf16"
+
+
 def test_q8_normalization_frontier_report_selects_lowest_cost_exact_safe_reciprocal() -> None:
     report = build_report(
         sweep_path=Path("tests/fixtures/decoder_q8_norm_frontier_sweep.json"),


### PR DESCRIPTION
## Summary

Adds a Layer 2 decoder PWL integer bit-width boundary job to narrow the q10/q11/q12/q13 precision floor after q12 proved quality-safe but expensive in PPA.

## Changes

- Adds `decoder_pwl_bitwidth_boundary_v1` rough grid with q10/q11/q12/q13 exact-logit and PWL exact-normalization rows plus bf16/unquantized controls.
- Adds `summarize_llm_decoder_pwl_bitwidth_boundary.py` to report the lowest exact-safe and top-k-safe integer PWL bit width.
- Registers `decoder_pwl_bitwidth_boundary` in the L2 task generator and adds proposal docs.
- Adds tests for the new grid and generated command manifest.

## Validation

- `python3 -m py_compile npu/eval/sweep_llm_decoder_candidate_quality.py npu/eval/summarize_llm_decoder_pwl_bitwidth_boundary.py control_plane/control_plane/services/l2_task_generator.py`
- `PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_q8_norm_frontier.py`
- Two-sample smoke run of the new rough grid and summarizer completed successfully using a temporary manifest.
