### PR TITLE
[codex] record trained tiny decoder request

### DIFF
--- a/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/README.md
@@ -1,0 +1,15 @@
+# Decoder Trained Tiny Quality Gate
+
+This proposal records the first trained-weight tiny decoder quality check for
+the bf16/PWL reciprocal normalization frontier.
+
+Primary files:
+
+- `proposal.json`: scope, hypothesis, dependencies, and required evaluation
+- `design_brief.md`: rationale for using a trained tiny GPT-2-family smoke
+- `quality_gate.md`: evaluator acceptance criteria
+- `evaluation_requests.json`: dispatched L2 work item metadata
+
+The evaluation is pending on `l2_decoder_trained_tiny_quality_v1`. A pass here
+only authorizes a larger trained-model confirmation; it does not prove behavior
+on distilgpt2, GPT-2, or larger arrays.

--- a/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/analysis_report.md
@@ -1,0 +1,30 @@
+# Analysis Report
+
+## Candidate
+
+- `proposal_id`: `prop_l2_decoder_trained_tiny_quality_v1`
+- `item_id`: `l2_decoder_trained_tiny_quality_v1`
+- abstraction: `decoder_trained_tiny_quality`
+
+## Evaluations Consumed
+
+Pending evaluator completion.
+
+## Baseline Comparison
+
+Pending. The evaluator should compare the bf16/PWL baseline row against the
+bf16/PWL logit tie-break row on the trained tiny decoder dataset.
+
+## Result
+
+Pending.
+
+## Failures and Caveats
+
+This is a trained tiny checkpoint smoke, not a larger-model proof. Any pass must
+be followed by a larger imported-model check before treating the result as
+distribution-robust.
+
+## Recommendation
+
+Pending evaluator result.

--- a/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-05-03T20:57:45Z
+- allowed_evaluations:
+  - `l2_decoder_trained_tiny_quality_v1`
+- note: first trained-weight tiny decoder quality gate before larger checkpoint import

--- a/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_trained_tiny_quality_v1",
-  "source_commit": "c85db5432a88549f68cef6623be3695455fe62e1",
+  "source_commit": "4b3085f0866e3940d56722d190f8630d06b5e3a5",
   "requested_items": [
     {
       "item_id": "l2_decoder_trained_tiny_quality_v1",
@@ -19,7 +19,7 @@
         "direction": "iterate",
         "reason": "Use the trained-weight tiny result to decide whether bf16/PWL recovery should move to distilgpt2/GPT-2 confirmation or return to logit-margin diagnosis."
       },
-      "status": "not_requested",
+      "status": "pending",
       "notes": "Prepared with trained tiny GPT-2-family model assets and the decoder_trained_tiny_quality task-generator hook."
     }
   ]

--- a/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/implementation_summary.md
@@ -1,0 +1,42 @@
+# Implementation Summary
+
+## Proposal
+
+- `proposal_id`: `prop_l2_decoder_trained_tiny_quality_v1`
+- title: Decoder trained-weight tiny quality gate
+
+## Scope
+
+Added a small trained GPT-2-family ONNX reference model, tokenizer assets, a
+24-sample trained tiny prompt set, proposal artifacts, and the
+`decoder_trained_tiny_quality` L2 task-generator hook.
+
+No RTL datapath or mapper behavior changed.
+
+## Files Changed
+
+- `runs/models/llm_decoder_tiny_gpt2_trained_v1/`
+- `runs/tokenizers/llm_decoder_tiny_gpt2_trained_v1/`
+- `runs/datasets/llm_decoder_eval_trained_tiny_v1/`
+- `control_plane/control_plane/services/l2_task_generator.py`
+- `control_plane/control_plane/tests/test_l2_task_generator.py`
+
+## Local Validation
+
+- py-compiled the touched generator and decoder harness scripts
+- JSON-validated the new proposal, model, tokenizer, and dataset manifests
+- generated local trained tiny reference/candidate traces
+- validated the decoder contract and ran the rough bf16/PWL recovery sweep
+- ran `control_plane/control_plane/tests/test_l2_task_generator.py`
+- ran `scripts/validate_runs.py --skip_eval_queue`
+
+## Evaluation Request
+
+- `item_id`: `l2_decoder_trained_tiny_quality_v1`
+- source commit: `4b3085f0866e3940d56722d190f8630d06b5e3a5`
+- dispatch target: `eval-daemon-b7c2d9c80c1c`
+
+## Risks
+
+The checkpoint is trained but intentionally tiny. The result should be used as
+a gate into larger trained-model checks, not as the final distribution claim.

--- a/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l2_decoder_trained_tiny_quality_v1",
+  "candidate_id": "decoder_trained_tiny_quality",
+  "decision": "pending",
+  "reason": "Await evaluator result for l2_decoder_trained_tiny_quality_v1.",
+  "evidence_refs": [
+    "item:l2_decoder_trained_tiny_quality_v1"
+  ],
+  "next_action": "Review the trained tiny quality result and decide whether to scale to a larger trained checkpoint.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note: wait for `l2_decoder_trained_tiny_quality_v1` evaluator result

--- a/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_trained_tiny_quality_v1/promotion_result.json
@@ -1,0 +1,8 @@
+{
+  "proposal_id": "prop_l2_decoder_trained_tiny_quality_v1",
+  "decision": "pending",
+  "item_id": "l2_decoder_trained_tiny_quality_v1",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}


### PR DESCRIPTION
## Summary

Records the dispatched trained tiny decoder quality request metadata after PR #362 merged.

- updates `evaluation_requests.json` to source commit `4b3085f0866e3940d56722d190f8630d06b5e3a5` and pending status
- fills the generated proposal bookkeeping files with proposal-specific pending content instead of template placeholders

## Validation

- `python3 -m json.tool` on the touched JSON files
- `python3 scripts/validate_runs.py --skip_eval_queue`