### PR TITLE
Queue measured merge PPA streaming rerun

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1880,12 +1880,16 @@ def _decoder_logit_rank_streaming_hierarchy_evidence(*, item_id: str) -> dict[st
     hierarchy_report = f"{base}/decoder_logit_rank_streaming_hierarchy__{item_id}.md"
     rank_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
     scale_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+    candidate_merge_ppa = (
+        "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
+    )
     return {
         "inputs": {
             "source_prompt_stress": prompt_stress,
             "source_logit_rank_bypass": logit_rank_bypass,
             "rank_datapath_ppa": rank_ppa,
             "rank_scale_ppa": scale_ppa,
+            "candidate_merge_ppa": candidate_merge_ppa,
             "streaming_hierarchy_out": hierarchy_out,
             "streaming_hierarchy_report": hierarchy_report,
             "streaming_hierarchy_scope": (
@@ -1902,6 +1906,7 @@ def _decoder_logit_rank_streaming_hierarchy_evidence(*, item_id: str) -> dict[st
                     f"--logit-rank-bypass {logit_rank_bypass} "
                     f"--rank-ppa {rank_ppa} "
                     f"--scale-ppa {scale_ppa} "
+                    f"--candidate-merge-ppa {candidate_merge_ppa} "
                     f"--out {hierarchy_out} "
                     f"--out-md {hierarchy_report}"
                 ),
@@ -1919,17 +1924,22 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
     overlap_report = f"{base}/decoder_logit_rank_streaming_overlap__{item_id}.md"
     rank_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
     scale_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+    candidate_merge_ppa = (
+        "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
+    )
     return {
         "inputs": {
             "source_prompt_stress": prompt_stress,
             "source_logit_rank_bypass": logit_rank_bypass,
             "rank_datapath_ppa": rank_ppa,
             "rank_scale_ppa": scale_ppa,
+            "candidate_merge_ppa": candidate_merge_ppa,
             "streaming_overlap_out": overlap_out,
             "streaming_overlap_report": overlap_report,
             "streaming_overlap_scope": (
-                "Refine the decoder logit-rank streaming hierarchy with producer-overlap, FIFO, "
-                "candidate-traffic, and perf-sim/RTL equivalence observables before selecting a merge RTL block"
+                "Refine the decoder logit-rank streaming hierarchy with measured candidate-stream "
+                "merge/FIFO PPA, producer-overlap, FIFO, candidate-traffic, and perf-sim/RTL "
+                "equivalence observables"
             ),
         },
         "commands": [
@@ -1941,6 +1951,7 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
                     f"--logit-rank-bypass {logit_rank_bypass} "
                     f"--rank-ppa {rank_ppa} "
                     f"--scale-ppa {scale_ppa} "
+                    f"--candidate-merge-ppa {candidate_merge_ppa} "
                     "--producer-lanes-list 8,16,32 "
                     "--top-k-list 1,4 "
                     "--producer-ii-cycles-list 1,2,4 "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1553,6 +1553,9 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_hierarchy_e
             assert decoder_inputs["rank_scale_ppa"] == (
                 "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
             )
+            assert decoder_inputs["candidate_merge_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
+            )
             assert decoder_inputs["streaming_hierarchy_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_logit_rank_streaming_hierarchy__l2_decoder_logit_rank_streaming_hierarchy_v1.json"
@@ -1560,6 +1563,7 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_hierarchy_e
             assert "avoids full-vocabulary probability materialization" in decoder_inputs["streaming_hierarchy_scope"]
             assert "estimate_llm_decoder_logit_rank_streaming_hierarchy.py" in work_item.command_manifest[0]["run"]
             assert "--scale-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json" in work_item.command_manifest[0]["run"]
+            assert "--candidate-merge-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json" in work_item.command_manifest[0]["run"]
             assert "--out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_logit_rank_streaming_hierarchy__l2_decoder_logit_rank_streaming_hierarchy_v1.json" in work_item.command_manifest[0]["run"]
             assert "--out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_logit_rank_streaming_hierarchy__l2_decoder_logit_rank_streaming_hierarchy_v1.md" in work_item.command_manifest[0]["run"]
             assert decoder_inputs["streaming_hierarchy_out"] in work_item.expected_outputs
@@ -1608,13 +1612,18 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             assert decoder_inputs["rank_scale_ppa"] == (
                 "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
             )
+            assert decoder_inputs["candidate_merge_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
+            )
             assert decoder_inputs["streaming_overlap_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_overlap_v1.json"
             )
+            assert "measured candidate-stream merge/FIFO PPA" in decoder_inputs["streaming_overlap_scope"]
             assert "perf-sim/RTL equivalence observables" in decoder_inputs["streaming_overlap_scope"]
             run = work_item.command_manifest[0]["run"]
             assert "estimate_llm_decoder_logit_rank_streaming_hierarchy.py" in run
+            assert "--candidate-merge-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json" in run
             assert "--producer-lanes-list 8,16,32" in run
             assert "--top-k-list 1,4" in run
             assert "--producer-ii-cycles-list 1,2,4" in run

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/README.md
@@ -1,0 +1,5 @@
+# Decoder Logit-Rank Streaming With Measured Merge PPA
+
+This proposal reruns the L2 decoder logit-rank streaming overlap model after the L1 candidate-stream merge/FIFO block has real Nangate45 PPA.
+
+The job should not change functional semantics. It should confirm that the L2 perf model and L1 RTL share the same ready-valid observable contract: accepted candidate groups, producer stalls, FIFO occupancy, valid masks, final completion, and lower-token-id tie breaking.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/design_brief.md
@@ -1,0 +1,11 @@
+# Design Brief
+
+Use the existing streaming overlap sweep, but bind the candidate-stream merge/FIFO promotion artifact explicitly through the L2 task generator.
+
+The report should answer three questions:
+
+- whether measured merge/FIFO critical path changes the latency ranking versus flat measured rank
+- whether area/power from local rank plus merge/FIFO makes the hierarchy unattractive even when overlap recovers cycles
+- whether the equivalence contract remains visible in the artifact before any memory hierarchy or NoC work is added
+
+This is still a rank-only decoder path. Temperature sampling, top-p, and probability reporting remain outside this job.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/evaluation_gate.md
@@ -1,0 +1,13 @@
+# Evaluation Gate
+
+Queue `l2_decoder_logit_rank_streaming_measured_merge_v1` only after:
+
+- PR #405 has merged the candidate-stream merge/FIFO PPA artifact
+- the L2 streaming model accepts `--candidate-merge-ppa`
+- the L2 task generator records that artifact in its input manifest and command manifest
+
+Acceptance:
+
+- output JSON and Markdown include measured candidate merge/FIFO PPA
+- component PPA fields include local ranker and candidate merge/FIFO terms
+- perf-sim/RTL equivalence observables remain present

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_measured_merge_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_measured_merge_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming overlap model using measured candidate-stream merge/FIFO PPA while preserving perf-sim/RTL equivalence observables.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_overlap_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the measured merge/FIFO-calibrated model to decide whether the next frontier is memory/NoC hierarchy or a return to flat rank datapath scaling."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_measured_merge_v1",
+  "created_utc": "2026-05-05T09:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+  "title": "Decoder logit-rank streaming with measured merge PPA",
+  "hypothesis": "The decoder logit-rank streaming overlap model should be rerun after binding the measured candidate-stream merge/FIFO block, so the hierarchy decision uses comparable Layer 1 PPA instead of a merge-ranker proxy while keeping the same ready-valid equivalence contract.",
+  "direct_comparison": {
+    "primary_question": "Does the rank-only streaming hierarchy remain a useful frontier once candidate merge/FIFO timing, area, and power come from the measured Nangate45 block?",
+    "include": [
+      "measured candidate_stream_merge_fifo top-1 and top-4 PPA",
+      "measured local logit-rank and scale PPA inputs",
+      "producer overlap, merge II, FIFO capacity, and candidate traffic sweep",
+      "component PPA fields for local ranker and candidate merge/FIFO",
+      "perf-sim/RTL equivalence observables for accepted groups, stalls, FIFO occupancy, masks, completion, and tie-breaking"
+    ],
+    "exclude": [
+      "new RTL generation",
+      "new OpenROAD synthesis",
+      "probability-producing softmax or sampling consumers",
+      "larger-model quality reruns"
+    ],
+    "follow_on_broad_sweep": [
+      "if measured merge PPA still leaves overlap attractive, add memory hierarchy/NoC arbitration terms",
+      "if flat rank remains dominant on latency, keep candidate-stream hierarchy as a traffic-reduction option only"
+    ]
+  },
+  "expected_benefit": [
+    "replaces the previous merge-ranker proxy with measured candidate-stream merge/FIFO PPA",
+    "keeps cost dimensions separate enough to compare latency, area, power, overlap, and traffic",
+    "confirms that the L2 perf model and L1 RTL block share the same observable equivalence contract"
+  ],
+  "risks": [
+    "the L2 model still lacks SRAM banking, NoC arbitration, and floorplan distance",
+    "current merge/FIFO PPA covers k1/k4, 16-bit logits, 16-bit token IDs, and depth 16 only",
+    "the model remains rank-only and does not cover temperature, top-p, or probability reporting"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_measured_merge_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming overlap model using measured candidate-stream merge/FIFO PPA while preserving perf-sim/RTL equivalence observables.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_overlap_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The gate should decide whether measured merge/FIFO PPA supports deeper hierarchy work or shifts focus back to flat rank plus later memory/NoC modeling."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_candidate_stream_merge_fifo_v1/proposal.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py",
+    "tests/test_llm_decoder_logit_rank_streaming_model.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "tests/candidate_stream_merge_fifo_tb.v"
+  ]
+}


### PR DESCRIPTION
## Summary
- pass the candidate-stream merge/FIFO promotion artifact explicitly in L2 streaming hierarchy and overlap task manifests
- add the proposal package for l2_decoder_logit_rank_streaming_measured_merge_v1
- keep the rerun focused on measured PPA calibration plus existing perf-sim/RTL equivalence observables

## Validation
- PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_logit_rank_streaming_model.py
- python3 -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/proposal.json >/dev/null
- python3 -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/evaluation_requests.json >/dev/null
- PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile control_plane/control_plane/services/l2_task_generator.py