### PR TITLE
[codex] Add logit-rank scale L1 proposal

### DIFF
--- a/docs/proposals/prop_l1_decoder_logit_rank_scale_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_logit_rank_scale_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l1_decoder_logit_rank_scale_v1",
+  "source_commit": "",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_logit_rank_scale_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA scaling for signed 16-bit logit-only rank datapaths at row_elems=16 and row_elems=32, with k=1 and k=4.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "comparison_role": "scale_component",
+      "paired_baseline_item_id": "l1_decoder_logit_rank_datapath_v1_r2",
+      "depends_on_item_ids": [
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l2_decoder_gpt2_logit_rank_bypass_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure",
+        "reason": "Use measured row-16 and row-32 logit-rank PPA to decide whether wider rank tiles or hierarchical row-8 composition should be the next decoder-output architecture path."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_logit_rank_scale_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_logit_rank_scale_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l1_decoder_logit_rank_scale_v1",
+  "created_utc": "2026-05-04T11:50:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "circuit_block",
+  "title": "Decoder logit-only rank scaling",
+  "hypothesis": "The row-8 logit-only rank datapath result may not extrapolate linearly to larger vocabulary tiles, so the next physical frontier should measure row-16 and row-32 argmax/top-k rankers directly before full decoder-array claims.",
+  "direct_comparison": {
+    "primary_question": "How do Nangate45 area, timing, and power scale when the raw-logit rank datapath grows from row_elems=8 to row_elems=16 and row_elems=32?",
+    "include": [
+      "logit_rank_r16_l16_k1 wrapper",
+      "logit_rank_r16_l16_k4 wrapper",
+      "logit_rank_r32_l16_k1 wrapper",
+      "logit_rank_r32_l16_k4 wrapper",
+      "Nangate45 high-utilization Layer 1 sweep",
+      "comparison against the merged row-8 k=1/k=4 logit-rank PPA"
+    ],
+    "exclude": [
+      "top_k=8 or larger candidate retention",
+      "full vocabulary reduction tree",
+      "softmax probability generation",
+      "sampling modes",
+      "full decoder macro integration"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the row-8 PPA anchor remains plausible for larger rank tiles",
+    "separates greedy argmax scaling from top-k candidate scaling",
+    "gives measured data for deciding whether to pursue wider rank tiles or hierarchical row-8 composition"
+  ],
+  "risks": [
+    "row_elems=16 and row_elems=32 are still tile-level circuit blocks, not full vocabulary reducers",
+    "top_k=4 does not cover wider beam or sampler candidate sets",
+    "isolated ranker PPA may change after integration with output buffering or cross-tile reduction"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_logit_rank_scale_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA scaling for signed 16-bit logit-only rank datapaths at row_elems=16 and row_elems=32, with k=1 and k=4.",
+      "config_paths": [
+        "runs/designs/activations/logit_rank_r16_l16_k1_wrapper/config_logit_rank_r16_l16_k1.json",
+        "runs/designs/activations/logit_rank_r16_l16_k4_wrapper/config_logit_rank_r16_l16_k4.json",
+        "runs/designs/activations/logit_rank_r32_l16_k1_wrapper/config_logit_rank_r32_l16_k1.json",
+        "runs/designs/activations/logit_rank_r32_l16_k4_wrapper/config_logit_rank_r32_l16_k4.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil.json",
+      "platform": "nangate45",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "depends_on_item_ids": [
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l2_decoder_gpt2_logit_rank_bypass_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_gpt2_logit_rank_bypass__l2_decoder_gpt2_logit_rank_bypass_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "src/rtlgen/rtl_operations.cpp",
+    "npu/eval/summarize_llm_decoder_logit_rank_bypass.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil.json
+++ b/runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil.json
@@ -1,0 +1,18 @@
+{
+  "tag_prefix": "logit_rank_scale_nangate45_highutil",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      2.5
+    ],
+    "CORE_UTILIZATION": [
+      60,
+      50
+    ],
+    "PLACE_DENSITY": [
+      0.68
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      32768
+    ]
+  }
+}

--- a/runs/designs/activations/logit_rank_r16_l16_k1_wrapper/config_logit_rank_r16_l16_k1.json
+++ b/runs/designs/activations/logit_rank_r16_l16_k1_wrapper/config_logit_rank_r16_l16_k1.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r16_l16_k1",
+      "operand": "logits",
+      "options": {
+        "row_elems": 16,
+        "logit_bits": 16,
+        "top_k": 1,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/logit_rank_r16_l16_k4_wrapper/config_logit_rank_r16_l16_k4.json
+++ b/runs/designs/activations/logit_rank_r16_l16_k4_wrapper/config_logit_rank_r16_l16_k4.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r16_l16_k4",
+      "operand": "logits",
+      "options": {
+        "row_elems": 16,
+        "logit_bits": 16,
+        "top_k": 4,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/logit_rank_r32_l16_k1_wrapper/config_logit_rank_r32_l16_k1.json
+++ b/runs/designs/activations/logit_rank_r32_l16_k1_wrapper/config_logit_rank_r32_l16_k1.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r32_l16_k1",
+      "operand": "logits",
+      "options": {
+        "row_elems": 32,
+        "logit_bits": 16,
+        "top_k": 1,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/logit_rank_r32_l16_k4_wrapper/config_logit_rank_r32_l16_k4.json
+++ b/runs/designs/activations/logit_rank_r32_l16_k4_wrapper/config_logit_rank_r32_l16_k4.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r32_l16_k4",
+      "operand": "logits",
+      "options": {
+        "row_elems": 32,
+        "logit_bits": 16,
+        "top_k": 4,
+        "logit_signed": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Layer 1 proposal for logit-rank scaling beyond the row-8 anchor
- add row-16 and row-32 signed 16-bit logit-rank configs for k=1 and k=4
- add a bounded Nangate45 high-utilization sweep for the scale job

## Why
The row-8 logit-rank result now anchors GPT-2 rank-bypass accounting, but it is not enough to reason about larger vocabulary tiles. This proposal measures the first scale step directly before we decide between wider rank tiles and hierarchical row-8 composition.

## Validation
- `cmake --build build --target rtlgen`
- `python3 -m json.tool` on all new configs, sweep, proposal, and evaluation request
- `python3 -m py_compile scripts/generate_design.py scripts/run_sweep.py control_plane/control_plane/services/l1_task_generator.py`
- `python3 scripts/generate_design.py ... nangate45 --force_gen true` for all four new configs
- `yosys -q -p 'read_verilog ...; hierarchy -top ...; proc'` for all four generated modules
- `git diff --check` on the new files
