### PR TITLE
[codex] Requeue assigned stale leases as ready

### DIFF
--- a/control_plane/control_plane/services/lease_service.py
+++ b/control_plane/control_plane/services/lease_service.py
@@ -268,7 +268,7 @@ def expire_stale_leases(session: Session) -> LeaseExpiryResult:
             RunStatus.TIMED_OUT,
         }
         if not latest_run_terminal and work_item.state in {WorkItemState.LEASED, WorkItemState.RUNNING}:
-            work_item.state = WorkItemState.DISPATCH_PENDING
+            work_item.state = WorkItemState.READY if work_item.assigned_machine_key else WorkItemState.DISPATCH_PENDING
             requeued_count += 1
 
     cleaned_run_count = 0

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -132,7 +132,7 @@ def test_heartbeat_updates_expiry_and_machine_progress() -> None:
         assert lease.machine.capabilities["last_progress"]["phase"] == "run_campaign"
 
 
-def test_expire_stale_leases_requeues_nonterminal_work() -> None:
+def test_expire_stale_leases_requeues_assigned_nonterminal_work_as_ready() -> None:
     with make_session() as session:
         _, item_b = seed_ready_items(session)
         from control_plane.services.lease_service import upsert_worker_machine
@@ -166,7 +166,7 @@ def test_expire_stale_leases_requeues_nonterminal_work() -> None:
         assert result.requeued_count == 1
         assert result.cleaned_run_count == 1
         assert lease.status == LeaseStatus.EXPIRED
-        assert item_b.state == WorkItemState.DISPATCH_PENDING
+        assert item_b.state == WorkItemState.READY
         assert run.status == RunStatus.CANCELED
         assert run.completed_at is not None
         assert run.failure_category == "lease_expired"


### PR DESCRIPTION
## Summary
- Requeue assigned stale-lease work items to READY instead of DISPATCH_PENDING.
- Update the lease regression test for the assigned stale-lease case.

## Root Cause
Issue #422 exposed that stale-lease cleanup expired the active lease and left the work item assigned to the remote evaluator, but moved the item to DISPATCH_PENDING. Assigned work in DISPATCH_PENDING is not claimable by workers, and auto-dispatch skips it because assigned_machine_key is already set.

The correct requeue state for assigned work is READY. Unassigned work still returns to DISPATCH_PENDING.

## Validation
- PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_leases.py::test_expire_stale_leases_requeues_assigned_nonterminal_work_as_ready
