### PR TITLE
[codex] Record decoder PWL bitwidth boundary request

### DIFF
--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_pwl_bitwidth_boundary_v1",
+  "source_commit": "735732d900d085082382db7777763b1afd1aad56",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_pwl_bitwidth_boundary_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a q10/q11/q12/q13 PWL bit-width boundary check on the expanded v2 decoder distribution.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_pwl_bitwidth_boundary",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_pwl_survivor_distribution_v1",
+        "l1_decoder_q12_pwl_recip_norm_datapath_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Determine whether q11 is exact-safe before spending another Layer 1 PPA run, or keep q12 as the integer exact-safe floor."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_pwl_bitwidth_boundary_v1/promotion_result.json
@@ -1,5 +1,8 @@
 {
   "proposal_id": "prop_l2_decoder_pwl_bitwidth_boundary_v1",
   "decision": "iterate",
-  "status": "pending_evaluation"
+  "status": "pending_evaluation",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
 }


### PR DESCRIPTION
## Summary

Records the generated control-plane request metadata for `l2_decoder_pwl_bitwidth_boundary_v1` after merging the setup PR.

## Details

- Adds `evaluation_requests.json` with source commit `735732d900d085082382db7777763b1afd1aad56`.
- Updates `promotion_result.json` with the standard pending evaluation merge fields.
- The control-plane item is generated and assigned to `eval-daemon-b7c2d9c80c1c`.

## Validation

- `generate-l2-campaign` completed with status `applied`.
- `scheduler assign-item` moved the item to `ready`.
