### PR TITLE
[codex] Add boundary scale stability evaluation request

### DIFF
--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/README.md
@@ -3,3 +3,5 @@
 This job broadens the SRAM-backed decoder streaming frontier across larger vocabulary sizes and wider producer-lane counts.
 
 The sweep is intentionally still a model-level L2 check. It does not add new RTL or measured NoC PPA; it asks whether the current conclusion remains stable enough to justify either NoC/banking work or larger-model quality confirmation.
+
+The boundary follow-up adds the r128/k1 explicit macro pin-perimeter result as sensitivity evidence. That value is useful for understanding artificial boundary pressure, but the padded macro die area is not charged to the normal integrated-ranker cost ranking.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/design_brief.md
@@ -11,4 +11,6 @@ Extend the decoder logit-rank streaming overlap report from one GPT-2 vocabulary
 
 The report must keep SRAM source data and NoC planning assumptions separate. The SRAM source is `runs/designs/sram/minimal_v0_2_draft/sram_metrics.json`; the NoC hop term remains a planning parameter.
 
+The boundary rerun must also keep the r128/k1 exposed-pin macro diagnostic separate from the integrated-ranker model. It may report the macro-boundary timing, power, and padded die area as sensitivity evidence, but the main ranking should continue to use the normal ranker PPA model for producer-integrated cases.
+
 Equivalence remains the same ready-valid stream contract: accepted `LogitTileStream` beats, accepted `CandidateStream` groups, producer stalls, FIFO occupancy, deterministic ordering, valid masks, and last-beat completion.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_gate.md
@@ -4,6 +4,8 @@ The evaluator should produce:
 
 - `decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_scale_stability_v1.json`
 - `decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_scale_stability_v1.md`
+- `decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_scale_stability_boundary_v1.json`
+- `decoder_logit_rank_streaming_overlap__l2_decoder_logit_rank_streaming_scale_stability_boundary_v1.md`
 
 Acceptance checks:
 
@@ -13,3 +15,5 @@ Acceptance checks:
 - SRAM provenance reports `nangate45` and `45 nm`
 - NoC provenance remains `planning_default_not_literature_backed`
 - ready-valid perf-sim/RTL equivalence observables remain unchanged
+- boundary rerun reports `boundary_sensitivity` for the r128/k1 pin-perimeter diagnostic
+- boundary rerun keeps padded exposed-pin macro area out of the main integrated-ranker ranking

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_requests.json
@@ -27,7 +27,33 @@
       "merge_commit": "72468ee2154cba00ac46598f404dcd9220bc554d",
       "merged_utc": "2026-05-05T12:12:34.403646Z",
       "notes": "Merged via PR #417 and merge 72468ee2154cba00ac46598f404dcd9220bc554d at 2026-05-05T12:12:34.403646Z."
+    },
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_scale_stability_boundary_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming scale-stability report with the r128/k1 explicit macro-boundary diagnostic reported as separate sensitivity evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_scale_stability_v1",
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1",
+        "l2_decoder_logit_rank_streaming_sram_nangate45_v1",
+        "l2_decoder_logit_rank_streaming_memory_noc_v1",
+        "l2_decoder_logit_rank_streaming_measured_merge_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Check whether the wider producer-lane conclusion changes after adding the r128/k1 boundary sensitivity without charging padded die area to integrated rankers."
+      },
+      "status": "requested",
+      "notes": "Dispatch after evaluator updates to a commit containing PR #437 so the L2 command includes --boundary-ppa."
     }
   ],
-  "source_commit": "c06374c1e379b074dda263af5b55f6cca0c6b7c4"
+  "source_commit": "f58c3bccdd1118bf223517af98ad143429369098"
 }

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/proposal.json
@@ -14,6 +14,7 @@
       "producer-lane sweep at 8, 16, 32, 64, and 128 lanes",
       "top-k sweep at 1 and 4",
       "measured logit-rank datapath and candidate-stream merge/FIFO PPA where available",
+      "r128/k1 exposed-pin macro boundary sensitivity as a separate diagnostic",
       "Nangate45 CACTI SRAM metrics from runs/designs/sram/minimal_v0_2_draft/sram_metrics.json",
       "NoC hop energy still marked as a planning term",
       "unchanged ready-valid perf-sim/RTL equivalence observables"
@@ -36,6 +37,7 @@
   ],
   "risks": [
     "producer lanes beyond measured ranker PPA points use explicit scaled proxies",
+    "the exposed-pin macro boundary diagnostic is not directly comparable to integrated-ranker area",
     "larger vocabularies are synthetic scale points, not full larger-model quality runs",
     "NoC and banking contention remain planning terms"
   ],
@@ -62,11 +64,36 @@
         "direction": "iterate",
         "reason": "The result should decide whether to spend the next implementation step on NoC/banking measurement or move to larger-model quality and larger-array hardware confirmation."
       }
+    },
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_scale_stability_boundary_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the decoder logit-rank streaming scale-stability report with the r128/k1 explicit macro-boundary diagnostic reported as separate sensitivity evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_overlap",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_scale_stability_v1",
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1",
+        "l2_decoder_logit_rank_streaming_sram_nangate45_v1",
+        "l2_decoder_logit_rank_streaming_memory_noc_v1",
+        "l2_decoder_logit_rank_streaming_measured_merge_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_logit_rank_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Check whether the wider producer-lane conclusion changes after adding the r128/k1 boundary sensitivity without charging padded die area to integrated rankers."
+      }
     }
   ],
   "baseline_refs": [
     "docs/proposals/prop_l2_decoder_logit_rank_streaming_sram_nangate45_v1/proposal.json",
-    "control_plane/shadow_exports/l2_decisions/l2_decoder_logit_rank_streaming_sram_nangate45_v1.json"
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_logit_rank_streaming_sram_nangate45_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json"
   ],
   "knowledge_refs": [
     "npu/eval/model_llm_decoder_logit_rank_streaming.py",


### PR DESCRIPTION
## Summary

- add a boundary-aware L2 scale-stability requested item for the decoder logit-rank streaming proposal

- document that r128/k1 exposed-pin macro boundary PPA is sensitivity evidence, not integrated-ranker ranking cost
- update the evaluation gate to require boundary_sensitivity output and keep padded macro area out of the main ranking


## Validation

- python3 -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/proposal.json
- python3 -m json.tool docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/evaluation_requests.json
