### PR TITLE
[codex] Fix producer-integrated dependency list

### DIFF
--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/evaluation_requests.json
@@ -11,7 +11,6 @@
       "comparison_role": "ranking",
       "paired_baseline_item_id": "",
       "depends_on_item_ids": [
-        "l2_decoder_logit_rank_streaming_overlap_v1",
         "l2_decoder_logit_rank_streaming_scale_stability_boundary_v1",
         "l1_decoder_candidate_stream_merge_fifo_v1",
         "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1"

--- a/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/proposal.json
@@ -44,7 +44,6 @@
       "abstraction_layer": "decoder_logit_rank_streaming_producer_integrated",
       "cost_class": "low",
       "depends_on_item_ids": [
-        "l2_decoder_logit_rank_streaming_overlap_v1",
         "l2_decoder_logit_rank_streaming_scale_stability_boundary_v1",
         "l1_decoder_candidate_stream_merge_fifo_v1",
         "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1"


### PR DESCRIPTION
## Summary

- remove the DB-missing overlap work item from the producer-integrated proposal dependency list
- keep the merged boundary sensitivity item as the direct Layer 2 dependency, because it subsumes the overlap evidence in the refreshed DB state

## Validation

- python3 -m json.tool on proposal.json and evaluation_requests.json
- git diff --check
