### PR TITLE
[codex] Compact attention KV memory evidence output

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_v1/quality_gate.md
@@ -1,7 +1,8 @@
 # Quality Gate
 
 - The estimator must run without generated model artifacts.
-- The JSON output must include inputs, assumptions, sweep rows, and a focus summary.
+- The committed JSON output must include inputs, assumptions, compact sweep rows, and a focus summary.
+- Full per-substage sweep detail must not be committed by default; it may only be written through an explicit optional detail path.
 - The markdown report must expose dominant attention substage, KV byte share, KV-limited cycle share, and effective KV bandwidth.
 - The control-plane generated task must carry `decoder_attention_kv_memory` abstraction metadata and expected output paths.
 - Unit tests must cover both the estimator and L2 generator hook.

--- a/npu/eval/estimate_llm_decoder_attention_kv_memory.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_memory.py
@@ -312,6 +312,33 @@ def _shape_rows(
     }
 
 
+def _compact_row(row: JsonDict) -> JsonDict:
+    return {
+        "label": row["label"],
+        "layers": row["layers"],
+        "hidden_size": row["hidden_size"],
+        "attention_heads": row["attention_heads"],
+        "sequence_length": row["sequence_length"],
+        "kv_sharing": row["kv_sharing"],
+        "kv_heads": row["kv_heads"],
+        "kv_bits": row["kv_bits"],
+        "kv_memory_tier": row["kv_memory_tier"],
+        "noc_hops": row["noc_hops"],
+        "effective_kv_bandwidth_bytes_per_cycle": row["effective_kv_bandwidth_bytes_per_cycle"],
+        "macs_per_cycle": row["macs_per_cycle"],
+        "weight_residency": row["weight_residency"],
+        "total_latency_us": row["total_latency_us"],
+        "total_macs": row["total_macs"],
+        "total_charged_bytes": row["total_charged_bytes"],
+        "total_kv_read_bytes": row["total_kv_read_bytes"],
+        "kv_read_byte_share": row["kv_read_byte_share"],
+        "kv_limited_cycle_share": row["kv_limited_cycle_share"],
+        "attention_arithmetic_intensity_macs_per_byte": row["attention_arithmetic_intensity_macs_per_byte"],
+        "dominant_substage": row["dominant_substage"],
+        "dominant_substage_share": row["dominant_substage_share"],
+    }
+
+
 def build_report(
     *,
     sequence_length_list: list[int],
@@ -328,6 +355,7 @@ def build_report(
     weight_bandwidth_bytes_per_cycle: float,
     activation_bandwidth_bytes_per_cycle: float,
     noc_bandwidth_bytes_per_cycle: float,
+    include_detail: bool = False,
 ) -> JsonDict:
     shapes = [
         {"label": "gpt2_small", "layers": 12, "hidden_size": 768, "attention_heads": 12},
@@ -389,7 +417,15 @@ def build_report(
         and row["kv_bits"] == min(kv_bits_list)
         and row["weight_residency"] == "resident_weights"
     ]
-    return {
+    compact_focus_rows = [_compact_row(row) for row in focus_rows]
+    dominant_substage_counts: dict[str, int] = {}
+    limiter_counts: dict[str, int] = {}
+    for row in rows:
+        dominant_substage_counts[row["dominant_substage"]] = dominant_substage_counts.get(row["dominant_substage"], 0) + 1
+        for stage in row["stages"]:
+            limiter_key = f"{stage['stage']}:{stage['limiter']}"
+            limiter_counts[limiter_key] = limiter_counts.get(limiter_key, 0) + 1
+    payload = {
         "version": 0.1,
         "model": "llm_decoder_attention_kv_memory_v1",
         "inputs": {
@@ -417,7 +453,27 @@ def build_report(
             "GQA/MQA reduce KV-cache width but not query/output projection width.",
             "streaming_weights charges attention projection weights each token; resident_weights exposes KV and compute pressure.",
         ],
-        "attention_kv_sweep": rows,
+        "detail_policy": {
+            "attention_kv_sweep": "compact scalar rows for the decision-focused slice only; full sweep rows are summarized by counts",
+            "full_detail": "available only through the optional --detail-out CLI path",
+        },
+        "sweep_summary": {
+            "generated_row_count": len(rows),
+            "committed_compact_row_count": len(compact_focus_rows),
+            "omitted_full_sweep_row_count": len(rows) - len(compact_focus_rows),
+            "dominant_substage_counts": dict(sorted(dominant_substage_counts.items())),
+            "stage_limiter_counts": dict(sorted(limiter_counts.items())),
+        },
+        "attention_kv_sweep": sorted(
+            compact_focus_rows,
+            key=lambda row: (
+                row["label"],
+                row["sequence_length"],
+                row["kv_memory_tier"],
+                row["kv_sharing"],
+                row["noc_hops"],
+            ),
+        ),
         "focus_summary": sorted(
             [
                 {
@@ -446,6 +502,9 @@ def build_report(
             ),
         ),
     }
+    if include_detail:
+        payload["attention_kv_sweep_detail"] = rows
+    return payload
 
 
 def _write_markdown(path: Path, payload: JsonDict) -> None:
@@ -502,6 +561,7 @@ def main() -> int:
     ap.add_argument("--noc-bandwidth-bytes-per-cycle", type=float, default=256.0)
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
+    ap.add_argument("--detail-out")
     args = ap.parse_args()
 
     payload = build_report(
@@ -519,11 +579,20 @@ def main() -> int:
         weight_bandwidth_bytes_per_cycle=args.weight_bandwidth_bytes_per_cycle,
         activation_bandwidth_bytes_per_cycle=args.activation_bandwidth_bytes_per_cycle,
         noc_bandwidth_bytes_per_cycle=args.noc_bandwidth_bytes_per_cycle,
+        include_detail=bool(args.detail_out),
     )
 
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    committed_payload = dict(payload)
+    detail_rows = committed_payload.pop("attention_kv_sweep_detail", None)
+    out.write_text(json.dumps(committed_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.detail_out:
+        detail_out = Path(args.detail_out)
+        detail_out.parent.mkdir(parents=True, exist_ok=True)
+        detail_payload = dict(payload)
+        detail_payload["attention_kv_sweep_detail"] = detail_rows or []
+        detail_out.write_text(json.dumps(detail_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     out_md = Path(args.out_md)
     out_md.parent.mkdir(parents=True, exist_ok=True)
     _write_markdown(out_md, payload)

--- a/tests/test_llm_decoder_attention_kv_memory.py
+++ b/tests/test_llm_decoder_attention_kv_memory.py
@@ -23,7 +23,8 @@ def test_attention_kv_memory_reports_tiers_and_sharing() -> None:
     assert report["model"] == "llm_decoder_attention_kv_memory_v1"
     assert {row["kv_memory_tier"] for row in rows} == {"local_sram", "hbm"}
     assert {row["kv_sharing"] for row in rows} == {"mha", "mqa"}
-    assert {stage["stage"] for stage in rows[0]["stages"]} == {
+    assert "stages" not in rows[0]
+    assert rows[0]["dominant_substage"] in {
         "qkv_projection",
         "kv_cache_write",
         "qk_score",
@@ -72,3 +73,44 @@ def test_attention_kv_memory_exposes_long_context_kv_pressure() -> None:
     assert remote["total_latency_us"] > local["total_latency_us"]
     assert remote["kv_read_byte_share"] > 0.5
     assert remote["dominant_substage"] in {"qk_score", "value_mix"}
+
+
+def test_attention_kv_memory_detail_rows_are_opt_in() -> None:
+    compact = build_report(
+        sequence_length_list=[128],
+        macs_per_cycle_list=[32768],
+        kv_memory_tier_list=["local_sram"],
+        kv_sharing_list=["mha"],
+        kv_bits_list=[8],
+        noc_hops_list=[0],
+        clock_ns=1.0,
+        weight_bits=16,
+        activation_bits=16,
+        score_bits=16,
+        vector_ops_per_cycle=32768,
+        weight_bandwidth_bytes_per_cycle=256.0,
+        activation_bandwidth_bytes_per_cycle=512.0,
+        noc_bandwidth_bytes_per_cycle=256.0,
+    )
+    detailed = build_report(
+        sequence_length_list=[128],
+        macs_per_cycle_list=[32768],
+        kv_memory_tier_list=["local_sram"],
+        kv_sharing_list=["mha"],
+        kv_bits_list=[8],
+        noc_hops_list=[0],
+        clock_ns=1.0,
+        weight_bits=16,
+        activation_bits=16,
+        score_bits=16,
+        vector_ops_per_cycle=32768,
+        weight_bandwidth_bytes_per_cycle=256.0,
+        activation_bandwidth_bytes_per_cycle=512.0,
+        noc_bandwidth_bytes_per_cycle=256.0,
+        include_detail=True,
+    )
+
+    assert "attention_kv_sweep_detail" not in compact
+    assert "attention_kv_sweep_detail" in detailed
+    assert "stages" not in compact["attention_kv_sweep"][0]
+    assert "stages" in detailed["attention_kv_sweep_detail"][0]


### PR DESCRIPTION
## Summary
- make the committed attention/KV estimator JSON compact by default
- keep the decision-focused slice plus aggregate sweep counts instead of per-substage detail for every sweep row
- add optional `--detail-out` for explicit full-detail output outside the default committed artifact path
- update tests and proposal quality gate wording to make this artifact contract explicit

## Validation
- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_memory.py`
- `./control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_attention_kv_memory.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence`
- full configured estimator smoke: default JSON is `303883` bytes and contains 240 compact decision rows, down from the prior ~34.9 MB full-detail output
- detail-output smoke confirmed `--out` stays compact while `--detail-out` includes full rows

## Impact
This fixes the cause of PR #456 committing a large full-sweep JSON artifact. The evaluator should rerun `l2_decoder_attention_kv_memory_v1` after this lands.