### PR TITLE
[codex] Evaluate Nangate45 wrappers with macro pin placement

### DIFF
--- a/control_plane/control_plane/tests/test_generate_design.py
+++ b/control_plane/control_plane/tests/test_generate_design.py
@@ -1,0 +1,33 @@
+"""Coverage for generated OpenROAD design collateral."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_generate_design_module():
+    script_path = Path(__file__).resolve().parents[3] / "scripts" / "generate_design.py"
+    spec = importlib.util.spec_from_file_location("rtlgen_generate_design", script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_nangate45_generated_config_uses_macro_pin_placement_defaults(tmp_path: Path) -> None:
+    generate_design = _load_generate_design_module()
+    design = {
+        "module_name": "logit_rank_r128_l16_k1",
+        "wrapper_name": "logit_rank_r128_l16_k1_wrapper",
+        "include_mg_cpa": False,
+    }
+
+    generate_design.generate_config_mk(tmp_path, "nangate45", design)
+
+    content = (tmp_path / "config.mk").read_text(encoding="utf-8")
+    assert "Register-wrapped Layer-1 blocks are evaluated as macro timing boundaries" in content
+    assert "export IO_PLACER_H ?= metal3 metal5" in content
+    assert "export IO_PLACER_V ?= metal4 metal6" in content
+    assert "export PLACE_PINS_ARGS ?= -min_distance 0" in content

--- a/runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil_macro_pins.json
+++ b/runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil_macro_pins.json
@@ -1,0 +1,27 @@
+{
+  "tag_prefix": "logit_rank_scale_nangate45_highutil_macro_pins",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      2.5
+    ],
+    "CORE_UTILIZATION": [
+      60,
+      50
+    ],
+    "PLACE_DENSITY": [
+      0.68
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      32768
+    ],
+    "IO_PLACER_H": [
+      "metal3 metal5"
+    ],
+    "IO_PLACER_V": [
+      "metal4 metal6"
+    ],
+    "PLACE_PINS_ARGS": [
+      "-min_distance 0"
+    ]
+  }
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -560,6 +560,11 @@ export CORE_UTILIZATION = 30
 """
     if platform == "nangate45":
         content += "export PDN_TCL ?= $(DESIGN_HOME)/nangate45/$(DESIGN_NAME)/grid_strategy-M1-M4-M7.tcl\n"
+        content += "\n# Register-wrapped Layer-1 blocks are evaluated as macro timing boundaries, not chip pads.\n"
+        content += "# Allow dense block-pin placement so wide datapath buses do not fail at IO placement.\n"
+        content += "export IO_PLACER_H ?= metal3 metal5\n"
+        content += "export IO_PLACER_V ?= metal4 metal6\n"
+        content += "export PLACE_PINS_ARGS ?= -min_distance 0\n"
     with open(os.path.join(platform_dir, "config.mk"), "w") as f:
         f.write(content)
 


### PR DESCRIPTION
## Summary
- Treat generated Nangate45 register-wrapped Layer-1 wrappers as macro timing boundaries for pin placement.
- Add dense macro pin-placement defaults to generated Nangate45 `config.mk` files.
- Add an explicit `nangate45_highutil_macro_pins` sweep so future metrics record the macro pin policy in `params_json`.
- Add focused coverage for the generated config defaults.

## Root Cause
The wide logit-rank wrapper failure in issue #424 was an IO-placement artifact. The `r128/k1` wrapper had 2072 top-level pins, and OpenROAD failed at `do-3_2_place_iop` because the default chip-style pin-placement grid did not have enough pin positions on the generated block perimeter. The register wrapper is still the right timing boundary, but these ports should be treated as macro/block pins, not chip pads.

## Behavior
Generated Nangate45 wrapper configs now default to:

```make
IO_PLACER_H ?= metal3 metal5
IO_PLACER_V ?= metal4 metal6
PLACE_PINS_ARGS ?= -min_distance 0
```

Sweeps can still override these values. The new macro-pin sweep includes the same values explicitly in `flow_params` so the pin policy is visible in `metrics.csv` rows.

## Validation
- `PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_generate_design.py`
- `python3 -m json.tool runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil_macro_pins.json >/dev/null`
- `python3 -m py_compile scripts/generate_design.py`
