### PR TITLE
Use export Python for distilgpt2 materializer

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1517,11 +1517,16 @@ def _decoder_distilgpt2_quality_evidence(*, item_id: str) -> dict[str, Any]:
     trained_out = f"{base}/decoder_distilgpt2_quality__{item_id}.json"
     trained_report = f"{base}/decoder_distilgpt2_quality__{item_id}.md"
     rough_grid = "decoder_bf16_pwl_scale_probe_v1"
+    materializer_python = (
+        "RTLGEN_HF_MATERIALIZER_PYTHON=${RTLGEN_HF_MATERIALIZER_PYTHON:-/orfs/tools/AutoTuner/autotuner_env/bin/python3}; "
+        'if [ ! -x "$RTLGEN_HF_MATERIALIZER_PYTHON" ]; then RTLGEN_HF_MATERIALIZER_PYTHON=python3; fi; '
+        '"$RTLGEN_HF_MATERIALIZER_PYTHON"'
+    )
     commands = [
         {
             "name": "materialize_decoder_distilgpt2_contract",
             "run": (
-                "python3 npu/eval/materialize_hf_decoder_contract.py "
+                f"{materializer_python} npu/eval/materialize_hf_decoder_contract.py "
                 "--model-id distilgpt2 "
                 "--contract-id llm_decoder_distilgpt2_trained_v1 "
                 f"--dataset-dir {base} "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1188,6 +1188,8 @@ def test_generate_l2_campaign_task_adds_decoder_distilgpt2_quality_evidence() ->
                 "runs/models/llm_decoder_distilgpt2_trained_v1/model_contract.json"
             )
             assert "evaluator-local generated" in decoder_inputs["materialized_model_scope"]
+            assert "RTLGEN_HF_MATERIALIZER_PYTHON" in work_item.command_manifest[0]["run"]
+            assert "/orfs/tools/AutoTuner/autotuner_env/bin/python3" in work_item.command_manifest[0]["run"]
             assert "--model-id distilgpt2" in work_item.command_manifest[0]["run"]
             assert "--rough-grid decoder_bf16_pwl_scale_probe_v1" in work_item.command_manifest[5]["run"]
             assert "summarize_llm_decoder_bf16_pwl_recovery.py" in work_item.command_manifest[6]["run"]

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -68,6 +68,13 @@ Python environment. Generated files under
 `runs/tokenizers/llm_decoder_distilgpt2_trained_v1/` are intentionally ignored
 and should not be committed by evaluator PRs.
 
+Control-plane workers usually run commands from the control-plane venv, which
+has `onnxruntime` for decoder inference but may not have the Hugging Face export
+stack. L2 distilgpt2 jobs therefore invoke the materializer with
+`RTLGEN_HF_MATERIALIZER_PYTHON` when set, otherwise with
+`/orfs/tools/AutoTuner/autotuner_env/bin/python3` when present, and then return
+to normal `python3` commands for ONNX Runtime inference.
+
 ## Validation
 Validate campaign manifest:
 ```sh


### PR DESCRIPTION
## Summary
- run the distilgpt2 Hugging Face materializer with RTLGEN_HF_MATERIALIZER_PYTHON or the AutoTuner Python fallback, instead of the control-plane venv
- keep subsequent decoder reference/candidate/sweep commands on normal python3 so they use the worker venv with onnxruntime
- document the split Python environment expectation

## Reason
The first dispatch of l2_decoder_distilgpt2_quality_v1 failed immediately in materialize_decoder_distilgpt2_contract. The worker venv has onnxruntime/tokenizers for inference but not torch/transformers/onnx for export; the AutoTuner Python has the export stack.

## Validation
- python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue