### PR TITLE
Add wide logit rank scaling proposal

### DIFF
--- a/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/README.md
@@ -1,0 +1,19 @@
+# Decoder Logit Rank Wide Scaling
+
+This proposal extends the merged Layer 1 decoder logit-rank scaling point from
+row-16/row-32 to row-64/row-128.
+
+The target is measurement only. The result should provide measured Nangate45 PPA
+for the current L2 streaming frontier widths, replacing the scaled-proxy data
+used for `w64` and `w128` candidates.
+
+Requested item:
+
+- `l1_decoder_logit_rank_wide_scale_v1`
+
+Requested configs:
+
+- `runs/designs/activations/logit_rank_r64_l16_k1_wrapper/config_logit_rank_r64_l16_k1.json`
+- `runs/designs/activations/logit_rank_r64_l16_k4_wrapper/config_logit_rank_r64_l16_k4.json`
+- `runs/designs/activations/logit_rank_r128_l16_k1_wrapper/config_logit_rank_r128_l16_k1.json`
+- `runs/designs/activations/logit_rank_r128_l16_k4_wrapper/config_logit_rank_r128_l16_k4.json`

--- a/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/design_brief.md
@@ -1,0 +1,76 @@
+# Design Brief
+
+## Proposal
+
+- `proposal_id`: `prop_l1_decoder_logit_rank_wide_scale_v1`
+- `title`: `Decoder logit rank wide scaling`
+
+## Problem
+
+The L2 decoder logit-rank streaming sweep now includes producer widths 64 and
+128 for larger-vocabulary scale stability, but those width points still rely on
+scaled ranker PPA proxies. That makes the current `w64` and `w128` rankings less
+trustworthy than the measured row-8, row-16, and row-32 points.
+
+## Hypothesis
+
+Direct row-64 and row-128 measurements will expose whether the wider rank tile
+frontier remains useful or whether the architecture should move toward a
+hierarchical or pipelined ranker before producer integration.
+
+## Evaluation Scope
+
+Direct comparison set:
+
+- `logit_rank_r64_l16_k1`
+- `logit_rank_r64_l16_k4`
+- `logit_rank_r128_l16_k1`
+- `logit_rank_r128_l16_k4`
+
+Evaluation mode:
+
+- `measurement_only`
+- `circuit_block`
+- Nangate45 high-utilization L1 sweep
+
+Dependency order:
+
+- depends on merged `l1_decoder_logit_rank_scale_v1`
+- depends on merged `l2_decoder_logit_rank_streaming_scale_stability_v1`
+- requires merged inputs and materialized refs
+
+Excluded first-stage comparisons:
+
+- producer-integrated macro
+- full-vocabulary merge tree
+- softmax probability generation
+- sampler and beam-search variants beyond `top_k=4`
+- floating-point logit quantization
+
+Follow-on broad sweep:
+
+- If row-64/row-128 measurements are usable, update the L2 streaming model to
+  consume the measured wide-rank PPA and rerun the scale-stability ranking.
+- If timing or PPA is poor, evaluate hierarchical or pipelined ranker
+  composition instead of continuing to widen the flat scan tile.
+
+## Knowledge Inputs
+
+- `control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json`
+- `control_plane/shadow_exports/l2_decisions/l2_decoder_logit_rank_streaming_scale_stability_v1.json`
+- `src/rtlgen/rtl_operations.cpp`
+- `npu/eval/model_llm_decoder_logit_rank_streaming.py`
+
+## Candidate Direction
+
+Generate four existing `logit_rank` operation configs with `row_elems` set to
+64 or 128 and `top_k` set to 1 or 4. Keep the RTL/perf-sim equivalence surface
+unchanged by using the existing `logit_rank` operation type and wrapper
+generation path.
+
+## Direction Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- note:

--- a/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - `l1_decoder_logit_rank_wide_scale_v1`
+- note: Measure row-64 and row-128 signed 16-bit logit-rank datapaths with `top_k=1` and `top_k=4`; do not promote this as a producer-integrated decoder macro result.

--- a/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l1_decoder_logit_rank_wide_scale_v1",
+  "source_commit": "28bacf78b58d1ec4c704a49d818a795ea9aa05e2",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_logit_rank_wide_scale_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA scaling for signed 16-bit logit-only rank datapaths at row_elems=64 and row_elems=128, with k=1 and k=4.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "comparison_role": "scale_frontier_component",
+      "paired_baseline_item_id": "l1_decoder_logit_rank_scale_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_logit_rank_scale_v1",
+        "l2_decoder_logit_rank_streaming_scale_stability_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure",
+        "reason": "Use measured row-64 and row-128 logit-rank PPA to replace the current scaled-proxy assumptions for L2 w64/w128 streaming decoder candidates."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l1_decoder_logit_rank_wide_scale_v1",
+  "created_utc": "2026-05-06T10:47:53Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "circuit_block",
+  "title": "Decoder logit rank wide scaling",
+  "hypothesis": "The L2 streaming decoder sweep now explores producer widths of 64 and 128, but those points still depend on scaled ranker PPA proxies. Measuring row-64 and row-128 logit-rank datapaths directly will show whether the wider frontier remains plausible or needs a hierarchical/pipelined ranker before larger-model conclusions.",
+  "direct_comparison": {
+    "primary_question": "How do Nangate45 area, timing, and power scale when the signed 16-bit raw-logit rank datapath grows from the merged row-16/row-32 measurements to row_elems=64 and row_elems=128?",
+    "include": [
+      "logit_rank_r64_l16_k1 wrapper",
+      "logit_rank_r64_l16_k4 wrapper",
+      "logit_rank_r128_l16_k1 wrapper",
+      "logit_rank_r128_l16_k4 wrapper",
+      "Nangate45 high-utilization Layer 1 sweep",
+      "comparison against merged row-16 and row-32 logit-rank PPA"
+    ],
+    "exclude": [
+      "producer-integrated decoder output macro",
+      "full vocabulary reduction tree",
+      "softmax probability generation",
+      "sampling modes",
+      "floating-point logit quantization"
+    ]
+  },
+  "expected_benefit": [
+    "replaces scaled-proxy PPA assumptions for the L2 w64 and w128 streaming candidates with measured circuit-block data",
+    "separates top-1 argmax scaling from top-4 candidate retention scaling at the current width frontier",
+    "provides a gate for deciding whether the next decoder-output ranker should be wider, hierarchical, or pipelined"
+  ],
+  "risks": [
+    "row_elems=64 and row_elems=128 may fail timing or produce unattractive area/power in the unpipelined circuit block",
+    "isolated ranker PPA still does not include producer output statistics, FIFO behavior, or global merge integration",
+    "top_k=4 does not cover wider sampler candidate sets or beam search"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_logit_rank_wide_scale_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA scaling for signed 16-bit logit-only rank datapaths at row_elems=64 and row_elems=128, with k=1 and k=4.",
+      "config_paths": [
+        "runs/designs/activations/logit_rank_r64_l16_k1_wrapper/config_logit_rank_r64_l16_k1.json",
+        "runs/designs/activations/logit_rank_r64_l16_k4_wrapper/config_logit_rank_r64_l16_k4.json",
+        "runs/designs/activations/logit_rank_r128_l16_k1_wrapper/config_logit_rank_r128_l16_k1.json",
+        "runs/designs/activations/logit_rank_r128_l16_k4_wrapper/config_logit_rank_r128_l16_k4.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil.json",
+      "platform": "nangate45",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "depends_on_item_ids": [
+        "l1_decoder_logit_rank_scale_v1",
+        "l2_decoder_logit_rank_streaming_scale_stability_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_logit_rank_streaming_scale_stability_v1.json"
+  ],
+  "knowledge_refs": [
+    "src/rtlgen/rtl_operations.cpp",
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/runs/designs/activations/logit_rank_r128_l16_k1_wrapper/config_logit_rank_r128_l16_k1.json
+++ b/runs/designs/activations/logit_rank_r128_l16_k1_wrapper/config_logit_rank_r128_l16_k1.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r128_l16_k1",
+      "operand": "logits",
+      "options": {
+        "row_elems": 128,
+        "logit_bits": 16,
+        "top_k": 1,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/logit_rank_r128_l16_k4_wrapper/config_logit_rank_r128_l16_k4.json
+++ b/runs/designs/activations/logit_rank_r128_l16_k4_wrapper/config_logit_rank_r128_l16_k4.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r128_l16_k4",
+      "operand": "logits",
+      "options": {
+        "row_elems": 128,
+        "logit_bits": 16,
+        "top_k": 4,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/logit_rank_r64_l16_k1_wrapper/config_logit_rank_r64_l16_k1.json
+++ b/runs/designs/activations/logit_rank_r64_l16_k1_wrapper/config_logit_rank_r64_l16_k1.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r64_l16_k1",
+      "operand": "logits",
+      "options": {
+        "row_elems": 64,
+        "logit_bits": 16,
+        "top_k": 1,
+        "logit_signed": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/logit_rank_r64_l16_k4_wrapper/config_logit_rank_r64_l16_k4.json
+++ b/runs/designs/activations/logit_rank_r64_l16_k4_wrapper/config_logit_rank_r64_l16_k4.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "logits",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "logit_rank",
+      "module_name": "logit_rank_r64_l16_k4",
+      "operand": "logits",
+      "options": {
+        "row_elems": 64,
+        "logit_bits": 16,
+        "top_k": 4,
+        "logit_signed": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add L1 proposal for measured row-64 and row-128 signed 16-bit logit-rank PPA
- add r64/r128, k1/k4 configs for the Nangate45 high-utilization sweep
- scope the job as measurement-only circuit-block data to replace L2 w64/w128 scaled proxies

## Validation
- python3 -m json.tool on new proposal/config JSON
- python3 identify_design check for all four configs
- PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_records_requested_item_in_proposal_evaluation_requests control_plane/control_plane/tests/test_cli_generate_l1.py