### PR TITLE
[codex] Record bf16 PWL scale probe request

### DIFF
--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_bf16_pwl_scale_probe_v1",
-  "source_commit": "8042fa99f01be718c091672c1f18e52a49400575",
+  "source_commit": "3e1537796e6e183d81eddd9a004d88cdb5885387",
   "requested_items": [
     {
       "item_id": "l2_decoder_bf16_pwl_scale_probe_v1",

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_decision.json
@@ -1,5 +1,5 @@
 {
   "proposal_id": "prop_l2_decoder_bf16_pwl_scale_probe_v1",
   "status": "pending",
-  "decision": "awaiting_evaluation"
+  "decision": "iterate"
 }

--- a/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_bf16_pwl_scale_probe_v1/promotion_result.json
@@ -1,5 +1,9 @@
 {
   "proposal_id": "prop_l2_decoder_bf16_pwl_scale_probe_v1",
   "status": "pending",
-  "promoted_item_id": ""
+  "promoted_item_id": "",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
 }


### PR DESCRIPTION
## Summary

Records the generated control-plane request metadata for `l2_decoder_bf16_pwl_scale_probe_v1` after PR #355 merged.

## Details

- Updates the proposal request `source_commit` to the merged implementation commit `3e1537796e6e183d81eddd9a004d88cdb5885387`.
- Keeps the proposal in pending/iterate state while the evaluator runs.
- Adds the standard pending promotion-result fields used by finalization.

## Validation

- Generated via `control_plane.cli.generate_l2_campaign`.
- The item was assigned to `eval-daemon-b7c2d9c80c1c` and the control plane shows one running item.
