### PR TITLE
Record score tie-rank L1 request

### DIFF
--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1",
-  "source_commit": "",
+  "source_commit": "f3f8d7fe4ef06477edd36827c90169621182defa",
   "requested_items": [
     {
       "item_id": "l1_decoder_bf16_pwl_tie_rank_datapath_v1",

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/promotion_result.json
@@ -1,4 +1,7 @@
 {
   "proposal_id": "prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1",
-  "decision": "pending"
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
 }


### PR DESCRIPTION
## Summary
- record the source commit for l1_decoder_bf16_pwl_tie_rank_datapath_v1
- add the generated promotion gate placeholder and normalized promotion_result fields

## Validation
- generated by control-plane generate-l1-sweep after PR #348 merged
- item was assigned to eval-daemon-b7c2d9c80c1c