### PR TITLE
[codex] Include attention KV evidence in submissions

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -23,6 +23,12 @@ _ALLOWED_RUNS_SUFFIXES = {
     "/objective_sweep.md",
 }
 
+_ALLOWED_DATASET_PREFIXES = {
+    "decoder_attention_kv_memory__",
+}
+
+_ALLOWED_DATASET_SUFFIXES = {".json", ".md"}
+
 
 def _normalize_rel_path(path_text: str) -> str:
     path = PurePosixPath(path_text.strip())
@@ -51,5 +57,11 @@ def is_transportable_expected_output(path_text: str) -> bool:
     if rel_path.startswith("runs/campaigns/"):
         name = PurePosixPath(rel_path).name
         if name == "campaign.json" or (name.startswith("campaign__") and name.endswith(".json")):
+            return True
+    if rel_path.startswith("runs/datasets/"):
+        path = PurePosixPath(rel_path)
+        if path.suffix in _ALLOWED_DATASET_SUFFIXES and any(
+            path.name.startswith(prefix) for prefix in _ALLOWED_DATASET_PREFIXES
+        ):
             return True
     return any(rel_path.endswith(suffix) for suffix in _ALLOWED_RUNS_SUFFIXES)

--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -436,6 +436,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("bitwidth_boundary_out", "bitwidth_boundary_report"),
     ("quantization_outline_out", "quantization_outline_report"),
     ("cost_proxy_out", "cost_proxy_report"),
+    ("attention_kv_memory_out", "attention_kv_memory_report"),
 )
 
 

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -11,3 +11,14 @@ def test_transportable_expected_output_rejects_campaign_artifacts_dir() -> None:
     assert not is_transportable_expected_output(
         "runs/campaigns/npu/demo_campaign__l2_demo_campaign/artifacts/mapper/x/schedule.yml"
     )
+
+
+def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> None:
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_memory__l2_decoder_attention_kv_memory_v1.json"
+    )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_memory__l2_decoder_attention_kv_memory_v1.md"
+    )

--- a/control_plane/control_plane/tests/test_artifact_stage.py
+++ b/control_plane/control_plane/tests/test_artifact_stage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from control_plane.workers.artifact_stage import collect_linked_results_artifacts
+from control_plane.workers.artifact_stage import collect_expected_output_artifacts, collect_linked_results_artifacts
 
 
 def _write_json(path: Path, doc: dict) -> None:
@@ -77,3 +77,28 @@ def test_collect_linked_results_artifacts_includes_decoder_sweep_sidecars(tmp_pa
     ]
     assert all(artifact.kind == "supporting_output" for artifact in artifacts)
     assert all(artifact.metadata["transport_policy"] == "inline_text_supporting" for artifact in artifacts)
+
+
+def test_collect_expected_output_artifacts_includes_attention_kv_dataset(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    json_rel = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_memory__l2_decoder_attention_kv_memory_v1.json"
+    )
+    report_rel = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_memory__l2_decoder_attention_kv_memory_v1.md"
+    )
+    _write_json(repo_root / json_rel, {"sweep_summary": {"generated_rows": 7200, "compact_rows": 240}})
+    (repo_root / report_rel).write_text("# attention kv\n", encoding="utf-8")
+
+    artifacts = collect_expected_output_artifacts(
+        repo_root=str(repo_root),
+        expected_outputs=[json_rel, report_rel],
+    )
+
+    assert [artifact.path for artifact in artifacts] == [json_rel, report_rel]
+    assert all(artifact.kind == "expected_output" for artifact in artifacts)
+    assert all(artifact.metadata["transport_policy"] == "inline_text_evidence" for artifact in artifacts)
+    assert all("inline_utf8" in artifact.metadata for artifact in artifacts)

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -893,6 +893,104 @@ def test_consume_l2_result_frontier_decoder_quality_uses_decoder_json_evidence()
             assert "baseline_summary_csv" not in decision_payload["source_refs"]
 
 
+def test_consume_l2_result_frontier_attention_kv_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "developer_loop" / "prop_l2_attention_kv_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_kv_v1",
+                        "kind": "architecture",
+                        "title": "Attention KV memory bottleneck",
+                        "direct_comparison": {
+                            "primary_question": "Which decoder attention substage dominates?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_memory__l2_decoder_attention_kv_memory_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_memory__l2_decoder_attention_kv_memory_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 0.1,
+                        "diagnosis": {
+                            "decision": "attention_kv_bottleneck_recorded",
+                            "recommended_next_step": "measure KV memory hierarchy",
+                        },
+                        "sweep_summary": {
+                            "generated_rows": 7200,
+                            "compact_rows": 240,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# attention kv\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_kv",
+                campaign_dir_rel="runs/campaigns/npu/attention_kv_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/developer_loop/prop_l2_attention_kv_v1",
+                comparison={"role": "ranking"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use attention/KV bottleneck evidence for next architecture selection.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_kv_memory",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_kv_memory_out": evidence_rel,
+                    "attention_kv_memory_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "attention_kv_bottleneck_recorded"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert decision_payload["evaluation_record"]["abstraction_layer"] == "decoder_attention_kv_memory"
+            assert decision_payload["source_refs"]["decoder_attention_kv_memory_out"] == evidence_rel
+            assert decision_payload["source_refs"]["decoder_attention_kv_memory_report"] == report_rel
+
+
 def test_consume_l2_result_resolves_prior_art_report_as_baseline() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- allow compact decoder attention/KV JSON and Markdown outputs to be transported from evaluator runs
- include `attention_kv_memory_out` and `attention_kv_memory_report` in L2 decision source refs
- add focused tests for transport, artifact staging, and L2 decision proposal refs

## Validation
- `./control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_artifact_stage.py control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_kv_uses_decoder_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_decoder_quality_uses_decoder_json_evidence`