### PR TITLE
[codex] record decoder JSON assessment

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -501,7 +501,8 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
     recommended_next = str(diagnosis_dict.get("recommended_next_step", "")).strip()
     if recommended_next:
         parts.append(f"recommended_next_step={recommended_next}")
-    return decision, "; ".join(parts) + "."
+    summary = "; ".join(parts)
+    return decision, summary if summary.endswith(".") else summary + "."
 
 
 def _build_decoder_evidence_assessment(

--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_trained_tiny_quality_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_trained_tiny_quality_v1.json
@@ -1,6 +1,6 @@
 {
   "version": 0.1,
-  "generated_utc": "2026-05-03T20:58:52.782202Z",
+  "generated_utc": "2026-05-03T21:36:51.300175Z",
   "item_id": "l2_decoder_trained_tiny_quality_v1",
   "run_key": "l2_decoder_trained_tiny_quality_v1_run_61435f2f5c602eb9",
   "layer": "layer2",
@@ -8,7 +8,7 @@
   "platform": "nangate45",
   "task_type": "l2_campaign",
   "source_commit": "4b3085f0866e3940d56722d190f8630d06b5e3a5",
-  "review_metadata_source_commit": "4b3085f0866e3940d56722d190f8630d06b5e3a5",
+  "review_metadata_source_commit": "ced77427c0ebefc9900bc8f0f6e87fa942c64735",
   "objective": "Check whether bf16/PWL plus logit tie-break recovery remains exact-safe on a trained tiny GPT-2-family decoder workload.",
   "input_manifest": {
     "sweeps": [
@@ -79,22 +79,66 @@
     "abstraction_layer": "decoder_trained_tiny_quality",
     "expected_direction": "iterate",
     "expected_reason": "Use the trained-weight tiny result to decide whether bf16/PWL recovery should move to distilgpt2/GPT-2 confirmation or return to logit-margin diagnosis.",
-    "summary": "Focused comparison baseline could not be resolved from proposal baseline_refs.",
-    "outcome": "unavailable",
+    "summary": "Decoder quality evidence recorded from runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_trained_tiny_quality__l2_decoder_trained_tiny_quality_v1.json: decision=tie_break_recovery_sufficient; exact_safe_after_recovery=True; recovered_count=1; regression_count=0; recommended_next_step=Treat bf16/PWL as the immediate low-cost frontier and follow with a hardware-friendly score-tie ranking check before full QAT infrastructure.",
+    "outcome": "tie_break_recovery_sufficient",
     "expectation_status": "unspecified"
   },
   "proposal_assessment": {
     "proposal_id": "prop_l2_decoder_trained_tiny_quality_v1",
     "title": "Decoder trained-weight tiny quality gate",
+    "kind": "architecture",
     "primary_question": "Does the current decoder bf16/PWL plus logit tie-break recovery remain exact-safe on a trained tiny GPT-2-family decoder workload?",
     "evaluation_mode": "frontier_detail",
     "comparison_role": "ranking",
-    "outcome": "unavailable",
-    "summary": "Focused comparison baseline could not be resolved from proposal baseline_refs.",
+    "outcome": "tie_break_recovery_sufficient",
+    "summary": "Decoder quality evidence recorded from runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_trained_tiny_quality__l2_decoder_trained_tiny_quality_v1.json: decision=tie_break_recovery_sufficient; exact_safe_after_recovery=True; recovered_count=1; regression_count=0; recommended_next_step=Treat bf16/PWL as the immediate low-cost frontier and follow with a hardware-friendly score-tie ranking check before full QAT infrastructure.",
     "baseline_ref": null,
     "baseline_item_id": null,
     "matched_row_count": 0,
-    "matched_rows": []
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_trained_tiny_quality__l2_decoder_trained_tiny_quality_v1.json",
+    "decoder_quality": {
+      "diagnosis": {
+        "decision": "tie_break_recovery_sufficient",
+        "exact_safe_after_recovery": true,
+        "recommended_next_step": "Treat bf16/PWL as the immediate low-cost frontier and follow with a hardware-friendly score-tie ranking check before full QAT infrastructure.",
+        "recovered_count": 1,
+        "regression_count": 0
+      },
+      "baseline": {
+        "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_bf16_w_bf16_norm_recip_bf16_prob_fp",
+        "next_token_matches": 23,
+        "next_token_mismatch_sample_ids": [
+          "trained_color_sky"
+        ],
+        "normalization_mode": "reciprocal_float",
+        "normalization_reciprocal_float_format": "bf16",
+        "sample_count": 24,
+        "score_tie_breaker": "",
+        "template": "grid_approx_pwl_bf16_path",
+        "topk_matches": 23,
+        "topk_miss_sample_ids": [
+          "trained_color_sky"
+        ]
+      },
+      "recovery": {
+        "candidate_semantics": "onnx_logits_fp_softmax_approx_pwl_in_bf16_w_bf16_norm_recip_bf16_prob_fp_tiebreak_logit",
+        "next_token_matches": 24,
+        "next_token_mismatch_sample_ids": [],
+        "normalization_mode": "reciprocal_float",
+        "normalization_reciprocal_float_format": "bf16",
+        "sample_count": 24,
+        "score_tie_breaker": "logit",
+        "template": "grid_approx_pwl_bf16_path_logit_tiebreak",
+        "topk_matches": 24,
+        "topk_miss_sample_ids": []
+      },
+      "recovered_sample_ids": [
+        "trained_color_sky"
+      ],
+      "regression_sample_ids": [],
+      "source_sweep": "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_quality_sweep__l2_decoder_trained_tiny_quality_v1.json"
+    }
   },
   "source_refs": {
     "best_point_json": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__l2_decoder_trained_tiny_quality_v1/best_point.json",
@@ -117,6 +161,13 @@
         "descriptors_bin": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__l2_decoder_trained_tiny_quality_v1/artifacts/mapper/fp16_nm1/mlp2/descriptors.bin",
         "perf_trace_json": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__l2_decoder_trained_tiny_quality_v1/artifacts/perf/fp16_nm1/mlp2/trace.json"
       }
-    ]
+    ],
+    "decoder_dataset_manifest": "runs/datasets/llm_decoder_eval_trained_tiny_v1/manifest.json",
+    "decoder_sample_file": "runs/datasets/llm_decoder_eval_trained_tiny_v1/samples.jsonl",
+    "decoder_validation_out": "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_contract_validation__l2_decoder_trained_tiny_quality_v1.json",
+    "decoder_quality_out": "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_quality_compare__l2_decoder_trained_tiny_quality_v1.json",
+    "decoder_candidate_sweep_out": "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_quality_sweep__l2_decoder_trained_tiny_quality_v1.json",
+    "decoder_trained_quality_out": "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_trained_tiny_quality__l2_decoder_trained_tiny_quality_v1.json",
+    "decoder_trained_quality_report": "runs/datasets/llm_decoder_eval_trained_tiny_v1/decoder_trained_tiny_quality__l2_decoder_trained_tiny_quality_v1.md"
   }
 }


### PR DESCRIPTION
## Summary

Records the corrected assessment for `l2_decoder_trained_tiny_quality_v1` after PR #365 taught the L2 consumer to read decoder JSON evidence directly.

- updates the existing decision artifact from `unavailable` / focused-baseline wording to `tie_break_recovery_sufficient`
- includes the decoder quality diagnosis, bf16/PWL baseline row, logit-tie-break recovery row, and decoder source refs
- removes a double-period edge case in generated decoder evidence summaries

## Validation

- `PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python3 -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -q`
- `python3 -m py_compile control_plane/control_plane/services/l2_result_consumer.py control_plane/control_plane/tests/test_l2_result_consumer.py`
- `python3 -m json.tool control_plane/shadow_exports/l2_decisions/l2_decoder_trained_tiny_quality_v1.json`
- `python3 scripts/validate_runs.py --skip_eval_queue`