### PR TITLE
[codex] Fix logit-rank Yosys loop bound

### DIFF
--- a/src/rtlgen/rtl_operations.cpp
+++ b/src/rtlgen/rtl_operations.cpp
@@ -1430,10 +1430,12 @@ void emitLogitRankModule(const LogitRankOperationConfig &config, const OperandDe
     os << "          insert_pos = k;\n";
     os << "      end\n\n";
     os << "      if (insert_pos < TOP_K) begin\n";
-    os << "        for (k = TOP_K - 1; k > insert_pos; k = k - 1) begin\n";
-    os << "          top_indices[(k*INDEX_W) +: INDEX_W] = top_indices[((k-1)*INDEX_W) +: INDEX_W];\n";
-    os << "          top_logits[(k*LOGIT_W) +: LOGIT_W] = top_logits[((k-1)*LOGIT_W) +: LOGIT_W];\n";
-    os << "          top_valid[k] = top_valid[k-1];\n";
+    os << "        for (k = TOP_K - 1; k > 0; k = k - 1) begin\n";
+    os << "          if (k > insert_pos) begin\n";
+    os << "            top_indices[(k*INDEX_W) +: INDEX_W] = top_indices[((k-1)*INDEX_W) +: INDEX_W];\n";
+    os << "            top_logits[(k*LOGIT_W) +: LOGIT_W] = top_logits[((k-1)*LOGIT_W) +: LOGIT_W];\n";
+    os << "            top_valid[k] = top_valid[k-1];\n";
+    os << "          end\n";
     os << "        end\n";
     os << "        top_indices[(insert_pos*INDEX_W) +: INDEX_W] = lane_index;\n";
     os << "        top_logits[(insert_pos*LOGIT_W) +: LOGIT_W] = logit_i;\n";

--- a/tests/test_logit_rank.sh
+++ b/tests/test_logit_rank.sh
@@ -14,6 +14,18 @@ pushd "$TMP" >/dev/null
 grep -q "module logit_rank_r4_l16_k2" logit_rank_r4_l16_k2.v
 grep -q "logit_i > top_logit_k" logit_rank_r4_l16_k2.v
 
+YOSYS_BIN="${YOSYS_BIN:-}"
+if [[ -z "$YOSYS_BIN" ]]; then
+  if command -v yosys >/dev/null 2>&1; then
+    YOSYS_BIN="$(command -v yosys)"
+  elif [[ -x /oss-cad-suite/bin/yosys ]]; then
+    YOSYS_BIN=/oss-cad-suite/bin/yosys
+  fi
+fi
+if [[ -n "$YOSYS_BIN" ]]; then
+  "$YOSYS_BIN" -q -p "read_verilog logit_rank_r4_l16_k2.v; hierarchy -top logit_rank_r4_l16_k2; proc"
+fi
+
 iverilog -g2012 -s logit_rank_tb -o sim logit_rank_r4_l16_k2.v "$ROOT/tests/logit_rank_tb.v"
 vvp sim
 


### PR DESCRIPTION
## Summary
- Rewrite the generated logit-rank insertion shift loop to use a constant procedural for-loop bound and a dynamic `if` guard.
- Add a Yosys `read_verilog; hierarchy; proc` smoke check to `tests/test_logit_rank.sh` so non-synthesizable procedural loop forms are caught before dispatch.

## Root Cause
PR #389 generated `for (k = TOP_K - 1; k > insert_pos; k = k - 1)`, and Yosys rejects a procedural for-loop whose second expression depends on a runtime variable. The evaluator therefore produced failed metrics rows for the first logit-rank dispatch.

## Validation
- `cmake --build build --target rtlgen`
- `bash tests/test_logit_rank.sh`
- `git diff --check -- src/rtlgen/rtl_operations.cpp tests/test_logit_rank.sh`
- Local temp OpenROAD reproduction: the original Yosys canonicalization error is cleared; k=1 completed through final PPA, and k=4 passed Yosys/synthesis and reached routing before I stopped the local temp run to avoid spending more local runtime.