### PR TITLE
Pin compatible HF materializer packages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -191,8 +191,8 @@ ENV RTLGEN_HF_MATERIALIZER_PYTHON=/orfs/tools/AutoTuner/autotuner_env/bin/python
 # Keep this late so rebuilding the HF materializer stack does not invalidate the
 # long OpenROAD/ORFS build layers. AutoTuner already provides torch in this venv.
 RUN ${RTLGEN_HF_MATERIALIZER_PYTHON} -m pip install --no-cache-dir \
-    transformers==5.7.0 \
-    onnx==1.21.0 && \
+    transformers==4.46.3 \
+    onnx==1.17.0 && \
     ${RTLGEN_HF_MATERIALIZER_PYTHON} -c 'import importlib.util; missing = [name for name in ("torch", "transformers", "onnx") if importlib.util.find_spec(name) is None]; assert not missing, "missing HF materializer dependencies after Dockerfile install: " + ", ".join(missing)'
 
 # Set the working directory


### PR DESCRIPTION
## Summary
- pin the devcontainer HF materializer install to the known-compatible AutoTuner env versions
- use `transformers==4.46.3` because `transformers==5.7.0` expects Cache-style `past_key_values` and breaks the current tuple-based distilgpt2 ONNX export
- use `onnx==1.17.0` to match the locally validated materializer environment

## Evidence
Remote smoke `remote_hf_materializer_wrapper_smoke_v3` selected the AutoTuner Python but failed in ONNX export with:

```text
AttributeError: 'tuple' object has no attribute 'get_seq_length'
```

The local working AutoTuner environment has:

```text
torch 2.11.0
transformers 4.46.3
onnx 1.17.0
```

## Validation
- `/orfs/tools/AutoTuner/autotuner_env/bin/python3` import/version check
- `control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q`
- `git diff --check -- .devcontainer/Dockerfile`

Related: #315