### PR TITLE
Queue decoder streaming scale stability sweep

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1931,6 +1931,8 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
     memory_model = {
         "memory_bandwidth_bytes_per_cycle": 64,
         "sram_metrics_json": sram_metrics_json,
+        "vocab_size_list": [50257, 100000, 200000],
+        "producer_lanes_list": [8, 16, 32, 64, 128],
         "sram_read_energy_pj_per_byte": 0.05,
         "sram_write_energy_pj_per_byte": 0.07,
         "noc_hops": 2,
@@ -1966,10 +1968,11 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
                     f"--scale-ppa {scale_ppa} "
                     f"--candidate-merge-ppa {candidate_merge_ppa} "
                     f"--sram-metrics-json {sram_metrics_json} "
-                    "--producer-lanes-list 8,16,32 "
+                    "--vocab-size-list 50257,100000,200000 "
+                    "--producer-lanes-list 8,16,32,64,128 "
                     "--top-k-list 1,4 "
-                    "--producer-ii-cycles-list 1,2,4 "
-                    "--global-merge-ii-cycles 1,2,4 "
+                    "--producer-ii-cycles-list 1,2 "
+                    "--global-merge-ii-cycles 1,2 "
                     "--candidate-fifo-depth-groups-list 16,256,4096 "
                     "--memory-bandwidth-bytes-per-cycle 64 "
                     "--sram-read-energy-pj-per-byte 0.05 "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1618,6 +1618,8 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             assert decoder_inputs["memory_model"] == {
                 "memory_bandwidth_bytes_per_cycle": 64,
                 "sram_metrics_json": "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json",
+                "vocab_size_list": [50257, 100000, 200000],
+                "producer_lanes_list": [8, 16, 32, 64, 128],
                 "sram_read_energy_pj_per_byte": 0.05,
                 "sram_write_energy_pj_per_byte": 0.07,
                 "noc_hops": 2,
@@ -1635,9 +1637,10 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             run = work_item.command_manifest[0]["run"]
             assert "estimate_llm_decoder_logit_rank_streaming_hierarchy.py" in run
             assert "--candidate-merge-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json" in run
-            assert "--producer-lanes-list 8,16,32" in run
+            assert "--vocab-size-list 50257,100000,200000" in run
+            assert "--producer-lanes-list 8,16,32,64,128" in run
             assert "--top-k-list 1,4" in run
-            assert "--producer-ii-cycles-list 1,2,4" in run
+            assert "--producer-ii-cycles-list 1,2" in run
             assert "--candidate-fifo-depth-groups-list 16,256,4096" in run
             assert "--sram-metrics-json runs/designs/sram/minimal_v0_2_draft/sram_metrics.json" in run
             assert "--noc-hops 2" in run

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/README.md
@@ -1,0 +1,5 @@
+# Decoder Logit-Rank Streaming Scale Stability
+
+This job broadens the SRAM-backed decoder streaming frontier across larger vocabulary sizes and wider producer-lane counts.
+
+The sweep is intentionally still a model-level L2 check. It does not add new RTL or measured NoC PPA; it asks whether the current conclusion remains stable enough to justify either NoC/banking work or larger-model quality confirmation.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/design_brief.md
@@ -1,0 +1,14 @@
+# Design Brief
+
+Extend the decoder logit-rank streaming overlap report from one GPT-2 vocabulary point to a small scale grid:
+
+- vocabulary sizes: `50257`, `100000`, `200000`
+- producer lanes: `8`, `16`, `32`, `64`, `128`
+- local top-k: `1`, `4`
+- producer II: `1`, `2`
+- merge II: `1`, `2`
+- FIFO depth groups: `16`, `256`, `4096`
+
+The report must keep SRAM source data and NoC planning assumptions separate. The SRAM source is `runs/designs/sram/minimal_v0_2_draft/sram_metrics.json`; the NoC hop term remains a planning parameter.
+
+Equivalence remains the same ready-valid stream contract: accepted `LogitTileStream` beats, accepted `CandidateStream` groups, producer stalls, FIFO occupancy, deterministic ordering, valid masks, and last-beat completion.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_gate.md
@@ -1,0 +1,15 @@
+# Evaluation Gate
+
+The evaluator should produce:
+
+- `decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_scale_stability_v1.json`
+- `decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_scale_stability_v1.md`
+
+Acceptance checks:
+
+- report inputs include `vocab_size_list` with `50257`, `100000`, and `200000`
+- report inputs include `producer_lanes_list` with `8`, `16`, `32`, `64`, and `128`
+- report includes a `scale_stability_summary` entry for each vocabulary size
+- SRAM provenance reports `nangate45` and `45 nm`
+- NoC provenance remains `planning_default_not_literature_backed`
+- ready-valid perf-sim/RTL equivalence observables remain unchanged

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_requests.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_scale_stability_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_scale_stability_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming report with SRAM-backed memory terms across larger vocabulary sizes and wider producer-lane options.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_sram_nangate45_v1",
+        "l2_decoder_logit_rank_streaming_memory_noc_v1",
+        "l2_decoder_logit_rank_streaming_measured_merge_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use larger vocabulary and producer-lane scale points to decide whether NoC/banking measurement or larger-model quality confirmation is the next useful step."
+      },
+      "status": "pending"
+    }
+  ],
+  "source_commit": "edaea838d766bfb70be2783e7fc0589e39d4fd8b"
+}

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/proposal.json
@@ -1,0 +1,76 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_scale_stability_v1",
+  "created_utc": "2026-05-05T12:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+  "title": "Decoder logit-rank streaming scale stability",
+  "hypothesis": "The current flat-rank versus streaming-rank conclusion should be checked across larger vocabulary sizes and wider producer arrays before committing to NoC/banking implementation work.",
+  "direct_comparison": {
+    "primary_question": "Does the SRAM-backed decoder logit-rank streaming frontier remain stable as vocabulary size and producer-lane count increase?",
+    "include": [
+      "vocabulary-size sweep at 50257, 100000, and 200000 tokens",
+      "producer-lane sweep at 8, 16, 32, 64, and 128 lanes",
+      "top-k sweep at 1 and 4",
+      "measured logit-rank datapath and candidate-stream merge/FIFO PPA where available",
+      "Nangate45 CACTI SRAM metrics from runs/designs/sram/minimal_v0_2_draft/sram_metrics.json",
+      "NoC hop energy still marked as a planning term",
+      "unchanged ready-valid perf-sim/RTL equivalence observables"
+    ],
+    "exclude": [
+      "new RTL",
+      "new SRAM macro hardening",
+      "measured NoC router PPA",
+      "quality changes from larger trained models"
+    ],
+    "follow_on_broad_sweep": [
+      "if the same memory frontier holds, move to larger-model quality and larger-array hardware points",
+      "if the memory frontier changes, prioritize NoC/banking measurement for the changed scale region"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the local GPT-2 vocabulary result generalizes to larger vocabulary pressure",
+    "exposes where ranker lane scaling relies on measured points versus log2-lane proxies",
+    "keeps equivalence constraints visible while the architecture search broadens"
+  ],
+  "risks": [
+    "producer lanes beyond measured ranker PPA points use explicit scaled proxies",
+    "larger vocabularies are synthetic scale points, not full larger-model quality runs",
+    "NoC and banking contention remain planning terms"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_scale_stability_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming report with SRAM-backed memory terms across larger vocabulary sizes and wider producer-lane options.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_sram_nangate45_v1",
+        "l2_decoder_logit_rank_streaming_memory_noc_v1",
+        "l2_decoder_logit_rank_streaming_measured_merge_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The result should decide whether to spend the next implementation step on NoC/banking measurement or move to larger-model quality and larger-array hardware confirmation."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/proposal.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_logit_rank_streaming_sram_nangate45_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py",
+    "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/model_llm_decoder_logit_rank_streaming.py
+++ b/npu/eval/model_llm_decoder_logit_rank_streaming.py
@@ -669,6 +669,7 @@ def _streaming_overlap_candidate(
     overlap_recovered_cycles = max(0, buffered_e2e_cycles - sim["total_cycles"])
     candidate = {
         "architecture": "hierarchical_streaming_local_rank_global_merge",
+        "vocab_size": vocab_size,
         "merge_variant": f"merge_ii_{global_merge_ii_cycles}",
         "sweep_key": (
             f"w{producer_lanes}_k{top_k}_prodii{producer_ii_cycles}_"
@@ -781,6 +782,7 @@ def build_report(
     global_merge_latency_cycles: int = 3,
     global_merge_ii_cycles_list: list[int] | None = None,
     candidate_fifo_depth_groups: int = 16,
+    vocab_size_list: list[int] | None = None,
     producer_lanes_list: list[int] | None = None,
     top_k_list: list[int] | None = None,
     producer_ii_cycles_list: list[int] | None = None,
@@ -817,11 +819,13 @@ def build_report(
         else sram_write_energy_pj_per_byte
     )
     merge_iis = global_merge_ii_cycles_list or [1, 2, 4]
+    vocab_options = vocab_size_list or [vocab_size]
     lane_options = producer_lanes_list or [producer_lanes]
     top_k_options = top_k_list or [top_k]
     producer_ii_options = producer_ii_cycles_list or [producer_ii_cycles]
     fifo_options = candidate_fifo_depth_groups_list or [candidate_fifo_depth_groups]
     for name, values in (
+        ("vocab_size_list", vocab_options),
         ("producer_lanes_list", lane_options),
         ("top_k_list", top_k_options),
         ("producer_ii_cycles_list", producer_ii_options),
@@ -907,36 +911,39 @@ def build_report(
     overlap_sweep: list[JsonDict] = []
     seen_sweep_keys: set[str] = set()
     for lanes in lane_options:
-        for local_k in top_k_options:
-            for prod_ii in producer_ii_options:
-                for merge_ii in merge_iis:
-                    for fifo_depth in fifo_options:
-                        candidate = _streaming_overlap_candidate(
-                            measured_points=measured_points,
-                            candidate_merge_points=candidate_merge_points,
-                            vocab_size=vocab_size,
-                            producer_lanes=lanes,
-                            top_k=local_k,
-                            producer_latency_cycles=producer_latency_cycles,
-                            producer_ii_cycles=prod_ii,
-                            local_ranker_latency_cycles=local_ranker_latency_cycles,
-                            local_ranker_ii_cycles=local_ranker_ii_cycles,
-                            global_merge_latency_cycles=global_merge_latency_cycles,
-                            global_merge_ii_cycles=merge_ii,
-                            candidate_fifo_depth_groups=fifo_depth,
-                            fallback_critical_path_ns=fallback_critical_path_ns,
-                            token_id_bits=token_id_bits,
-                            memory_bandwidth_bytes_per_cycle=memory_bandwidth_bytes_per_cycle,
-                            sram_read_energy_pj_per_byte=effective_sram_read_energy_pj_per_byte,
-                            sram_write_energy_pj_per_byte=effective_sram_write_energy_pj_per_byte,
-                            noc_hops=noc_hops,
-                            noc_energy_pj_per_byte_hop=noc_energy_pj_per_byte_hop,
-                            sram_model=sram_model,
-                        )
-                        if candidate["sweep_key"] in seen_sweep_keys:
-                            continue
-                        seen_sweep_keys.add(candidate["sweep_key"])
-                        overlap_sweep.append(candidate)
+        for sweep_vocab_size in vocab_options:
+            for local_k in top_k_options:
+                for prod_ii in producer_ii_options:
+                    for merge_ii in merge_iis:
+                        for fifo_depth in fifo_options:
+                            candidate = _streaming_overlap_candidate(
+                                measured_points=measured_points,
+                                candidate_merge_points=candidate_merge_points,
+                                vocab_size=sweep_vocab_size,
+                                producer_lanes=lanes,
+                                top_k=local_k,
+                                producer_latency_cycles=producer_latency_cycles,
+                                producer_ii_cycles=prod_ii,
+                                local_ranker_latency_cycles=local_ranker_latency_cycles,
+                                local_ranker_ii_cycles=local_ranker_ii_cycles,
+                                global_merge_latency_cycles=global_merge_latency_cycles,
+                                global_merge_ii_cycles=merge_ii,
+                                candidate_fifo_depth_groups=fifo_depth,
+                                fallback_critical_path_ns=fallback_critical_path_ns,
+                                token_id_bits=token_id_bits,
+                                memory_bandwidth_bytes_per_cycle=memory_bandwidth_bytes_per_cycle,
+                                sram_read_energy_pj_per_byte=effective_sram_read_energy_pj_per_byte,
+                                sram_write_energy_pj_per_byte=effective_sram_write_energy_pj_per_byte,
+                                noc_hops=noc_hops,
+                                noc_energy_pj_per_byte_hop=noc_energy_pj_per_byte_hop,
+                                sram_model=sram_model,
+                            )
+                            if len(vocab_options) > 1:
+                                candidate["sweep_key"] = f"v{sweep_vocab_size}_{candidate['sweep_key']}"
+                            if candidate["sweep_key"] in seen_sweep_keys:
+                                continue
+                            seen_sweep_keys.add(candidate["sweep_key"])
+                            overlap_sweep.append(candidate)
 
     all_candidates = flat + alternatives
     best = min(
@@ -948,6 +955,24 @@ def build_report(
         ),
     )
     baseline = min(flat, key=lambda row: row["timing"]["latency_us_per_token"]) if flat else None
+    flat_baseline_by_vocab: dict[int, JsonDict] = {}
+    if measured_points:
+        for sweep_vocab_size in vocab_options:
+            sweep_flat = [
+                _flat_point_report(
+                    point=point,
+                    vocab_size=sweep_vocab_size,
+                    ranker_latency_cycles=local_ranker_latency_cycles,
+                    ranker_ii_cycles=local_ranker_ii_cycles,
+                )
+                for point in measured_points
+                if _as_int(point.get("lanes")) > 0
+            ]
+            if sweep_flat:
+                flat_baseline_by_vocab[sweep_vocab_size] = min(
+                    sweep_flat,
+                    key=lambda row: row["timing"]["latency_us_per_token"],
+                )
     for row in alternatives:
         if baseline is None:
             row["speedup_vs_best_flat"] = None
@@ -956,30 +981,76 @@ def build_report(
                 baseline["timing"]["latency_us_per_token"] / row["timing"]["latency_us_per_token"], 6
             )
     for row in overlap_sweep:
-        if baseline is None:
+        row_baseline = flat_baseline_by_vocab.get(_as_int(row.get("vocab_size"), vocab_size))
+        if row_baseline is None:
             row["speedup_vs_best_flat"] = None
         else:
             row["speedup_vs_best_flat"] = round(
-                baseline["timing"]["latency_us_per_token"] / row["timing"]["latency_us_per_token"], 6
+                row_baseline["timing"]["latency_us_per_token"] / row["timing"]["latency_us_per_token"], 6
             )
+    primary_overlap_sweep = [
+        row
+        for row in overlap_sweep
+        if _as_int(row.get("vocab_size"), vocab_size) == vocab_size
+    ] or overlap_sweep
     best_overlap = min(
-        overlap_sweep,
+        primary_overlap_sweep,
         key=lambda row: (
             not bool(row.get("fifo_capacity_ok", True)),
             -row["buffered_baseline"]["overlap_recovered_fraction"],
             row["timing"]["latency_us_per_token"],
             row["traffic"]["streaming_candidate_memory_bytes"],
         ),
-    ) if overlap_sweep else None
+    ) if primary_overlap_sweep else None
     best_memory_traffic = min(
-        overlap_sweep,
+        primary_overlap_sweep,
         key=lambda row: (
             not bool(row.get("fifo_capacity_ok", True)),
             row["memory_hierarchy"]["total_bytes"],
             row["memory_hierarchy"]["memory_bound_latency_us"],
             row["timing"]["latency_us_per_token"],
         ),
-    ) if overlap_sweep else None
+    ) if primary_overlap_sweep else None
+    scale_stability_summary: list[JsonDict] = []
+    for sweep_vocab_size in vocab_options:
+        rows = [
+            row
+            for row in overlap_sweep
+            if _as_int(row.get("vocab_size"), vocab_size) == sweep_vocab_size
+        ]
+        if not rows:
+            continue
+        overlap_row = min(
+            rows,
+            key=lambda row: (
+                not bool(row.get("fifo_capacity_ok", True)),
+                -row["buffered_baseline"]["overlap_recovered_fraction"],
+                row["timing"]["latency_us_per_token"],
+                row["traffic"]["streaming_candidate_memory_bytes"],
+            ),
+        )
+        memory_row = min(
+            rows,
+            key=lambda row: (
+                not bool(row.get("fifo_capacity_ok", True)),
+                row["memory_hierarchy"]["total_bytes"],
+                row["memory_hierarchy"]["memory_bound_latency_us"],
+                row["timing"]["latency_us_per_token"],
+            ),
+        )
+        scale_stability_summary.append(
+            {
+                "vocab_size": sweep_vocab_size,
+                "best_overlap_sweep_key": overlap_row["sweep_key"],
+                "best_overlap_latency_us_per_token": overlap_row["timing"]["latency_us_per_token"],
+                "best_overlap_recovered_fraction": overlap_row["buffered_baseline"]["overlap_recovered_fraction"],
+                "best_memory_sweep_key": memory_row["sweep_key"],
+                "best_memory_total_bytes": memory_row["memory_hierarchy"]["total_bytes"],
+                "best_memory_bound_latency_us": memory_row["memory_hierarchy"]["memory_bound_latency_us"],
+                "best_memory_energy_nj": memory_row["memory_hierarchy"]["total_memory_energy_nj"],
+                "best_memory_traffic_reduction_vs_materialized": memory_row["traffic"]["traffic_reduction_vs_materialized"],
+            }
+        )
 
     return {
         "version": 0.1,
@@ -1011,6 +1082,7 @@ def build_report(
             "global_merge_latency_cycles": global_merge_latency_cycles,
             "global_merge_ii_cycles_list": merge_iis,
             "candidate_fifo_depth_groups": candidate_fifo_depth_groups,
+            "vocab_size_list": vocab_options,
             "producer_lanes_list": lane_options,
             "top_k_list": top_k_options,
             "producer_ii_cycles_list": producer_ii_options,
@@ -1067,6 +1139,14 @@ def build_report(
         "flat_measured_ranker_points": flat,
         "hierarchical_streaming_alternatives": alternatives,
         "overlap_traffic_sweep": overlap_sweep,
+        "scale_stability_summary": scale_stability_summary,
+        "sweep_recommendation_scope": {
+            "vocab_size": vocab_size,
+            "reason": (
+                "Top-level overlap and memory recommendations are scoped to the primary vocab_size; "
+                "scale_stability_summary compares each vocabulary size separately."
+            ),
+        },
         "recommendation": {
             "architecture": best["architecture"],
             "merge_variant": best.get("merge_variant"),
@@ -1204,15 +1284,16 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
             "",
             "## Overlap And Traffic Sweep",
             "",
-            "| key | cycles | latency_us | memory_bytes | memory_energy_nj | fifo required/capacity | overlap recovered | traffic reduction | speedup vs flat |",
-            "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+            "| key | vocab | cycles | latency_us | memory_bytes | memory_energy_nj | fifo required/capacity | overlap recovered | traffic reduction | speedup vs flat |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
     for row in payload["overlap_traffic_sweep"][:24]:
         mem = row.get("memory_hierarchy") or {}
         lines.append(
-            "| `{key}` | {cycles} | {latency} | {mem_bytes} | {mem_energy} | {fifo}/{cap} | {overlap} | {traffic} | {speedup} |".format(
+            "| `{key}` | {vocab} | {cycles} | {latency} | {mem_bytes} | {mem_energy} | {fifo}/{cap} | {overlap} | {traffic} | {speedup} |".format(
                 key=row["sweep_key"],
+                vocab=row.get("vocab_size"),
                 cycles=row["total_cycles"],
                 latency=row["timing"]["latency_us_per_token"],
                 mem_bytes=mem.get("total_bytes"),
@@ -1262,6 +1343,7 @@ def main() -> int:
     ap.add_argument("--global-merge-latency-cycles", type=int, default=3)
     ap.add_argument("--global-merge-ii-cycles", type=_int_list, default=[1, 2, 4])
     ap.add_argument("--candidate-fifo-depth-groups", type=int, default=16)
+    ap.add_argument("--vocab-size-list", type=_int_list, help="comma-separated vocabulary-size sweep")
     ap.add_argument("--producer-lanes-list", type=_int_list, help="comma-separated producer lane sweep")
     ap.add_argument("--top-k-list", type=_int_list, help="comma-separated local top-k sweep")
     ap.add_argument("--producer-ii-cycles-list", type=_int_list, help="comma-separated producer II sweep")
@@ -1294,6 +1376,7 @@ def main() -> int:
         global_merge_latency_cycles=args.global_merge_latency_cycles,
         global_merge_ii_cycles_list=args.global_merge_ii_cycles,
         candidate_fifo_depth_groups=args.candidate_fifo_depth_groups,
+        vocab_size_list=args.vocab_size_list,
         producer_lanes_list=args.producer_lanes_list,
         top_k_list=args.top_k_list,
         producer_ii_cycles_list=args.producer_ii_cycles_list,

--- a/tests/test_llm_decoder_logit_rank_streaming_model.py
+++ b/tests/test_llm_decoder_logit_rank_streaming_model.py
@@ -345,3 +345,60 @@ def test_logit_rank_streaming_overlap_sweep_varies_producer_and_fifo(tmp_path: P
     assert {row["producer_lanes"] for row in report["overlap_traffic_sweep"]} == {8, 16}
     assert any(not row["fifo_capacity_ok"] for row in report["overlap_traffic_sweep"])
     assert report["overlap_recommendation"]["traffic_reduction_vs_materialized"] > 0
+
+
+def test_logit_rank_streaming_overlap_sweep_varies_vocab_size(tmp_path: Path) -> None:
+    ppa = tmp_path / "rank_ppa.json"
+    ppa.write_text(
+        json.dumps(
+            {
+                "proposals": [
+                    {
+                        "metrics_ref": {
+                            "metrics_csv": "runs/designs/activations/logit_rank_r8_l16_k1_wrapper/metrics.csv",
+                            "status": "ok",
+                        },
+                        "metric_summary": {
+                            "critical_path_ns": 3.0,
+                            "die_area": 10.0,
+                            "total_power_mw": 0.1,
+                        },
+                    },
+                    {
+                        "metrics_ref": {
+                            "metrics_csv": "runs/designs/activations/logit_rank_r16_l16_k1_wrapper/metrics.csv",
+                            "status": "ok",
+                        },
+                        "metric_summary": {
+                            "critical_path_ns": 5.0,
+                            "die_area": 16.0,
+                            "total_power_mw": 0.2,
+                        },
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_report(
+        rank_ppa_path=ppa,
+        scale_ppa_path=None,
+        candidate_merge_ppa_path=None,
+        vocab_size=64,
+        producer_lanes=8,
+        top_k=1,
+        global_merge_ii_cycles_list=[1],
+        vocab_size_list=[64, 128],
+        producer_lanes_list=[8, 16],
+        producer_ii_cycles_list=[1],
+        candidate_fifo_depth_groups_list=[16],
+    )
+
+    assert len(report["overlap_traffic_sweep"]) == 4
+    assert {row["vocab_size"] for row in report["overlap_traffic_sweep"]} == {64, 128}
+    assert all(row["sweep_key"].startswith("v") for row in report["overlap_traffic_sweep"])
+    assert [row["vocab_size"] for row in report["scale_stability_summary"]] == [64, 128]
+    assert report["sweep_recommendation_scope"]["vocab_size"] == 64
+    assert report["memory_traffic_recommendation"]["sweep_key"].startswith("v64_")
+    assert report["inputs"]["vocab_size_list"] == [64, 128]


### PR DESCRIPTION
## Summary
- add `--vocab-size-list` support to the decoder logit-rank streaming model
- keep top-level sweep recommendations scoped to the primary vocab size and add per-vocab `scale_stability_summary`
- update the L2 overlap generator to sweep vocab sizes 50257/100000/200000 and producer lanes 8/16/32/64/128 with SRAM-backed memory terms
- add proposal `prop_l2_decoder_logit_rank_streaming_scale_stability_v1`

## Validation
- `PYTHONPATH=/workspaces/RTLGen/control_plane:/workspaces/RTLGen /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_logit_rank_streaming_model.py`
- `python -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/proposal.json >/dev/null`
- `python -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_requests.json >/dev/null`
- `python -m py_compile npu/eval/model_llm_decoder_logit_rank_streaming.py control_plane/control_plane/services/l2_task_generator.py`
- real CLI smoke with the full scale-stability sweep to `/tmp/decoder_streaming_scale_stability.json`