### PR TITLE
Add logit-rank boundary sensitivity modeling

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -1883,6 +1883,10 @@ def _decoder_logit_rank_streaming_hierarchy_evidence(*, item_id: str) -> dict[st
     candidate_merge_ppa = (
         "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
     )
+    boundary_ppa = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json"
+    )
     return {
         "inputs": {
             "source_prompt_stress": prompt_stress,
@@ -1890,6 +1894,7 @@ def _decoder_logit_rank_streaming_hierarchy_evidence(*, item_id: str) -> dict[st
             "rank_datapath_ppa": rank_ppa,
             "rank_scale_ppa": scale_ppa,
             "candidate_merge_ppa": candidate_merge_ppa,
+            "boundary_ppa": boundary_ppa,
             "streaming_hierarchy_out": hierarchy_out,
             "streaming_hierarchy_report": hierarchy_report,
             "streaming_hierarchy_scope": (
@@ -1907,6 +1912,7 @@ def _decoder_logit_rank_streaming_hierarchy_evidence(*, item_id: str) -> dict[st
                     f"--rank-ppa {rank_ppa} "
                     f"--scale-ppa {scale_ppa} "
                     f"--candidate-merge-ppa {candidate_merge_ppa} "
+                    f"--boundary-ppa {boundary_ppa} "
                     f"--out {hierarchy_out} "
                     f"--out-md {hierarchy_report}"
                 ),
@@ -1926,6 +1932,10 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
     scale_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
     candidate_merge_ppa = (
         "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
+    )
+    boundary_ppa = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json"
     )
     sram_metrics_json = "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json"
     memory_model = {
@@ -1948,6 +1958,7 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
             "rank_datapath_ppa": rank_ppa,
             "rank_scale_ppa": scale_ppa,
             "candidate_merge_ppa": candidate_merge_ppa,
+            "boundary_ppa": boundary_ppa,
             "memory_model": memory_model,
             "streaming_overlap_out": overlap_out,
             "streaming_overlap_report": overlap_report,
@@ -1967,6 +1978,7 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
                     f"--rank-ppa {rank_ppa} "
                     f"--scale-ppa {scale_ppa} "
                     f"--candidate-merge-ppa {candidate_merge_ppa} "
+                    f"--boundary-ppa {boundary_ppa} "
                     f"--sram-metrics-json {sram_metrics_json} "
                     "--vocab-size-list 50257,100000,200000 "
                     "--producer-lanes-list 8,16,32,64,128 "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1556,6 +1556,10 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_hierarchy_e
             assert decoder_inputs["candidate_merge_ppa"] == (
                 "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
             )
+            assert decoder_inputs["boundary_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/"
+                "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json"
+            )
             assert decoder_inputs["streaming_hierarchy_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_logit_rank_streaming_hierarchy__l2_decoder_logit_rank_streaming_hierarchy_v1.json"
@@ -1564,6 +1568,7 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_hierarchy_e
             assert "estimate_llm_decoder_logit_rank_streaming_hierarchy.py" in work_item.command_manifest[0]["run"]
             assert "--scale-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json" in work_item.command_manifest[0]["run"]
             assert "--candidate-merge-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json" in work_item.command_manifest[0]["run"]
+            assert "--boundary-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json" in work_item.command_manifest[0]["run"]
             assert "--out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_logit_rank_streaming_hierarchy__l2_decoder_logit_rank_streaming_hierarchy_v1.json" in work_item.command_manifest[0]["run"]
             assert "--out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_logit_rank_streaming_hierarchy__l2_decoder_logit_rank_streaming_hierarchy_v1.md" in work_item.command_manifest[0]["run"]
             assert decoder_inputs["streaming_hierarchy_out"] in work_item.expected_outputs
@@ -1615,6 +1620,10 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             assert decoder_inputs["candidate_merge_ppa"] == (
                 "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
             )
+            assert decoder_inputs["boundary_ppa"] == (
+                "control_plane/shadow_exports/l1_promotions/"
+                "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json"
+            )
             assert decoder_inputs["memory_model"] == {
                 "memory_bandwidth_bytes_per_cycle": 64,
                 "sram_metrics_json": "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json",
@@ -1637,6 +1646,7 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             run = work_item.command_manifest[0]["run"]
             assert "estimate_llm_decoder_logit_rank_streaming_hierarchy.py" in run
             assert "--candidate-merge-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json" in run
+            assert "--boundary-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json" in run
             assert "--vocab-size-list 50257,100000,200000" in run
             assert "--producer-lanes-list 8,16,32,64,128" in run
             assert "--top-k-list 1,4" in run

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -389,6 +389,23 @@ argmax cost anchor, while the k=4 row is the current top-k/beam ranking anchor.
 Sampling and probability-reporting modes remain outside this bypass because
 they need calibrated probabilities, not only rank order.
 
+Run the decoder logit-rank streaming hierarchy estimate with the explicit
+macro-boundary diagnostic as sensitivity evidence:
+```sh
+python3 npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py \
+  --rank-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json \
+  --scale-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json \
+  --candidate-merge-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json \
+  --boundary-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json \
+  --out /tmp/decoder_logit_rank_streaming.json \
+  --out-md /tmp/decoder_logit_rank_streaming.md
+```
+
+The boundary PPA is reported separately from normal ranker PPA. Use it to track
+how exposed scalar-pin macro assumptions affect wide `r128/k1` timing and
+perimeter feasibility; do not charge its padded die area to a producer-integrated
+ranker unless explicitly modelling a standalone exposed-pin macro.
+
 After the corresponding Layer 1 multiplier and accumulator/adder calibration
 jobs merge, synthesize the measured primitive evidence into a decoder
 normalization report:

--- a/npu/eval/model_llm_decoder_logit_rank_streaming.py
+++ b/npu/eval/model_llm_decoder_logit_rank_streaming.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import math
 import re
@@ -21,6 +22,9 @@ DEFAULT_SCALE_PPA = Path(
 )
 DEFAULT_CANDIDATE_MERGE_PPA = Path(
     "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
+)
+DEFAULT_BOUNDARY_PPA = Path(
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json"
 )
 
 
@@ -77,6 +81,28 @@ def _parse_candidate_merge_csv_point(path: str) -> JsonDict:
         "logit_bits": int(match.group("logit_bits")),
         "token_id_bits": int(match.group("token_id_bits")),
         "fifo_depth_groups": int(match.group("fifo_depth_groups")),
+    }
+
+
+def _parse_area_box(value: Any) -> JsonDict | None:
+    parts = str(value or "").split()
+    if len(parts) != 4:
+        return None
+    try:
+        x0, y0, x1, y1 = [float(part) for part in parts]
+    except ValueError:
+        return None
+    width = max(0.0, x1 - x0)
+    height = max(0.0, y1 - y0)
+    return {
+        "x0_um": x0,
+        "y0_um": y0,
+        "x1_um": x1,
+        "y1_um": y1,
+        "width_um": width,
+        "height_um": height,
+        "perimeter_um": 2.0 * (width + height),
+        "area_um2": width * height,
     }
 
 
@@ -269,6 +295,155 @@ def load_candidate_merge_points(path: Path | None) -> list[JsonDict]:
         )
     )
     return rows
+
+
+def load_boundary_points(path: Path | None) -> list[JsonDict]:
+    """Load explicit macro-boundary diagnostic rows without mixing them into normal PPA."""
+    if path is None or not path.exists():
+        return []
+    payload = _load_json(path)
+    metrics_paths: list[str] = []
+    source_refs = payload.get("source_refs") if isinstance(payload, dict) else {}
+    if isinstance(source_refs, dict):
+        for item in source_refs.get("trial_metrics_csvs") or []:
+            if isinstance(item, str) and item not in metrics_paths:
+                metrics_paths.append(item)
+    for proposal in payload.get("proposals") or []:
+        if not isinstance(proposal, dict):
+            continue
+        ref = proposal.get("metrics_ref")
+        if not isinstance(ref, dict):
+            continue
+        metrics_csv = str(ref.get("metrics_csv") or "")
+        if metrics_csv and metrics_csv not in metrics_paths:
+            metrics_paths.append(metrics_csv)
+
+    rows: list[JsonDict] = []
+    for metrics_csv in metrics_paths:
+        csv_path = Path(metrics_csv)
+        if not csv_path.is_absolute():
+            csv_path = Path.cwd() / csv_path
+        if not csv_path.exists():
+            continue
+        point = _parse_csv_point(metrics_csv)
+        with csv_path.open(newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                if str(row.get("status") or "") != "ok":
+                    continue
+                params = {}
+                try:
+                    params = json.loads(row.get("params_json") or "{}")
+                except json.JSONDecodeError:
+                    params = {}
+                die_area = _parse_area_box(params.get("DIE_AREA"))
+                core_area = _parse_area_box(params.get("CORE_AREA"))
+                if die_area is None:
+                    continue
+                rows.append(
+                    {
+                        "source": str(path),
+                        "artifact_item_id": payload.get("item_id"),
+                        "metrics_csv": metrics_csv,
+                        "result_path": row.get("result_path") or None,
+                        "tag": row.get("tag") or None,
+                        "param_hash": row.get("param_hash") or None,
+                        "lanes": point["lanes"],
+                        "logit_bits": point["logit_bits"],
+                        "top_k": point["top_k"],
+                        "boundary_model": "standalone_exposed_pin_macro",
+                        "interpretation": (
+                            "Explicit macro-boundary diagnostic. Use timing/power as rough "
+                            "datapath evidence; padded die area is not normal logic area."
+                        ),
+                        "die": die_area,
+                        "core": core_area,
+                        "metrics": {
+                            "critical_path_ns": _as_float(row.get("critical_path_ns")),
+                            "die_area": _as_float(row.get("die_area")),
+                            "total_power_mw": _as_float(row.get("total_power_mw")),
+                        },
+                    }
+                )
+    rows.sort(
+        key=lambda row: (
+            _as_int(row.get("lanes"), 10**9),
+            _as_int(row.get("top_k"), 10**9),
+            _as_float((row.get("die") or {}).get("perimeter_um"), 10**18),
+            row["metrics"]["critical_path_ns"],
+        )
+    )
+    return rows
+
+
+def _boundary_sensitivity_summary(
+    *,
+    boundary_points: list[JsonDict],
+    measured_points: list[JsonDict],
+    lane_options: list[int],
+    top_k_options: list[int],
+    fallback_critical_path_ns: float,
+) -> JsonDict:
+    comparisons: list[JsonDict] = []
+    for lanes in lane_options:
+        for top_k in top_k_options:
+            matches = [
+                point
+                for point in boundary_points
+                if _as_int(point.get("lanes")) == lanes and _as_int(point.get("top_k")) == top_k
+            ]
+            if not matches:
+                continue
+            min_boundary = min(
+                matches,
+                key=lambda point: (
+                    _as_float((point.get("die") or {}).get("perimeter_um"), 10**18),
+                    _as_float(point["metrics"].get("critical_path_ns"), 10**18),
+                ),
+            )
+            selected = _select_ranker_point(
+                measured_points,
+                lanes=lanes,
+                top_k=top_k,
+                default_critical_path_ns=fallback_critical_path_ns,
+            )
+            selected_cp = _as_float(selected["metrics"].get("critical_path_ns"), fallback_critical_path_ns)
+            boundary_cp = _as_float(min_boundary["metrics"].get("critical_path_ns"), fallback_critical_path_ns)
+            comparisons.append(
+                {
+                    "lanes": lanes,
+                    "top_k": top_k,
+                    "normal_model_source": selected.get("source"),
+                    "normal_model_metrics_csv": selected.get("metrics_csv"),
+                    "normal_model_critical_path_ns": selected_cp,
+                    "boundary_metrics_csv": min_boundary.get("metrics_csv"),
+                    "boundary_tag": min_boundary.get("tag"),
+                    "boundary_critical_path_ns": boundary_cp,
+                    "boundary_total_power_mw": min_boundary["metrics"].get("total_power_mw"),
+                    "boundary_padded_die_area_um2": min_boundary["metrics"].get("die_area"),
+                    "boundary_die_width_um": (min_boundary.get("die") or {}).get("width_um"),
+                    "boundary_die_height_um": (min_boundary.get("die") or {}).get("height_um"),
+                    "boundary_die_perimeter_um": (min_boundary.get("die") or {}).get("perimeter_um"),
+                    "critical_path_delta_ns": round(boundary_cp - selected_cp, 6),
+                    "critical_path_ratio_vs_normal_model": (
+                        round(boundary_cp / selected_cp, 6) if selected_cp > 0 else None
+                    ),
+                    "policy": (
+                        "Do not charge boundary_padded_die_area_um2 in producer-integrated "
+                        "ranker estimates unless modelling an exposed-pin standalone macro."
+                    ),
+                }
+            )
+    return {
+        "boundary_ppa_paths": sorted({str(point.get("source")) for point in boundary_points}),
+        "boundary_points": boundary_points,
+        "comparisons": comparisons,
+        "policy": {
+            "normal_rankings": "unchanged",
+            "standalone_exposed_pin_macro": "may charge padded die area as a pessimistic boundary scenario",
+            "producer_integrated_ranker": "use timing/power as diagnostic evidence; do not charge padded die area blindly",
+            "streaming_tiled_ranker": "prefer internal producer interface to avoid scalar top-level pin pressure",
+        },
+    }
 
 
 def _fallback_ranker_point(*, lanes: int, top_k: int, critical_path_ns: float) -> JsonDict:
@@ -769,6 +944,7 @@ def build_report(
     rank_ppa_path: Path | None = DEFAULT_RANK_PPA,
     scale_ppa_path: Path | None = DEFAULT_SCALE_PPA,
     candidate_merge_ppa_path: Path | None = DEFAULT_CANDIDATE_MERGE_PPA,
+    boundary_ppa_path: Path | None = None,
     prompt_stress_path: Path | None = None,
     logit_rank_bypass_path: Path | None = None,
     sram_metrics_json_path: Path | None = None,
@@ -835,6 +1011,7 @@ def build_report(
             raise ValueError(f"{name} values must be positive")
     measured_points = load_ranker_points_from_paths([rank_ppa_path, scale_ppa_path])
     candidate_merge_points = load_candidate_merge_points(candidate_merge_ppa_path)
+    boundary_points = load_boundary_points(boundary_ppa_path)
     if not measured_points:
         measured_points = [
             _fallback_ranker_point(
@@ -1058,7 +1235,7 @@ def build_report(
         "rank_ppa_path": str(rank_ppa_path) if rank_ppa_path is not None else None,
         "rank_ppa_paths": [
             str(path)
-            for path in [rank_ppa_path, scale_ppa_path, candidate_merge_ppa_path]
+            for path in [rank_ppa_path, scale_ppa_path, candidate_merge_ppa_path, boundary_ppa_path]
             if path is not None
         ],
         "inputs": {
@@ -1067,6 +1244,7 @@ def build_report(
             "candidate_merge_ppa_path": (
                 str(candidate_merge_ppa_path) if candidate_merge_ppa_path is not None else None
             ),
+            "boundary_ppa_path": str(boundary_ppa_path) if boundary_ppa_path is not None else None,
             "prompt_stress_path": str(prompt_stress_path) if prompt_stress_path is not None else None,
             "logit_rank_bypass_path": str(logit_rank_bypass_path) if logit_rank_bypass_path is not None else None,
             "sram_metrics_json_path": (
@@ -1129,6 +1307,7 @@ def build_report(
             "Traffic model counts materialized-logit write+read bytes versus candidate FIFO write+read bytes.",
             "Measured row-8 datapath and row-16/row-32 scale critical_path_ns values are used as ranker clock proxies.",
             "Measured candidate-stream merge/FIFO PPA is used for global merge buffering when an exact or nearest-depth point is available.",
+            "Explicit macro-boundary diagnostics are reported separately from normal ranker PPA; padded die area is charged only in exposed-pin standalone macro sensitivity checks.",
             "Memory hierarchy estimates use explicit SRAM source data when provided, keep NoC terms as "
             "planning parameters, and are reported separately from measured cell PPA.",
             "Missing lane points are explicit defaults or log2-lane scaled proxies.",
@@ -1136,6 +1315,13 @@ def build_report(
         ],
         "measured_ranker_points": measured_points,
         "measured_candidate_merge_fifo_points": candidate_merge_points,
+        "boundary_sensitivity": _boundary_sensitivity_summary(
+            boundary_points=boundary_points,
+            measured_points=measured_points,
+            lane_options=lane_options,
+            top_k_options=top_k_options,
+            fallback_critical_path_ns=fallback_critical_path_ns,
+        ),
         "flat_measured_ranker_points": flat,
         "hierarchical_streaming_alternatives": alternatives,
         "overlap_traffic_sweep": overlap_sweep,
@@ -1223,6 +1409,32 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
     ]
     for key, value in payload["inputs"].items():
         lines.append(f"| `{key}` | `{value}` |")
+    lines.extend(
+        [
+            "",
+            "## Boundary Sensitivity",
+            "",
+            "| lanes | top_k | boundary tag | perimeter_um | padded_area_um2 | boundary_cp_ns | normal_cp_ns | cp_ratio | policy |",
+            "|---:|---:|---|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    boundary = payload.get("boundary_sensitivity") or {}
+    for row in boundary.get("comparisons") or []:
+        lines.append(
+            "| {lanes} | {topk} | `{tag}` | {perim} | {area} | {bcp} | {ncp} | {ratio} | {policy} |".format(
+                lanes=row.get("lanes"),
+                topk=row.get("top_k"),
+                tag=row.get("boundary_tag") or "",
+                perim=row.get("boundary_die_perimeter_um"),
+                area=row.get("boundary_padded_die_area_um2"),
+                bcp=row.get("boundary_critical_path_ns"),
+                ncp=row.get("normal_model_critical_path_ns"),
+                ratio=row.get("critical_path_ratio_vs_normal_model"),
+                policy=row.get("policy"),
+            )
+        )
+    if not (boundary.get("comparisons") or []):
+        lines.append("|  |  |  |  |  |  |  |  | no boundary diagnostic input |")
     lines.extend(
         [
             "",
@@ -1333,6 +1545,10 @@ def main() -> int:
         default=str(DEFAULT_CANDIDATE_MERGE_PPA),
         help="candidate-stream merge/FIFO PPA JSON",
     )
+    ap.add_argument(
+        "--boundary-ppa",
+        help="explicit macro-boundary diagnostic PPA JSON, reported as sensitivity evidence",
+    )
     ap.add_argument("--vocab-size", type=int, default=50257, help="decoder vocabulary size")
     ap.add_argument("--producer-lanes", type=int, default=8, help="W-lane producer tile width")
     ap.add_argument("--top-k", type=int, default=4, help="local candidates per tile")
@@ -1363,6 +1579,7 @@ def main() -> int:
         rank_ppa_path=Path(args.rank_ppa) if args.rank_ppa else None,
         scale_ppa_path=Path(args.scale_ppa) if args.scale_ppa else None,
         candidate_merge_ppa_path=Path(args.candidate_merge_ppa) if args.candidate_merge_ppa else None,
+        boundary_ppa_path=Path(args.boundary_ppa) if args.boundary_ppa else None,
         prompt_stress_path=Path(args.prompt_stress) if args.prompt_stress else None,
         logit_rank_bypass_path=Path(args.logit_rank_bypass) if args.logit_rank_bypass else None,
         sram_metrics_json_path=Path(args.sram_metrics_json) if args.sram_metrics_json else None,

--- a/tests/test_llm_decoder_logit_rank_streaming_model.py
+++ b/tests/test_llm_decoder_logit_rank_streaming_model.py
@@ -402,3 +402,85 @@ def test_logit_rank_streaming_overlap_sweep_varies_vocab_size(tmp_path: Path) ->
     assert report["sweep_recommendation_scope"]["vocab_size"] == 64
     assert report["memory_traffic_recommendation"]["sweep_key"].startswith("v64_")
     assert report["inputs"]["vocab_size_list"] == [64, 128]
+
+
+def test_logit_rank_streaming_report_keeps_boundary_diagnostic_separate(tmp_path: Path) -> None:
+    rank_ppa = tmp_path / "rank_ppa.json"
+    rank_ppa.write_text(
+        json.dumps(
+            {
+                "proposals": [
+                    {
+                        "metrics_ref": {
+                            "metrics_csv": "runs/designs/activations/logit_rank_r32_l16_k1_wrapper/metrics.csv",
+                            "status": "ok",
+                        },
+                        "metric_summary": {
+                            "critical_path_ns": 10.0,
+                            "die_area": 32.0,
+                            "total_power_mw": 0.32,
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics_csv = (
+        tmp_path
+        / "runs"
+        / "designs"
+        / "activations"
+        / "logit_rank_r128_l16_k1_wrapper"
+        / "metrics.csv"
+    )
+    metrics_csv.parent.mkdir(parents=True)
+    metrics_csv.write_text(
+        "\n".join(
+            [
+                "design,platform,config_hash,param_hash,tag,status,critical_path_ns,die_area,total_power_mw,params_json,result_path",
+                (
+                    'logit_rank_r128_l16_k1_wrapper,nangate45,h,87f21ce3,'
+                    'pinbound_540,ok,60.216,291600.0,3.72,'
+                    '"{""DIE_AREA"": ""0 0 540 540"", ""CORE_AREA"": ""20 20 520 520""}",'
+                    'runs/designs/activations/logit_rank_r128_l16_k1_wrapper/work/87f21ce3/result.json'
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    boundary_ppa = tmp_path / "boundary_ppa.json"
+    boundary_ppa.write_text(
+        json.dumps(
+            {
+                "item_id": "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1",
+                "source_refs": {"trial_metrics_csvs": [str(metrics_csv)]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_report(
+        rank_ppa_path=rank_ppa,
+        scale_ppa_path=None,
+        candidate_merge_ppa_path=None,
+        boundary_ppa_path=boundary_ppa,
+        vocab_size=128,
+        producer_lanes=128,
+        top_k=1,
+        global_merge_ii_cycles_list=[1],
+        producer_lanes_list=[128],
+        top_k_list=[1],
+        candidate_fifo_depth_groups_list=[16],
+    )
+
+    comparison = report["boundary_sensitivity"]["comparisons"][0]
+    assert comparison["boundary_die_perimeter_um"] == 2160.0
+    assert comparison["boundary_padded_die_area_um2"] == 291600.0
+    assert comparison["boundary_critical_path_ns"] == 60.216
+    assert comparison["normal_model_critical_path_ns"] == 14.0
+    assert "Do not charge" in comparison["policy"]
+    assert report["hierarchical_streaming_alternatives"][0]["local_ranker_point"]["source"].endswith(
+        "#scaled_nearest_lane"
+    )


### PR DESCRIPTION
## Summary
- add a separate boundary PPA input to the decoder logit-rank streaming estimator
- report r128/k1 explicit macro-boundary sensitivity without changing normal ranker PPA rankings
- pass the merged boundary diagnostic artifact through L2 streaming hierarchy/overlap job generation
- document that padded die area is only for exposed-pin macro sensitivity

## Verification
- control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_logit_rank_streaming_model.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 -m py_compile npu/eval/model_llm_decoder_logit_rank_streaming.py control_plane/control_plane/services/l2_task_generator.py
- python3 npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py --prompt-stress runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_gpt2_prompt_stress__l2_decoder_gpt2_prompt_stress_v1.json --logit-rank-bypass runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_gpt2_logit_rank_bypass__l2_decoder_gpt2_logit_rank_bypass_v1.json --rank-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json --scale-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json --candidate-merge-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json --boundary-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json --vocab-size-list 50257,100000,200000 --producer-lanes-list 8,16,32,64,128 --top-k-list 1,4 --producer-ii-cycles-list 1,2 --global-merge-ii-cycles 1,2 --candidate-fifo-depth-groups-list 16,256,4096 --memory-bandwidth-bytes-per-cycle 64 --sram-read-energy-pj-per-byte 0.05 --sram-write-energy-pj-per-byte 0.07 --noc-hops 2 --noc-energy-pj-per-byte-hop 0.02 --out /tmp/rtlgen_boundary_model.json --out-md /tmp/rtlgen_boundary_model.md