### PR TITLE
Record score tie-rank L1 r2 request

### DIFF
--- a/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_decoder_bf16_pwl_tie_rank_datapath_v1",
-  "source_commit": "f3f8d7fe4ef06477edd36827c90169621182defa",
+  "source_commit": "f20792b7148976c2e8fbaa6b86e0964447a5eab1",
   "requested_items": [
     {
       "item_id": "l1_decoder_bf16_pwl_tie_rank_datapath_v1",
@@ -19,6 +19,14 @@
         "direction": "measure",
         "reason": "Use the measured ranker PPA as an additive cost term for the recovered bf16/PWL frontier."
       },
+      "status": "pending"
+    },
+    {
+      "item_id": "l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2",
+      "task_type": "l1_sweep",
+      "objective": "Measure the isolated 8-lane score/logit tie-rank datapath used to price the bf16/PWL recovery path after sweep-script support was fixed.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
       "status": "pending"
     }
   ]


### PR DESCRIPTION
## Summary
- update proposal request source_commit to the sweep-script fix commit
- add l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2 as the replacement measurement item

## Validation
- generated by control-plane generate-l1-sweep after PR #351 merged
- item assigned to eval-daemon-b7c2d9c80c1c and is running