### PR TITLE
Queue decoder streaming SRAM metrics rerun

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1927,13 +1927,17 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
     candidate_merge_ppa = (
         "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
     )
+    sram_metrics_json = "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json"
     memory_model = {
         "memory_bandwidth_bytes_per_cycle": 64,
+        "sram_metrics_json": sram_metrics_json,
         "sram_read_energy_pj_per_byte": 0.05,
         "sram_write_energy_pj_per_byte": 0.07,
         "noc_hops": 2,
         "noc_energy_pj_per_byte_hop": 0.02,
-        "source": "planning_default_not_literature_backed",
+        "source": "sram_metrics_json_plus_planning_noc",
+        "sram_source": "cacti_estimated_nangate45_minimal_v0_2_draft",
+        "noc_source": "planning_default_not_literature_backed",
     }
     return {
         "inputs": {
@@ -1961,6 +1965,7 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
                     f"--rank-ppa {rank_ppa} "
                     f"--scale-ppa {scale_ppa} "
                     f"--candidate-merge-ppa {candidate_merge_ppa} "
+                    f"--sram-metrics-json {sram_metrics_json} "
                     "--producer-lanes-list 8,16,32 "
                     "--top-k-list 1,4 "
                     "--producer-ii-cycles-list 1,2,4 "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1617,11 +1617,14 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             )
             assert decoder_inputs["memory_model"] == {
                 "memory_bandwidth_bytes_per_cycle": 64,
+                "sram_metrics_json": "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json",
                 "sram_read_energy_pj_per_byte": 0.05,
                 "sram_write_energy_pj_per_byte": 0.07,
                 "noc_hops": 2,
                 "noc_energy_pj_per_byte_hop": 0.02,
-                "source": "planning_default_not_literature_backed",
+                "source": "sram_metrics_json_plus_planning_noc",
+                "sram_source": "cacti_estimated_nangate45_minimal_v0_2_draft",
+                "noc_source": "planning_default_not_literature_backed",
             }
             assert decoder_inputs["streaming_overlap_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
@@ -1636,6 +1639,7 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             assert "--top-k-list 1,4" in run
             assert "--producer-ii-cycles-list 1,2,4" in run
             assert "--candidate-fifo-depth-groups-list 16,256,4096" in run
+            assert "--sram-metrics-json runs/designs/sram/minimal_v0_2_draft/sram_metrics.json" in run
             assert "--noc-hops 2" in run
             assert "--memory-bandwidth-bytes-per-cycle 64" in run
             assert decoder_inputs["streaming_overlap_out"] in work_item.expected_outputs

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/README.md
@@ -1,0 +1,5 @@
+# Decoder Logit-Rank Streaming With Nangate45 SRAM Metrics
+
+This job reruns the decoder logit-rank streaming memory/NoC report with the committed Nangate45 CACTI SRAM artifact at `runs/designs/sram/minimal_v0_2_draft/sram_metrics.json`.
+
+The SRAM energy source is now an explicit artifact. The NoC hop term remains a planning parameter and must stay separated from SRAM provenance in the report.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/design_brief.md
@@ -1,0 +1,14 @@
+# Design Brief
+
+Use the same decoder logit-rank streaming overlap model and measured rank/merge PPA as the memory/NoC run, but bind SRAM energy to the Nangate45 CACTI artifact committed for `minimal_v0_2_draft`.
+
+The report should preserve the existing perf-sim/RTL equivalence contract:
+
+- accepted `LogitTileStream` beat count
+- accepted `CandidateStream` group count
+- producer stall cycles
+- candidate FIFO max occupancy
+- final last-beat completion cycle
+- deterministic candidate ordering and lower-token tie-break
+
+NoC energy remains a first-order planning term until a measured NoC/router artifact exists.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/evaluation_gate.md
@@ -1,0 +1,14 @@
+# Evaluation Gate
+
+The evaluator should produce:
+
+- `decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_sram_nangate45_v1.json`
+- `decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_sram_nangate45_v1.md`
+
+Acceptance checks:
+
+- report `memory_hierarchy_model.source` is `sram_metrics_json_plus_planning_noc`
+- report inputs include `sram_metrics_json_path` set to `runs/designs/sram/minimal_v0_2_draft/sram_metrics.json`
+- SRAM model provenance reports `pdk` containing `nangate45` and `tech_node_nm` containing `45`
+- NoC model provenance remains `planning_default_not_literature_backed`
+- ready-valid perf-sim/RTL equivalence observables are unchanged from the prior measured-merge streaming run

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_sram_nangate45_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming memory/NoC report with the committed Nangate45 SRAM metrics artifact, measured merge/FIFO PPA, and unchanged perf-sim/RTL equivalence observables.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_memory_noc_v1",
+        "l2_decoder_logit_rank_streaming_measured_merge_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use SRAM-artifact-backed memory energy to decide whether the next hierarchy step should be NoC/banking measurement or larger-model and larger-array stability checks."
+      },
+      "status": "pending"
+    }
+  ],
+  "source_commit": "e00db7bf1af490642d15fa922cb63f876a2b04d9"
+}

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1",
+  "created_utc": "2026-05-05T11:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+  "title": "Decoder logit-rank streaming with Nangate45 SRAM metrics",
+  "hypothesis": "Replacing hand-entered SRAM energy defaults with a committed Nangate45 CACTI SRAM artifact should make the decoder streaming memory ranking more comparable to the existing Nangate45 compute PPA while preserving the ready-valid perf-sim/RTL equivalence contract.",
+  "direct_comparison": {
+    "primary_question": "Does the memory-aware decoder streaming frontier change when SRAM energy comes from the Nangate45 minimal_v0_2_draft SRAM artifact instead of a planning default?",
+    "include": [
+      "measured logit-rank datapath PPA",
+      "measured candidate-stream merge/FIFO PPA",
+      "Nangate45 CACTI SRAM metrics from runs/designs/sram/minimal_v0_2_draft/sram_metrics.json",
+      "NoC hop energy still marked as a planning term",
+      "separate latency, overlap, traffic, and memory recommendations",
+      "unchanged ready-valid perf-sim/RTL equivalence observables"
+    ],
+    "exclude": [
+      "measured NoC router PPA",
+      "new SRAM macro RTL or OpenROAD hardening",
+      "new RTL merge semantics",
+      "probability-producing sampling modes"
+    ],
+    "follow_on_broad_sweep": [
+      "add measured NoC/router or banking terms if SRAM-backed memory ranking becomes a useful discriminator",
+      "otherwise prioritize larger-model and larger-array stability checks for the current rank/merge frontier"
+    ]
+  },
+  "expected_benefit": [
+    "removes one hand-entered SRAM energy heuristic from the decoder streaming report",
+    "keeps NoC planning assumptions auditable and separate from SRAM source data",
+    "establishes a repeatable path for later SRAM and NoC artifact-backed hierarchy evaluations"
+  ],
+  "risks": [
+    "CACTI estimates are still pre-synthesis memory estimates, not measured SRAM macro PPA",
+    "the model does not yet account for SRAM banking conflicts or NoC contention",
+    "the minimal_v0_2_draft SRAM sizes may not match every future decoder hierarchy point"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_sram_nangate45_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming memory/NoC report with the committed Nangate45 SRAM metrics artifact, measured merge/FIFO PPA, and unchanged perf-sim/RTL equivalence observables.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_memory_noc_v1",
+        "l2_decoder_logit_rank_streaming_measured_merge_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The result should show whether SRAM-artifact-backed memory energy changes the local streaming frontier before spending work on NoC or larger-array hierarchy points."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/proposal.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_logit_rank_streaming_memory_noc_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py",
+    "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}


### PR DESCRIPTION
## Summary
- pass `--sram-metrics-json runs/designs/sram/minimal_v0_2_draft/sram_metrics.json` from the decoder streaming overlap L2 generator
- record SRAM artifact provenance separately from NoC planning parameters in the task input manifest
- add proposal `prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1` for the next ordinary L2 workflow item

## Validation
- `PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_logit_rank_streaming_model.py tests/test_sram_metrics_validation.py`
- `python -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/proposal.json >/dev/null`
- `python -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/evaluation_requests.json >/dev/null`
- `python -m py_compile control_plane/control_plane/services/l2_task_generator.py`