### PR TITLE
[codex] Add bf16 PWL scale probe job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1301,6 +1301,107 @@ def _decoder_bf16_pwl_recovery_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_bf16_pwl_scale_probe_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_tiny_v1"
+    dataset_manifest = f"{base}/manifest_scale_proxy_v1.json"
+    sample_file = f"{base}/samples_scale_proxy_v1.jsonl"
+    reference_dir = f"{base}/reference_scale_proxy_v1"
+    reference_manifest = f"{base}/reference_scale_proxy_v1_manifest.json"
+    candidate_dir = f"{base}/candidate_scale_proxy_v1"
+    candidate_manifest = f"{base}/candidate_scale_proxy_v1_manifest.json"
+    validation_out = f"{base}/decoder_contract_validation__{item_id}.json"
+    quality_out = f"{base}/decoder_quality_compare__{item_id}.json"
+    sweep_dir = f"{base}/candidate_sweeps/{item_id}"
+    sweep_out = f"{base}/decoder_quality_sweep__{item_id}.json"
+    recovery_out = f"{base}/decoder_bf16_pwl_scale_probe__{item_id}.json"
+    recovery_report = f"{base}/decoder_bf16_pwl_scale_probe__{item_id}.md"
+    rough_grid = "decoder_bf16_pwl_scale_probe_v1"
+    commands = [
+        {
+            "name": "generate_decoder_bf16_pwl_scale_probe_reference",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_reference_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {reference_dir} "
+                f"--out-manifest {reference_manifest}"
+            ),
+        },
+        {
+            "name": "generate_decoder_bf16_pwl_scale_probe_candidate",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_candidate_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {candidate_dir} "
+                f"--out-manifest {candidate_manifest}"
+            ),
+        },
+        {
+            "name": "validate_decoder_bf16_pwl_scale_probe_contract",
+            "run": f"python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest {dataset_manifest} --out {validation_out}",
+        },
+        {
+            "name": "compare_decoder_bf16_pwl_scale_probe_quality",
+            "run": (
+                "python3 npu/eval/compare_llm_decoder_quality.py "
+                f"--reference-manifest {reference_manifest} "
+                f"--candidate-manifest {candidate_manifest} "
+                f"--out {quality_out}"
+            ),
+        },
+        {
+            "name": "sweep_decoder_bf16_pwl_scale_probe",
+            "run": (
+                "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--rough-grid {rough_grid} "
+                f"--out-dir {sweep_dir} "
+                f"--out {sweep_out}"
+            ),
+        },
+        {
+            "name": "summarize_decoder_bf16_pwl_scale_probe",
+            "run": (
+                "python3 npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py "
+                f"--sweep {sweep_out} "
+                f"--out {recovery_out} "
+                f"--out-md {recovery_report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            "dataset_manifest": dataset_manifest,
+            "sample_file": sample_file,
+            "reference_dir": reference_dir,
+            "reference_manifest": reference_manifest,
+            "candidate_dir": candidate_dir,
+            "candidate_manifest": candidate_manifest,
+            "validation_out": validation_out,
+            "quality_out": quality_out,
+            "candidate_sweep_dir": sweep_dir,
+            "candidate_sweep_out": sweep_out,
+            "candidate_sweep_grid": rough_grid,
+            "scale_probe_out": recovery_out,
+            "scale_probe_report": recovery_report,
+            "scale_probe_scope": (
+                "scale-sensitivity screen for the bf16/PWL plus logit tie-break path using "
+                "larger top-k rank pressure and broader prompt regimes on the tiny decoder harness; "
+                "not a substitute for a larger-model evaluation"
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            reference_manifest,
+            candidate_manifest,
+            validation_out,
+            quality_out,
+            sweep_out,
+            recovery_out,
+            recovery_report,
+        ],
+    }
+
+
 def _decoder_pwl_logit_sensitivity_ladder_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_tiny_v1"
     dataset_manifest = f"{base}/manifest_pwl_failure_focus_v1.json"
@@ -1724,6 +1825,7 @@ def _build_payload(
         "decoder_q8_normalization_distribution",
         "decoder_q8_normalization_distribution_broad_v2",
         "decoder_bf16_pwl_recovery",
+        "decoder_bf16_pwl_scale_probe",
         "decoder_bf16_pwl_recoverability",
         "decoder_pwl_failure_diagnosis",
         "decoder_pwl_logit_sensitivity_ladder",
@@ -1733,6 +1835,8 @@ def _build_payload(
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_bf16_pwl_scale_probe":
+            decoder_evidence = _decoder_bf16_pwl_scale_probe_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_bf16_pwl_recovery":
             decoder_evidence = _decoder_bf16_pwl_recovery_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_bf16_pwl_recoverability":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1025,6 +1025,66 @@ def test_generate_l2_campaign_task_adds_decoder_bf16_pwl_recovery_evidence() -> 
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_bf16_pwl_scale_probe_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_bf16_pwl_scale_probe_v1",
+                    proposal_id="prop_l2_decoder_bf16_pwl_scale_probe_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_bf16_pwl_scale_probe",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:6] == [
+                "generate_decoder_bf16_pwl_scale_probe_reference",
+                "generate_decoder_bf16_pwl_scale_probe_candidate",
+                "validate_decoder_bf16_pwl_scale_probe_contract",
+                "compare_decoder_bf16_pwl_scale_probe_quality",
+                "sweep_decoder_bf16_pwl_scale_probe",
+                "summarize_decoder_bf16_pwl_scale_probe",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["dataset_manifest"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/manifest_scale_proxy_v1.json"
+            )
+            assert decoder_inputs["sample_file"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/samples_scale_proxy_v1.jsonl"
+            )
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_bf16_pwl_scale_probe_v1"
+            assert "scale-sensitivity screen" in decoder_inputs["scale_probe_scope"]
+            assert "--rough-grid decoder_bf16_pwl_scale_probe_v1" in work_item.command_manifest[4]["run"]
+            assert "summarize_llm_decoder_bf16_pwl_recovery.py" in work_item.command_manifest[5]["run"]
+            assert decoder_inputs["scale_probe_out"] == (
+                "runs/datasets/llm_decoder_eval_tiny_v1/"
+                "decoder_bf16_pwl_scale_probe__l2_decoder_bf16_pwl_scale_probe_v1.json"
+            )
+            assert decoder_inputs["scale_probe_out"] in work_item.expected_outputs
+            assert decoder_inputs["scale_probe_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_bf16_pwl_scale_probe",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/README.md
@@ -1,0 +1,3 @@
+# Decoder bf16/PWL Scale-Proxy Recovery Probe
+
+See `design_brief.md`.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending evaluation.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/design_brief.md
@@ -1,0 +1,29 @@
+# Decoder bf16/PWL Scale-Proxy Recovery Probe
+
+- `proposal_id`: `prop_l2_decoder_bf16_pwl_scale_probe_v1`
+- `item_id`: `l2_decoder_bf16_pwl_scale_probe_v1`
+- abstraction: `decoder_bf16_pwl_scale_probe`
+
+The current bf16/PWL plus logit tie-break recovery is exact-safe on the broad-v2
+tiny decoder setup, but that result can fail to generalize as model outputs and
+ranking pressure grow. This job adds a rough scale-proxy screen before claiming
+that the recovery is the next architectural frontier.
+
+The screen keeps the same tiny ONNX model so it remains cheap, but changes the
+stress axes:
+
+- top-k increases from 5 to 16 while still ranking over the full 50k-token vocab
+- prompt regimes add longer context, denser code/symbolic text, repetition,
+  low-margin continuations, and instruction/dialogue cases
+- q12 exact-normalization and q8 reciprocal rows remain as controls beside the
+  bf16/PWL baseline and bf16/PWL logit tie-break recovery
+
+Expected output:
+
+- `decoder_quality_sweep__l2_decoder_bf16_pwl_scale_probe_v1.json`
+- `decoder_bf16_pwl_scale_probe__l2_decoder_bf16_pwl_scale_probe_v1.json`
+- `decoder_bf16_pwl_scale_probe__l2_decoder_bf16_pwl_scale_probe_v1.md`
+
+This is not evidence from a larger trained LLM. It is a cheap guard against a
+false conclusion from one small benchmark setup, and it decides whether the next
+step should be larger-model import or integrated datapath PPA.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/evaluation_gate.md
@@ -1,0 +1,12 @@
+# Evaluation Gate
+
+Pass criteria:
+
+- `grid_approx_pwl_bf16_path_logit_tiebreak` has no next-token mismatches.
+- `grid_approx_pwl_bf16_path_logit_tiebreak` has no top-k misses.
+- Any remaining bf16/PWL baseline misses are recovered without regressions.
+- q12 and q8 controls are retained in the sweep output for interpretation.
+
+If the recovered bf16 row fails, do not promote the tie-rank path as broadly
+robust. Move to larger-model diagnosis or train-aware recovery before further
+datapath spending.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_scale_probe_v1",
+  "source_commit": "8042fa99f01be718c091672c1f18e52a49400575",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_bf16_pwl_scale_probe_v1",
+      "task_type": "l2_campaign",
+      "objective": "Check whether bf16/PWL plus logit tie-break recovery holds under a scale-proxy decoder prompt/rank-pressure screen.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_bf16_pwl_scale_probe",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_bf16_pwl_recovery_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the scale-proxy result to decide whether bf16/PWL recovery should move to larger imported-model confirmation or return to diagnosis."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/implementation_summary.md
@@ -1,0 +1,3 @@
+# Implementation Summary
+
+Pending evaluation.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_decision.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_scale_probe_v1",
+  "status": "pending",
+  "decision": "awaiting_evaluation"
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_gate.md
@@ -1,0 +1,6 @@
+# Promotion Gate
+
+Promotion is allowed only if the scale-proxy summary is exact-safe after
+recovery. A pass promotes the recovered bf16/PWL path to larger-model
+confirmation. It does not replace the need for larger imported-model evidence or
+integrated decoder PPA.

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_result.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_scale_probe_v1",
+  "status": "pending",
+  "promoted_item_id": ""
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l2_decoder_bf16_pwl_scale_probe_v1",
+  "created_utc": "2026-05-03T14:05:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_bf16_pwl_scale_probe",
+  "title": "Decoder bf16/PWL scale-proxy recovery probe",
+  "hypothesis": "The bf16 reciprocal PWL path plus logit score tie-break may be exact-safe on the current broad-v2 tiny decoder set, but rank-inversion risk should grow with larger LLM use cases and wider output/ranking pressure. A scale-proxy dataset with longer prompts, broader regimes, and top-16 ranking can check whether the recovery still holds before moving to a larger imported model.",
+  "direct_comparison": {
+    "primary_question": "Does bf16/PWL plus logit tie-break remain exact-safe when prompt diversity and ranking pressure are increased in the tiny decoder harness?",
+    "include": [
+      "bf16/PWL baseline and logit tie-break recovery",
+      "q12 exact-normalization and q8 reciprocal controls",
+      "top-16 rank containment over the full vocabulary",
+      "long-context, code, symbolic, repetition, low-margin, and instruction prompt regimes"
+    ],
+    "exclude": [
+      "claiming proof for a larger trained LLM",
+      "new RTL/OpenROAD measurement",
+      "training or QAT"
+    ]
+  },
+  "expected_benefit": [
+    "catches whether the tie-break fix only fits the current 48-sample setup",
+    "separates scale/rank-pressure risk from datapath PPA risk",
+    "provides the gate for either larger imported-model evaluation or integrated decoder datapath measurement"
+  ],
+  "risks": [
+    "still uses the tiny decoder model and cannot represent hidden-size or layer-count scaling directly",
+    "top-k and prompt diversity are only proxies for larger arrays and larger LLM output distributions",
+    "a pass here does not remove the need for larger-model confirmation"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_bf16_pwl_scale_probe_v1",
+      "task_type": "l2_campaign",
+      "objective": "Check whether bf16/PWL plus logit tie-break recovery holds under a scale-proxy decoder prompt/rank-pressure screen.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_bf16_pwl_scale_probe",
+      "depends_on_item_ids": [
+        "l2_decoder_bf16_pwl_recovery_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_bf16_pwl_recovery_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/decoder_bf16_pwl_recovery__l2_decoder_bf16_pwl_recovery_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "runs/datasets/llm_decoder_eval_tiny_v1/manifest_scale_proxy_v1.json",
+    "runs/datasets/llm_decoder_eval_tiny_v1/samples_scale_proxy_v1.jsonl",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/quality_gate.md
@@ -1,0 +1,7 @@
+# Quality Gate
+
+The evaluator must generate fresh reference and candidate manifests from
+`manifest_scale_proxy_v1.json`, then run the built-in
+`decoder_bf16_pwl_scale_probe_v1` grid. The final summary must report baseline
+misses, recovered sample ids, regression sample ids, and the exact-safe status
+of the logit tie-break row.

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -308,6 +308,26 @@ additive component model: bf16 reciprocal normalization plus score tie-rank.
 q8 exact normalization uses the measured row-wise int8 softmax baseline when
 that artifact is available.
 
+Run the bf16/PWL scale-proxy recovery screen:
+```sh
+python3 npu/eval/sweep_llm_decoder_candidate_quality.py \
+  --dataset-manifest runs/datasets/llm_decoder_eval_tiny_v1/manifest_scale_proxy_v1.json \
+  --rough-grid decoder_bf16_pwl_scale_probe_v1 \
+  --out-dir /tmp/decoder_bf16_pwl_scale_probe \
+  --out /tmp/decoder_bf16_pwl_scale_probe.json
+python3 npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py \
+  --sweep /tmp/decoder_bf16_pwl_scale_probe.json \
+  --out /tmp/decoder_bf16_pwl_scale_probe_summary.json \
+  --out-md /tmp/decoder_bf16_pwl_scale_probe_summary.md
+```
+
+This screen keeps the same tiny ONNX decoder but raises rank pressure by
+requesting top-16 over the full 50k-token vocabulary and broadens prompt
+categories to include longer contexts, denser code/symbolic prompts, repeated
+patterns, and low-margin continuations. It answers whether the bf16/PWL plus
+logit tie-break behavior survives a rough scale proxy before spending evaluator
+time on a larger imported model or an integrated decoder datapath.
+
 After the corresponding Layer 1 multiplier and accumulator/adder calibration
 jobs merge, synthesize the measured primitive evidence into a decoder
 normalization report:

--- a/npu/eval/sweep_llm_decoder_candidate_quality.py
+++ b/npu/eval/sweep_llm_decoder_candidate_quality.py
@@ -96,6 +96,7 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
         "decoder_pwl_survivor_distribution_v1",
         "decoder_pwl_bitwidth_boundary_v1",
         "decoder_bf16_pwl_recovery_v1",
+        "decoder_bf16_pwl_scale_probe_v1",
     }:
         raise ValueError(f"unsupported rough grid: {grid_name}")
     exact = _candidate_template(model_contract, "candidate_onnx_softmax_exact")
@@ -568,7 +569,7 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
             ),
         ]
         return {name: cfg for name, cfg in points}
-    if grid_name == "decoder_bf16_pwl_recovery_v1":
+    if grid_name in {"decoder_bf16_pwl_recovery_v1", "decoder_bf16_pwl_scale_probe_v1"}:
         points = [
             ("candidate_onnx_softmax_exact", exact),
             _named_grid_point(
@@ -596,6 +597,31 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
                 score_tie_breaker="logit",
             ),
         ]
+        if grid_name == "decoder_bf16_pwl_scale_probe_v1":
+            points.extend(
+                [
+                    _named_grid_point(
+                        approx,
+                        "grid_approx_pwl_in_q12_w_q12_norm_exact",
+                        softmax_input_quant_bits=12,
+                        softmax_weight_quant_bits=12,
+                        normalization_mode="exact",
+                        normalization_reciprocal_bits=None,
+                        normalization_reciprocal_float_format=None,
+                        score_tie_breaker=None,
+                    ),
+                    _named_grid_point(
+                        approx,
+                        "grid_approx_pwl_in_q8_w_q8_norm_recip_q12",
+                        softmax_input_quant_bits=8,
+                        softmax_weight_quant_bits=8,
+                        normalization_mode="reciprocal_quantized",
+                        normalization_reciprocal_bits=12,
+                        normalization_reciprocal_float_format=None,
+                        score_tie_breaker=None,
+                    ),
+                ]
+            )
         return {name: cfg for name, cfg in points}
     points = [
         ("candidate_onnx_softmax_exact", exact),
@@ -813,7 +839,8 @@ def main() -> int:
             "decoder_probability_fp_formats_v1, decoder_distribution_robustness_v1, or "
             "decoder_survivor_prompt_stress_v1, decoder_q8_normalization_frontier_v1, "
             "decoder_pwl_logit_sensitivity_ladder_v1, decoder_pwl_survivor_distribution_v1, "
-            "decoder_pwl_bitwidth_boundary_v1, or decoder_bf16_pwl_recovery_v1."
+            "decoder_pwl_bitwidth_boundary_v1, decoder_bf16_pwl_recovery_v1, or "
+            "decoder_bf16_pwl_scale_probe_v1."
         ),
     )
     ap.add_argument("--out-dir", default="runs/datasets/llm_decoder_eval_tiny_v1/candidate_sweeps/local")

--- a/runs/datasets/llm_decoder_eval_tiny_v1/manifest_scale_proxy_v1.json
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/manifest_scale_proxy_v1.json
@@ -1,0 +1,68 @@
+{
+  "candidate_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/candidate_scale_proxy_v1_manifest.json",
+  "dataset_id": "llm_decoder_eval_tiny_v1",
+  "decoder_backend_configs": {
+    "candidate": {
+      "backend_id": "command_json_v1",
+      "candidate_semantics": "onnx_logits_fp_softmax_exact_norm_exact_prob_fp",
+      "command": [
+        "python3",
+        "npu/eval/run_llm_decoder_onnx_candidate.py"
+      ],
+      "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
+      "input_name": "input_ids",
+      "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
+      "normalization_mode": "exact",
+      "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
+      "output_name": "logits",
+      "runtime_target": "software_emulation",
+      "softmax_mode": "exact",
+      "topk": 16,
+      "trace_output_patterns": [
+        "present.*"
+      ],
+      "trace_tensor_quant_bits": 4
+    },
+    "reference": {
+      "backend_id": "command_json_v1",
+      "command": [
+        "python3",
+        "npu/eval/run_llm_decoder_onnx_reference.py"
+      ],
+      "equivalence_group": "llm_decoder_tiny_v1_reference_onnx_v1",
+      "input_name": "input_ids",
+      "model_config_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/config.json",
+      "onnx_model_path": "runs/models/llm_decoder_tiny_v1/reference_onnx/model.onnx",
+      "output_name": "logits",
+      "runtime_target": "cpu_reference",
+      "topk": 16,
+      "trace_output_patterns": [
+        "present.*"
+      ]
+    }
+  },
+  "decoder_backend_interface": "v1",
+  "model_contract": "runs/models/llm_decoder_tiny_v1/model_contract.json",
+  "notes": "Scale-proxy prompt and rank-pressure set for checking whether the bf16/PWL plus logit tie-break result holds as decoder use cases grow. This is still the tiny ONNX model, so it is a scale-sensitivity screen, not evidence from a larger trained LLM.",
+  "reference_manifest": "runs/datasets/llm_decoder_eval_tiny_v1/reference_scale_proxy_v1_manifest.json",
+  "sample_count": 80,
+  "sample_file": "runs/datasets/llm_decoder_eval_tiny_v1/samples_scale_proxy_v1.jsonl",
+  "scale_proxy_axes": {
+    "compute_array_pressure": [
+      "topk_increased_from_5_to_16",
+      "full_vocab_argmax_and_topk_ordering_over_50257_logits",
+      "more opportunities for equal-score and near-score rank inversions"
+    ],
+    "llm_workload_pressure": [
+      "longer prompts",
+      "instruction and dialogue variants",
+      "code, list, arithmetic, punctuation, and ambiguous continuation regimes",
+      "repeated categories to expose distribution dependence"
+    ]
+  },
+  "status": "scale_proxy_manifest_v1",
+  "task": "greedy_next_token",
+  "tokenizer_id": "llm_decoder_gpt2_bpe_stub_v1",
+  "tokenizer_manifest": "runs/tokenizers/llm_decoder_gpt2_bpe_stub_v1/manifest.json",
+  "version": 0.3
+}

--- a/runs/datasets/llm_decoder_eval_tiny_v1/samples_scale_proxy_v1.jsonl
+++ b/runs/datasets/llm_decoder_eval_tiny_v1/samples_scale_proxy_v1.jsonl
@@ -1,0 +1,80 @@
+{"sample_id":"scale_geo_capital_france","prompt":"The capital of France is","expected_continuation":" Paris","category":"factual_geo"}
+{"sample_id":"scale_geo_capital_japan","prompt":"The capital of Japan is","expected_continuation":" Tokyo","category":"factual_geo"}
+{"sample_id":"scale_geo_capital_germany","prompt":"The capital of Germany is","expected_continuation":" Berlin","category":"factual_geo"}
+{"sample_id":"scale_geo_capital_italy","prompt":"The capital of Italy is","expected_continuation":" Rome","category":"factual_geo"}
+{"sample_id":"scale_color_banana","prompt":"A ripe banana is usually","expected_continuation":" yellow","category":"commonsense_color"}
+{"sample_id":"scale_color_sky","prompt":"On a clear day, the sky is","expected_continuation":" blue","category":"commonsense_color"}
+{"sample_id":"scale_color_grass","prompt":"Fresh grass is often","expected_continuation":" green","category":"commonsense_color"}
+{"sample_id":"scale_color_snow","prompt":"Fresh snow is usually","expected_continuation":" white","category":"commonsense_color"}
+{"sample_id":"scale_arith_two_plus_two","prompt":"2 + 2 =","expected_continuation":" 4","category":"arithmetic_short"}
+{"sample_id":"scale_arith_three_plus_five","prompt":"3 + 5 =","expected_continuation":" 8","category":"arithmetic_short"}
+{"sample_id":"scale_arith_ten_minus_one","prompt":"10 - 1 =","expected_continuation":" 9","category":"arithmetic_short"}
+{"sample_id":"scale_arith_six_times_two","prompt":"6 * 2 =","expected_continuation":" 12","category":"arithmetic_short"}
+{"sample_id":"scale_sequence_numbers","prompt":"one, two, three,","expected_continuation":" four","category":"list_continuation"}
+{"sample_id":"scale_sequence_letters","prompt":"A, B, C,","expected_continuation":" D","category":"list_continuation"}
+{"sample_id":"scale_sequence_weekdays","prompt":"Monday, Tuesday, Wednesday,","expected_continuation":" Thursday","category":"list_continuation"}
+{"sample_id":"scale_sequence_months","prompt":"January, February, March,","expected_continuation":" April","category":"list_continuation"}
+{"sample_id":"scale_code_python_return","prompt":"def add(a, b): return a","expected_continuation":" +","category":"code_like"}
+{"sample_id":"scale_code_python_if","prompt":"if value > 0: print","expected_continuation":"(","category":"code_like"}
+{"sample_id":"scale_code_json_key","prompt":"{\"enabled\":","expected_continuation":" true","category":"code_like"}
+{"sample_id":"scale_code_comment","prompt":"// TODO: update the","expected_continuation":" test","category":"code_like"}
+{"sample_id":"scale_dialogue_greeting","prompt":"User: hello\nAssistant:","expected_continuation":" Hi","category":"dialogue_short"}
+{"sample_id":"scale_dialogue_thanks","prompt":"User: thanks\nAssistant:","expected_continuation":" You","category":"dialogue_short"}
+{"sample_id":"scale_dialogue_question","prompt":"User: what time is it?\nAssistant:","expected_continuation":" It","category":"dialogue_short"}
+{"sample_id":"scale_dialogue_yesno","prompt":"User: can you help?\nAssistant:","expected_continuation":" Yes","category":"dialogue_short"}
+{"sample_id":"scale_punctuation_period","prompt":"The answer is yes","expected_continuation":".","category":"punctuation"}
+{"sample_id":"scale_punctuation_comma","prompt":"First we measure latency","expected_continuation":",","category":"punctuation"}
+{"sample_id":"scale_punctuation_colon","prompt":"The result was clear","expected_continuation":":","category":"punctuation"}
+{"sample_id":"scale_punctuation_quote","prompt":"She said","expected_continuation":" \"","category":"punctuation"}
+{"sample_id":"scale_long_lab","prompt":"In a small laboratory notebook, the engineer wrote down the measured latency and then checked whether the output token was","expected_continuation":" correct","category":"long_context"}
+{"sample_id":"scale_long_story","prompt":"After walking through the old station for nearly an hour, Mira finally found the platform where the train would","expected_continuation":" arrive","category":"long_context"}
+{"sample_id":"scale_long_design","prompt":"The hardware team compared area, timing, and power before deciding that the next experiment should","expected_continuation":" focus","category":"long_context"}
+{"sample_id":"scale_long_report","prompt":"The report listed the failing samples first and then summarized the reason each approximation had","expected_continuation":" failed","category":"long_context"}
+{"sample_id":"scale_repetition_ha","prompt":"ha ha ha ha","expected_continuation":" ha","category":"repetition"}
+{"sample_id":"scale_repetition_test","prompt":"test test test","expected_continuation":" test","category":"repetition"}
+{"sample_id":"scale_repetition_go","prompt":"go go go","expected_continuation":" go","category":"repetition"}
+{"sample_id":"scale_repetition_tick","prompt":"tick tock tick","expected_continuation":" tock","category":"repetition"}
+{"sample_id":"scale_ambiguous_article","prompt":"The old book was on","expected_continuation":" the","category":"ambiguous_short"}
+{"sample_id":"scale_ambiguous_preposition","prompt":"The meeting starts at","expected_continuation":" noon","category":"ambiguous_short"}
+{"sample_id":"scale_ambiguous_object","prompt":"Please put it in","expected_continuation":" the","category":"ambiguous_short"}
+{"sample_id":"scale_ambiguous_common","prompt":"This is a test of","expected_continuation":" the","category":"ambiguous_short"}
+{"sample_id":"scale_instruction_short","prompt":"Translate yes to Spanish:","expected_continuation":" si","category":"instruction_short"}
+{"sample_id":"scale_instruction_label","prompt":"Sentiment: I love this.\nLabel:","expected_continuation":" positive","category":"instruction_short"}
+{"sample_id":"scale_instruction_classify","prompt":"Animal: cat\nType:","expected_continuation":" mammal","category":"instruction_short"}
+{"sample_id":"scale_instruction_complete","prompt":"Complete the phrase: bread and","expected_continuation":" butter","category":"instruction_short"}
+{"sample_id":"scale_symbol_paren","prompt":"The expression (a + b","expected_continuation":")","category":"symbolic"}
+{"sample_id":"scale_symbol_bracket","prompt":"items[0","expected_continuation":"]","category":"symbolic"}
+{"sample_id":"scale_symbol_arrow","prompt":"input -> hidden","expected_continuation":" ->","category":"symbolic"}
+{"sample_id":"scale_symbol_equals","prompt":"x = y","expected_continuation":" +","category":"symbolic"}
+{"sample_id":"scale_long_instruction_json","prompt":"Read the record and choose the next field name. Record: {\"user\":\"alpha\",\"status\":\"active\",\"score\":17,\"next\"","expected_continuation":":","category":"long_instruction"}
+{"sample_id":"scale_long_instruction_markdown","prompt":"Summarize the checklist item in one word:\n- build rtl\n- run synthesis\n- compare ppa\nAnswer:","expected_continuation":" compare","category":"long_instruction"}
+{"sample_id":"scale_long_instruction_table","prompt":"Column A is latency, column B is area, column C is power. The metric that measures timing is","expected_continuation":" latency","category":"long_instruction"}
+{"sample_id":"scale_long_instruction_translation","prompt":"Translate the short answer only. English: yes. Spanish:","expected_continuation":" si","category":"long_instruction"}
+{"sample_id":"scale_long_dialogue_multi","prompt":"User: I need the status.\nAssistant: The build passed.\nUser: What should I check next?\nAssistant:","expected_continuation":" The","category":"long_dialogue"}
+{"sample_id":"scale_long_dialogue_correction","prompt":"User: The result failed.\nAssistant: Which sample failed?\nUser: The arithmetic sample.\nAssistant:","expected_continuation":" The","category":"long_dialogue"}
+{"sample_id":"scale_long_dialogue_compare","prompt":"User: Compare q8 and bf16.\nAssistant: q8 is integer, bf16 is floating-like.\nUser: Which keeps range?\nAssistant:","expected_continuation":" bf","category":"long_dialogue"}
+{"sample_id":"scale_long_dialogue_plan","prompt":"User: Start broad, then go deep.\nAssistant: I will map the rough frontier first.\nUser: Next?\nAssistant:","expected_continuation":" Run","category":"long_dialogue"}
+{"sample_id":"scale_code_nested_if","prompt":"if (ready && valid) {\n  result = input","expected_continuation":";","category":"code_long"}
+{"sample_id":"scale_code_function_doc","prompt":"def normalize(x):\n    \"\"\"Return x divided by the","expected_continuation":" sum","category":"code_long"}
+{"sample_id":"scale_code_sql_select","prompt":"SELECT latency, area, power FROM runs WHERE platform =","expected_continuation":" '","category":"code_long"}
+{"sample_id":"scale_code_verilog_assign","prompt":"assign best_index = score_a > score_b ? index_a","expected_continuation":" :","category":"code_long"}
+{"sample_id":"scale_array_pressure_numbers_a","prompt":"Scores: 0.91, 0.90, 0.90, 0.89. The highest score is","expected_continuation":" 0","category":"rank_pressure"}
+{"sample_id":"scale_array_pressure_numbers_b","prompt":"Scores: 12, 12, 11, 10. The tie should use the larger","expected_continuation":" log","category":"rank_pressure"}
+{"sample_id":"scale_array_pressure_letters_a","prompt":"Candidates A B C D E F G H I J K L M N O P. Choose candidate","expected_continuation":" A","category":"rank_pressure"}
+{"sample_id":"scale_array_pressure_letters_b","prompt":"The ordered labels are first, second, third, fourth, fifth. The next label is","expected_continuation":" sixth","category":"rank_pressure"}
+{"sample_id":"scale_margin_close_word_a","prompt":"The phrase could end with the or a, but the expected article is","expected_continuation":" the","category":"low_margin_language"}
+{"sample_id":"scale_margin_close_word_b","prompt":"The sentence starts with There and usually continues with","expected_continuation":" is","category":"low_margin_language"}
+{"sample_id":"scale_margin_close_word_c","prompt":"In this context the answer may be yes or no. The selected answer is","expected_continuation":" yes","category":"low_margin_language"}
+{"sample_id":"scale_margin_close_word_d","prompt":"A common continuation after because is often","expected_continuation":" of","category":"low_margin_language"}
+{"sample_id":"scale_long_context_repeated_a","prompt":"alpha beta gamma alpha beta gamma alpha beta gamma alpha beta","expected_continuation":" gamma","category":"long_repetition"}
+{"sample_id":"scale_long_context_repeated_b","prompt":"red blue green red blue green red blue","expected_continuation":" green","category":"long_repetition"}
+{"sample_id":"scale_long_context_repeated_c","prompt":"tick tick tock tick tick tock tick tick","expected_continuation":" tock","category":"long_repetition"}
+{"sample_id":"scale_long_context_repeated_d","prompt":"zero one zero one zero one zero","expected_continuation":" one","category":"long_repetition"}
+{"sample_id":"scale_symbolic_dense_a","prompt":"((((a+b)*c)-d)/e","expected_continuation":")","category":"symbolic_dense"}
+{"sample_id":"scale_symbolic_dense_b","prompt":"path/to/module/src/rtlgen","expected_continuation":"/","category":"symbolic_dense"}
+{"sample_id":"scale_symbolic_dense_c","prompt":"key=value; next_key","expected_continuation":"=","category":"symbolic_dense"}
+{"sample_id":"scale_symbolic_dense_d","prompt":"[INFO] build complete [WARN] timing","expected_continuation":" margin","category":"symbolic_dense"}
+{"sample_id":"scale_report_dense_a","prompt":"The measured datapath had lower area but higher latency, so the ranking depended on the objective","expected_continuation":" weight","category":"report_dense"}
+{"sample_id":"scale_report_dense_b","prompt":"The candidate recovered exact top one on all samples, but the result still needed a broader","expected_continuation":" distribution","category":"report_dense"}
+{"sample_id":"scale_report_dense_c","prompt":"When the array width grows, equal score collisions become more likely, so the tie breaker should use","expected_continuation":" logits","category":"report_dense"}
+{"sample_id":"scale_report_dense_d","prompt":"If the larger model changes the activation distribution, the approximation frontier may","expected_continuation":" shift","category":"report_dense"}

--- a/tests/test_llm_decoder_q8_norm_frontier.py
+++ b/tests/test_llm_decoder_q8_norm_frontier.py
@@ -64,6 +64,22 @@ def test_bf16_pwl_recovery_grid_adds_logit_tiebreak_variant() -> None:
     assert recovery["score_tie_breaker"] == "logit"
 
 
+def test_bf16_pwl_scale_probe_grid_keeps_integer_controls() -> None:
+    model_contract = load_json(Path("runs/models/llm_decoder_tiny_v1/model_contract.json"))
+    grid = _rough_grid_templates(model_contract, "decoder_bf16_pwl_scale_probe_v1")
+
+    assert set(grid) == {
+        "candidate_onnx_softmax_exact",
+        "grid_approx_pwl_bf16_path",
+        "grid_approx_pwl_bf16_path_logit_tiebreak",
+        "grid_approx_pwl_in_q12_w_q12_norm_exact",
+        "grid_approx_pwl_in_q8_w_q8_norm_recip_q12",
+    }
+    assert grid["grid_approx_pwl_bf16_path_logit_tiebreak"]["score_tie_breaker"] == "logit"
+    assert grid["grid_approx_pwl_in_q12_w_q12_norm_exact"]["normalization_mode"] == "exact"
+    assert grid["grid_approx_pwl_in_q8_w_q8_norm_recip_q12"]["normalization_reciprocal_bits"] == 12
+
+
 def test_q8_normalization_frontier_report_selects_lowest_cost_exact_safe_reciprocal() -> None:
     report = build_report(
         sweep_path=Path("tests/fixtures/decoder_q8_norm_frontier_sweep.json"),


### PR DESCRIPTION
## Summary

Adds a scale-proxy L2 evaluation path for the recovered bf16/PWL decoder candidate.

The new job keeps the tiny ONNX decoder harness but increases rank pressure with top-16 output ranking over the full vocabulary and broadens prompt regimes with longer contexts, code/symbolic cases, repetition, low-margin continuations, and instruction/dialogue samples.

## Changes

- Add `manifest_scale_proxy_v1.json` and an 80-sample scale-proxy prompt set.
- Add `decoder_bf16_pwl_scale_probe_v1` rough grid with bf16 baseline, bf16 logit tie-break recovery, q12 exact, and q8 reciprocal controls.
- Add control-plane L2 evidence generation for `decoder_bf16_pwl_scale_probe`.
- Add proposal docs under `prop_l2_decoder_bf16_pwl_scale_probe_v1`.
- Document the local scale-proxy commands in `npu/eval/README.md`.

## Validation

- `python3 -m json.tool` on the new manifest/proposal/evaluation request JSON.
- JSONL sample parse plus count check: 80 rows, 80 unique ids, manifest count matches.
- `python3 -m py_compile npu/eval/sweep_llm_decoder_candidate_quality.py control_plane/control_plane/services/l2_task_generator.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest -q tests/test_llm_decoder_q8_norm_frontier.py control_plane/control_plane/tests/test_l2_task_generator.py`

Note: direct `validate_llm_decoder_contract.py` before generation fails because `reference_scale_proxy_v1_manifest.json` is intentionally produced by the evaluator's first generation command, matching the existing L2 job ordering.
