### PR TITLE
Add candidate-stream merge FIFO block

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,9 @@ set_tests_properties(test_softmax_rowwise PROPERTIES WORKING_DIRECTORY ${PROJECT
 add_test(NAME test_mac_pp_feedback COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_mac_pp_feedback.sh)
 set_tests_properties(test_mac_pp_feedback PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
+add_test(NAME test_candidate_stream_merge_fifo COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_candidate_stream_merge_fifo.sh)
+set_tests_properties(test_candidate_stream_merge_fifo PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
 if(RTLGEN_BUILD_FLOPOCO)
     set(FLOPOCO_STAGED_BIN ${PROJECT_SOURCE_DIR}/bin/flopoco)
     set(FLOPOCO_READY OFF)

--- a/apps/rtlgen_main.cpp
+++ b/apps/rtlgen_main.cpp
@@ -195,7 +195,9 @@ int main(int argc, char** argv) {
               << config.softmax_rowwise_operations.size() << " row-wise softmax block(s), "
               << config.bf16_recip_norm_operations.size() << " bf16 reciprocal-normalization block(s), "
               << config.score_tie_rank_operations.size() << " score tie-rank block(s), "
-              << config.logit_rank_operations.size() << " logit-rank block(s)\n";
+              << config.logit_rank_operations.size() << " logit-rank block(s), "
+              << config.candidate_stream_merge_fifo_operations.size()
+              << " candidate-stream merge FIFO block(s)\n";
 
     try {
         std::filesystem::path flopocoPath;
@@ -333,6 +335,16 @@ int main(int argc, char** argv) {
                       << ", logit_bits=" << rank.logit_bits
                       << ", top_k=" << rank.top_k << ")\n";
             emitLogitRankModule(rank, operandDef);
+        }
+
+        for (const auto &merge : config.candidate_stream_merge_fifo_operations) {
+            OperandDefinition operandDef = resolveOperand(config, merge.operand);
+            std::cout << "[INFO] Generating candidate-stream merge FIFO " << merge.module_name
+                      << " (top_k=" << merge.top_k
+                      << ", logit_bits=" << merge.logit_bits
+                      << ", token_id_bits=" << merge.token_id_bits
+                      << ", fifo_depth_groups=" << merge.fifo_depth_groups << ")\n";
+            emitCandidateStreamMergeFifoModule(merge, operandDef);
         }
 
         for (const auto &fp : config.fp_operations) {

--- a/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/README.md
@@ -1,0 +1,13 @@
+# Decoder Candidate-Stream Merge FIFO
+
+This proposal measures the first RTL block for the decoder logit-rank streaming hierarchy after the overlap model.
+
+The block consumes local candidate groups through a ready-valid interface, buffers them in a bounded FIFO, merges candidates by logit with lower-token tie-break, and exposes the observables required for perf-sim/RTL equivalence:
+
+- accepted candidate group count
+- producer stall cycles
+- FIFO max occupancy
+- final completion cycle
+- output valid mask, token ids, logits, and deterministic tie order
+
+The first measurement targets top-1 and top-4, signed 16-bit logits, 16-bit token ids, and a 16-group FIFO.

--- a/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/design_brief.md
@@ -1,0 +1,24 @@
+# Design Brief
+
+## Scope
+
+Add `candidate_stream_merge_fifo` as an RTLGen operation and measure it as a Layer 1 circuit block.
+
+## Interface
+
+The generated module has a `CandidateStream`-style input:
+
+- `in_valid`, `in_ready`, `in_last`
+- `in_valid_mask`
+- `in_token_ids`
+- `in_logits`
+
+The output is held on `out_valid` until `out_ready`, with merged top-k token ids, logits, and valid mask.
+
+## Equivalence Contract
+
+Perf-sim and RTL must agree on accepted group count, stall cycles, FIFO maximum occupancy, final completion cycle, output valid mask, and top-k ordering. Exact logit ties choose the lower token id.
+
+## Follow-On
+
+After L1 PPA merges, bind the measured area/timing/power back into the decoder streaming overlap model and decide whether to keep register FIFO, try SRAM-backed FIFO, or broaden producer widths.

--- a/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+Queue `l1_decoder_candidate_stream_merge_fifo_v1` only after the generator support for `candidate_stream_merge_fifo` is merged and materialized on the evaluator.
+
+The local gate is:
+
+- `cmake --build build --target rtlgen`
+- `bash tests/test_candidate_stream_merge_fifo.sh`
+- `ctest --test-dir build -R candidate_stream_merge_fifo --output-on-failure`

--- a/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/evaluation_requests.json
@@ -1,0 +1,24 @@
+{
+  "proposal_id": "prop_l1_decoder_candidate_stream_merge_fifo_v1",
+  "requests": [
+    {
+      "item_id": "l1_decoder_candidate_stream_merge_fifo_v1",
+      "task_type": "l1_sweep",
+      "status": "planned",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "candidate_stream_merge_fifo",
+      "config_paths": [
+        "runs/designs/activations/candidate_stream_merge_fifo_k1_l16_t16_d16_wrapper/config_candidate_stream_merge_fifo_k1_l16_t16_d16.json",
+        "runs/designs/activations/candidate_stream_merge_fifo_k4_l16_t16_d16_wrapper/config_candidate_stream_merge_fifo_k4_l16_t16_d16.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/candidate_stream_merge_fifo/sweeps/nangate45_highutil.json",
+      "platform": "nangate45",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_overlap_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "notes": "Queue after the generator support and proposal package merge so the evaluator can build the new operation type."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l1_decoder_candidate_stream_merge_fifo_v1",
+  "created_utc": "2026-05-05T07:30:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "candidate_stream_merge_fifo",
+  "title": "Decoder candidate-stream merge FIFO datapath",
+  "hypothesis": "The decoder logit-rank streaming hierarchy should not use modeled merge costs until a ready-valid candidate-stream merge/FIFO RTL block is measured and checked against the perf-sim observables recorded in the overlap model.",
+  "direct_comparison": {
+    "primary_question": "What is the Nangate45 PPA cost of a candidate-stream merge/FIFO block that preserves the overlap model's ready-valid equivalence contract for top-1 and top-4 candidate streams?",
+    "include": [
+      "candidate-stream ready-valid input/output RTL",
+      "top-k merge by larger logit with lower token-id tie-break",
+      "accepted candidate group count",
+      "producer stall cycle count",
+      "FIFO max occupancy",
+      "final completion cycle",
+      "top-1 and top-4 signed 16-bit logit, 16-bit token-id variants with 16 candidate-group FIFO depth"
+    ],
+    "exclude": [
+      "full decoder integration",
+      "new prompt quality rerun",
+      "NoC/SRAM banking arbitration",
+      "probability-producing softmax or sampling consumers"
+    ]
+  },
+  "expected_benefit": [
+    "replaces proxy merge latency and area with measured L1 RTL PPA",
+    "creates a concrete perf-sim/RTL equivalence target for the streaming hierarchy",
+    "separates candidate traffic buffering cost from local logit-rank datapath cost"
+  ],
+  "risks": [
+    "the first RTL block uses register FIFO storage; later SRAM-backed queues may differ",
+    "isolated PPA may improve or worsen after integration with producer and consumer timing",
+    "the equivalence test covers stream ordering and counters, not full decoder token quality"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_candidate_stream_merge_fifo_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for ready-valid candidate-stream merge/FIFO blocks used by decoder logit-rank streaming overlap.",
+      "config_paths": [
+        "runs/designs/activations/candidate_stream_merge_fifo_k1_l16_t16_d16_wrapper/config_candidate_stream_merge_fifo_k1_l16_t16_d16.json",
+        "runs/designs/activations/candidate_stream_merge_fifo_k4_l16_t16_d16_wrapper/config_candidate_stream_merge_fifo_k4_l16_t16_d16.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/candidate_stream_merge_fifo/sweeps/nangate45_highutil.json",
+      "platform": "nangate45",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "candidate_stream_merge_fifo",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_overlap_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_overlap_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+  ],
+  "knowledge_refs": [
+    "src/rtlgen/rtl_operations.cpp",
+    "examples/config_candidate_stream_merge_fifo.json",
+    "tests/candidate_stream_merge_fifo_tb.v",
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py"
+  ]
+}

--- a/examples/config_candidate_stream_merge_fifo.json
+++ b/examples/config_candidate_stream_merge_fifo.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "candidate_logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "candidate_stream_merge_fifo",
+      "module_name": "candidate_stream_merge_fifo_k2_l16_t8_d2",
+      "operand": "candidate_logits",
+      "options": {
+        "top_k": 2,
+        "logit_bits": 16,
+        "token_id_bits": 8,
+        "fifo_depth_groups": 2,
+        "counter_bits": 16,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/campaigns/activations/candidate_stream_merge_fifo/sweeps/nangate45_highutil.json
+++ b/runs/campaigns/activations/candidate_stream_merge_fifo/sweeps/nangate45_highutil.json
@@ -1,0 +1,9 @@
+{
+  "tag_prefix": "candidate_stream_merge_fifo_nangate45_highutil",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.5],
+    "CORE_UTILIZATION": [60, 50],
+    "PLACE_DENSITY": [0.68],
+    "SYNTH_MEMORY_MAX_BITS": [32768]
+  }
+}

--- a/runs/designs/activations/candidate_stream_merge_fifo_k1_l16_t16_d16_wrapper/config_candidate_stream_merge_fifo_k1_l16_t16_d16.json
+++ b/runs/designs/activations/candidate_stream_merge_fifo_k1_l16_t16_d16_wrapper/config_candidate_stream_merge_fifo_k1_l16_t16_d16.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "candidate_logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "candidate_stream_merge_fifo",
+      "module_name": "candidate_stream_merge_fifo_k1_l16_t16_d16",
+      "operand": "candidate_logits",
+      "options": {
+        "top_k": 1,
+        "logit_bits": 16,
+        "token_id_bits": 16,
+        "fifo_depth_groups": 16,
+        "counter_bits": 32,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/candidate_stream_merge_fifo_k4_l16_t16_d16_wrapper/config_candidate_stream_merge_fifo_k4_l16_t16_d16.json
+++ b/runs/designs/activations/candidate_stream_merge_fifo_k4_l16_t16_d16_wrapper/config_candidate_stream_merge_fifo_k4_l16_t16_d16.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "candidate_logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "candidate_stream_merge_fifo",
+      "module_name": "candidate_stream_merge_fifo_k4_l16_t16_d16",
+      "operand": "candidate_logits",
+      "options": {
+        "top_k": 4,
+        "logit_bits": 16,
+        "token_id_bits": 16,
+        "fifo_depth_groups": 16,
+        "counter_bits": 32,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -173,6 +173,36 @@ def identify_design(config):
             "logit_signed": bool(options.get("logit_signed", True)),
             "include_mg_cpa": False,
         }
+    if op_type == "candidate_stream_merge_fifo":
+        options = entry.get("options", {})
+        top_k = int(options.get("top_k", 1))
+        logit_bits = int(options.get("logit_bits", bit_width) or bit_width)
+        token_id_bits = int(options.get("token_id_bits", 16))
+        fifo_depth_groups = int(options.get("fifo_depth_groups", 16))
+        counter_bits = int(options.get("counter_bits", 32))
+        if top_k <= 0:
+            raise ValueError("candidate_stream_merge_fifo top_k must be positive")
+        if logit_bits <= 0:
+            raise ValueError("candidate_stream_merge_fifo logit_bits must be positive")
+        if token_id_bits <= 0:
+            raise ValueError("candidate_stream_merge_fifo token_id_bits must be positive")
+        if fifo_depth_groups <= 0:
+            raise ValueError("candidate_stream_merge_fifo fifo_depth_groups must be positive")
+        if counter_bits <= 0:
+            raise ValueError("candidate_stream_merge_fifo counter_bits must be positive")
+        return {
+            "kind": "candidate_stream_merge_fifo",
+            "module_name": module_name,
+            "wrapper_name": f"{module_name}_wrapper",
+            "top_k": top_k,
+            "logit_bits": logit_bits,
+            "token_id_bits": token_id_bits,
+            "token_width": token_id_bits * top_k,
+            "logit_width": logit_bits * top_k,
+            "counter_bits": counter_bits,
+            "logit_signed": bool(options.get("logit_signed", True)),
+            "include_mg_cpa": False,
+        }
     raise ValueError(f"generate_design.py does not support operation type: {op_type}")
 
 
@@ -452,6 +482,55 @@ module {wrapper_name}(
 
   assign top_indices = top_indices_reg;
   assign top_logits = top_logits_reg;
+
+endmodule
+"""
+    elif design["kind"] == "candidate_stream_merge_fifo":
+        top_k = int(design["top_k"])
+        token_width = int(design["token_width"])
+        logit_width = int(design["logit_width"])
+        counter_bits = int(design["counter_bits"])
+        signed_kw = "signed " if design.get("logit_signed", True) else ""
+        wrapper_content = f"""
+module {wrapper_name}(
+  input clk,
+  input rst_n,
+  input in_valid,
+  output in_ready,
+  input in_last,
+  input [{top_k-1}:0] in_valid_mask,
+  input [{token_width-1}:0] in_token_ids,
+  input {signed_kw}[{logit_width-1}:0] in_logits,
+  output out_valid,
+  input out_ready,
+  output [{top_k-1}:0] out_valid_mask,
+  output [{token_width-1}:0] out_token_ids,
+  output {signed_kw}[{logit_width-1}:0] out_logits,
+  output [{counter_bits-1}:0] accepted_group_count,
+  output [{counter_bits-1}:0] producer_stall_cycles,
+  output [{counter_bits-1}:0] fifo_max_occupancy,
+  output [{counter_bits-1}:0] final_completion_cycle
+);
+
+  {module_name} dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .in_valid(in_valid),
+    .in_ready(in_ready),
+    .in_last(in_last),
+    .in_valid_mask(in_valid_mask),
+    .in_token_ids(in_token_ids),
+    .in_logits(in_logits),
+    .out_valid(out_valid),
+    .out_ready(out_ready),
+    .out_valid_mask(out_valid_mask),
+    .out_token_ids(out_token_ids),
+    .out_logits(out_logits),
+    .accepted_group_count(accepted_group_count),
+    .producer_stall_cycles(producer_stall_cycles),
+    .fifo_max_occupancy(fifo_max_occupancy),
+    .final_completion_cycle(final_completion_cycle)
+  );
 
 endmodule
 """

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -118,7 +118,14 @@ def read_design_names(config_path: Path) -> Tuple[str, str]:
         module_name = cfg["adder"]["module_name"]
     elif "operations" in cfg and len(cfg["operations"]) == 1:
         entry = cfg["operations"][0]
-        if entry["type"] not in ("activation", "softmax_rowwise", "bf16_recip_norm", "score_tie_rank", "logit_rank"):
+        if entry["type"] not in (
+            "activation",
+            "softmax_rowwise",
+            "bf16_recip_norm",
+            "score_tie_rank",
+            "logit_rank",
+            "candidate_stream_merge_fifo",
+        ):
             raise ValueError(f"Unsupported single-operation design type in {config_path}: {entry['type']}")
         module_name = entry["module_name"]
     else:

--- a/src/rtlgen/config.cpp
+++ b/src/rtlgen/config.cpp
@@ -62,6 +62,7 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
         config.bf16_recip_norm_operations.clear();
         config.score_tie_rank_operations.clear();
         config.logit_rank_operations.clear();
+        config.candidate_stream_merge_fifo_operations.clear();
         config.onnx_model.reset();
 
         if (j.contains("operand")) {
@@ -458,6 +459,33 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                         throw std::runtime_error("logit_rank top_k must be in [1, row_elems] for " + rank.module_name);
                     }
                     config.logit_rank_operations.push_back(rank);
+                } else if (type == "candidate_stream_merge_fifo") {
+                    const json &options = entry.contains("options") ? entry["options"] : entry;
+                    CandidateStreamMergeFifoOperationConfig merge;
+                    merge.module_name = module_name;
+                    merge.operand = operand_name;
+                    merge.top_k = options.value("top_k", 1);
+                    merge.logit_bits = options.value("logit_bits", 16);
+                    merge.token_id_bits = options.value("token_id_bits", 16);
+                    merge.fifo_depth_groups = options.value("fifo_depth_groups", 16);
+                    merge.counter_bits = options.value("counter_bits", 32);
+                    merge.logit_signed = options.value("logit_signed", true);
+                    if (merge.top_k <= 0 || merge.top_k > 16) {
+                        throw std::runtime_error("candidate_stream_merge_fifo top_k must be in [1, 16] for " + merge.module_name);
+                    }
+                    if (merge.logit_bits <= 0 || merge.logit_bits > 64) {
+                        throw std::runtime_error("candidate_stream_merge_fifo logit_bits must be in [1, 64] for " + merge.module_name);
+                    }
+                    if (merge.token_id_bits <= 0 || merge.token_id_bits > 32) {
+                        throw std::runtime_error("candidate_stream_merge_fifo token_id_bits must be in [1, 32] for " + merge.module_name);
+                    }
+                    if (merge.fifo_depth_groups <= 0 || merge.fifo_depth_groups > 4096) {
+                        throw std::runtime_error("candidate_stream_merge_fifo fifo_depth_groups must be in [1, 4096] for " + merge.module_name);
+                    }
+                    if (merge.counter_bits <= 0 || merge.counter_bits > 64) {
+                        throw std::runtime_error("candidate_stream_merge_fifo counter_bits must be in [1, 64] for " + merge.module_name);
+                    }
+                    config.candidate_stream_merge_fifo_operations.push_back(merge);
                 } else {
                     throw std::runtime_error("Unknown operation type: " + type);
                 }

--- a/src/rtlgen/config.hpp
+++ b/src/rtlgen/config.hpp
@@ -236,6 +236,17 @@ struct LogitRankOperationConfig {
     bool logit_signed{true};
 };
 
+struct CandidateStreamMergeFifoOperationConfig {
+    std::string module_name;
+    std::string operand;
+    int top_k{1};
+    int logit_bits{16};
+    int token_id_bits{16};
+    int fifo_depth_groups{16};
+    int counter_bits{32};
+    bool logit_signed{true};
+};
+
 struct CircuitConfig {
     OperandConfig operand;
     std::vector<OperandDefinition> operands;
@@ -251,6 +262,7 @@ struct CircuitConfig {
     std::vector<Bf16RecipNormOperationConfig> bf16_recip_norm_operations;
     std::vector<ScoreTieRankOperationConfig> score_tie_rank_operations;
     std::vector<LogitRankOperationConfig> logit_rank_operations;
+    std::vector<CandidateStreamMergeFifoOperationConfig> candidate_stream_merge_fifo_operations;
     std::optional<std::string> onnx_model; // Added ONNX model path
 };
 

--- a/src/rtlgen/rtl_operations.cpp
+++ b/src/rtlgen/rtl_operations.cpp
@@ -1445,3 +1445,197 @@ void emitLogitRankModule(const LogitRankOperationConfig &config, const OperandDe
     os << "  end\n";
     os << "endmodule\n";
 }
+
+void emitCandidateStreamMergeFifoModule(const CandidateStreamMergeFifoOperationConfig &config,
+                                        const OperandDefinition &operand) {
+    const int logit_bits = config.logit_bits > 0 ? config.logit_bits : operand.bit_width;
+    if (config.top_k <= 0 || config.top_k > 16) {
+        throw std::runtime_error("candidate_stream_merge_fifo top_k must be in [1, 16]");
+    }
+    if (logit_bits <= 0 || logit_bits > 64) {
+        throw std::runtime_error("candidate_stream_merge_fifo logit_bits must be in [1, 64]");
+    }
+    if (config.token_id_bits <= 0 || config.token_id_bits > 32) {
+        throw std::runtime_error("candidate_stream_merge_fifo token_id_bits must be in [1, 32]");
+    }
+    if (config.fifo_depth_groups <= 0 || config.fifo_depth_groups > 4096) {
+        throw std::runtime_error("candidate_stream_merge_fifo fifo_depth_groups must be in [1, 4096]");
+    }
+    if (config.counter_bits <= 0 || config.counter_bits > 64) {
+        throw std::runtime_error("candidate_stream_merge_fifo counter_bits must be in [1, 64]");
+    }
+
+    const int ptr_bits = std::max(1, ceilLog2U64(static_cast<unsigned long long>(config.fifo_depth_groups)));
+    const int token_row_width = config.top_k * config.token_id_bits;
+    const int logit_row_width = config.top_k * logit_bits;
+    const std::string signed_kw = config.logit_signed ? "signed " : "";
+
+    std::string filename = config.module_name + ".v";
+    std::ofstream os(filename);
+    if (!os) {
+        throw std::runtime_error("Failed to open " + filename + " for writing");
+    }
+
+    os << "`timescale 1ns/1ps\n\n";
+    os << "module " << config.module_name << "(\n";
+    os << "  input  clk,\n";
+    os << "  input  rst_n,\n";
+    os << "  input  in_valid,\n";
+    os << "  output in_ready,\n";
+    os << "  input  in_last,\n";
+    os << "  input  [" << (config.top_k - 1) << ":0] in_valid_mask,\n";
+    os << "  input  [" << (token_row_width - 1) << ":0] in_token_ids,\n";
+    os << "  input  " << signed_kw << "[" << (logit_row_width - 1) << ":0] in_logits,\n";
+    os << "  output reg out_valid,\n";
+    os << "  input  out_ready,\n";
+    os << "  output reg [" << (config.top_k - 1) << ":0] out_valid_mask,\n";
+    os << "  output reg [" << (token_row_width - 1) << ":0] out_token_ids,\n";
+    os << "  output reg " << signed_kw << "[" << (logit_row_width - 1) << ":0] out_logits,\n";
+    os << "  output reg [" << (config.counter_bits - 1) << ":0] accepted_group_count,\n";
+    os << "  output reg [" << (config.counter_bits - 1) << ":0] producer_stall_cycles,\n";
+    os << "  output reg [" << (config.counter_bits - 1) << ":0] fifo_max_occupancy,\n";
+    os << "  output reg [" << (config.counter_bits - 1) << ":0] final_completion_cycle\n";
+    os << ");\n\n";
+    os << "  // CandidateStream ready-valid merger for decoder logit-rank streaming.\n";
+    os << "  // Ordering contract: larger logit wins; exact ties keep the lower token id.\n";
+    os << "  // Observable counters match the perf-sim/RTL equivalence contract.\n";
+    os << "  localparam integer TOP_K = " << config.top_k << ";\n";
+    os << "  localparam integer LOGIT_W = " << logit_bits << ";\n";
+    os << "  localparam integer TOKEN_ID_W = " << config.token_id_bits << ";\n";
+    os << "  localparam integer FIFO_DEPTH = " << config.fifo_depth_groups << ";\n";
+    os << "  localparam integer PTR_W = " << ptr_bits << ";\n";
+    os << "  localparam integer COUNT_W = " << config.counter_bits << ";\n\n";
+    os << "  localparam [COUNT_W-1:0] FIFO_DEPTH_COUNT = " << config.counter_bits << "'d" << config.fifo_depth_groups << ";\n";
+    os << "  localparam [PTR_W-1:0] FIFO_LAST_PTR = " << ptr_bits << "'d" << (config.fifo_depth_groups - 1) << ";\n\n";
+    os << "  reg fifo_last [0:FIFO_DEPTH-1];\n";
+    os << "  reg [TOP_K-1:0] fifo_mask [0:FIFO_DEPTH-1];\n";
+    os << "  reg [TOP_K*TOKEN_ID_W-1:0] fifo_token_ids [0:FIFO_DEPTH-1];\n";
+    os << "  reg " << signed_kw << "[TOP_K*LOGIT_W-1:0] fifo_logits [0:FIFO_DEPTH-1];\n";
+    os << "  reg [PTR_W-1:0] rd_ptr;\n";
+    os << "  reg [PTR_W-1:0] wr_ptr;\n";
+    os << "  reg [COUNT_W-1:0] occupancy;\n";
+    os << "  reg [COUNT_W-1:0] cycle_count;\n\n";
+    os << "  reg [TOP_K-1:0] top_valid;\n";
+    os << "  reg [TOKEN_ID_W-1:0] top_token [0:TOP_K-1];\n";
+    os << "  reg " << signed_kw << "[LOGIT_W-1:0] top_logit [0:TOP_K-1];\n";
+    os << "  reg [TOP_K-1:0] work_valid;\n";
+    os << "  reg [TOKEN_ID_W-1:0] work_token [0:TOP_K-1];\n";
+    os << "  reg " << signed_kw << "[LOGIT_W-1:0] work_logit [0:TOP_K-1];\n";
+    os << "  reg [TOP_K-1:0] read_mask;\n";
+    os << "  reg [TOP_K*TOKEN_ID_W-1:0] read_token_ids;\n";
+    os << "  reg " << signed_kw << "[TOP_K*LOGIT_W-1:0] read_logits;\n";
+    os << "  reg read_last;\n";
+    os << "  reg [TOKEN_ID_W-1:0] cand_token;\n";
+    os << "  reg " << signed_kw << "[LOGIT_W-1:0] cand_logit;\n";
+    os << "  integer i;\n";
+    os << "  integer k;\n";
+    os << "  integer insert_pos;\n";
+    os << "  integer pop_group;\n";
+    os << "  integer push_group;\n\n";
+    os << "  assign in_ready = (occupancy < FIFO_DEPTH_COUNT);\n\n";
+    os << "  always @(posedge clk or negedge rst_n) begin\n";
+    os << "    if (!rst_n) begin\n";
+    os << "      rd_ptr <= {PTR_W{1'b0}};\n";
+    os << "      wr_ptr <= {PTR_W{1'b0}};\n";
+    os << "      occupancy <= {COUNT_W{1'b0}};\n";
+    os << "      cycle_count <= {COUNT_W{1'b0}};\n";
+    os << "      accepted_group_count <= {COUNT_W{1'b0}};\n";
+    os << "      producer_stall_cycles <= {COUNT_W{1'b0}};\n";
+    os << "      fifo_max_occupancy <= {COUNT_W{1'b0}};\n";
+    os << "      final_completion_cycle <= {COUNT_W{1'b0}};\n";
+    os << "      out_valid <= 1'b0;\n";
+    os << "      out_valid_mask <= {TOP_K{1'b0}};\n";
+    os << "      out_token_ids <= {TOP_K*TOKEN_ID_W{1'b0}};\n";
+    os << "      out_logits <= {TOP_K*LOGIT_W{1'b0}};\n";
+    os << "      top_valid <= {TOP_K{1'b0}};\n";
+    os << "      for (i = 0; i < TOP_K; i = i + 1) begin\n";
+    os << "        top_token[i] <= {TOKEN_ID_W{1'b0}};\n";
+    os << "        top_logit[i] <= {LOGIT_W{1'b0}};\n";
+    os << "      end\n";
+    os << "    end else begin\n";
+    os << "      cycle_count <= cycle_count + {{(COUNT_W-1){1'b0}}, 1'b1};\n";
+    os << "      push_group = in_valid && in_ready;\n";
+    os << "      pop_group = (occupancy != {COUNT_W{1'b0}}) && !out_valid;\n\n";
+    os << "      if (in_valid && !in_ready)\n";
+    os << "        producer_stall_cycles <= producer_stall_cycles + {{(COUNT_W-1){1'b0}}, 1'b1};\n\n";
+    os << "      if (out_valid && out_ready) begin\n";
+    os << "        out_valid <= 1'b0;\n";
+    os << "        top_valid <= {TOP_K{1'b0}};\n";
+    os << "      end\n\n";
+    os << "      if (push_group) begin\n";
+    os << "        fifo_last[wr_ptr] <= in_last;\n";
+    os << "        fifo_mask[wr_ptr] <= in_valid_mask;\n";
+    os << "        fifo_token_ids[wr_ptr] <= in_token_ids;\n";
+    os << "        fifo_logits[wr_ptr] <= in_logits;\n";
+    os << "        accepted_group_count <= accepted_group_count + {{(COUNT_W-1){1'b0}}, 1'b1};\n";
+    os << "        if (wr_ptr == FIFO_LAST_PTR)\n";
+    os << "          wr_ptr <= {PTR_W{1'b0}};\n";
+    os << "        else\n";
+    os << "          wr_ptr <= wr_ptr + {{(PTR_W-1){1'b0}}, 1'b1};\n";
+    os << "      end\n\n";
+    os << "      if (pop_group) begin\n";
+    os << "        read_last = fifo_last[rd_ptr];\n";
+    os << "        read_mask = fifo_mask[rd_ptr];\n";
+    os << "        read_token_ids = fifo_token_ids[rd_ptr];\n";
+    os << "        read_logits = fifo_logits[rd_ptr];\n";
+    os << "        work_valid = top_valid;\n";
+    os << "        for (i = 0; i < TOP_K; i = i + 1) begin\n";
+    os << "          work_token[i] = top_token[i];\n";
+    os << "          work_logit[i] = top_logit[i];\n";
+    os << "        end\n\n";
+    os << "        for (i = 0; i < TOP_K; i = i + 1) begin\n";
+    os << "          if (read_mask[i]) begin\n";
+    os << "            cand_token = read_token_ids[(i*TOKEN_ID_W) +: TOKEN_ID_W];\n";
+    if (config.logit_signed) {
+        os << "            cand_logit = $signed(read_logits[(i*LOGIT_W) +: LOGIT_W]);\n";
+    } else {
+        os << "            cand_logit = read_logits[(i*LOGIT_W) +: LOGIT_W];\n";
+    }
+    os << "            insert_pos = TOP_K;\n";
+    os << "            for (k = 0; k < TOP_K; k = k + 1) begin\n";
+    os << "              if ((insert_pos == TOP_K) && (!work_valid[k] || (cand_logit > work_logit[k]) || ((cand_logit == work_logit[k]) && (cand_token < work_token[k]))))\n";
+    os << "                insert_pos = k;\n";
+    os << "            end\n";
+    os << "            if (insert_pos < TOP_K) begin\n";
+    os << "              for (k = TOP_K - 1; k > 0; k = k - 1) begin\n";
+    os << "                if (k > insert_pos) begin\n";
+    os << "                  work_valid[k] = work_valid[k-1];\n";
+    os << "                  work_token[k] = work_token[k-1];\n";
+    os << "                  work_logit[k] = work_logit[k-1];\n";
+    os << "                end\n";
+    os << "              end\n";
+    os << "              work_valid[insert_pos] = 1'b1;\n";
+    os << "              work_token[insert_pos] = cand_token;\n";
+    os << "              work_logit[insert_pos] = cand_logit;\n";
+    os << "            end\n";
+    os << "          end\n";
+    os << "        end\n\n";
+    os << "        top_valid <= work_valid;\n";
+    os << "        for (i = 0; i < TOP_K; i = i + 1) begin\n";
+    os << "          top_token[i] <= work_token[i];\n";
+    os << "          top_logit[i] <= work_logit[i];\n";
+    os << "        end\n";
+    os << "        if (read_last) begin\n";
+    os << "          out_valid <= 1'b1;\n";
+    os << "          out_valid_mask <= work_valid;\n";
+    os << "          for (i = 0; i < TOP_K; i = i + 1) begin\n";
+    os << "            out_token_ids[(i*TOKEN_ID_W) +: TOKEN_ID_W] <= work_token[i];\n";
+    os << "            out_logits[(i*LOGIT_W) +: LOGIT_W] <= work_logit[i];\n";
+    os << "          end\n";
+    os << "          final_completion_cycle <= cycle_count + {{(COUNT_W-1){1'b0}}, 1'b1};\n";
+    os << "        end\n";
+    os << "        if (rd_ptr == FIFO_LAST_PTR)\n";
+    os << "          rd_ptr <= {PTR_W{1'b0}};\n";
+    os << "        else\n";
+    os << "          rd_ptr <= rd_ptr + {{(PTR_W-1){1'b0}}, 1'b1};\n";
+    os << "      end\n\n";
+    os << "      if (push_group && !pop_group)\n";
+    os << "        occupancy <= occupancy + {{(COUNT_W-1){1'b0}}, 1'b1};\n";
+    os << "      else if (!push_group && pop_group)\n";
+    os << "        occupancy <= occupancy - {{(COUNT_W-1){1'b0}}, 1'b1};\n\n";
+    os << "      if ((occupancy + (push_group ? {{(COUNT_W-1){1'b0}}, 1'b1} : {COUNT_W{1'b0}}) - (pop_group ? {{(COUNT_W-1){1'b0}}, 1'b1} : {COUNT_W{1'b0}})) > fifo_max_occupancy)\n";
+    os << "        fifo_max_occupancy <= occupancy + (push_group ? {{(COUNT_W-1){1'b0}}, 1'b1} : {COUNT_W{1'b0}}) - (pop_group ? {{(COUNT_W-1){1'b0}}, 1'b1} : {COUNT_W{1'b0}});\n";
+    os << "    end\n";
+    os << "  end\n";
+    os << "endmodule\n";
+}

--- a/src/rtlgen/rtl_operations.hpp
+++ b/src/rtlgen/rtl_operations.hpp
@@ -9,3 +9,5 @@ void emitSoftmaxRowwiseModule(const SoftmaxRowwiseOperationConfig &config, const
 void emitBf16RecipNormModule(const Bf16RecipNormOperationConfig &config, const OperandDefinition &operand);
 void emitScoreTieRankModule(const ScoreTieRankOperationConfig &config, const OperandDefinition &operand);
 void emitLogitRankModule(const LogitRankOperationConfig &config, const OperandDefinition &operand);
+void emitCandidateStreamMergeFifoModule(const CandidateStreamMergeFifoOperationConfig &config,
+                                        const OperandDefinition &operand);

--- a/tests/candidate_stream_merge_fifo_tb.v
+++ b/tests/candidate_stream_merge_fifo_tb.v
@@ -1,0 +1,126 @@
+`timescale 1ns/1ps
+
+module candidate_stream_merge_fifo_tb;
+  reg clk;
+  reg rst_n;
+  reg in_valid;
+  wire in_ready;
+  reg in_last;
+  reg [1:0] in_valid_mask;
+  reg [15:0] in_token_ids;
+  reg signed [31:0] in_logits;
+  wire out_valid;
+  reg out_ready;
+  wire [1:0] out_valid_mask;
+  wire [15:0] out_token_ids;
+  wire signed [31:0] out_logits;
+  wire [15:0] accepted_group_count;
+  wire [15:0] producer_stall_cycles;
+  wire [15:0] fifo_max_occupancy;
+  wire [15:0] final_completion_cycle;
+
+  candidate_stream_merge_fifo_k2_l16_t8_d2 dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .in_valid(in_valid),
+    .in_ready(in_ready),
+    .in_last(in_last),
+    .in_valid_mask(in_valid_mask),
+    .in_token_ids(in_token_ids),
+    .in_logits(in_logits),
+    .out_valid(out_valid),
+    .out_ready(out_ready),
+    .out_valid_mask(out_valid_mask),
+    .out_token_ids(out_token_ids),
+    .out_logits(out_logits),
+    .accepted_group_count(accepted_group_count),
+    .producer_stall_cycles(producer_stall_cycles),
+    .fifo_max_occupancy(fifo_max_occupancy),
+    .final_completion_cycle(final_completion_cycle)
+  );
+
+  always #5 clk = ~clk;
+
+  task send_group;
+    input last;
+    input [1:0] mask;
+    input [7:0] token0;
+    input signed [15:0] logit0;
+    input [7:0] token1;
+    input signed [15:0] logit1;
+    begin
+      @(negedge clk);
+      in_valid = 1'b1;
+      in_last = last;
+      in_valid_mask = mask;
+      in_token_ids = {token1, token0};
+      in_logits = {logit1, logit0};
+      @(negedge clk);
+      while (!in_ready) begin
+        @(negedge clk);
+      end
+      in_valid = 1'b0;
+      in_last = 1'b0;
+      in_valid_mask = 2'b00;
+      in_token_ids = 16'h0000;
+      in_logits = 32'sh00000000;
+    end
+  endtask
+
+  initial begin
+    clk = 1'b0;
+    rst_n = 1'b0;
+    in_valid = 1'b0;
+    in_last = 1'b0;
+    in_valid_mask = 2'b00;
+    in_token_ids = 16'h0000;
+    in_logits = 32'sh00000000;
+    out_ready = 1'b0;
+
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+
+    // The second group ties token 5's logit with token 1; lower token id wins.
+    send_group(1'b0, 2'b11, 8'd5, 16'sd10, 8'd2, 16'sd7);
+    send_group(1'b1, 2'b11, 8'd1, 16'sd10, 8'd3, 16'sd12);
+
+    repeat (8) @(negedge clk);
+    if (!out_valid) begin
+      $display("FAIL candidate_stream_merge_fifo: out_valid was not asserted");
+      $fatal;
+    end
+    if (out_valid_mask !== 2'b11 ||
+        out_token_ids[7:0] !== 8'd3 ||
+        out_token_ids[15:8] !== 8'd1 ||
+        $signed(out_logits[15:0]) !== 16'sd12 ||
+        $signed(out_logits[31:16]) !== 16'sd10) begin
+      $display(
+        "FAIL candidate_stream_merge_fifo: tokens=[%0d,%0d] logits=[%0d,%0d] mask=%b",
+        out_token_ids[7:0],
+        out_token_ids[15:8],
+        $signed(out_logits[15:0]),
+        $signed(out_logits[31:16]),
+        out_valid_mask
+      );
+      $fatal;
+    end
+    if (accepted_group_count !== 16'd2 || producer_stall_cycles !== 16'd0 ||
+        fifo_max_occupancy === 16'd0 || final_completion_cycle === 16'd0) begin
+      $display(
+        "FAIL candidate_stream_merge_fifo observables: accepted=%0d stalls=%0d fifo_max=%0d final_cycle=%0d",
+        accepted_group_count,
+        producer_stall_cycles,
+        fifo_max_occupancy,
+        final_completion_cycle
+      );
+      $fatal;
+    end
+
+    out_ready = 1'b1;
+    @(negedge clk);
+    out_ready = 1'b0;
+
+    $display("All candidate-stream merge FIFO tests passed.");
+    $finish;
+  end
+endmodule

--- a/tests/test_candidate_stream_merge_fifo.sh
+++ b/tests/test_candidate_stream_merge_fifo.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+cp "$ROOT/examples/config_candidate_stream_merge_fifo.json" "$TMP/config.json"
+
+pushd "$TMP" >/dev/null
+"$ROOT/build/rtlgen" config.json
+
+grep -q "module candidate_stream_merge_fifo_k2_l16_t8_d2" candidate_stream_merge_fifo_k2_l16_t8_d2.v
+grep -q "CandidateStream ready-valid merger" candidate_stream_merge_fifo_k2_l16_t8_d2.v
+grep -q "producer_stall_cycles" candidate_stream_merge_fifo_k2_l16_t8_d2.v
+grep -q "final_completion_cycle" candidate_stream_merge_fifo_k2_l16_t8_d2.v
+
+YOSYS_BIN="${YOSYS_BIN:-}"
+if [[ -z "$YOSYS_BIN" ]]; then
+  if command -v yosys >/dev/null 2>&1; then
+    YOSYS_BIN="$(command -v yosys)"
+  elif [[ -x /oss-cad-suite/bin/yosys ]]; then
+    YOSYS_BIN=/oss-cad-suite/bin/yosys
+  fi
+fi
+if [[ -n "$YOSYS_BIN" ]]; then
+  "$YOSYS_BIN" -q -p "read_verilog candidate_stream_merge_fifo_k2_l16_t8_d2.v; hierarchy -top candidate_stream_merge_fifo_k2_l16_t8_d2; proc"
+fi
+
+iverilog -g2012 -s candidate_stream_merge_fifo_tb -o sim \
+  candidate_stream_merge_fifo_k2_l16_t8_d2.v "$ROOT/tests/candidate_stream_merge_fifo_tb.v"
+vvp sim
+
+WRAP_DIR="$TMP/wrapper"
+mkdir -p "$WRAP_DIR"
+PYTHONPATH="$ROOT/scripts" python3 - "$ROOT/examples/config_candidate_stream_merge_fifo.json" "$WRAP_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from generate_design import generate_wrapper, identify_design
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+design = identify_design(config)
+assert design["kind"] == "candidate_stream_merge_fifo"
+assert design["top_k"] == 2
+generate_wrapper(config, sys.argv[2], design)
+PY
+iverilog -g2012 -s candidate_stream_merge_fifo_k2_l16_t8_d2_wrapper -t null \
+  candidate_stream_merge_fifo_k2_l16_t8_d2.v \
+  "$WRAP_DIR/candidate_stream_merge_fifo_k2_l16_t8_d2_wrapper.v"
+
+cat > "$TMP/sweep.json" <<'JSON'
+{
+  "tag_prefix": "candidate_stream_merge_fifo_dryrun",
+  "flow_params": {
+    "CLOCK_PERIOD": [10.0]
+  }
+}
+JSON
+python3 "$ROOT/scripts/run_sweep.py" \
+  --configs "$ROOT/examples/config_candidate_stream_merge_fifo.json" \
+  --platform nangate45 \
+  --sweep "$TMP/sweep.json" \
+  --out_root "$TMP/runs" \
+  --dry_run
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add a generated candidate_stream_merge_fifo RTLGen operation for decoder logit-rank streaming
- expose the ready-valid equivalence observables: accepted groups, producer stalls, FIFO max occupancy, and final completion cycle
- add top-1/top-4 Nangate45 L1 configs plus a proposal package for the follow-on physical measurement

## Equivalence
The block merges candidate groups by larger signed logit with lower token-id tie-break and holds merged output on out_valid until out_ready. The Verilog test drives two candidate groups through the ready-valid input and checks the merged top-k order and reset-scoped observability counters.

## Validation
- cmake --build /workspaces/RTLGen/build --target rtlgen -j2
- bash /workspaces/RTLGen/tests/test_candidate_stream_merge_fifo.sh
- ctest --test-dir /workspaces/RTLGen/build -R candidate_stream_merge_fifo --output-on-failure
- python3 -m py_compile /workspaces/RTLGen/scripts/generate_design.py /workspaces/RTLGen/scripts/run_sweep.py
- python3 /workspaces/RTLGen/scripts/validate_runs.py --skip_eval_queue