### PR TITLE
Add GPT-2 prompt-stress L2 item

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1686,6 +1686,35 @@ def _decoder_gpt2_quality_evidence(*, item_id: str) -> dict[str, Any]:
     )
 
 
+def _decoder_gpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
+    return _decoder_distilgpt2_quality_evidence_for_dataset(
+        item_id=item_id,
+        base="runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1",
+        dataset_id="llm_decoder_eval_gpt2_prompt_stress_v1",
+        output_prefix="decoder_gpt2_prompt_stress",
+        command_suffix="prompt_stress",
+        command_family="gpt2",
+        hf_model_id="gpt2",
+        contract_id="llm_decoder_gpt2_trained_v1",
+        model_dir="runs/models/llm_decoder_gpt2_trained_v1",
+        tokenizer_dir="runs/tokenizers/llm_decoder_gpt2_trained_v1",
+        materialized_model_scope=(
+            "GPT-2 prompt-stress confirmation using evaluator-local generated ONNX/tokenizer "
+            "artifacts; generated model files are intentionally gitignored and shared with the "
+            "GPT-2 quality gate"
+        ),
+        trained_quality_scope=(
+            "broader prompt/input-distribution stress check on GPT-2 small after the 24-sample "
+            "GPT-2 checkpoint gate stayed exact-safe"
+        ),
+        dataset_status="materialized_gpt2_prompt_stress_manifest_v1",
+        dataset_notes=(
+            "GPT-2 prompt-stress dataset. Run materialize_hf_decoder_contract.py before generating "
+            "reference/candidate manifests because the model/tokenizer artifacts are gitignored."
+        ),
+    )
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2143,10 +2172,13 @@ def _build_payload(
         "decoder_distilgpt2_quality",
         "decoder_distilgpt2_prompt_stress",
         "decoder_gpt2_quality",
+        "decoder_gpt2_prompt_stress",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_gpt2_prompt_stress":
+            decoder_evidence = _decoder_gpt2_prompt_stress_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_gpt2_quality":
             decoder_evidence = _decoder_gpt2_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_distilgpt2_prompt_stress":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1330,6 +1330,71 @@ def test_generate_l2_campaign_task_adds_decoder_gpt2_quality_evidence() -> None:
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_gpt2_prompt_stress_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_gpt2_prompt_stress_v1",
+                    proposal_id="prop_l2_decoder_gpt2_prompt_stress_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_gpt2_prompt_stress_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_gpt2_prompt_stress",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:7] == [
+                "materialize_decoder_gpt2_prompt_stress_contract",
+                "generate_decoder_gpt2_prompt_stress_reference",
+                "generate_decoder_gpt2_prompt_stress_candidate",
+                "validate_decoder_gpt2_prompt_stress_contract",
+                "compare_decoder_gpt2_prompt_stress_quality",
+                "sweep_decoder_gpt2_prompt_stress_quality",
+                "summarize_decoder_gpt2_prompt_stress_quality",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["dataset_manifest"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/manifest.json"
+            )
+            assert decoder_inputs["sample_file"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/samples.jsonl"
+            )
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_bf16_pwl_scale_probe_v1"
+            assert decoder_inputs["materialized_model_contract"] == (
+                "runs/models/llm_decoder_gpt2_trained_v1/model_contract.json"
+            )
+            assert decoder_inputs["trained_quality_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_gpt2_prompt_stress__l2_decoder_gpt2_prompt_stress_v1.json"
+            )
+            assert "prompt/input-distribution stress" in decoder_inputs["trained_quality_scope"]
+            assert "--dataset-id llm_decoder_eval_gpt2_prompt_stress_v1" in work_item.command_manifest[0]["run"]
+            assert "--model-id gpt2" in work_item.command_manifest[0]["run"]
+            assert "--rough-grid decoder_bf16_pwl_scale_probe_v1" in work_item.command_manifest[5]["run"]
+            assert decoder_inputs["trained_quality_out"] in work_item.expected_outputs
+            assert decoder_inputs["trained_quality_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_gpt2_prompt_stress",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_gpt2_prompt_stress_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_gpt2_prompt_stress_v1/evaluation_requests.json
@@ -1,0 +1,18 @@
+{
+  "proposal_id": "prop_l2_decoder_gpt2_prompt_stress_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_gpt2_prompt_stress_v1",
+      "task_type": "l2_campaign",
+      "objective": "Check whether bf16/PWL remains exact-safe on a broader GPT-2 small prompt-stress workload before moving to QAT or larger-array claims.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_gpt2_prompt_stress",
+      "depends_on_item_ids": [
+        "l2_decoder_gpt2_quality_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_gpt2_prompt_stress_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_gpt2_prompt_stress_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l2_decoder_gpt2_prompt_stress_v1",
+  "created_utc": "2026-05-04T03:35:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_gpt2_prompt_stress",
+  "title": "Decoder GPT-2 prompt-stress quality gate",
+  "hypothesis": "The 24-prompt GPT-2 checkpoint gate found bf16/PWL exact-safe, while q8 reciprocal already showed one prompt-sensitive miss. A broader GPT-2 prompt-stress screen should test whether bf16/PWL remains stable across factual, arithmetic, sequence, code, dialogue, quote, narrative, long-context, ambiguous, and symbolic prompt regimes before moving to QAT or larger-array claims.",
+  "direct_comparison": {
+    "primary_question": "Does the current bf16/PWL path remain exact-safe across a broader GPT-2 small next-token prompt distribution?",
+    "include": [
+      "runtime materialization of gpt2 into the decoder ONNX contract",
+      "96-prompt stress set spanning factual, arithmetic, sequence, code, dialogue, quote, narrative, long-context, ambiguous, and symbolic categories",
+      "exact reference and approximated candidate next-token traces",
+      "q12 exact-normalization and q8 reciprocal controls",
+      "bf16/PWL baseline and bf16/PWL logit tie-break rows"
+    ],
+    "exclude": [
+      "committing large ONNX or tokenizer artifacts",
+      "full task-accuracy benchmarking",
+      "new RTL/OpenROAD PPA measurement",
+      "training, fine tuning, or quantization-aware training",
+      "claiming robustness for larger production LLM families"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the GPT-2 exact-safe result survives broader prompt/input distributions",
+    "keeps the next frontier step on the existing decoder quality harness",
+    "exposes miss buckets before spending evaluator time on QAT, GPT-2-scale prompt expansion, or larger hardware arrays"
+  ],
+  "risks": [
+    "GPT-2 small is still much smaller than current production LLMs",
+    "the prompt set is a next-token stress screen, not a full application benchmark",
+    "export requires torch, transformers, and onnx in the evaluator Python environment",
+    "a failure may reflect distribution sensitivity rather than hardware infeasibility"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_gpt2_prompt_stress_v1",
+      "task_type": "l2_campaign",
+      "objective": "Check whether bf16/PWL remains exact-safe on a broader GPT-2 small prompt-stress workload before moving to QAT or larger-array claims.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_gpt2_prompt_stress",
+      "depends_on_item_ids": [
+        "l2_decoder_gpt2_quality_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_gpt2_quality_v1/proposal.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_gpt2_quality_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_trained_v1/decoder_gpt2_quality__l2_decoder_gpt2_quality_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/materialize_hf_decoder_contract.py",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/samples.jsonl",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "npu/eval/summarize_llm_decoder_bf16_pwl_recovery.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/samples.jsonl
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/samples.jsonl
@@ -1,0 +1,96 @@
+{"sample_id":"gpt2_stress_geo_france_capital","prompt":"The capital city of France is","expected_continuation":" Paris","category":"factual_geo"}
+{"sample_id":"gpt2_stress_geo_japan_capital","prompt":"The capital city of Japan is","expected_continuation":" Tokyo","category":"factual_geo"}
+{"sample_id":"gpt2_stress_geo_germany_capital","prompt":"The capital city of Germany is","expected_continuation":" Berlin","category":"factual_geo"}
+{"sample_id":"gpt2_stress_geo_italy_capital","prompt":"The capital city of Italy is","expected_continuation":" Rome","category":"factual_geo"}
+{"sample_id":"gpt2_stress_geo_spain_capital","prompt":"The capital city of Spain is","expected_continuation":" Madrid","category":"factual_geo"}
+{"sample_id":"gpt2_stress_geo_canada_capital","prompt":"The capital city of Canada is","expected_continuation":" Ottawa","category":"factual_geo"}
+{"sample_id":"gpt2_stress_geo_australia_capital","prompt":"The capital city of Australia is","expected_continuation":" Canberra","category":"factual_geo"}
+{"sample_id":"gpt2_stress_geo_brazil_capital","prompt":"The capital city of Brazil is","expected_continuation":" Brasilia","category":"factual_geo"}
+{"sample_id":"gpt2_stress_science_water_freezes","prompt":"Water freezes at zero degrees","expected_continuation":" Celsius","category":"science_fact"}
+{"sample_id":"gpt2_stress_science_water_boils","prompt":"Water boils at one hundred degrees","expected_continuation":" Celsius","category":"science_fact"}
+{"sample_id":"gpt2_stress_science_earth_orbits","prompt":"The Earth orbits around the","expected_continuation":" Sun","category":"science_fact"}
+{"sample_id":"gpt2_stress_science_moon_orbits","prompt":"The Moon orbits around the","expected_continuation":" Earth","category":"science_fact"}
+{"sample_id":"gpt2_stress_science_humans_breathe","prompt":"Humans breathe in oxygen and breathe out","expected_continuation":" carbon","category":"science_fact"}
+{"sample_id":"gpt2_stress_science_plants_need","prompt":"Plants need sunlight, water, and","expected_continuation":" carbon","category":"science_fact"}
+{"sample_id":"gpt2_stress_science_ice_is","prompt":"Ice is the solid form of","expected_continuation":" water","category":"science_fact"}
+{"sample_id":"gpt2_stress_science_fire_is","prompt":"Fire is usually hot and produces","expected_continuation":" light","category":"science_fact"}
+{"sample_id":"gpt2_stress_color_banana","prompt":"A ripe banana is usually","expected_continuation":" yellow","category":"commonsense_color"}
+{"sample_id":"gpt2_stress_color_sky","prompt":"On a clear day, the sky is","expected_continuation":" blue","category":"commonsense_color"}
+{"sample_id":"gpt2_stress_color_grass","prompt":"Healthy grass is usually","expected_continuation":" green","category":"commonsense_color"}
+{"sample_id":"gpt2_stress_color_snow","prompt":"Fresh snow is usually","expected_continuation":" white","category":"commonsense_color"}
+{"sample_id":"gpt2_stress_color_coal","prompt":"A piece of coal is usually","expected_continuation":" black","category":"commonsense_color"}
+{"sample_id":"gpt2_stress_color_lime","prompt":"A ripe lime is usually","expected_continuation":" green","category":"commonsense_color"}
+{"sample_id":"gpt2_stress_color_strawberry","prompt":"A ripe strawberry is usually","expected_continuation":" red","category":"commonsense_color"}
+{"sample_id":"gpt2_stress_color_ocean","prompt":"From far away, the ocean often looks","expected_continuation":" blue","category":"commonsense_color"}
+{"sample_id":"gpt2_stress_math_two_plus_two","prompt":"2 + 2 =","expected_continuation":" 4","category":"arithmetic_short"}
+{"sample_id":"gpt2_stress_math_seven_plus_five","prompt":"7 + 5 =","expected_continuation":" 12","category":"arithmetic_short"}
+{"sample_id":"gpt2_stress_math_ten_minus_three","prompt":"10 - 3 =","expected_continuation":" 7","category":"arithmetic_short"}
+{"sample_id":"gpt2_stress_math_nine_minus_four","prompt":"9 - 4 =","expected_continuation":" 5","category":"arithmetic_short"}
+{"sample_id":"gpt2_stress_math_three_times_three","prompt":"3 * 3 =","expected_continuation":" 9","category":"arithmetic_short"}
+{"sample_id":"gpt2_stress_math_four_times_five","prompt":"4 * 5 =","expected_continuation":" 20","category":"arithmetic_short"}
+{"sample_id":"gpt2_stress_math_eight_div_two","prompt":"8 / 2 =","expected_continuation":" 4","category":"arithmetic_short"}
+{"sample_id":"gpt2_stress_math_half_of_ten","prompt":"Half of ten is","expected_continuation":" five","category":"arithmetic_short"}
+{"sample_id":"gpt2_stress_sequence_numbers","prompt":"One, two, three, four,","expected_continuation":" five","category":"sequence"}
+{"sample_id":"gpt2_stress_sequence_letters","prompt":"A, B, C, D,","expected_continuation":" E","category":"sequence"}
+{"sample_id":"gpt2_stress_sequence_weekdays","prompt":"Monday, Tuesday, Wednesday,","expected_continuation":" Thursday","category":"sequence"}
+{"sample_id":"gpt2_stress_sequence_months","prompt":"January, February, March,","expected_continuation":" April","category":"sequence"}
+{"sample_id":"gpt2_stress_sequence_countdown","prompt":"Five, four, three, two,","expected_continuation":" one","category":"sequence"}
+{"sample_id":"gpt2_stress_sequence_planets","prompt":"Mercury, Venus, Earth,","expected_continuation":" Mars","category":"sequence"}
+{"sample_id":"gpt2_stress_sequence_directions","prompt":"North, south, east, and","expected_continuation":" west","category":"sequence"}
+{"sample_id":"gpt2_stress_sequence_alphabet_end","prompt":"X, Y,","expected_continuation":" Z","category":"sequence"}
+{"sample_id":"gpt2_stress_code_python_return_sum","prompt":"def add(a, b):\n    return","expected_continuation":" a","category":"code_python"}
+{"sample_id":"gpt2_stress_code_python_loop_print","prompt":"for i in range(3):\n    print","expected_continuation":"(i)","category":"code_python"}
+{"sample_id":"gpt2_stress_code_python_if_positive","prompt":"if x > 0:\n    print","expected_continuation":"(\"","category":"code_python"}
+{"sample_id":"gpt2_stress_code_python_list_append","prompt":"items = []\nitems.append","expected_continuation":"(","category":"code_python"}
+{"sample_id":"gpt2_stress_code_js_function","prompt":"function add(a, b) { return","expected_continuation":" a","category":"code_javascript"}
+{"sample_id":"gpt2_stress_code_js_console","prompt":"for (let i = 0; i < 3; i++) console.log","expected_continuation":"(","category":"code_javascript"}
+{"sample_id":"gpt2_stress_code_json_key","prompt":"{\"name\":","expected_continuation":" \"","category":"code_json"}
+{"sample_id":"gpt2_stress_code_sql_select","prompt":"SELECT name FROM users WHERE id =","expected_continuation":" 1","category":"code_sql"}
+{"sample_id":"gpt2_stress_dialogue_greeting","prompt":"User: Hello\nAssistant:","expected_continuation":" Hello","category":"dialogue"}
+{"sample_id":"gpt2_stress_dialogue_help","prompt":"User: Can you help me?\nAssistant:","expected_continuation":" Yes","category":"dialogue"}
+{"sample_id":"gpt2_stress_dialogue_thanks","prompt":"User: Thanks for your help.\nAssistant:","expected_continuation":" You","category":"dialogue"}
+{"sample_id":"gpt2_stress_dialogue_question","prompt":"User: What time is it?\nAssistant:","expected_continuation":" I","category":"dialogue"}
+{"sample_id":"gpt2_stress_dialogue_weather","prompt":"User: Is it raining?\nAssistant:","expected_continuation":" I","category":"dialogue"}
+{"sample_id":"gpt2_stress_dialogue_name","prompt":"User: What is your name?\nAssistant:","expected_continuation":" I","category":"dialogue"}
+{"sample_id":"gpt2_stress_dialogue_goodbye","prompt":"User: Goodbye\nAssistant:","expected_continuation":" Goodbye","category":"dialogue"}
+{"sample_id":"gpt2_stress_dialogue_summary","prompt":"User: Summarize this in one word: excellent.\nAssistant:","expected_continuation":" excellent","category":"dialogue"}
+{"sample_id":"gpt2_stress_quote_shakespeare","prompt":"To be or not to be, that is the","expected_continuation":" question","category":"quote_completion"}
+{"sample_id":"gpt2_stress_quote_kennedy","prompt":"Ask not what your country can do for","expected_continuation":" you","category":"quote_completion"}
+{"sample_id":"gpt2_stress_quote_lorem","prompt":"Lorem ipsum dolor sit","expected_continuation":" amet","category":"quote_completion"}
+{"sample_id":"gpt2_stress_quote_once_time","prompt":"Once upon a time, there was a","expected_continuation":" little","category":"quote_completion"}
+{"sample_id":"gpt2_stress_quote_call_me","prompt":"Call me","expected_continuation":" Ishmael","category":"quote_completion"}
+{"sample_id":"gpt2_stress_quote_best_times","prompt":"It was the best of times, it was the","expected_continuation":" worst","category":"quote_completion"}
+{"sample_id":"gpt2_stress_quote_dark_stormy","prompt":"It was a dark and stormy","expected_continuation":" night","category":"quote_completion"}
+{"sample_id":"gpt2_stress_quote_four_score","prompt":"Four score and seven years","expected_continuation":" ago","category":"quote_completion"}
+{"sample_id":"gpt2_stress_narrative_meeting","prompt":"In today's meeting, the team decided to","expected_continuation":" continue","category":"narrative"}
+{"sample_id":"gpt2_stress_narrative_story","prompt":"The small village was quiet until","expected_continuation":" the","category":"narrative"}
+{"sample_id":"gpt2_stress_narrative_robot","prompt":"The robot opened its eyes and","expected_continuation":" saw","category":"narrative"}
+{"sample_id":"gpt2_stress_narrative_lab","prompt":"Inside the laboratory, the experiment began to","expected_continuation":" fail","category":"narrative"}
+{"sample_id":"gpt2_stress_narrative_train","prompt":"The train arrived late because","expected_continuation":" the","category":"narrative"}
+{"sample_id":"gpt2_stress_narrative_market","prompt":"At the market, she bought apples and","expected_continuation":" oranges","category":"narrative"}
+{"sample_id":"gpt2_stress_narrative_letter","prompt":"He opened the letter and read the","expected_continuation":" first","category":"narrative"}
+{"sample_id":"gpt2_stress_narrative_map","prompt":"The old map showed a path through the","expected_continuation":" forest","category":"narrative"}
+{"sample_id":"gpt2_stress_long_decoder","prompt":"In a compact language model evaluation, we compare exact and approximate probability paths because small numerical changes can alter","expected_continuation":" the","category":"long_context"}
+{"sample_id":"gpt2_stress_long_quant","prompt":"When a decoder uses a quantized softmax approximation, the most useful diagnostic is not only aggregate accuracy but also the distribution of","expected_continuation":" errors","category":"long_context"}
+{"sample_id":"gpt2_stress_long_hardware","prompt":"A hardware accelerator that looks efficient on a tiny prompt can still fail when the same approximation meets a broader set of","expected_continuation":" inputs","category":"long_context"}
+{"sample_id":"gpt2_stress_long_margin","prompt":"The top two logits can be separated by a large margin or by a very small margin, and this matters because","expected_continuation":" the","category":"long_context"}
+{"sample_id":"gpt2_stress_long_training","prompt":"Quantization-aware training can sometimes recover ranking errors, but before adding that machinery we should first measure whether","expected_continuation":" the","category":"long_context"}
+{"sample_id":"gpt2_stress_long_model","prompt":"Moving from a tiny decoder to gpt2 changes the trained weight distribution, hidden dimension, and layer count while keeping","expected_continuation":" the","category":"long_context"}
+{"sample_id":"gpt2_stress_long_cache","prompt":"During autoregressive decoding, the key value cache grows with each token, so a practical accelerator must manage both compute and","expected_continuation":" memory","category":"long_context"}
+{"sample_id":"gpt2_stress_long_frontier","prompt":"The current frontier is promising only if the exact-safe result remains stable across prompts that represent different entropy and","expected_continuation":" margin","category":"long_context"}
+{"sample_id":"gpt2_stress_ambiguous_yes_no","prompt":"The answer could be yes or","expected_continuation":" no","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_stress_ambiguous_many_options","prompt":"The next token might be one of many","expected_continuation":" possible","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_stress_ambiguous_left_right","prompt":"Turn left or","expected_continuation":" right","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_stress_ambiguous_hot_cold","prompt":"The drink may be hot or","expected_continuation":" cold","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_stress_ambiguous_up_down","prompt":"The switch can be up or","expected_continuation":" down","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_stress_ambiguous_true_false","prompt":"The statement is either true or","expected_continuation":" false","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_stress_ambiguous_start_stop","prompt":"The command says start or","expected_continuation":" stop","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_stress_ambiguous_more_less","prompt":"The value may become more or","expected_continuation":" less","category":"ambiguous_low_margin"}
+{"sample_id":"gpt2_stress_symbolic_if_positive","prompt":"if x > 0 and y > 0 then","expected_continuation":" x","category":"symbolic_logic"}
+{"sample_id":"gpt2_stress_symbolic_boolean","prompt":"True and False equals","expected_continuation":" False","category":"symbolic_logic"}
+{"sample_id":"gpt2_stress_symbolic_compare","prompt":"If A is greater than B, then B is","expected_continuation":" less","category":"symbolic_logic"}
+{"sample_id":"gpt2_stress_symbolic_set","prompt":"If every cat is an animal and Luna is a cat, then Luna is an","expected_continuation":" animal","category":"symbolic_logic"}
+{"sample_id":"gpt2_stress_symbolic_parentheses","prompt":"The expression (a + b) * c expands to","expected_continuation":" a","category":"symbolic_logic"}
+{"sample_id":"gpt2_stress_symbolic_negation","prompt":"If it is not raining, then the ground may be","expected_continuation":" dry","category":"symbolic_logic"}
+{"sample_id":"gpt2_stress_symbolic_either","prompt":"Either the test passes or it","expected_continuation":" fails","category":"symbolic_logic"}
+{"sample_id":"gpt2_stress_symbolic_all_some","prompt":"All squares are rectangles, but not all rectangles are","expected_continuation":" squares","category":"symbolic_logic"}


### PR DESCRIPTION
## Summary
- add `decoder_gpt2_prompt_stress` as a first-class L2 generator abstraction
- reuse the GPT-2 materialized contract dirs with a separate 96-prompt stress dataset
- add the GPT-2 prompt-stress proposal and evaluation request

## Verification
- `control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q`
- `python3 -m json.tool docs/proposals/prop_l2_decoder_gpt2_prompt_stress_v1/proposal.json >/dev/null`
- `python3 -m json.tool docs/proposals/prop_l2_decoder_gpt2_prompt_stress_v1/evaluation_requests.json >/dev/null`
- `wc -l runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/samples.jsonl`
