### PR TITLE
Queue decoder streaming memory NoC rerun

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1927,6 +1927,14 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
     candidate_merge_ppa = (
         "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
     )
+    memory_model = {
+        "memory_bandwidth_bytes_per_cycle": 64,
+        "sram_read_energy_pj_per_byte": 0.05,
+        "sram_write_energy_pj_per_byte": 0.07,
+        "noc_hops": 2,
+        "noc_energy_pj_per_byte_hop": 0.02,
+        "source": "planning_default_not_literature_backed",
+    }
     return {
         "inputs": {
             "source_prompt_stress": prompt_stress,
@@ -1934,6 +1942,7 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
             "rank_datapath_ppa": rank_ppa,
             "rank_scale_ppa": scale_ppa,
             "candidate_merge_ppa": candidate_merge_ppa,
+            "memory_model": memory_model,
             "streaming_overlap_out": overlap_out,
             "streaming_overlap_report": overlap_report,
             "streaming_overlap_scope": (
@@ -1957,6 +1966,11 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
                     "--producer-ii-cycles-list 1,2,4 "
                     "--global-merge-ii-cycles 1,2,4 "
                     "--candidate-fifo-depth-groups-list 16,256,4096 "
+                    "--memory-bandwidth-bytes-per-cycle 64 "
+                    "--sram-read-energy-pj-per-byte 0.05 "
+                    "--sram-write-energy-pj-per-byte 0.07 "
+                    "--noc-hops 2 "
+                    "--noc-energy-pj-per-byte-hop 0.02 "
                     f"--out {overlap_out} "
                     f"--out-md {overlap_report}"
                 ),

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1615,6 +1615,14 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             assert decoder_inputs["candidate_merge_ppa"] == (
                 "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
             )
+            assert decoder_inputs["memory_model"] == {
+                "memory_bandwidth_bytes_per_cycle": 64,
+                "sram_read_energy_pj_per_byte": 0.05,
+                "sram_write_energy_pj_per_byte": 0.07,
+                "noc_hops": 2,
+                "noc_energy_pj_per_byte_hop": 0.02,
+                "source": "planning_default_not_literature_backed",
+            }
             assert decoder_inputs["streaming_overlap_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_overlap_v1.json"
@@ -1628,6 +1636,8 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             assert "--top-k-list 1,4" in run
             assert "--producer-ii-cycles-list 1,2,4" in run
             assert "--candidate-fifo-depth-groups-list 16,256,4096" in run
+            assert "--noc-hops 2" in run
+            assert "--memory-bandwidth-bytes-per-cycle 64" in run
             assert decoder_inputs["streaming_overlap_out"] in work_item.expected_outputs
             assert decoder_inputs["streaming_overlap_report"] in work_item.expected_outputs
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/README.md
@@ -1,0 +1,5 @@
+# Decoder Logit-Rank Streaming Memory And NoC Model
+
+This job records the next L2 report after measured merge/FIFO PPA: the same rank-only streaming model with explicit memory bandwidth, SRAM energy, and NoC hop planning terms.
+
+The memory terms are planning defaults. They must remain separate from measured Nangate45 cell PPA until RTLGen has measured SRAM/NoC blocks.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/design_brief.md
@@ -1,0 +1,12 @@
+# Design Brief
+
+The measured merge/FIFO result showed flat rank remains the compute-latency winner. The unresolved question is whether streaming remains useful as a memory-traffic hierarchy.
+
+This job reruns the existing overlap sweep with:
+
+- measured rank datapath PPA
+- measured candidate merge/FIFO PPA
+- explicit memory bandwidth and energy planning parameters
+- NoC hop energy planning parameters
+
+The result should report separate recommendations for compute latency, overlap recovery, and memory traffic.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+Queue after the model and generator expose explicit memory/NoC parameters.
+
+Acceptance:
+
+- JSON and Markdown include `memory_hierarchy_model`
+- streaming rows include `memory_hierarchy`
+- report includes `memory_traffic_recommendation`
+- equivalence observables remain unchanged from the measured merge/FIFO report

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_memory_noc_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_memory_noc_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming model with explicit memory/NoC planning terms, measured merge/FIFO PPA, and unchanged perf-sim/RTL equivalence observables.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_measured_merge_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use memory/NoC-aware ranking to choose measured SRAM/NoC hierarchy work or flat rank scaling."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/proposal.json
@@ -1,0 +1,73 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_memory_noc_v1",
+  "created_utc": "2026-05-05T10:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+  "title": "Decoder logit-rank streaming memory and NoC model",
+  "hypothesis": "The measured candidate-stream merge/FIFO hierarchy should be judged on both latency and memory traffic. A first-order SRAM/NoC service model can identify whether the streaming path is worth deeper hierarchy work even when flat rank remains the compute-latency winner.",
+  "direct_comparison": {
+    "primary_question": "Does the rank-only streaming hierarchy become attractive under explicit memory bandwidth, SRAM energy, and NoC hop assumptions?",
+    "include": [
+      "measured logit-rank datapath PPA",
+      "measured candidate-stream merge/FIFO PPA",
+      "memory service cycles from explicit bandwidth parameters",
+      "SRAM read/write energy and NoC hop energy planning terms",
+      "separate latency, overlap, traffic, and memory recommendations",
+      "unchanged ready-valid perf-sim/RTL equivalence observables"
+    ],
+    "exclude": [
+      "measured SRAM macro PPA",
+      "measured NoC router PPA",
+      "new RTL",
+      "probability-producing sampling modes"
+    ],
+    "follow_on_broad_sweep": [
+      "replace planning memory terms with measured SRAM/NoC blocks if the memory recommendation is compelling",
+      "otherwise prioritize flat rank datapath scaling and larger-model quality checks"
+    ]
+  },
+  "expected_benefit": [
+    "keeps the streaming hierarchy evaluation from being decided by compute latency alone",
+    "makes the memory/traffic argument explicit and auditable",
+    "preserves the perf-sim/RTL equivalence contract while adding hierarchy-level cost terms"
+  ],
+  "risks": [
+    "memory and NoC parameters are planning defaults, not literature-backed or measured",
+    "the model does not yet account for SRAM banking conflicts or NoC contention",
+    "the best memory point may prefer top-1 traffic reduction while top-4 consumers need separate treatment"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_memory_noc_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming model with explicit memory/NoC planning terms, measured merge/FIFO PPA, and unchanged perf-sim/RTL equivalence observables.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_measured_merge_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The result should decide whether the next concrete implementation frontier is measured SRAM/NoC hierarchy blocks or flat rank datapath scaling."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_logit_rank_streaming_measured_merge_v1/proposal.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_logit_rank_streaming_measured_merge_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py",
+    "tests/test_llm_decoder_logit_rank_streaming_model.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}


### PR DESCRIPTION
## Summary
- make L2 streaming overlap jobs pass explicit memory/NoC planning parameters
- add the proposal package for l2_decoder_logit_rank_streaming_memory_noc_v1
- keep memory/NoC terms labeled as planning defaults, separate from measured Nangate45 PPA

## Validation
- PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_logit_rank_streaming_model.py
- python3 -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/proposal.json >/dev/null
- python3 -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/evaluation_requests.json >/dev/null
- PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile control_plane/control_plane/services/l2_task_generator.py