### PR TITLE
[codex] Avoid zero-distance macro pin placement

### DIFF
--- a/control_plane/control_plane/tests/test_generate_design.py
+++ b/control_plane/control_plane/tests/test_generate_design.py
@@ -30,4 +30,4 @@ def test_nangate45_generated_config_uses_macro_pin_placement_defaults(tmp_path: 
     assert "Register-wrapped Layer-1 blocks are evaluated as macro timing boundaries" in content
     assert "export IO_PLACER_H ?= metal3 metal5" in content
     assert "export IO_PLACER_V ?= metal4 metal6" in content
-    assert "export PLACE_PINS_ARGS ?= -min_distance 0" in content
+    assert "export PLACE_PINS_ARGS ?= -min_distance 1" in content

--- a/runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil_macro_pins.json
+++ b/runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil_macro_pins.json
@@ -21,7 +21,7 @@
       "metal4 metal6"
     ],
     "PLACE_PINS_ARGS": [
-      "-min_distance 0"
+      "-min_distance 1"
     ]
   }
 }

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -564,7 +564,7 @@ export CORE_UTILIZATION = 30
         content += "# Allow dense block-pin placement so wide datapath buses do not fail at IO placement.\n"
         content += "export IO_PLACER_H ?= metal3 metal5\n"
         content += "export IO_PLACER_V ?= metal4 metal6\n"
-        content += "export PLACE_PINS_ARGS ?= -min_distance 0\n"
+        content += "export PLACE_PINS_ARGS ?= -min_distance 1\n"
     with open(os.path.join(platform_dir, "config.mk"), "w") as f:
         f.write(content)
 


### PR DESCRIPTION
## Summary
- Change the Nangate45 macro-pin placement default from `-min_distance 0` to `-min_distance 1`.
- Update the explicit macro-pin sweep to record the same policy.
- Update coverage for generated Nangate45 config defaults.

## Root Cause
Issue #427 showed OpenROAD `place_pins` failing at `3_2_place_iop` with `io_placement.tcl, 18 divide by zero` when the macro-pin sweep used `PLACE_PINS_ARGS=-min_distance 0`.

ORFS examples use positive minimum pin distances. Keeping a positive distance avoids that OpenROAD code path while still using denser macro-style block pin placement than the original chip-style single-layer policy.

## Validation
- `PYTHONPATH=/workspaces/RTLGen/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_generate_design.py control_plane/control_plane/tests/test_run_sweep.py`
- `python3 -m json.tool runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_highutil_macro_pins.json >/dev/null`
- `python3 -m py_compile scripts/generate_design.py scripts/run_sweep.py`
