### PR TITLE
[codex] Add decoder bf16 PWL recovery job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1201,6 +1201,106 @@ def _decoder_bf16_pwl_recoverability_evidence(*, item_id: str) -> dict[str, Any]
     }
 
 
+def _decoder_bf16_pwl_recovery_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    dataset_manifest = f"{base}/manifest_distribution_v2.json"
+    sample_file = f"{base}/samples_distribution_v2.jsonl"
+    reference_dir = f"{base}/reference_distribution_v2"
+    reference_manifest = f"{base}/reference_distribution_v2_manifest.json"
+    candidate_dir = f"{base}/candidate_distribution_v2"
+    candidate_manifest = f"{base}/candidate_distribution_v2_manifest.json"
+    validation_out = f"{base}/decoder_contract_validation__{item_id}.json"
+    quality_out = f"{base}/decoder_quality_compare__{item_id}.json"
+    sweep_dir = f"{base}/candidate_sweeps/{item_id}"
+    sweep_out = f"{base}/decoder_quality_sweep__{item_id}.json"
+    recovery_out = f"{base}/decoder_bf16_pwl_recovery__{item_id}.json"
+    recovery_report = f"{base}/decoder_bf16_pwl_recovery__{item_id}.md"
+    rough_grid = "decoder_bf16_pwl_recovery_v1"
+    commands = [
+        {
+            "name": "generate_decoder_bf16_pwl_recovery_reference",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_reference_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {reference_dir} "
+                f"--out-manifest {reference_manifest}"
+            ),
+        },
+        {
+            "name": "generate_decoder_bf16_pwl_recovery_candidate",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_candidate_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {candidate_dir} "
+                f"--out-manifest {candidate_manifest}"
+            ),
+        },
+        {
+            "name": "validate_decoder_bf16_pwl_recovery_contract",
+            "run": f"python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest {dataset_manifest} --out {validation_out}",
+        },
+        {
+            "name": "compare_decoder_bf16_pwl_recovery_quality",
+            "run": (
+                "python3 npu/eval/compare_llm_decoder_quality.py "
+                f"--reference-manifest {reference_manifest} "
+                f"--candidate-manifest {candidate_manifest} "
+                f"--out {quality_out}"
+            ),
+        },
+        {
+            "name": "sweep_decoder_bf16_pwl_recovery",
+            "run": (
+                "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--rough-grid {rough_grid} "
+                f"--out-dir {sweep_dir} "
+                f"--out {sweep_out}"
+            ),
+        },
+        {
+            "name": "summarize_decoder_bf16_pwl_recovery",
+            "run": (
+                "python3 npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py "
+                f"--sweep {sweep_out} "
+                f"--out {recovery_out} "
+                f"--out-md {recovery_report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            "dataset_manifest": dataset_manifest,
+            "sample_file": sample_file,
+            "reference_dir": reference_dir,
+            "reference_manifest": reference_manifest,
+            "candidate_dir": candidate_dir,
+            "candidate_manifest": candidate_manifest,
+            "validation_out": validation_out,
+            "quality_out": quality_out,
+            "candidate_sweep_dir": sweep_dir,
+            "candidate_sweep_out": sweep_out,
+            "candidate_sweep_grid": rough_grid,
+            "recovery_out": recovery_out,
+            "recovery_report": recovery_report,
+            "recovery_scope": (
+                "narrow bf16/PWL calibration proxy that preserves the same score arithmetic and "
+                "tests whether logit tie-breaking recovers equal-score exact-next losses"
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            reference_manifest,
+            candidate_manifest,
+            validation_out,
+            quality_out,
+            sweep_out,
+            recovery_out,
+            recovery_report,
+        ],
+    }
+
+
 def _decoder_pwl_logit_sensitivity_ladder_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_tiny_v1"
     dataset_manifest = f"{base}/manifest_pwl_failure_focus_v1.json"
@@ -1623,6 +1723,7 @@ def _build_payload(
         "decoder_q8_normalization_frontier",
         "decoder_q8_normalization_distribution",
         "decoder_q8_normalization_distribution_broad_v2",
+        "decoder_bf16_pwl_recovery",
         "decoder_bf16_pwl_recoverability",
         "decoder_pwl_failure_diagnosis",
         "decoder_pwl_logit_sensitivity_ladder",
@@ -1632,6 +1733,8 @@ def _build_payload(
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_bf16_pwl_recovery":
+            decoder_evidence = _decoder_bf16_pwl_recovery_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_bf16_pwl_recoverability":
             decoder_evidence = _decoder_bf16_pwl_recoverability_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pwl_bitwidth_boundary":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -965,6 +965,66 @@ def test_generate_l2_campaign_task_adds_decoder_bf16_pwl_recoverability_evidence
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_bf16_pwl_recovery_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_bf16_pwl_recovery_v1",
+                    proposal_id="prop_l2_decoder_bf16_pwl_recovery_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_bf16_pwl_recovery",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:6] == [
+                "generate_decoder_bf16_pwl_recovery_reference",
+                "generate_decoder_bf16_pwl_recovery_candidate",
+                "validate_decoder_bf16_pwl_recovery_contract",
+                "compare_decoder_bf16_pwl_recovery_quality",
+                "sweep_decoder_bf16_pwl_recovery",
+                "summarize_decoder_bf16_pwl_recovery",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["dataset_manifest"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/manifest_distribution_v2.json"
+            )
+            assert decoder_inputs["sample_file"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/samples_distribution_v2.jsonl"
+            )
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_bf16_pwl_recovery_v1"
+            assert "logit tie-breaking" in decoder_inputs["recovery_scope"]
+            assert "--rough-grid decoder_bf16_pwl_recovery_v1" in work_item.command_manifest[4]["run"]
+            assert "summarize_llm_decoder_bf16_pwl_recovery.py" in work_item.command_manifest[5]["run"]
+            assert decoder_inputs["recovery_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_bf16_pwl_recovery__l2_decoder_bf16_pwl_recovery_v1.json"
+            )
+            assert decoder_inputs["recovery_out"] in work_item.expected_outputs
+            assert decoder_inputs["recovery_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_bf16_pwl_recovery",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/README.md
@@ -1,0 +1,3 @@
+# prop_l2_decoder_bf16_pwl_recovery_v1
+
+Proposal workspace for the Layer 2 decoder bf16/PWL recovery proxy.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending evaluator result.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/design_brief.md
@@ -1,0 +1,17 @@
+# Design Brief
+
+- `proposal_id`: `prop_l2_decoder_bf16_pwl_recovery_v1`
+- `item_id`: `l2_decoder_bf16_pwl_recovery_v1`
+- abstraction: `decoder_bf16_pwl_recovery`
+
+The prior recoverability job found two bf16/PWL exact-next misses, both with
+the reference token still rank 2 and a zero score gap. This job tests the
+smallest useful recovery mechanism: keep the bf16/PWL score path unchanged and
+use the post-logit value only as a deterministic tie-breaker when scores are
+exactly equal.
+
+Expected artifacts:
+
+- `decoder_quality_sweep__l2_decoder_bf16_pwl_recovery_v1.json`
+- `decoder_bf16_pwl_recovery__l2_decoder_bf16_pwl_recovery_v1.json`
+- `decoder_bf16_pwl_recovery__l2_decoder_bf16_pwl_recovery_v1.md`

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/evaluation_gate.md
@@ -1,0 +1,7 @@
+# Evaluation Gate
+
+Before dispatch:
+
+- `l2_decoder_q8_norm_distribution_broad_v2` is merged and finalized.
+- `l2_decoder_bf16_pwl_recoverability_v1` is merged and finalized.
+- the evaluator is running code that includes `decoder_bf16_pwl_recovery_v1`.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/implementation_summary.md
@@ -1,0 +1,14 @@
+# Implementation Summary
+
+Implemented the bf16/PWL recovery proxy:
+
+- added `score_tie_breaker=logit` support to the ONNX candidate runner
+- added the `decoder_bf16_pwl_recovery_v1` rough grid
+- added `summarize_llm_decoder_bf16_pwl_recovery.py`
+- registered `decoder_bf16_pwl_recovery` in the Layer 2 task generator
+
+Local validation:
+
+- `python3 -m py_compile npu/eval/run_llm_decoder_onnx_candidate.py npu/eval/sweep_llm_decoder_candidate_quality.py npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py control_plane/control_plane/services/l2_task_generator.py`
+- `PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q tests/test_llm_decoder_bf16_pwl_recovery.py tests/test_llm_decoder_q8_norm_frontier.py control_plane/control_plane/tests/test_l2_task_generator.py`
+- local recovery sweep produced `tie_break_recovery_sufficient`: baseline bf16/PWL was 46/48 next-token and 48/48 top-k; logit tie-break recovery was 48/48 next-token and 48/48 top-k.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/promotion_decision.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_recovery_v1",
+  "status": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+Promote the bf16/PWL recovery path only if:
+
+- logit tie-breaking recovers all baseline bf16/PWL exact-next misses
+- no new next-token regressions appear on distribution v2
+- top-k containment remains complete

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_recovery_v1",
+  "status": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/proposal.json
@@ -1,0 +1,61 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_recovery_v1",
+  "created_utc": "2026-05-03T13:05:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_bf16_pwl_recovery",
+  "title": "Decoder bf16/PWL tie-break recovery",
+  "hypothesis": "The bf16/PWL exact-next losses are equal-score rank-2 cases, so a hardware-friendly ranking calibration that uses logits only to break exact score ties may recover exact-next behavior without changing the bf16/PWL arithmetic path.",
+  "direct_comparison": {
+    "primary_question": "Does bf16/PWL with logit tie-breaking recover the two broad-v2 exact-next misses while preserving top-k containment and avoiding regressions?",
+    "include": [
+      "candidate_onnx_softmax_exact reference path",
+      "grid_approx_pwl_bf16_path baseline",
+      "grid_approx_pwl_bf16_path_logit_tiebreak recovery proxy",
+      "next-token and top-k match counts on distribution v2"
+    ],
+    "exclude": [
+      "weight updates",
+      "full QAT training",
+      "new RTL/OpenROAD implementation of the ranking comparator"
+    ]
+  },
+  "expected_benefit": [
+    "distinguishes pure equal-score ranking loss from true arithmetic quality loss",
+    "tests a cheaper recovery path before building a full bf16 QAT harness",
+    "keeps q12 exact-safe hardware as the fallback if ranking recovery regresses"
+  ],
+  "risks": [
+    "logit tie-breaking is a calibration proxy, not proof that QAT will recover a larger model",
+    "the test remains tied to the tiny decoder distribution v2 set",
+    "hardware needs a clean contract for score equality and logit availability if this wins"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_bf16_pwl_recovery_v1",
+      "task_type": "l2_campaign",
+      "objective": "decoder_bf16_pwl_recovery",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_bf16_pwl_recovery",
+      "depends_on_item_ids": [
+        "l2_decoder_q8_norm_distribution_broad_v2",
+        "l2_decoder_bf16_pwl_recoverability_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_quality_sweep__l2_decoder_q8_norm_distribution_broad_v2.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_bf16_pwl_recoverability__l2_decoder_bf16_pwl_recoverability_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/run_llm_decoder_onnx_candidate.py",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/quality_gate.md
@@ -1,0 +1,10 @@
+# Quality Gate
+
+Acceptance for this exploratory recovery job is a completed report with:
+
+- baseline bf16/PWL next-token and top-k counts
+- logit-tiebreak bf16/PWL next-token and top-k counts
+- recovered sample IDs and regression sample IDs
+- a decision on whether tie-breaking is sufficient or full QAT remains needed
+
+This is a calibration proxy. It does not claim trained-weight recovery.

--- a/npu/eval/run_llm_decoder_onnx_candidate.py
+++ b/npu/eval/run_llm_decoder_onnx_candidate.py
@@ -40,10 +40,19 @@ from npu.eval.tensor_trace_summary import (
 JsonDict = Dict[str, Any]
 
 
-def _topk_pairs(values: Sequence[float], *, k: int) -> Iterable[Tuple[int, float]]:
+def _topk_pairs(values: Sequence[float], *, k: int, tie_break_values: Sequence[float] | None = None) -> Iterable[Tuple[int, float]]:
     if k <= 0:
         return []
-    order = sorted(range(len(values)), key=lambda idx: float(values[idx]), reverse=True)[:k]
+    if tie_break_values is not None and len(tie_break_values) != len(values):
+        raise SystemExit('tie_break_values length must match score length')
+    if tie_break_values is None:
+        order = sorted(range(len(values)), key=lambda idx: float(values[idx]), reverse=True)[:k]
+    else:
+        order = sorted(
+            range(len(values)),
+            key=lambda idx: (float(values[idx]), float(tie_break_values[idx])),
+            reverse=True,
+        )[:k]
     return [(int(idx), float(values[idx])) for idx in order]
 
 
@@ -511,13 +520,39 @@ def _derive_candidate_semantics(backend_config: JsonDict) -> str:
         parts.append(f'prob_{prob_float}')
     else:
         parts.append('prob_fp')
+    score_tie_breaker = str(backend_config.get('score_tie_breaker', '') or '').strip()
+    if score_tie_breaker:
+        parts.append(f'tiebreak_{score_tie_breaker}')
     return '_'.join(parts)
 
 
-def _build_result(*, request: JsonDict, vocab: Dict[str, int], next_token_id: int, scores: Sequence[float], topk: int, tokenizer_runtime: Any | None = None, prompt_doc: JsonDict, ort_version: str, approximation: JsonDict, candidate_semantics: str, selected_tensors: Sequence[JsonDict] | None = None) -> JsonDict:
+def _tie_break_values(*, score_values: Sequence[float], logit_values: Sequence[float], backend_config: JsonDict) -> tuple[list[float] | None, JsonDict]:
+    mode = str(backend_config.get('score_tie_breaker', '') or '').strip()
+    if not mode:
+        return None, {'mode': 'score_only'}
+    if mode == 'logit':
+        return [float(v) for v in logit_values], {
+            'mode': 'score_then_logit',
+            'scope': 'ranking_only',
+            'note': 'Scores remain unchanged; logits only break exact score ties.',
+        }
+    raise SystemExit(f'unsupported backend_config.score_tie_breaker: {mode}')
+
+
+def _select_next_token_id(scores: Sequence[float], *, tie_break_values: Sequence[float] | None = None) -> int:
+    if not scores:
+        raise SystemExit('cannot select next token from empty scores')
+    if tie_break_values is None:
+        return max(range(len(scores)), key=lambda idx: float(scores[idx]))
+    if len(tie_break_values) != len(scores):
+        raise SystemExit('tie_break_values length must match score length')
+    return max(range(len(scores)), key=lambda idx: (float(scores[idx]), float(tie_break_values[idx])))
+
+
+def _build_result(*, request: JsonDict, vocab: Dict[str, int], next_token_id: int, scores: Sequence[float], topk: int, tokenizer_runtime: Any | None = None, prompt_doc: JsonDict, ort_version: str, approximation: JsonDict, candidate_semantics: str, selected_tensors: Sequence[JsonDict] | None = None, tie_break_values: Sequence[float] | None = None, ranking_meta: JsonDict | None = None) -> JsonDict:
     backend_config = request['backend_config']
     next_token_text = _decode_token(next_token_id, vocab, tokenizer_runtime=tokenizer_runtime)
-    topk_pairs = list(_topk_pairs(scores, k=topk))
+    topk_pairs = list(_topk_pairs(scores, k=topk, tie_break_values=tie_break_values))
     top_score = float(topk_pairs[0][1]) if topk_pairs else float(scores[next_token_id])
     runner = {
         'runner': 'onnx_candidate_v1',
@@ -534,6 +569,7 @@ def _build_result(*, request: JsonDict, vocab: Dict[str, int], next_token_id: in
             'next_token_id': next_token_id,
             'confidence': top_score,
             'distribution': _score_distribution_stats(scores, topk=topk),
+            'ranking': dict(ranking_meta or {'mode': 'score_only'}),
             'selected_tensors': list(selected_tensors or []),
             'selected_tensors_sha256': _selected_tensor_trace_hash(selected_tensors),
             'topk': [
@@ -592,7 +628,12 @@ def main() -> int:
     softmax_weights, softmax_meta = _apply_softmax_path(logit_values, backend_config)
     normalized_probs, normalization_meta = _apply_normalization_path(softmax_weights, backend_config)
     score_values, probability_meta = _apply_probability_quantization(normalized_probs, backend_config)
-    next_token_id = max(range(len(score_values)), key=lambda idx: float(score_values[idx]))
+    ranking_values, ranking_meta = _tie_break_values(
+        score_values=score_values,
+        logit_values=logit_values,
+        backend_config=backend_config,
+    )
+    next_token_id = _select_next_token_id(score_values, tie_break_values=ranking_values)
     result = _build_result(
         request=request,
         vocab=vocab,
@@ -609,6 +650,8 @@ def main() -> int:
             'probabilities': probability_meta,
         },
         candidate_semantics=candidate_semantics,
+        tie_break_values=ranking_values,
+        ranking_meta=ranking_meta,
         selected_tensors=_trace_selected_outputs_candidate(
             outputs_by_name=outputs_by_name,
             trace_patterns=trace_patterns,

--- a/npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py
+++ b/npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Summarize bf16/PWL decoder recovery from a narrow calibration grid."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+DEFAULT_BASELINE = "grid_approx_pwl_bf16_path"
+DEFAULT_RECOVERY = "grid_approx_pwl_bf16_path_logit_tiebreak"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve(path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return _repo_root() / candidate
+
+
+def _portable(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(_repo_root()))
+    except ValueError:
+        return str(path)
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    with _resolve(path).open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _template_row(sweep: JsonDict, template: str) -> JsonDict:
+    rows = sweep.get("templates")
+    if not isinstance(rows, list):
+        raise SystemExit("sweep JSON must contain templates list")
+    for row in rows:
+        if isinstance(row, dict) and row.get("template") == template:
+            return row
+    raise SystemExit(f"template not found in sweep: {template}")
+
+
+def _matches(row: JsonDict) -> tuple[int, int, int]:
+    sample_count = int(row.get("sample_count") or 0)
+    next_matches = round(float(row.get("next_token_id_match_rate") or 0.0) * sample_count)
+    topk_matches = round(float(row.get("topk_contains_reference_id_rate") or 0.0) * sample_count)
+    return sample_count, next_matches, topk_matches
+
+
+def _mismatch_ids(row: JsonDict) -> list[str]:
+    return [str(v) for v in row.get("next_token_mismatch_sample_ids") or []]
+
+
+def _topk_miss_ids(row: JsonDict) -> list[str]:
+    return [str(v) for v in row.get("topk_miss_sample_ids") or []]
+
+
+def _row_summary(row: JsonDict) -> JsonDict:
+    sample_count, next_matches, topk_matches = _matches(row)
+    return {
+        "template": row.get("template"),
+        "candidate_semantics": row.get("candidate_semantics"),
+        "sample_count": sample_count,
+        "next_token_matches": next_matches,
+        "topk_matches": topk_matches,
+        "next_token_mismatch_sample_ids": _mismatch_ids(row),
+        "topk_miss_sample_ids": _topk_miss_ids(row),
+        "score_tie_breaker": row.get("score_tie_breaker", ""),
+        "normalization_mode": row.get("normalization_mode", ""),
+        "normalization_reciprocal_float_format": row.get("normalization_reciprocal_float_format", ""),
+    }
+
+
+def build_report(
+    *,
+    sweep_path: Path,
+    baseline_template: str = DEFAULT_BASELINE,
+    recovery_template: str = DEFAULT_RECOVERY,
+) -> JsonDict:
+    sweep_path = _resolve(sweep_path)
+    sweep = _load_json(sweep_path)
+    baseline = _row_summary(_template_row(sweep, baseline_template))
+    recovery = _row_summary(_template_row(sweep, recovery_template))
+
+    baseline_misses = set(baseline["next_token_mismatch_sample_ids"])
+    recovery_misses = set(recovery["next_token_mismatch_sample_ids"])
+    recovered = sorted(baseline_misses - recovery_misses)
+    regressions = sorted(recovery_misses - baseline_misses)
+    sample_count = int(recovery["sample_count"])
+    exact_safe = (
+        sample_count > 0
+        and int(recovery["next_token_matches"]) == sample_count
+        and int(recovery["topk_matches"]) == sample_count
+    )
+    if exact_safe and baseline_misses and not recovery_misses:
+        decision = "tie_break_recovery_sufficient"
+        recommended = (
+            "Treat bf16/PWL as the immediate low-cost frontier and follow with a hardware-friendly "
+            "score-tie ranking check before full QAT infrastructure."
+        )
+    elif recovered and not regressions:
+        decision = "partial_recovery"
+        recommended = "Keep bf16/PWL on the frontier, but run a real QAT/fine-tuning experiment before replacing q12."
+    elif regressions:
+        decision = "recovery_regresses"
+        recommended = "Do not use this ranking calibration without a broader prompt-distribution guard."
+    else:
+        decision = "no_recovery"
+        recommended = "Move to a real QAT/fine-tuning experiment or stay with q12 exact-safe hardware."
+
+    return {
+        "version": 0.1,
+        "source_sweep": _portable(sweep_path),
+        "baseline_template": baseline_template,
+        "recovery_template": recovery_template,
+        "mechanism": {
+            "type": "score_tie_breaker",
+            "tie_breaker": "logit",
+            "training_interpretation": (
+                "This is a narrow QAT/calibration proxy. It does not update weights; it checks whether "
+                "the bf16/PWL exact-next losses are pure equal-score ranking losses that a tiny "
+                "logit-preserving calibration could recover."
+            ),
+        },
+        "baseline": baseline,
+        "recovery": recovery,
+        "recovered_sample_ids": recovered,
+        "regression_sample_ids": regressions,
+        "diagnosis": {
+            "decision": decision,
+            "exact_safe_after_recovery": exact_safe,
+            "recovered_count": len(recovered),
+            "regression_count": len(regressions),
+            "recommended_next_step": recommended,
+        },
+    }
+
+
+def _fmt_ids(values: list[str]) -> str:
+    return ", ".join(f"`{value}`" for value in values) if values else ""
+
+
+def _write_md(doc: JsonDict, path: Path) -> None:
+    baseline = doc["baseline"]
+    recovery = doc["recovery"]
+    lines = [
+        "# Decoder bf16/PWL Recovery",
+        "",
+        f"- source_sweep: `{doc['source_sweep']}`",
+        f"- decision: `{doc['diagnosis']['decision']}`",
+        f"- exact_safe_after_recovery: `{doc['diagnosis']['exact_safe_after_recovery']}`",
+        f"- recovered_count: {doc['diagnosis']['recovered_count']}",
+        f"- regression_count: {doc['diagnosis']['regression_count']}",
+        f"- recommended_next_step: {doc['diagnosis']['recommended_next_step']}",
+        "",
+        "## Mechanism",
+        "",
+        doc["mechanism"]["training_interpretation"],
+        "",
+        "## Quality",
+        "",
+        "| template | next-token | top-k | mismatches |",
+        "|---|---:|---:|---|",
+        (
+            f"| `{baseline['template']}` | {baseline['next_token_matches']}/{baseline['sample_count']} | "
+            f"{baseline['topk_matches']}/{baseline['sample_count']} | "
+            f"{_fmt_ids(baseline['next_token_mismatch_sample_ids'])} |"
+        ),
+        (
+            f"| `{recovery['template']}` | {recovery['next_token_matches']}/{recovery['sample_count']} | "
+            f"{recovery['topk_matches']}/{recovery['sample_count']} | "
+            f"{_fmt_ids(recovery['next_token_mismatch_sample_ids'])} |"
+        ),
+        "",
+        f"- recovered_sample_ids: {_fmt_ids(doc['recovered_sample_ids'])}",
+        f"- regression_sample_ids: {_fmt_ids(doc['regression_sample_ids'])}",
+    ]
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sweep", required=True)
+    ap.add_argument("--baseline-template", default=DEFAULT_BASELINE)
+    ap.add_argument("--recovery-template", default=DEFAULT_RECOVERY)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    doc = build_report(
+        sweep_path=Path(args.sweep),
+        baseline_template=str(args.baseline_template),
+        recovery_template=str(args.recovery_template),
+    )
+    out_path = _resolve(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_md(doc, _resolve(args.out_md))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/sweep_llm_decoder_candidate_quality.py
+++ b/npu/eval/sweep_llm_decoder_candidate_quality.py
@@ -95,6 +95,7 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
         "decoder_pwl_logit_sensitivity_ladder_v1",
         "decoder_pwl_survivor_distribution_v1",
         "decoder_pwl_bitwidth_boundary_v1",
+        "decoder_bf16_pwl_recovery_v1",
     }:
         raise ValueError(f"unsupported rough grid: {grid_name}")
     exact = _candidate_template(model_contract, "candidate_onnx_softmax_exact")
@@ -567,6 +568,35 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
             ),
         ]
         return {name: cfg for name, cfg in points}
+    if grid_name == "decoder_bf16_pwl_recovery_v1":
+        points = [
+            ("candidate_onnx_softmax_exact", exact),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_bf16_path",
+                softmax_input_quant_bits=None,
+                softmax_weight_quant_bits=None,
+                softmax_input_float_format="bf16",
+                softmax_weight_float_format="bf16",
+                normalization_mode="reciprocal_float",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format="bf16",
+                score_tie_breaker=None,
+            ),
+            _named_grid_point(
+                approx,
+                "grid_approx_pwl_bf16_path_logit_tiebreak",
+                softmax_input_quant_bits=None,
+                softmax_weight_quant_bits=None,
+                softmax_input_float_format="bf16",
+                softmax_weight_float_format="bf16",
+                normalization_mode="reciprocal_float",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format="bf16",
+                score_tie_breaker="logit",
+            ),
+        ]
+        return {name: cfg for name, cfg in points}
     points = [
         ("candidate_onnx_softmax_exact", exact),
         _named_grid_point(exact, "grid_exact_logits_q8", logit_quant_bits=8),
@@ -751,6 +781,7 @@ def _aggregate_row(template_name: str, manifest_path: Path, quality_path: Path, 
         "normalization_reciprocal_float_format": backend_config.get("normalization_reciprocal_float_format", ""),
         "probability_quant_bits": backend_config.get("probability_quant_bits", 0),
         "probability_float_format": backend_config.get("probability_float_format", ""),
+        "score_tie_breaker": backend_config.get("score_tie_breaker", ""),
         "sample_count": aggregate.get("sample_count"),
         "next_token_id_match_rate": aggregate.get("next_token_id_match_rate"),
         "next_token_text_match_rate": aggregate.get("next_token_text_match_rate"),
@@ -782,7 +813,7 @@ def main() -> int:
             "decoder_probability_fp_formats_v1, decoder_distribution_robustness_v1, or "
             "decoder_survivor_prompt_stress_v1, decoder_q8_normalization_frontier_v1, "
             "decoder_pwl_logit_sensitivity_ladder_v1, decoder_pwl_survivor_distribution_v1, "
-            "or decoder_pwl_bitwidth_boundary_v1."
+            "decoder_pwl_bitwidth_boundary_v1, or decoder_bf16_pwl_recovery_v1."
         ),
     )
     ap.add_argument("--out-dir", default="runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/local")

--- a/tests/test_llm_decoder_bf16_pwl_recovery.py
+++ b/tests/test_llm_decoder_bf16_pwl_recovery.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+
+from npu.eval.run_llm_decoder_onnx_candidate import _select_next_token_id, _topk_pairs
+from npu.eval.summarize_llm_decoder_bf16_pwl_recovery import build_report
+
+
+def test_logit_tiebreak_changes_only_equal_score_ranking() -> None:
+    scores = [0.4, 0.4, 0.3]
+    logits = [1.0, 2.0, 9.0]
+
+    assert _select_next_token_id(scores) == 0
+    assert _select_next_token_id(scores, tie_break_values=logits) == 1
+    assert list(_topk_pairs(scores, k=3, tie_break_values=logits)) == [
+        (1, 0.4),
+        (0, 0.4),
+        (2, 0.3),
+    ]
+
+
+def test_bf16_pwl_recovery_summary_detects_exact_safe_tiebreak(tmp_path: Path) -> None:
+    sweep = {
+        "templates": [
+            {
+                "template": "grid_approx_pwl_bf16_path",
+                "candidate_semantics": "baseline",
+                "sample_count": 4,
+                "next_token_id_match_rate": 0.5,
+                "topk_contains_reference_id_rate": 1.0,
+                "next_token_mismatch_sample_ids": ["a", "b"],
+                "topk_miss_sample_ids": [],
+            },
+            {
+                "template": "grid_approx_pwl_bf16_path_logit_tiebreak",
+                "candidate_semantics": "recovered",
+                "score_tie_breaker": "logit",
+                "sample_count": 4,
+                "next_token_id_match_rate": 1.0,
+                "topk_contains_reference_id_rate": 1.0,
+                "next_token_mismatch_sample_ids": [],
+                "topk_miss_sample_ids": [],
+            },
+        ],
+    }
+    sweep_path = tmp_path / "sweep.json"
+    sweep_path.write_text(json.dumps(sweep), encoding="utf-8")
+
+    report = build_report(sweep_path=sweep_path)
+
+    assert report["diagnosis"]["decision"] == "tie_break_recovery_sufficient"
+    assert report["diagnosis"]["exact_safe_after_recovery"]
+    assert report["recovered_sample_ids"] == ["a", "b"]
+    assert report["regression_sample_ids"] == []

--- a/tests/test_llm_decoder_q8_norm_frontier.py
+++ b/tests/test_llm_decoder_q8_norm_frontier.py
@@ -47,6 +47,23 @@ def test_pwl_bitwidth_boundary_grid_narrows_integer_precision_floor() -> None:
     assert grid["grid_approx_pwl_bf16_path"]["normalization_reciprocal_float_format"] == "bf16"
 
 
+def test_bf16_pwl_recovery_grid_adds_logit_tiebreak_variant() -> None:
+    model_contract = load_json(Path("runs/models/llm_decoder_tiny_v1/model_contract.json"))
+    grid = _rough_grid_templates(model_contract, "decoder_bf16_pwl_recovery_v1")
+
+    assert set(grid) == {
+        "candidate_onnx_softmax_exact",
+        "grid_approx_pwl_bf16_path",
+        "grid_approx_pwl_bf16_path_logit_tiebreak",
+    }
+    baseline = grid["grid_approx_pwl_bf16_path"]
+    recovery = grid["grid_approx_pwl_bf16_path_logit_tiebreak"]
+    assert baseline["normalization_reciprocal_float_format"] == "bf16"
+    assert "score_tie_breaker" not in baseline
+    assert recovery["normalization_reciprocal_float_format"] == "bf16"
+    assert recovery["score_tie_breaker"] == "logit"
+
+
 def test_q8_normalization_frontier_report_selects_lowest_cost_exact_safe_reciprocal() -> None:
     report = build_report(
         sweep_path=Path("tests/fixtures/decoder_q8_norm_frontier_sweep.json"),


### PR DESCRIPTION
## Summary

Adds a narrow Layer 2 recovery job for the decoder bf16/PWL frontier. The new path preserves the bf16/PWL score arithmetic and adds an optional `score_tie_breaker=logit` ranking mode so exact score ties can be resolved by the logits that produced the scores.

## Why

The previous recoverability result showed both bf16/PWL exact-next misses were rank-2, top-k-contained, zero-gap ties. This PR tests whether the miss is a ranking/calibration issue before we spend effort on a full bf16 QAT harness or fall back to q12 exact-safe hardware.

## Changes

- Adds optional logit tie-breaking to `run_llm_decoder_onnx_candidate.py`.
- Adds the `decoder_bf16_pwl_recovery_v1` rough grid.
- Adds `summarize_llm_decoder_bf16_pwl_recovery.py`.
- Registers `decoder_bf16_pwl_recovery` in the Layer 2 task generator.
- Adds proposal docs and focused tests.

## Validation

- `python3 -m py_compile npu/eval/run_llm_decoder_onnx_candidate.py npu/eval/sweep_llm_decoder_candidate_quality.py npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py control_plane/control_plane/services/l2_task_generator.py`
- `PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q tests/test_llm_decoder_bf16_pwl_recovery.py tests/test_llm_decoder_q8_norm_frontier.py control_plane/control_plane/tests/test_l2_task_generator.py`
- Local recovery sweep: baseline bf16/PWL 46/48 next-token and 48/48 top-k; logit tie-break recovery 48/48 next-token and 48/48 top-k.