### PR TITLE
[codex] Add GPT-2 logit rank bypass L2 item

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1751,6 +1751,126 @@ def _decoder_gpt2_tie_rank_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_gpt2_logit_rank_bypass_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    dataset_id = "llm_decoder_eval_gpt2_prompt_stress_v1"
+    dataset_manifest = f"{base}/manifest.json"
+    sample_file = f"{base}/samples.jsonl"
+    reference_dir = f"{base}/reference"
+    reference_manifest = f"{base}/reference_manifest.json"
+    candidate_dir = f"{base}/candidate"
+    candidate_manifest = f"{base}/candidate_manifest.json"
+    validation_out = f"{base}/decoder_contract_validation__{item_id}.json"
+    quality_out = f"{base}/decoder_quality_compare__{item_id}.json"
+    sweep_dir = f"{base}/candidate_sweeps/{item_id}"
+    sweep_out = f"{base}/decoder_quality_sweep__{item_id}.json"
+    bypass_out = f"{base}/decoder_gpt2_logit_rank_bypass__{item_id}.json"
+    bypass_report = f"{base}/decoder_gpt2_logit_rank_bypass__{item_id}.md"
+    rough_grid = "decoder_logit_rank_bypass_v1"
+    rank_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json"
+    commands = [
+        {
+            "name": "materialize_decoder_gpt2_logit_rank_bypass_contract",
+            "run": (
+                "bash npu/eval/run_hf_decoder_materializer.sh "
+                "--model-id gpt2 "
+                "--contract-id llm_decoder_gpt2_trained_v1 "
+                "--model-dir runs/models/llm_decoder_gpt2_trained_v1 "
+                "--tokenizer-dir runs/tokenizers/llm_decoder_gpt2_trained_v1 "
+                f"--dataset-id {dataset_id} "
+                f"--dataset-dir {base} "
+                f"--sample-file {sample_file} "
+                "--dataset-status materialized_gpt2_logit_rank_bypass_manifest_v1 "
+                "--dataset-notes 'GPT-2 prompt-stress logit-rank bypass dataset. Run materialization because model/tokenizer artifacts are gitignored.'"
+            ),
+        },
+        {
+            "name": "generate_decoder_gpt2_logit_rank_bypass_reference",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_reference_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {reference_dir} "
+                f"--out-manifest {reference_manifest}"
+            ),
+        },
+        {
+            "name": "generate_decoder_gpt2_logit_rank_bypass_candidate",
+            "run": (
+                "python3 npu/eval/gen_llm_decoder_candidate_suite.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--out-dir {candidate_dir} "
+                f"--out-manifest {candidate_manifest}"
+            ),
+        },
+        {
+            "name": "validate_decoder_gpt2_logit_rank_bypass_contract",
+            "run": f"python3 npu/eval/validate_llm_decoder_contract.py --dataset-manifest {dataset_manifest} --out {validation_out}",
+        },
+        {
+            "name": "compare_decoder_gpt2_logit_rank_bypass_quality",
+            "run": (
+                "python3 npu/eval/compare_llm_decoder_quality.py "
+                f"--reference-manifest {reference_manifest} "
+                f"--candidate-manifest {candidate_manifest} "
+                f"--out {quality_out}"
+            ),
+        },
+        {
+            "name": "sweep_decoder_gpt2_logit_rank_bypass_quality",
+            "run": (
+                "python3 npu/eval/sweep_llm_decoder_candidate_quality.py "
+                f"--dataset-manifest {dataset_manifest} "
+                f"--rough-grid {rough_grid} "
+                f"--out-dir {sweep_dir} "
+                f"--out {sweep_out}"
+            ),
+        },
+        {
+            "name": "summarize_decoder_gpt2_logit_rank_bypass",
+            "run": (
+                "python3 npu/eval/summarize_llm_decoder_logit_rank_bypass.py "
+                f"--sweep {sweep_out} "
+                f"--rank-ppa {rank_ppa} "
+                f"--out {bypass_out} "
+                f"--out-md {bypass_report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            "dataset_manifest": dataset_manifest,
+            "sample_file": sample_file,
+            "reference_dir": reference_dir,
+            "reference_manifest": reference_manifest,
+            "candidate_dir": candidate_dir,
+            "candidate_manifest": candidate_manifest,
+            "validation_out": validation_out,
+            "quality_out": quality_out,
+            "candidate_sweep_dir": sweep_dir,
+            "candidate_sweep_out": sweep_out,
+            "candidate_sweep_grid": rough_grid,
+            "logit_rank_bypass_out": bypass_out,
+            "logit_rank_bypass_report": bypass_report,
+            "rank_datapath_proxy_ppa": rank_ppa,
+            "logit_rank_bypass_scope": (
+                "greedy/top-k GPT-2 prompt-stress check that bypasses softmax and ranks transformed logits "
+                "directly; sampling modes remain out of scope because they require probabilities"
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            dataset_manifest,
+            reference_manifest,
+            candidate_manifest,
+            validation_out,
+            quality_out,
+            sweep_out,
+            bypass_out,
+            bypass_report,
+        ],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2210,10 +2330,13 @@ def _build_payload(
         "decoder_gpt2_quality",
         "decoder_gpt2_prompt_stress",
         "decoder_gpt2_tie_rank_frontier",
+        "decoder_gpt2_logit_rank_bypass",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_gpt2_logit_rank_bypass":
+            decoder_evidence = _decoder_gpt2_logit_rank_bypass_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_gpt2_tie_rank_frontier":
             decoder_evidence = _decoder_gpt2_tie_rank_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_gpt2_prompt_stress":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1448,6 +1448,64 @@ def test_generate_l2_campaign_task_adds_decoder_gpt2_tie_rank_frontier_evidence(
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_gpt2_logit_rank_bypass_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_gpt2_logit_rank_bypass_v1",
+                    proposal_id="prop_l2_decoder_gpt2_logit_rank_bypass_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_gpt2_logit_rank_bypass",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:7] == [
+                "materialize_decoder_gpt2_logit_rank_bypass_contract",
+                "generate_decoder_gpt2_logit_rank_bypass_reference",
+                "generate_decoder_gpt2_logit_rank_bypass_candidate",
+                "validate_decoder_gpt2_logit_rank_bypass_contract",
+                "compare_decoder_gpt2_logit_rank_bypass_quality",
+                "sweep_decoder_gpt2_logit_rank_bypass_quality",
+                "summarize_decoder_gpt2_logit_rank_bypass",
+            ]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["candidate_sweep_grid"] == "decoder_logit_rank_bypass_v1"
+            assert decoder_inputs["rank_datapath_proxy_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json"
+            )
+            assert decoder_inputs["logit_rank_bypass_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_gpt2_logit_rank_bypass__l2_decoder_gpt2_logit_rank_bypass_v1.json"
+            )
+            assert "sampling modes remain out of scope" in decoder_inputs["logit_rank_bypass_scope"]
+            assert "--rough-grid decoder_logit_rank_bypass_v1" in work_item.command_manifest[5]["run"]
+            assert "summarize_llm_decoder_logit_rank_bypass.py" in work_item.command_manifest[6]["run"]
+            assert decoder_inputs["logit_rank_bypass_out"] in work_item.expected_outputs
+            assert decoder_inputs["logit_rank_bypass_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_gpt2_logit_rank_bypass",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_gpt2_logit_rank_bypass_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_gpt2_logit_rank_bypass_v1",
+      "task_type": "l2_campaign",
+      "objective": "Confirm that GPT-2 prompt-stress greedy/top-k decoding can bypass softmax and rank raw logits exactly, with sampling modes explicitly out of scope.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_gpt2_logit_rank_bypass",
+      "depends_on_item_ids": [
+        "l2_decoder_gpt2_prompt_stress_v1",
+        "l2_decoder_gpt2_tie_rank_frontier_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The job should determine whether rank-only GPT-2 decoding can remove the softmax and reciprocal-normalization datapaths from the current frontier without changing greedy next-token or top-k decisions."
+      },
+      "status": "planned"
+    }
+  ],
+  "source_commit": "5ffb53d8be5021027ed206af7836aa9a913632f3"
+}

--- a/docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l2_decoder_gpt2_logit_rank_bypass_v1",
+  "created_utc": "2026-05-04T07:05:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_gpt2_logit_rank_bypass",
+  "title": "Decoder GPT-2 raw-logit rank bypass",
+  "hypothesis": "For greedy next-token, top-k, and beam candidate ranking, decoder logits can be ranked directly without computing softmax probabilities, removing the reciprocal-normalization datapath from the current GPT-2 prompt-stress frontier while preserving exact rank decisions.",
+  "direct_comparison": {
+    "primary_question": "Does a GPT-2 prompt-stress candidate that bypasses softmax and ranks raw logits match the exact-softmax next-token and top-k decisions?",
+    "include": [
+      "GPT-2 prompt-stress materialization",
+      "exact-softmax reference candidate",
+      "raw-logit rank-bypass candidate",
+      "next-token and top-k exactness checks",
+      "explicit scope split between rank-only decoding and sampling/probability consumers",
+      "rank datapath PPA proxy from the merged bf16 score/logit tie-rank block"
+    ],
+    "exclude": [
+      "temperature sampling",
+      "top-p sampling",
+      "probability reporting",
+      "new OpenROAD physical synthesis",
+      "training or quantization-aware training",
+      "larger-model or larger-array proof"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the immediate decoder frontier can remove softmax normalization entirely for rank-only generation paths",
+    "separates rank-only serving from probability-producing serving modes before starting QAT",
+    "keeps the claim quality-gated on GPT-2 prompt-stress evidence instead of relying only on mathematical monotonicity"
+  ],
+  "risks": [
+    "the claim only applies to monotonic rank consumers and does not cover sampling modes",
+    "the PPA row is a conservative rank-datapath proxy until a dedicated logit-only top-k/rank block is measured",
+    "the GPT-2 prompt-stress set is still a bounded next-token screen, not a larger-model conclusion"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_gpt2_logit_rank_bypass_v1",
+      "task_type": "l2_campaign",
+      "objective": "Confirm that GPT-2 prompt-stress greedy/top-k decoding can bypass softmax and rank raw logits exactly, with sampling modes explicitly out of scope.",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign.json",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_gpt2_logit_rank_bypass",
+      "depends_on_item_ids": [
+        "l2_decoder_gpt2_prompt_stress_v1",
+        "l2_decoder_gpt2_tie_rank_frontier_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_gpt2_prompt_stress_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_gpt2_tie_rank_frontier_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_gpt2_prompt_stress__l2_decoder_gpt2_prompt_stress_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_gpt2_tie_rank_frontier__l2_decoder_gpt2_tie_rank_frontier_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/run_llm_decoder_onnx_candidate.py",
+    "npu/eval/sweep_llm_decoder_candidate_quality.py",
+    "npu/eval/summarize_llm_decoder_logit_rank_bypass.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/run_llm_decoder_onnx_candidate.py
+++ b/npu/eval/run_llm_decoder_onnx_candidate.py
@@ -406,6 +406,12 @@ def _apply_softmax_path(logits: Sequence[float], backend_config: JsonDict) -> Tu
     mode = str(backend_config.get('softmax_mode', 'exact'))
     input_float_format = str(backend_config.get('softmax_input_float_format', '') or '').strip()
     weight_float_format = str(backend_config.get('softmax_weight_float_format', '') or '').strip()
+    if mode == 'logit_rank_bypass':
+        return [float(v) for v in logits], {
+            'mode': 'logit_rank_bypass',
+            'scope': 'greedy_or_topk_ranking_only',
+            'note': 'Softmax is bypassed; scores are transformed logits used directly for ranking.',
+        }
     if mode == 'exact':
         return _softmax_exact(
             logits,
@@ -427,6 +433,12 @@ def _apply_softmax_path(logits: Sequence[float], backend_config: JsonDict) -> Tu
 
 def _apply_normalization_path(weights: Sequence[float], backend_config: JsonDict) -> Tuple[list[float], JsonDict]:
     mode = str(backend_config.get('normalization_mode', 'exact'))
+    if mode == 'rank_bypass':
+        return [float(v) for v in weights], {
+            'mode': 'rank_bypass',
+            'scope': 'greedy_or_topk_ranking_only',
+            'note': 'Normalization is bypassed because logit ranking does not require probabilities.',
+        }
     if mode == 'exact':
         return _normalize_exact(weights)
     if mode == 'reciprocal_quantized':

--- a/npu/eval/summarize_llm_decoder_logit_rank_bypass.py
+++ b/npu/eval/summarize_llm_decoder_logit_rank_bypass.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Summarize greedy/top-k decoder quality for raw-logit rank bypass."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+EXACT_TEMPLATE = "candidate_onnx_softmax_exact"
+BYPASS_TEMPLATE = "candidate_onnx_logit_rank_bypass"
+DEFAULT_TIE_RANK_PPA = Path(
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json"
+)
+
+
+def _load_json(path: Path) -> JsonDict:
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _template_row(sweep: JsonDict, template: str) -> JsonDict:
+    rows = sweep.get("templates")
+    if not isinstance(rows, list):
+        raise SystemExit("sweep JSON must contain a templates list")
+    for row in rows:
+        if isinstance(row, dict) and str(row.get("template") or "") == template:
+            return row
+    raise SystemExit(f"missing required template row: {template}")
+
+
+def _quality(row: JsonDict) -> JsonDict:
+    sample_count = _as_int(row.get("sample_count"))
+    next_rate = _as_float(row.get("next_token_id_match_rate"))
+    topk_rate = _as_float(row.get("topk_contains_reference_id_rate"))
+    next_matches = round(next_rate * sample_count)
+    topk_matches = round(topk_rate * sample_count)
+    exact_safe = sample_count > 0 and next_matches == sample_count and topk_matches == sample_count
+    return {
+        "sample_count": sample_count,
+        "next_token_matches": next_matches,
+        "topk_matches": topk_matches,
+        "next_token_match_rate": next_rate,
+        "topk_contains_reference_rate": topk_rate,
+        "next_token_mismatch_sample_ids": row.get("next_token_mismatch_sample_ids") or [],
+        "topk_miss_sample_ids": row.get("topk_miss_sample_ids") or [],
+        "exact_safe": exact_safe,
+    }
+
+
+def _best_ppa(path: Path | None) -> JsonDict | None:
+    if path is None or not path.exists():
+        return None
+    payload = _load_json(path)
+    rows = []
+    for proposal in payload.get("proposals") or []:
+        if not isinstance(proposal, dict):
+            continue
+        metrics_ref = proposal.get("metrics_ref")
+        metrics = proposal.get("metric_summary")
+        if not isinstance(metrics_ref, dict) or not isinstance(metrics, dict):
+            continue
+        if str(metrics_ref.get("status") or "") != "ok":
+            continue
+        row = {
+            "metrics_ref": metrics_ref,
+            "metrics": {
+                "critical_path_ns": _as_float(metrics.get("critical_path_ns")),
+                "die_area": _as_float(metrics.get("die_area")),
+                "total_power_mw": _as_float(metrics.get("total_power_mw")),
+            },
+            "selection_reason": proposal.get("selection_reason", ""),
+        }
+        rows.append(row)
+    if not rows:
+        return None
+    rows.sort(key=lambda row: (
+        row["metrics"]["critical_path_ns"],
+        row["metrics"]["die_area"],
+        row["metrics"]["total_power_mw"],
+    ))
+    return rows[0]
+
+
+def build_report(*, sweep_path: Path, rank_ppa_path: Path | None = DEFAULT_TIE_RANK_PPA) -> JsonDict:
+    sweep = _load_json(sweep_path)
+    exact = _template_row(sweep, EXACT_TEMPLATE)
+    bypass = _template_row(sweep, BYPASS_TEMPLATE)
+    exact_quality = _quality(exact)
+    bypass_quality = _quality(bypass)
+    rank_ppa = _best_ppa(rank_ppa_path)
+    exact_safe = bypass_quality["exact_safe"]
+    if exact_safe:
+        decision = "logit_rank_bypass_exact_safe"
+        reason = (
+            "Raw-logit ranking matches the reference next-token and top-k gate, so greedy/top-k generation "
+            "does not need softmax, reciprocal normalization, or probability quantization on this workload."
+        )
+    else:
+        decision = "logit_rank_bypass_blocked"
+        reason = "Raw-logit ranking did not preserve the reference next-token/top-k gate."
+    return {
+        "version": 0.1,
+        "source_sweep": str(sweep_path),
+        "rough_grid": sweep.get("rough_grid"),
+        "task": sweep.get("task", "greedy_next_token"),
+        "decision": {
+            "decision": decision,
+            "reason": reason,
+            "selected_candidate": BYPASS_TEMPLATE if exact_safe else None,
+            "reference_candidate": EXACT_TEMPLATE,
+        },
+        "quality": {
+            "exact_softmax": exact_quality,
+            "logit_rank_bypass": bypass_quality,
+        },
+        "bypass_scope": {
+            "generation_modes": ["greedy_next_token", "topk_ranking", "beam_candidate_ranking"],
+            "not_valid_for": ["temperature_sampling", "top_p_sampling", "probability_reporting"],
+            "removed_datapaths": [
+                "softmax_exp_or_pwl",
+                "softmax_sum_normalization",
+                "reciprocal_normalization",
+                "probability_quantization",
+            ],
+            "kept_datapaths": ["logit_transform", "topk_or_argmax_rank"],
+        },
+        "rank_datapath_proxy": {
+            "status": "upper_bound_from_score_tie_rank" if rank_ppa is not None else "missing_rank_ppa",
+            "source": str(rank_ppa_path) if rank_ppa_path is not None else None,
+            "note": (
+                "The existing score/logit tie-rank block is a conservative rank-like upper bound because "
+                "raw-logit ranking needs only one comparison key. A dedicated logit-only top-k block should "
+                "be measured before final array-level PPA claims."
+            ),
+            "ppa": rank_ppa,
+        },
+        "next_step": [
+            "Use logit-rank bypass as the greedy/top-k architecture path if the evaluator result stays exact-safe.",
+            "Open a dedicated Layer 1 logit-only top-k/argmax datapath measurement before full array-level PPA comparison.",
+            "Keep approximate softmax work for sampling modes where calibrated probabilities are required.",
+        ],
+    }
+
+
+def _write_markdown(path: Path, report: JsonDict) -> None:
+    decision = report["decision"]
+    q = report["quality"]
+    proxy = report["rank_datapath_proxy"]
+    ppa = (proxy.get("ppa") or {}).get("metrics") or {}
+    lines = [
+        "# Decoder Logit-Rank Bypass",
+        "",
+        f"- source_sweep: `{report['source_sweep']}`",
+        f"- decision: `{decision['decision']}`",
+        f"- selected_candidate: `{decision['selected_candidate'] or ''}`",
+        f"- reason: {decision['reason']}",
+        "",
+        "## Quality",
+        "",
+        "| candidate | next-token | top-k | exact-safe | misses |",
+        "|---|---:|---:|---|---|",
+    ]
+    for label, row in (("exact_softmax", q["exact_softmax"]), ("logit_rank_bypass", q["logit_rank_bypass"])):
+        misses = ", ".join(row["next_token_mismatch_sample_ids"] or row["topk_miss_sample_ids"]) or "none"
+        lines.append(
+            f"| `{label}` | {row['next_token_matches']}/{row['sample_count']} | "
+            f"{row['topk_matches']}/{row['sample_count']} | `{row['exact_safe']}` | {misses} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Bypass Scope",
+            "",
+            "- valid_for: `greedy_next_token`, `topk_ranking`, `beam_candidate_ranking`",
+            "- not_valid_for: `temperature_sampling`, `top_p_sampling`, `probability_reporting`",
+            "- removed: `softmax_exp_or_pwl`, `softmax_sum_normalization`, `reciprocal_normalization`, `probability_quantization`",
+            "",
+            "## Rank Datapath Proxy",
+            "",
+            f"- status: `{proxy['status']}`",
+            f"- source: `{proxy['source'] or ''}`",
+            f"- critical_path_ns: `{ppa.get('critical_path_ns', '')}`",
+            f"- die_area: `{ppa.get('die_area', '')}`",
+            f"- total_power_mw: `{ppa.get('total_power_mw', '')}`",
+            f"- note: {proxy['note']}",
+            "",
+            "## Next Step",
+            "",
+        ]
+    )
+    for item in report["next_step"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Summarize raw-logit rank bypass quality")
+    ap.add_argument("--sweep", required=True, help="decoder quality sweep JSON")
+    ap.add_argument("--rank-ppa", default=str(DEFAULT_TIE_RANK_PPA), help="rank-like datapath PPA proxy JSON")
+    ap.add_argument("--out", required=True, help="output JSON path")
+    ap.add_argument("--out-md", required=True, help="output Markdown path")
+    args = ap.parse_args()
+    report = build_report(
+        sweep_path=Path(args.sweep),
+        rank_ppa_path=Path(args.rank_ppa) if args.rank_ppa else None,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    _write_markdown(out_md, report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/sweep_llm_decoder_candidate_quality.py
+++ b/npu/eval/sweep_llm_decoder_candidate_quality.py
@@ -97,10 +97,26 @@ def _rough_grid_templates(model_contract: JsonDict, grid_name: str) -> Dict[str,
         "decoder_pwl_bitwidth_boundary_v1",
         "decoder_bf16_pwl_recovery_v1",
         "decoder_bf16_pwl_scale_probe_v1",
+        "decoder_logit_rank_bypass_v1",
     }:
         raise ValueError(f"unsupported rough grid: {grid_name}")
     exact = _candidate_template(model_contract, "candidate_onnx_softmax_exact")
     approx = _candidate_template(model_contract, "candidate_onnx_softmax_approx")
+    if grid_name == "decoder_logit_rank_bypass_v1":
+        points = [
+            ("candidate_onnx_softmax_exact", exact),
+            _named_grid_point(
+                exact,
+                "candidate_onnx_logit_rank_bypass",
+                softmax_mode="logit_rank_bypass",
+                normalization_mode="rank_bypass",
+                normalization_reciprocal_bits=None,
+                normalization_reciprocal_float_format=None,
+                probability_quant_bits=None,
+                probability_float_format=None,
+            ),
+        ]
+        return {name: cfg for name, cfg in points}
     if grid_name == "decoder_probability_fp_formats_v1":
         points = [
             ("candidate_onnx_softmax_exact", exact),

--- a/tests/test_llm_decoder_logit_rank_bypass.py
+++ b/tests/test_llm_decoder_logit_rank_bypass.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+from npu.eval.summarize_llm_decoder_logit_rank_bypass import build_report
+
+
+def test_logit_rank_bypass_report_marks_exact_safe_and_scope(tmp_path: Path) -> None:
+    sweep = tmp_path / "sweep.json"
+    sweep.write_text(
+        json.dumps(
+            {
+                "rough_grid": "decoder_logit_rank_bypass_v1",
+                "task": "greedy_next_token",
+                "templates": [
+                    {
+                        "template": "candidate_onnx_softmax_exact",
+                        "sample_count": 2,
+                        "next_token_id_match_rate": 1.0,
+                        "topk_contains_reference_id_rate": 1.0,
+                        "next_token_mismatch_sample_ids": [],
+                        "topk_miss_sample_ids": [],
+                    },
+                    {
+                        "template": "candidate_onnx_logit_rank_bypass",
+                        "sample_count": 2,
+                        "next_token_id_match_rate": 1.0,
+                        "topk_contains_reference_id_rate": 1.0,
+                        "next_token_mismatch_sample_ids": [],
+                        "topk_miss_sample_ids": [],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_report(sweep_path=sweep, rank_ppa_path=None)
+
+    assert report["decision"]["decision"] == "logit_rank_bypass_exact_safe"
+    assert report["decision"]["selected_candidate"] == "candidate_onnx_logit_rank_bypass"
+    assert report["quality"]["logit_rank_bypass"]["next_token_matches"] == 2
+    assert "temperature_sampling" in report["bypass_scope"]["not_valid_for"]
+    assert "reciprocal_normalization" in report["bypass_scope"]["removed_datapaths"]
+    assert report["rank_datapath_proxy"]["status"] == "missing_rank_ppa"

--- a/tests/test_llm_decoder_onnx_candidate_runner.py
+++ b/tests/test_llm_decoder_onnx_candidate_runner.py
@@ -43,6 +43,16 @@ class LlmDecoderOnnxCandidateRunnerRegressionTest(unittest.TestCase):
         self.assertGreater(probs[0], probs[1])
         self.assertGreater(probs[1], probs[2])
 
+    def test_logit_rank_bypass_uses_logits_as_scores(self):
+        logits = [1.0, -2.0, 0.5]
+        scores, softmax_meta = self.runner._apply_softmax_path(logits, {'softmax_mode': 'logit_rank_bypass'})
+        ranked, norm_meta = self.runner._apply_normalization_path(scores, {'normalization_mode': 'rank_bypass'})
+        self.assertEqual(logits, scores)
+        self.assertEqual(logits, ranked)
+        self.assertEqual('logit_rank_bypass', softmax_meta['mode'])
+        self.assertEqual('rank_bypass', norm_meta['mode'])
+        self.assertEqual(0, self.runner._select_next_token_id(ranked))
+
     def test_score_distribution_stats_reports_score_sum_and_margin(self):
         stats = self.runner._score_distribution_stats([0.7, 0.2, 0.1, 0.0], topk=2)
         self.assertEqual(4, stats['vocab_size'])

--- a/tests/test_llm_decoder_q8_norm_frontier.py
+++ b/tests/test_llm_decoder_q8_norm_frontier.py
@@ -64,6 +64,19 @@ def test_bf16_pwl_recovery_grid_adds_logit_tiebreak_variant() -> None:
     assert recovery["score_tie_breaker"] == "logit"
 
 
+def test_logit_rank_bypass_grid_skips_softmax_and_normalization() -> None:
+    model_contract = load_json(Path("runs/models/llm_decoder_tiny_v1/model_contract.json"))
+    grid = _rough_grid_templates(model_contract, "decoder_logit_rank_bypass_v1")
+
+    assert set(grid) == {
+        "candidate_onnx_softmax_exact",
+        "candidate_onnx_logit_rank_bypass",
+    }
+    bypass = grid["candidate_onnx_logit_rank_bypass"]
+    assert bypass["softmax_mode"] == "logit_rank_bypass"
+    assert bypass["normalization_mode"] == "rank_bypass"
+
+
 def test_bf16_pwl_scale_probe_grid_keeps_integer_controls() -> None:
     model_contract = load_json(Path("runs/models/llm_decoder_tiny_v1/model_contract.json"))
     grid = _rough_grid_templates(model_contract, "decoder_bf16_pwl_scale_probe_v1")


### PR DESCRIPTION
## Summary
- add explicit logit-rank bypass and rank-normalization bypass modes to the decoder candidate runner
- add a decoder_logit_rank_bypass_v1 sweep grid and summarizer for greedy/top-k scope
- add L2 task generation and proposal docs for l2_decoder_gpt2_logit_rank_bypass_v1

## Validation
- PYTHONPATH=/workspaces/RTLGen control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_onnx_candidate_runner.py tests/test_llm_decoder_q8_norm_frontier.py tests/test_llm_decoder_logit_rank_bypass.py -q
- control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 -m py_compile npu/eval/summarize_llm_decoder_logit_rank_bypass.py npu/eval/run_llm_decoder_onnx_candidate.py npu/eval/sweep_llm_decoder_candidate_quality.py control_plane/control_plane/services/l2_task_generator.py
- python3 -m json.tool docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json
- python3 -m json.tool docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/evaluation_requests.json
- git diff --check -- scoped touched paths

## Notes
This PR intentionally scopes the claim to greedy next-token, top-k ranking, and beam candidate ranking. Temperature/top-p sampling and probability reporting remain outside the bypass path because they require probabilities.