### PR TITLE
[codex] Add decoder bf16 PWL recoverability job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1163,6 +1163,44 @@ def _decoder_pwl_failure_diagnosis_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_bf16_pwl_recoverability_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    sweep = f"{base}/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json"
+    sample_file = f"{base}/samples_distribution_v2.jsonl"
+    recoverability_out = f"{base}/decoder_bf16_pwl_recoverability__{item_id}.json"
+    recoverability_report = f"{base}/decoder_bf16_pwl_recoverability__{item_id}.md"
+    commands = [
+        {
+            "name": "estimate_decoder_bf16_pwl_recoverability",
+            "run": (
+                "python3 npu/eval/estimate_llm_decoder_bf16_recoverability.py "
+                f"--sweep {sweep} "
+                f"--sample-file {sample_file} "
+                f"--out {recoverability_out} "
+                f"--out-md {recoverability_report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            "source_sweep": sweep,
+            "sample_file": sample_file,
+            "recoverability_out": recoverability_out,
+            "recoverability_report": recoverability_report,
+            "target_template": "grid_approx_pwl_bf16_path",
+            "recoverability_scope": (
+                "score-gap screen for whether bf16/PWL exact-next misses are small-margin "
+                "top-k-contained cases that are worth testing with QAT or fine-tuning"
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            recoverability_out,
+            recoverability_report,
+        ],
+    }
+
+
 def _decoder_pwl_logit_sensitivity_ladder_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_tiny_v1"
     dataset_manifest = f"{base}/manifest_pwl_failure_focus_v1.json"
@@ -1585,6 +1623,7 @@ def _build_payload(
         "decoder_q8_normalization_frontier",
         "decoder_q8_normalization_distribution",
         "decoder_q8_normalization_distribution_broad_v2",
+        "decoder_bf16_pwl_recoverability",
         "decoder_pwl_failure_diagnosis",
         "decoder_pwl_logit_sensitivity_ladder",
         "decoder_pwl_survivor_distribution",
@@ -1593,6 +1632,8 @@ def _build_payload(
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_bf16_pwl_recoverability":
+            decoder_evidence = _decoder_bf16_pwl_recoverability_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pwl_bitwidth_boundary":
             decoder_evidence = _decoder_pwl_bitwidth_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pwl_survivor_distribution":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -916,6 +916,55 @@ def test_generate_l2_campaign_task_adds_decoder_pwl_failure_diagnosis_evidence()
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_bf16_pwl_recoverability_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_bf16_pwl_recoverability_v1",
+                    proposal_id="prop_l2_decoder_bf16_pwl_recoverability_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_bf16_pwl_recoverability",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert work_item.command_manifest[0]["name"] == "estimate_decoder_bf16_pwl_recoverability"
+            assert "estimate_llm_decoder_bf16_recoverability.py" in work_item.command_manifest[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["source_sweep"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json"
+            )
+            assert decoder_inputs["target_template"] == "grid_approx_pwl_bf16_path"
+            assert "score-gap screen" in decoder_inputs["recoverability_scope"]
+            assert decoder_inputs["recoverability_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_bf16_pwl_recoverability__l2_decoder_bf16_pwl_recoverability_v1.json"
+            )
+            assert decoder_inputs["recoverability_out"] in work_item.expected_outputs
+            assert decoder_inputs["recoverability_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_bf16_pwl_recoverability",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/README.md
@@ -1,0 +1,7 @@
+# Decoder bf16/PWL Exact-Next Recoverability
+
+Proposal workspace for `prop_l2_decoder_bf16_pwl_recoverability_v1`.
+
+This job measures whether the bf16 reciprocal PWL exact-next misses are small
+rank-2 margin shifts. It is a screen for whether a bf16/PWL-aware training or
+QAT experiment is worth running.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending evaluator result.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/design_brief.md
@@ -1,0 +1,21 @@
+# Decoder bf16/PWL Exact-Next Recoverability
+
+- `proposal_id`: `prop_l2_decoder_bf16_pwl_recoverability_v1`
+- `item_id`: `l2_decoder_bf16_pwl_recoverability_v1`
+- abstraction: `decoder_bf16_pwl_recoverability`
+
+bf16 reciprocal PWL is still the practical PPA frontier, but it is exact-next
+46/48 on the expanded v2 set. Both misses preserve top-k, so the next question
+is whether exact-next recovery requires only small top-1 margin movement.
+
+This job reads the existing broad-v2 bf16/PWL sweep and reports:
+
+- reference token rank in the bf16/PWL candidate top-k
+- score gap between the selected wrong token and the reference token
+- normal correct-sample top1/top2 margin distribution
+- an easy/moderate/hard recoverability class for each miss
+
+Expected output:
+
+- `decoder_bf16_pwl_recoverability__l2_decoder_bf16_pwl_recoverability_v1.json`
+- `decoder_bf16_pwl_recoverability__l2_decoder_bf16_pwl_recoverability_v1.md`

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+Queue `l2_decoder_bf16_pwl_recoverability_v1` after the broad q8/bf16
+distribution result and the PWL bit-width boundary result are merged.
+
+Required inputs:
+
+- `runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json`
+- `runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl`
+- `runs/datasets/llm_decoder_eval_tiny_v1/decoder_pwl_bitwidth_boundary__l2_decoder_pwl_bitwidth_boundary_v1.json`

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/implementation_summary.md
@@ -1,0 +1,6 @@
+# Implementation Summary
+
+- Added `estimate_llm_decoder_bf16_recoverability.py` to quantify bf16/PWL
+  score gaps for exact-next misses.
+- Registered `decoder_bf16_pwl_recoverability` in the Layer 2 task generator.
+- Added proposal docs and tests for the report and generated task manifest.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/promotion_decision.json
@@ -1,0 +1,10 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_recoverability_v1",
+  "status": "pending_evaluation",
+  "decision": "iterate",
+  "candidate_id": "l2_decoder_bf16_pwl_recoverability_v1",
+  "reason": "Awaiting bf16/PWL score-gap recoverability evidence.",
+  "evidence_refs": [],
+  "next_action": "run l2_decoder_bf16_pwl_recoverability_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/promotion_gate.md
@@ -1,0 +1,6 @@
+# Promotion Gate
+
+- promote a training/QAT job only if misses are top-k contained and the required
+  score gaps are small relative to normal correct-sample margins
+- otherwise keep q12 exact-safe hardware as the exact-next fallback and continue
+  using bf16/q8 reciprocal as the practical PPA frontier

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/promotion_result.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_recoverability_v1",
+  "decision": "iterate",
+  "status": "pending_evaluation"
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_recoverability_v1",
+  "created_utc": "2026-05-03T12:20:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_bf16_pwl_recoverability",
+  "title": "Decoder bf16/PWL exact-next recoverability",
+  "hypothesis": "The bf16 reciprocal PWL path preserves top-k on the expanded v2 decoder distribution but misses exact top-1 on two small-margin samples. Measuring the score gap required to flip those samples back to the reference token can determine whether a bf16/PWL-aware training experiment is justified before spending more area on exact-safe integer hardware.",
+  "direct_comparison": {
+    "primary_question": "For bf16/PWL exact-next misses, is the reference token still rank-2 with a small candidate score gap relative to normal correct-sample margins?",
+    "include": [
+      "bf16/PWL broad-v2 next-token misses",
+      "reference token rank in bf16/PWL top-k",
+      "candidate score gap needed to restore reference top-1",
+      "comparison against correct-sample top1/top2 margin distribution"
+    ],
+    "exclude": [
+      "running training or QAT",
+      "new RTL/OpenROAD measurement",
+      "claiming that training will definitely recover exact top-1"
+    ]
+  },
+  "expected_benefit": [
+    "separates easy rank-2 margin shifts from hard top-k loss",
+    "decides whether a bf16/PWL-aware training job is worth adding",
+    "keeps q12 exact-safe hardware as a fallback rather than the immediate next spend"
+  ],
+  "risks": [
+    "score-gap analysis is only a proxy for training recoverability",
+    "the sample set remains tied to one tiny decoder model",
+    "training dynamics may differ from a static top-k margin screen"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_bf16_pwl_recoverability_v1",
+      "task_type": "l2_campaign",
+      "objective": "decoder_bf16_pwl_recoverability",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_bf16_pwl_recoverability",
+      "depends_on_item_ids": [
+        "l2_decoder_q8_norm_distribution_broad_v2",
+        "l2_decoder_pwl_bitwidth_boundary_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_q8_norm_distribution_broad_v2/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_q8_norm_frontier__l2_decoder_q8_norm_distribution_broad_v2.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_pwl_bitwidth_boundary__l2_decoder_pwl_bitwidth_boundary_v1.json"
+  ],
+  "knowledge_refs": [
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl",
+    "npu/eval/estimate_llm_decoder_bf16_recoverability.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recoverability_v1/quality_gate.md
@@ -1,0 +1,12 @@
+# Quality Gate
+
+Acceptance for this exploratory job is a completed margin report with:
+
+- exact next-token and top-k counts for bf16/PWL
+- per-miss reference rank in candidate top-k
+- per-miss score gap needed to restore reference top-1
+- comparison against correct-sample margin distribution
+- a recommendation on whether to run bf16/PWL-aware training or QAT
+
+This is not training proof; it only decides whether training is the next
+reasonable experiment.

--- a/npu/eval/estimate_llm_decoder_bf16_recoverability.py
+++ b/npu/eval/estimate_llm_decoder_bf16_recoverability.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Estimate top-1 recovery room for the decoder bf16/PWL path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+DEFAULT_SWEEP = Path("runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json")
+DEFAULT_SAMPLE_FILE = Path("runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl")
+DEFAULT_TEMPLATE = "grid_approx_pwl_bf16_path"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve(path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return _repo_root() / candidate
+
+
+def _portable(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(_repo_root()))
+    except ValueError:
+        return str(path)
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    with _resolve(path).open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _load_jsonl(path: str | Path) -> list[JsonDict]:
+    rows: list[JsonDict] = []
+    with _resolve(path).open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if not isinstance(payload, dict):
+                raise SystemExit(f"expected object at {path}:{line_no}")
+            rows.append(payload)
+    return rows
+
+
+def _manifest_samples_by_id(manifest_path: str | Path) -> dict[str, JsonDict]:
+    manifest = _load_json(manifest_path)
+    samples = manifest.get("samples")
+    if not isinstance(samples, list):
+        raise SystemExit(f"candidate manifest must contain samples list: {manifest_path}")
+    return {str(sample.get("sample_id") or ""): sample for sample in samples if isinstance(sample, dict)}
+
+
+def _quality_samples_by_id(quality_path: str | Path) -> dict[str, JsonDict]:
+    quality = _load_json(quality_path)
+    samples = quality.get("samples")
+    if not isinstance(samples, list):
+        raise SystemExit(f"quality JSON must contain samples list: {quality_path}")
+    return {str(sample.get("sample_id") or ""): sample for sample in samples if isinstance(sample, dict)}
+
+
+def _candidate_doc(manifest_sample: JsonDict) -> JsonDict:
+    candidate_json = str(manifest_sample.get("candidate_json") or "").strip()
+    if not candidate_json:
+        raise SystemExit(f"candidate manifest sample missing candidate_json: {manifest_sample}")
+    return _load_json(candidate_json)
+
+
+def _next(doc: JsonDict) -> JsonDict:
+    candidate = doc.get("candidate")
+    if not isinstance(candidate, dict):
+        return {"token_id": None, "token_text": ""}
+    return {
+        "token_id": candidate.get("next_token_id"),
+        "token_text": candidate.get("next_token_text"),
+    }
+
+
+def _topk(doc: JsonDict) -> list[JsonDict]:
+    candidate = doc.get("candidate")
+    if not isinstance(candidate, dict):
+        return []
+    topk = candidate.get("topk")
+    return [dict(row) for row in topk] if isinstance(topk, list) else []
+
+
+def _score_for(topk: list[JsonDict], token_id: Any) -> float | None:
+    for row in topk:
+        if row.get("token_id") == token_id:
+            try:
+                return float(row.get("score"))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _rank_for(topk: list[JsonDict], token_id: Any) -> int | None:
+    for index, row in enumerate(topk, start=1):
+        if row.get("token_id") == token_id:
+            return index
+    return None
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _quantile(values: list[float], fraction: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((len(ordered) - 1) * fraction)))
+    return ordered[index]
+
+
+def _template_row(sweep: JsonDict, template: str) -> JsonDict:
+    rows = sweep.get("templates")
+    if not isinstance(rows, list):
+        raise SystemExit("sweep JSON must contain templates list")
+    for row in rows:
+        if isinstance(row, dict) and row.get("template") == template:
+            return row
+    raise SystemExit(f"template not found in sweep: {template}")
+
+
+def _samples_by_id(sample_file: str | Path) -> dict[str, JsonDict]:
+    return {str(row.get("sample_id") or ""): row for row in _load_jsonl(sample_file)}
+
+
+def _miss_record(
+    *,
+    sample_id: str,
+    sample: JsonDict,
+    exact_doc: JsonDict,
+    candidate_doc: JsonDict,
+    quality_sample: JsonDict,
+    correct_margin_stats: JsonDict,
+) -> JsonDict:
+    exact_next = _next(exact_doc)
+    candidate_next = _next(candidate_doc)
+    candidate_topk = _topk(candidate_doc)
+    exact_token_id = exact_next.get("token_id")
+    candidate_token_id = candidate_next.get("token_id")
+    exact_rank = _rank_for(candidate_topk, exact_token_id)
+    candidate_score = _score_for(candidate_topk, candidate_token_id)
+    exact_score = _score_for(candidate_topk, exact_token_id)
+    gap = None
+    if candidate_score is not None and exact_score is not None:
+        gap = candidate_score - exact_score
+    median_margin = correct_margin_stats.get("median")
+    p90_margin = correct_margin_stats.get("p90")
+    if exact_rank == 2 and gap is not None and median_margin is not None and gap <= median_margin:
+        class_name = "easy_rank2_below_median_margin"
+    elif exact_rank is not None and exact_rank <= 3 and gap is not None and p90_margin is not None and gap <= p90_margin:
+        class_name = "moderate_top3_within_p90_margin"
+    elif exact_rank is not None and exact_rank <= 5:
+        class_name = "hard_topk_present"
+    else:
+        class_name = "blocked_reference_missing_from_topk"
+    distribution = quality_sample.get("candidate_distribution")
+    return {
+        "sample_id": sample_id,
+        "category": sample.get("category"),
+        "prompt": sample.get("prompt"),
+        "expected_continuation": sample.get("expected_continuation"),
+        "exact_next": exact_next,
+        "candidate_next": candidate_next,
+        "reference_rank_in_candidate_topk": exact_rank,
+        "candidate_score": candidate_score,
+        "reference_token_candidate_score": exact_score,
+        "score_gap_to_flip_top1": gap,
+        "candidate_top1_top2_margin": (distribution or {}).get("top1_top2_score_margin")
+        if isinstance(distribution, dict)
+        else None,
+        "recovery_class": class_name,
+        "topk_contains_reference": bool((quality_sample.get("aggregate") or {}).get("topk_contains_reference_id")),
+    }
+
+
+def build_report(
+    *,
+    sweep_path: Path = DEFAULT_SWEEP,
+    sample_file: Path = DEFAULT_SAMPLE_FILE,
+    template: str = DEFAULT_TEMPLATE,
+) -> JsonDict:
+    sweep_path = _resolve(sweep_path)
+    sample_file = _resolve(sample_file)
+    sweep = _load_json(sweep_path)
+    row = _template_row(sweep, template)
+    exact_row = _template_row(sweep, "candidate_onnx_softmax_exact")
+    samples = _samples_by_id(sample_file)
+    quality_by_id = _quality_samples_by_id(row["quality_json"])
+    candidate_manifest = _manifest_samples_by_id(row["candidate_manifest"])
+    exact_manifest = _manifest_samples_by_id(exact_row["candidate_manifest"])
+
+    correct_margins: list[float] = []
+    for sample_id, quality_sample in quality_by_id.items():
+        aggregate = quality_sample.get("aggregate") or {}
+        if not aggregate.get("next_token_id_match"):
+            continue
+        distribution = quality_sample.get("candidate_distribution")
+        if not isinstance(distribution, dict):
+            continue
+        margin = _as_float(distribution.get("top1_top2_score_margin"))
+        if margin is not None:
+            correct_margins.append(margin)
+    margin_stats = {
+        "count": len(correct_margins),
+        "min": min(correct_margins) if correct_margins else None,
+        "p25": _quantile(correct_margins, 0.25),
+        "median": median(correct_margins) if correct_margins else None,
+        "p90": _quantile(correct_margins, 0.90),
+        "max": max(correct_margins) if correct_margins else None,
+    }
+
+    miss_ids = [str(v) for v in row.get("next_token_mismatch_sample_ids") or []]
+    misses = [
+        _miss_record(
+            sample_id=sample_id,
+            sample=samples.get(sample_id, {}),
+            exact_doc=_candidate_doc(exact_manifest[sample_id]),
+            candidate_doc=_candidate_doc(candidate_manifest[sample_id]),
+            quality_sample=quality_by_id[sample_id],
+            correct_margin_stats=margin_stats,
+        )
+        for sample_id in miss_ids
+    ]
+    topk_safe = not row.get("topk_miss_sample_ids")
+    easy_count = sum(1 for miss in misses if str(miss["recovery_class"]).startswith("easy_"))
+    moderate_count = sum(1 for miss in misses if str(miss["recovery_class"]).startswith("moderate_"))
+    hard_count = len(misses) - easy_count - moderate_count
+    if topk_safe and misses and hard_count == 0 and easy_count >= 1:
+        decision = "recoverable_margin_shift"
+        recommended = "Prototype bf16/PWL-aware fine-tuning or QAT before spending more exact-safe integer PPA effort."
+    elif topk_safe and misses and hard_count == 0:
+        decision = "plausibly_recoverable_margin_shift"
+        recommended = "Measure training sensitivity on the miss samples before treating q12 exact-safe hardware as necessary."
+    elif topk_safe:
+        decision = "topk_safe_but_recovery_unclear"
+        recommended = "Inspect low-rank or large-gap misses before a training experiment."
+    else:
+        decision = "not_recoverable_from_topk_only"
+        recommended = "Do not rely on training recovery without first restoring top-k containment."
+
+    sample_count = int(row.get("sample_count") or 0)
+    next_matches = round(float(row.get("next_token_id_match_rate") or 0.0) * sample_count)
+    topk_matches = round(float(row.get("topk_contains_reference_id_rate") or 0.0) * sample_count)
+    return {
+        "version": 0.1,
+        "source_sweep": _portable(sweep_path),
+        "sample_file": _portable(sample_file),
+        "template": template,
+        "sample_count": sample_count,
+        "next_token_matches": next_matches,
+        "topk_matches": topk_matches,
+        "correct_sample_margin_stats": margin_stats,
+        "misses": misses,
+        "diagnosis": {
+            "decision": decision,
+            "summary": (
+                "Recoverability is estimated from the score gap required to move the exact-reference "
+                "token back to top-1 in the bf16/PWL candidate output. This is not training proof; it "
+                "is a margin screen for whether a QAT/fine-tuning experiment is worth running."
+            ),
+            "topk_safe": topk_safe,
+            "miss_count": len(misses),
+            "easy_count": easy_count,
+            "moderate_count": moderate_count,
+            "hard_count": hard_count,
+            "recommended_next_step": recommended,
+        },
+    }
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        return f"{value:.8g}"
+    return str(value)
+
+
+def _write_md(doc: JsonDict, path: Path) -> None:
+    stats = doc["correct_sample_margin_stats"]
+    lines = [
+        "# Decoder bf16/PWL Recoverability",
+        "",
+        f"- source_sweep: `{doc['source_sweep']}`",
+        f"- template: `{doc['template']}`",
+        f"- decision: `{doc['diagnosis']['decision']}`",
+        f"- next-token: {doc['next_token_matches']}/{doc['sample_count']}",
+        f"- top-k: {doc['topk_matches']}/{doc['sample_count']}",
+        f"- summary: {doc['diagnosis']['summary']}",
+        f"- recommended_next_step: {doc['diagnosis']['recommended_next_step']}",
+        "",
+        "## Correct-Sample Margins",
+        "",
+        "| count | min | p25 | median | p90 | max |",
+        "|---:|---:|---:|---:|---:|---:|",
+        (
+            f"| {stats['count']} | {_fmt(stats['min'])} | {_fmt(stats['p25'])} | "
+            f"{_fmt(stats['median'])} | {_fmt(stats['p90'])} | {_fmt(stats['max'])} |"
+        ),
+        "",
+        "## Miss Recovery Gaps",
+        "",
+        "| sample | category | rank | wrong token | reference token | gap | class |",
+        "|---|---|---:|---|---|---:|---|",
+    ]
+    for miss in doc["misses"]:
+        lines.append(
+            "| `{sample}` | `{category}` | {rank} | `{wrong}` | `{ref}` | {gap} | `{cls}` |".format(
+                sample=miss["sample_id"],
+                category=miss.get("category") or "",
+                rank=miss.get("reference_rank_in_candidate_topk") or "",
+                wrong=miss["candidate_next"].get("token_text"),
+                ref=miss["exact_next"].get("token_text"),
+                gap=_fmt(miss.get("score_gap_to_flip_top1")),
+                cls=miss["recovery_class"],
+            )
+        )
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sweep", default=str(DEFAULT_SWEEP))
+    ap.add_argument("--sample-file", default=str(DEFAULT_SAMPLE_FILE))
+    ap.add_argument("--template", default=DEFAULT_TEMPLATE)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    doc = build_report(sweep_path=Path(args.sweep), sample_file=Path(args.sample_file), template=str(args.template))
+    out_path = _resolve(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_md(doc, _resolve(args.out_md))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_bf16_recoverability.py
+++ b/tests/test_llm_decoder_bf16_recoverability.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from npu.eval.estimate_llm_decoder_bf16_recoverability import build_report
+
+
+def test_bf16_recoverability_report_quantifies_topk_contained_misses() -> None:
+    report = build_report(
+        sweep_path=Path("runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json"),
+        sample_file=Path("runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl"),
+    )
+
+    assert report["template"] == "grid_approx_pwl_bf16_path"
+    assert report["sample_count"] == 48
+    assert report["next_token_matches"] == 46
+    assert report["topk_matches"] == 48
+    assert report["diagnosis"]["topk_safe"]
+    assert report["diagnosis"]["miss_count"] == 2
+    assert report["diagnosis"]["decision"] in {
+        "recoverable_margin_shift",
+        "plausibly_recoverable_margin_shift",
+        "topk_safe_but_recovery_unclear",
+    }
+    assert {miss["sample_id"] for miss in report["misses"]} == {
+        "dist2_arith_three_plus_five",
+        "dist2_sequence_months",
+    }
+    for miss in report["misses"]:
+        assert miss["reference_rank_in_candidate_topk"] == 2
+        assert miss["score_gap_to_flip_top1"] is not None
+        assert miss["score_gap_to_flip_top1"] >= 0
+        assert miss["recovery_class"] == "easy_rank2_below_median_margin"


### PR DESCRIPTION
## Summary

Adds a Layer 2 score-gap recoverability job for the bf16 reciprocal PWL decoder path. The job reads the existing broad-v2 sweep and estimates whether exact-next misses are rank-2, top-k-contained margin shifts worth testing with bf16/PWL-aware training or QAT.

## Changes

- Adds `estimate_llm_decoder_bf16_recoverability.py` with a reusable `build_report()` and Markdown/JSON output.
- Registers `decoder_bf16_pwl_recoverability` in the L2 task generator.
- Adds proposal docs for `prop_l2_decoder_bf16_pwl_recoverability_v1`.
- Adds tests for the report and generated command manifest.

## Validation

- `python3 -m py_compile npu/eval/estimate_llm_decoder_bf16_recoverability.py control_plane/control_plane/services/l2_task_generator.py`
- `PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q tests/test_llm_decoder_bf16_recoverability.py control_plane/control_plane/tests/test_l2_task_generator.py`
- Local report generation to `/tmp/bf16_recoverability.{json,md}` completed successfully.
