### PR TITLE
[codex] Automate evaluator refresh requests

### DIFF
--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -22,6 +22,7 @@ from control_plane.cli.import_queue import main as import_queue_main
 from control_plane.cli.operate_submission import main as operate_submission_main
 from control_plane.cli.poll_github import main as poll_github_main
 from control_plane.cli.report_failure_issues import main as report_failure_issues_main
+from control_plane.cli.request_evaluator_refresh import main as request_evaluator_refresh_main
 from control_plane.cli.operator_status import main as operator_status_main
 from control_plane.cli.process_completions import main as process_completions_main
 from control_plane.cli.prepare_submission import main as prepare_submission_main
@@ -161,6 +162,17 @@ def main(argv: list[str] | None = None) -> int:
     failure_issue_parser.add_argument("--database-url", required=True)
     failure_issue_parser.add_argument("--repo", required=True)
     failure_issue_parser.add_argument("--max-items", type=int)
+
+    evaluator_refresh_parser = subparsers.add_parser(
+        "request-evaluator-refresh",
+        help="Open or update a GitHub issue requesting evaluator source refresh and daemon restart",
+    )
+    evaluator_refresh_parser.add_argument("--repo", required=True)
+    evaluator_refresh_parser.add_argument("--repo-root", default=".")
+    evaluator_refresh_parser.add_argument("--target-commit")
+    evaluator_refresh_parser.add_argument("--reason", default="control-plane source changed")
+    evaluator_refresh_parser.add_argument("--evaluator", default="remote evaluator")
+    evaluator_refresh_parser.add_argument("--dry-run", action="store_true")
 
     resolver_parser = subparsers.add_parser(
         "run-dev-resolver",
@@ -1039,6 +1051,22 @@ def main(argv: list[str] | None = None) -> int:
         if args.apply:
             argv2.append("--apply")
         return cleanup_main(argv2)
+    if args.command == "request-evaluator-refresh":
+        argv2 = [
+            "--repo",
+            args.repo,
+            "--repo-root",
+            args.repo_root,
+            "--reason",
+            args.reason,
+            "--evaluator",
+            args.evaluator,
+        ]
+        if args.target_commit is not None:
+            argv2.extend(["--target-commit", str(args.target_commit)])
+        if args.dry_run:
+            argv2.append("--dry-run")
+        return request_evaluator_refresh_main(argv2)
     if args.command == "show-config":
         print(json.dumps(Settings.from_env().__dict__, indent=2, sort_keys=True))
         return 0

--- a/control_plane/control_plane/cli/request_evaluator_refresh.py
+++ b/control_plane/control_plane/cli/request_evaluator_refresh.py
@@ -1,0 +1,51 @@
+"""CLI for requesting remote evaluator source refresh and daemon restart."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+
+from control_plane.services.evaluator_refresh_request import (
+    EvaluatorRefreshRequest,
+    request_evaluator_refresh,
+)
+
+
+def _current_commit(repo_root: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(Path(repo_root).resolve()), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Request evaluator source refresh and daemon restart")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--target-commit")
+    parser.add_argument("--reason", default="control-plane source changed")
+    parser.add_argument("--evaluator", default="remote evaluator")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    target_commit = args.target_commit or _current_commit(args.repo_root)
+    result = request_evaluator_refresh(
+        EvaluatorRefreshRequest(
+            repo=args.repo,
+            target_commit=target_commit,
+            reason=args.reason,
+            evaluator=args.evaluator,
+            dry_run=args.dry_run,
+        )
+    )
+    print(json.dumps(result.__dict__, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/control_plane/control_plane/services/evaluator_refresh_request.py
+++ b/control_plane/control_plane/services/evaluator_refresh_request.py
@@ -1,0 +1,176 @@
+"""Request remote evaluator source refresh and daemon restart through GitHub."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import re
+import subprocess
+from typing import Any
+
+
+class EvaluatorRefreshRequestError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class EvaluatorRefreshRequest:
+    repo: str
+    target_commit: str
+    reason: str = "control-plane source changed"
+    evaluator: str = "remote evaluator"
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class EvaluatorRefreshResult:
+    repo: str
+    target_commit: str
+    issue_number: int | None
+    issue_url: str | None
+    action: str
+    dry_run: bool
+    body: str
+
+
+_REFRESH_BLOCK_RE = re.compile(r"<!--\s*evaluator-refresh\n(.*?)-->", re.DOTALL)
+
+
+def _gh_api_json(path: str, *, method: str = "GET", fields: dict[str, str] | None = None) -> Any:
+    command = ["gh", "api", path]
+    if method != "GET":
+        command.extend(["--method", method])
+    for key, value in (fields or {}).items():
+        command.extend(["-f", f"{key}={value}"])
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = str(exc.stderr or "").strip()
+        raise EvaluatorRefreshRequestError(f"gh api failed for {path}: {stderr or exc}") from exc
+    except OSError as exc:
+        raise EvaluatorRefreshRequestError(f"gh api unavailable for {path}: {exc}") from exc
+    return json.loads(result.stdout)
+
+
+def _gh_api(path: str, *, method: str = "GET", fields: dict[str, str] | None = None) -> dict[str, Any]:
+    payload = _gh_api_json(path, method=method, fields=fields)
+    if not isinstance(payload, dict):
+        raise EvaluatorRefreshRequestError(f"unexpected gh api payload for {path}")
+    return payload
+
+
+def _parse_refresh_block(text: str) -> dict[str, str]:
+    match = _REFRESH_BLOCK_RE.search(text or "")
+    if match is None:
+        return {}
+    parsed: dict[str, str] = {}
+    for raw_line in match.group(1).splitlines():
+        line = raw_line.strip()
+        if not line or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def _find_open_refresh_issue(repo: str) -> dict[str, Any] | None:
+    payload = _gh_api_json(f"repos/{repo}/issues?state=open&per_page=100")
+    if not isinstance(payload, list):
+        raise EvaluatorRefreshRequestError(f"unexpected gh api issues payload for {repo}")
+    for row in payload:
+        if not isinstance(row, dict):
+            continue
+        if row.get("pull_request"):
+            continue
+        title = str(row.get("title") or "")
+        body = str(row.get("body") or "")
+        if title.startswith("Evaluator refresh:") or _parse_refresh_block(body):
+            return row
+    return None
+
+
+def build_refresh_body(request: EvaluatorRefreshRequest) -> str:
+    return "\n".join(
+        [
+            "<!-- evaluator-refresh",
+            f"target_commit: {request.target_commit}",
+            f"evaluator: {request.evaluator}",
+            f"reason: {request.reason}",
+            "-->",
+            "",
+            "Please refresh the evaluator environment to the requested RTLGen commit and restart daemons.",
+            "",
+            "Requested target:",
+            f"- repository: `{request.repo}`",
+            f"- target_commit: `{request.target_commit}`",
+            f"- evaluator: `{request.evaluator}`",
+            f"- reason: {request.reason}",
+            "",
+            "Expected evaluator procedure:",
+            "1. Fetch `origin/master` and update the evaluator worktree to the target commit.",
+            "2. Refresh Python dependencies if repository dependency files changed.",
+            "3. Restart evaluator-side daemons: worker daemon and eval resolver; restart the API daemon if it runs on the evaluator host.",
+            "4. Confirm daemon status and queue readiness.",
+            "",
+            "Please reply with:",
+            "```md",
+            "<!-- evaluator-refresh-ack",
+            f"target_commit: {request.target_commit}",
+            "status: updated|blocked",
+            "daemons_restarted: true|false",
+            "notes: <short note>",
+            "-->",
+            "```",
+            "",
+        ]
+    )
+
+
+def request_evaluator_refresh(request: EvaluatorRefreshRequest) -> EvaluatorRefreshResult:
+    body = build_refresh_body(request)
+    existing = _find_open_refresh_issue(request.repo)
+    if request.dry_run:
+        return EvaluatorRefreshResult(
+            repo=request.repo,
+            target_commit=request.target_commit,
+            issue_number=int(existing["number"]) if existing else None,
+            issue_url=str(existing.get("html_url") or "") or None if existing else None,
+            action="would_comment" if existing else "would_create",
+            dry_run=True,
+            body=body,
+        )
+
+    if existing is not None:
+        issue_number = int(existing["number"])
+        payload = _gh_api(
+            f"repos/{request.repo}/issues/{issue_number}/comments",
+            method="POST",
+            fields={"body": body},
+        )
+        return EvaluatorRefreshResult(
+            repo=request.repo,
+            target_commit=request.target_commit,
+            issue_number=issue_number,
+            issue_url=str(existing.get("html_url") or "") or None,
+            action="commented",
+            dry_run=False,
+            body=str(payload.get("body") or body),
+        )
+
+    payload = _gh_api(
+        f"repos/{request.repo}/issues",
+        method="POST",
+        fields={
+            "title": f"Evaluator refresh: {request.target_commit[:12]}",
+            "body": body,
+        },
+    )
+    return EvaluatorRefreshResult(
+        repo=request.repo,
+        target_commit=request.target_commit,
+        issue_number=int(payload["number"]),
+        issue_url=str(payload.get("html_url") or "") or None,
+        action="created",
+        dry_run=False,
+        body=body,
+    )

--- a/control_plane/control_plane/tests/test_evaluator_refresh_request.py
+++ b/control_plane/control_plane/tests/test_evaluator_refresh_request.py
@@ -1,0 +1,78 @@
+"""Tests for evaluator refresh GitHub issue requests."""
+
+from __future__ import annotations
+
+import json
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+from control_plane.services.evaluator_refresh_request import (
+    EvaluatorRefreshRequest,
+    build_refresh_body,
+    request_evaluator_refresh,
+)
+
+
+def test_build_refresh_body_includes_ack_block() -> None:
+    body = build_refresh_body(
+        EvaluatorRefreshRequest(
+            repo="yhmtmt/RTLGen",
+            target_commit="abcdef1234567890",
+            reason="merged PR #450",
+            evaluator="remote-fast",
+        )
+    )
+
+    assert "target_commit: abcdef1234567890" in body
+    assert "evaluator: remote-fast" in body
+    assert "evaluator-refresh-ack" in body
+    assert "Restart evaluator-side daemons" in body
+
+
+def test_request_evaluator_refresh_creates_issue_when_none_open() -> None:
+    calls = []
+
+    def fake_run(argv, check, capture_output, text):
+        calls.append(argv)
+        if argv[2].endswith("/issues?state=open&per_page=100"):
+            return CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return CompletedProcess(
+            argv,
+            0,
+            stdout=json.dumps({"number": 451, "html_url": "https://github.com/yhmtmt/RTLGen/issues/451"}),
+            stderr="",
+        )
+
+    with patch("control_plane.services.evaluator_refresh_request.subprocess.run", side_effect=fake_run):
+        result = request_evaluator_refresh(
+            EvaluatorRefreshRequest(repo="yhmtmt/RTLGen", target_commit="abcdef123456")
+        )
+
+    assert result.action == "created"
+    assert result.issue_number == 451
+    assert calls[-1][:5] == ["gh", "api", "repos/yhmtmt/RTLGen/issues", "--method", "POST"]
+
+
+def test_request_evaluator_refresh_comments_existing_issue() -> None:
+    issue = {
+        "number": 440,
+        "title": "Evaluator refresh: old",
+        "body": "<!-- evaluator-refresh\ntarget_commit: old\n-->",
+        "html_url": "https://github.com/yhmtmt/RTLGen/issues/440",
+    }
+    calls = []
+
+    def fake_run(argv, check, capture_output, text):
+        calls.append(argv)
+        if argv[2].endswith("/issues?state=open&per_page=100"):
+            return CompletedProcess(argv, 0, stdout=json.dumps([issue]), stderr="")
+        return CompletedProcess(argv, 0, stdout=json.dumps({"body": "comment body"}), stderr="")
+
+    with patch("control_plane.services.evaluator_refresh_request.subprocess.run", side_effect=fake_run):
+        result = request_evaluator_refresh(
+            EvaluatorRefreshRequest(repo="yhmtmt/RTLGen", target_commit="newcommit")
+        )
+
+    assert result.action == "commented"
+    assert result.issue_number == 440
+    assert calls[-1][2] == "repos/yhmtmt/RTLGen/issues/440/comments"

--- a/control_plane/operator_runbook.md
+++ b/control_plane/operator_runbook.md
@@ -122,6 +122,14 @@ Cleanup dry-run:
 /workspaces/RTLGen/control_plane/scripts/cleanup.sh
 ```
 
+Request remote evaluator refresh after a control-plane merge:
+```sh
+/workspaces/RTLGen/control_plane/scripts/request_evaluator_refresh.sh \
+  --reason "merged control-plane change; evaluator should pull master and restart daemons"
+```
+
+The command opens or updates a GitHub issue with the target commit, pull/update checklist, daemon restart checklist, and a machine-readable evaluator acknowledgement block. Use it instead of drafting ad hoc evaluator update issues.
+
 ## What Healthy Looks Like
 
 Healthy idle state:

--- a/control_plane/scripts/request_evaluator_refresh.sh
+++ b/control_plane/scripts/request_evaluator_refresh.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if [[ -d "$REPO_ROOT/control_plane/.venv" ]]; then
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/control_plane/.venv/bin/activate"
+fi
+
+export PYTHONPATH="$REPO_ROOT/control_plane${PYTHONPATH:+:$PYTHONPATH}"
+
+python3 -m control_plane.cli.main request-evaluator-refresh \
+  --repo "${RTLCP_GITHUB_REPO:-yhmtmt/RTLGen}" \
+  --repo-root "$REPO_ROOT" \
+  "$@"


### PR DESCRIPTION
## Summary

Adds an idempotent control-plane command for requesting remote evaluator source refresh and daemon restart through GitHub issues.

This replaces the repeated manual process of drafting an evaluator update issue after control-plane changes. The command opens a new issue when none is active, or comments on the existing refresh issue when one is already open.

## Changes

- Add `request-evaluator-refresh` CLI and shell wrapper.
- Add machine-readable `evaluator-refresh` and requested `evaluator-refresh-ack` blocks.
- Add tests for issue creation, issue reuse/commenting, and body contents.
- Document the workflow in the operator runbook.

## Validation

- `./control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_evaluator_refresh_request.py -q`
- Dry-run verified that existing issue #451 would be reused instead of duplicated.
