### PR TITLE
Add decoder logit-rank overlap sweep

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1911,6 +1911,50 @@ def _decoder_logit_rank_streaming_hierarchy_evidence(*, item_id: str) -> dict[st
     }
 
 
+def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    prompt_stress = f"{base}/decoder_gpt2_prompt_stress__l2_decoder_gpt2_prompt_stress_v1.json"
+    logit_rank_bypass = f"{base}/decoder_gpt2_logit_rank_bypass__l2_decoder_gpt2_logit_rank_bypass_v1.json"
+    overlap_out = f"{base}/decoder_logit_rank_streaming_overlap__{item_id}.json"
+    overlap_report = f"{base}/decoder_logit_rank_streaming_overlap__{item_id}.md"
+    rank_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
+    scale_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+    return {
+        "inputs": {
+            "source_prompt_stress": prompt_stress,
+            "source_logit_rank_bypass": logit_rank_bypass,
+            "rank_datapath_ppa": rank_ppa,
+            "rank_scale_ppa": scale_ppa,
+            "streaming_overlap_out": overlap_out,
+            "streaming_overlap_report": overlap_report,
+            "streaming_overlap_scope": (
+                "Refine the decoder logit-rank streaming hierarchy with producer-overlap, FIFO, "
+                "candidate-traffic, and perf-sim/RTL equivalence observables before selecting a merge RTL block"
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_logit_rank_streaming_overlap",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py "
+                    f"--prompt-stress {prompt_stress} "
+                    f"--logit-rank-bypass {logit_rank_bypass} "
+                    f"--rank-ppa {rank_ppa} "
+                    f"--scale-ppa {scale_ppa} "
+                    "--producer-lanes-list 8,16,32 "
+                    "--top-k-list 1,4 "
+                    "--producer-ii-cycles-list 1,2,4 "
+                    "--global-merge-ii-cycles 1,2,4 "
+                    "--candidate-fifo-depth-groups-list 16,256,4096 "
+                    f"--out {overlap_out} "
+                    f"--out-md {overlap_report}"
+                ),
+            },
+        ],
+        "expected_outputs": [overlap_out, overlap_report],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2372,10 +2416,13 @@ def _build_payload(
         "decoder_gpt2_tie_rank_frontier",
         "decoder_gpt2_logit_rank_bypass",
         "decoder_logit_rank_streaming_hierarchy",
+        "decoder_logit_rank_streaming_overlap",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_logit_rank_streaming_overlap":
+            decoder_evidence = _decoder_logit_rank_streaming_overlap_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_hierarchy":
             decoder_evidence = _decoder_logit_rank_streaming_hierarchy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_gpt2_logit_rank_bypass":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1570,6 +1570,62 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_hierarchy_e
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_logit_rank_streaming_overlap_v1",
+                    proposal_id="prop_l2_decoder_logit_rank_streaming_overlap_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_logit_rank_streaming_overlap",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[0] == "estimate_decoder_logit_rank_streaming_overlap"
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["rank_datapath_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
+            )
+            assert decoder_inputs["rank_scale_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+            )
+            assert decoder_inputs["streaming_overlap_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_overlap_v1.json"
+            )
+            assert "perf-sim/RTL equivalence observables" in decoder_inputs["streaming_overlap_scope"]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_logit_rank_streaming_hierarchy.py" in run
+            assert "--producer-lanes-list 8,16,32" in run
+            assert "--top-k-list 1,4" in run
+            assert "--producer-ii-cycles-list 1,2,4" in run
+            assert "--candidate-fifo-depth-groups-list 16,256,4096" in run
+            assert decoder_inputs["streaming_overlap_out"] in work_item.expected_outputs
+            assert decoder_inputs["streaming_overlap_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_logit_rank_streaming_overlap",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/README.md
@@ -1,0 +1,15 @@
+# Decoder Logit-Rank Streaming Overlap
+
+This proposal refines the rank-only decoder streaming hierarchy with producer
+overlap, candidate FIFO pressure, and byte traffic estimates.
+
+Artifacts:
+
+- `proposal.json`: proposal metadata and review scope
+- `evaluation_requests.json`: frontier-detail request
+- `design_brief.md`: problem, hypothesis, and equivalence plan
+- `evaluation_gate.md`: pending review gate
+
+The model keeps the perf-sim/RTL boundary explicit. A follow-on RTL merge block
+must match the same ready/valid stream observables before its PPA can replace
+the proxy merge cost.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/design_brief.md
@@ -1,0 +1,41 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_logit_rank_streaming_overlap_v1`
+- `title`: `Decoder logit-rank streaming overlap and traffic model`
+
+## Problem
+The first hierarchy model established the stream contract, but its simple
+latency proxy still favored flat row-8 rank scanning. The missing question is
+whether hierarchy value appears when output projection, local ranking, global
+merge, FIFO depth, and memory traffic are considered together.
+
+## Hypothesis
+If the producer emits logit tiles continuously, a streaming rank path can hide
+part of rank latency behind projection and avoid full-vocabulary logit
+materialization traffic. The model is useful only if it records the exact
+stream observables that future RTL must match.
+
+## Evaluation Scope
+- compare buffered rank-after-materialization cycles with streaming cycles
+- sweep producer lane width, local top-k, producer II, merge II, and FIFO depth
+- report candidate FIFO occupancy and capacity validity
+- report candidate traffic versus full-logit write/read traffic
+- preserve perf-sim/RTL equivalence observables:
+  - accepted `LogitTileStream` beat count
+  - accepted `CandidateStream` group count
+  - producer stall cycles
+  - candidate FIFO max occupancy
+  - final `last` completion cycle
+  - valid-mask and lower-token-id tie-break behavior
+
+## Exclusions
+- no RTL implementation in this proposal
+- no new physical synthesis
+- no probability-producing decoder modes
+- no larger-model quality rerun
+
+## Follow-On Gate
+The next job after this model should be an L1 candidate-stream merge datapath
+measurement. That RTL block should include a reference-model equivalence test
+before PPA metrics are used in architecture rankings.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - frontier-detail review for `l2_decoder_logit_rank_streaming_overlap_v1`
+- note: Gate covers overlap/traffic model readiness and perf-sim/RTL equivalence observables. RTL and physical implementation work require a follow-on proposal.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_overlap_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_overlap_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the refined decoder logit-rank streaming overlap and traffic model with explicit perf-sim/RTL equivalence observables.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_hierarchy_v1",
+        "l2_decoder_gpt2_logit_rank_bypass_v1_r2",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the model output to define the first candidate-stream merge RTL measurement, with equivalence checked on ready/valid stream observables."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/proposal.json
@@ -1,0 +1,76 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_overlap_v1",
+  "created_utc": "2026-05-04T21:10:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+  "title": "Decoder logit-rank streaming overlap and traffic model",
+  "hypothesis": "A rank-only decoder hierarchy should be judged by overlapped producer/reducer latency and candidate traffic, not only standalone rank latency. The perf model must expose the same ready/valid stream observables that later RTL will be required to match.",
+  "direct_comparison": {
+    "primary_question": "Which producer lane width, producer II, merge II, top-k, and FIFO depth combinations preserve the logit-rank stream contract while recovering materialized-rank latency and reducing memory traffic?",
+    "include": [
+      "buffered rank-after-materialization cycle baseline",
+      "streaming producer/ranker/reducer overlap cycles",
+      "candidate FIFO occupancy and capacity validity",
+      "candidate traffic versus materialized-logit write/read traffic",
+      "perf-sim/RTL equivalence observables for ready/valid streams",
+      "sweep over producer lanes, top-k, producer II, merge II, and FIFO depth"
+    ],
+    "exclude": [
+      "new RTL implementation",
+      "new physical synthesis",
+      "probability-producing softmax or sampling consumers",
+      "larger-model quality reruns"
+    ],
+    "follow_on_broad_sweep": [
+      "select the first candidate-stream merge RTL block using the sweep frontier",
+      "measure candidate-stream merge PPA and bind the measured merge block back into this model"
+    ]
+  },
+  "expected_benefit": [
+    "separates rank-only interface readiness from latency and memory-traffic readiness",
+    "identifies whether hierarchy value comes from overlap, traffic reduction, or neither",
+    "sets explicit perf-sim/RTL equivalence observables before measuring a merge datapath"
+  ],
+  "risks": [
+    "traffic model is byte-count based and does not yet include SRAM banking, NoC arbitration, or floorplan distance",
+    "merge latency remains a proxy until candidate-stream merge RTL is measured",
+    "equivalence observables are specified but not yet checked against RTL"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_overlap_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the refined decoder logit-rank streaming overlap and traffic model, preserving explicit perf-sim/RTL equivalence observables for the follow-on merge RTL block.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_hierarchy_v1",
+        "l2_decoder_gpt2_logit_rank_bypass_v1_r2",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The expected next step is to choose the first measured candidate-stream merge RTL block, not to claim the hierarchy is already a PPA win."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_logit_rank_streaming_hierarchy_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_gpt2_logit_rank_bypass_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_logit_rank_datapath_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_logit_rank_scale_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/decoder_logit_rank_streaming_hierarchy.md",
+    "npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py",
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py",
+    "tests/test_llm_decoder_logit_rank_streaming_model.py"
+  ]
+}

--- a/npu/eval/model_llm_decoder_logit_rank_streaming.py
+++ b/npu/eval/model_llm_decoder_logit_rank_streaming.py
@@ -41,6 +41,10 @@ def _ceil_div(numerator: int, denominator: int) -> int:
     return (numerator + denominator - 1) // denominator
 
 
+def _byte_width(bits: int) -> int:
+    return _ceil_div(bits, 8)
+
+
 def _parse_csv_point(path: str) -> JsonDict:
     match = re.search(r"logit_rank_r(?P<lanes>\d+)_l(?P<bits>\d+)_k(?P<topk>\d+)", path)
     if not match:
@@ -277,6 +281,144 @@ def _flat_point_report(
     }
 
 
+def _traffic_summary(
+    *,
+    vocab_size: int,
+    tile_count: int,
+    producer_lanes: int,
+    top_k: int,
+    logit_bits: int,
+    token_id_bits: int,
+) -> JsonDict:
+    logit_bytes = _byte_width(logit_bits)
+    token_bytes = _byte_width(token_id_bits)
+    materialized_logit_bytes = vocab_size * logit_bytes
+    candidate_bytes_per_entry = logit_bytes + token_bytes
+    candidate_entries = tile_count * top_k
+    candidate_payload_bytes = candidate_entries * candidate_bytes_per_entry
+    candidate_fifo_round_trip_bytes = candidate_payload_bytes * 2
+    final_topk_bytes = top_k * candidate_bytes_per_entry
+    materialized_rank_memory_bytes = materialized_logit_bytes * 2
+    streaming_memory_bytes = candidate_fifo_round_trip_bytes + final_topk_bytes
+    reduction = 0.0
+    if materialized_rank_memory_bytes > 0:
+        reduction = 1.0 - (streaming_memory_bytes / materialized_rank_memory_bytes)
+    return {
+        "logit_bits": logit_bits,
+        "token_id_bits": token_id_bits,
+        "producer_lanes": producer_lanes,
+        "top_k": top_k,
+        "materialized_rank_memory_bytes": materialized_rank_memory_bytes,
+        "streaming_candidate_memory_bytes": streaming_memory_bytes,
+        "candidate_payload_bytes": candidate_payload_bytes,
+        "candidate_fifo_round_trip_bytes": candidate_fifo_round_trip_bytes,
+        "final_topk_bytes": final_topk_bytes,
+        "candidate_entries": candidate_entries,
+        "traffic_reduction_vs_materialized": round(reduction, 6),
+    }
+
+
+def _streaming_overlap_candidate(
+    *,
+    measured_points: list[JsonDict],
+    vocab_size: int,
+    producer_lanes: int,
+    top_k: int,
+    producer_latency_cycles: int,
+    producer_ii_cycles: int,
+    local_ranker_latency_cycles: int,
+    local_ranker_ii_cycles: int,
+    global_merge_latency_cycles: int,
+    global_merge_ii_cycles: int,
+    candidate_fifo_depth_groups: int,
+    fallback_critical_path_ns: float,
+    token_id_bits: int,
+) -> JsonDict:
+    local_point = _select_ranker_point(
+        measured_points,
+        lanes=producer_lanes,
+        top_k=top_k,
+        default_critical_path_ns=fallback_critical_path_ns,
+    )
+    merge_lanes = max(producer_lanes, top_k)
+    global_point = _select_ranker_point(
+        measured_points,
+        lanes=merge_lanes,
+        top_k=top_k,
+        default_critical_path_ns=fallback_critical_path_ns,
+    )
+    local_clock = _as_float(local_point["metrics"].get("critical_path_ns"), fallback_critical_path_ns)
+    global_clock = _as_float(global_point["metrics"].get("critical_path_ns"), fallback_critical_path_ns)
+    hierarchy_clock_ns = max(local_clock, global_clock)
+    sim = simulate_streaming_hierarchy(
+        vocab_size=vocab_size,
+        producer_lanes=producer_lanes,
+        producer_latency_cycles=producer_latency_cycles,
+        producer_ii_cycles=producer_ii_cycles,
+        local_ranker_latency_cycles=local_ranker_latency_cycles,
+        local_ranker_ii_cycles=local_ranker_ii_cycles,
+        local_top_k=top_k,
+        global_merge_latency_cycles=global_merge_latency_cycles,
+        global_merge_ii_cycles=global_merge_ii_cycles,
+        candidate_fifo_depth_groups=candidate_fifo_depth_groups,
+    )
+    rank_scan_cycles = local_ranker_latency_cycles + max(0, sim["tile_count"] - 1) * local_ranker_ii_cycles
+    buffered_e2e_cycles = sim["producer_last_tile_ready_cycle"] + rank_scan_cycles + global_merge_latency_cycles
+    overlap_recovered_cycles = max(0, buffered_e2e_cycles - sim["total_cycles"])
+    logit_bits = _as_int(local_point.get("logit_bits"), 16) or 16
+    candidate = {
+        "architecture": "hierarchical_streaming_local_rank_global_merge",
+        "merge_variant": f"merge_ii_{global_merge_ii_cycles}",
+        "sweep_key": (
+            f"w{producer_lanes}_k{top_k}_prodii{producer_ii_cycles}_"
+            f"mergeii{global_merge_ii_cycles}_fifo{candidate_fifo_depth_groups}"
+        ),
+        **sim,
+        "timing": _time_summary(
+            cycles=sim["total_cycles"],
+            clock_ns=hierarchy_clock_ns,
+            vocab_size=vocab_size,
+        ),
+        "buffered_baseline": {
+            "rank_after_materialization_cycles": buffered_e2e_cycles,
+            "streaming_cycles": sim["total_cycles"],
+            "overlap_recovered_cycles": overlap_recovered_cycles,
+            "overlap_recovered_fraction": (
+                round(overlap_recovered_cycles / buffered_e2e_cycles, 6)
+                if buffered_e2e_cycles > 0
+                else 0.0
+            ),
+        },
+        "traffic": _traffic_summary(
+            vocab_size=vocab_size,
+            tile_count=sim["tile_count"],
+            producer_lanes=producer_lanes,
+            top_k=top_k,
+            logit_bits=logit_bits,
+            token_id_bits=token_id_bits,
+        ),
+        "local_ranker_point": local_point,
+        "global_merge_point": global_point,
+        "equivalence_contract": {
+            "stream_contract": "LogitTileStream/CandidateStream ready-valid v1",
+            "ordering": "accepted tile_id order, lower token_id tie-break",
+            "perf_sim_observables": [
+                "accepted LogitTileStream beat count",
+                "accepted CandidateStream group count",
+                "producer stall cycles",
+                "candidate FIFO max occupancy",
+                "final last-beat completion cycle",
+            ],
+            "rtl_equivalence_requirement": (
+                "A future RTL merge block must match the same candidate ordering, "
+                "valid masking, backpressure, and last-beat completion observables "
+                "before PPA numbers are used in rankings."
+            ),
+        },
+    }
+    return candidate
+
+
 def build_report(
     *,
     rank_ppa_path: Path | None = DEFAULT_RANK_PPA,
@@ -293,6 +435,11 @@ def build_report(
     global_merge_latency_cycles: int = 3,
     global_merge_ii_cycles_list: list[int] | None = None,
     candidate_fifo_depth_groups: int = 16,
+    producer_lanes_list: list[int] | None = None,
+    top_k_list: list[int] | None = None,
+    producer_ii_cycles_list: list[int] | None = None,
+    candidate_fifo_depth_groups_list: list[int] | None = None,
+    token_id_bits: int = 16,
     fallback_critical_path_ns: float = 3.6,
 ) -> JsonDict:
     if vocab_size <= 0:
@@ -301,7 +448,21 @@ def build_report(
         raise ValueError("producer_lanes must be positive")
     if top_k <= 0:
         raise ValueError("top_k must be positive")
+    if token_id_bits <= 0:
+        raise ValueError("token_id_bits must be positive")
     merge_iis = global_merge_ii_cycles_list or [1, 2, 4]
+    lane_options = producer_lanes_list or [producer_lanes]
+    top_k_options = top_k_list or [top_k]
+    producer_ii_options = producer_ii_cycles_list or [producer_ii_cycles]
+    fifo_options = candidate_fifo_depth_groups_list or [candidate_fifo_depth_groups]
+    for name, values in (
+        ("producer_lanes_list", lane_options),
+        ("top_k_list", top_k_options),
+        ("producer_ii_cycles_list", producer_ii_options),
+        ("candidate_fifo_depth_groups_list", fifo_options),
+    ):
+        if any(item <= 0 for item in values):
+            raise ValueError(f"{name} values must be positive")
     measured_points = load_ranker_points_from_paths([rank_ppa_path, scale_ppa_path])
     if not measured_points:
         measured_points = [
@@ -324,49 +485,52 @@ def build_report(
         if _as_int(point.get("lanes")) > 0
     ]
 
-    local_point = _select_ranker_point(
-        measured_points,
-        lanes=producer_lanes,
-        top_k=top_k,
-        default_critical_path_ns=fallback_critical_path_ns,
-    )
-    global_point = _select_ranker_point(
-        measured_points,
-        lanes=max(producer_lanes, top_k),
-        top_k=top_k,
-        default_critical_path_ns=fallback_critical_path_ns,
-    )
-    local_clock = _as_float(local_point["metrics"].get("critical_path_ns"), fallback_critical_path_ns)
-    global_clock = _as_float(global_point["metrics"].get("critical_path_ns"), fallback_critical_path_ns)
-    hierarchy_clock_ns = max(local_clock, global_clock)
     alternatives: list[JsonDict] = []
     for merge_ii in merge_iis:
-        sim = simulate_streaming_hierarchy(
-            vocab_size=vocab_size,
-            producer_lanes=producer_lanes,
-            producer_latency_cycles=producer_latency_cycles,
-            producer_ii_cycles=producer_ii_cycles,
-            local_ranker_latency_cycles=local_ranker_latency_cycles,
-            local_ranker_ii_cycles=local_ranker_ii_cycles,
-            local_top_k=top_k,
-            global_merge_latency_cycles=global_merge_latency_cycles,
-            global_merge_ii_cycles=merge_ii,
-            candidate_fifo_depth_groups=candidate_fifo_depth_groups,
-        )
         alternatives.append(
-            {
-                "architecture": "hierarchical_streaming_local_rank_global_merge",
-                "merge_variant": f"merge_ii_{merge_ii}",
-                **sim,
-                "timing": _time_summary(
-                    cycles=sim["total_cycles"],
-                    clock_ns=hierarchy_clock_ns,
-                    vocab_size=vocab_size,
-                ),
-                "local_ranker_point": local_point,
-                "global_merge_point": global_point,
-            }
+            _streaming_overlap_candidate(
+                measured_points=measured_points,
+                vocab_size=vocab_size,
+                producer_lanes=producer_lanes,
+                top_k=top_k,
+                producer_latency_cycles=producer_latency_cycles,
+                producer_ii_cycles=producer_ii_cycles,
+                local_ranker_latency_cycles=local_ranker_latency_cycles,
+                local_ranker_ii_cycles=local_ranker_ii_cycles,
+                global_merge_latency_cycles=global_merge_latency_cycles,
+                global_merge_ii_cycles=merge_ii,
+                candidate_fifo_depth_groups=candidate_fifo_depth_groups,
+                fallback_critical_path_ns=fallback_critical_path_ns,
+                token_id_bits=token_id_bits,
+            )
         )
+
+    overlap_sweep: list[JsonDict] = []
+    seen_sweep_keys: set[str] = set()
+    for lanes in lane_options:
+        for local_k in top_k_options:
+            for prod_ii in producer_ii_options:
+                for merge_ii in merge_iis:
+                    for fifo_depth in fifo_options:
+                        candidate = _streaming_overlap_candidate(
+                            measured_points=measured_points,
+                            vocab_size=vocab_size,
+                            producer_lanes=lanes,
+                            top_k=local_k,
+                            producer_latency_cycles=producer_latency_cycles,
+                            producer_ii_cycles=prod_ii,
+                            local_ranker_latency_cycles=local_ranker_latency_cycles,
+                            local_ranker_ii_cycles=local_ranker_ii_cycles,
+                            global_merge_latency_cycles=global_merge_latency_cycles,
+                            global_merge_ii_cycles=merge_ii,
+                            candidate_fifo_depth_groups=fifo_depth,
+                            fallback_critical_path_ns=fallback_critical_path_ns,
+                            token_id_bits=token_id_bits,
+                        )
+                        if candidate["sweep_key"] in seen_sweep_keys:
+                            continue
+                        seen_sweep_keys.add(candidate["sweep_key"])
+                        overlap_sweep.append(candidate)
 
     all_candidates = flat + alternatives
     best = min(
@@ -385,6 +549,22 @@ def build_report(
             row["speedup_vs_best_flat"] = round(
                 baseline["timing"]["latency_us_per_token"] / row["timing"]["latency_us_per_token"], 6
             )
+    for row in overlap_sweep:
+        if baseline is None:
+            row["speedup_vs_best_flat"] = None
+        else:
+            row["speedup_vs_best_flat"] = round(
+                baseline["timing"]["latency_us_per_token"] / row["timing"]["latency_us_per_token"], 6
+            )
+    best_overlap = min(
+        overlap_sweep,
+        key=lambda row: (
+            not bool(row.get("fifo_capacity_ok", True)),
+            -row["buffered_baseline"]["overlap_recovered_fraction"],
+            row["timing"]["latency_us_per_token"],
+            row["traffic"]["streaming_candidate_memory_bytes"],
+        ),
+    ) if overlap_sweep else None
 
     return {
         "version": 0.1,
@@ -410,6 +590,11 @@ def build_report(
             "global_merge_latency_cycles": global_merge_latency_cycles,
             "global_merge_ii_cycles_list": merge_iis,
             "candidate_fifo_depth_groups": candidate_fifo_depth_groups,
+            "producer_lanes_list": lane_options,
+            "top_k_list": top_k_options,
+            "producer_ii_cycles_list": producer_ii_options,
+            "candidate_fifo_depth_groups_list": fifo_options,
+            "token_id_bits": token_id_bits,
             "fallback_critical_path_ns": fallback_critical_path_ns,
         },
         "assumptions": [
@@ -417,12 +602,16 @@ def build_report(
             "Local ranker accepts one producer tile per local ranker II and emits one candidate group after local ranker latency.",
             "Candidate FIFO depth is reported in local candidate groups; overflow is reported as capacity evidence, not hidden by backpressure.",
             "Global merge consumes one local candidate group per merge II and produces the final token rank after the last merge latency.",
+            "Buffered baseline waits for the producer to materialize all logits before rank reduction starts.",
+            "Traffic model counts materialized-logit write+read bytes versus candidate FIFO write+read bytes.",
             "Measured row-8 datapath and row-16/row-32 scale critical_path_ns values are used as ranker clock proxies.",
             "Missing lane points are explicit defaults or log2-lane scaled proxies.",
+            "Perf-sim and future RTL equivalence is defined at accepted ready-valid stream beats, FIFO occupancy, valid masks, last-beat completion, and tie-breaking.",
         ],
         "measured_ranker_points": measured_points,
         "flat_measured_ranker_points": flat,
         "hierarchical_streaming_alternatives": alternatives,
+        "overlap_traffic_sweep": overlap_sweep,
         "recommendation": {
             "architecture": best["architecture"],
             "merge_variant": best.get("merge_variant"),
@@ -434,11 +623,28 @@ def build_report(
                 "hierarchical streaming alternatives."
             ),
         },
+        "overlap_recommendation": (
+            {
+                "sweep_key": best_overlap["sweep_key"],
+                "latency_us_per_token": best_overlap["timing"]["latency_us_per_token"],
+                "tokens_per_s": best_overlap["timing"]["tokens_per_s"],
+                "fifo_capacity_ok": best_overlap["fifo_capacity_ok"],
+                "overlap_recovered_fraction": best_overlap["buffered_baseline"]["overlap_recovered_fraction"],
+                "traffic_reduction_vs_materialized": best_overlap["traffic"]["traffic_reduction_vs_materialized"],
+                "reason": (
+                    "Best FIFO-valid overlap candidate by recovered buffered-baseline cycles, "
+                    "then latency and candidate memory traffic."
+                ),
+            }
+            if best_overlap is not None
+            else None
+        ),
     }
 
 
 def _write_markdown(path: Path, payload: JsonDict) -> None:
     rec = payload["recommendation"]
+    overlap = payload.get("overlap_recommendation") or {}
     lines = [
         "# Decoder Logit-Rank Streaming Hierarchy",
         "",
@@ -450,6 +656,9 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         f"- tokens_per_s: `{rec['tokens_per_s']}`",
         f"- fifo_capacity_ok: `{rec['fifo_capacity_ok']}`",
         f"- reason: {rec['reason']}",
+        f"- overlap_sweep_best: `{overlap.get('sweep_key', '')}`",
+        f"- overlap_recovered_fraction: `{overlap.get('overlap_recovered_fraction', '')}`",
+        f"- traffic_reduction_vs_materialized: `{overlap.get('traffic_reduction_vs_materialized', '')}`",
         "",
         "## Inputs",
         "",
@@ -503,6 +712,28 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
                 speedup=row["speedup_vs_best_flat"],
             )
         )
+    lines.extend(
+        [
+            "",
+            "## Overlap And Traffic Sweep",
+            "",
+            "| key | cycles | latency_us | fifo required/capacity | overlap recovered | traffic reduction | speedup vs flat |",
+            "|---|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in payload["overlap_traffic_sweep"][:24]:
+        lines.append(
+            "| `{key}` | {cycles} | {latency} | {fifo}/{cap} | {overlap} | {traffic} | {speedup} |".format(
+                key=row["sweep_key"],
+                cycles=row["total_cycles"],
+                latency=row["timing"]["latency_us_per_token"],
+                fifo=row["required_fifo_depth_groups"],
+                cap=row["candidate_fifo_depth_groups"],
+                overlap=row["buffered_baseline"]["overlap_recovered_fraction"],
+                traffic=row["traffic"]["traffic_reduction_vs_materialized"],
+                speedup=row["speedup_vs_best_flat"],
+            )
+        )
     lines.extend(["", "## Assumptions", ""])
     for item in payload["assumptions"]:
         lines.append(f"- {item}")
@@ -535,6 +766,11 @@ def main() -> int:
     ap.add_argument("--global-merge-latency-cycles", type=int, default=3)
     ap.add_argument("--global-merge-ii-cycles", type=_int_list, default=[1, 2, 4])
     ap.add_argument("--candidate-fifo-depth-groups", type=int, default=16)
+    ap.add_argument("--producer-lanes-list", type=_int_list, help="comma-separated producer lane sweep")
+    ap.add_argument("--top-k-list", type=_int_list, help="comma-separated local top-k sweep")
+    ap.add_argument("--producer-ii-cycles-list", type=_int_list, help="comma-separated producer II sweep")
+    ap.add_argument("--candidate-fifo-depth-groups-list", type=_int_list, help="comma-separated FIFO depth sweep")
+    ap.add_argument("--token-id-bits", type=int, default=16)
     ap.add_argument("--fallback-critical-path-ns", type=float, default=3.6)
     ap.add_argument("--out", required=True, help="output JSON path")
     ap.add_argument("--out-md", required=True, help="output Markdown path")
@@ -555,6 +791,11 @@ def main() -> int:
         global_merge_latency_cycles=args.global_merge_latency_cycles,
         global_merge_ii_cycles_list=args.global_merge_ii_cycles,
         candidate_fifo_depth_groups=args.candidate_fifo_depth_groups,
+        producer_lanes_list=args.producer_lanes_list,
+        top_k_list=args.top_k_list,
+        producer_ii_cycles_list=args.producer_ii_cycles_list,
+        candidate_fifo_depth_groups_list=args.candidate_fifo_depth_groups_list,
+        token_id_bits=args.token_id_bits,
         fallback_critical_path_ns=args.fallback_critical_path_ns,
     )
     out = Path(args.out)

--- a/tests/test_llm_decoder_logit_rank_streaming_model.py
+++ b/tests/test_llm_decoder_logit_rank_streaming_model.py
@@ -81,7 +81,65 @@ def test_logit_rank_streaming_report_compares_flat_and_hierarchy(tmp_path: Path)
     assert fast["merge_variant"] == "merge_ii_1"
     assert fast["fifo_capacity_ok"]
     assert fast["timing"]["latency_us_per_token"] == 0.044
+    assert fast["buffered_baseline"]["rank_after_materialization_cycles"] == 14
+    assert fast["buffered_baseline"]["overlap_recovered_cycles"] == 3
+    assert fast["traffic"]["traffic_reduction_vs_materialized"] == -0.125
+    assert fast["equivalence_contract"]["stream_contract"] == "LogitTileStream/CandidateStream ready-valid v1"
     assert report["recommendation"]["architecture"] in {
         "flat_measured_ranker_scan",
         "hierarchical_streaming_local_rank_global_merge",
     }
+    assert len(report["overlap_traffic_sweep"]) == 2
+    assert report["overlap_recommendation"]["sweep_key"] == "w8_k4_prodii1_mergeii1_fifo8"
+
+
+def test_logit_rank_streaming_overlap_sweep_varies_producer_and_fifo(tmp_path: Path) -> None:
+    ppa = tmp_path / "rank_ppa.json"
+    ppa.write_text(
+        json.dumps(
+            {
+                "proposals": [
+                    {
+                        "metrics_ref": {
+                            "metrics_csv": "runs/designs/activations/logit_rank_r8_l16_k1_wrapper/metrics.csv",
+                            "status": "ok",
+                        },
+                        "metric_summary": {
+                            "critical_path_ns": 3.0,
+                            "die_area": 10.0,
+                            "total_power_mw": 0.1,
+                        },
+                    },
+                    {
+                        "metrics_ref": {
+                            "metrics_csv": "runs/designs/activations/logit_rank_r16_l16_k1_wrapper/metrics.csv",
+                            "status": "ok",
+                        },
+                        "metric_summary": {
+                            "critical_path_ns": 5.0,
+                            "die_area": 16.0,
+                            "total_power_mw": 0.2,
+                        },
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_report(
+        rank_ppa_path=ppa,
+        scale_ppa_path=None,
+        vocab_size=64,
+        producer_lanes=8,
+        top_k=1,
+        global_merge_ii_cycles_list=[1, 2],
+        producer_lanes_list=[8, 16],
+        producer_ii_cycles_list=[1, 2],
+        candidate_fifo_depth_groups_list=[1, 16],
+    )
+
+    assert len(report["overlap_traffic_sweep"]) == 16
+    assert {row["producer_lanes"] for row in report["overlap_traffic_sweep"]} == {8, 16}
+    assert any(not row["fifo_capacity_ok"] for row in report["overlap_traffic_sweep"])
+    assert report["overlap_recommendation"]["traffic_reduction_vs_materialized"] > 0


### PR DESCRIPTION
## Summary
- add a decoder logit-rank streaming overlap and traffic sweep
- attach a perf-sim/RTL equivalence contract to every streaming candidate
- add the control-plane L2 abstraction and proposal package for evaluator dispatch

## Equivalence
The estimator now records ready-valid stream observables for RTL comparison: accepted logit tile beats, accepted candidate groups, producer stall cycles, candidate FIFO max occupancy, and final last-beat completion cycle. Tie-breaking remains lower token id, matching the rank datapath contract.

## Validation
- PYTHONPATH=/workspaces/RTLGen:/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_logit_rank_streaming_model.py control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 -m py_compile npu/eval/model_llm_decoder_logit_rank_streaming.py npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py tests/test_llm_decoder_logit_rank_streaming_model.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py --rank-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json --scale-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json --producer-lanes-list 8,16,32 --top-k-list 1,4 --producer-ii-cycles-list 1,2,4 --global-merge-ii-cycles 1,2,4 --candidate-fifo-depth-groups-list 16,256,4096 --out /tmp/decoder_overlap.json --out-md /tmp/decoder_overlap.md