### PR TITLE
[codex] Add logit-only rank datapath L1 item

### DIFF
--- a/apps/rtlgen_main.cpp
+++ b/apps/rtlgen_main.cpp
@@ -194,7 +194,8 @@ int main(int argc, char** argv) {
               << config.activation_operations.size() << " activation(s), "
               << config.softmax_rowwise_operations.size() << " row-wise softmax block(s), "
               << config.bf16_recip_norm_operations.size() << " bf16 reciprocal-normalization block(s), "
-              << config.score_tie_rank_operations.size() << " score tie-rank block(s)\n";
+              << config.score_tie_rank_operations.size() << " score tie-rank block(s), "
+              << config.logit_rank_operations.size() << " logit-rank block(s)\n";
 
     try {
         std::filesystem::path flopocoPath;
@@ -323,6 +324,15 @@ int main(int argc, char** argv) {
                       << " (row_elems=" << rank.row_elems
                       << ", logit_bits=" << rank.logit_bits << ")\n";
             emitScoreTieRankModule(rank, operandDef);
+        }
+
+        for (const auto &rank : config.logit_rank_operations) {
+            OperandDefinition operandDef = resolveOperand(config, rank.operand);
+            std::cout << "[INFO] Generating logit-rank " << rank.module_name
+                      << " (row_elems=" << rank.row_elems
+                      << ", logit_bits=" << rank.logit_bits
+                      << ", top_k=" << rank.top_k << ")\n";
+            emitLogitRankModule(rank, operandDef);
         }
 
         for (const auto &fp : config.fp_operations) {

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -398,7 +398,7 @@ def _read_config_target(
     elif "operations" in cfg and len(cfg["operations"]) == 1:
         entry = cfg["operations"][0]
         op_type = entry.get("type")
-        if op_type not in {"activation", "softmax_rowwise", "bf16_recip_norm", "score_tie_rank"}:
+        if op_type not in {"activation", "softmax_rowwise", "bf16_recip_norm", "score_tie_rank", "logit_rank"}:
             raise Layer1TaskGenerationError(f"unsupported single-operation design type in {config_path}: {op_type}")
         module_name = entry["module_name"]
         wrapper = f"{module_name}_wrapper"

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -178,6 +178,44 @@ def _write_score_tie_rank_config(repo_root: Path) -> str:
     return str(config_path.relative_to(repo_root))
 
 
+def _write_logit_rank_config(repo_root: Path) -> str:
+    config_path = repo_root / "examples" / "config_logit_rank.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "operands": [
+                    {
+                        "name": "logits",
+                        "dimensions": 1,
+                        "bit_width": 16,
+                        "signed": True,
+                        "kind": "int",
+                    }
+                ],
+                "operations": [
+                    {
+                        "type": "logit_rank",
+                        "module_name": "logit_rank_r4_l16_k2",
+                        "operand": "logits",
+                        "options": {
+                            "row_elems": 4,
+                            "logit_bits": 16,
+                            "top_k": 2,
+                            "logit_signed": True,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
 def _init_git_repo(repo_root: Path) -> str:
     origin_root = repo_root.parent / "origin.git"
     subprocess.run(["git", "init", "--bare", str(origin_root)], check=True, capture_output=True, text=True)
@@ -442,6 +480,39 @@ def test_generate_l1_sweep_task_supports_score_tie_rank_wrapper_config() -> None
             assert result.status == "applied"
             assert work_item.expected_outputs == [
                 "runs/designs/activations/score_tie_rank_r4_s16_l16_wrapper/metrics.csv",
+            ]
+
+
+def test_generate_l1_sweep_task_supports_logit_rank_wrapper_config() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _, sweep_path = _write_example_repo(repo_root)
+        config_path = _write_logit_rank_config(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    item_id="l1_demo_logit_rank",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="circuit_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert work_item.expected_outputs == [
+                "runs/designs/activations/logit_rank_r4_l16_k2_wrapper/metrics.csv",
             ]
 
 

--- a/docs/proposals/prop_l1_decoder_logit_rank_datapath_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_logit_rank_datapath_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l1_decoder_logit_rank_datapath_v1",
+  "source_commit": "15da63a88b9b04e1b9917f7e0c2e5b70f2ce1ec7",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_logit_rank_datapath_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for row-8 signed 16-bit logit-only rank datapaths (argmax k=1 and top-k k=4) used by raw-logit GPT-2 decoding.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "comparison_role": "cost_component",
+      "paired_baseline_item_id": "l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_gpt2_logit_rank_bypass_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure",
+        "reason": "Use direct logit-only rank PPA to replace the conservative score/logit tie-rank proxy in the raw-logit GPT-2 bypass cost accounting."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_logit_rank_datapath_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_logit_rank_datapath_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l1_decoder_logit_rank_datapath_v1",
+  "created_utc": "2026-05-04T10:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "circuit_block",
+  "title": "Decoder logit-only rank datapath",
+  "hypothesis": "Greedy next-token, top-k, and beam candidate ordering can rank raw decoder logits directly, so a dedicated logit-only top-k datapath should be materially smaller than the existing score/logit tie-rank proxy used to price the GPT-2 raw-logit bypass frontier.",
+  "direct_comparison": {
+    "primary_question": "What is the Nangate45 PPA cost of row-8 signed 16-bit raw-logit argmax and top-k rank datapaths for the GPT-2 logit-rank bypass path?",
+    "include": [
+      "logit_rank_r8_l16_k1 wrapper",
+      "logit_rank_r8_l16_k4 wrapper",
+      "Nangate45 high-utilization Layer 1 sweep",
+      "area, timing, and power metrics for isolated rank-only datapaths",
+      "comparison against the merged score/logit tie-rank proxy PPA"
+    ],
+    "exclude": [
+      "softmax probability generation",
+      "temperature sampling",
+      "top-p sampling",
+      "full decoder quality rerun",
+      "larger-model or larger-array proof"
+    ]
+  },
+  "expected_benefit": [
+    "replaces the conservative score/logit tie-rank proxy with measured logit-only PPA",
+    "separates rank-only decoder serving cost from probability-producing serving modes",
+    "gives separate costs for greedy argmax and top-k candidate selection"
+  ],
+  "risks": [
+    "row_elems=8 matches the current tiny decoder frontier and must be scaled in later work",
+    "isolated ranker PPA may differ after integration with output buffering or larger vocab tiling",
+    "the datapath is only valid for monotonic rank consumers, not probability consumers"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_logit_rank_datapath_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for row-8 signed 16-bit logit-only rank datapaths (argmax k=1 and top-k k=4) used by raw-logit GPT-2 decoding.",
+      "config_paths": [
+        "runs/designs/activations/logit_rank_r8_l16_k1_wrapper/config_logit_rank_r8_l16_k1.json",
+        "runs/designs/activations/logit_rank_r8_l16_k4_wrapper/config_logit_rank_r8_l16_k4.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/logit_rank/sweeps/nangate45_highutil.json",
+      "platform": "nangate45",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "depends_on_item_ids": [
+        "l2_decoder_gpt2_logit_rank_bypass_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_gpt2_logit_rank_bypass__l2_decoder_gpt2_logit_rank_bypass_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json",
+    "runs/designs/activations/score_tie_rank_r8_s16_l16_wrapper/metrics.csv"
+  ],
+  "knowledge_refs": [
+    "src/rtlgen/rtl_operations.cpp",
+    "examples/config_logit_rank.json",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/examples/config_logit_rank.json
+++ b/examples/config_logit_rank.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r4_l16_k2",
+      "operand": "logits",
+      "options": {
+        "row_elems": 4,
+        "logit_bits": 16,
+        "top_k": 2,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/npu/rtlgen/config_spec.md
+++ b/npu/rtlgen/config_spec.md
@@ -198,6 +198,11 @@ can later be extended without breaking v0.1.
 - `compute.softmax.enabled=true` emits a dedicated row-wise SOFTMAX wrapper
   tagged with `(* keep_hierarchy = 1 *)` so hierarchical OpenROAD flows can
   preserve and blackbox it independently from the rest of `npu_top`.
+- Standalone C++ RTLGen operation configs used by Layer 1 campaigns include
+  `logit_rank`, a combinational signed-logit top-k/argmax datapath with
+  `row_elems`, `logit_bits`, `top_k`, and `logit_signed` options. It is a
+  rank-only block for greedy/top-k/beam candidate ordering and does not produce
+  probabilities for sampling or probability reporting.
 - The current dedicated SOFTMAX generator is structural/PPA-oriented:
   it models the descriptor path and instantiates the selected row-wise module,
   but it does not yet implement full SRAM-backed source/destination dataflow.

--- a/runs/campaigns/activations/logit_rank/sweeps/nangate45_highutil.json
+++ b/runs/campaigns/activations/logit_rank/sweeps/nangate45_highutil.json
@@ -1,0 +1,9 @@
+{
+  "tag_prefix": "logit_rank_nangate45_highutil",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.5],
+    "CORE_UTILIZATION": [60, 50],
+    "PLACE_DENSITY": [0.68],
+    "SYNTH_MEMORY_MAX_BITS": [32768]
+  }
+}

--- a/runs/designs/activations/logit_rank_r8_l16_k1_wrapper/config_logit_rank_r8_l16_k1.json
+++ b/runs/designs/activations/logit_rank_r8_l16_k1_wrapper/config_logit_rank_r8_l16_k1.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r8_l16_k1",
+      "operand": "logits",
+      "options": {
+        "row_elems": 8,
+        "logit_bits": 16,
+        "top_k": 1,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/logit_rank_r8_l16_k4_wrapper/config_logit_rank_r8_l16_k4.json
+++ b/runs/designs/activations/logit_rank_r8_l16_k4_wrapper/config_logit_rank_r8_l16_k4.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r8_l16_k4",
+      "operand": "logits",
+      "options": {
+        "row_elems": 8,
+        "logit_bits": 16,
+        "top_k": 4,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -148,6 +148,31 @@ def identify_design(config):
             "logit_signed": bool(options.get("logit_signed", True)),
             "include_mg_cpa": False,
         }
+    if op_type == "logit_rank":
+        options = entry.get("options", {})
+        row_elems = int(options.get("row_elems", 1))
+        logit_bits = int(options.get("logit_bits", bit_width) or bit_width)
+        top_k = int(options.get("top_k", 1))
+        if row_elems <= 0:
+            raise ValueError("logit_rank row_elems must be positive")
+        if logit_bits <= 0:
+            raise ValueError("logit_rank logit_bits must be positive")
+        if top_k <= 0 or top_k > row_elems:
+            raise ValueError("logit_rank top_k must be in [1, row_elems]")
+        index_width = _ceil_log2_at_least_one(row_elems)
+        return {
+            "kind": "logit_rank",
+            "module_name": module_name,
+            "wrapper_name": f"{module_name}_wrapper",
+            "logit_width": logit_bits * row_elems,
+            "top_index_width": index_width * top_k,
+            "top_logit_width": logit_bits * top_k,
+            "index_bits": index_width,
+            "logit_bits": logit_bits,
+            "top_k": top_k,
+            "logit_signed": bool(options.get("logit_signed", True)),
+            "include_mg_cpa": False,
+        }
     raise ValueError(f"generate_design.py does not support operation type: {op_type}")
 
 
@@ -391,6 +416,42 @@ module {wrapper_name}(
   assign best_index = best_index_reg;
   assign best_score = best_score_reg;
   assign best_logit = best_logit_reg;
+
+endmodule
+"""
+    elif design["kind"] == "logit_rank":
+        logit_width = int(design["logit_width"])
+        top_index_width = int(design["top_index_width"])
+        top_logit_width = int(design["top_logit_width"])
+        signed_kw = "signed " if design.get("logit_signed", True) else ""
+        wrapper_content = f"""
+module {wrapper_name}(
+  input clk,
+  input {signed_kw}[{logit_width-1}:0] logits,
+  output [{top_index_width-1}:0] top_indices,
+  output {signed_kw}[{top_logit_width-1}:0] top_logits
+);
+
+  reg {signed_kw}[{logit_width-1}:0] logits_reg;
+  wire [{top_index_width-1}:0] top_indices_wire;
+  wire {signed_kw}[{top_logit_width-1}:0] top_logits_wire;
+  reg [{top_index_width-1}:0] top_indices_reg;
+  reg {signed_kw}[{top_logit_width-1}:0] top_logits_reg;
+
+  {module_name} dut (
+    .logits(logits_reg),
+    .top_indices(top_indices_wire),
+    .top_logits(top_logits_wire)
+  );
+
+  always @(posedge clk) begin
+    logits_reg <= logits;
+    top_indices_reg <= top_indices_wire;
+    top_logits_reg <= top_logits_wire;
+  end
+
+  assign top_indices = top_indices_reg;
+  assign top_logits = top_logits_reg;
 
 endmodule
 """

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -118,7 +118,7 @@ def read_design_names(config_path: Path) -> Tuple[str, str]:
         module_name = cfg["adder"]["module_name"]
     elif "operations" in cfg and len(cfg["operations"]) == 1:
         entry = cfg["operations"][0]
-        if entry["type"] not in ("activation", "softmax_rowwise", "bf16_recip_norm", "score_tie_rank"):
+        if entry["type"] not in ("activation", "softmax_rowwise", "bf16_recip_norm", "score_tie_rank", "logit_rank"):
             raise ValueError(f"Unsupported single-operation design type in {config_path}: {entry['type']}")
         module_name = entry["module_name"]
     else:

--- a/src/rtlgen/config.cpp
+++ b/src/rtlgen/config.cpp
@@ -61,6 +61,7 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
         config.softmax_rowwise_operations.clear();
         config.bf16_recip_norm_operations.clear();
         config.score_tie_rank_operations.clear();
+        config.logit_rank_operations.clear();
         config.onnx_model.reset();
 
         if (j.contains("operand")) {
@@ -438,6 +439,25 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                         throw std::runtime_error("score_tie_rank logit_bits must be in [1, 64] for " + rank.module_name);
                     }
                     config.score_tie_rank_operations.push_back(rank);
+                } else if (type == "logit_rank") {
+                    const json &options = entry.contains("options") ? entry["options"] : entry;
+                    LogitRankOperationConfig rank;
+                    rank.module_name = module_name;
+                    rank.operand = operand_name;
+                    rank.row_elems = options.value("row_elems", 1);
+                    rank.logit_bits = options.value("logit_bits", 16);
+                    rank.top_k = options.value("top_k", 1);
+                    rank.logit_signed = options.value("logit_signed", true);
+                    if (rank.row_elems <= 0 || rank.row_elems > 1024) {
+                        throw std::runtime_error("logit_rank row_elems must be in [1, 1024] for " + rank.module_name);
+                    }
+                    if (rank.logit_bits <= 0 || rank.logit_bits > 64) {
+                        throw std::runtime_error("logit_rank logit_bits must be in [1, 64] for " + rank.module_name);
+                    }
+                    if (rank.top_k <= 0 || rank.top_k > rank.row_elems) {
+                        throw std::runtime_error("logit_rank top_k must be in [1, row_elems] for " + rank.module_name);
+                    }
+                    config.logit_rank_operations.push_back(rank);
                 } else {
                     throw std::runtime_error("Unknown operation type: " + type);
                 }

--- a/src/rtlgen/config.hpp
+++ b/src/rtlgen/config.hpp
@@ -227,6 +227,15 @@ struct ScoreTieRankOperationConfig {
     bool logit_signed{true};
 };
 
+struct LogitRankOperationConfig {
+    std::string module_name;
+    std::string operand;
+    int row_elems{1};
+    int logit_bits{16};
+    int top_k{1};
+    bool logit_signed{true};
+};
+
 struct CircuitConfig {
     OperandConfig operand;
     std::vector<OperandDefinition> operands;
@@ -241,6 +250,7 @@ struct CircuitConfig {
     std::vector<SoftmaxRowwiseOperationConfig> softmax_rowwise_operations;
     std::vector<Bf16RecipNormOperationConfig> bf16_recip_norm_operations;
     std::vector<ScoreTieRankOperationConfig> score_tie_rank_operations;
+    std::vector<LogitRankOperationConfig> logit_rank_operations;
     std::optional<std::string> onnx_model; // Added ONNX model path
 };
 

--- a/src/rtlgen/rtl_operations.cpp
+++ b/src/rtlgen/rtl_operations.cpp
@@ -1362,3 +1362,84 @@ void emitScoreTieRankModule(const ScoreTieRankOperationConfig &config, const Ope
     os << "  end\n";
     os << "endmodule\n";
 }
+
+void emitLogitRankModule(const LogitRankOperationConfig &config, const OperandDefinition &operand) {
+    const int logit_bits = config.logit_bits > 0 ? config.logit_bits : operand.bit_width;
+    if (logit_bits <= 0 || logit_bits > 64) {
+        throw std::runtime_error("logit_rank logit_bits must be in [1, 64]");
+    }
+    if (config.row_elems <= 0 || config.row_elems > 1024) {
+        throw std::runtime_error("logit_rank row_elems must be in [1, 1024]");
+    }
+    if (config.top_k <= 0 || config.top_k > config.row_elems) {
+        throw std::runtime_error("logit_rank top_k must be in [1, row_elems]");
+    }
+
+    const int index_bits = std::max(1, ceilLog2U64(static_cast<unsigned long long>(config.row_elems)));
+    const int logit_row_width = config.row_elems * logit_bits;
+    const int top_index_width = config.top_k * index_bits;
+    const int top_logit_width = config.top_k * logit_bits;
+    const std::string signed_kw = config.logit_signed ? "signed " : "";
+
+    std::string filename = config.module_name + ".v";
+    std::ofstream os(filename);
+    if (!os) {
+        throw std::runtime_error("Failed to open " + filename + " for writing");
+    }
+
+    os << "`timescale 1ns/1ps\n\n";
+    os << "module " << config.module_name << "(\n";
+    os << "  input  " << signed_kw << "[" << (logit_row_width - 1) << ":0] logits,\n";
+    os << "  output reg [" << (top_index_width - 1) << ":0] top_indices,\n";
+    os << "  output reg " << signed_kw << "[" << (top_logit_width - 1) << ":0] top_logits\n";
+    os << ");\n\n";
+    os << "  // Row-wise logit-only rank selection.\n";
+    os << "  // Primary key: larger logit. Exact ties retain the lowest lane index.\n";
+    os << "  localparam integer ROW_ELEMS = " << config.row_elems << ";\n";
+    os << "  localparam integer LOGIT_W = " << logit_bits << ";\n";
+    os << "  localparam integer TOP_K = " << config.top_k << ";\n";
+    os << "  localparam integer INDEX_W = " << index_bits << ";\n\n";
+    os << "  integer i;\n";
+    os << "  integer k;\n";
+    os << "  integer insert_pos;\n";
+    os << "  reg [TOP_K-1:0] top_valid;\n";
+    os << "  reg [INDEX_W-1:0] lane_index;\n";
+    os << "  reg [INDEX_W-1:0] top_index_k;\n";
+    os << "  reg " << signed_kw << "[LOGIT_W-1:0] logit_i;\n";
+    os << "  reg " << signed_kw << "[LOGIT_W-1:0] top_logit_k;\n\n";
+    os << "  always @* begin\n";
+    os << "    top_indices = {" << top_index_width << "{1'b0}};\n";
+    os << "    top_logits = {" << top_logit_width << "{1'b0}};\n";
+    os << "    top_valid = {TOP_K{1'b0}};\n\n";
+    os << "    for (i = 0; i < ROW_ELEMS; i = i + 1) begin\n";
+    os << "      lane_index = i;\n";
+    if (config.logit_signed) {
+        os << "      logit_i = $signed(logits[(i*LOGIT_W) +: LOGIT_W]);\n";
+    } else {
+        os << "      logit_i = logits[(i*LOGIT_W) +: LOGIT_W];\n";
+    }
+    os << "      insert_pos = TOP_K;\n";
+    os << "      for (k = 0; k < TOP_K; k = k + 1) begin\n";
+    os << "        top_index_k = top_indices[(k*INDEX_W) +: INDEX_W];\n";
+    if (config.logit_signed) {
+        os << "        top_logit_k = $signed(top_logits[(k*LOGIT_W) +: LOGIT_W]);\n";
+    } else {
+        os << "        top_logit_k = top_logits[(k*LOGIT_W) +: LOGIT_W];\n";
+    }
+    os << "        if ((insert_pos == TOP_K) && (!top_valid[k] || (logit_i > top_logit_k) || ((logit_i == top_logit_k) && (lane_index < top_index_k))))\n";
+    os << "          insert_pos = k;\n";
+    os << "      end\n\n";
+    os << "      if (insert_pos < TOP_K) begin\n";
+    os << "        for (k = TOP_K - 1; k > insert_pos; k = k - 1) begin\n";
+    os << "          top_indices[(k*INDEX_W) +: INDEX_W] = top_indices[((k-1)*INDEX_W) +: INDEX_W];\n";
+    os << "          top_logits[(k*LOGIT_W) +: LOGIT_W] = top_logits[((k-1)*LOGIT_W) +: LOGIT_W];\n";
+    os << "          top_valid[k] = top_valid[k-1];\n";
+    os << "        end\n";
+    os << "        top_indices[(insert_pos*INDEX_W) +: INDEX_W] = lane_index;\n";
+    os << "        top_logits[(insert_pos*LOGIT_W) +: LOGIT_W] = logit_i;\n";
+    os << "        top_valid[insert_pos] = 1'b1;\n";
+    os << "      end\n";
+    os << "    end\n";
+    os << "  end\n";
+    os << "endmodule\n";
+}

--- a/src/rtlgen/rtl_operations.hpp
+++ b/src/rtlgen/rtl_operations.hpp
@@ -8,3 +8,4 @@ void emitActivationModule(const ActivationOperationConfig &config, const Operand
 void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const OperandDefinition &operand);
 void emitBf16RecipNormModule(const Bf16RecipNormOperationConfig &config, const OperandDefinition &operand);
 void emitScoreTieRankModule(const ScoreTieRankOperationConfig &config, const OperandDefinition &operand);
+void emitLogitRankModule(const LogitRankOperationConfig &config, const OperandDefinition &operand);

--- a/tests/logit_rank_tb.v
+++ b/tests/logit_rank_tb.v
@@ -1,0 +1,61 @@
+`timescale 1ns/1ps
+
+module logit_rank_tb;
+  reg  signed [63:0] logits;
+  wire [3:0] top_indices;
+  wire signed [31:0] top_logits;
+
+  logit_rank_r4_l16_k2 dut (
+    .logits(logits),
+    .top_indices(top_indices),
+    .top_logits(top_logits)
+  );
+
+  task check_rank;
+    input signed [63:0] l;
+    input [1:0] exp_index0;
+    input signed [15:0] exp_logit0;
+    input [1:0] exp_index1;
+    input signed [15:0] exp_logit1;
+    begin
+      logits = l;
+      #1;
+      if (top_indices[1:0] !== exp_index0 || top_logits[15:0] !== exp_logit0 ||
+          top_indices[3:2] !== exp_index1 || top_logits[31:16] !== exp_logit1) begin
+        $display(
+          "FAIL logit_rank: got idx=[%0d,%0d] logits=[%0d,%0d] expected idx=[%0d,%0d] logits=[%0d,%0d]",
+          top_indices[1:0], top_indices[3:2],
+          $signed(top_logits[15:0]), $signed(top_logits[31:16]),
+          exp_index0, exp_index1, exp_logit0, exp_logit1
+        );
+        $fatal;
+      end
+    end
+  endtask
+
+  initial begin
+    check_rank(
+      {16'sd4, -16'sd2, 16'sd9, 16'sd1},
+      2'd1,
+      16'sd9,
+      2'd3,
+      16'sd4
+    );
+    check_rank(
+      {16'sd5, 16'sd5, 16'sd5, 16'sd4},
+      2'd1,
+      16'sd5,
+      2'd2,
+      16'sd5
+    );
+    check_rank(
+      {-16'sd8, -16'sd2, -16'sd5, -16'sd9},
+      2'd2,
+      -16'sd2,
+      2'd1,
+      -16'sd5
+    );
+    $display("All logit-rank tests passed.");
+    $finish;
+  end
+endmodule

--- a/tests/test_logit_rank.sh
+++ b/tests/test_logit_rank.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+cp "$ROOT/examples/config_logit_rank.json" "$TMP/config.json"
+
+pushd "$TMP" >/dev/null
+"$ROOT/build/rtlgen" config.json
+
+grep -q "module logit_rank_r4_l16_k2" logit_rank_r4_l16_k2.v
+grep -q "logit_i > top_logit_k" logit_rank_r4_l16_k2.v
+
+iverilog -g2012 -s logit_rank_tb -o sim logit_rank_r4_l16_k2.v "$ROOT/tests/logit_rank_tb.v"
+vvp sim
+
+WRAP_DIR="$TMP/wrapper"
+mkdir -p "$WRAP_DIR"
+PYTHONPATH="$ROOT/scripts" python3 - "$ROOT/examples/config_logit_rank.json" "$WRAP_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from generate_design import generate_wrapper, identify_design
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+design = identify_design(config)
+assert design["kind"] == "logit_rank"
+assert design["top_k"] == 2
+generate_wrapper(config, sys.argv[2], design)
+PY
+iverilog -g2012 -s logit_rank_r4_l16_k2_wrapper -t null \
+  logit_rank_r4_l16_k2.v "$WRAP_DIR/logit_rank_r4_l16_k2_wrapper.v"
+
+cat > "$TMP/sweep.json" <<'JSON'
+{
+  "tag_prefix": "logit_rank_dryrun",
+  "flow_params": {
+    "CLOCK_PERIOD": [10.0]
+  }
+}
+JSON
+python3 "$ROOT/scripts/run_sweep.py" \
+  --configs "$ROOT/examples/config_logit_rank.json" \
+  --platform nangate45 \
+  --sweep "$TMP/sweep.json" \
+  --out_root "$TMP/runs" \
+  --dry_run
+
+for cfg in \
+  "$ROOT/runs/designs/activations/logit_rank_r8_l16_k1_wrapper/config_logit_rank_r8_l16_k1.json" \
+  "$ROOT/runs/designs/activations/logit_rank_r8_l16_k4_wrapper/config_logit_rank_r8_l16_k4.json"; do
+  cfg_name="$(basename "$cfg" .json)"
+  cfg_tmp="$TMP/$cfg_name"
+  mkdir -p "$cfg_tmp/wrapper"
+  cp "$cfg" "$cfg_tmp/config.json"
+  (
+    cd "$cfg_tmp"
+    "$ROOT/build/rtlgen" config.json
+  )
+  module_name="$(python3 -c "import json; print(json.load(open('$cfg'))['operations'][0]['module_name'])")"
+  PYTHONPATH="$ROOT/scripts" python3 - "$cfg" "$cfg_tmp/wrapper" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from generate_design import generate_wrapper, identify_design
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+design = identify_design(config)
+generate_wrapper(config, sys.argv[2], design)
+PY
+  iverilog -g2012 -s "${module_name}_wrapper" -t null \
+    "$cfg_tmp/${module_name}.v" "$cfg_tmp/wrapper/${module_name}_wrapper.v"
+done
+popd >/dev/null


### PR DESCRIPTION
## Summary
- Add a standalone C++ RTLGen `logit_rank` operation for signed raw-logit argmax/top-k ranking.
- Add wrapper/sweep support, row-8 k=1 and k=4 campaign configs, and the Layer 1 proposal/request metadata for `l1_decoder_logit_rank_datapath_v1`.
- Document the rank-only scope: greedy/top-k/beam ordering only, not sampling or probability reporting.

## Why
The merged GPT-2 raw-logit bypass result removed softmax from rank-only decoding, but its current cost accounting still uses the conservative score/logit tie-rank proxy. This PR adds the direct datapath and evaluation request needed to measure the real logit-only PPA term.

## Validation
- `cmake --build build --target rtlgen`
- `bash tests/test_logit_rank.sh`
- `bash tests/test_score_tie_rank.sh`
- `control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py -q`
- `python3 -m py_compile scripts/generate_design.py scripts/run_sweep.py control_plane/control_plane/services/l1_task_generator.py control_plane/control_plane/tests/test_l1_task_generator.py`
- JSON validation with `python3 -m json.tool` for the new configs, sweep, proposal, and evaluation request
- `git diff --check` on the scoped touched files