### PR TITLE
Add GPT-2 decoder quality L2 item

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1514,6 +1514,11 @@ def _decoder_distilgpt2_quality_evidence_for_dataset(
     trained_quality_scope: str,
     dataset_status: str,
     dataset_notes: str,
+    command_family: str = "distilgpt2",
+    hf_model_id: str = "distilgpt2",
+    contract_id: str = "llm_decoder_distilgpt2_trained_v1",
+    model_dir: str = "runs/models/llm_decoder_distilgpt2_trained_v1",
+    tokenizer_dir: str = "runs/tokenizers/llm_decoder_distilgpt2_trained_v1",
 ) -> dict[str, Any]:
     dataset_manifest = f"{base}/manifest.json"
     sample_file = f"{base}/samples.jsonl"
@@ -1531,11 +1536,13 @@ def _decoder_distilgpt2_quality_evidence_for_dataset(
     name_mid = f"_{command_suffix}" if command_suffix else ""
     commands = [
         {
-            "name": f"materialize_decoder_distilgpt2{name_mid}_contract",
+            "name": f"materialize_decoder_{command_family}{name_mid}_contract",
             "run": (
                 "bash npu/eval/run_hf_decoder_materializer.sh "
-                "--model-id distilgpt2 "
-                "--contract-id llm_decoder_distilgpt2_trained_v1 "
+                f"--model-id {shlex.quote(hf_model_id)} "
+                f"--contract-id {contract_id} "
+                f"--model-dir {model_dir} "
+                f"--tokenizer-dir {tokenizer_dir} "
                 f"--dataset-id {dataset_id} "
                 f"--dataset-dir {base} "
                 f"--sample-file {sample_file} "
@@ -1544,7 +1551,7 @@ def _decoder_distilgpt2_quality_evidence_for_dataset(
             ),
         },
         {
-            "name": f"generate_decoder_distilgpt2{name_mid}_reference",
+            "name": f"generate_decoder_{command_family}{name_mid}_reference",
             "run": (
                 "python3 npu/eval/gen_llm_decoder_reference_suite.py "
                 f"--dataset-manifest {dataset_manifest} "
@@ -1553,7 +1560,7 @@ def _decoder_distilgpt2_quality_evidence_for_dataset(
             ),
         },
         {
-            "name": f"generate_decoder_distilgpt2{name_mid}_candidate",
+            "name": f"generate_decoder_{command_family}{name_mid}_candidate",
             "run": (
                 "python3 npu/eval/gen_llm_decoder_candidate_suite.py "
                 f"--dataset-manifest {dataset_manifest} "
@@ -1562,11 +1569,11 @@ def _decoder_distilgpt2_quality_evidence_for_dataset(
             ),
         },
         {
-            "name": f"validate_decoder_distilgpt2{name_mid}_contract",
+            "name": f"validate_decoder_{command_family}{name_mid}_contract",
             "run": f"python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest {dataset_manifest} --out {validation_out}",
         },
         {
-            "name": f"compare_decoder_distilgpt2{name_mid}_quality",
+            "name": f"compare_decoder_{command_family}{name_mid}_quality",
             "run": (
                 "python3 npu/eval/compare_llm_decoder_quality.py "
                 f"--reference-manifest {reference_manifest} "
@@ -1575,7 +1582,7 @@ def _decoder_distilgpt2_quality_evidence_for_dataset(
             ),
         },
         {
-            "name": f"sweep_decoder_distilgpt2{name_mid}_quality",
+            "name": f"sweep_decoder_{command_family}{name_mid}_quality",
             "run": (
                 "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
                 f"--dataset-manifest {dataset_manifest} "
@@ -1585,7 +1592,7 @@ def _decoder_distilgpt2_quality_evidence_for_dataset(
             ),
         },
         {
-            "name": f"summarize_decoder_distilgpt2{name_mid}_quality",
+            "name": f"summarize_decoder_{command_family}{name_mid}_quality",
             "run": (
                 "python3 npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py "
                 f"--sweep {sweep_out} "
@@ -1609,8 +1616,8 @@ def _decoder_distilgpt2_quality_evidence_for_dataset(
             "candidate_sweep_grid": rough_grid,
             "trained_quality_out": trained_out,
             "trained_quality_report": trained_report,
-            "materialized_model_contract": "runs/models/llm_decoder_distilgpt2_trained_v1/model_contract.json",
-            "materialized_tokenizer_manifest": "runs/tokenizers/llm_decoder_distilgpt2_trained_v1/manifest.json",
+            "materialized_model_contract": f"{model_dir}/model_contract.json",
+            "materialized_tokenizer_manifest": f"{tokenizer_dir}/manifest.json",
             "materialized_model_scope": materialized_model_scope,
             "trained_quality_scope": trained_quality_scope,
         },
@@ -1646,6 +1653,34 @@ def _decoder_distilgpt2_quality_evidence(*, item_id: str) -> dict[str, Any]:
         dataset_status="materialized_distilgpt2_quality_manifest_v1",
         dataset_notes=(
             "distilgpt2 trained-checkpoint confirmation dataset. Run materialize_hf_decoder_contract.py "
+            "before generating reference/candidate manifests because the model/tokenizer artifacts are gitignored."
+        ),
+    )
+
+
+def _decoder_gpt2_quality_evidence(*, item_id: str) -> dict[str, Any]:
+    return _decoder_distilgpt2_quality_evidence_for_dataset(
+        item_id=item_id,
+        base="runs/datasets/llm_decoder_eval_gpt2_trained_v1",
+        dataset_id="llm_decoder_eval_gpt2_trained_v1",
+        output_prefix="decoder_gpt2_quality",
+        command_suffix="",
+        command_family="gpt2",
+        hf_model_id="gpt2",
+        contract_id="llm_decoder_gpt2_trained_v1",
+        model_dir="runs/models/llm_decoder_gpt2_trained_v1",
+        tokenizer_dir="runs/tokenizers/llm_decoder_gpt2_trained_v1",
+        materialized_model_scope=(
+            "GPT-2 trained-checkpoint confirmation using evaluator-local generated "
+            "ONNX/tokenizer artifacts; generated model files are intentionally gitignored"
+        ),
+        trained_quality_scope=(
+            "larger 12-layer GPT-2 checkpoint confirmation for the bf16/PWL frontier after "
+            "distilgpt2 prompt-stress stayed exact-safe"
+        ),
+        dataset_status="materialized_gpt2_quality_manifest_v1",
+        dataset_notes=(
+            "GPT-2 trained-checkpoint confirmation dataset. Run materialize_hf_decoder_contract.py "
             "before generating reference/candidate manifests because the model/tokenizer artifacts are gitignored."
         ),
     )
@@ -2107,10 +2142,13 @@ def _build_payload(
         "decoder_trained_tiny_quality",
         "decoder_distilgpt2_quality",
         "decoder_distilgpt2_prompt_stress",
+        "decoder_gpt2_quality",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_gpt2_quality":
+            decoder_evidence = _decoder_gpt2_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_distilgpt2_prompt_stress":
             decoder_evidence = _decoder_distilgpt2_prompt_stress_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_distilgpt2_quality":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1265,6 +1265,71 @@ def test_generate_l2_campaign_task_adds_decoder_distilgpt2_prompt_stress_evidenc
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_gpt2_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_gpt2_quality_v1",
+                    proposal_id="prop_l2_decoder_gpt2_quality_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_gpt2_quality_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_gpt2_quality",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:7] == [
+                "materialize_decoder_gpt2_contract",
+                "generate_decoder_gpt2_reference",
+                "generate_decoder_gpt2_candidate",
+                "validate_decoder_gpt2_contract",
+                "compare_decoder_gpt2_quality",
+                "sweep_decoder_gpt2_quality",
+                "summarize_decoder_gpt2_quality",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["dataset_manifest"] == "runs/datasets/llm_decoder_eval_gpt2_trained_v1/manifest.json"
+            assert decoder_inputs["sample_file"] == "runs/datasets/llm_decoder_eval_gpt2_trained_v1/samples.jsonl"
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_bf16_pwl_scale_probe_v1"
+            assert decoder_inputs["materialized_model_contract"] == (
+                "runs/models/llm_decoder_gpt2_trained_v1/model_contract.json"
+            )
+            assert decoder_inputs["materialized_tokenizer_manifest"] == (
+                "runs/tokenizers/llm_decoder_gpt2_trained_v1/manifest.json"
+            )
+            assert "--model-id gpt2" in work_item.command_manifest[0]["run"]
+            assert "--contract-id llm_decoder_gpt2_trained_v1" in work_item.command_manifest[0]["run"]
+            assert "--model-dir runs/models/llm_decoder_gpt2_trained_v1" in work_item.command_manifest[0]["run"]
+            assert "--rough-grid decoder_bf16_pwl_scale_probe_v1" in work_item.command_manifest[5]["run"]
+            assert decoder_inputs["trained_quality_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_trained_v1/"
+                "decoder_gpt2_quality__l2_decoder_gpt2_quality_v1.json"
+            )
+            assert "12-layer GPT-2 checkpoint" in decoder_inputs["trained_quality_scope"]
+            assert decoder_inputs["trained_quality_out"] in work_item.expected_outputs
+            assert decoder_inputs["trained_quality_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_gpt2_quality",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_gpt2_quality_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_gpt2_quality_v1/evaluation_requests.json
@@ -1,0 +1,18 @@
+{
+  "proposal_id": "prop_l2_decoder_gpt2_quality_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_gpt2_quality_v1",
+      "task_type": "l2_campaign",
+      "objective": "Check whether bf16/PWL remains exact-safe on a materialized GPT-2 small decoder workload before moving to broader GPT-2 stress or QAT.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_gpt2_quality",
+      "depends_on_item_ids": [
+        "l2_decoder_distilgpt2_prompt_stress_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_gpt2_quality_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_gpt2_quality_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l2_decoder_gpt2_quality_v1",
+  "created_utc": "2026-05-04T03:20:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_gpt2_quality",
+  "title": "Decoder GPT-2 trained-checkpoint quality gate",
+  "hypothesis": "The distilgpt2 prompt-stress gate found the bf16/PWL path exact-safe across 96 prompts, but that may not hold when the trained checkpoint grows from a 6-layer distilled model to the 12-layer GPT-2 small checkpoint. A GPT-2 quality gate should isolate checkpoint scale before moving to broader GPT-2 prompt stress, QAT, or larger-array claims.",
+  "direct_comparison": {
+    "primary_question": "Does the current bf16/PWL path remain exact-safe on a GPT-2 small next-token workload?",
+    "include": [
+      "runtime materialization of gpt2 into the decoder ONNX contract",
+      "24-prompt checkpoint-scale screen aligned with the earlier distilgpt2 quality gate",
+      "exact reference and approximated candidate next-token traces",
+      "q12 exact-normalization and q8 reciprocal controls",
+      "bf16/PWL baseline and bf16/PWL logit tie-break rows"
+    ],
+    "exclude": [
+      "committing large ONNX or tokenizer artifacts",
+      "full task-accuracy benchmarking",
+      "new RTL/OpenROAD PPA measurement",
+      "training, fine tuning, or quantization-aware training",
+      "claiming robustness for larger production LLM families"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the distilgpt2 exact-safe result survives a larger trained GPT-2-family checkpoint",
+    "keeps model-scale exploration on the existing decoder quality harness",
+    "separates checkpoint-size sensitivity from prompt-distribution sensitivity before spending evaluator time on both at once"
+  ],
+  "risks": [
+    "GPT-2 small is still much smaller than current production LLMs",
+    "the prompt set is a next-token screen, not a full application benchmark",
+    "export requires torch, transformers, and onnx in the evaluator Python environment",
+    "a failure may reflect distribution or checkpoint sensitivity rather than hardware infeasibility"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_gpt2_quality_v1",
+      "task_type": "l2_campaign",
+      "objective": "Check whether bf16/PWL remains exact-safe on a materialized GPT-2 small decoder workload before moving to broader GPT-2 stress or QAT.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_gpt2_quality",
+      "depends_on_item_ids": [
+        "l2_decoder_distilgpt2_prompt_stress_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_distilgpt2_prompt_stress_v1/proposal.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_distilgpt2_prompt_stress_v1.json",
+    "runs/datasets/llm_decoder_eval_distilgpt2_prompt_stress_v1/decoder_distilgpt2_prompt_stress__l2_decoder_distilgpt2_prompt_stress_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/materialize_hf_decoder_contract.py",
+    "runs/datasets/llm_decoder_eval_gpt2_trained_v1/samples.jsonl",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_trained_v1/samples.jsonl
+++ b/runs/datasets/llm_decoder_eval_gpt2_trained_v1/samples.jsonl
@@ -1,0 +1,24 @@
+{"sample_id":"gpt2_geo_france","prompt":"The capital of France is","expected_continuation":" Paris","category":"factual_geo"}
+{"sample_id":"gpt2_geo_japan","prompt":"The capital of Japan is","expected_continuation":" Tokyo","category":"factual_geo"}
+{"sample_id":"gpt2_color_banana","prompt":"A ripe banana is usually","expected_continuation":" yellow","category":"commonsense_color"}
+{"sample_id":"gpt2_color_sky","prompt":"On a clear day, the sky is","expected_continuation":" blue","category":"commonsense_color"}
+{"sample_id":"gpt2_math_two_plus_two","prompt":"2 + 2 =","expected_continuation":" 4","category":"arithmetic_short"}
+{"sample_id":"gpt2_math_ten_minus_one","prompt":"10 - 1 =","expected_continuation":" 9","category":"arithmetic_short"}
+{"sample_id":"gpt2_weekday","prompt":"The day after Monday is","expected_continuation":" Tuesday","category":"calendar"}
+{"sample_id":"gpt2_quote","prompt":"To be or not to be, that is the","expected_continuation":" question","category":"quote_completion"}
+{"sample_id":"gpt2_code_python","prompt":"def add(a, b): return","expected_continuation":" a","category":"code_python"}
+{"sample_id":"gpt2_code_loop","prompt":"for i in range(3): print","expected_continuation":"(i)","category":"code_python"}
+{"sample_id":"gpt2_list_numbers","prompt":"One, two, three,","expected_continuation":" four","category":"sequence"}
+{"sample_id":"gpt2_list_letters","prompt":"A, B, C,","expected_continuation":" D","category":"sequence"}
+{"sample_id":"gpt2_dialogue","prompt":"User: Hello\nAssistant:","expected_continuation":" Hello","category":"dialogue"}
+{"sample_id":"gpt2_instruction","prompt":"Summarize this sentence in one word: The experiment passed.","expected_continuation":" success","category":"instruction"}
+{"sample_id":"gpt2_repetition","prompt":"ha ha ha ha","expected_continuation":" ha","category":"repetition"}
+{"sample_id":"gpt2_punctuation","prompt":"Wait, what happens next?","expected_continuation":" The","category":"punctuation"}
+{"sample_id":"gpt2_news","prompt":"In today's meeting, the team decided to","expected_continuation":" continue","category":"narrative"}
+{"sample_id":"gpt2_story","prompt":"Once upon a time, there was a small","expected_continuation":" village","category":"narrative"}
+{"sample_id":"gpt2_science","prompt":"Water freezes at","expected_continuation":" zero","category":"science_fact"}
+{"sample_id":"gpt2_history","prompt":"The first president of the United States was","expected_continuation":" George","category":"history_fact"}
+{"sample_id":"gpt2_low_margin_a","prompt":"The answer could be yes or","expected_continuation":" no","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_low_margin_b","prompt":"The next token might be one of many","expected_continuation":" possible","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_long_context","prompt":"In a compact language model evaluation, we compare exact and approximate probability paths because","expected_continuation":" small","category":"long_context"}
+{"sample_id":"gpt2_symbolic","prompt":"if x > 0 and y > 0 then","expected_continuation":" x","category":"symbolic_logic"}


### PR DESCRIPTION
## Summary
- add `decoder_gpt2_quality` as a first-class L2 generator abstraction
- parameterize the HF decoder materializer command path so GPT-2 uses separate model/tokenizer artifact dirs
- add the GPT-2 quality proposal plus 24-sample checkpoint-scale screen

## Verification
- `control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q`
- `python3 -m json.tool docs/proposals/prop_l2_decoder_gpt2_quality_v1/proposal.json >/dev/null`
- `python3 -m json.tool docs/proposals/prop_l2_decoder_gpt2_quality_v1/evaluation_requests.json >/dev/null`
