### PR TITLE
Add decoder logit-rank streaming hierarchy plan

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1872,6 +1872,45 @@ def _decoder_gpt2_logit_rank_bypass_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_logit_rank_streaming_hierarchy_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    prompt_stress = f"{base}/decoder_gpt2_prompt_stress__l2_decoder_gpt2_prompt_stress_v1.json"
+    logit_rank_bypass = f"{base}/decoder_gpt2_logit_rank_bypass__l2_decoder_gpt2_logit_rank_bypass_v1.json"
+    hierarchy_out = f"{base}/decoder_logit_rank_streaming_hierarchy__{item_id}.json"
+    hierarchy_report = f"{base}/decoder_logit_rank_streaming_hierarchy__{item_id}.md"
+    rank_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
+    scale_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+    return {
+        "inputs": {
+            "source_prompt_stress": prompt_stress,
+            "source_logit_rank_bypass": logit_rank_bypass,
+            "rank_datapath_ppa": rank_ppa,
+            "rank_scale_ppa": scale_ppa,
+            "streaming_hierarchy_out": hierarchy_out,
+            "streaming_hierarchy_report": hierarchy_report,
+            "streaming_hierarchy_scope": (
+                "GPT-2 prompt-stress planning gate for a streaming hierarchy decoder that ranks logits "
+                "directly and avoids full-vocabulary probability materialization for greedy/top-k modes"
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_logit_rank_streaming_hierarchy",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py "
+                    f"--prompt-stress {prompt_stress} "
+                    f"--logit-rank-bypass {logit_rank_bypass} "
+                    f"--rank-ppa {rank_ppa} "
+                    f"--scale-ppa {scale_ppa} "
+                    f"--out {hierarchy_out} "
+                    f"--out-md {hierarchy_report}"
+                ),
+            },
+        ],
+        "expected_outputs": [hierarchy_out, hierarchy_report],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2332,10 +2371,13 @@ def _build_payload(
         "decoder_gpt2_prompt_stress",
         "decoder_gpt2_tie_rank_frontier",
         "decoder_gpt2_logit_rank_bypass",
+        "decoder_logit_rank_streaming_hierarchy",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_logit_rank_streaming_hierarchy":
+            decoder_evidence = _decoder_logit_rank_streaming_hierarchy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_gpt2_logit_rank_bypass":
             decoder_evidence = _decoder_gpt2_logit_rank_bypass_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_gpt2_tie_rank_frontier":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1507,6 +1507,69 @@ def test_generate_l2_campaign_task_adds_decoder_gpt2_logit_rank_bypass_evidence(
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_hierarchy_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_logit_rank_streaming_hierarchy_v1",
+                    proposal_id="prop_l2_decoder_logit_rank_streaming_hierarchy_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_logit_rank_streaming_hierarchy",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[0] == "estimate_decoder_logit_rank_streaming_hierarchy"
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["source_prompt_stress"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_gpt2_prompt_stress__l2_decoder_gpt2_prompt_stress_v1.json"
+            )
+            assert decoder_inputs["source_logit_rank_bypass"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_gpt2_logit_rank_bypass__l2_decoder_gpt2_logit_rank_bypass_v1.json"
+            )
+            assert decoder_inputs["rank_datapath_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
+            )
+            assert decoder_inputs["rank_scale_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+            )
+            assert decoder_inputs["streaming_hierarchy_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_logit_rank_streaming_hierarchy__l2_decoder_logit_rank_streaming_hierarchy_v1.json"
+            )
+            assert "avoids full-vocabulary probability materialization" in decoder_inputs["streaming_hierarchy_scope"]
+            assert "estimate_llm_decoder_logit_rank_streaming_hierarchy.py" in work_item.command_manifest[0]["run"]
+            assert "--scale-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json" in work_item.command_manifest[0]["run"]
+            assert "--out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_logit_rank_streaming_hierarchy__l2_decoder_logit_rank_streaming_hierarchy_v1.json" in work_item.command_manifest[0]["run"]
+            assert "--out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_logit_rank_streaming_hierarchy__l2_decoder_logit_rank_streaming_hierarchy_v1.md" in work_item.command_manifest[0]["run"]
+            assert decoder_inputs["streaming_hierarchy_out"] in work_item.expected_outputs
+            assert decoder_inputs["streaming_hierarchy_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_logit_rank_streaming_hierarchy",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/README.md
@@ -1,0 +1,17 @@
+# Decoder Logit-Rank Streaming Hierarchy
+
+This proposal records the documentation/spec slice and first-order estimator
+for composing measured logit-rank tiles into a full-vocabulary decoder
+reduction path.
+
+Artifacts:
+
+- `proposal.json`: proposal metadata and review scope
+- `evaluation_requests.json`: frontier-detail review request
+- `design_brief.md`: problem, hypothesis, and scope
+- `evaluation_gate.md`: pending review gate
+- `npu/docs/decoder_logit_rank_streaming_hierarchy.md`: architecture spec
+- `npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py`: estimator
+  entry point
+
+No RTL or physical implementation changes are part of this slice.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/design_brief.md
@@ -1,0 +1,62 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_logit_rank_streaming_hierarchy_v1`
+- `title`: `Decoder logit-rank streaming hierarchy`
+
+## Problem
+The rank-only decoder path has evidence for raw-logit bypass and measured
+tile-level rank datapaths, but the integration boundary is still implicit. A
+full vocabulary reduction needs stable token identity, tile completion, lane
+masking, and backpressure semantics before implementation can safely overlap
+output projection with rank reduction.
+
+## Hypothesis
+A pair of ready/valid streams can carry raw logits into tile rankers and
+ranked candidates out to a cross-tile reducer without materializing softmax
+probabilities. The contract is sufficient if it defines packet stability,
+`tile_id`, `base_token_id`, `lane_valid`, and `last` behavior, and if it
+states when upstream producers may overlap subsequent tiles with downstream
+ranking.
+
+## Evaluation Scope
+- direct comparison set:
+  - spec review of `LogitTileStream`
+  - spec review of `CandidateStream`
+  - overlap and backpressure rule review
+  - rough latency/FIFO estimate versus measured flat r8/r16/r32 logit-rank
+    datapaths
+- evaluation mode:
+  - `frontier_detail`
+- dependency order:
+  - depends on the raw-logit bypass evidence and logit-rank datapath/scale
+    measurements
+  - requires merged inputs and materialized repo refs
+- excluded first-stage comparisons:
+  - RTL generation
+  - physical synthesis
+  - probability-producing decoder modes
+- follow-on broad sweep:
+  - compare tile width, top-k width, and reducer-depth choices after a narrow
+    implementation exists
+
+## Knowledge Inputs
+- `docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json`
+- `docs/proposals/prop_l1_decoder_logit_rank_datapath_v1/proposal.json`
+- `docs/proposals/prop_l1_decoder_logit_rank_scale_v1/proposal.json`
+- `npu/docs/decoder_logit_rank_streaming_hierarchy.md`
+- `npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py`
+
+## Candidate Direction
+Define a rank-only hierarchy:
+
+- output projection emits raw logits in fixed-width `LogitTileStream` beats
+- per-tile rankers emit bounded `CandidateStream` beats
+- a cross-tile reducer consumes candidates and emits greedy or top-k decisions
+- probability consumers remain out of scope and must use a probability path
+
+## Direction Gate
+- status: pending
+- approved_by:
+- approved_utc:
+- note:

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - frontier-detail review for `l2_decoder_logit_rank_streaming_hierarchy_v1`
+- note: Gate covers documentation/spec readiness and first-order latency/FIFO model readiness. RTL and physical implementation work require a follow-on proposal.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_hierarchy_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_hierarchy_v1",
+      "task_type": "l2_campaign",
+      "objective": "Review and gate the decoder logit-rank streaming hierarchy contract and rough latency/FIFO estimate before RTL implementation.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_hierarchy",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_gpt2_logit_rank_bypass_v1_r2",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "approve_or_iterate",
+        "reason": "The review should confirm whether LogitTileStream and CandidateStream contracts, backpressure, overlap assumptions, and first-order performance model are implementation-ready."
+      },
+      "status": "pending"
+    }
+  ],
+  "source_commit": "1c7f5a4e440ba17011ef883206c02ebbb55cdd03"
+}

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/proposal.json
@@ -1,0 +1,77 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_hierarchy_v1",
+  "created_utc": "2026-05-04T12:30:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_logit_rank_streaming_hierarchy",
+  "title": "Decoder logit-rank streaming hierarchy",
+  "hypothesis": "A full-vocabulary rank-only decoder path can compose the measured logit-rank tiles behind ready/valid streams, carrying token identity and tile completion metadata explicitly so output projection, tile rank, and cross-tile candidate reduction can overlap without requiring softmax probability materialization.",
+  "direct_comparison": {
+    "primary_question": "Is the proposed LogitTileStream-to-CandidateStream hierarchy, plus a first-order streaming performance model, precise enough to guide implementation of overlapped rank-only decoder reduction?",
+    "include": [
+      "LogitTileStream field and handshake contract",
+      "CandidateStream field and handshake contract",
+      "tile_id, base_token_id, lane_valid, and last semantics",
+      "backpressure and packet stability rules",
+      "producer overlap assumptions between output projection and rank reduction",
+      "integration notes for greedy and top-k consumers",
+      "rough latency comparison against measured flat r8/r16/r32 logit-rank datapaths"
+    ],
+    "exclude": [
+      "new RTL implementation",
+      "probability-producing softmax or sampling consumers",
+      "new physical synthesis",
+      "larger-model quality reruns"
+    ],
+    "follow_on_broad_sweep": [
+      "evaluate tile width, candidate count, and reducer-depth choices once the streaming hierarchy is implemented",
+      "compare overlapped streaming reduction against a buffered full-vocabulary rank pass"
+    ]
+  },
+  "expected_benefit": [
+    "turns the logit-rank bypass result into an integration-ready streaming contract",
+    "keeps rank-only serving separated from probability-producing decoder modes",
+    "allows projection and rank reduction latency to overlap while preserving deterministic token identity"
+  ],
+  "risks": [
+    "the proposal is a documentation/spec slice and does not prove RTL timing closure",
+    "candidate buffering requirements depend on downstream ready behavior and chosen top-k width",
+    "the contract applies only to rank-preserving consumers and excludes temperature, top-p, and probability reporting"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_hierarchy_v1",
+      "task_type": "l2_campaign",
+      "objective": "Review and gate the decoder logit-rank streaming hierarchy contract and rough performance estimate before RTL implementation.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_hierarchy",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_gpt2_logit_rank_bypass_v1_r2",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "approve_or_iterate",
+        "reason": "The gate should determine whether the documented stream hierarchy and first-order latency/FIFO model are sufficient to start a narrow RTL implementation slice."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_logit_rank_datapath_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_logit_rank_scale_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/decoder_logit_rank_streaming_hierarchy.md",
+    "npu/eval/summarize_llm_decoder_logit_rank_bypass.py",
+    "npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py",
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py",
+    "src/rtlgen/rtl_operations.cpp",
+    "npu/shell/spec.md"
+  ]
+}

--- a/npu/docs/decoder_logit_rank_streaming_hierarchy.md
+++ b/npu/docs/decoder_logit_rank_streaming_hierarchy.md
@@ -1,0 +1,163 @@
+# Decoder Logit-Rank Streaming Hierarchy
+
+## Purpose
+Define the rank-only streaming boundary for decoder output-logit reduction.
+This contract covers greedy next-token, top-k, and beam-candidate ordering paths
+that rank raw logits directly. It does not cover softmax probabilities,
+temperature sampling, top-p sampling, or probability reporting.
+
+## Hierarchy
+The intended pipeline is:
+
+1. output projection produces raw logits by vocabulary tile
+2. a tile ranker consumes each `LogitTileStream` beat and selects local
+   candidates
+3. a cross-tile reducer consumes `CandidateStream` beats and selects global
+   candidates
+
+The hierarchy is completion-bound at stream level: downstream results for a
+sequence are complete only after the accepted beat with `last=1` has drained
+through the cross-tile reducer.
+
+## LogitTileStream
+`LogitTileStream` carries one fixed-width vocabulary tile per accepted beat.
+
+Fields:
+
+- `valid`: producer asserts when all payload fields are meaningful.
+- `ready`: consumer asserts when it can accept the beat.
+- `tile_id`: monotonically increasing tile index within the current decoder
+  step, starting at zero.
+- `base_token_id`: vocabulary token id represented by lane zero.
+- `logit[lane]`: signed raw decoder logit for each lane.
+- `lane_valid[lane]`: one bit per lane. A lane with `lane_valid=0` is padding
+  and must not produce a candidate.
+- `last`: asserted on the final tile beat for the decoder step.
+
+Ready/valid rules:
+
+- A beat transfers only on `valid && ready`.
+- While `valid=1 && ready=0`, the producer must hold every payload field
+  stable, including `tile_id`, `base_token_id`, `logit`, `lane_valid`, and
+  `last`.
+- The consumer may deassert `ready` on any cycle. This is the only backpressure
+  mechanism.
+- The producer may deassert `valid` between beats. Gaps do not change tile
+  ordering.
+- `tile_id` increments by one per accepted beat for a decoder step. It resets
+  to zero on the first accepted beat after the prior accepted `last=1` beat.
+- `base_token_id` must equal the first token id covered by the tile. For dense
+  vocabulary tiling it normally equals `tile_id * lanes`, but consumers must
+  use the explicit field rather than recomputing it.
+- `lane_valid` may be sparse only on the final tile unless a later sparse
+  vocabulary mode explicitly permits holes. Current dense mode requires all
+  non-final tiles to have every lane valid.
+- `last=1` marks the final tile for the current decoder step. It is legal for
+  `last=1` to appear with some invalid lanes.
+
+Token identity:
+
+- Lane `i` maps to `token_id = base_token_id + i` when `lane_valid[i]=1`.
+- Invalid lanes have no token identity and must be ignored for ranking.
+- If two valid lanes have equal logits, the stable tie-break is lower
+  `token_id` first unless a future mode overrides the tie policy explicitly.
+
+## CandidateStream
+`CandidateStream` carries ranked local candidates from tile rankers to the
+cross-tile reducer.
+
+Fields:
+
+- `valid`: producer asserts when all candidate payload fields are meaningful.
+- `ready`: reducer asserts when it can accept the beat.
+- `tile_id`: source tile for the candidates in this beat.
+- `base_token_id`: source `LogitTileStream` base token for the tile.
+- `rank_base`: rank offset of candidate lane zero within the source tile.
+- `candidate_token_id[lane]`: token id for each candidate lane.
+- `candidate_logit[lane]`: raw logit paired with each candidate token.
+- `candidate_valid[lane]`: one bit per candidate lane.
+- `last`: asserted on the final candidate beat for the decoder step.
+
+Ready/valid rules:
+
+- A beat transfers only on `valid && ready`.
+- While `valid=1 && ready=0`, the tile ranker must hold all candidate payload
+  fields stable, including `tile_id`, `base_token_id`, `rank_base`, candidate
+  arrays, valid masks, and `last`.
+- The reducer may deassert `ready` on any cycle. Tile rankers must either
+  buffer accepted input tiles or backpressure their `LogitTileStream` input.
+- `tile_id` identifies the source tile. Candidate beats from different tiles
+  may arrive out of order only if the reducer advertises out-of-order support.
+  The base contract assumes in-order tile completion.
+- `base_token_id` repeats the accepted source tile base. It is redundant with
+  explicit `candidate_token_id` values in dense mode, but it preserves tile
+  provenance for tracing, debug, and future compressed token encodings.
+- `rank_base` increments by the candidate beat width for multi-beat tile
+  candidate output. A single-beat top-k tile ranker sets `rank_base=0`.
+- `candidate_valid=0` marks padding and must not enter global reduction.
+- `last=1` marks the final candidate beat for the decoder step, not merely the
+  final candidate from a tile.
+
+Candidate semantics:
+
+- For each valid candidate lane, `candidate_token_id` must correspond to a
+  valid input lane from the source tile.
+- For dense token encoding, each valid `candidate_token_id` must be in the
+  half-open range `[base_token_id, base_token_id + logit_lanes)`.
+- Candidates within a tile are sorted by descending `candidate_logit`, with the
+  lower `candidate_token_id` tie-break.
+- The tile ranker must not emit more than the configured local `k` valid
+  candidates per tile.
+- The cross-tile reducer applies the same descending-logit and lower-token-id
+  tie-break globally.
+
+## Backpressure
+Backpressure is local and lossless:
+
+- `CandidateStream.ready=0` may stall tile ranker output.
+- A stalled tile ranker may continue accepting `LogitTileStream` input only if
+  it has bounded buffering for the accepted tiles and their pending
+  candidates.
+- If that buffering is unavailable or full, the tile ranker must deassert
+  `LogitTileStream.ready`.
+- The output projection must treat `LogitTileStream.ready=0` as a hard stall
+  for the current beat and must keep the payload stable until transfer.
+- No stream participant may drop a valid lane or candidate because downstream
+  `ready` is low.
+
+The minimum implementation may use one-entry skid buffers on both stream
+boundaries. Deeper buffering is an optimization, not a contract requirement.
+
+## Producer Overlap Assumptions
+The overlap model assumes the output projection can produce tile `N+1` while
+the ranker/reducer are processing candidates derived from tile `N`, subject to
+ready/valid backpressure.
+
+Allowed overlap:
+
+- projection of later vocabulary tiles may continue while earlier tile
+  candidates are being reduced
+- a tile ranker may accept the next tile before emitting all candidates for the
+  prior tile only when internal buffering preserves both tile identity and
+  payload stability
+- the cross-tile reducer may update a running global top-k after each accepted
+  candidate beat and does not need to wait for `last=1`
+
+Required assumptions:
+
+- all tiles in a decoder step use the same hidden-state vector and projection
+  parameters
+- `tile_id` and `base_token_id` are assigned before any overlapping stage can
+  reorder or buffer the beat
+- a new decoder step must not reuse `tile_id=0` on a shared stream until the
+  prior step's `last=1` beat has been accepted, unless a future `step_id`
+  field is added
+- consumers must not publish the final next-token/top-k result until the
+  accepted `CandidateStream` beat with `last=1` has been reduced
+
+## Integration Notes
+This spec intentionally keeps mapper and evaluator changes out of scope. A
+follow-on implementation should bind concrete widths for logit lanes, candidate
+lanes, local `k`, and buffering depth, then add validation that random
+backpressure preserves the same rank result as an unstreamed full-vocabulary
+reference.

--- a/npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py
+++ b/npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""CLI entry point for the decoder logit-rank streaming hierarchy estimate."""
+
+from __future__ import annotations
+
+from model_llm_decoder_logit_rank_streaming import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/model_llm_decoder_logit_rank_streaming.py
+++ b/npu/eval/model_llm_decoder_logit_rank_streaming.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Model decoder logit-rank streaming hierarchy throughput and latency."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+DEFAULT_RANK_PPA = Path(
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
+)
+DEFAULT_SCALE_PPA = Path(
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+)
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        raise ValueError("denominator must be positive")
+    return (numerator + denominator - 1) // denominator
+
+
+def _parse_csv_point(path: str) -> JsonDict:
+    match = re.search(r"logit_rank_r(?P<lanes>\d+)_l(?P<bits>\d+)_k(?P<topk>\d+)", path)
+    if not match:
+        return {"lanes": None, "logit_bits": None, "top_k": None}
+    return {
+        "lanes": int(match.group("lanes")),
+        "logit_bits": int(match.group("bits")),
+        "top_k": int(match.group("topk")),
+    }
+
+
+def _load_json(path: Path) -> JsonDict:
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def load_ranker_points(path: Path | None) -> list[JsonDict]:
+    if path is None or not path.exists():
+        return []
+    payload = _load_json(path)
+    rows: list[JsonDict] = []
+    for proposal in payload.get("proposals") or []:
+        if not isinstance(proposal, dict):
+            continue
+        ref = proposal.get("metrics_ref")
+        metrics = proposal.get("metric_summary")
+        if not isinstance(ref, dict) or not isinstance(metrics, dict):
+            continue
+        if str(ref.get("status") or "") != "ok":
+            continue
+        metrics_csv = str(ref.get("metrics_csv") or "")
+        point = _parse_csv_point(metrics_csv)
+        rows.append(
+            {
+                "source": str(path),
+                "artifact_item_id": payload.get("item_id"),
+                "metrics_csv": metrics_csv,
+                "lanes": point["lanes"],
+                "logit_bits": point["logit_bits"],
+                "top_k": point["top_k"],
+                "metrics": {
+                    "critical_path_ns": _as_float(metrics.get("critical_path_ns")),
+                    "die_area": _as_float(metrics.get("die_area")),
+                    "total_power_mw": _as_float(metrics.get("total_power_mw")),
+                },
+            }
+        )
+    rows.sort(
+        key=lambda row: (
+            _as_int(row.get("lanes"), 10**9),
+            _as_int(row.get("top_k"), 10**9),
+            row["metrics"]["critical_path_ns"],
+        )
+    )
+    return rows
+
+
+def load_ranker_points_from_paths(paths: list[Path | None]) -> list[JsonDict]:
+    points: list[JsonDict] = []
+    seen: set[tuple[str | None, int, int]] = set()
+    for path in paths:
+        for point in load_ranker_points(path):
+            key = (
+                point.get("metrics_csv"),
+                _as_int(point.get("lanes")),
+                _as_int(point.get("top_k")),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            points.append(point)
+    points.sort(
+        key=lambda row: (
+            _as_int(row.get("lanes"), 10**9),
+            _as_int(row.get("top_k"), 10**9),
+            row["metrics"]["critical_path_ns"],
+        )
+    )
+    return points
+
+
+def _fallback_ranker_point(*, lanes: int, top_k: int, critical_path_ns: float) -> JsonDict:
+    return {
+        "source": "cli_default",
+        "metrics_csv": None,
+        "lanes": lanes,
+        "logit_bits": 16,
+        "top_k": top_k,
+        "metrics": {
+            "critical_path_ns": critical_path_ns,
+            "die_area": None,
+            "total_power_mw": None,
+        },
+    }
+
+
+def _select_ranker_point(
+    points: list[JsonDict], *, lanes: int, top_k: int, default_critical_path_ns: float
+) -> JsonDict:
+    exact = [
+        row
+        for row in points
+        if _as_int(row.get("lanes")) == lanes and _as_int(row.get("top_k")) == top_k
+    ]
+    if exact:
+        return exact[0]
+    same_k = [row for row in points if _as_int(row.get("top_k")) == top_k and _as_int(row.get("lanes")) > 0]
+    if same_k:
+        nearest = min(same_k, key=lambda row: abs(_as_int(row.get("lanes")) - lanes))
+        scale = math.log2(max(2, lanes)) / math.log2(max(2, _as_int(nearest.get("lanes"), lanes)))
+        clone = json.loads(json.dumps(nearest))
+        clone["source"] = f"{nearest['source']}#scaled_nearest_lane"
+        clone["lanes"] = lanes
+        clone["metrics"]["critical_path_ns"] = round(nearest["metrics"]["critical_path_ns"] * scale, 6)
+        clone["model_note"] = (
+            f"critical_path_ns scaled from measured r{nearest['lanes']} k{nearest['top_k']} "
+            f"by log2(lanes) ratio"
+        )
+        return clone
+    return _fallback_ranker_point(
+        lanes=lanes, top_k=top_k, critical_path_ns=default_critical_path_ns
+    )
+
+
+def simulate_streaming_hierarchy(
+    *,
+    vocab_size: int,
+    producer_lanes: int,
+    producer_latency_cycles: int,
+    producer_ii_cycles: int,
+    local_ranker_latency_cycles: int,
+    local_ranker_ii_cycles: int,
+    local_top_k: int,
+    global_merge_latency_cycles: int,
+    global_merge_ii_cycles: int,
+    candidate_fifo_depth_groups: int,
+) -> JsonDict:
+    tile_count = _ceil_div(vocab_size, producer_lanes)
+    local_done_times: list[int] = []
+    local_available = 0
+    for tile in range(tile_count):
+        producer_ready = producer_latency_cycles + tile * producer_ii_cycles
+        local_start = max(producer_ready, local_available)
+        local_done_times.append(local_start + local_ranker_latency_cycles)
+        local_available = local_start + local_ranker_ii_cycles
+
+    merge_start_times: list[int] = []
+    merge_done_times: list[int] = []
+    merge_available = 0
+    for local_done in local_done_times:
+        merge_start = max(local_done, merge_available)
+        merge_start_times.append(merge_start)
+        merge_done_times.append(merge_start + global_merge_latency_cycles)
+        merge_available = merge_start + global_merge_ii_cycles
+
+    events: list[tuple[int, int]] = []
+    for t in local_done_times:
+        events.append((t, 1))
+    for t in merge_start_times:
+        events.append((t, -1))
+    events.sort(key=lambda item: (item[0], -item[1]))
+    occupancy = 0
+    max_occupancy = 0
+    for _, delta in events:
+        occupancy += delta
+        max_occupancy = max(max_occupancy, occupancy)
+
+    total_candidates = tile_count * local_top_k
+    total_cycles = max(merge_done_times) if merge_done_times else 0
+    return {
+        "tile_count": tile_count,
+        "producer_lanes": producer_lanes,
+        "local_top_k": local_top_k,
+        "total_candidates_emitted": total_candidates,
+        "total_cycles": total_cycles,
+        "producer_last_tile_ready_cycle": producer_latency_cycles + max(0, tile_count - 1) * producer_ii_cycles,
+        "local_last_done_cycle": max(local_done_times) if local_done_times else 0,
+        "global_last_done_cycle": total_cycles,
+        "required_fifo_depth_groups": max_occupancy,
+        "candidate_fifo_depth_groups": candidate_fifo_depth_groups,
+        "fifo_capacity_ok": max_occupancy <= candidate_fifo_depth_groups,
+        "producer_ii_cycles": producer_ii_cycles,
+        "local_ranker_latency_cycles": local_ranker_latency_cycles,
+        "local_ranker_ii_cycles": local_ranker_ii_cycles,
+        "global_merge_latency_cycles": global_merge_latency_cycles,
+        "global_merge_ii_cycles": global_merge_ii_cycles,
+    }
+
+
+def _time_summary(*, cycles: int, clock_ns: float, vocab_size: int) -> JsonDict:
+    latency_ns = cycles * clock_ns
+    latency_us = latency_ns / 1000.0
+    tokens_per_s = 1_000_000_000.0 / latency_ns if latency_ns > 0 else 0.0
+    logits_per_s = vocab_size * tokens_per_s
+    return {
+        "clock_ns": round(clock_ns, 6),
+        "latency_cycles": cycles,
+        "latency_us_per_token": round(latency_us, 6),
+        "tokens_per_s": round(tokens_per_s, 3),
+        "logits_per_s": round(logits_per_s, 3),
+    }
+
+
+def _flat_point_report(
+    *,
+    point: JsonDict,
+    vocab_size: int,
+    ranker_latency_cycles: int,
+    ranker_ii_cycles: int,
+) -> JsonDict:
+    lanes = _as_int(point.get("lanes"), 1) or 1
+    tiles = _ceil_div(vocab_size, lanes)
+    cycles = ranker_latency_cycles + max(0, tiles - 1) * ranker_ii_cycles
+    metrics = point["metrics"]
+    return {
+        "architecture": "flat_measured_ranker_scan",
+        "lanes": lanes,
+        "top_k": point.get("top_k"),
+        "tile_count": tiles,
+        "ranker_latency_cycles": ranker_latency_cycles,
+        "ranker_ii_cycles": ranker_ii_cycles,
+        "total_cycles": cycles,
+        "timing": _time_summary(
+            cycles=cycles,
+            clock_ns=_as_float(metrics.get("critical_path_ns"), 1.0),
+            vocab_size=vocab_size,
+        ),
+        "metrics": metrics,
+        "source": point.get("source"),
+        "metrics_csv": point.get("metrics_csv"),
+    }
+
+
+def build_report(
+    *,
+    rank_ppa_path: Path | None = DEFAULT_RANK_PPA,
+    scale_ppa_path: Path | None = DEFAULT_SCALE_PPA,
+    prompt_stress_path: Path | None = None,
+    logit_rank_bypass_path: Path | None = None,
+    vocab_size: int = 50257,
+    producer_lanes: int = 8,
+    top_k: int = 4,
+    producer_latency_cycles: int = 1,
+    producer_ii_cycles: int = 1,
+    local_ranker_latency_cycles: int = 4,
+    local_ranker_ii_cycles: int = 1,
+    global_merge_latency_cycles: int = 3,
+    global_merge_ii_cycles_list: list[int] | None = None,
+    candidate_fifo_depth_groups: int = 16,
+    fallback_critical_path_ns: float = 3.6,
+) -> JsonDict:
+    if vocab_size <= 0:
+        raise ValueError("vocab_size must be positive")
+    if producer_lanes <= 0:
+        raise ValueError("producer_lanes must be positive")
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    merge_iis = global_merge_ii_cycles_list or [1, 2, 4]
+    measured_points = load_ranker_points_from_paths([rank_ppa_path, scale_ppa_path])
+    if not measured_points:
+        measured_points = [
+            _fallback_ranker_point(
+                lanes=producer_lanes, top_k=1, critical_path_ns=fallback_critical_path_ns
+            ),
+            _fallback_ranker_point(
+                lanes=producer_lanes, top_k=top_k, critical_path_ns=fallback_critical_path_ns
+            ),
+        ]
+
+    flat = [
+        _flat_point_report(
+            point=point,
+            vocab_size=vocab_size,
+            ranker_latency_cycles=local_ranker_latency_cycles,
+            ranker_ii_cycles=local_ranker_ii_cycles,
+        )
+        for point in measured_points
+        if _as_int(point.get("lanes")) > 0
+    ]
+
+    local_point = _select_ranker_point(
+        measured_points,
+        lanes=producer_lanes,
+        top_k=top_k,
+        default_critical_path_ns=fallback_critical_path_ns,
+    )
+    global_point = _select_ranker_point(
+        measured_points,
+        lanes=max(producer_lanes, top_k),
+        top_k=top_k,
+        default_critical_path_ns=fallback_critical_path_ns,
+    )
+    local_clock = _as_float(local_point["metrics"].get("critical_path_ns"), fallback_critical_path_ns)
+    global_clock = _as_float(global_point["metrics"].get("critical_path_ns"), fallback_critical_path_ns)
+    hierarchy_clock_ns = max(local_clock, global_clock)
+    alternatives: list[JsonDict] = []
+    for merge_ii in merge_iis:
+        sim = simulate_streaming_hierarchy(
+            vocab_size=vocab_size,
+            producer_lanes=producer_lanes,
+            producer_latency_cycles=producer_latency_cycles,
+            producer_ii_cycles=producer_ii_cycles,
+            local_ranker_latency_cycles=local_ranker_latency_cycles,
+            local_ranker_ii_cycles=local_ranker_ii_cycles,
+            local_top_k=top_k,
+            global_merge_latency_cycles=global_merge_latency_cycles,
+            global_merge_ii_cycles=merge_ii,
+            candidate_fifo_depth_groups=candidate_fifo_depth_groups,
+        )
+        alternatives.append(
+            {
+                "architecture": "hierarchical_streaming_local_rank_global_merge",
+                "merge_variant": f"merge_ii_{merge_ii}",
+                **sim,
+                "timing": _time_summary(
+                    cycles=sim["total_cycles"],
+                    clock_ns=hierarchy_clock_ns,
+                    vocab_size=vocab_size,
+                ),
+                "local_ranker_point": local_point,
+                "global_merge_point": global_point,
+            }
+        )
+
+    all_candidates = flat + alternatives
+    best = min(
+        all_candidates,
+        key=lambda row: (
+            not bool(row.get("fifo_capacity_ok", True)),
+            row["timing"]["latency_us_per_token"],
+            str(row["architecture"]),
+        ),
+    )
+    baseline = min(flat, key=lambda row: row["timing"]["latency_us_per_token"]) if flat else None
+    for row in alternatives:
+        if baseline is None:
+            row["speedup_vs_best_flat"] = None
+        else:
+            row["speedup_vs_best_flat"] = round(
+                baseline["timing"]["latency_us_per_token"] / row["timing"]["latency_us_per_token"], 6
+            )
+
+    return {
+        "version": 0.1,
+        "model": "decoder_logit_rank_streaming_hierarchy_v1",
+        "rank_ppa_path": str(rank_ppa_path) if rank_ppa_path is not None else None,
+        "rank_ppa_paths": [
+            str(path)
+            for path in [rank_ppa_path, scale_ppa_path]
+            if path is not None
+        ],
+        "inputs": {
+            "rank_ppa_path": str(rank_ppa_path) if rank_ppa_path is not None else None,
+            "scale_ppa_path": str(scale_ppa_path) if scale_ppa_path is not None else None,
+            "prompt_stress_path": str(prompt_stress_path) if prompt_stress_path is not None else None,
+            "logit_rank_bypass_path": str(logit_rank_bypass_path) if logit_rank_bypass_path is not None else None,
+            "vocab_size": vocab_size,
+            "producer_lanes": producer_lanes,
+            "top_k": top_k,
+            "producer_latency_cycles": producer_latency_cycles,
+            "producer_ii_cycles": producer_ii_cycles,
+            "local_ranker_latency_cycles": local_ranker_latency_cycles,
+            "local_ranker_ii_cycles": local_ranker_ii_cycles,
+            "global_merge_latency_cycles": global_merge_latency_cycles,
+            "global_merge_ii_cycles_list": merge_iis,
+            "candidate_fifo_depth_groups": candidate_fifo_depth_groups,
+            "fallback_critical_path_ns": fallback_critical_path_ns,
+        },
+        "assumptions": [
+            "Producer emits one W-lane logit tile after producer latency and then every producer II cycles.",
+            "Local ranker accepts one producer tile per local ranker II and emits one candidate group after local ranker latency.",
+            "Candidate FIFO depth is reported in local candidate groups; overflow is reported as capacity evidence, not hidden by backpressure.",
+            "Global merge consumes one local candidate group per merge II and produces the final token rank after the last merge latency.",
+            "Measured row-8 datapath and row-16/row-32 scale critical_path_ns values are used as ranker clock proxies.",
+            "Missing lane points are explicit defaults or log2-lane scaled proxies.",
+        ],
+        "measured_ranker_points": measured_points,
+        "flat_measured_ranker_points": flat,
+        "hierarchical_streaming_alternatives": alternatives,
+        "recommendation": {
+            "architecture": best["architecture"],
+            "merge_variant": best.get("merge_variant"),
+            "latency_us_per_token": best["timing"]["latency_us_per_token"],
+            "tokens_per_s": best["timing"]["tokens_per_s"],
+            "fifo_capacity_ok": best.get("fifo_capacity_ok", True),
+            "reason": (
+                "Lowest modelled latency per token among FIFO-valid measured flat scans and "
+                "hierarchical streaming alternatives."
+            ),
+        },
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    rec = payload["recommendation"]
+    lines = [
+        "# Decoder Logit-Rank Streaming Hierarchy",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- rank_ppa_paths: `{', '.join(payload.get('rank_ppa_paths') or [])}`",
+        f"- recommendation: `{rec['architecture']}`",
+        f"- merge_variant: `{rec['merge_variant'] or ''}`",
+        f"- latency_us_per_token: `{rec['latency_us_per_token']}`",
+        f"- tokens_per_s: `{rec['tokens_per_s']}`",
+        f"- fifo_capacity_ok: `{rec['fifo_capacity_ok']}`",
+        f"- reason: {rec['reason']}",
+        "",
+        "## Inputs",
+        "",
+        "| input | value |",
+        "|---|---:|",
+    ]
+    for key, value in payload["inputs"].items():
+        lines.append(f"| `{key}` | `{value}` |")
+    lines.extend(
+        [
+            "",
+            "## Flat Measured Ranker Points",
+            "",
+            "| lanes | top_k | cycles | latency_us | tokens_per_s | critical_path_ns | source |",
+            "|---:|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for row in payload["flat_measured_ranker_points"]:
+        lines.append(
+            "| {lanes} | {topk} | {cycles} | {latency} | {tps} | {cp} | `{source}` |".format(
+                lanes=row["lanes"],
+                topk=row["top_k"],
+                cycles=row["total_cycles"],
+                latency=row["timing"]["latency_us_per_token"],
+                tps=row["timing"]["tokens_per_s"],
+                cp=row["timing"]["clock_ns"],
+                source=row.get("metrics_csv") or row.get("source") or "",
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Hierarchical Streaming Alternatives",
+            "",
+            "| variant | W | top_k | cycles | latency_us | tokens_per_s | fifo required/capacity | fifo ok | speedup vs flat |",
+            "|---|---:|---:|---:|---:|---:|---:|---|---:|",
+        ]
+    )
+    for row in payload["hierarchical_streaming_alternatives"]:
+        lines.append(
+            "| `{variant}` | {lanes} | {topk} | {cycles} | {latency} | {tps} | {fifo}/{cap} | `{ok}` | {speedup} |".format(
+                variant=row["merge_variant"],
+                lanes=row["producer_lanes"],
+                topk=row["local_top_k"],
+                cycles=row["total_cycles"],
+                latency=row["timing"]["latency_us_per_token"],
+                tps=row["timing"]["tokens_per_s"],
+                fifo=row["required_fifo_depth_groups"],
+                cap=row["candidate_fifo_depth_groups"],
+                ok=row["fifo_capacity_ok"],
+                speedup=row["speedup_vs_best_flat"],
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def _int_list(value: str) -> list[int]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated integer list")
+    parsed = [int(item) for item in items]
+    if any(item <= 0 for item in parsed):
+        raise argparse.ArgumentTypeError("all list items must be positive")
+    return parsed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Model decoder logit-rank streaming hierarchy")
+    ap.add_argument("--prompt-stress", help="prompt-stress evidence JSON path")
+    ap.add_argument("--logit-rank-bypass", help="logit-rank bypass evidence JSON path")
+    ap.add_argument("--rank-ppa", default=str(DEFAULT_RANK_PPA), help="rank datapath PPA JSON")
+    ap.add_argument("--scale-ppa", default=str(DEFAULT_SCALE_PPA), help="rank scale PPA JSON")
+    ap.add_argument("--vocab-size", type=int, default=50257, help="decoder vocabulary size")
+    ap.add_argument("--producer-lanes", type=int, default=8, help="W-lane producer tile width")
+    ap.add_argument("--top-k", type=int, default=4, help="local candidates per tile")
+    ap.add_argument("--producer-latency-cycles", type=int, default=1)
+    ap.add_argument("--producer-ii-cycles", type=int, default=1)
+    ap.add_argument("--local-ranker-latency-cycles", type=int, default=4)
+    ap.add_argument("--local-ranker-ii-cycles", type=int, default=1)
+    ap.add_argument("--global-merge-latency-cycles", type=int, default=3)
+    ap.add_argument("--global-merge-ii-cycles", type=_int_list, default=[1, 2, 4])
+    ap.add_argument("--candidate-fifo-depth-groups", type=int, default=16)
+    ap.add_argument("--fallback-critical-path-ns", type=float, default=3.6)
+    ap.add_argument("--out", required=True, help="output JSON path")
+    ap.add_argument("--out-md", required=True, help="output Markdown path")
+    args = ap.parse_args()
+
+    payload = build_report(
+        rank_ppa_path=Path(args.rank_ppa) if args.rank_ppa else None,
+        scale_ppa_path=Path(args.scale_ppa) if args.scale_ppa else None,
+        prompt_stress_path=Path(args.prompt_stress) if args.prompt_stress else None,
+        logit_rank_bypass_path=Path(args.logit_rank_bypass) if args.logit_rank_bypass else None,
+        vocab_size=args.vocab_size,
+        producer_lanes=args.producer_lanes,
+        top_k=args.top_k,
+        producer_latency_cycles=args.producer_latency_cycles,
+        producer_ii_cycles=args.producer_ii_cycles,
+        local_ranker_latency_cycles=args.local_ranker_latency_cycles,
+        local_ranker_ii_cycles=args.local_ranker_ii_cycles,
+        global_merge_latency_cycles=args.global_merge_latency_cycles,
+        global_merge_ii_cycles_list=args.global_merge_ii_cycles,
+        candidate_fifo_depth_groups=args.candidate_fifo_depth_groups,
+        fallback_critical_path_ns=args.fallback_critical_path_ns,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    _write_markdown(out_md, payload)
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "out": str(out),
+                "out_md": str(out_md),
+                "recommendation": payload["recommendation"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_logit_rank_streaming_model.py
+++ b/tests/test_llm_decoder_logit_rank_streaming_model.py
@@ -1,0 +1,87 @@
+import json
+from pathlib import Path
+
+from npu.eval.model_llm_decoder_logit_rank_streaming import (
+    build_report,
+    simulate_streaming_hierarchy,
+)
+
+
+def test_streaming_hierarchy_cycle_model_tracks_fifo_depth() -> None:
+    sim = simulate_streaming_hierarchy(
+        vocab_size=16,
+        producer_lanes=4,
+        producer_latency_cycles=1,
+        producer_ii_cycles=1,
+        local_ranker_latency_cycles=2,
+        local_ranker_ii_cycles=1,
+        local_top_k=2,
+        global_merge_latency_cycles=1,
+        global_merge_ii_cycles=2,
+        candidate_fifo_depth_groups=1,
+    )
+
+    assert sim["tile_count"] == 4
+    assert sim["total_candidates_emitted"] == 8
+    assert sim["local_last_done_cycle"] == 6
+    assert sim["global_last_done_cycle"] == 10
+    assert sim["required_fifo_depth_groups"] == 2
+    assert not sim["fifo_capacity_ok"]
+
+
+def test_logit_rank_streaming_report_compares_flat_and_hierarchy(tmp_path: Path) -> None:
+    ppa = tmp_path / "rank_ppa.json"
+    ppa.write_text(
+        json.dumps(
+            {
+                "proposals": [
+                    {
+                        "metrics_ref": {
+                            "metrics_csv": "runs/designs/activations/logit_rank_r8_l16_k1_wrapper/metrics.csv",
+                            "status": "ok",
+                        },
+                        "metric_summary": {
+                            "critical_path_ns": 3.0,
+                            "die_area": 10.0,
+                            "total_power_mw": 0.1,
+                        },
+                    },
+                    {
+                        "metrics_ref": {
+                            "metrics_csv": "runs/designs/activations/logit_rank_r8_l16_k4_wrapper/metrics.csv",
+                            "status": "ok",
+                        },
+                        "metric_summary": {
+                            "critical_path_ns": 4.0,
+                            "die_area": 20.0,
+                            "total_power_mw": 0.2,
+                        },
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_report(
+        rank_ppa_path=ppa,
+        scale_ppa_path=None,
+        vocab_size=32,
+        producer_lanes=8,
+        top_k=4,
+        global_merge_ii_cycles_list=[1, 2],
+        candidate_fifo_depth_groups=8,
+    )
+
+    assert report["model"] == "decoder_logit_rank_streaming_hierarchy_v1"
+    assert len(report["flat_measured_ranker_points"]) == 2
+    assert len(report["hierarchical_streaming_alternatives"]) == 2
+    assert report["flat_measured_ranker_points"][0]["lanes"] == 8
+    fast = report["hierarchical_streaming_alternatives"][0]
+    assert fast["merge_variant"] == "merge_ii_1"
+    assert fast["fifo_capacity_ok"]
+    assert fast["timing"]["latency_us_per_token"] == 0.044
+    assert report["recommendation"]["architecture"] in {
+        "flat_measured_ranker_scan",
+        "hierarchical_streaming_local_rank_global_merge",
+    }


### PR DESCRIPTION
## Summary
- add a LogitTileStream/CandidateStream architecture proposal for rank-only decoder reduction
- add a first-order streaming hierarchy estimator using measured r8/r16/r32 logit-rank PPA artifacts
- wire the new decoder_logit_rank_streaming_hierarchy abstraction into L2 task generation

## Validation
- python3 -m py_compile npu/eval/model_llm_decoder_logit_rank_streaming.py npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py tests/test_llm_decoder_logit_rank_streaming_model.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/proposal.json >/dev/null
- python3 -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/evaluation_requests.json >/dev/null
- python3 npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py --rank-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json --scale-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json --out /tmp/decoder_logit_rank_streaming_hierarchy.json --out-md /tmp/decoder_logit_rank_streaming_hierarchy.md
- PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_logit_rank_streaming_model.py control_plane/control_plane/tests/test_l2_task_generator.py -q
- git diff --check -- scoped changed files