### PR TITLE
[codex] Add producer-integrated ranker focus

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2000,6 +2000,86 @@ def _decoder_logit_rank_streaming_overlap_evidence(*, item_id: str) -> dict[str,
     }
 
 
+def _decoder_logit_rank_streaming_producer_integrated_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    prompt_stress = f"{base}/decoder_gpt2_prompt_stress__l2_decoder_gpt2_prompt_stress_v1.json"
+    logit_rank_bypass = f"{base}/decoder_gpt2_logit_rank_bypass__l2_decoder_gpt2_logit_rank_bypass_v1.json"
+    interface_out = f"{base}/decoder_logit_rank_streaming_producer_integrated__{item_id}.json"
+    interface_report = f"{base}/decoder_logit_rank_streaming_producer_integrated__{item_id}.md"
+    rank_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
+    scale_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+    candidate_merge_ppa = (
+        "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
+    )
+    boundary_ppa = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json"
+    )
+    sram_metrics_json = "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json"
+    memory_model = {
+        "memory_bandwidth_bytes_per_cycle": 64,
+        "sram_metrics_json": sram_metrics_json,
+        "vocab_size_list": [50257, 100000, 200000],
+        "producer_lanes_list": [8, 16, 32, 64, 128],
+        "producer_interface_focus_lanes": [64, 128],
+        "sram_read_energy_pj_per_byte": 0.05,
+        "sram_write_energy_pj_per_byte": 0.07,
+        "noc_hops": 2,
+        "noc_energy_pj_per_byte_hop": 0.02,
+        "source": "sram_metrics_json_plus_planning_noc",
+        "sram_source": "cacti_estimated_nangate45_minimal_v0_2_draft",
+        "noc_source": "planning_default_not_literature_backed",
+    }
+    return {
+        "inputs": {
+            "source_prompt_stress": prompt_stress,
+            "source_logit_rank_bypass": logit_rank_bypass,
+            "rank_datapath_ppa": rank_ppa,
+            "rank_scale_ppa": scale_ppa,
+            "candidate_merge_ppa": candidate_merge_ppa,
+            "boundary_ppa": boundary_ppa,
+            "memory_model": memory_model,
+            "producer_integrated_out": interface_out,
+            "producer_integrated_report": interface_report,
+            "producer_integrated_scope": (
+                "Focus r64/r128 decoder logit-rank candidates as producer-integrated ready-valid "
+                "interfaces. Keep exposed-pin macro-boundary PPA diagnostic-only, exclude padded "
+                "die area from main cost, and preserve perf-sim/RTL equivalence observables."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_logit_rank_streaming_producer_integrated",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py "
+                    f"--prompt-stress {prompt_stress} "
+                    f"--logit-rank-bypass {logit_rank_bypass} "
+                    f"--rank-ppa {rank_ppa} "
+                    f"--scale-ppa {scale_ppa} "
+                    f"--candidate-merge-ppa {candidate_merge_ppa} "
+                    f"--boundary-ppa {boundary_ppa} "
+                    f"--sram-metrics-json {sram_metrics_json} "
+                    "--vocab-size-list 50257,100000,200000 "
+                    "--producer-lanes-list 8,16,32,64,128 "
+                    "--producer-interface-focus-lanes 64,128 "
+                    "--top-k-list 1,4 "
+                    "--producer-ii-cycles-list 1,2 "
+                    "--global-merge-ii-cycles 1,2 "
+                    "--candidate-fifo-depth-groups-list 16,256,4096 "
+                    "--memory-bandwidth-bytes-per-cycle 64 "
+                    "--sram-read-energy-pj-per-byte 0.05 "
+                    "--sram-write-energy-pj-per-byte 0.07 "
+                    "--noc-hops 2 "
+                    "--noc-energy-pj-per-byte-hop 0.02 "
+                    f"--out {interface_out} "
+                    f"--out-md {interface_report}"
+                ),
+            },
+        ],
+        "expected_outputs": [interface_out, interface_report],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2462,10 +2542,13 @@ def _build_payload(
         "decoder_gpt2_logit_rank_bypass",
         "decoder_logit_rank_streaming_hierarchy",
         "decoder_logit_rank_streaming_overlap",
+        "decoder_logit_rank_streaming_producer_integrated",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":
+            decoder_evidence = _decoder_logit_rank_streaming_producer_integrated_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_overlap":
             decoder_evidence = _decoder_logit_rank_streaming_overlap_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_hierarchy":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1662,6 +1662,60 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_producer_integrated_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_logit_rank_streaming_producer_integrated_v1",
+                    proposal_id="prop_l2_decoder_logit_rank_streaming_producer_integrated_v1",
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/"
+                        "proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_logit_rank_streaming_producer_integrated",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[0] == "estimate_decoder_logit_rank_streaming_producer_integrated"
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["producer_integrated_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_logit_rank_streaming_producer_integrated__"
+                "l2_decoder_logit_rank_streaming_producer_integrated_v1.json"
+            )
+            assert decoder_inputs["memory_model"]["producer_interface_focus_lanes"] == [64, 128]
+            assert "exposed-pin macro-boundary PPA diagnostic-only" in decoder_inputs["producer_integrated_scope"]
+            assert "perf-sim/RTL equivalence observables" in decoder_inputs["producer_integrated_scope"]
+            run = work_item.command_manifest[0]["run"]
+            assert "--producer-interface-focus-lanes 64,128" in run
+            assert "--producer-lanes-list 8,16,32,64,128" in run
+            assert "--boundary-ppa control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json" in run
+            assert decoder_inputs["producer_integrated_out"] in work_item.expected_outputs
+            assert decoder_inputs["producer_integrated_report"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_logit_rank_streaming_producer_integrated",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/README.md
@@ -1,0 +1,5 @@
+# Decoder Logit-Rank Producer-Integrated Interface Focus
+
+This proposal adds a Layer 2 evidence view for the r64/r128 logit-rank frontier when the ranker is integrated behind a producer ready-valid stream.
+
+The key policy is that exposed-pin macro-boundary PPA is diagnostic only. The main cost view must not charge padded die area or scalar top-level logit-pin pressure to a producer-integrated ranker. Future RTL PPA may enter rankings only after matching the same accepted beats, valid masks, FIFO occupancy, tie order, and last-beat completion observables used by the perf simulator.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/evaluation_gate.md
@@ -1,0 +1,6 @@
+# Evaluation Gate
+
+- Run `l2_decoder_logit_rank_streaming_producer_integrated_v1`.
+- Confirm the report contains r64 and r128 producer-integrated focus rows.
+- Confirm boundary sensitivity remains diagnostic-only and padded macro die area is excluded from main cost.
+- Confirm the report lists the perf-sim/RTL ready-valid equivalence observables needed before producer-integrated RTL PPA is ranked.

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_producer_integrated_v1",
+  "source_commit": "20002199ee186a4724560b293007f3ceb4522cfa",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_producer_integrated_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the decoder logit-rank producer-integrated interface focus view for r64/r128, keeping exposed-pin macro-boundary PPA diagnostic-only and preserving perf-sim/RTL equivalence observables.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_producer_integrated",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_overlap_v1",
+        "l2_decoder_logit_rank_streaming_scale_stability_boundary_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The expected result is a clearer r64/r128 producer-integrated frontier and an explicit RTL-equivalence checklist before implementing the combined producer/ranker macro."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_logit_rank_streaming_producer_integrated_v1",
+  "created_utc": "2026-05-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_logit_rank_streaming_producer_integrated",
+  "title": "Decoder logit-rank producer-integrated interface focus",
+  "hypothesis": "The r64/r128 logit-rank candidates should be judged as producer-integrated ready-valid interfaces, not standalone chips with scalar top-level logit pins. Boundary PPA remains useful as a diagnostic sensitivity, but padded macro die area and exposed-pin pressure should not enter the main ranker cost.",
+  "direct_comparison": {
+    "primary_question": "For r64 and r128 producer widths, which top-k, producer-II, merge-II, and FIFO choices remain latency- and traffic-competitive while preserving perf-sim/RTL stream equivalence observables?",
+    "include": [
+      "r64 and r128 producer-integrated focus rows",
+      "candidate FIFO capacity validity",
+      "streaming overlap versus buffered materialized-rank baseline",
+      "candidate traffic versus materialized-logit write/read traffic",
+      "explicit ready-valid equivalence observables for future RTL",
+      "boundary sensitivity as a diagnostic-only section"
+    ],
+    "exclude": [
+      "charging standalone exposed-pin macro padded die area to the main cost",
+      "new RTL implementation",
+      "probability-producing softmax or sampling consumers",
+      "larger-model quality reruns"
+    ]
+  },
+  "expected_benefit": [
+    "keeps the ranker frontier aligned with the intended producer-integrated macro use",
+    "prevents I/O-bound standalone macro artifacts from dominating architecture rankings",
+    "keeps the perf simulator and future RTL tied to the same ready-valid stream contract"
+  ],
+  "risks": [
+    "producer timing is still modeled by lane/II parameters rather than measured producer RTL",
+    "memory and NoC terms remain first-order planning estimates",
+    "the RTL equivalence contract is specified here but must still be checked when a producer-integrated macro is implemented"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_logit_rank_streaming_producer_integrated_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the decoder logit-rank producer-integrated interface focus view for r64/r128, keeping exposed-pin macro-boundary PPA diagnostic-only and preserving perf-sim/RTL equivalence observables.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_logit_rank_streaming_producer_integrated",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_overlap_v1",
+        "l2_decoder_logit_rank_streaming_scale_stability_boundary_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The expected result is a clearer r64/r128 producer-integrated frontier and an explicit RTL-equivalence checklist before implementing the combined producer/ranker macro."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_logit_rank_streaming_overlap_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_logit_rank_streaming_memory_noc_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_logit_rank_streaming_scale_stability_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py",
+    "npu/eval/estimate_llm_decoder_logit_rank_streaming_hierarchy.py",
+    "tests/test_llm_decoder_logit_rank_streaming_model.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/docs/decoder_logit_rank_streaming_hierarchy.md
+++ b/npu/docs/decoder_logit_rank_streaming_hierarchy.md
@@ -155,6 +155,19 @@ Required assumptions:
 - consumers must not publish the final next-token/top-k result until the
   accepted `CandidateStream` beat with `last=1` has been reduced
 
+## Producer-Integrated Boundary
+The intended r64/r128 ranker use is a producer-integrated ready/valid macro,
+not a standalone chip with one top-level scalar pin per logit lane. Explicit
+macro-boundary experiments that pad die size to satisfy exposed-pin placement
+are diagnostic sensitivity checks. They may be reported beside the normal
+model, but their padded die area and scalar top-level pin pressure must not be
+charged to the main producer-integrated ranker cost.
+
+A producer-integrated implementation still has to preserve the same stream
+contract as the perf simulator: accepted beat counts, valid masks, stable
+lower-token tie order, FIFO occupancy under backpressure, and final last-beat
+completion must match before RTL PPA is used in rankings.
+
 ## Integration Notes
 This spec intentionally keeps mapper and evaluator changes out of scope. A
 follow-on implementation should bind concrete widths for logit lanes, candidate

--- a/npu/eval/model_llm_decoder_logit_rank_streaming.py
+++ b/npu/eval/model_llm_decoder_logit_rank_streaming.py
@@ -939,6 +939,128 @@ def _streaming_overlap_candidate(
     return candidate
 
 
+def _producer_integrated_interface_summary(
+    *,
+    overlap_sweep: list[JsonDict],
+    boundary_sensitivity: JsonDict,
+    primary_vocab_size: int,
+    focus_lanes: list[int],
+) -> JsonDict:
+    focus_lane_set = set(focus_lanes)
+    primary_rows = [
+        row
+        for row in overlap_sweep
+        if _as_int(row.get("vocab_size"), primary_vocab_size) == primary_vocab_size
+        and _as_int(row.get("producer_lanes")) in focus_lane_set
+    ]
+    focus_rows: list[JsonDict] = []
+    for lanes in sorted({_as_int(row.get("producer_lanes")) for row in primary_rows}):
+        for top_k in sorted({_as_int(row.get("local_top_k")) for row in primary_rows if _as_int(row.get("producer_lanes")) == lanes}):
+            for producer_ii in sorted(
+                {
+                    _as_int(row.get("producer_ii_cycles"))
+                    for row in primary_rows
+                    if _as_int(row.get("producer_lanes")) == lanes
+                    and _as_int(row.get("local_top_k")) == top_k
+                }
+            ):
+                candidates = [
+                    row
+                    for row in primary_rows
+                    if _as_int(row.get("producer_lanes")) == lanes
+                    and _as_int(row.get("local_top_k")) == top_k
+                    and _as_int(row.get("producer_ii_cycles")) == producer_ii
+                ]
+                if not candidates:
+                    continue
+                selected = min(
+                    candidates,
+                    key=lambda row: (
+                        not bool(row.get("fifo_capacity_ok", True)),
+                        row["timing"]["latency_us_per_token"],
+                        row["memory_hierarchy"]["total_bytes"],
+                        row["candidate_fifo_depth_groups"],
+                    ),
+                )
+                focus_rows.append(
+                    {
+                        "sweep_key": selected["sweep_key"],
+                        "producer_lanes": selected["producer_lanes"],
+                        "top_k": selected["local_top_k"],
+                        "producer_ii_cycles": selected["producer_ii_cycles"],
+                        "merge_ii_cycles": selected["global_merge_ii_cycles"],
+                        "candidate_fifo_depth_groups": selected["candidate_fifo_depth_groups"],
+                        "required_fifo_depth_groups": selected["required_fifo_depth_groups"],
+                        "fifo_capacity_ok": selected["fifo_capacity_ok"],
+                        "latency_us_per_token": selected["timing"]["latency_us_per_token"],
+                        "memory_total_bytes": selected["memory_hierarchy"]["total_bytes"],
+                        "overlap_recovered_fraction": selected["buffered_baseline"]["overlap_recovered_fraction"],
+                        "traffic_reduction_vs_materialized": selected["traffic"]["traffic_reduction_vs_materialized"],
+                        "speedup_vs_best_flat": selected.get("speedup_vs_best_flat"),
+                    }
+                )
+
+    boundary_comparisons = [
+        {
+            "lanes": row.get("lanes"),
+            "top_k": row.get("top_k"),
+            "boundary_critical_path_ns": row.get("boundary_critical_path_ns"),
+            "normal_model_critical_path_ns": row.get("normal_model_critical_path_ns"),
+            "critical_path_ratio_vs_normal_model": row.get("critical_path_ratio_vs_normal_model"),
+            "boundary_die_perimeter_um": row.get("boundary_die_perimeter_um"),
+            "policy": row.get("policy"),
+        }
+        for row in boundary_sensitivity.get("comparisons", [])
+        if _as_int(row.get("lanes")) in focus_lane_set
+    ]
+    fifo_valid_rows = [row for row in focus_rows if bool(row.get("fifo_capacity_ok"))]
+    best_latency_row = min(
+        fifo_valid_rows or focus_rows,
+        key=lambda row: (
+            row["latency_us_per_token"],
+            row["memory_total_bytes"],
+            row["candidate_fifo_depth_groups"],
+        ),
+        default=None,
+    )
+    return {
+        "scope": "producer_integrated_ready_valid_ranker_interface",
+        "primary_vocab_size": primary_vocab_size,
+        "focus_lanes": focus_lanes,
+        "summary_rows": focus_rows,
+        "best_latency_sweep_key": best_latency_row.get("sweep_key") if best_latency_row else None,
+        "all_focus_rows_fifo_valid": bool(focus_rows) and all(
+            bool(row.get("fifo_capacity_ok")) for row in focus_rows
+        ),
+        "boundary_policy": (
+            "Treat exposed-pin macro-boundary PPA as diagnostic sensitivity only. "
+            "Do not charge padded die area or scalar top-level pin pressure to the "
+            "producer-integrated ready-valid ranker interface."
+        ),
+        "boundary_diagnostics": boundary_comparisons,
+        "excluded_from_main_cost": [
+            "boundary_padded_die_area_um2",
+            "standalone_exposed_pin_macro_perimeter",
+            "top_level_scalar_logit_pin_count",
+        ],
+        "equivalence_observables": [
+            "accepted LogitTileStream beat count",
+            "accepted CandidateStream group count",
+            "producer stall cycles",
+            "ranker backpressure cycles",
+            "candidate FIFO max occupancy",
+            "valid mask per accepted tile",
+            "lower token_id tie-break order",
+            "final last-beat completion cycle",
+        ],
+        "recommendation": (
+            "Use this view to judge r64/r128 producer-integrated ranker candidates. "
+            "A follow-on RTL macro must prove these ready-valid observables against "
+            "the perf simulator before its PPA is used in rankings."
+        ),
+    }
+
+
 def build_report(
     *,
     rank_ppa_path: Path | None = DEFAULT_RANK_PPA,
@@ -960,6 +1082,7 @@ def build_report(
     candidate_fifo_depth_groups: int = 16,
     vocab_size_list: list[int] | None = None,
     producer_lanes_list: list[int] | None = None,
+    producer_interface_focus_lanes: list[int] | None = None,
     top_k_list: list[int] | None = None,
     producer_ii_cycles_list: list[int] | None = None,
     candidate_fifo_depth_groups_list: list[int] | None = None,
@@ -1000,9 +1123,13 @@ def build_report(
     top_k_options = top_k_list or [top_k]
     producer_ii_options = producer_ii_cycles_list or [producer_ii_cycles]
     fifo_options = candidate_fifo_depth_groups_list or [candidate_fifo_depth_groups]
+    interface_focus_lanes = producer_interface_focus_lanes or [
+        lane for lane in sorted(set(lane_options)) if lane >= 64
+    ] or [max(lane_options)]
     for name, values in (
         ("vocab_size_list", vocab_options),
         ("producer_lanes_list", lane_options),
+        ("producer_interface_focus_lanes", interface_focus_lanes),
         ("top_k_list", top_k_options),
         ("producer_ii_cycles_list", producer_ii_options),
         ("candidate_fifo_depth_groups_list", fifo_options),
@@ -1164,7 +1291,7 @@ def build_report(
         else:
             row["speedup_vs_best_flat"] = round(
                 row_baseline["timing"]["latency_us_per_token"] / row["timing"]["latency_us_per_token"], 6
-            )
+        )
     primary_overlap_sweep = [
         row
         for row in overlap_sweep
@@ -1188,6 +1315,19 @@ def build_report(
             row["timing"]["latency_us_per_token"],
         ),
     ) if primary_overlap_sweep else None
+    boundary_sensitivity = _boundary_sensitivity_summary(
+        boundary_points=boundary_points,
+        measured_points=measured_points,
+        lane_options=lane_options,
+        top_k_options=top_k_options,
+        fallback_critical_path_ns=fallback_critical_path_ns,
+    )
+    producer_integrated_interface = _producer_integrated_interface_summary(
+        overlap_sweep=overlap_sweep,
+        boundary_sensitivity=boundary_sensitivity,
+        primary_vocab_size=vocab_size,
+        focus_lanes=interface_focus_lanes,
+    )
     scale_stability_summary: list[JsonDict] = []
     for sweep_vocab_size in vocab_options:
         rows = [
@@ -1262,6 +1402,7 @@ def build_report(
             "candidate_fifo_depth_groups": candidate_fifo_depth_groups,
             "vocab_size_list": vocab_options,
             "producer_lanes_list": lane_options,
+            "producer_interface_focus_lanes": interface_focus_lanes,
             "top_k_list": top_k_options,
             "producer_ii_cycles_list": producer_ii_options,
             "candidate_fifo_depth_groups_list": fifo_options,
@@ -1315,16 +1456,11 @@ def build_report(
         ],
         "measured_ranker_points": measured_points,
         "measured_candidate_merge_fifo_points": candidate_merge_points,
-        "boundary_sensitivity": _boundary_sensitivity_summary(
-            boundary_points=boundary_points,
-            measured_points=measured_points,
-            lane_options=lane_options,
-            top_k_options=top_k_options,
-            fallback_critical_path_ns=fallback_critical_path_ns,
-        ),
+        "boundary_sensitivity": boundary_sensitivity,
         "flat_measured_ranker_points": flat,
         "hierarchical_streaming_alternatives": alternatives,
         "overlap_traffic_sweep": overlap_sweep,
+        "producer_integrated_interface": producer_integrated_interface,
         "scale_stability_summary": scale_stability_summary,
         "sweep_recommendation_scope": {
             "vocab_size": vocab_size,
@@ -1494,6 +1630,39 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
     lines.extend(
         [
             "",
+            "## Producer-Integrated Interface Focus",
+            "",
+            f"- scope: `{(payload.get('producer_integrated_interface') or {}).get('scope', '')}`",
+            f"- boundary_policy: {(payload.get('producer_integrated_interface') or {}).get('boundary_policy', '')}",
+            f"- best_latency_sweep_key: `{(payload.get('producer_integrated_interface') or {}).get('best_latency_sweep_key', '')}`",
+            "",
+            "| key | W | top_k | producer_ii | merge_ii | fifo required/capacity | fifo ok | latency_us | memory_bytes | overlap recovered | traffic reduction |",
+            "|---|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|",
+        ]
+    )
+    producer_interface = payload.get("producer_integrated_interface") or {}
+    for row in producer_interface.get("summary_rows") or []:
+        lines.append(
+            "| {key} | {lanes} | {topk} | {prodii} | {mergeii} | {fifo}/{cap} | `{ok}` | {latency} | {mem_bytes} | {overlap} | {traffic} |".format(
+                key=f"`{row.get('sweep_key')}`",
+                lanes=row.get("producer_lanes"),
+                topk=row.get("top_k"),
+                prodii=row.get("producer_ii_cycles"),
+                mergeii=row.get("merge_ii_cycles"),
+                fifo=row.get("required_fifo_depth_groups"),
+                cap=row.get("candidate_fifo_depth_groups"),
+                ok=row.get("fifo_capacity_ok"),
+                latency=row.get("latency_us_per_token"),
+                mem_bytes=row.get("memory_total_bytes"),
+                overlap=row.get("overlap_recovered_fraction"),
+                traffic=row.get("traffic_reduction_vs_materialized"),
+            )
+        )
+    if not (producer_interface.get("summary_rows") or []):
+        lines.append("|  |  |  |  |  |  |  |  |  |  | no producer-integrated focus rows |")
+    lines.extend(
+        [
+            "",
             "## Overlap And Traffic Sweep",
             "",
             "| key | vocab | cycles | latency_us | memory_bytes | memory_energy_nj | fifo required/capacity | overlap recovered | traffic reduction | speedup vs flat |",
@@ -1561,6 +1730,11 @@ def main() -> int:
     ap.add_argument("--candidate-fifo-depth-groups", type=int, default=16)
     ap.add_argument("--vocab-size-list", type=_int_list, help="comma-separated vocabulary-size sweep")
     ap.add_argument("--producer-lanes-list", type=_int_list, help="comma-separated producer lane sweep")
+    ap.add_argument(
+        "--producer-interface-focus-lanes",
+        type=_int_list,
+        help="comma-separated producer lanes summarized as integrated ready-valid interface focus",
+    )
     ap.add_argument("--top-k-list", type=_int_list, help="comma-separated local top-k sweep")
     ap.add_argument("--producer-ii-cycles-list", type=_int_list, help="comma-separated producer II sweep")
     ap.add_argument("--candidate-fifo-depth-groups-list", type=_int_list, help="comma-separated FIFO depth sweep")
@@ -1595,6 +1769,7 @@ def main() -> int:
         candidate_fifo_depth_groups=args.candidate_fifo_depth_groups,
         vocab_size_list=args.vocab_size_list,
         producer_lanes_list=args.producer_lanes_list,
+        producer_interface_focus_lanes=args.producer_interface_focus_lanes,
         top_k_list=args.top_k_list,
         producer_ii_cycles_list=args.producer_ii_cycles_list,
         candidate_fifo_depth_groups_list=args.candidate_fifo_depth_groups_list,

--- a/tests/test_llm_decoder_logit_rank_streaming_model.py
+++ b/tests/test_llm_decoder_logit_rank_streaming_model.py
@@ -470,7 +470,8 @@ def test_logit_rank_streaming_report_keeps_boundary_diagnostic_separate(tmp_path
         producer_lanes=128,
         top_k=1,
         global_merge_ii_cycles_list=[1],
-        producer_lanes_list=[128],
+        producer_lanes_list=[64, 128],
+        producer_interface_focus_lanes=[64, 128],
         top_k_list=[1],
         candidate_fifo_depth_groups_list=[16],
     )
@@ -484,3 +485,10 @@ def test_logit_rank_streaming_report_keeps_boundary_diagnostic_separate(tmp_path
     assert report["hierarchical_streaming_alternatives"][0]["local_ranker_point"]["source"].endswith(
         "#scaled_nearest_lane"
     )
+    interface = report["producer_integrated_interface"]
+    assert interface["scope"] == "producer_integrated_ready_valid_ranker_interface"
+    assert interface["focus_lanes"] == [64, 128]
+    assert "top_level_scalar_logit_pin_count" in interface["excluded_from_main_cost"]
+    assert "valid mask per accepted tile" in interface["equivalence_observables"]
+    assert interface["boundary_diagnostics"][0]["critical_path_ratio_vs_normal_model"] == 4.301143
+    assert {row["producer_lanes"] for row in interface["summary_rows"]} == {64, 128}


### PR DESCRIPTION
## Summary

- adds a producer-integrated ready-valid interface summary to the decoder logit-rank streaming estimator
- wires a new Layer 2 task-generator abstraction for r64/r128 producer-integrated focus
- documents the boundary policy: exposed-pin macro PPA is diagnostic-only and excluded from main cost
- adds the proposal/evaluation request for l2_decoder_logit_rank_streaming_producer_integrated_v1

## Validation

- python3 -m py_compile npu/eval/model_llm_decoder_logit_rank_streaming.py control_plane/control_plane/services/l2_task_generator.py
- estimator smoke run with --producer-interface-focus-lanes 64,128 emitted producer_integrated_interface summary and Markdown section
- targeted direct test invocation for the new model assertion and task-generator assertion passed
- full pytest not run: active rebuilt container Python does not have pytest installed
