### PR TITLE
[codex] Add decoder attention KV memory estimator

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2217,6 +2217,49 @@ def _decoder_stage_breakdown_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_attention_kv_memory_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_memory__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_memory__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_memory_scope": (
+                "Coarse single-token decoder attention model that separates QKV projection, "
+                "QK score, softmax, value mix, output projection, KV-cache memory tier, "
+                "NoC hops, KV precision, and MHA/GQA/MQA sharing."
+            ),
+            "attention_kv_memory_grid": {
+                "sequence_length_list": [128, 512, 2048, 8192, 32768],
+                "macs_per_cycle_list": [8192, 32768, 131072],
+                "kv_memory_tier_list": ["local_sram", "shared_sram", "hbm", "remote_hbm"],
+                "kv_sharing_list": ["mha", "gqa4", "mqa"],
+                "kv_bits_list": [8, 16],
+                "noc_hops_list": [0, 1, 2, 4],
+            },
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_memory",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_memory.py "
+                    "--sequence-length-list 128,512,2048,8192,32768 "
+                    "--macs-per-cycle-list 8192,32768,131072 "
+                    "--kv-memory-tier-list local_sram,shared_sram,hbm,remote_hbm "
+                    "--kv-sharing-list mha,gqa4,mqa "
+                    "--kv-bits-list 8,16 "
+                    "--noc-hops-list 1,2,4 "
+                    "--noc-bandwidth-bytes-per-cycle 256 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2683,10 +2726,13 @@ def _build_payload(
         "decoder_output_projection_service",
         "decoder_producer_ranker_coupled_noc",
         "decoder_stage_breakdown",
+        "decoder_attention_kv_memory",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_memory":
+            decoder_evidence = _decoder_attention_kv_memory_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_stage_breakdown":
             decoder_evidence = _decoder_stage_breakdown_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_producer_ranker_coupled_noc":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1849,6 +1849,52 @@ def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> No
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_memory_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_memory_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_attention_kv_memory_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_memory",
+                    expected_direction="iterate",
+                    comparison_role="ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == "estimate_decoder_attention_kv_memory"
+            run = work_item.command_manifest[0]["run"]
+            assert "--sequence-length-list 128,512,2048,8192,32768" in run
+            assert "--kv-memory-tier-list local_sram,shared_sram,hbm,remote_hbm" in run
+            assert "--kv-sharing-list mha,gqa4,mqa" in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_memory__l2_decoder_attention_kv_memory_v1.json"
+            )
+            assert "KV-cache memory tier" in decoder_inputs["attention_kv_memory_scope"]
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_memory",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/README.md
@@ -1,0 +1,7 @@
+# Decoder Attention/KV Memory Hierarchy Breakdown
+
+This proposal follows the whole-decoder stage breakdown and narrows the next question to attention.
+
+The estimator separates QKV projection, QK score, softmax score movement, value mix, attention output projection, and KV-cache read/write traffic. It sweeps context length, larger model proxy shapes, KV memory tier, NoC hops, KV precision, and MHA/GQA/MQA sharing.
+
+The result is not RTL PPA. It is a low-cost bottleneck map for deciding whether the next measured work should target KV locality, NoC bandwidth, attention compute, or score/softmax movement.

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/analysis_report.md
@@ -1,0 +1,24 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_kv_memory_v1`
+- `candidate_id`: `l2_decoder_attention_kv_memory_v1`
+
+## Evaluations Consumed
+- pending remote evaluation
+
+## Baseline Comparison
+- baseline_ref: `docs/proposals/prop_l2_decoder_stage_breakdown_v1/proposal.json`
+- baseline_item_id: `l2_decoder_stage_breakdown_v1`
+- expected comparison: ranking/frontier evidence, not a focused pass/fail delta
+
+## Result
+- pending `l2_decoder_attention_kv_memory_v1`
+
+## Failures and Caveats
+- no remote evaluation consumed yet
+- estimator is analytical and should not be treated as RTL PPA
+
+## Recommendation
+- run the proposal-backed attention/KV memory hierarchy evaluation
+- use the result to choose between KV memory hierarchy, NoC coupling, and attention-compute datapath follow-up work

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/design_brief.md
@@ -1,0 +1,14 @@
+# Design Brief
+
+The previous decoder-stage result showed that ranker-only work is not enough to explain decoder-scale behavior. Attention becomes dominant in long-context resident-weight cases, while MLP and output projection remain important in streaming-weight cases.
+
+This job keeps the sweep broad and rough:
+
+- memory tiers: `local_sram`, `shared_sram`, `hbm`, `remote_hbm`
+- network sensitivity: non-local KV tiers use a NoC-hop effective bandwidth bound
+- KV sharing: `mha`, `gqa4`, `mqa`
+- KV precision: 8-bit and 16-bit cache traffic
+- context lengths: 128 through 32768 tokens
+- model shapes: GPT-2-like through larger long-context proxies
+
+The report should identify whether the attention frontier is primarily compute, KV movement, score/softmax movement, or memory/network locality.

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- Run `l2_decoder_attention_kv_memory_v1`.
+- Confirm the report includes QKV projection, QK score, softmax, value mix, output projection, and KV-cache read/write terms.
+- Confirm local SRAM, shared SRAM, HBM, and remote-HBM tier rows are present.
+- Confirm MHA, GQA, and MQA sharing rows are present.
+- Treat the result as an analytical memory hierarchy map, not measured RTL.
+- Use the result to choose the next job only after checking whether conclusions are stable across context length, memory tier, and KV sharing.

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_memory_v1",
+  "source_commit": "6c82791a5b42a3e17bdb8221eb323e1f40e98c5f",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_memory_v1",
+      "task_type": "l2_campaign",
+      "objective": "Model-set revision campaign that reuses existing physical baselines and reruns mapper+perf reporting.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_memory",
+      "comparison_role": "ranking",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The expected output is an attention/KV bottleneck map used to choose whether the next architecture job should measure KV memory hierarchy, NoC coupling, or attention compute datapath."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/implementation_summary.md
@@ -1,0 +1,33 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_memory_v1`
+- title: Decoder attention/KV memory hierarchy breakdown
+
+## Scope
+- added a low-cost analytical attention/KV memory hierarchy estimator
+- added a control-plane `decoder_attention_kv_memory` abstraction hook
+- added proposal documentation and gates for `l2_decoder_attention_kv_memory_v1`
+- did not add RTL, mapper changes, SRAM macro banking, or NoC arbitration RTL
+
+## Files Changed
+- `npu/eval/estimate_llm_decoder_attention_kv_memory.py`
+- `tests/test_llm_decoder_attention_kv_memory.py`
+- `control_plane/control_plane/services/l2_task_generator.py`
+- `control_plane/control_plane/tests/test_l2_task_generator.py`
+- `docs/proposals/prop_l2_decoder_attention_kv_memory_v1/`
+
+## Local Validation
+- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_memory.py control_plane/control_plane/services/l2_task_generator.py`
+- `./control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_attention_kv_memory.py tests/test_llm_decoder_stage_breakdown.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence`
+- local estimator smoke wrote JSON and markdown outputs under `/tmp`
+
+## Evaluation Request
+- requested item: `l2_decoder_attention_kv_memory_v1`
+- cost class: low
+- baseline context: `l2_decoder_stage_breakdown_v1`
+
+## Risks
+- memory-tier bandwidths are planning values, not measured macros
+- NoC effect is an effective bandwidth bound, not arbitration RTL
+- quality effects of KV precision and MHA/GQA/MQA are out of scope

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/promotion_decision.json
@@ -1,0 +1,12 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_memory_v1",
+  "candidate_id": "l2_decoder_attention_kv_memory_v1",
+  "decision": "iterate",
+  "reason": "Run the proposal-backed attention/KV memory hierarchy evaluation before choosing the next measured architecture point.",
+  "evidence_refs": [
+    "docs/proposals/prop_l2_decoder_stage_breakdown_v1/proposal.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_stage_breakdown_v1.json"
+  ],
+  "next_action": "dispatch l2_decoder_attention_kv_memory_v1",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action: dispatch `l2_decoder_attention_kv_memory_v1`
+- note: Run the analytical attention/KV hierarchy map before selecting RTL or measured memory/NoC follow-up work.

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/promotion_result.json
@@ -1,0 +1,8 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_memory_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": "",
+  "next_item_id": "l2_decoder_attention_kv_memory_v1"
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_memory_v1",
+  "created_utc": "2026-05-11T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_memory",
+  "title": "Decoder attention/KV memory hierarchy breakdown",
+  "hypothesis": "The whole-decoder breakdown showed attention can dominate long-context decode once weight traffic is resident. The next frontier should isolate whether attention is limited by QKV/output projection compute, QK/value MACs, softmax score movement, or KV-cache memory and NoC service across memory tiers and KV sharing assumptions.",
+  "direct_comparison": {
+    "primary_question": "Across GPT-2-like and larger proxy shapes, which attention substage dominates when sequence length, compute throughput, KV memory tier, NoC hops, KV precision, and MHA/GQA/MQA sharing are varied?",
+    "include": [
+      "single-token causal decode attention substage model",
+      "QKV projection, QK score, softmax score, value mix, and attention output projection terms",
+      "KV-cache read and write traffic",
+      "local SRAM, shared SRAM, HBM, and remote-HBM memory tier bounds",
+      "NoC-hop bandwidth sensitivity for non-local KV tiers",
+      "MHA, GQA, and MQA KV sharing",
+      "8-bit and 16-bit KV-cache precision bounds",
+      "resident-weight and streaming-weight bounds"
+    ],
+    "exclude": [
+      "new RTL implementation",
+      "measured SRAM macro banking or NoC arbitration",
+      "full decoder scheduler overlap",
+      "training, batching, and prefill behavior",
+      "quality impact of KV-cache quantization"
+    ]
+  },
+  "expected_benefit": [
+    "turns the broad decoder-stage result into an attention-specific bottleneck map",
+    "shows whether the next hardware work should target KV locality, NoC bandwidth, attention compute, or score/softmax movement",
+    "keeps larger-model and longer-context scaling visible before choosing a combined producer/ranker RTL point"
+  ],
+  "risks": [
+    "memory-tier bandwidths are planning values, not measured macros",
+    "NoC contention is modeled as an effective bandwidth bound, not arbitration RTL",
+    "quality effects of KV precision and GQA/MQA are not measured in this job",
+    "stage serialization may overstate latency if future scheduler overlap hides some traffic"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_memory_v1",
+      "task_type": "l2_campaign",
+      "objective": "Estimate attention/KV memory hierarchy pressure across larger model proxies, context lengths, memory tiers, NoC hops, KV precision, and KV sharing assumptions.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_memory",
+      "cost_class": "low",
+      "comparison_role": "ranking",
+      "depends_on_item_ids": [
+        "l2_decoder_stage_breakdown_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The expected output is an attention/KV bottleneck map used to choose whether the next architecture job should measure KV memory hierarchy, NoC coupling, or attention compute datapath."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_stage_breakdown_v1/proposal.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_stage_breakdown_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_memory.py",
+    "tests/test_llm_decoder_attention_kv_memory.py",
+    "control_plane/control_plane/tests/test_l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/quality_gate.md
@@ -1,0 +1,7 @@
+# Quality Gate
+
+- The estimator must run without generated model artifacts.
+- The JSON output must include inputs, assumptions, sweep rows, and a focus summary.
+- The markdown report must expose dominant attention substage, KV byte share, KV-limited cycle share, and effective KV bandwidth.
+- The control-plane generated task must carry `decoder_attention_kv_memory` abstraction metadata and expected output paths.
+- Unit tests must cover both the estimator and L2 generator hook.

--- a/npu/eval/estimate_llm_decoder_attention_kv_memory.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_memory.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+"""Estimate decoder attention/KV memory hierarchy pressure."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _int_list(value: str) -> list[int]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated integer list")
+    parsed = [int(item) for item in items]
+    if any(item <= 0 for item in parsed):
+        raise argparse.ArgumentTypeError("all list items must be positive")
+    return parsed
+
+
+def _float_list(value: str) -> list[float]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated float list")
+    parsed = [float(item) for item in items]
+    if any(item <= 0.0 for item in parsed):
+        raise argparse.ArgumentTypeError("all list items must be positive")
+    return parsed
+
+
+def _str_list(value: str) -> list[str]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated string list")
+    return items
+
+
+def _byte_width(bits: int) -> int:
+    return max(1, math.ceil(bits / 8))
+
+
+def _ceil_div(numerator: float, denominator: float) -> int:
+    return int(math.ceil(numerator / denominator)) if numerator else 0
+
+
+def _kv_heads(*, attention_heads: int, kv_sharing: str) -> int:
+    if kv_sharing == "mha":
+        return attention_heads
+    if kv_sharing == "gqa4":
+        return max(1, math.ceil(attention_heads / 4))
+    if kv_sharing == "gqa8":
+        return max(1, math.ceil(attention_heads / 8))
+    if kv_sharing == "mqa":
+        return 1
+    raise ValueError(f"unsupported kv sharing model: {kv_sharing}")
+
+
+def _stage(
+    *,
+    name: str,
+    macs: int,
+    vector_ops: int,
+    activation_bytes: int,
+    weight_bytes: int,
+    kv_read_bytes: int,
+    kv_write_bytes: int,
+    macs_per_cycle: int,
+    vector_ops_per_cycle: int,
+    weight_bandwidth_bytes_per_cycle: float,
+    activation_bandwidth_bytes_per_cycle: float,
+    kv_bandwidth_bytes_per_cycle: float,
+    clock_ns: float,
+    charge_weights: bool,
+) -> JsonDict:
+    weight_charged = weight_bytes if charge_weights else 0
+    compute_work = macs + vector_ops
+    compute_rate = macs_per_cycle if macs >= vector_ops else vector_ops_per_cycle
+    compute_cycles = _ceil_div(compute_work, compute_rate)
+    activation_cycles = _ceil_div(activation_bytes, activation_bandwidth_bytes_per_cycle)
+    weight_cycles = _ceil_div(weight_charged, weight_bandwidth_bytes_per_cycle)
+    kv_cycles = _ceil_div(kv_read_bytes + kv_write_bytes, kv_bandwidth_bytes_per_cycle)
+    memory_cycles = max(activation_cycles, weight_cycles, kv_cycles)
+    cycles = max(compute_cycles, memory_cycles)
+    return {
+        "stage": name,
+        "macs": macs,
+        "vector_ops": vector_ops,
+        "activation_bytes": activation_bytes,
+        "weight_bytes": weight_bytes,
+        "charged_weight_bytes": weight_charged,
+        "kv_read_bytes": kv_read_bytes,
+        "kv_write_bytes": kv_write_bytes,
+        "charged_bytes": activation_bytes + weight_charged + kv_read_bytes + kv_write_bytes,
+        "compute_cycles": compute_cycles,
+        "activation_cycles": activation_cycles,
+        "weight_cycles": weight_cycles,
+        "kv_cycles": kv_cycles,
+        "memory_cycles": memory_cycles,
+        "cycles": cycles,
+        "latency_us": round(cycles * clock_ns / 1000.0, 6),
+        "limiter": "memory" if memory_cycles >= compute_cycles else "compute",
+    }
+
+
+def _shape_rows(
+    *,
+    label: str,
+    layers: int,
+    hidden_size: int,
+    attention_heads: int,
+    sequence_length: int,
+    kv_sharing: str,
+    kv_memory_tier: str,
+    kv_bandwidth_bytes_per_cycle: float,
+    noc_bandwidth_bytes_per_cycle: float,
+    noc_hops: int,
+    macs_per_cycle: int,
+    vector_ops_per_cycle: int,
+    weight_bandwidth_bytes_per_cycle: float,
+    activation_bandwidth_bytes_per_cycle: float,
+    clock_ns: float,
+    weight_bits: int,
+    activation_bits: int,
+    kv_bits: int,
+    score_bits: int,
+    weight_residency: str,
+) -> JsonDict:
+    h = hidden_size
+    heads = attention_heads
+    head_dim = h // heads
+    kv_heads = _kv_heads(attention_heads=heads, kv_sharing=kv_sharing)
+    kv_width = kv_heads * head_dim
+    s = sequence_length
+    charge_weights = weight_residency == "streaming_weights"
+
+    weight_b = _byte_width(weight_bits)
+    act_b = _byte_width(activation_bits)
+    kv_b = _byte_width(kv_bits)
+    score_b = _byte_width(score_bits)
+
+    effective_kv_bw = kv_bandwidth_bytes_per_cycle
+    if noc_hops > 0:
+        effective_kv_bw = min(effective_kv_bw, noc_bandwidth_bytes_per_cycle / noc_hops)
+
+    q_proj_macs = h * h
+    kv_proj_macs = 2 * h * kv_width
+    qkv_weight_bytes = (q_proj_macs + kv_proj_macs) * weight_b
+    qkv_activation_bytes = (h + h + (2 * kv_width)) * act_b
+
+    kv_read_bytes = 2 * s * kv_width * kv_b
+    score_bytes = heads * s * score_b
+    stages = [
+        _stage(
+            name="qkv_projection",
+            macs=q_proj_macs + kv_proj_macs,
+            vector_ops=0,
+            activation_bytes=qkv_activation_bytes,
+            weight_bytes=qkv_weight_bytes,
+            kv_read_bytes=0,
+            kv_write_bytes=0,
+            macs_per_cycle=macs_per_cycle,
+            vector_ops_per_cycle=vector_ops_per_cycle,
+            weight_bandwidth_bytes_per_cycle=weight_bandwidth_bytes_per_cycle,
+            activation_bandwidth_bytes_per_cycle=activation_bandwidth_bytes_per_cycle,
+            kv_bandwidth_bytes_per_cycle=effective_kv_bw,
+            clock_ns=clock_ns,
+            charge_weights=charge_weights,
+        ),
+        _stage(
+            name="kv_cache_write",
+            macs=0,
+            vector_ops=0,
+            activation_bytes=0,
+            weight_bytes=0,
+            kv_read_bytes=0,
+            kv_write_bytes=2 * kv_width * kv_b,
+            macs_per_cycle=macs_per_cycle,
+            vector_ops_per_cycle=vector_ops_per_cycle,
+            weight_bandwidth_bytes_per_cycle=weight_bandwidth_bytes_per_cycle,
+            activation_bandwidth_bytes_per_cycle=activation_bandwidth_bytes_per_cycle,
+            kv_bandwidth_bytes_per_cycle=effective_kv_bw,
+            clock_ns=clock_ns,
+            charge_weights=charge_weights,
+        ),
+        _stage(
+            name="qk_score",
+            macs=s * h,
+            vector_ops=0,
+            activation_bytes=h * act_b,
+            weight_bytes=0,
+            kv_read_bytes=s * kv_width * kv_b,
+            kv_write_bytes=score_bytes,
+            macs_per_cycle=macs_per_cycle,
+            vector_ops_per_cycle=vector_ops_per_cycle,
+            weight_bandwidth_bytes_per_cycle=weight_bandwidth_bytes_per_cycle,
+            activation_bandwidth_bytes_per_cycle=activation_bandwidth_bytes_per_cycle,
+            kv_bandwidth_bytes_per_cycle=effective_kv_bw,
+            clock_ns=clock_ns,
+            charge_weights=charge_weights,
+        ),
+        _stage(
+            name="softmax_scores",
+            macs=0,
+            vector_ops=5 * heads * s,
+            activation_bytes=2 * score_bytes,
+            weight_bytes=0,
+            kv_read_bytes=0,
+            kv_write_bytes=0,
+            macs_per_cycle=macs_per_cycle,
+            vector_ops_per_cycle=vector_ops_per_cycle,
+            weight_bandwidth_bytes_per_cycle=weight_bandwidth_bytes_per_cycle,
+            activation_bandwidth_bytes_per_cycle=activation_bandwidth_bytes_per_cycle,
+            kv_bandwidth_bytes_per_cycle=effective_kv_bw,
+            clock_ns=clock_ns,
+            charge_weights=charge_weights,
+        ),
+        _stage(
+            name="value_mix",
+            macs=s * h,
+            vector_ops=0,
+            activation_bytes=score_bytes + h * act_b,
+            weight_bytes=0,
+            kv_read_bytes=s * kv_width * kv_b,
+            kv_write_bytes=0,
+            macs_per_cycle=macs_per_cycle,
+            vector_ops_per_cycle=vector_ops_per_cycle,
+            weight_bandwidth_bytes_per_cycle=weight_bandwidth_bytes_per_cycle,
+            activation_bandwidth_bytes_per_cycle=activation_bandwidth_bytes_per_cycle,
+            kv_bandwidth_bytes_per_cycle=effective_kv_bw,
+            clock_ns=clock_ns,
+            charge_weights=charge_weights,
+        ),
+        _stage(
+            name="attention_output_projection",
+            macs=h * h,
+            vector_ops=0,
+            activation_bytes=2 * h * act_b,
+            weight_bytes=h * h * weight_b,
+            kv_read_bytes=0,
+            kv_write_bytes=0,
+            macs_per_cycle=macs_per_cycle,
+            vector_ops_per_cycle=vector_ops_per_cycle,
+            weight_bandwidth_bytes_per_cycle=weight_bandwidth_bytes_per_cycle,
+            activation_bandwidth_bytes_per_cycle=activation_bandwidth_bytes_per_cycle,
+            kv_bandwidth_bytes_per_cycle=effective_kv_bw,
+            clock_ns=clock_ns,
+            charge_weights=charge_weights,
+        ),
+    ]
+    for stage in stages:
+        for key in (
+            "macs",
+            "vector_ops",
+            "activation_bytes",
+            "weight_bytes",
+            "charged_weight_bytes",
+            "kv_read_bytes",
+            "kv_write_bytes",
+            "charged_bytes",
+            "compute_cycles",
+            "activation_cycles",
+            "weight_cycles",
+            "kv_cycles",
+            "memory_cycles",
+            "cycles",
+        ):
+            stage[key] *= layers
+        stage["latency_us"] = round(stage["cycles"] * clock_ns / 1000.0, 6)
+
+    total_cycles = sum(stage["cycles"] for stage in stages)
+    total_bytes = sum(stage["charged_bytes"] for stage in stages)
+    total_macs = sum(stage["macs"] for stage in stages)
+    total_kv_read = sum(stage["kv_read_bytes"] for stage in stages)
+    for stage in stages:
+        stage["cycle_share"] = round(stage["cycles"] / total_cycles, 6) if total_cycles else 0.0
+        stage["byte_share"] = round(stage["charged_bytes"] / total_bytes, 6) if total_bytes else 0.0
+    dominant = max(stages, key=lambda row: row["cycles"])
+    kv_cycle_share = sum(stage["cycles"] for stage in stages if stage["kv_cycles"] >= stage["compute_cycles"])
+    return {
+        "label": label,
+        "layers": layers,
+        "hidden_size": hidden_size,
+        "attention_heads": attention_heads,
+        "head_dim": head_dim,
+        "sequence_length": sequence_length,
+        "kv_sharing": kv_sharing,
+        "kv_heads": kv_heads,
+        "kv_bits": kv_bits,
+        "kv_memory_tier": kv_memory_tier,
+        "kv_bandwidth_bytes_per_cycle": kv_bandwidth_bytes_per_cycle,
+        "noc_bandwidth_bytes_per_cycle": noc_bandwidth_bytes_per_cycle,
+        "noc_hops": noc_hops,
+        "effective_kv_bandwidth_bytes_per_cycle": round(effective_kv_bw, 6),
+        "macs_per_cycle": macs_per_cycle,
+        "vector_ops_per_cycle": vector_ops_per_cycle,
+        "weight_residency": weight_residency,
+        "total_cycles": total_cycles,
+        "total_latency_us": round(total_cycles * clock_ns / 1000.0, 6),
+        "total_macs": total_macs,
+        "total_charged_bytes": total_bytes,
+        "total_kv_read_bytes": total_kv_read,
+        "kv_read_byte_share": round(total_kv_read / total_bytes, 6) if total_bytes else 0.0,
+        "attention_arithmetic_intensity_macs_per_byte": round(total_macs / total_bytes, 6) if total_bytes else 0.0,
+        "kv_limited_cycle_share": round(kv_cycle_share / total_cycles, 6) if total_cycles else 0.0,
+        "dominant_substage": dominant["stage"],
+        "dominant_substage_share": dominant["cycle_share"],
+        "stages": stages,
+    }
+
+
+def build_report(
+    *,
+    sequence_length_list: list[int],
+    macs_per_cycle_list: list[int],
+    kv_memory_tier_list: list[str],
+    kv_sharing_list: list[str],
+    kv_bits_list: list[int],
+    noc_hops_list: list[int],
+    clock_ns: float,
+    weight_bits: int,
+    activation_bits: int,
+    score_bits: int,
+    vector_ops_per_cycle: int,
+    weight_bandwidth_bytes_per_cycle: float,
+    activation_bandwidth_bytes_per_cycle: float,
+    noc_bandwidth_bytes_per_cycle: float,
+) -> JsonDict:
+    shapes = [
+        {"label": "gpt2_small", "layers": 12, "hidden_size": 768, "attention_heads": 12},
+        {"label": "gpt2_medium_proxy", "layers": 24, "hidden_size": 1024, "attention_heads": 16},
+        {"label": "llama7b_proxy", "layers": 32, "hidden_size": 4096, "attention_heads": 32},
+        {"label": "large_context_proxy", "layers": 40, "hidden_size": 5120, "attention_heads": 40},
+    ]
+    tier_bandwidths = {
+        "local_sram": 1024.0,
+        "shared_sram": 256.0,
+        "hbm": 64.0,
+        "remote_hbm": 32.0,
+    }
+    rows: list[JsonDict] = []
+    for shape in shapes:
+        for sequence_length in sequence_length_list:
+            for macs_per_cycle in macs_per_cycle_list:
+                for kv_memory_tier in kv_memory_tier_list:
+                    if kv_memory_tier not in tier_bandwidths:
+                        raise ValueError(f"unsupported kv memory tier: {kv_memory_tier}")
+                    for kv_sharing in kv_sharing_list:
+                        for kv_bits in kv_bits_list:
+                            for noc_hops in noc_hops_list:
+                                if kv_memory_tier == "local_sram" and noc_hops != 0:
+                                    continue
+                                if kv_memory_tier != "local_sram" and noc_hops == 0:
+                                    continue
+                                for weight_residency in ["resident_weights", "streaming_weights"]:
+                                    rows.append(
+                                        _shape_rows(
+                                            label=shape["label"],
+                                            layers=shape["layers"],
+                                            hidden_size=shape["hidden_size"],
+                                            attention_heads=shape["attention_heads"],
+                                            sequence_length=sequence_length,
+                                            kv_sharing=kv_sharing,
+                                            kv_memory_tier=kv_memory_tier,
+                                            kv_bandwidth_bytes_per_cycle=tier_bandwidths[kv_memory_tier],
+                                            noc_bandwidth_bytes_per_cycle=noc_bandwidth_bytes_per_cycle,
+                                            noc_hops=noc_hops,
+                                            macs_per_cycle=macs_per_cycle,
+                                            vector_ops_per_cycle=vector_ops_per_cycle,
+                                            weight_bandwidth_bytes_per_cycle=weight_bandwidth_bytes_per_cycle,
+                                            activation_bandwidth_bytes_per_cycle=activation_bandwidth_bytes_per_cycle,
+                                            clock_ns=clock_ns,
+                                            weight_bits=weight_bits,
+                                            activation_bits=activation_bits,
+                                            kv_bits=kv_bits,
+                                            score_bits=score_bits,
+                                            weight_residency=weight_residency,
+                                        )
+                                    )
+
+    focus_rows = [
+        row
+        for row in rows
+        if row["macs_per_cycle"] == max(macs_per_cycle_list)
+        and row["sequence_length"] in {min(sequence_length_list), max(sequence_length_list)}
+        and row["kv_bits"] == min(kv_bits_list)
+        and row["weight_residency"] == "resident_weights"
+    ]
+    return {
+        "version": 0.1,
+        "model": "llm_decoder_attention_kv_memory_v1",
+        "inputs": {
+            "sequence_length_list": sequence_length_list,
+            "macs_per_cycle_list": macs_per_cycle_list,
+            "kv_memory_tier_list": kv_memory_tier_list,
+            "kv_sharing_list": kv_sharing_list,
+            "kv_bits_list": kv_bits_list,
+            "noc_hops_list": noc_hops_list,
+            "clock_ns": clock_ns,
+            "weight_bits": weight_bits,
+            "activation_bits": activation_bits,
+            "score_bits": score_bits,
+            "vector_ops_per_cycle": vector_ops_per_cycle,
+            "weight_bandwidth_bytes_per_cycle": weight_bandwidth_bytes_per_cycle,
+            "activation_bandwidth_bytes_per_cycle": activation_bandwidth_bytes_per_cycle,
+            "noc_bandwidth_bytes_per_cycle": noc_bandwidth_bytes_per_cycle,
+        },
+        "assumptions": [
+            "This is an analytical single-token decode attention model, not measured RTL.",
+            "Q/K/V projection, QK score, softmax, value mix, and attention output projection are separated.",
+            "KV read traffic is charged to QK score and value mix; KV write traffic is charged once per token.",
+            "KV memory tier bandwidths are planning values: local_sram=1024, shared_sram=256, hbm=64, remote_hbm=32 bytes/cycle.",
+            "NoC contention is represented by effective KV bandwidth min(tier_bandwidth, noc_bandwidth / hops) for non-local tiers.",
+            "GQA/MQA reduce KV-cache width but not query/output projection width.",
+            "streaming_weights charges attention projection weights each token; resident_weights exposes KV and compute pressure.",
+        ],
+        "attention_kv_sweep": rows,
+        "focus_summary": sorted(
+            [
+                {
+                    "label": row["label"],
+                    "sequence_length": row["sequence_length"],
+                    "kv_memory_tier": row["kv_memory_tier"],
+                    "kv_sharing": row["kv_sharing"],
+                    "kv_bits": row["kv_bits"],
+                    "noc_hops": row["noc_hops"],
+                    "total_latency_us": row["total_latency_us"],
+                    "dominant_substage": row["dominant_substage"],
+                    "dominant_substage_share": row["dominant_substage_share"],
+                    "kv_read_byte_share": row["kv_read_byte_share"],
+                    "kv_limited_cycle_share": row["kv_limited_cycle_share"],
+                    "effective_kv_bandwidth_bytes_per_cycle": row["effective_kv_bandwidth_bytes_per_cycle"],
+                    "arithmetic_intensity": row["attention_arithmetic_intensity_macs_per_byte"],
+                }
+                for row in focus_rows
+            ],
+            key=lambda row: (
+                row["label"],
+                row["sequence_length"],
+                row["kv_memory_tier"],
+                row["kv_sharing"],
+                row["noc_hops"],
+            ),
+        ),
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Attention/KV Memory Breakdown",
+        "",
+        f"- model: `{payload['model']}`",
+        "",
+        "## Focus Summary",
+        "",
+        "| shape | seq | tier | share | bits | hops | total_us | dominant | dom_share | kv_byte_share | kv_cycle_share | eff_kv_B/cyc | intensity |",
+        "|---|---:|---|---|---:|---:|---:|---|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["focus_summary"]:
+        lines.append(
+            "| {label} | {seq} | {tier} | {share} | {bits} | {hops} | {total} | {dom} | {dom_share} | {kv_bytes} | {kv_cycles} | {eff_bw} | {intensity} |".format(
+                label=row["label"],
+                seq=row["sequence_length"],
+                tier=row["kv_memory_tier"],
+                share=row["kv_sharing"],
+                bits=row["kv_bits"],
+                hops=row["noc_hops"],
+                total=row["total_latency_us"],
+                dom=row["dominant_substage"],
+                dom_share=row["dominant_substage_share"],
+                kv_bytes=row["kv_read_byte_share"],
+                kv_cycles=row["kv_limited_cycle_share"],
+                eff_bw=row["effective_kv_bandwidth_bytes_per_cycle"],
+                intensity=row["arithmetic_intensity"],
+            )
+        )
+
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Estimate LLM decoder attention/KV memory hierarchy pressure")
+    ap.add_argument("--sequence-length-list", type=_int_list, default=[128, 512, 2048, 8192, 32768])
+    ap.add_argument("--macs-per-cycle-list", type=_int_list, default=[8192, 32768, 131072])
+    ap.add_argument("--kv-memory-tier-list", type=_str_list, default=["local_sram", "shared_sram", "hbm", "remote_hbm"])
+    ap.add_argument("--kv-sharing-list", type=_str_list, default=["mha", "gqa4", "mqa"])
+    ap.add_argument("--kv-bits-list", type=_int_list, default=[8, 16])
+    ap.add_argument("--noc-hops-list", type=_int_list, default=[1, 2, 4])
+    ap.add_argument("--clock-ns", type=float, default=1.0)
+    ap.add_argument("--weight-bits", type=int, default=16)
+    ap.add_argument("--activation-bits", type=int, default=16)
+    ap.add_argument("--score-bits", type=int, default=16)
+    ap.add_argument("--vector-ops-per-cycle", type=int, default=32768)
+    ap.add_argument("--weight-bandwidth-bytes-per-cycle", type=float, default=256.0)
+    ap.add_argument("--activation-bandwidth-bytes-per-cycle", type=float, default=512.0)
+    ap.add_argument("--noc-bandwidth-bytes-per-cycle", type=float, default=256.0)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    payload = build_report(
+        sequence_length_list=args.sequence_length_list,
+        macs_per_cycle_list=args.macs_per_cycle_list,
+        kv_memory_tier_list=args.kv_memory_tier_list,
+        kv_sharing_list=args.kv_sharing_list,
+        kv_bits_list=args.kv_bits_list,
+        noc_hops_list=[0, *args.noc_hops_list],
+        clock_ns=args.clock_ns,
+        weight_bits=args.weight_bits,
+        activation_bits=args.activation_bits,
+        score_bits=args.score_bits,
+        vector_ops_per_cycle=args.vector_ops_per_cycle,
+        weight_bandwidth_bytes_per_cycle=args.weight_bandwidth_bytes_per_cycle,
+        activation_bandwidth_bytes_per_cycle=args.activation_bandwidth_bytes_per_cycle,
+        noc_bandwidth_bytes_per_cycle=args.noc_bandwidth_bytes_per_cycle,
+    )
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    _write_markdown(out_md, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_attention_kv_memory.py
+++ b/tests/test_llm_decoder_attention_kv_memory.py
@@ -1,0 +1,74 @@
+from npu.eval.estimate_llm_decoder_attention_kv_memory import build_report
+
+
+def test_attention_kv_memory_reports_tiers_and_sharing() -> None:
+    report = build_report(
+        sequence_length_list=[128, 8192],
+        macs_per_cycle_list=[32768],
+        kv_memory_tier_list=["local_sram", "hbm"],
+        kv_sharing_list=["mha", "mqa"],
+        kv_bits_list=[8],
+        noc_hops_list=[0, 2],
+        clock_ns=1.0,
+        weight_bits=16,
+        activation_bits=16,
+        score_bits=16,
+        vector_ops_per_cycle=32768,
+        weight_bandwidth_bytes_per_cycle=256.0,
+        activation_bandwidth_bytes_per_cycle=512.0,
+        noc_bandwidth_bytes_per_cycle=256.0,
+    )
+
+    rows = report["attention_kv_sweep"]
+    assert report["model"] == "llm_decoder_attention_kv_memory_v1"
+    assert {row["kv_memory_tier"] for row in rows} == {"local_sram", "hbm"}
+    assert {row["kv_sharing"] for row in rows} == {"mha", "mqa"}
+    assert {stage["stage"] for stage in rows[0]["stages"]} == {
+        "qkv_projection",
+        "kv_cache_write",
+        "qk_score",
+        "softmax_scores",
+        "value_mix",
+        "attention_output_projection",
+    }
+
+
+def test_attention_kv_memory_exposes_long_context_kv_pressure() -> None:
+    report = build_report(
+        sequence_length_list=[128, 8192],
+        macs_per_cycle_list=[131072],
+        kv_memory_tier_list=["local_sram", "remote_hbm"],
+        kv_sharing_list=["mha"],
+        kv_bits_list=[16],
+        noc_hops_list=[0, 4],
+        clock_ns=1.0,
+        weight_bits=16,
+        activation_bits=16,
+        score_bits=16,
+        vector_ops_per_cycle=32768,
+        weight_bandwidth_bytes_per_cycle=256.0,
+        activation_bandwidth_bytes_per_cycle=512.0,
+        noc_bandwidth_bytes_per_cycle=128.0,
+    )
+
+    local = next(
+        row
+        for row in report["attention_kv_sweep"]
+        if row["label"] == "llama7b_proxy"
+        and row["sequence_length"] == 8192
+        and row["kv_memory_tier"] == "local_sram"
+        and row["weight_residency"] == "resident_weights"
+    )
+    remote = next(
+        row
+        for row in report["attention_kv_sweep"]
+        if row["label"] == "llama7b_proxy"
+        and row["sequence_length"] == 8192
+        and row["kv_memory_tier"] == "remote_hbm"
+        and row["weight_residency"] == "resident_weights"
+    )
+
+    assert remote["effective_kv_bandwidth_bytes_per_cycle"] < local["effective_kv_bandwidth_bytes_per_cycle"]
+    assert remote["total_latency_us"] > local["total_latency_us"]
+    assert remote["kv_read_byte_share"] > 0.5
+    assert remote["dominant_substage"] in {"qk_score", "value_mix"}


### PR DESCRIPTION
## Summary
- add an analytical decoder attention/KV memory hierarchy estimator
- add the `decoder_attention_kv_memory` L2 control-plane hook and tests
- add proposal docs for `l2_decoder_attention_kv_memory_v1`

## Validation
- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_memory.py control_plane/control_plane/services/l2_task_generator.py`
- `./control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_attention_kv_memory.py tests/test_llm_decoder_stage_breakdown.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence`
- local estimator smoke generated JSON and markdown under `/tmp`

## Notes
This is a low-cost planning model, not measured RTL PPA. It is intended to choose the next measured architecture point around KV locality, NoC coupling, or attention compute.