### PR TITLE
[codex] use decoder JSON evidence in L2 assessment

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -417,6 +417,145 @@ def _is_ranking_or_frontier_mode(*, evaluation_mode: str, comparison_role: str) 
     return comparison_role == "ranking" or evaluation_mode in {"broad_ranking", "frontier_detail"}
 
 
+def _decoder_contract_inputs(work_item: WorkItem) -> dict[str, Any]:
+    input_manifest = work_item.input_manifest if isinstance(work_item.input_manifest, dict) else {}
+    decoder_contract = input_manifest.get("decoder_contract")
+    return dict(decoder_contract) if isinstance(decoder_contract, dict) else {}
+
+
+_DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
+    ("trained_quality_out", "trained_quality_report"),
+    ("scale_probe_out", "scale_probe_report"),
+    ("recovery_out", "recovery_report"),
+    ("recoverability_out", "recoverability_report"),
+    ("frontier_out", "frontier_report"),
+    ("frontier_detail_out", "frontier_detail_report"),
+    ("diagnosis_out", "diagnosis_report"),
+    ("ladder_out", "ladder_report"),
+    ("survivor_distribution_out", "survivor_distribution_report"),
+    ("bitwidth_boundary_out", "bitwidth_boundary_report"),
+    ("quantization_outline_out", "quantization_outline_report"),
+    ("cost_proxy_out", "cost_proxy_report"),
+)
+
+
+def _decoder_evidence_paths(
+    *,
+    repo_root: Path,
+    work_item: WorkItem,
+) -> tuple[str, dict[str, str]] | tuple[None, dict[str, str]]:
+    decoder_contract = _decoder_contract_inputs(work_item)
+    if not decoder_contract:
+        return None, {}
+    source_refs: dict[str, str] = {}
+    for ref_key in ("dataset_manifest", "sample_file", "validation_out", "quality_out", "candidate_sweep_out"):
+        value = str(decoder_contract.get(ref_key, "")).strip()
+        if value:
+            source_refs[f"decoder_{ref_key}"] = value
+    for out_key, report_key in _DECODER_EVIDENCE_OUTPUT_KEYS:
+        out_rel = str(decoder_contract.get(out_key, "")).strip()
+        if not out_rel:
+            continue
+        out_path = _resolve_path(repo_root=repo_root, path_text=out_rel)
+        if not out_path.exists():
+            continue
+        source_refs[f"decoder_{out_key}"] = out_rel
+        report_rel = str(decoder_contract.get(report_key, "")).strip()
+        if report_rel and _resolve_path(repo_root=repo_root, path_text=report_rel).exists():
+            source_refs[f"decoder_{report_key}"] = report_rel
+        return out_rel, source_refs
+    return None, source_refs
+
+
+def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
+    diagnosis = evidence_payload.get("diagnosis")
+    diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+    brief: dict[str, Any] = {
+        "diagnosis": diagnosis_dict,
+    }
+    for key in (
+        "baseline",
+        "recovery",
+        "recovered_sample_ids",
+        "regression_sample_ids",
+        "template_summaries",
+        "sample_count",
+        "source_sweep",
+    ):
+        if key in evidence_payload:
+            brief[key] = evidence_payload[key]
+    return brief
+
+
+def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, Any]) -> tuple[str, str]:
+    diagnosis = evidence_payload.get("diagnosis")
+    diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+    decision = str(diagnosis_dict.get("decision", "")).strip() or "decoder_evidence_recorded"
+    parts = [f"Decoder quality evidence recorded from {evidence_ref}: decision={decision}"]
+    if "exact_safe_after_recovery" in diagnosis_dict:
+        parts.append(f"exact_safe_after_recovery={bool(diagnosis_dict.get('exact_safe_after_recovery'))}")
+    if "recovered_count" in diagnosis_dict:
+        parts.append(f"recovered_count={diagnosis_dict.get('recovered_count')}")
+    if "regression_count" in diagnosis_dict:
+        parts.append(f"regression_count={diagnosis_dict.get('regression_count')}")
+    recommended_next = str(diagnosis_dict.get("recommended_next_step", "")).strip()
+    if recommended_next:
+        parts.append(f"recommended_next_step={recommended_next}")
+    return decision, "; ".join(parts) + "."
+
+
+def _build_decoder_evidence_assessment(
+    *,
+    work_item: WorkItem,
+    proposal: dict[str, Any] | None,
+    repo_root: Path,
+    evaluation_mode: str,
+    comparison_role: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, dict[str, str]]:
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=repo_root, work_item=work_item)
+    if not evidence_ref:
+        return None, None, source_refs
+    evidence_path = _resolve_path(repo_root=repo_root, path_text=evidence_ref)
+    try:
+        evidence_payload = _load_json(evidence_path)
+    except Exception:
+        return None, None, source_refs
+    context = _proposal_context(work_item, proposal)
+    outcome, summary = _decoder_evidence_summary(evidence_ref=evidence_ref, evidence_payload=evidence_payload)
+    assessment = {
+        "proposal_id": str(context.get("proposal_id", "")).strip(),
+        "title": str(context.get("title", "")).strip(),
+        "kind": str(context.get("kind", "")).strip(),
+        "primary_question": str(context.get("primary_question", "")).strip(),
+        "evaluation_mode": evaluation_mode,
+        "comparison_role": comparison_role,
+        "outcome": outcome,
+        "summary": summary,
+        "baseline_ref": None,
+        "baseline_item_id": None,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": evidence_ref,
+        "decoder_quality": _decoder_quality_brief(evidence_payload),
+    }
+    return (
+        assessment,
+        _build_evaluation_record(
+            work_item=work_item,
+            proposal=proposal,
+            repo_root=repo_root,
+            evaluation_mode=evaluation_mode,
+            comparison_role=comparison_role,
+            baseline_ref=None,
+            baseline_item_id=None,
+            outcome=outcome,
+            expectation_outcome=outcome,
+            summary=summary,
+        ),
+        source_refs,
+    )
+
+
 def _resolve_baseline_summary_from_decision_payload(
     *,
     repo_root: Path,
@@ -740,6 +879,15 @@ def _build_proposal_assessment(
             ),
             {},
         )
+    decoder_assessment, decoder_evaluation_record, decoder_source_refs = _build_decoder_evidence_assessment(
+        work_item=work_item,
+        proposal=proposal,
+        repo_root=repo_root,
+        evaluation_mode=evaluation_mode,
+        comparison_role=comparison_role,
+    )
+    if decoder_assessment is not None or decoder_evaluation_record is not None:
+        return decoder_assessment, decoder_evaluation_record, decoder_source_refs
     if _is_ranking_or_frontier_mode(evaluation_mode=evaluation_mode, comparison_role=comparison_role):
         summary = (
             "Ranking/frontier evidence was recorded for this proposal; focused baseline comparison is not required "

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -775,6 +775,124 @@ def test_consume_l2_result_frontier_ranking_does_not_require_baseline_refs() -> 
             assert "baseline comparison is not required" in assessment["summary"]
 
 
+def test_consume_l2_result_frontier_decoder_quality_uses_decoder_json_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "developer_loop" / "prop_l2_decoder_quality_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_quality_v1",
+                        "kind": "architecture",
+                        "title": "Decoder trained quality",
+                        "direct_comparison": {
+                            "primary_question": "Does the decoder recovery remain exact-safe?"
+                        },
+                        "baseline_refs": [
+                            "runs/datasets/llm_decoder_eval_tiny_v1/decoder_bf16_pwl_recovery.json"
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_trained_tiny_quality__l2_decoder_quality.json"
+            report_rel = "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_trained_tiny_quality__l2_decoder_quality.md"
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 0.1,
+                        "baseline": {
+                            "template": "grid_approx_pwl_bf16_path",
+                            "next_token_matches": 23,
+                            "sample_count": 24,
+                            "next_token_mismatch_sample_ids": ["trained_color_sky"],
+                        },
+                        "recovery": {
+                            "template": "grid_approx_pwl_bf16_path_logit_tiebreak",
+                            "next_token_matches": 24,
+                            "sample_count": 24,
+                            "next_token_mismatch_sample_ids": [],
+                        },
+                        "diagnosis": {
+                            "decision": "tie_break_recovery_sufficient",
+                            "exact_safe_after_recovery": True,
+                            "recovered_count": 1,
+                            "regression_count": 0,
+                            "recommended_next_step": "scale to a larger trained checkpoint",
+                        },
+                        "recovered_sample_ids": ["trained_color_sky"],
+                        "regression_sample_ids": [],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# decoder quality\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_decoder_quality",
+                campaign_dir_rel="runs/campaigns/npu/decoder_quality_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/developer_loop/prop_l2_decoder_quality_v1",
+                comparison={"role": "ranking"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use decoder quality before a larger trained checkpoint.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_trained_tiny_quality",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "dataset_manifest": "runs/datasets/llm_decoder_eval_trained_tiny_v1/manifest.json",
+                    "quality_out": "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_quality_compare__l2_decoder_quality.json",
+                    "candidate_sweep_out": "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_quality_sweep__l2_decoder_quality.json",
+                    "trained_quality_out": evidence_rel,
+                    "trained_quality_report": report_rel,
+                }
+            }
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            evaluation_record = decision_payload["evaluation_record"]
+            assert assessment["evaluation_mode"] == "frontier_detail"
+            assert assessment["comparison_role"] == "ranking"
+            assert assessment["outcome"] == "tie_break_recovery_sufficient"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert assessment["decoder_quality"]["diagnosis"]["exact_safe_after_recovery"] is True
+            assert assessment["decoder_quality"]["recovery"]["next_token_matches"] == 24
+            assert assessment["baseline_ref"] is None
+            assert "Focused comparison baseline" not in assessment["summary"]
+            assert evaluation_record["outcome"] == "tie_break_recovery_sufficient"
+            assert decision_payload["source_refs"]["decoder_trained_quality_out"] == evidence_rel
+            assert decision_payload["source_refs"]["decoder_trained_quality_report"] == report_rel
+            assert "baseline_summary_csv" not in decision_payload["source_refs"]
+
+
 def test_consume_l2_result_resolves_prior_art_report_as_baseline() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary

Fixes the repeated decoder result-assessment issue where decoder quality jobs were treated like generic PPA paired comparisons that require a campaign `summary.csv` baseline.

- adds a decoder-evidence assessment path in `l2_result_consumer`
- reads decoder JSON outputs from `work_item.input_manifest.decoder_contract` such as `trained_quality_out`, `scale_probe_out`, and `recovery_out`
- records decoder diagnosis, baseline/recovery rows, and decoder source refs in the decision payload
- leaves generic `summary.csv` baseline comparison for actual paired PPA comparisons
- adds a regression test for a `frontier_detail`/`ranking` decoder job whose baseline ref is not a campaign `summary.csv`

## Validation

- `PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -q`
- `python3 -m py_compile control_plane/control_plane/services/l2_result_consumer.py control_plane/control_plane/tests/test_l2_result_consumer.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`