### PR TITLE
[codex] Schedule producer/ranker coupling jobs

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2080,6 +2080,104 @@ def _decoder_logit_rank_streaming_producer_integrated_evidence(*, item_id: str) 
     }
 
 
+def _decoder_output_projection_service_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_service__{item_id}.json"
+    report = f"{base}/decoder_output_projection_service__{item_id}.md"
+    return {
+        "inputs": {
+            "producer_service_out": out,
+            "producer_service_report": report,
+            "producer_service_scope": (
+                "Stage-serialized output-projection producer service model for shared GEMM: "
+                "derive producer latency and integer II from tile MAC count, weight traffic, "
+                "hidden-vector load, and memory bandwidth."
+            ),
+            "producer_service_grid": {
+                "vocab_size_list": [50257, 100000, 200000],
+                "hidden_size_list": [768, 1024, 2048],
+                "producer_lanes_list": [64, 128, 256],
+                "macs_per_cycle_list": [8192, 32768],
+                "memory_bandwidth_bytes_per_cycle_list": [64, 256],
+            },
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_output_projection_service",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_producer_ranker_coupling.py "
+                    "--mode producer_service "
+                    "--vocab-size-list 50257,100000,200000 "
+                    "--hidden-size-list 768,1024,2048 "
+                    "--producer-lanes-list 64,128,256 "
+                    "--macs-per-cycle-list 8192,32768 "
+                    "--memory-bandwidth-bytes-per-cycle-list 64,256 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
+def _decoder_producer_ranker_coupled_noc_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_producer_ranker_coupled_noc__{item_id}.json"
+    report = f"{base}/decoder_producer_ranker_coupled_noc__{item_id}.md"
+    rank_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_datapath_v1_r2.json"
+    scale_ppa = "control_plane/shadow_exports/l1_promotions/l1_decoder_logit_rank_scale_v1.json"
+    candidate_merge_ppa = (
+        "control_plane/shadow_exports/l1_promotions/l1_decoder_candidate_stream_merge_fifo_v1.json"
+    )
+    boundary_ppa = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json"
+    )
+    sram_metrics_json = "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json"
+    return {
+        "inputs": {
+            "producer_ranker_coupled_out": out,
+            "producer_ranker_coupled_report": report,
+            "rank_datapath_ppa": rank_ppa,
+            "rank_scale_ppa": scale_ppa,
+            "candidate_merge_ppa": candidate_merge_ppa,
+            "boundary_ppa": boundary_ppa,
+            "sram_metrics_json": sram_metrics_json,
+            "producer_ranker_coupled_scope": (
+                "Couple stage-serialized output-projection producer service curves to the "
+                "producer-integrated ready-valid ranker frontier, including shared NoC/memory "
+                "bandwidth shares for contention sensitivity."
+            ),
+            "memory_share_list": [1.0, 0.5, 0.25],
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_producer_ranker_coupled_noc",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_producer_ranker_coupling.py "
+                    "--mode coupled_noc "
+                    f"--rank-ppa {rank_ppa} "
+                    f"--scale-ppa {scale_ppa} "
+                    f"--candidate-merge-ppa {candidate_merge_ppa} "
+                    f"--boundary-ppa {boundary_ppa} "
+                    f"--sram-metrics-json {sram_metrics_json} "
+                    "--vocab-size-list 50257,100000,200000 "
+                    "--hidden-size-list 768,1024,2048 "
+                    "--producer-lanes-list 64,128,256 "
+                    "--macs-per-cycle-list 8192,32768 "
+                    "--memory-bandwidth-bytes-per-cycle-list 64,256 "
+                    "--memory-share-list 1.0,0.5,0.25 "
+                    "--top-k-list 1,4 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2543,10 +2641,16 @@ def _build_payload(
         "decoder_logit_rank_streaming_hierarchy",
         "decoder_logit_rank_streaming_overlap",
         "decoder_logit_rank_streaming_producer_integrated",
+        "decoder_output_projection_service",
+        "decoder_producer_ranker_coupled_noc",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_producer_ranker_coupled_noc":
+            decoder_evidence = _decoder_producer_ranker_coupled_noc_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_service":
+            decoder_evidence = _decoder_output_projection_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":
             decoder_evidence = _decoder_logit_rank_streaming_producer_integrated_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_overlap":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1716,6 +1716,94 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_producer_in
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_output_projection_service_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_service_v1",
+                    proposal_id="prop_l2_decoder_output_projection_service_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_output_projection_service_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_service",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == "estimate_decoder_output_projection_service"
+            assert "--mode producer_service" in work_item.command_manifest[0]["run"]
+            assert decoder_inputs["producer_service_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_service__l2_decoder_output_projection_service_v1.json"
+            )
+            assert "Stage-serialized output-projection producer service model" in decoder_inputs["producer_service_scope"]
+            assert decoder_inputs["producer_service_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_service",
+            }
+
+
+def test_generate_l2_campaign_task_adds_decoder_producer_ranker_coupled_noc_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_producer_ranker_coupled_noc_v1",
+                    proposal_id="prop_l2_decoder_producer_ranker_coupled_noc_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_producer_ranker_coupled_noc_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_producer_ranker_coupled_noc",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == "estimate_decoder_producer_ranker_coupled_noc"
+            run = work_item.command_manifest[0]["run"]
+            assert "--mode coupled_noc" in run
+            assert "--memory-share-list 1.0,0.5,0.25" in run
+            assert decoder_inputs["producer_ranker_coupled_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_producer_ranker_coupled_noc__l2_decoder_producer_ranker_coupled_noc_v1.json"
+            )
+            assert "shared NoC/memory bandwidth shares" in decoder_inputs["producer_ranker_coupled_scope"]
+            assert decoder_inputs["producer_ranker_coupled_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_producer_ranker_coupled_noc",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_service_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_service_v1/README.md
@@ -1,0 +1,5 @@
+# Decoder Output-Projection Producer Service
+
+This proposal measures the planning-level service curve for the decoder final output-projection stage. The producer is not a full decoder; it is the stage that computes vocabulary-logit tiles from the current hidden vector and streams those tiles to the ranker.
+
+The model derives integer producer II from tile MAC count and output-projection weight-memory service under a stage-serialized shared GEMM assumption.

--- a/docs/proposals/prop_l2_decoder_output_projection_service_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_service_v1/evaluation_gate.md
@@ -1,0 +1,6 @@
+# Evaluation Gate
+
+- Run `l2_decoder_output_projection_service_v1`.
+- Confirm producer II is reported as an integer cycle count derived from compute and memory service.
+- Confirm the report identifies whether each point is compute-limited or weight-memory-limited.
+- Use the service curve as input to producer/ranker coupling; do not interpret it as a measured RTL result.

--- a/docs/proposals/prop_l2_decoder_output_projection_service_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_service_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_service_v1",
+  "source_commit": "bbb3fdc6022fc9fc64d444ff20475c1c8f924174",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_output_projection_service_v1",
+      "task_type": "l2_campaign",
+      "objective": "Estimate output-projection producer service curves for a stage-serialized shared GEMM final decoder stage.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_service",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": false,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The expected output is a producer service curve used to select realistic producer_ii values before combined producer/ranker RTL."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_service_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_service_v1/proposal.json
@@ -1,0 +1,57 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_service_v1",
+  "created_utc": "2026-05-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_service",
+  "title": "Decoder output-projection producer service model",
+  "hypothesis": "The logit-rank producer should be modeled as the final decoder output-projection stage on a shared GEMM/memory fabric. Its producer II should be derived from tile MAC throughput and weight-memory service, not assumed as an abstract activity ratio.",
+  "direct_comparison": {
+    "primary_question": "For plausible vocabulary sizes, hidden sizes, producer tile widths, GEMM throughput, and memory bandwidth, what integer producer II and latency service curves should feed the ranker model?",
+    "include": [
+      "stage-serialized shared GEMM output projection",
+      "hidden vector load charged once per token",
+      "output-projection weight traffic charged per vocabulary tile",
+      "producer II derived from compute cycles and memory service cycles"
+    ],
+    "exclude": [
+      "new RTL implementation",
+      "attention or MLP stage overlap",
+      "KV-cache traffic",
+      "sampling or probability-producing softmax consumers"
+    ]
+  },
+  "expected_benefit": [
+    "removes ambiguity in producer_ii assumptions",
+    "separates producer service limits from ranker limits",
+    "sets a producer service curve for the follow-on producer+ranker NoC coupling job"
+  ],
+  "risks": [
+    "GEMM throughput and memory bandwidth are still planning parameters",
+    "weight locality and SRAM banking are represented only by service bandwidth",
+    "stage scheduling assumes output projection starts after attention/MLP completion"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_service_v1",
+      "task_type": "l2_campaign",
+      "objective": "Estimate output-projection producer service curves for a stage-serialized shared GEMM final decoder stage.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_service",
+      "cost_class": "low",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": false,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The expected output is a producer service curve used to select realistic producer_ii values before combined producer/ranker RTL."
+      }
+    }
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_producer_ranker_coupling.py",
+    "tests/test_llm_decoder_producer_ranker_coupling.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_producer_ranker_coupled_noc_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_producer_ranker_coupled_noc_v1/README.md
@@ -1,0 +1,3 @@
+# Decoder Producer/Ranker Shared NoC Coupling
+
+This proposal couples output-projection producer service curves to the producer-integrated ranker model. The purpose is to stop treating producer II as a free parameter and check whether the current r64/r128 ranker points survive shared memory and NoC bandwidth assumptions.

--- a/docs/proposals/prop_l2_decoder_producer_ranker_coupled_noc_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_producer_ranker_coupled_noc_v1/evaluation_gate.md
@@ -1,0 +1,6 @@
+# Evaluation Gate
+
+- Run `l2_decoder_producer_ranker_coupled_noc_v1`.
+- Confirm producer II comes from output-projection compute and memory service.
+- Confirm r64/r128/r256, top-k 1/4, and memory-share sensitivity rows are present.
+- Confirm ranker FIFO validity and candidate traffic remain reported separately from producer service.

--- a/docs/proposals/prop_l2_decoder_producer_ranker_coupled_noc_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_producer_ranker_coupled_noc_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_producer_ranker_coupled_noc_v1",
+  "source_commit": "bbb3fdc6022fc9fc64d444ff20475c1c8f924174",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_producer_ranker_coupled_noc_v1",
+      "task_type": "l2_campaign",
+      "objective": "Couple output-projection producer service curves to the producer-integrated ranker frontier under shared memory/NoC contention assumptions.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_producer_ranker_coupled_noc",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_producer_integrated_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The expected output is a coupled producer/ranker frontier used to choose the next combined RTL target."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_producer_ranker_coupled_noc_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_producer_ranker_coupled_noc_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l2_decoder_producer_ranker_coupled_noc_v1",
+  "created_utc": "2026-05-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_producer_ranker_coupled_noc",
+  "title": "Decoder producer/ranker shared NoC coupling",
+  "hypothesis": "The r64/r128 producer-integrated ranker frontier should be checked against output-projection producer service curves and shared memory/NoC contention before choosing a combined RTL point.",
+  "direct_comparison": {
+    "primary_question": "Do the r64/r128 ranker winners remain useful when producer II is derived from shared-GEMM output projection and memory bandwidth is reduced by NoC contention?",
+    "include": [
+      "stage-serialized output-projection service curves",
+      "shared NoC/memory bandwidth shares",
+      "r64/r128/r256 producer tile widths",
+      "top-k 1 and 4 ranker coupling",
+      "ready-valid ranker FIFO validity and candidate traffic"
+    ],
+    "exclude": [
+      "new RTL implementation",
+      "full decoder scheduler",
+      "attention/MLP overlap",
+      "KV-cache traffic interaction"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the current r128/k1 frontier survives realistic producer service assumptions",
+    "identifies memory/NoC sensitivity before RTL work",
+    "chooses the next combined producer/ranker RTL target with clearer assumptions"
+  ],
+  "risks": [
+    "NoC contention is represented by bandwidth shares, not measured arbitration",
+    "producer service remains a planning model until output-projection RTL is measured",
+    "larger decoder scheduling effects are still out of scope"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_producer_ranker_coupled_noc_v1",
+      "task_type": "l2_campaign",
+      "objective": "Couple output-projection producer service curves to the producer-integrated ranker frontier under shared memory/NoC contention assumptions.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_producer_ranker_coupled_noc",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_logit_rank_streaming_producer_integrated_v1",
+        "l1_decoder_candidate_stream_merge_fifo_v1",
+        "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The expected output is a coupled producer/ranker frontier used to choose the next combined RTL target."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_logit_rank_streaming_producer_integrated_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_output_projection_service_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_producer_ranker_coupling.py",
+    "npu/eval/model_llm_decoder_logit_rank_streaming.py",
+    "tests/test_llm_decoder_producer_ranker_coupling.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_producer_ranker_coupling.py
+++ b/npu/eval/estimate_llm_decoder_producer_ranker_coupling.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Estimate decoder output-projection producer service coupled to logit ranker."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import sys
+from typing import Any
+
+try:
+    from npu.eval.model_llm_decoder_logit_rank_streaming import build_report
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from model_llm_decoder_logit_rank_streaming import build_report
+
+JsonDict = dict[str, Any]
+
+
+def _int_list(value: str) -> list[int]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated integer list")
+    parsed = [int(item) for item in items]
+    if any(item <= 0 for item in parsed):
+        raise argparse.ArgumentTypeError("all list items must be positive")
+    return parsed
+
+
+def _float_list(value: str) -> list[float]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated float list")
+    parsed = [float(item) for item in items]
+    if any(item <= 0.0 for item in parsed):
+        raise argparse.ArgumentTypeError("all list items must be positive")
+    return parsed
+
+
+def _byte_width(bits: int) -> int:
+    return max(1, math.ceil(bits / 8))
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _producer_service_row(
+    *,
+    scenario: str,
+    vocab_size: int,
+    hidden_size: int,
+    producer_lanes: int,
+    macs_per_cycle: int,
+    memory_bandwidth_bytes_per_cycle: float,
+    memory_share: float,
+    weight_bits: int,
+    activation_bits: int,
+    clock_ns: float,
+) -> JsonDict:
+    if memory_share <= 0.0:
+        raise ValueError("memory_share must be positive")
+    effective_bandwidth = memory_bandwidth_bytes_per_cycle * memory_share
+    tile_count = _ceil_div(vocab_size, producer_lanes)
+    weight_bytes_per_tile = producer_lanes * hidden_size * _byte_width(weight_bits)
+    hidden_bytes_per_token = hidden_size * _byte_width(activation_bits)
+    macs_per_tile = producer_lanes * hidden_size
+    compute_cycles_per_tile = _ceil_div(macs_per_tile, macs_per_cycle)
+    weight_cycles_per_tile = math.ceil(weight_bytes_per_tile / effective_bandwidth)
+    hidden_load_cycles = math.ceil(hidden_bytes_per_token / effective_bandwidth)
+    producer_ii_cycles = max(1, compute_cycles_per_tile, weight_cycles_per_tile)
+    producer_latency_cycles = hidden_load_cycles + compute_cycles_per_tile
+    total_cycles = producer_latency_cycles + max(0, tile_count - 1) * producer_ii_cycles
+    return {
+        "scenario": scenario,
+        "vocab_size": vocab_size,
+        "hidden_size": hidden_size,
+        "producer_lanes": producer_lanes,
+        "tile_count": tile_count,
+        "macs_per_cycle": macs_per_cycle,
+        "memory_bandwidth_bytes_per_cycle": memory_bandwidth_bytes_per_cycle,
+        "memory_share": memory_share,
+        "effective_memory_bandwidth_bytes_per_cycle": effective_bandwidth,
+        "weight_bits": weight_bits,
+        "activation_bits": activation_bits,
+        "macs_per_tile": macs_per_tile,
+        "weight_bytes_per_tile": weight_bytes_per_tile,
+        "hidden_bytes_per_token": hidden_bytes_per_token,
+        "weight_bytes_per_token": weight_bytes_per_tile * tile_count,
+        "compute_cycles_per_tile": compute_cycles_per_tile,
+        "weight_cycles_per_tile": weight_cycles_per_tile,
+        "hidden_load_cycles": hidden_load_cycles,
+        "producer_latency_cycles": producer_latency_cycles,
+        "producer_ii_cycles": producer_ii_cycles,
+        "producer_total_cycles": total_cycles,
+        "producer_latency_us_per_token": round(total_cycles * clock_ns / 1000.0, 6),
+        "service_limiter": (
+            "weight_memory"
+            if weight_cycles_per_tile >= compute_cycles_per_tile
+            else "compute_array"
+        ),
+    }
+
+
+def build_coupling_report(
+    *,
+    mode: str,
+    rank_ppa_path: Path | None,
+    scale_ppa_path: Path | None,
+    candidate_merge_ppa_path: Path | None,
+    boundary_ppa_path: Path | None,
+    sram_metrics_json_path: Path | None,
+    vocab_size_list: list[int],
+    hidden_size_list: list[int],
+    producer_lanes_list: list[int],
+    macs_per_cycle_list: list[int],
+    memory_bandwidth_bytes_per_cycle_list: list[float],
+    memory_share_list: list[float],
+    top_k_list: list[int],
+    weight_bits: int,
+    activation_bits: int,
+    clock_ns: float,
+) -> JsonDict:
+    scenarios = (
+        ["shared_gemm_stage_serial"]
+        if mode == "producer_service"
+        else ["shared_gemm_stage_serial", "shared_noc_contention"]
+    )
+    producer_rows: list[JsonDict] = []
+    for scenario in scenarios:
+        shares = [1.0] if scenario == "shared_gemm_stage_serial" else memory_share_list
+        for vocab_size in vocab_size_list:
+            for hidden_size in hidden_size_list:
+                for lanes in producer_lanes_list:
+                    for macs_per_cycle in macs_per_cycle_list:
+                        for bandwidth in memory_bandwidth_bytes_per_cycle_list:
+                            for share in shares:
+                                producer_rows.append(
+                                    _producer_service_row(
+                                        scenario=scenario,
+                                        vocab_size=vocab_size,
+                                        hidden_size=hidden_size,
+                                        producer_lanes=lanes,
+                                        macs_per_cycle=macs_per_cycle,
+                                        memory_bandwidth_bytes_per_cycle=bandwidth,
+                                        memory_share=share,
+                                        weight_bits=weight_bits,
+                                        activation_bits=activation_bits,
+                                        clock_ns=clock_ns,
+                                    )
+                                )
+
+    coupled_rows: list[JsonDict] = []
+    if mode == "coupled_noc":
+        primary_vocab = vocab_size_list[0]
+        producer_iis = sorted({row["producer_ii_cycles"] for row in producer_rows})
+        rank_report = build_report(
+            rank_ppa_path=rank_ppa_path,
+            scale_ppa_path=scale_ppa_path,
+            candidate_merge_ppa_path=candidate_merge_ppa_path,
+            boundary_ppa_path=boundary_ppa_path,
+            sram_metrics_json_path=sram_metrics_json_path,
+            vocab_size=primary_vocab,
+            vocab_size_list=vocab_size_list,
+            producer_lanes_list=producer_lanes_list,
+            producer_interface_focus_lanes=[lane for lane in producer_lanes_list if lane >= 64],
+            top_k_list=top_k_list,
+            producer_ii_cycles_list=producer_iis,
+            global_merge_ii_cycles_list=[1, 2],
+            candidate_fifo_depth_groups_list=[16, 256],
+            memory_bandwidth_bytes_per_cycle=memory_bandwidth_bytes_per_cycle_list[0],
+            noc_hops=2,
+        )
+        rank_rows = {
+            (
+                row.get("vocab_size"),
+                row.get("producer_lanes"),
+                row.get("producer_ii_cycles"),
+                row.get("local_top_k"),
+            ): row
+            for row in rank_report.get("overlap_traffic_sweep", [])
+            if row.get("global_merge_ii_cycles") == 1
+            and row.get("candidate_fifo_depth_groups") == 16
+        }
+        for producer in producer_rows:
+            for top_k in top_k_list:
+                rank = rank_rows.get(
+                    (
+                        producer["vocab_size"],
+                        producer["producer_lanes"],
+                        producer["producer_ii_cycles"],
+                        top_k,
+                    )
+                )
+                if rank is None:
+                    continue
+                coupled_latency_us = max(
+                    producer["producer_latency_us_per_token"],
+                    rank["timing"]["latency_us_per_token"],
+                )
+                coupled_rows.append(
+                    {
+                        "scenario": producer["scenario"],
+                        "vocab_size": producer["vocab_size"],
+                        "hidden_size": producer["hidden_size"],
+                        "producer_lanes": producer["producer_lanes"],
+                        "top_k": top_k,
+                        "macs_per_cycle": producer["macs_per_cycle"],
+                        "memory_share": producer["memory_share"],
+                        "producer_ii_cycles": producer["producer_ii_cycles"],
+                        "producer_latency_us_per_token": producer["producer_latency_us_per_token"],
+                        "ranker_latency_us_per_token": rank["timing"]["latency_us_per_token"],
+                        "coupled_latency_us_per_token": coupled_latency_us,
+                        "ranker_fifo_capacity_ok": rank["fifo_capacity_ok"],
+                        "ranker_required_fifo_depth_groups": rank["required_fifo_depth_groups"],
+                        "ranker_candidate_memory_bytes": rank["traffic"]["streaming_candidate_memory_bytes"],
+                        "ranker_traffic_reduction_vs_materialized": rank["traffic"]["traffic_reduction_vs_materialized"],
+                        "service_limiter": producer["service_limiter"],
+                    }
+                )
+    else:
+        rank_report = None
+
+    producer_best = min(
+        producer_rows,
+        key=lambda row: (
+            row["producer_latency_us_per_token"],
+            row["weight_bytes_per_token"],
+            -row["producer_lanes"],
+        ),
+    )
+    coupled_best = (
+        min(
+            coupled_rows,
+            key=lambda row: (
+                not row["ranker_fifo_capacity_ok"],
+                row["coupled_latency_us_per_token"],
+                row["ranker_candidate_memory_bytes"],
+            ),
+        )
+        if coupled_rows
+        else None
+    )
+    return {
+        "version": 0.1,
+        "model": "decoder_output_projection_producer_ranker_coupling_v1",
+        "mode": mode,
+        "inputs": {
+            "vocab_size_list": vocab_size_list,
+            "hidden_size_list": hidden_size_list,
+            "producer_lanes_list": producer_lanes_list,
+            "macs_per_cycle_list": macs_per_cycle_list,
+            "memory_bandwidth_bytes_per_cycle_list": memory_bandwidth_bytes_per_cycle_list,
+            "memory_share_list": memory_share_list,
+            "top_k_list": top_k_list,
+            "weight_bits": weight_bits,
+            "activation_bits": activation_bits,
+            "clock_ns": clock_ns,
+        },
+        "assumptions": [
+            "Producer means only the final decoder output-projection logit source.",
+            "Shared GEMM is stage-serialized: attention/MLP have completed before output projection starts.",
+            "producer_ii_cycles is derived as max(compute cycles per tile, weight-memory service cycles per tile).",
+            "Hidden vector load is charged once per token; output projection weights are streamed per vocabulary tile.",
+            "shared_noc_contention reduces effective producer memory bandwidth by memory_share.",
+            "Ranker coupling reuses the ready-valid logit-rank model and preserves its equivalence observables.",
+        ],
+        "producer_service_sweep": producer_rows,
+        "coupled_ranker_sweep": coupled_rows,
+        "ranker_report_summary": (
+            {
+                "recommendation": rank_report.get("recommendation"),
+                "producer_integrated_interface": rank_report.get("producer_integrated_interface"),
+            }
+            if mode == "coupled_noc" and rank_report is not None
+            else None
+        ),
+        "recommendation": {
+            "producer_service_best": producer_best,
+            "coupled_best": coupled_best,
+            "reason": (
+                "Lowest producer service latency first; coupled mode additionally requires FIFO-valid "
+                "ranker rows and then minimizes candidate traffic."
+            ),
+        },
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    rec = payload["recommendation"]
+    lines = [
+        "# Decoder Producer/Ranker Coupling",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- mode: `{payload['mode']}`",
+        f"- producer_service_best: `{rec['producer_service_best']['scenario']} "
+        f"w{rec['producer_service_best']['producer_lanes']} "
+        f"ii{rec['producer_service_best']['producer_ii_cycles']}`",
+    ]
+    if rec.get("coupled_best"):
+        best = rec["coupled_best"]
+        lines.append(
+            f"- coupled_best: `{best['scenario']} w{best['producer_lanes']} k{best['top_k']} "
+            f"ii{best['producer_ii_cycles']}`"
+        )
+    lines.extend(
+        [
+            "",
+            "## Producer Service Sweep",
+            "",
+            "| scenario | vocab | hidden | W | MAC/cycle | BW | share | II | limiter | latency_us | weight_bytes/token |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|",
+        ]
+    )
+    for row in payload["producer_service_sweep"][:48]:
+        lines.append(
+            "| {scenario} | {vocab} | {hidden} | {lanes} | {macs} | {bw} | {share} | {ii} | {limiter} | {latency} | {bytes} |".format(
+                scenario=row["scenario"],
+                vocab=row["vocab_size"],
+                hidden=row["hidden_size"],
+                lanes=row["producer_lanes"],
+                macs=row["macs_per_cycle"],
+                bw=row["memory_bandwidth_bytes_per_cycle"],
+                share=row["memory_share"],
+                ii=row["producer_ii_cycles"],
+                limiter=row["service_limiter"],
+                latency=row["producer_latency_us_per_token"],
+                bytes=row["weight_bytes_per_token"],
+            )
+        )
+    if payload.get("coupled_ranker_sweep"):
+        lines.extend(
+            [
+                "",
+                "## Coupled Ranker Sweep",
+                "",
+                "| scenario | vocab | hidden | W | top_k | MAC/cycle | share | producer_ii | producer_us | ranker_us | coupled_us | fifo ok | candidate_bytes | traffic reduction |",
+                "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|",
+            ]
+        )
+        for row in payload["coupled_ranker_sweep"][:48]:
+            lines.append(
+                "| {scenario} | {vocab} | {hidden} | {lanes} | {topk} | {macs} | {share} | {ii} | {prod_us} | {rank_us} | {coupled_us} | `{ok}` | {cand_bytes} | {traffic} |".format(
+                    scenario=row["scenario"],
+                    vocab=row["vocab_size"],
+                    hidden=row["hidden_size"],
+                    lanes=row["producer_lanes"],
+                    topk=row["top_k"],
+                    macs=row["macs_per_cycle"],
+                    share=row["memory_share"],
+                    ii=row["producer_ii_cycles"],
+                    prod_us=row["producer_latency_us_per_token"],
+                    rank_us=row["ranker_latency_us_per_token"],
+                    coupled_us=row["coupled_latency_us_per_token"],
+                    ok=row["ranker_fifo_capacity_ok"],
+                    cand_bytes=row["ranker_candidate_memory_bytes"],
+                    traffic=row["ranker_traffic_reduction_vs_materialized"],
+                )
+            )
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Estimate output-projection producer and ranker coupling")
+    ap.add_argument("--mode", choices=["producer_service", "coupled_noc"], required=True)
+    ap.add_argument("--rank-ppa", help="rank datapath PPA JSON")
+    ap.add_argument("--scale-ppa", help="rank scale PPA JSON")
+    ap.add_argument("--candidate-merge-ppa", help="candidate merge PPA JSON")
+    ap.add_argument("--boundary-ppa", help="boundary diagnostic PPA JSON")
+    ap.add_argument("--sram-metrics-json", help="SRAM metrics JSON")
+    ap.add_argument("--vocab-size-list", type=_int_list, default=[50257, 100000, 200000])
+    ap.add_argument("--hidden-size-list", type=_int_list, default=[768, 1024, 2048])
+    ap.add_argument("--producer-lanes-list", type=_int_list, default=[64, 128])
+    ap.add_argument("--macs-per-cycle-list", type=_int_list, default=[8192, 32768])
+    ap.add_argument("--memory-bandwidth-bytes-per-cycle-list", type=_float_list, default=[64.0, 256.0])
+    ap.add_argument("--memory-share-list", type=_float_list, default=[1.0, 0.5, 0.25])
+    ap.add_argument("--top-k-list", type=_int_list, default=[1, 4])
+    ap.add_argument("--weight-bits", type=int, default=16)
+    ap.add_argument("--activation-bits", type=int, default=16)
+    ap.add_argument("--clock-ns", type=float, default=1.0)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+    payload = build_coupling_report(
+        mode=args.mode,
+        rank_ppa_path=Path(args.rank_ppa) if args.rank_ppa else None,
+        scale_ppa_path=Path(args.scale_ppa) if args.scale_ppa else None,
+        candidate_merge_ppa_path=Path(args.candidate_merge_ppa) if args.candidate_merge_ppa else None,
+        boundary_ppa_path=Path(args.boundary_ppa) if args.boundary_ppa else None,
+        sram_metrics_json_path=Path(args.sram_metrics_json) if args.sram_metrics_json else None,
+        vocab_size_list=args.vocab_size_list,
+        hidden_size_list=args.hidden_size_list,
+        producer_lanes_list=args.producer_lanes_list,
+        macs_per_cycle_list=args.macs_per_cycle_list,
+        memory_bandwidth_bytes_per_cycle_list=args.memory_bandwidth_bytes_per_cycle_list,
+        memory_share_list=args.memory_share_list,
+        top_k_list=args.top_k_list,
+        weight_bits=args.weight_bits,
+        activation_bits=args.activation_bits,
+        clock_ns=args.clock_ns,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    _write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_producer_ranker_coupling.py
+++ b/tests/test_llm_decoder_producer_ranker_coupling.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from npu.eval.estimate_llm_decoder_producer_ranker_coupling import build_coupling_report
+
+
+def test_producer_service_derives_integer_ii_from_compute_and_memory() -> None:
+    report = build_coupling_report(
+        mode="producer_service",
+        rank_ppa_path=None,
+        scale_ppa_path=None,
+        candidate_merge_ppa_path=None,
+        boundary_ppa_path=None,
+        sram_metrics_json_path=None,
+        vocab_size_list=[256],
+        hidden_size_list=[64],
+        producer_lanes_list=[64],
+        macs_per_cycle_list=[4096],
+        memory_bandwidth_bytes_per_cycle_list=[128.0],
+        memory_share_list=[1.0],
+        top_k_list=[1],
+        weight_bits=16,
+        activation_bits=16,
+        clock_ns=1.0,
+    )
+
+    row = report["producer_service_sweep"][0]
+    assert row["compute_cycles_per_tile"] == 1
+    assert row["weight_cycles_per_tile"] == 64
+    assert row["producer_ii_cycles"] == 64
+    assert row["service_limiter"] == "weight_memory"
+    assert report["coupled_ranker_sweep"] == []
+
+
+def test_coupled_noc_reports_ranker_rows(tmp_path: Path) -> None:
+    report = build_coupling_report(
+        mode="coupled_noc",
+        rank_ppa_path=None,
+        scale_ppa_path=None,
+        candidate_merge_ppa_path=None,
+        boundary_ppa_path=None,
+        sram_metrics_json_path=None,
+        vocab_size_list=[256],
+        hidden_size_list=[64],
+        producer_lanes_list=[64],
+        macs_per_cycle_list=[4096],
+        memory_bandwidth_bytes_per_cycle_list=[128.0],
+        memory_share_list=[1.0, 0.5],
+        top_k_list=[1],
+        weight_bits=16,
+        activation_bits=16,
+        clock_ns=1.0,
+    )
+
+    assert report["coupled_ranker_sweep"]
+    row = report["coupled_ranker_sweep"][0]
+    assert row["producer_lanes"] == 64
+    assert row["top_k"] == 1
+    assert row["producer_ii_cycles"] >= 1
+    assert "ranker_latency_us_per_token" in row
+    assert row["coupled_latency_us_per_token"] >= row["producer_latency_us_per_token"]
+    assert report["recommendation"]["coupled_best"] is not None


### PR DESCRIPTION
## Summary

- adds a producer service estimator for the final decoder output-projection stage
- adds a producer/ranker coupled NoC mode that derives producer II from GEMM throughput and memory service before checking ranker FIFO/traffic rows
- wires two new Layer 2 abstractions and proposal requests:
  - `l2_decoder_output_projection_service_v1`
  - `l2_decoder_producer_ranker_coupled_noc_v1`

## Planned design points

- stage-serialized shared GEMM output projection with vocab `50k/100k/200k`, hidden `768/1024/2048`, lanes `64/128/256`, MAC/cycle `8192/32768`, bandwidth `64/256 B/cycle`
- coupled producer+ranker with memory shares `1.0/0.5/0.25`, top-k `1/4`, and existing producer-integrated ranker PPA/boundary diagnostics

## Validation

- `./control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_producer_ranker_coupling.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_output_projection_service_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_producer_ranker_coupled_noc_evidence -q`
- smoke: `estimate_llm_decoder_producer_ranker_coupling.py --mode producer_service ...`
- smoke: `estimate_llm_decoder_producer_ranker_coupling.py --mode coupled_noc ...`
- `python3 -m py_compile npu/eval/estimate_llm_decoder_producer_ranker_coupling.py control_plane/control_plane/services/l2_task_generator.py`
- `python3 -m json.tool` on new proposal/request JSON files
- `git diff --check`
