### PR TITLE
Add score tie-rank datapath proposal

### DIFF
--- a/apps/rtlgen_main.cpp
+++ b/apps/rtlgen_main.cpp
@@ -193,7 +193,8 @@ int main(int argc, char** argv) {
               << config.fp_operations.size() << " FP op(s), "
               << config.activation_operations.size() << " activation(s), "
               << config.softmax_rowwise_operations.size() << " row-wise softmax block(s), "
-              << config.bf16_recip_norm_operations.size() << " bf16 reciprocal-normalization block(s)\n";
+              << config.bf16_recip_norm_operations.size() << " bf16 reciprocal-normalization block(s), "
+              << config.score_tie_rank_operations.size() << " score tie-rank block(s)\n";
 
     try {
         std::filesystem::path flopocoPath;
@@ -314,6 +315,14 @@ int main(int argc, char** argv) {
                       << ", q_frac_bits=" << norm.q_frac_bits
                       << ", reciprocal_bits=" << norm.reciprocal_bits << ")\n";
             emitBf16RecipNormModule(norm, operandDef);
+        }
+
+        for (const auto &rank : config.score_tie_rank_operations) {
+            OperandDefinition operandDef = resolveOperand(config, rank.operand);
+            std::cout << "[INFO] Generating score tie-rank " << rank.module_name
+                      << " (row_elems=" << rank.row_elems
+                      << ", logit_bits=" << rank.logit_bits << ")\n";
+            emitScoreTieRankModule(rank, operandDef);
         }
 
         for (const auto &fp : config.fp_operations) {

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -398,7 +398,7 @@ def _read_config_target(
     elif "operations" in cfg and len(cfg["operations"]) == 1:
         entry = cfg["operations"][0]
         op_type = entry.get("type")
-        if op_type not in {"activation", "softmax_rowwise", "bf16_recip_norm"}:
+        if op_type not in {"activation", "softmax_rowwise", "bf16_recip_norm", "score_tie_rank"}:
             raise Layer1TaskGenerationError(f"unsupported single-operation design type in {config_path}: {op_type}")
         module_name = entry["module_name"]
         wrapper = f"{module_name}_wrapper"

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -140,6 +140,44 @@ def _write_bf16_recip_norm_config(repo_root: Path) -> str:
     return str(config_path.relative_to(repo_root))
 
 
+def _write_score_tie_rank_config(repo_root: Path) -> str:
+    config_path = repo_root / "examples" / "config_score_tie_rank.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "operands": [
+                    {
+                        "name": "scores",
+                        "dimensions": 1,
+                        "bit_width": 16,
+                        "signed": False,
+                        "kind": "int",
+                    }
+                ],
+                "operations": [
+                    {
+                        "type": "score_tie_rank",
+                        "module_name": "score_tie_rank_r4_s16_l16",
+                        "operand": "scores",
+                        "options": {
+                            "row_elems": 4,
+                            "score_bits": 16,
+                            "logit_bits": 16,
+                            "logit_signed": True,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
 def _init_git_repo(repo_root: Path) -> str:
     origin_root = repo_root.parent / "origin.git"
     subprocess.run(["git", "init", "--bare", str(origin_root)], check=True, capture_output=True, text=True)
@@ -371,6 +409,39 @@ def test_generate_l1_sweep_task_supports_bf16_recip_norm_wrapper_config() -> Non
             assert result.status == "applied"
             assert work_item.expected_outputs == [
                 "runs/designs/activations/bf16_recip_norm_r4_wrapper/metrics.csv",
+            ]
+
+
+def test_generate_l1_sweep_task_supports_score_tie_rank_wrapper_config() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _, sweep_path = _write_example_repo(repo_root)
+        config_path = _write_score_tie_rank_config(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    item_id="l1_demo_score_tie_rank",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="circuit_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert work_item.expected_outputs == [
+                "runs/designs/activations/score_tie_rank_r4_s16_l16_wrapper/metrics.csv",
             ]
 
 

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/README.md
@@ -1,0 +1,4 @@
+# prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1
+
+Layer 1 proposal workspace for measuring the score/logit tie-rank datapath
+needed by the recovered decoder bf16/PWL path.

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/analysis_report.md
@@ -1,0 +1,14 @@
+# Analysis Report
+
+## Candidate
+
+- `proposal_id`: `prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1`
+- `candidate_id`: `l1_decoder_bf16_pwl_tie_rank_datapath_v1`
+
+## Evaluations Consumed
+
+- pending
+
+## Recommendation
+
+- pending remote Layer 1 result

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/design_brief.md
@@ -1,0 +1,25 @@
+# Design Brief
+
+## Problem
+
+The decoder bf16/PWL recovery run showed that the two exact-next misses were
+recovered by using logits only as an exact score tie-break key. The current
+frontier cost model still lacks a measured hardware cost for that rank step.
+
+## Hypothesis
+
+An 8-lane unsigned 16-bit score ranker with a signed 16-bit logit tie-break
+comparator is small enough that bf16/PWL remains the likely low-cost frontier,
+but it should be priced by OpenROAD before being folded into the ranking view.
+
+## Evaluation Scope
+
+- Generate and synthesize `score_tie_rank_r8_s16_l16`.
+- Record Nangate45 area, timing, and power from the standard high-utilization
+  Layer 1 sweep.
+- Do not rerun decoder quality; this proposal only prices the recovery datapath.
+
+## Follow-On
+
+If the isolated ranker cost is material, measure an integrated decoder output
+rank block and compare against a q12 fallback path.

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-05-03T13:11:42Z
+- allowed_evaluations:
+  - `l1_decoder_bf16_pwl_tie_rank_datapath_v1`
+- note: isolated PPA measurement only; no quality regression surface changes.

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1",
+  "source_commit": "",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_bf16_pwl_tie_rank_datapath_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the isolated 8-lane score/logit tie-rank datapath used to price the bf16/PWL recovery path.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "comparison_role": "cost_component",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_bf16_pwl_recovery_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure",
+        "reason": "Use the measured ranker PPA as an additive cost term for the recovered bf16/PWL frontier."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/implementation_summary.md
@@ -1,0 +1,19 @@
+# Implementation Summary
+
+## Scope
+
+- Add RTLGen `score_tie_rank` single-operation support.
+- Add an 8-lane score/logit ranker config and Nangate45 sweep.
+- Add a behavioral Verilog test for ranking semantics.
+- Extend Layer 1 task generation to accept the new wrapper type.
+
+## Local Validation
+
+- `cmake --build /workspaces/RTLGen/build --target rtlgen`: pass
+- `bash tests/test_score_tie_rank.sh`: pass
+- `python3 -m py_compile control_plane/control_plane/services/l1_task_generator.py`: pass
+- `PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py`: 17 passed, 1 warning
+
+## Evaluation Request
+
+- `l1_decoder_bf16_pwl_tie_rank_datapath_v1`

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1",
+  "candidate_id": "l1_decoder_bf16_pwl_tie_rank_datapath_v1",
+  "decision": "pending",
+  "reason": "Awaiting Layer 1 PPA result for the score/logit tie-rank datapath.",
+  "evidence_refs": [],
+  "next_action": "dispatch Layer 1 sweep after setup PR merges",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1",
+  "decision": "pending"
+}

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/proposal.json
@@ -1,0 +1,63 @@
+{
+  "proposal_id": "prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1",
+  "created_utc": "2026-05-03T13:11:42Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "circuit_block",
+  "title": "Decoder bf16/PWL score tie-rank datapath",
+  "hypothesis": "The recovered bf16/PWL decoder path needs only a small score-equality logit tie-break ranking block, so its PPA overhead should be measured directly before adding it to the bf16/PWL frontier cost model.",
+  "direct_comparison": {
+    "primary_question": "What is the Nangate45 PPA overhead of an 8-lane 16-bit score ranker with a signed 16-bit logit tie-break key?",
+    "include": [
+      "score_tie_rank_r8_s16_l16 wrapper",
+      "Nangate45 high-utilization Layer 1 sweep",
+      "area, timing, and power metrics for the isolated rank datapath"
+    ],
+    "exclude": [
+      "decoder quality rerun",
+      "full bf16 total-order comparator",
+      "training or QAT recovery"
+    ]
+  },
+  "expected_benefit": [
+    "replaces an unpriced recovery assumption with a measured PPA term",
+    "lets the bf16/PWL frontier be compared against q12 fallback using a concrete rank overhead",
+    "keeps the quality recovery result separate from physical cost measurement"
+  ],
+  "risks": [
+    "16-bit signed logit compare is a fixed-point proxy and not a full bf16 comparator",
+    "isolated ranker PPA may differ after integration with decoder output buffering",
+    "row_elems=8 matches the current tiny decoder frontier and may need scaling later"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_bf16_pwl_tie_rank_datapath_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the isolated 8-lane score/logit tie-rank datapath used to price the bf16/PWL recovery path.",
+      "config_paths": [
+        "runs/designs/activations/score_tie_rank_r8_s16_l16_wrapper/config_score_tie_rank_r8_s16_l16.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/score_tie_rank/sweeps/nangate45_highutil.json",
+      "platform": "nangate45",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "depends_on_item_ids": [
+        "l2_decoder_bf16_pwl_recovery_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_bf16_pwl_recovery__l2_decoder_bf16_pwl_recovery_v1.json",
+    "runs/designs/activations/bf16_recip_norm_r8_wrapper/metrics.csv",
+    "runs/campaigns/activations/softmax_rowwise_q12_pwl_recip_norm/sweeps/nangate45_highutil.json"
+  ],
+  "knowledge_refs": [
+    "src/rtlgen/rtl_operations.cpp",
+    "examples/config_score_tie_rank.json",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/quality_gate.md
@@ -1,0 +1,19 @@
+# Quality Gate
+
+## Checks
+
+- RTL generation succeeds for `examples/config_score_tie_rank.json`.
+- Behavioral simulation covers score priority, logit tie-break, stable exact ties,
+  and signed negative logit ordering.
+- Layer 1 task generation accepts `score_tie_rank` as a single-operation wrapper.
+
+## Local Commands
+
+- `bash tests/test_score_tie_rank.sh`
+- `python3 -m py_compile control_plane/control_plane/services/l1_task_generator.py`
+- `PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py`
+
+## Result
+
+- status: pass
+- note: local RTL generation, Verilog simulation, Python syntax check, and Layer 1 generator tests passed on 2026-05-03.

--- a/examples/config_score_tie_rank.json
+++ b/examples/config_score_tie_rank.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "scores",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "score_tie_rank",
+      "module_name": "score_tie_rank_r4_s16_l16",
+      "operand": "scores",
+      "options": {
+        "row_elems": 4,
+        "score_bits": 16,
+        "logit_bits": 16,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/campaigns/activations/score_tie_rank/sweeps/nangate45_highutil.json
+++ b/runs/campaigns/activations/score_tie_rank/sweeps/nangate45_highutil.json
@@ -1,0 +1,9 @@
+{
+  "tag_prefix": "score_tie_rank_nangate45_highutil",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.5],
+    "CORE_UTILIZATION": [60, 50],
+    "PLACE_DENSITY": [0.68],
+    "SYNTH_MEMORY_MAX_BITS": [32768]
+  }
+}

--- a/runs/designs/activations/score_tie_rank_r8_s16_l16_wrapper/README.md
+++ b/runs/designs/activations/score_tie_rank_r8_s16_l16_wrapper/README.md
@@ -1,0 +1,7 @@
+# score_tie_rank_r8_s16_l16_wrapper
+
+Layer 1 datapath proxy for decoder score ranking with a logit tie-break key.
+
+The block selects the best lane from 8 unsigned 16-bit quantized scores. When
+scores are exactly equal it selects the lane with the larger signed 16-bit logit
+proxy. Exact score and logit ties keep the lowest lane index.

--- a/runs/designs/activations/score_tie_rank_r8_s16_l16_wrapper/config_score_tie_rank_r8_s16_l16.json
+++ b/runs/designs/activations/score_tie_rank_r8_s16_l16_wrapper/config_score_tie_rank_r8_s16_l16.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "scores",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "score_tie_rank",
+      "module_name": "score_tie_rank_r8_s16_l16",
+      "operand": "scores",
+      "options": {
+        "row_elems": 8,
+        "score_bits": 16,
+        "logit_bits": 16,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/src/rtlgen/config.cpp
+++ b/src/rtlgen/config.cpp
@@ -60,6 +60,7 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
         config.activation_operations.clear();
         config.softmax_rowwise_operations.clear();
         config.bf16_recip_norm_operations.clear();
+        config.score_tie_rank_operations.clear();
         config.onnx_model.reset();
 
         if (j.contains("operand")) {
@@ -418,6 +419,25 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                         throw std::runtime_error("bf16_recip_norm reciprocal_lut_bucket_shift must be in [0, 12] for " + norm.module_name);
                     }
                     config.bf16_recip_norm_operations.push_back(norm);
+                } else if (type == "score_tie_rank") {
+                    const json &options = entry.contains("options") ? entry["options"] : entry;
+                    ScoreTieRankOperationConfig rank;
+                    rank.module_name = module_name;
+                    rank.operand = operand_name;
+                    rank.row_elems = options.value("row_elems", 1);
+                    rank.score_bits = options.value("score_bits", 0);
+                    rank.logit_bits = options.value("logit_bits", 16);
+                    rank.logit_signed = options.value("logit_signed", true);
+                    if (rank.row_elems <= 0 || rank.row_elems > 1024) {
+                        throw std::runtime_error("score_tie_rank row_elems must be in [1, 1024] for " + rank.module_name);
+                    }
+                    if (rank.score_bits < 0 || rank.score_bits > 64) {
+                        throw std::runtime_error("score_tie_rank score_bits must be in [0, 64] for " + rank.module_name);
+                    }
+                    if (rank.logit_bits <= 0 || rank.logit_bits > 64) {
+                        throw std::runtime_error("score_tie_rank logit_bits must be in [1, 64] for " + rank.module_name);
+                    }
+                    config.score_tie_rank_operations.push_back(rank);
                 } else {
                     throw std::runtime_error("Unknown operation type: " + type);
                 }

--- a/src/rtlgen/config.hpp
+++ b/src/rtlgen/config.hpp
@@ -218,6 +218,15 @@ struct Bf16RecipNormOperationConfig {
     int reciprocal_lut_bucket_shift{4};
 };
 
+struct ScoreTieRankOperationConfig {
+    std::string module_name;
+    std::string operand;
+    int row_elems{1};
+    int score_bits{0};
+    int logit_bits{16};
+    bool logit_signed{true};
+};
+
 struct CircuitConfig {
     OperandConfig operand;
     std::vector<OperandDefinition> operands;
@@ -231,6 +240,7 @@ struct CircuitConfig {
     std::vector<ActivationOperationConfig> activation_operations;
     std::vector<SoftmaxRowwiseOperationConfig> softmax_rowwise_operations;
     std::vector<Bf16RecipNormOperationConfig> bf16_recip_norm_operations;
+    std::vector<ScoreTieRankOperationConfig> score_tie_rank_operations;
     std::optional<std::string> onnx_model; // Added ONNX model path
 };
 

--- a/src/rtlgen/rtl_operations.cpp
+++ b/src/rtlgen/rtl_operations.cpp
@@ -1296,3 +1296,69 @@ void emitBf16RecipNormModule(const Bf16RecipNormOperationConfig &config, const O
     os << "  end\n";
     os << "endmodule\n";
 }
+
+void emitScoreTieRankModule(const ScoreTieRankOperationConfig &config, const OperandDefinition &operand) {
+    const int score_bits = config.score_bits > 0 ? config.score_bits : operand.bit_width;
+    if (score_bits <= 0 || score_bits > 64) {
+        throw std::runtime_error("score_tie_rank score_bits must be in [1, 64]");
+    }
+    if (config.row_elems <= 0 || config.row_elems > 1024) {
+        throw std::runtime_error("score_tie_rank row_elems must be in [1, 1024]");
+    }
+    if (config.logit_bits <= 0 || config.logit_bits > 64) {
+        throw std::runtime_error("score_tie_rank logit_bits must be in [1, 64]");
+    }
+
+    const int index_bits = std::max(1, ceilLog2U64(static_cast<unsigned long long>(config.row_elems)));
+    const int score_row_width = config.row_elems * score_bits;
+    const int logit_row_width = config.row_elems * config.logit_bits;
+    const std::string signed_kw = config.logit_signed ? "signed " : "";
+
+    std::string filename = config.module_name + ".v";
+    std::ofstream os(filename);
+    if (!os) {
+        throw std::runtime_error("Failed to open " + filename + " for writing");
+    }
+
+    os << "`timescale 1ns/1ps\n\n";
+    os << "module " << config.module_name << "(\n";
+    os << "  input  [" << (score_row_width - 1) << ":0] scores,\n";
+    os << "  input  " << signed_kw << "[" << (logit_row_width - 1) << ":0] logits,\n";
+    os << "  output reg [" << (index_bits - 1) << ":0] best_index,\n";
+    os << "  output reg [" << (score_bits - 1) << ":0] best_score,\n";
+    os << "  output reg " << signed_kw << "[" << (config.logit_bits - 1) << ":0] best_logit\n";
+    os << ");\n\n";
+    os << "  // Row-wise rank selection for quantized decoder scores.\n";
+    os << "  // Primary key: larger score. Tie-break key: larger pre-quantized logit.\n";
+    os << "  // Exact ties retain the lowest lane index for deterministic ranking.\n";
+    os << "  localparam integer ROW_ELEMS = " << config.row_elems << ";\n";
+    os << "  localparam integer SCORE_W = " << score_bits << ";\n";
+    os << "  localparam integer LOGIT_W = " << config.logit_bits << ";\n";
+    os << "  localparam integer INDEX_W = " << index_bits << ";\n\n";
+    os << "  integer i;\n";
+    os << "  reg [SCORE_W-1:0] score_i;\n";
+    os << "  reg " << signed_kw << "[LOGIT_W-1:0] logit_i;\n\n";
+    os << "  always @* begin\n";
+    os << "    best_index = {INDEX_W{1'b0}};\n";
+    os << "    best_score = scores[0 +: SCORE_W];\n";
+    if (config.logit_signed) {
+        os << "    best_logit = $signed(logits[0 +: LOGIT_W]);\n";
+    } else {
+        os << "    best_logit = logits[0 +: LOGIT_W];\n";
+    }
+    os << "    for (i = 1; i < ROW_ELEMS; i = i + 1) begin\n";
+    os << "      score_i = scores[(i*SCORE_W) +: SCORE_W];\n";
+    if (config.logit_signed) {
+        os << "      logit_i = $signed(logits[(i*LOGIT_W) +: LOGIT_W]);\n";
+    } else {
+        os << "      logit_i = logits[(i*LOGIT_W) +: LOGIT_W];\n";
+    }
+    os << "      if ((score_i > best_score) || ((score_i == best_score) && (logit_i > best_logit))) begin\n";
+    os << "        best_index = i;\n";
+    os << "        best_score = score_i;\n";
+    os << "        best_logit = logit_i;\n";
+    os << "      end\n";
+    os << "    end\n";
+    os << "  end\n";
+    os << "endmodule\n";
+}

--- a/src/rtlgen/rtl_operations.hpp
+++ b/src/rtlgen/rtl_operations.hpp
@@ -7,3 +7,4 @@ void emitCmvmModule(const CmvmOperationConfig &config, const OperandDefinition &
 void emitActivationModule(const ActivationOperationConfig &config, const OperandDefinition &operand);
 void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const OperandDefinition &operand);
 void emitBf16RecipNormModule(const Bf16RecipNormOperationConfig &config, const OperandDefinition &operand);
+void emitScoreTieRankModule(const ScoreTieRankOperationConfig &config, const OperandDefinition &operand);

--- a/tests/score_tie_rank_tb.v
+++ b/tests/score_tie_rank_tb.v
@@ -1,0 +1,70 @@
+`timescale 1ns/1ps
+
+module score_tie_rank_tb;
+  reg  [63:0] scores;
+  reg  signed [63:0] logits;
+  wire [1:0] best_index;
+  wire [15:0] best_score;
+  wire signed [15:0] best_logit;
+
+  score_tie_rank_r4_s16_l16 dut (
+    .scores(scores),
+    .logits(logits),
+    .best_index(best_index),
+    .best_score(best_score),
+    .best_logit(best_logit)
+  );
+
+  task check_rank;
+    input [63:0] s;
+    input signed [63:0] l;
+    input [1:0] exp_index;
+    input [15:0] exp_score;
+    input signed [15:0] exp_logit;
+    begin
+      scores = s;
+      logits = l;
+      #1;
+      if (best_index !== exp_index || best_score !== exp_score || best_logit !== exp_logit) begin
+        $display(
+          "FAIL score_tie_rank: index=%0d score=%0d logit=%0d expected index=%0d score=%0d logit=%0d",
+          best_index, best_score, best_logit, exp_index, exp_score, exp_logit
+        );
+        $fatal;
+      end
+    end
+  endtask
+
+  initial begin
+    check_rank(
+      {16'd7, 16'd25, 16'd8, 16'd5},
+      {16'sd4, -16'sd2, 16'sd9, 16'sd1},
+      2'd2,
+      16'd25,
+      -16'sd2
+    );
+    check_rank(
+      {16'd10, 16'd10, 16'd10, 16'd9},
+      {-16'sd4, 16'sd6, 16'sd3, 16'sd8},
+      2'd2,
+      16'd10,
+      16'sd6
+    );
+    check_rank(
+      {16'd11, 16'd11, 16'd10, 16'd4},
+      {16'sd2, 16'sd2, 16'sd9, 16'sd1},
+      2'd2,
+      16'd11,
+      16'sd2
+    );
+    check_rank(
+      {16'd1, 16'd3, 16'd3, 16'd3},
+      {-16'sd1, -16'sd5, -16'sd2, -16'sd8},
+      2'd1,
+      16'd3,
+      -16'sd2
+    );
+    $display("All score tie-rank tests passed.");
+    $finish;
+  end
+endmodule

--- a/tests/test_score_tie_rank.sh
+++ b/tests/test_score_tie_rank.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+cp "$ROOT/examples/config_score_tie_rank.json" "$TMP/config.json"
+
+pushd "$TMP" >/dev/null
+"$ROOT/build/rtlgen" config.json
+
+grep -q "module score_tie_rank_r4_s16_l16" score_tie_rank_r4_s16_l16.v
+grep -q "score_i == best_score" score_tie_rank_r4_s16_l16.v
+
+iverilog -g2012 -s score_tie_rank_tb -o sim score_tie_rank_r4_s16_l16.v "$ROOT/tests/score_tie_rank_tb.v"
+vvp sim
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add RTLGen support for a score_tie_rank single-operation wrapper
- add an r8/s16/l16 rank datapath config, Nangate45 sweep, and proposal workspace
- extend Layer 1 task generation and tests so the evaluator can dispatch the ranker sweep

## Validation
- cmake --build /workspaces/RTLGen/build --target rtlgen
- bash tests/test_score_tie_rank.sh
- python3 -m py_compile control_plane/control_plane/services/l1_task_generator.py
- PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py

## Notes
This prices the comparator/ranking recovery datapath for the bf16/PWL frontier. It does not rerun decoder quality or implement a full bf16 total-order comparator.