### PR TITLE
Add r128/k1 pin perimeter diagnostic

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -289,15 +289,29 @@ def _validate_architecture_block_sweep_policy(
     if str(abstraction_layer or "").strip() != "architecture_block":
         return
     sweep = _load_json(sweep_path)
-    flow_params = sweep.get("flow_params") or {}
+    flow_params = sweep.get("flow_params")
+    if flow_params is None:
+        flow_params = {}
     if not isinstance(flow_params, dict):
         raise Layer1TaskGenerationError(f"flow_params must be an object in {sweep_path}")
-    hier_value = flow_params.get("SYNTH_HIERARCHICAL")
-    if hier_value is not None and _contains_disabled_hierarchy(hier_value):
-        raise Layer1TaskGenerationError(
-            "architecture_block sweeps must keep hierarchy in early-stage evaluation; "
-            f"found non-hierarchical SYNTH_HIERARCHICAL setting in {sweep_path}"
-        )
+    hier_values = []
+    if "SYNTH_HIERARCHICAL" in flow_params:
+        hier_values.append(flow_params.get("SYNTH_HIERARCHICAL"))
+    flow_param_sets = sweep.get("flow_param_sets")
+    if flow_param_sets is not None:
+        if not isinstance(flow_param_sets, list):
+            raise Layer1TaskGenerationError(f"flow_param_sets must be a list in {sweep_path}")
+        for idx, params in enumerate(flow_param_sets):
+            if not isinstance(params, dict):
+                raise Layer1TaskGenerationError(f"flow_param_sets[{idx}] must be an object in {sweep_path}")
+            if "SYNTH_HIERARCHICAL" in params:
+                hier_values.append(params.get("SYNTH_HIERARCHICAL"))
+    for hier_value in hier_values:
+        if _contains_disabled_hierarchy(hier_value):
+            raise Layer1TaskGenerationError(
+                "architecture_block sweeps must keep hierarchy in early-stage evaluation; "
+                f"found non-hierarchical SYNTH_HIERARCHICAL setting in {sweep_path}"
+            )
     if sweep.get("mode_compare") is not None:
         raise Layer1TaskGenerationError(
             "architecture_block sweeps must not use mode_compare/flat_nomacro in early-stage evaluation; "

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -1032,6 +1032,54 @@ def test_generate_l1_sweep_task_accepts_explicit_hierarchical_architecture_block
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {"layer": "architecture_block"}
 
 
+def test_generate_l1_sweep_task_rejects_disabled_hierarchy_in_explicit_param_sets() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_block_repo(repo_root, mode_compare=False)
+        sweep_file = repo_root / sweep_path
+        sweep_file.write_text(
+            json.dumps(
+                {
+                    "flow_param_sets": [
+                        {
+                            "CLOCK_PERIOD": 10.0,
+                            "DIE_AREA": "0 0 1500 1500",
+                            "CORE_AREA": "50 50 1450 1450",
+                            "SYNTH_HIERARCHICAL": 0,
+                        }
+                    ],
+                    "tag_prefix": "npu_fp16_nm1_sigmoidcmp",
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l1_sweep_task(
+                    session,
+                    Layer1SweepGenerateRequest(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/npu_blocks",
+                        requested_by="@tester",
+                        abstraction_layer="architecture_block",
+                    ),
+                )
+            except Layer1TaskGenerationError as exc:
+                assert "architecture_block sweeps must keep hierarchy" in str(exc)
+            else:
+                raise AssertionError("expected Layer1TaskGenerationError for disabled hierarchy")
+
+
 def test_generate_l1_sweep_task_rejects_invalid_explicit_source_commit() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_run_sweep.py
+++ b/control_plane/control_plane/tests/test_run_sweep.py
@@ -18,6 +18,40 @@ def _load_run_sweep_module():
     return module
 
 
+def test_load_sweep_param_sets_keeps_floorplan_bounds_paired() -> None:
+    run_sweep = _load_run_sweep_module()
+
+    combos = run_sweep.load_sweep_param_sets(
+        {
+            "flow_param_sets": [
+                {
+                    "CLOCK_PERIOD": 2.5,
+                    "DIE_AREA": "0 0 581 581",
+                    "CORE_AREA": "20 20 561 561",
+                },
+                {
+                    "CLOCK_PERIOD": 2.5,
+                    "DIE_AREA": "0 0 640 640",
+                    "CORE_AREA": "20 20 620 620",
+                },
+            ]
+        }
+    )
+
+    assert combos == [
+        {
+            "CLOCK_PERIOD": 2.5,
+            "DIE_AREA": "0 0 581 581",
+            "CORE_AREA": "20 20 561 561",
+        },
+        {
+            "CLOCK_PERIOD": 2.5,
+            "DIE_AREA": "0 0 640 640",
+            "CORE_AREA": "20 20 620 620",
+        },
+    ]
+
+
 def test_failed_run_does_not_parse_stale_base_reports(tmp_path: Path, monkeypatch) -> None:
     run_sweep = _load_run_sweep_module()
     config_path = tmp_path / "config.json"

--- a/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/README.md
@@ -10,6 +10,7 @@ used for `w64` and `w128` candidates.
 Requested item:
 
 - `l1_decoder_logit_rank_wide_scale_v1`
+- `l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1`
 
 Requested configs:
 
@@ -17,3 +18,18 @@ Requested configs:
 - `runs/designs/activations/logit_rank_r64_l16_k4_wrapper/config_logit_rank_r64_l16_k4.json`
 - `runs/designs/activations/logit_rank_r128_l16_k1_wrapper/config_logit_rank_r128_l16_k1.json`
 - `runs/designs/activations/logit_rank_r128_l16_k4_wrapper/config_logit_rank_r128_l16_k4.json`
+
+Pin-perimeter diagnostic:
+
+- `l1_decoder_logit_rank_wide_scale_macro_pins_v2` showed that
+  `logit_rank_r128_l16_k1_wrapper` still fails at OpenROAD `3_2_place_iop`
+  after dense macro-pin placement is enabled.
+- The failing PPL-0024 report says 2072 pins require `2320.64um` die
+  perimeter. For a square diagnostic block, the minimum side bound is
+  `ceil(2320.64 / 4) = 581um`.
+- `runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_r128_k1_pin_perimeter_bound.json`
+  evaluates a below-bound control at `540um`, the computed bound at `581um`,
+  and a margin point at `640um`.
+- The resulting die area is artificial perimeter padding. Use the sweep to
+  separate pin-capacity failure from later placement/timing/routing behavior,
+  not to rank `r128/k1` area against utilization-derived PPA rows.

--- a/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/design_brief.md
@@ -54,6 +54,20 @@ Follow-on broad sweep:
 - If timing or PPA is poor, evaluate hierarchical or pipelined ranker
   composition instead of continuing to widen the flat scan tile.
 
+Pin-perimeter bound diagnostic:
+
+- `l1_decoder_logit_rank_wide_scale_macro_pins_v2` narrowed the remaining
+  `r128/k1` failure to OpenROAD IO placement capacity, not global placement,
+  routing, DRC, or timing.
+- The evaluator-preserved OpenROAD error reported 2072 pins and a required
+  die perimeter of `2320.64um`. For a square macro diagnostic, this gives
+  `ceil(2320.64 / 4) = 581um` as the minimum side bound.
+- The bound sweep keeps `DIE_AREA` and `CORE_AREA` paired explicitly:
+  `540um` below-bound control, `581um` computed bound, and `640um` margin.
+- Treat the resulting die area as artificial boundary padding. The useful
+  answer is whether the design reaches later OpenROAD stages once the boundary
+  is physically large enough.
+
 ## Knowledge Inputs
 
 - `control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json`

--- a/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/evaluation_requests.json
@@ -1,11 +1,11 @@
 {
   "proposal_id": "prop_l1_decoder_logit_rank_wide_scale_v1",
-  "source_commit": "28bacf78b58d1ec4c704a49d818a795ea9aa05e2",
+  "source_commit": "f5787028a39ef1f5546b23627e81d40c21a96de6",
   "requested_items": [
     {
-      "item_id": "l1_decoder_logit_rank_wide_scale_v1",
+      "item_id": "l1_decoder_logit_rank_wide_scale_macro_pins_v2",
       "task_type": "l1_sweep",
-      "objective": "Measure Nangate45 PPA scaling for signed 16-bit logit-only rank datapaths at row_elems=64 and row_elems=128, with k=1 and k=4.",
+      "objective": "Rerun Nangate45 PPA scaling for signed 16-bit logit-only rank datapaths at row_elems=64 and row_elems=128, with k=1 and k=4, using macro-style dense block-pin placement with positive min-distance and failed-row stale-metric protection.",
       "evaluation_mode": "measurement_only",
       "abstraction_layer": "circuit_block",
       "comparison_role": "scale_frontier_component",
@@ -20,7 +20,38 @@
         "direction": "measure",
         "reason": "Use measured row-64 and row-128 logit-rank PPA to replace the current scaled-proxy assumptions for L2 w64/w128 streaming decoder candidates."
       },
-      "status": "proposed"
+      "status": "pending",
+      "prior_item_ids": [
+        "l1_decoder_logit_rank_wide_scale_v1",
+        "l1_decoder_logit_rank_wide_scale_macro_pins_v1"
+      ]
+    },
+    {
+      "item_id": "l1_decoder_logit_rank_wide_scale_v1_r2",
+      "task_type": "l1_sweep",
+      "objective": "Rerun Nangate45 PPA scaling for signed 16-bit logit-only rank datapaths at row_elems=64 and row_elems=128, with k=1 and k=4, after strict metrics acceptance enforcement.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "status": "pending"
+    },
+    {
+      "item_id": "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1",
+      "task_type": "l1_sweep",
+      "objective": "Diagnose the r128/k1 macro-pin failure with explicit square die-perimeter bounds computed from the OpenROAD PPL-0024 requirement: 2072 pins require 2320.64um perimeter, so the minimum square side is ceil(2320.64 / 4) = 581um. Sweep 540um below-bound control, 581um bound, and 640um margin.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "comparison_role": "pin_perimeter_diagnostic",
+      "paired_baseline_item_id": "l1_decoder_logit_rank_wide_scale_macro_pins_v2",
+      "depends_on_item_ids": [
+        "l1_decoder_logit_rank_wide_scale_macro_pins_v2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "diagnose",
+        "reason": "Determine whether r128/k1 reaches later OpenROAD stages once the macro boundary has enough perimeter for 2072 pins. Treat padded die area as diagnostic, not directly rankable PPA."
+      },
+      "status": "pending"
     }
   ]
 }

--- a/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_logit_rank_wide_scale_v1/proposal.json
@@ -57,6 +57,24 @@
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true
+    },
+    {
+      "item_id": "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1",
+      "task_type": "l1_sweep",
+      "objective": "Diagnose the r128/k1 macro-pin failure by sweeping explicit square die-perimeter bounds derived from the OpenROAD PPL-0024 requirement of 2320.64um perimeter for 2072 pins.",
+      "config_paths": [
+        "runs/designs/activations/logit_rank_r128_l16_k1_wrapper/config_logit_rank_r128_l16_k1.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_r128_k1_pin_perimeter_bound.json",
+      "platform": "nangate45",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "circuit_block",
+      "depends_on_item_ids": [
+        "l1_decoder_logit_rank_wide_scale_macro_pins_v2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "interpretation_note": "The 581um square point is the computed lower bound ceil(2320.64 / 4). The 540um point is an expected below-bound control and the 640um point is a margin check. Padded die area is diagnostic and should not be ranked against utilization-derived PPA rows."
     }
   ],
   "baseline_refs": [

--- a/runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_r128_k1_pin_perimeter_bound.json
+++ b/runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_r128_k1_pin_perimeter_bound.json
@@ -1,0 +1,42 @@
+{
+  "tag_prefix": "logit_rank_scale_nangate45_r128_k1_pin_perimeter_bound",
+  "description": "Diagnostic r128/k1 macro-pin floorplan bound. OpenROAD PPL-0024 reported 2072 pins requiring 2320.64um die perimeter, so the square lower-bound side is ceil(2320.64 / 4) = 581um. Area from this sweep is perimeter padding and should not be ranked against utilization-derived PPA.",
+  "flow_param_sets": [
+    {
+      "CLOCK_PERIOD": 2.5,
+      "CORE_UTILIZATION": "",
+      "DIE_AREA": "0 0 540 540",
+      "CORE_AREA": "20 20 520 520",
+      "PLACE_DENSITY": 0.68,
+      "SYNTH_MEMORY_MAX_BITS": 32768,
+      "IO_PLACER_H": "metal3 metal5",
+      "IO_PLACER_V": "metal4 metal6",
+      "PLACE_PINS_ARGS": "-min_distance 1",
+      "TAG": "logit_rank_scale_nangate45_r128_k1_pinbound_below_540"
+    },
+    {
+      "CLOCK_PERIOD": 2.5,
+      "CORE_UTILIZATION": "",
+      "DIE_AREA": "0 0 581 581",
+      "CORE_AREA": "20 20 561 561",
+      "PLACE_DENSITY": 0.68,
+      "SYNTH_MEMORY_MAX_BITS": 32768,
+      "IO_PLACER_H": "metal3 metal5",
+      "IO_PLACER_V": "metal4 metal6",
+      "PLACE_PINS_ARGS": "-min_distance 1",
+      "TAG": "logit_rank_scale_nangate45_r128_k1_pinbound_min_581"
+    },
+    {
+      "CLOCK_PERIOD": 2.5,
+      "CORE_UTILIZATION": "",
+      "DIE_AREA": "0 0 640 640",
+      "CORE_AREA": "20 20 620 620",
+      "PLACE_DENSITY": 0.68,
+      "SYNTH_MEMORY_MAX_BITS": 32768,
+      "IO_PLACER_H": "metal3 metal5",
+      "IO_PLACER_V": "metal4 metal6",
+      "PLACE_PINS_ARGS": "-min_distance 1",
+      "TAG": "logit_rank_scale_nangate45_r128_k1_pinbound_margin_640"
+    }
+  ]
+}

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -10,8 +10,9 @@ Usage example:
         --out_root runs/designs/multipliers \
         --dry_run
 
-The sweep file is JSON and must contain a `flow_params` dictionary whose values
-are arrays. The Cartesian product of all entries forms the sweep:
+The sweep file is JSON and may contain either a `flow_params` dictionary whose
+values are arrays or an explicit `flow_param_sets` list. The Cartesian product
+of all `flow_params` entries forms the sweep:
 {
   "flow_params": {
     "CLOCK_PERIOD": [4.5, 5.0, 6.0],
@@ -19,6 +20,15 @@ are arrays. The Cartesian product of all entries forms the sweep:
     "PLACE_DENSITY": [0.55, 0.65]
   },
   "tag_prefix": "sweep1"
+}
+
+Use `flow_param_sets` when parameters must stay paired, such as DIE_AREA and
+CORE_AREA floorplan bounds:
+{
+  "flow_param_sets": [
+    {"CLOCK_PERIOD": 2.5, "DIE_AREA": "0 0 400 400", "CORE_AREA": "20 20 380 380"}
+  ],
+  "tag_prefix": "floorplan_bound"
 }
 
 For each parameter set the script:
@@ -182,6 +192,29 @@ def cartesian_product(grid: Dict[str, List]) -> List[Dict[str, object]]:
     for prod in itertools.product(*values):
         combos.append({k: v for k, v in zip(keys, prod)})
     return combos
+
+
+def load_sweep_param_sets(sweep_spec: Dict[str, object]) -> List[Dict[str, object]]:
+    has_grid = "flow_params" in sweep_spec
+    has_sets = "flow_param_sets" in sweep_spec
+    if has_grid and has_sets:
+        raise ValueError("Sweep file must contain only one of 'flow_params' or 'flow_param_sets'.")
+    if has_sets:
+        param_sets = sweep_spec["flow_param_sets"]
+        if not isinstance(param_sets, list) or not param_sets:
+            raise ValueError("'flow_param_sets' must be a non-empty list of parameter objects.")
+        combos = []
+        for idx, params in enumerate(param_sets):
+            if not isinstance(params, dict):
+                raise ValueError(f"flow_param_sets[{idx}] must be an object.")
+            combos.append(dict(params))
+        return combos
+    if not has_grid:
+        raise ValueError("Sweep file must contain a 'flow_params' dictionary or 'flow_param_sets' list.")
+    flow_grid = sweep_spec["flow_params"]
+    if not isinstance(flow_grid, dict):
+        raise ValueError("'flow_params' must be an object.")
+    return cartesian_product(flow_grid)
 
 
 def make_run_id(params: Dict[str, object]) -> str:
@@ -471,14 +504,11 @@ def main():
 
     args = parser.parse_args()
     sweep_spec = load_json(Path(args.sweep))
-    if "flow_params" not in sweep_spec:
-        raise ValueError("Sweep file must contain a 'flow_params' dictionary.")
-    flow_grid = sweep_spec["flow_params"]
     tag_prefix = sweep_spec.get("tag_prefix", "sweep")
     out_root = (REPO_ROOT / args.out_root).resolve()
     out_root.mkdir(parents=True, exist_ok=True)
 
-    combos = cartesian_product(flow_grid)
+    combos = load_sweep_param_sets(sweep_spec)
     print(f"[INFO] Loaded {len(combos)} parameter sets from {args.sweep}")
 
     for cfg in args.configs:


### PR DESCRIPTION
## Summary
- add explicit flow_param_sets support to run_sweep so paired DIE_AREA/CORE_AREA bounds do not expand as a Cartesian product
- add the r128/k1 macro-pin perimeter-bound diagnostic sweep using the PPL-0024 bound: ceil(2320.64 / 4) = 581um
- document that padded die area is diagnostic only, and extend architecture-block sweep validation to check flow_param_sets hierarchy policy

## Verification
- control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_run_sweep.py control_plane/control_plane/tests/test_l1_task_generator.py
- python3 -m py_compile scripts/run_sweep.py control_plane/control_plane/services/l1_task_generator.py control_plane/control_plane/tests/test_run_sweep.py control_plane/control_plane/tests/test_l1_task_generator.py
- python3 scripts/run_sweep.py --configs runs/designs/activations/logit_rank_r128_l16_k1_wrapper/config_logit_rank_r128_l16_k1.json --platform nangate45 --sweep runs/campaigns/activations/logit_rank_scale/sweeps/nangate45_r128_k1_pin_perimeter_bound.json --out_root runs/designs/activations --dry_run