### PR TITLE
[codex] Avoid stale metrics on failed sweeps

### DIFF
--- a/control_plane/control_plane/tests/test_run_sweep.py
+++ b/control_plane/control_plane/tests/test_run_sweep.py
@@ -1,0 +1,74 @@
+"""Coverage for the standalone OpenROAD sweep runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+
+def _load_run_sweep_module():
+    script_path = Path(__file__).resolve().parents[3] / "scripts" / "run_sweep.py"
+    spec = importlib.util.spec_from_file_location("rtlgen_run_sweep", script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_failed_run_does_not_parse_stale_base_reports(tmp_path: Path, monkeypatch) -> None:
+    run_sweep = _load_run_sweep_module()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "operands": [{"name": "logits", "dimensions": 1, "bit_width": 16, "signed": True, "kind": "int"}],
+                "operations": [
+                    {
+                        "type": "logit_rank",
+                        "module_name": "logit_rank_r64_l16_k1",
+                        "operand": "logits",
+                        "options": {"row_elems": 64, "logit_bits": 16, "top_k": 1, "logit_signed": True},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    wrapper = "logit_rank_r64_l16_k1_wrapper"
+    report_base = tmp_path / "orfs" / "reports"
+    result_base = tmp_path / "orfs" / "results"
+    stale_report = report_base / "nangate45" / wrapper / "base" / "6_finish.rpt"
+    stale_def = result_base / "nangate45" / wrapper / "base" / "6_final.def"
+    stale_report.parent.mkdir(parents=True)
+    stale_def.parent.mkdir(parents=True)
+    stale_report.write_text("stale report that must not be parsed\n", encoding="utf-8")
+    stale_def.write_text("UNITS DISTANCE MICRONS 1000 ;\nDIEAREA ( 0 0 ) ( 1000 1000 ) ;\n", encoding="utf-8")
+
+    monkeypatch.setattr(run_sweep, "REPORT_BASE", report_base)
+    monkeypatch.setattr(run_sweep, "RESULT_BASE", result_base)
+    monkeypatch.setattr(run_sweep, "ensure_design_assets", lambda *_args, **_kwargs: tmp_path / "config.mk")
+    monkeypatch.setattr(run_sweep, "snapshot_artifacts", lambda *_args, **_kwargs: None)
+
+    def fail_make(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(2, "make")
+
+    monkeypatch.setattr(run_sweep.subprocess, "run", fail_make)
+
+    run_sweep.run_single(
+        config_path=config_path,
+        platform="nangate45",
+        flow_params={"CLOCK_PERIOD": 2.5, "CORE_UTILIZATION": 60, "TAG": "macro_pin_failed"},
+        out_root=tmp_path / "runs",
+        skip_existing=False,
+        dry_run=False,
+    )
+
+    result_path = tmp_path / "runs" / wrapper / "work" / run_sweep.make_run_id({"CLOCK_PERIOD": 2.5, "CORE_UTILIZATION": 60, "TAG": "macro_pin_failed"}) / "result.json"
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["status"] == "failed"
+    assert result["metrics"] == {}
+    assert result["reports"]["finish"].endswith("macro_pin_failed/6_finish.rpt")

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -360,30 +360,34 @@ def run_single(
         run_record["status"] = "failed"
         run_record["error"] = str(e)
 
-    # Parse outputs
+    # Parse outputs. ORFS commonly writes successful outputs under FLOW_VARIANT=base
+    # even when TAG is passed, so successful runs may fall back to base reports.
+    # Failed runs must not use that fallback: base can contain stale reports from
+    # an earlier successful parameter point for the same design.
     finish_rpt = REPORT_BASE / platform / wrapper / str(tag) / "6_finish.rpt"
     def_path = RESULT_BASE / platform / wrapper / str(tag) / "6_final.def"
-    # ORFS defaults to FLOW_VARIANT=base; if tag-scoped folders do not exist, fall back.
-    if not finish_rpt.exists():
-        finish_rpt = REPORT_BASE / platform / wrapper / "base" / "6_finish.rpt"
-    if not def_path.exists():
-        def_path = RESULT_BASE / platform / wrapper / "base" / "6_final.def"
+    if run_record["status"] == "ok":
+        if not finish_rpt.exists():
+            finish_rpt = REPORT_BASE / platform / wrapper / "base" / "6_finish.rpt"
+        if not def_path.exists():
+            def_path = RESULT_BASE / platform / wrapper / "base" / "6_final.def"
     run_record["reports"] = {
         "finish": str(finish_rpt),
         "def": str(def_path),
     }
-    metrics = parse_finish_report(finish_rpt, platform=platform)
-    # ASAP7 finish reports emit picoseconds; convert to nanoseconds for consistency.
-    if platform.lower() == "asap7":
-        if "critical_path_ns" in metrics and metrics["critical_path_ns"] is not None:
-            metrics["critical_path_ns"] = metrics["critical_path_ns"] / 1000.0
-        if "total_power_mw" in metrics and metrics["total_power_mw"] is not None:
-            # ASAP7 report_power totals are reported in uW.
-            metrics["total_power_mw"] = metrics["total_power_mw"] / 1000.0
-    die_area = parse_die_area(def_path)
-    if die_area:
-        metrics["die_area"] = die_area
-    run_record["metrics"] = metrics
+    if run_record["status"] == "ok":
+        metrics = parse_finish_report(finish_rpt, platform=platform)
+        # ASAP7 finish reports emit picoseconds; convert to nanoseconds for consistency.
+        if platform.lower() == "asap7":
+            if "critical_path_ns" in metrics and metrics["critical_path_ns"] is not None:
+                metrics["critical_path_ns"] = metrics["critical_path_ns"] / 1000.0
+            if "total_power_mw" in metrics and metrics["total_power_mw"] is not None:
+                # ASAP7 report_power totals are reported in uW.
+                metrics["total_power_mw"] = metrics["total_power_mw"] / 1000.0
+        die_area = parse_die_area(def_path)
+        if die_area:
+            metrics["die_area"] = die_area
+        run_record["metrics"] = metrics
 
     run_record["result_path"] = normalize_repo_path(str(result_path))
     result_path.write_text(json.dumps(run_record, indent=2))


### PR DESCRIPTION
## Summary
- Stop parsing fallback ORFS `base` reports after a failed sweep command.
- Leave failed sweep rows without timing/area/power metrics instead of copying stale data from a previous successful run.
- Add a regression test for a failed run with stale base reports present.

## Root Cause
ORFS often writes successful outputs under `FLOW_VARIANT=base`, so `run_sweep.py` falls back to `reports/<platform>/<design>/base/6_finish.rpt` and `results/<platform>/<design>/base/6_final.def` when tag-scoped outputs are absent. That fallback is valid for successful runs, but unsafe after `make` fails: `base` may contain reports from an earlier parameter point for the same design.

Issue #427 exposed this: every macro-pin point had `status=failed`, but several failed rows still carried timing/area/power values that matched older successful rows.

## Behavior
- Successful runs keep the existing tag-to-base fallback.
- Failed runs record the tag-scoped report paths but do not parse metrics from fallback reports.
- Failed metrics rows therefore stay blank for `critical_path_ns`, `die_area`, and `total_power_mw`.

## Validation
- `PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_run_sweep.py`
- `python3 -m py_compile scripts/run_sweep.py`
