### PR TITLE
Support score tie-rank sweeps

### DIFF
--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -209,7 +209,7 @@ def _inferred_l1_abstraction_layer(repo_root: Path, work_item: WorkItem) -> str:
             operations = cfg.get("operations")
             if isinstance(operations, list) and len(operations) == 1:
                 op_type = str((operations[0] or {}).get("type", "")).strip()
-                if op_type in {"activation", "softmax_rowwise"}:
+                if op_type in {"activation", "softmax_rowwise", "bf16_recip_norm", "score_tie_rank"}:
                     return "circuit_block"
     expected_outputs = [str(path_text) for path_text in (work_item.expected_outputs or [])]
     joined = "\n".join(expected_outputs)

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -41,6 +41,18 @@ def _operand_signal_width(operand):
     return int(operand["bit_width"])
 
 
+def _ceil_log2_at_least_one(value):
+    value = int(value)
+    if value <= 1:
+        return 1
+    bits = 0
+    span = 1
+    while span < value:
+        span <<= 1
+        bits += 1
+    return max(bits, 1)
+
+
 def identify_design(config):
     if "multiplier" in config:
         operand = _resolve_operand(config, config["multiplier"].get("operand", ""))
@@ -111,6 +123,29 @@ def identify_design(config):
             "wrapper_name": f"{module_name}_wrapper",
             "input_width": row_width,
             "output_width": row_width,
+            "include_mg_cpa": False,
+        }
+    if op_type == "score_tie_rank":
+        options = entry.get("options", {})
+        row_elems = int(options.get("row_elems", 1))
+        score_bits = int(options.get("score_bits", bit_width) or bit_width)
+        logit_bits = int(options.get("logit_bits", 16))
+        if row_elems <= 0:
+            raise ValueError("score_tie_rank row_elems must be positive")
+        if score_bits <= 0:
+            raise ValueError("score_tie_rank score_bits must be positive")
+        if logit_bits <= 0:
+            raise ValueError("score_tie_rank logit_bits must be positive")
+        return {
+            "kind": "score_tie_rank",
+            "module_name": module_name,
+            "wrapper_name": f"{module_name}_wrapper",
+            "score_width": score_bits * row_elems,
+            "logit_width": logit_bits * row_elems,
+            "index_width": _ceil_log2_at_least_one(row_elems),
+            "score_bits": score_bits,
+            "logit_bits": logit_bits,
+            "logit_signed": bool(options.get("logit_signed", True)),
             "include_mg_cpa": False,
         }
     raise ValueError(f"generate_design.py does not support operation type: {op_type}")
@@ -216,8 +251,8 @@ def main():
 def generate_wrapper(config, src_dir, design):
     module_name = design["module_name"]
     wrapper_name = design["wrapper_name"]
-    input_width = int(design["input_width"])
-    output_width = int(design["output_width"])
+    input_width = int(design.get("input_width", 0))
+    output_width = int(design.get("output_width", 0))
 
     if design["kind"] in ("multiplier", "multiplier_yosys"):
         wrapper_content = f"""
@@ -308,6 +343,54 @@ module {wrapper_name}(
   end
 
   assign Y = y_reg;
+
+endmodule
+"""
+    elif design["kind"] == "score_tie_rank":
+        score_width = int(design["score_width"])
+        logit_width = int(design["logit_width"])
+        index_width = int(design["index_width"])
+        score_bits = int(design["score_bits"])
+        logit_bits = int(design["logit_bits"])
+        signed_kw = "signed " if design.get("logit_signed", True) else ""
+        wrapper_content = f"""
+module {wrapper_name}(
+  input clk,
+  input [{score_width-1}:0] scores,
+  input {signed_kw}[{logit_width-1}:0] logits,
+  output [{index_width-1}:0] best_index,
+  output [{score_bits-1}:0] best_score,
+  output {signed_kw}[{logit_bits-1}:0] best_logit
+);
+
+  reg [{score_width-1}:0] scores_reg;
+  reg {signed_kw}[{logit_width-1}:0] logits_reg;
+  wire [{index_width-1}:0] best_index_wire;
+  wire [{score_bits-1}:0] best_score_wire;
+  wire {signed_kw}[{logit_bits-1}:0] best_logit_wire;
+  reg [{index_width-1}:0] best_index_reg;
+  reg [{score_bits-1}:0] best_score_reg;
+  reg {signed_kw}[{logit_bits-1}:0] best_logit_reg;
+
+  {module_name} dut (
+    .scores(scores_reg),
+    .logits(logits_reg),
+    .best_index(best_index_wire),
+    .best_score(best_score_wire),
+    .best_logit(best_logit_wire)
+  );
+
+  always @(posedge clk) begin
+    scores_reg <= scores;
+    logits_reg <= logits;
+    best_index_reg <= best_index_wire;
+    best_score_reg <= best_score_wire;
+    best_logit_reg <= best_logit_wire;
+  end
+
+  assign best_index = best_index_reg;
+  assign best_score = best_score_reg;
+  assign best_logit = best_logit_reg;
 
 endmodule
 """

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -118,7 +118,7 @@ def read_design_names(config_path: Path) -> Tuple[str, str]:
         module_name = cfg["adder"]["module_name"]
     elif "operations" in cfg and len(cfg["operations"]) == 1:
         entry = cfg["operations"][0]
-        if entry["type"] not in ("activation", "softmax_rowwise", "bf16_recip_norm"):
+        if entry["type"] not in ("activation", "softmax_rowwise", "bf16_recip_norm", "score_tie_rank"):
             raise ValueError(f"Unsupported single-operation design type in {config_path}: {entry['type']}")
         module_name = entry["module_name"]
     else:

--- a/tests/test_score_tie_rank.sh
+++ b/tests/test_score_tie_rank.sh
@@ -16,4 +16,36 @@ grep -q "score_i == best_score" score_tie_rank_r4_s16_l16.v
 
 iverilog -g2012 -s score_tie_rank_tb -o sim score_tie_rank_r4_s16_l16.v "$ROOT/tests/score_tie_rank_tb.v"
 vvp sim
+
+WRAP_DIR="$TMP/wrapper"
+mkdir -p "$WRAP_DIR"
+PYTHONPATH="$ROOT/scripts" python3 - "$ROOT/examples/config_score_tie_rank.json" "$WRAP_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from generate_design import generate_wrapper, identify_design
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+design = identify_design(config)
+assert design["kind"] == "score_tie_rank"
+generate_wrapper(config, sys.argv[2], design)
+PY
+iverilog -g2012 -s score_tie_rank_r4_s16_l16_wrapper -t null \
+  score_tie_rank_r4_s16_l16.v "$WRAP_DIR/score_tie_rank_r4_s16_l16_wrapper.v"
+
+cat > "$TMP/sweep.json" <<'JSON'
+{
+  "tag_prefix": "score_tie_rank_dryrun",
+  "flow_params": {
+    "CLOCK_PERIOD": [10.0]
+  }
+}
+JSON
+python3 "$ROOT/scripts/run_sweep.py" \
+  --configs "$ROOT/examples/config_score_tie_rank.json" \
+  --platform nangate45 \
+  --sweep "$TMP/sweep.json" \
+  --out_root "$TMP/runs" \
+  --dry_run
 popd >/dev/null


### PR DESCRIPTION
## Summary
- allow scripts/run_sweep.py to resolve score_tie_rank configs
- teach generate_design.py to emit a registered score/logit ranker wrapper
- extend the score_tie_rank test to compile the wrapper and exercise run_sweep --dry_run
- include score_tie_rank in L1 result abstraction inference

## Root cause
PR #348 added RTLGen and control-plane request support, but the older sweep scripts still had their own allow-lists and wrapper assumptions. The evaluator failed at run_sweep before OpenROAD.

## Validation
- bash tests/test_score_tie_rank.sh
- python3 -m py_compile scripts/run_sweep.py scripts/generate_design.py control_plane/control_plane/services/l1_result_consumer.py
- PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py control_plane/control_plane/tests/test_l1_result_consumer.py