### PR TITLE
[codex] Use measured logit-rank PPA in decoder accounting

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1767,7 +1767,7 @@ def _decoder_gpt2_logit_rank_bypass_evidence(*, item_id: str) -> dict[str, Any]:
     bypass_out = f"{base}/decoder_gpt2_logit_rank_bypass__{item_id}.json"
     bypass_report = f"{base}/decoder_gpt2_logit_rank_bypass__{item_id}.md"
     rough_grid = "decoder_logit_rank_bypass_v1"
-    rank_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json"
+    rank_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
     commands = [
         {
             "name": "materialize_decoder_gpt2_logit_rank_bypass_contract",
@@ -1851,10 +1851,11 @@ def _decoder_gpt2_logit_rank_bypass_evidence(*, item_id: str) -> dict[str, Any]:
             "candidate_sweep_grid": rough_grid,
             "logit_rank_bypass_out": bypass_out,
             "logit_rank_bypass_report": bypass_report,
-            "rank_datapath_proxy_ppa": rank_ppa,
+            "rank_datapath_ppa": rank_ppa,
             "logit_rank_bypass_scope": (
                 "greedy/top-k GPT-2 prompt-stress check that bypasses softmax and ranks transformed logits "
-                "directly; sampling modes remain out of scope because they require probabilities"
+                "directly; sampling modes remain out of scope because they require probabilities; "
+                "rank cost is anchored to the measured logit-only argmax/top-k Layer 1 datapath"
             ),
         },
         "commands": commands,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1489,14 +1489,15 @@ def test_generate_l2_campaign_task_adds_decoder_gpt2_logit_rank_bypass_evidence(
             ]
             decoder_inputs = work_item.input_manifest["decoder_contract"]
             assert decoder_inputs["candidate_sweep_grid"] == "decoder_logit_rank_bypass_v1"
-            assert decoder_inputs["rank_datapath_proxy_ppa"] == (
-                "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json"
+            assert decoder_inputs["rank_datapath_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
             )
             assert decoder_inputs["logit_rank_bypass_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_gpt2_logit_rank_bypass__l2_decoder_gpt2_logit_rank_bypass_v1.json"
             )
             assert "sampling modes remain out of scope" in decoder_inputs["logit_rank_bypass_scope"]
+            assert "measured logit-only" in decoder_inputs["logit_rank_bypass_scope"]
             assert "--rough-grid decoder_logit_rank_bypass_v1" in work_item.command_manifest[5]["run"]
             assert "summarize_llm_decoder_logit_rank_bypass.py" in work_item.command_manifest[6]["run"]
             assert decoder_inputs["logit_rank_bypass_out"] in work_item.expected_outputs

--- a/docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json
@@ -15,7 +15,7 @@
       "raw-logit rank-bypass candidate",
       "next-token and top-k exactness checks",
       "explicit scope split between rank-only decoding and sampling/probability consumers",
-      "rank datapath PPA proxy from the merged bf16 score/logit tie-rank block"
+      "rank datapath PPA from the merged logit-only argmax/top-k block"
     ],
     "exclude": [
       "temperature sampling",
@@ -33,7 +33,7 @@
   ],
   "risks": [
     "the claim only applies to monotonic rank consumers and does not cover sampling modes",
-    "the PPA row is a conservative rank-datapath proxy until a dedicated logit-only top-k/rank block is measured",
+    "the PPA rows are row-8 Nangate45 circuit-block measurements and still need larger-row/full-array scaling evidence",
     "the GPT-2 prompt-stress set is still a bounded next-token screen, not a larger-model conclusion"
   ],
   "needs_mapper_change": false,
@@ -47,7 +47,8 @@
       "abstraction_layer": "decoder_gpt2_logit_rank_bypass",
       "depends_on_item_ids": [
         "l2_decoder_gpt2_prompt_stress_v1",
-        "l2_decoder_gpt2_tie_rank_frontier_v1"
+        "l2_decoder_gpt2_tie_rank_frontier_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true
@@ -58,7 +59,7 @@
     "docs/proposals/prop_l2_decoder_gpt2_tie_rank_frontier_v1/proposal.json",
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_gpt2_prompt_stress__l2_decoder_gpt2_prompt_stress_v1.json",
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_gpt2_tie_rank_frontier__l2_decoder_gpt2_tie_rank_frontier_v1.json",
-    "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json"
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
   ],
   "knowledge_refs": [
     "npu/eval/run_llm_decoder_onnx_candidate.py",

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -374,6 +374,21 @@ patterns, and low-margin continuations. It answers whether the bf16/PWL plus
 logit tie-break behavior survives a rough scale proxy before spending evaluator
 time on a larger imported model or an integrated decoder datapath.
 
+Run the GPT-2 raw-logit rank-bypass summary with measured rank PPA:
+```sh
+python3 npu/eval/summarize_llm_decoder_logit_rank_bypass.py \
+  --sweep runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_quality_sweep__l2_decoder_gpt2_logit_rank_bypass_v1.json \
+  --rank-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json \
+  --out /tmp/decoder_gpt2_logit_rank_bypass.json \
+  --out-md /tmp/decoder_gpt2_logit_rank_bypass.md
+```
+
+This summary uses the merged row-8 Nangate45 logit-only rank datapath instead
+of the older bf16 score/tie-rank proxy. The k=1 row is the current greedy
+argmax cost anchor, while the k=4 row is the current top-k/beam ranking anchor.
+Sampling and probability-reporting modes remain outside this bypass because
+they need calibrated probabilities, not only rank order.
+
 After the corresponding Layer 1 multiplier and accumulator/adder calibration
 jobs merge, synthesize the measured primitive evidence into a decoder
 normalization report:

--- a/npu/eval/summarize_llm_decoder_logit_rank_bypass.py
+++ b/npu/eval/summarize_llm_decoder_logit_rank_bypass.py
@@ -13,7 +13,10 @@ JsonDict = dict[str, Any]
 
 EXACT_TEMPLATE = "candidate_onnx_softmax_exact"
 BYPASS_TEMPLATE = "candidate_onnx_logit_rank_bypass"
-DEFAULT_TIE_RANK_PPA = Path(
+DEFAULT_LOGIT_RANK_PPA = Path(
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
+)
+LEGACY_TIE_RANK_PPA = Path(
     "control_plane/shadow_exports/l1_promotions/l1_decoder_bf16_pwl_tie_rank_datapath_v1_r2.json"
 )
 
@@ -69,7 +72,29 @@ def _quality(row: JsonDict) -> JsonDict:
     }
 
 
-def _best_ppa(path: Path | None) -> JsonDict | None:
+def _rank_role(row: JsonDict) -> str:
+    metrics_ref = row.get("metrics_ref") or {}
+    metrics_csv = str(metrics_ref.get("metrics_csv") or "")
+    if "_k1_" in metrics_csv or "k1" in metrics_csv:
+        return "argmax_k1"
+    if "_k4_" in metrics_csv or "k4" in metrics_csv:
+        return "topk_k4"
+    return "rank"
+
+
+def _artifact_status(*, path: Path, payload: JsonDict, rows: list[JsonDict]) -> str:
+    item_id = str(payload.get("item_id") or "")
+    source = f"{path} {item_id}"
+    if "logit_rank" in source:
+        return "measured_logit_rank_datapath"
+    if "tie_rank" in source:
+        return "upper_bound_from_score_tie_rank"
+    if rows:
+        return "measured_rank_datapath"
+    return "missing_rank_ppa"
+
+
+def _ppa_summary(path: Path | None) -> JsonDict | None:
     if path is None or not path.exists():
         return None
     payload = _load_json(path)
@@ -92,6 +117,7 @@ def _best_ppa(path: Path | None) -> JsonDict | None:
             },
             "selection_reason": proposal.get("selection_reason", ""),
         }
+        row["role"] = _rank_role(row)
         rows.append(row)
     if not rows:
         return None
@@ -100,16 +126,25 @@ def _best_ppa(path: Path | None) -> JsonDict | None:
         row["metrics"]["die_area"],
         row["metrics"]["total_power_mw"],
     ))
-    return rows[0]
+    by_role = {str(row["role"]): row for row in rows}
+    return {
+        "status": _artifact_status(path=path, payload=payload, rows=rows),
+        "source": str(path),
+        "item_id": payload.get("item_id"),
+        "selected": rows[0],
+        "argmax": by_role.get("argmax_k1") or rows[0],
+        "topk": by_role.get("topk_k4") or rows[0],
+        "rows": rows,
+    }
 
 
-def build_report(*, sweep_path: Path, rank_ppa_path: Path | None = DEFAULT_TIE_RANK_PPA) -> JsonDict:
+def build_report(*, sweep_path: Path, rank_ppa_path: Path | None = DEFAULT_LOGIT_RANK_PPA) -> JsonDict:
     sweep = _load_json(sweep_path)
     exact = _template_row(sweep, EXACT_TEMPLATE)
     bypass = _template_row(sweep, BYPASS_TEMPLATE)
     exact_quality = _quality(exact)
     bypass_quality = _quality(bypass)
-    rank_ppa = _best_ppa(rank_ppa_path)
+    rank_ppa = _ppa_summary(rank_ppa_path)
     exact_safe = bypass_quality["exact_safe"]
     if exact_safe:
         decision = "logit_rank_bypass_exact_safe"
@@ -146,19 +181,23 @@ def build_report(*, sweep_path: Path, rank_ppa_path: Path | None = DEFAULT_TIE_R
             ],
             "kept_datapaths": ["logit_transform", "topk_or_argmax_rank"],
         },
-        "rank_datapath_proxy": {
-            "status": "upper_bound_from_score_tie_rank" if rank_ppa is not None else "missing_rank_ppa",
+        "rank_datapath_ppa": {
+            "status": rank_ppa["status"] if rank_ppa is not None else "missing_rank_ppa",
             "source": str(rank_ppa_path) if rank_ppa_path is not None else None,
             "note": (
-                "The existing score/logit tie-rank block is a conservative rank-like upper bound because "
-                "raw-logit ranking needs only one comparison key. A dedicated logit-only top-k block should "
-                "be measured before final array-level PPA claims."
+                "A merged logit-only datapath artifact is used when available. For greedy decoding, "
+                "the argmax k=1 row is the closest physical proxy; for top-k/beam ranking, the k=4 row "
+                "is the current measured proxy. Older score/tie-rank artifacts remain accepted only as "
+                "conservative fallback evidence."
             ),
-            "ppa": rank_ppa,
+            "ppa": rank_ppa["selected"] if rank_ppa is not None else None,
+            "argmax_ppa": rank_ppa["argmax"] if rank_ppa is not None else None,
+            "topk_ppa": rank_ppa["topk"] if rank_ppa is not None else None,
+            "ppa_rows": rank_ppa["rows"] if rank_ppa is not None else [],
         },
         "next_step": [
             "Use logit-rank bypass as the greedy/top-k architecture path if the evaluator result stays exact-safe.",
-            "Open a dedicated Layer 1 logit-only top-k/argmax datapath measurement before full array-level PPA comparison.",
+            "Use the measured logit-only argmax/top-k rows in decoder ranking instead of the older score/tie-rank proxy.",
             "Keep approximate softmax work for sampling modes where calibrated probabilities are required.",
         ],
     }
@@ -167,8 +206,10 @@ def build_report(*, sweep_path: Path, rank_ppa_path: Path | None = DEFAULT_TIE_R
 def _write_markdown(path: Path, report: JsonDict) -> None:
     decision = report["decision"]
     q = report["quality"]
-    proxy = report["rank_datapath_proxy"]
+    proxy = report["rank_datapath_ppa"]
     ppa = (proxy.get("ppa") or {}).get("metrics") or {}
+    argmax = (proxy.get("argmax_ppa") or {}).get("metrics") or {}
+    topk = (proxy.get("topk_ppa") or {}).get("metrics") or {}
     lines = [
         "# Decoder Logit-Rank Bypass",
         "",
@@ -197,13 +238,19 @@ def _write_markdown(path: Path, report: JsonDict) -> None:
             "- not_valid_for: `temperature_sampling`, `top_p_sampling`, `probability_reporting`",
             "- removed: `softmax_exp_or_pwl`, `softmax_sum_normalization`, `reciprocal_normalization`, `probability_quantization`",
             "",
-            "## Rank Datapath Proxy",
+            "## Rank Datapath PPA",
             "",
             f"- status: `{proxy['status']}`",
             f"- source: `{proxy['source'] or ''}`",
-            f"- critical_path_ns: `{ppa.get('critical_path_ns', '')}`",
-            f"- die_area: `{ppa.get('die_area', '')}`",
-            f"- total_power_mw: `{ppa.get('total_power_mw', '')}`",
+            f"- selected_critical_path_ns: `{ppa.get('critical_path_ns', '')}`",
+            f"- selected_die_area: `{ppa.get('die_area', '')}`",
+            f"- selected_total_power_mw: `{ppa.get('total_power_mw', '')}`",
+            f"- argmax_k1_critical_path_ns: `{argmax.get('critical_path_ns', '')}`",
+            f"- argmax_k1_die_area: `{argmax.get('die_area', '')}`",
+            f"- argmax_k1_total_power_mw: `{argmax.get('total_power_mw', '')}`",
+            f"- topk_k4_critical_path_ns: `{topk.get('critical_path_ns', '')}`",
+            f"- topk_k4_die_area: `{topk.get('die_area', '')}`",
+            f"- topk_k4_total_power_mw: `{topk.get('total_power_mw', '')}`",
             f"- note: {proxy['note']}",
             "",
             "## Next Step",
@@ -218,7 +265,7 @@ def _write_markdown(path: Path, report: JsonDict) -> None:
 def main() -> int:
     ap = argparse.ArgumentParser(description="Summarize raw-logit rank bypass quality")
     ap.add_argument("--sweep", required=True, help="decoder quality sweep JSON")
-    ap.add_argument("--rank-ppa", default=str(DEFAULT_TIE_RANK_PPA), help="rank-like datapath PPA proxy JSON")
+    ap.add_argument("--rank-ppa", default=str(DEFAULT_LOGIT_RANK_PPA), help="rank datapath PPA promotion JSON")
     ap.add_argument("--out", required=True, help="output JSON path")
     ap.add_argument("--out-md", required=True, help="output Markdown path")
     args = ap.parse_args()

--- a/tests/test_llm_decoder_logit_rank_bypass.py
+++ b/tests/test_llm_decoder_logit_rank_bypass.py
@@ -41,4 +41,73 @@ def test_logit_rank_bypass_report_marks_exact_safe_and_scope(tmp_path: Path) -> 
     assert report["quality"]["logit_rank_bypass"]["next_token_matches"] == 2
     assert "temperature_sampling" in report["bypass_scope"]["not_valid_for"]
     assert "reciprocal_normalization" in report["bypass_scope"]["removed_datapaths"]
-    assert report["rank_datapath_proxy"]["status"] == "missing_rank_ppa"
+    assert report["rank_datapath_ppa"]["status"] == "missing_rank_ppa"
+
+
+def test_logit_rank_bypass_report_uses_measured_logit_rank_ppa(tmp_path: Path) -> None:
+    sweep = tmp_path / "sweep.json"
+    sweep.write_text(
+        json.dumps(
+            {
+                "rough_grid": "decoder_logit_rank_bypass_v1",
+                "task": "greedy_next_token",
+                "templates": [
+                    {
+                        "template": "candidate_onnx_softmax_exact",
+                        "sample_count": 1,
+                        "next_token_id_match_rate": 1.0,
+                        "topk_contains_reference_id_rate": 1.0,
+                    },
+                    {
+                        "template": "candidate_onnx_logit_rank_bypass",
+                        "sample_count": 1,
+                        "next_token_id_match_rate": 1.0,
+                        "topk_contains_reference_id_rate": 1.0,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    ppa = tmp_path / "l1_decoder_logit_rank_datapath_v1_r2.json"
+    ppa.write_text(
+        json.dumps(
+            {
+                "item_id": "l1_decoder_logit_rank_datapath_v1_r2",
+                "proposals": [
+                    {
+                        "metrics_ref": {
+                            "metrics_csv": "runs/designs/activations/logit_rank_r8_l16_k1_wrapper/metrics.csv",
+                            "status": "ok",
+                        },
+                        "metric_summary": {
+                            "critical_path_ns": 3.1833,
+                            "die_area": 3738.711025,
+                            "total_power_mw": 0.00348,
+                        },
+                    },
+                    {
+                        "metrics_ref": {
+                            "metrics_csv": "runs/designs/activations/logit_rank_r8_l16_k4_wrapper/metrics.csv",
+                            "status": "ok",
+                        },
+                        "metric_summary": {
+                            "critical_path_ns": 3.6015,
+                            "die_area": 8605.345225,
+                            "total_power_mw": 0.0164,
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_report(sweep_path=sweep, rank_ppa_path=ppa)
+
+    proxy = report["rank_datapath_ppa"]
+    assert proxy["status"] == "measured_logit_rank_datapath"
+    assert proxy["argmax_ppa"]["role"] == "argmax_k1"
+    assert proxy["topk_ppa"]["role"] == "topk_k4"
+    assert proxy["argmax_ppa"]["metrics"]["die_area"] == 3738.711025
+    assert proxy["topk_ppa"]["metrics"]["die_area"] == 8605.345225


### PR DESCRIPTION
## Summary
- switch GPT-2 logit-rank bypass accounting from the old bf16 score/tie-rank proxy to the merged logit-only rank datapath PPA
- report both measured argmax k=1 and top-k k=4 PPA rows in the bypass summary
- update proposal wording, README guidance, and focused tests

## Root Cause
The L2 logit-rank bypass evidence still referenced the conservative bf16 score/tie-rank PPA even after the dedicated logit-only datapath had been measured and merged. That kept future reruns from reflecting the more precise physical cost anchor.

## Validation
- `python3 -m py_compile npu/eval/summarize_llm_decoder_logit_rank_bypass.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_logit_rank_bypass.py`
- `PYTHONPATH=/workspaces/RTLGen /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_logit_rank_bypass.py control_plane/control_plane/tests/test_l2_task_generator.py -q`
- `python3 -m json.tool docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json`
- `python3 npu/eval/summarize_llm_decoder_logit_rank_bypass.py --sweep runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_quality_sweep__l2_decoder_gpt2_logit_rank_bypass_v1.json --rank-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json --out /tmp/decoder_gpt2_logit_rank_bypass_ppa.json --out-md /tmp/decoder_gpt2_logit_rank_bypass_ppa.md`
