### PR TITLE
Fix remote HF materializer command wrapper

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1529,16 +1529,11 @@ def _decoder_distilgpt2_quality_evidence_for_dataset(
     trained_report = f"{base}/{output_prefix}__{item_id}.md"
     rough_grid = "decoder_bf16_pwl_scale_probe_v1"
     name_mid = f"_{command_suffix}" if command_suffix else ""
-    materializer_python = (
-        "RTLGEN_HF_MATERIALIZER_PYTHON=${RTLGEN_HF_MATERIALIZER_PYTHON:-/orfs/tools/AutoTuner/autotuner_env/bin/python3}; "
-        'if [ ! -x "$RTLGEN_HF_MATERIALIZER_PYTHON" ]; then RTLGEN_HF_MATERIALIZER_PYTHON=python3; fi; '
-        '"$RTLGEN_HF_MATERIALIZER_PYTHON"'
-    )
     commands = [
         {
             "name": f"materialize_decoder_distilgpt2{name_mid}_contract",
             "run": (
-                f"{materializer_python} npu/eval/materialize_hf_decoder_contract.py "
+                "bash npu/eval/run_hf_decoder_materializer.sh "
                 "--model-id distilgpt2 "
                 "--contract-id llm_decoder_distilgpt2_trained_v1 "
                 f"--dataset-id {dataset_id} "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1188,8 +1188,7 @@ def test_generate_l2_campaign_task_adds_decoder_distilgpt2_quality_evidence() ->
                 "runs/models/llm_decoder_distilgpt2_trained_v1/model_contract.json"
             )
             assert "evaluator-local generated" in decoder_inputs["materialized_model_scope"]
-            assert "RTLGEN_HF_MATERIALIZER_PYTHON" in work_item.command_manifest[0]["run"]
-            assert "/orfs/tools/AutoTuner/autotuner_env/bin/python3" in work_item.command_manifest[0]["run"]
+            assert "bash npu/eval/run_hf_decoder_materializer.sh" in work_item.command_manifest[0]["run"]
             assert "--model-id distilgpt2" in work_item.command_manifest[0]["run"]
             assert "--rough-grid decoder_bf16_pwl_scale_probe_v1" in work_item.command_manifest[5]["run"]
             assert "summarize_llm_decoder_bf16_pwl_recovery.py" in work_item.command_manifest[6]["run"]
@@ -1257,7 +1256,7 @@ def test_generate_l2_campaign_task_adds_decoder_distilgpt2_prompt_stress_evidenc
             )
             assert "prompt/input-distribution stress" in decoder_inputs["trained_quality_scope"]
             assert "--dataset-id llm_decoder_eval_distilgpt2_prompt_stress_v1" in work_item.command_manifest[0]["run"]
-            assert "RTLGEN_HF_MATERIALIZER_PYTHON" in work_item.command_manifest[0]["run"]
+            assert "bash npu/eval/run_hf_decoder_materializer.sh" in work_item.command_manifest[0]["run"]
             assert "--rough-grid decoder_bf16_pwl_scale_probe_v1" in work_item.command_manifest[5]["run"]
             assert decoder_inputs["trained_quality_out"] in work_item.expected_outputs
             assert decoder_inputs["trained_quality_report"] in work_item.expected_outputs

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -40,6 +40,10 @@ It is the first step toward a reproducible closed-loop flow:
   for larger Hugging Face causal decoders such as `distilgpt2`. It writes the
   decoder model/tokenizer contracts expected by the existing harness while
   leaving large generated artifacts under gitignored paths.
+- `npu/eval/run_hf_decoder_materializer.sh`: control-plane entry point for the
+  materializer. It selects an evaluator Python with `torch`, `transformers`, and
+  `onnx`, preferring `RTLGEN_HF_MATERIALIZER_PYTHON`, then the AutoTuner env,
+  then `python3`, and reports dependency failures before running the export.
 
 The repo can now express a future exact-reference pair explicitly even before the
 assets are present: the model contract may point at a `reference_onnx_binding.json`
@@ -82,10 +86,12 @@ and should not be committed by evaluator PRs.
 
 Control-plane workers usually run commands from the control-plane venv, which
 has `onnxruntime` for decoder inference but may not have the Hugging Face export
-stack. L2 distilgpt2 jobs therefore invoke the materializer with
-`RTLGEN_HF_MATERIALIZER_PYTHON` when set, otherwise with
-`/orfs/tools/AutoTuner/autotuner_env/bin/python3` when present, and then return
-to normal `python3` commands for ONNX Runtime inference.
+stack. L2 distilgpt2 jobs therefore invoke `run_hf_decoder_materializer.sh` for
+the materialization step. Set `RTLGEN_HF_MATERIALIZER_PYTHON` in the evaluator
+daemon environment when a host uses a non-default export environment; otherwise
+the wrapper tries `/orfs/tools/AutoTuner/autotuner_env/bin/python3` and then
+`python3`. Later reference/candidate commands still use normal `python3` for
+ONNX Runtime inference.
 
 ## Validation
 Validate campaign manifest:

--- a/npu/eval/run_hf_decoder_materializer.sh
+++ b/npu/eval/run_hf_decoder_materializer.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+materializer="${repo_root}/npu/eval/materialize_hf_decoder_contract.py"
+
+declare -a candidates=()
+if [[ -n "${RTLGEN_HF_MATERIALIZER_PYTHON:-}" ]]; then
+  candidates+=("${RTLGEN_HF_MATERIALIZER_PYTHON}")
+fi
+candidates+=("/orfs/tools/AutoTuner/autotuner_env/bin/python3" "python3")
+
+resolve_python() {
+  local candidate="$1"
+  if [[ "${candidate}" == */* ]]; then
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+    return 1
+  fi
+  command -v "${candidate}"
+}
+
+probe_python() {
+  local python_bin="$1"
+  "${python_bin}" - <<'PY'
+import importlib.util
+import sys
+
+required = ("torch", "transformers", "onnx")
+missing = [name for name in required if importlib.util.find_spec(name) is None]
+if missing:
+    print(
+        "missing Hugging Face materializer dependencies: " + ", ".join(missing),
+        file=sys.stderr,
+    )
+    sys.exit(42)
+PY
+}
+
+selected_python=""
+declare -a attempts=()
+for candidate in "${candidates[@]}"; do
+  if ! resolved="$(resolve_python "${candidate}")"; then
+    attempts+=("${candidate}: not found or not executable")
+    printf 'rtlgen hf materializer: skipped %s: not found or not executable\n' "${candidate}" >&2
+    continue
+  fi
+
+  if probe_output="$(probe_python "${resolved}" 2>&1)"; then
+    selected_python="${resolved}"
+    break
+  fi
+
+  attempts+=("${resolved}: ${probe_output}")
+  printf 'rtlgen hf materializer: skipped %s: %s\n' "${resolved}" "${probe_output}" >&2
+done
+
+if [[ -z "${selected_python}" ]]; then
+  printf 'rtlgen hf materializer: no usable Python found for Hugging Face export.\n' >&2
+  printf 'rtlgen hf materializer: set RTLGEN_HF_MATERIALIZER_PYTHON to an interpreter with torch, transformers, and onnx.\n' >&2
+  for attempt in "${attempts[@]}"; do
+    printf '  - %s\n' "${attempt}" >&2
+  done
+  exit 42
+fi
+
+version="$("${selected_python}" -c 'import sys; print(sys.version.split()[0])')"
+printf 'rtlgen hf materializer: using %s (Python %s)\n' "${selected_python}" "${version}" >&2
+
+cd "${repo_root}"
+exec "${selected_python}" "${materializer}" "$@"


### PR DESCRIPTION
## Summary
- replace the inline distilgpt2 materializer shell snippet with a repo-owned wrapper
- probe candidate Python interpreters for torch/transformers/onnx before export
- document the evaluator environment override path and update generator tests

Fixes #370

## Validation
- bash -n npu/eval/run_hf_decoder_materializer.sh
- python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py
- control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check
- bash npu/eval/run_hf_decoder_materializer.sh --help