### PR TITLE
[codex] Auto-reconcile evaluator source revision

### DIFF
--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -304,6 +304,9 @@ def main(argv: list[str] | None = None) -> int:
     worker_daemon_parser.add_argument("--max-polls", type=int)
     worker_daemon_parser.add_argument("--stop-on-no-work", action="store_true")
     worker_daemon_parser.add_argument("--no-scheduler-maintenance", action="store_true")
+    worker_daemon_parser.add_argument("--auto-update-source", action="store_true")
+    worker_daemon_parser.add_argument("--source-update-ref", default="origin/master")
+    worker_daemon_parser.add_argument("--no-restart-on-source-update", action="store_true")
 
     sync_parser = subparsers.add_parser("sync-artifacts", help="Sync a completed run into an evaluated queue snapshot")
     sync_parser.add_argument("--database-url", required=True)
@@ -765,6 +768,7 @@ def main(argv: list[str] | None = None) -> int:
             ("--completion-worktree-root", args.completion_worktree_root),
             ("--completion-commit-message", args.completion_commit_message),
             ("--completion-pr-base", args.completion_pr_base),
+            ("--source-update-ref", args.source_update_ref),
         ]:
             if value is not None:
                 argv2.extend([key, str(value)])
@@ -838,6 +842,10 @@ def main(argv: list[str] | None = None) -> int:
             argv2.append("--stop-on-no-work")
         if args.no_scheduler_maintenance:
             argv2.append("--no-scheduler-maintenance")
+        if args.auto_update_source:
+            argv2.append("--auto-update-source")
+        if args.no_restart_on_source_update:
+            argv2.append("--no-restart-on-source-update")
         return run_worker_daemon_main(argv2)
     if args.command == "sync-artifacts":
         argv2 = [

--- a/control_plane/control_plane/cli/run_worker_daemon.py
+++ b/control_plane/control_plane/cli/run_worker_daemon.py
@@ -56,6 +56,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--max-polls", type=int)
     parser.add_argument("--stop-on-no-work", action="store_true")
     parser.add_argument("--no-scheduler-maintenance", action="store_true")
+    parser.add_argument("--auto-update-source", action="store_true")
+    parser.add_argument("--source-update-ref", default="origin/master")
+    parser.add_argument("--no-restart-on-source-update", action="store_true")
     args = parser.parse_args(argv)
 
     engine = build_engine(args.database_url)
@@ -102,6 +105,9 @@ def main(argv: list[str] | None = None) -> int:
             max_polls=args.max_polls,
             stop_on_no_work=args.stop_on_no_work,
             run_scheduler_maintenance=not args.no_scheduler_maintenance,
+            auto_update_source=args.auto_update_source,
+            source_update_ref=args.source_update_ref,
+            restart_on_source_update=not args.no_restart_on_source_update,
         ),
     )
     print(

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -20,6 +20,7 @@ from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
 from control_plane.services.docs_paths import canonicalize_proposal_path, resolve_proposal_dir, resolve_proposal_file
 from control_plane.services.proposal_scaffold import ensure_proposal_scaffold
+from control_plane.services.source_requirement import build_source_requirement
 
 
 class Layer1TaskGenerationError(RuntimeError):
@@ -736,6 +737,10 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         ),
         abstraction_layer=effective_abstraction_layer,
         trial_policy=trial_policy,
+    )
+    payload["source_requirement"] = build_source_requirement(
+        repo_root=repo_root,
+        required_sha=source_commit,
     )
     _upsert_evaluation_request_entry(
         repo_root=repo_root,

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -21,6 +21,7 @@ from control_plane.models.work_items import WorkItem
 from control_plane.services.dependency_gate import evaluate_work_item_dependencies
 from control_plane.services.docs_paths import canonicalize_proposal_path, resolve_proposal_dir
 from control_plane.services.proposal_scaffold import ensure_proposal_scaffold
+from control_plane.services.source_requirement import build_source_requirement
 
 
 class Layer2TaskGenerationError(RuntimeError):
@@ -2985,6 +2986,10 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
         depends_on_item_ids=effective_depends_on_item_ids,
         requires_merged_inputs=effective_requires_merged_inputs,
         requires_materialized_refs=effective_requires_materialized_refs,
+    )
+    payload["source_requirement"] = build_source_requirement(
+        repo_root=repo_root,
+        required_sha=source_commit,
     )
     initial_state = WorkItemState.DISPATCH_PENDING
     transient_work_item = WorkItem(

--- a/control_plane/control_plane/services/queue_importer.py
+++ b/control_plane/control_plane/services/queue_importer.py
@@ -92,6 +92,16 @@ def _semantic_payload(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _payload_source_commit(payload: dict[str, Any]) -> str | None:
+    source_requirement = payload.get("source_requirement")
+    if isinstance(source_requirement, dict):
+        required_sha = str(source_requirement.get("required_sha") or "").strip()
+        if required_sha:
+            return required_sha
+    source_commit = str(payload.get("source_commit") or "").strip()
+    return source_commit or None
+
+
 def _queue_state_to_work_item_state(queue_state: str) -> WorkItemState:
     if queue_state == "evaluated":
         return WorkItemState.AWAITING_REVIEW
@@ -200,13 +210,16 @@ def _record_reconciliation(
 
 def import_queue_item(session: Session, request: QueueImportRequest) -> QueueImportResult:
     repo_root = Path(request.repo_root)
-    resolved_source_commit = _resolve_source_commit(repo_root, request.source_commit)
 
     queue_file = request.resolve_path()
     if not queue_file.exists():
         raise QueueImportError(f"queue file not found: {queue_file}")
 
     payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    resolved_source_commit = _resolve_source_commit(
+        repo_root,
+        request.source_commit or _payload_source_commit(payload),
+    )
     item_id = payload.get("item_id")
     if not item_id:
         raise QueueImportError(f"queue item missing item_id: {queue_file}")
@@ -295,7 +308,7 @@ def import_queue_item(session: Session, request: QueueImportRequest) -> QueueImp
         existing.task_request.title = payload.get("title", existing.task_request.title)
         existing.task_request.description = (payload.get("task") or {}).get("objective", existing.task_request.description)
         existing.task_request.priority = int(payload.get("priority", existing.task_request.priority))
-        existing.task_request.source_commit = request.source_commit
+        existing.task_request.source_commit = resolved_source_commit
         changed = True
 
     imported_state = _queue_state_to_work_item_state(payload.get("state", "queued"))

--- a/control_plane/control_plane/services/source_reconciler.py
+++ b/control_plane/control_plane/services/source_reconciler.py
@@ -1,0 +1,214 @@
+"""Evaluator service-repo source reconciliation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+import subprocess
+import sys
+from typing import NoReturn
+
+from sqlalchemy.orm import Session
+
+from control_plane.models.enums import FlowName, LeaseStatus, WorkItemState
+from control_plane.models.worker_leases import WorkerLease
+from control_plane.models.work_items import WorkItem
+from control_plane.services.lease_service import upsert_worker_machine
+
+
+class SourceReconciliationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SourceReconciliationResult:
+    status: str
+    item_id: str | None = None
+    required_sha: str | None = None
+    current_sha: str | None = None
+    source_commit_relation: str | None = None
+    message: str | None = None
+    restart_required: bool = False
+
+
+def _run_git(repo_root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_stdout(repo_root: Path, *args: str) -> str:
+    return _run_git(repo_root, *args).stdout.strip()
+
+
+def _git_success(repo_root: Path, *args: str) -> bool:
+    return _run_git(repo_root, *args, check=False).returncode == 0
+
+
+def _current_head(repo_root: Path) -> str | None:
+    try:
+        return _git_stdout(repo_root, "rev-parse", "HEAD")
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _source_relation(repo_root: Path, required_sha: str, head_sha: str | None = None) -> str:
+    if not required_sha:
+        return "unspecified"
+    if not _git_success(repo_root, "cat-file", "-e", f"{required_sha}^{{commit}}"):
+        return "missing"
+    head = head_sha or _current_head(repo_root)
+    if head == required_sha:
+        return "exact"
+    if _git_success(repo_root, "merge-base", "--is-ancestor", required_sha, "HEAD"):
+        return "descendant"
+    return "mismatch"
+
+
+def _machine_matches_item(*, capability_filter: dict[str, object] | None, work_item: WorkItem) -> bool:
+    effective = dict(capability_filter or {})
+    platform = str(effective.get("platform") or "").strip()
+    flow = str(effective.get("flow") or "").strip()
+    if platform and work_item.platform != platform:
+        return False
+    if flow and work_item.flow != FlowName(flow):
+        return False
+    return True
+
+
+def next_source_required_item(
+    session: Session,
+    *,
+    machine_key: str,
+    hostname: str | None,
+    executor_kind: str,
+    machine_role: str,
+    slot_capacity: int,
+    capabilities: dict[str, object] | None,
+    capability_filter: dict[str, object] | None,
+) -> WorkItem | None:
+    """Return the next READY item whose source requirement should gate dispatch."""
+
+    machine = upsert_worker_machine(
+        session,
+        machine_key=machine_key,
+        hostname=hostname,
+        executor_kind=executor_kind,
+        capabilities=capabilities,
+        role=machine_role,
+        slot_capacity=slot_capacity,
+    )
+    effective_filter = dict(machine.capabilities or {})
+    effective_filter.update(capability_filter or {})
+    query = (
+        session.query(WorkItem)
+        .filter(WorkItem.state == WorkItemState.READY)
+        .filter(WorkItem.assigned_machine_key == machine.machine_key)
+        .filter(~WorkItem.leases.any(WorkerLease.status == LeaseStatus.ACTIVE))
+        .order_by(WorkItem.priority.desc(), WorkItem.created_at.asc(), WorkItem.item_id.asc())
+    )
+    for item in query.all():
+        if str(item.source_commit or "").strip() and _machine_matches_item(
+            capability_filter=effective_filter,
+            work_item=item,
+        ):
+            session.commit()
+            return item
+    session.commit()
+    return None
+
+
+def reconcile_service_repo_source(
+    *,
+    repo_root: str,
+    required_sha: str,
+    update_ref: str = "origin/master",
+    allow_update: bool = True,
+) -> SourceReconciliationResult:
+    """Ensure the service repo contains the queued source commit before execution."""
+
+    repo_path = Path(repo_root).resolve()
+    required = str(required_sha or "").strip()
+    if not required:
+        return SourceReconciliationResult(status="no_requirement")
+
+    current = _current_head(repo_path)
+    relation = _source_relation(repo_path, required, current)
+    if relation in {"exact", "descendant"}:
+        return SourceReconciliationResult(
+            status="satisfied",
+            required_sha=required,
+            current_sha=current,
+            source_commit_relation=relation,
+        )
+
+    if not allow_update:
+        return SourceReconciliationResult(
+            status="update_required",
+            required_sha=required,
+            current_sha=current,
+            source_commit_relation=relation,
+            restart_required=True,
+            message="service repo does not contain required source commit",
+        )
+
+    try:
+        _run_git(repo_path, "fetch", "--quiet", "origin")
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise SourceReconciliationError(f"failed to fetch origin for source reconciliation: {exc}") from exc
+
+    if not _git_success(repo_path, "cat-file", "-e", f"{required}^{{commit}}"):
+        return SourceReconciliationResult(
+            status="blocked",
+            required_sha=required,
+            current_sha=current,
+            source_commit_relation="missing",
+            message=f"required source commit is not reachable after fetch: {required}",
+        )
+
+    target = required
+    if update_ref and _git_success(repo_path, "merge-base", "--is-ancestor", required, update_ref):
+        target = update_ref
+
+    if _git_stdout(repo_path, "status", "--porcelain", "--untracked-files=no"):
+        return SourceReconciliationResult(
+            status="blocked",
+            required_sha=required,
+            current_sha=current,
+            source_commit_relation=relation,
+            message="service repo has tracked local modifications; refusing automatic checkout",
+        )
+
+    try:
+        _run_git(repo_path, "checkout", "--detach", target)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise SourceReconciliationError(f"failed to checkout source target {target}: {exc}") from exc
+
+    new_head = _current_head(repo_path)
+    new_relation = _source_relation(repo_path, required, new_head)
+    if new_relation not in {"exact", "descendant"}:
+        return SourceReconciliationResult(
+            status="blocked",
+            required_sha=required,
+            current_sha=new_head,
+            source_commit_relation=new_relation,
+            message=f"updated service repo does not satisfy required source commit: {required}",
+        )
+
+    return SourceReconciliationResult(
+        status="updated",
+        required_sha=required,
+        current_sha=new_head,
+        source_commit_relation=new_relation,
+        restart_required=True,
+        message=f"service repo updated to {target}",
+    )
+
+
+def reexec_current_process() -> NoReturn:
+    os.execvpe(sys.executable, [sys.executable, *sys.argv], os.environ)
+    raise AssertionError("unreachable")

--- a/control_plane/control_plane/services/source_requirement.py
+++ b/control_plane/control_plane/services/source_requirement.py
@@ -1,0 +1,30 @@
+"""Source revision requirements for queued evaluator work."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+DEFAULT_REQUIRED_REF = "origin/master"
+SOURCE_REQUIREMENT_VERSION = 1
+
+
+def build_source_requirement(
+    *,
+    repo_root: str | Path,
+    required_sha: str,
+    required_ref: str = DEFAULT_REQUIRED_REF,
+    requires_daemon_restart: bool = True,
+    reason: str = "evaluator runtime must contain the queued job source commit",
+) -> dict[str, object]:
+    """Return the queue/DB contract block describing evaluator source needs."""
+
+    Path(repo_root).resolve()
+    return {
+        "version": SOURCE_REQUIREMENT_VERSION,
+        "repo": "",
+        "required_ref": required_ref,
+        "required_sha": required_sha,
+        "requires_daemon_restart": requires_daemon_restart,
+        "reason": reason,
+    }

--- a/control_plane/control_plane/services/worker_daemon.py
+++ b/control_plane/control_plane/services/worker_daemon.py
@@ -11,6 +11,12 @@ from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.orm import sessionmaker
 
 from control_plane.clock import utcnow
+from control_plane.services.source_reconciler import (
+    SourceReconciliationError,
+    next_source_required_item,
+    reconcile_service_repo_source,
+    reexec_current_process,
+)
 from control_plane.services.lease_service import expire_stale_leases
 from control_plane.services.worker_service import run_worker
 from control_plane.workers.executor import WorkerConfig, WorkerLoopResult
@@ -25,6 +31,9 @@ class WorkerDaemonConfig:
     max_polls: int | None = None
     stop_on_no_work: bool = False
     run_scheduler_maintenance: bool = True
+    auto_update_source: bool = False
+    source_update_ref: str = "origin/master"
+    restart_on_source_update: bool = True
 
 
 @dataclass(frozen=True)
@@ -82,6 +91,67 @@ def _run_parallel_batch(
     return results
 
 
+def _reconcile_next_item_source(
+    session_factory: sessionmaker,
+    *,
+    config: WorkerDaemonConfig,
+    logger: Callable[[str], None],
+) -> WorkerLoopResult | None:
+    if not config.auto_update_source:
+        return None
+    with session_factory() as session:
+        item = next_source_required_item(
+            session,
+            machine_key=config.worker.machine_key,
+            hostname=config.worker.hostname,
+            executor_kind=config.worker.executor_kind,
+            machine_role=config.worker.machine_role,
+            slot_capacity=config.worker.slot_capacity,
+            capabilities=config.worker.capabilities,
+            capability_filter=config.worker.capability_filter,
+        )
+    if item is None:
+        return None
+
+    required_sha = str(item.source_commit or "").strip()
+    try:
+        result = reconcile_service_repo_source(
+            repo_root=config.worker.repo_root,
+            required_sha=required_sha,
+            update_ref=config.source_update_ref,
+            allow_update=config.auto_update_source,
+        )
+    except SourceReconciliationError as exc:
+        logger(
+            "worker-daemon source_reconcile_error "
+            f"item_id={item.item_id} required_sha={required_sha} error={exc}"
+        )
+        return WorkerLoopResult(
+            status="source_reconcile_error",
+            item_id=item.item_id,
+            summary=str(exc),
+        )
+
+    if result.status in {"satisfied", "no_requirement"}:
+        return None
+
+    logger(
+        "worker-daemon source_reconcile "
+        f"item_id={item.item_id} status={result.status} "
+        f"required_sha={result.required_sha} current_sha={result.current_sha} "
+        f"relation={result.source_commit_relation} message={result.message or ''}"
+    )
+    if result.status == "updated" and result.restart_required and config.restart_on_source_update:
+        logger("worker-daemon source_reconcile reexec reason=service_repo_updated")
+        reexec_current_process()
+
+    return WorkerLoopResult(
+        status=f"source_{result.status}",
+        item_id=item.item_id,
+        summary=result.message or result.source_commit_relation or result.status,
+    )
+
+
 def run_worker_daemon(
     session_factory: sessionmaker,
     *,
@@ -121,7 +191,17 @@ def run_worker_daemon(
                 raise
 
         try:
-            batch = _run_parallel_batch(session_factory, config=config)
+            reconcile_result = _reconcile_next_item_source(
+                session_factory,
+                config=config,
+                logger=logger,
+            )
+            if reconcile_result is not None:
+                batch = [reconcile_result]
+            else:
+                batch = _run_parallel_batch(session_factory, config=config)
+        except SystemExit:
+            raise
         except Exception as exc:
             if _is_retryable_db_error(exc):
                 logger(f"worker-daemon db_unavailable stage=batch error={exc}")

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -377,6 +377,9 @@ def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
             ]
             payload = work_item.task_request.request_payload
             assert payload["layer"] == "layer1"
+            assert payload["source_requirement"]["required_sha"] == source_commit
+            assert payload["source_requirement"]["required_ref"] == "origin/master"
+            assert payload["source_requirement"]["requires_daemon_restart"] is True
             assert payload["task"]["inputs"]["sweeps"] == [sweep_path]
             assert payload["task"]["inputs"]["required_submodules"] == [
                 "third_party/nlohmann_json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -171,6 +171,9 @@ def test_generate_l2_campaign_task_creates_ready_work_item() -> None:
             ]
             payload = work_item.task_request.request_payload
             assert payload["layer"] == "layer2"
+            assert payload["source_requirement"]["required_sha"] == source_commit
+            assert payload["source_requirement"]["required_ref"] == "origin/master"
+            assert payload["source_requirement"]["requires_daemon_restart"] is True
             assert payload["task"]["inputs"]["candidate_manifests"] == [
                 "runs/candidates/nangate45/module_candidates.json"
             ]

--- a/control_plane/control_plane/tests/test_queue_importer.py
+++ b/control_plane/control_plane/tests/test_queue_importer.py
@@ -66,6 +66,32 @@ def test_import_real_queue_item(tmp_path: Path) -> None:
         assert reconciliation.status.value == "applied"
 
 
+def test_import_uses_payload_source_requirement(tmp_path: Path) -> None:
+    repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    payload["source_requirement"] = {
+        "version": 1,
+        "required_ref": "origin/master",
+        "required_sha": source_commit,
+        "requires_daemon_restart": True,
+    }
+    queue_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    with make_session() as session:
+        import_queue_item(
+            session,
+            QueueImportRequest(
+                repo_root=str(repo_root),
+                queue_path=str(queue_file),
+            ),
+        )
+
+        work_item = session.query(WorkItem).filter_by(item_id="l2_e2e_softmax_macro_tail_v1").one()
+        task_request = session.query(TaskRequest).filter_by(request_key="queue:l2_e2e_softmax_macro_tail_v1").one()
+        assert work_item.source_commit == source_commit
+        assert task_request.source_commit == source_commit
+
+
 def test_import_same_item_is_idempotent() -> None:
     with make_session() as session:
         first = import_queue_item(

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -33,7 +33,14 @@ from control_plane.workers.executor import (
 )
 
 
-def _seed_ready_work_item(session: Session, *, item_id: str, repo_root: Path, assigned_machine_key: str | None = None) -> None:
+def _seed_ready_work_item(
+    session: Session,
+    *,
+    item_id: str,
+    repo_root: Path,
+    assigned_machine_key: str | None = None,
+    source_commit: str | None = None,
+) -> None:
     task = TaskRequest(
         request_key=f"queue:{item_id}",
         source="test",
@@ -86,6 +93,7 @@ def _seed_ready_work_item(session: Session, *, item_id: str, repo_root: Path, as
             str(report_path.relative_to(repo_root)),
         ],
         acceptance_rules=[],
+        source_commit=source_commit,
     )
     session.add(work_item)
     session.commit()
@@ -290,6 +298,71 @@ def _init_git_repo(repo_root: Path) -> None:
     (repo_root / "README.md").write_text("worker daemon test\n", encoding="utf-8")
     subprocess.run(["git", "-C", str(repo_root), "add", "README.md"], check=True, capture_output=True, text=True)
     subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "init"], check=True, capture_output=True, text=True)
+
+
+def _init_git_repo_with_origin(repo_root: Path) -> tuple[str, str]:
+    origin_root = repo_root.parent / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin_root)], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "init", str(repo_root)], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.email", "tester@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.name", "Tester"], check=True)
+    (repo_root / "README.md").write_text("worker daemon test\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo_root), "add", "README.md"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "init"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "remote", "add", "origin", str(origin_root)], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "push", "-u", "origin", "HEAD:master"], check=True, capture_output=True, text=True)
+    first = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True).stdout.strip()
+    (repo_root / "SOURCE.txt").write_text("new source\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo_root), "add", "SOURCE.txt"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "source update"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "push", "origin", "HEAD:master"], check=True, capture_output=True, text=True)
+    second = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True).stdout.strip()
+    subprocess.run(["git", "-C", str(repo_root), "checkout", "--detach", first], check=True, capture_output=True, text=True)
+    return first, second
+
+
+def test_worker_daemon_updates_service_repo_before_leasing_required_source() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        first_commit, required_commit = _init_git_repo_with_origin(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            _seed_ready_work_item(
+                session,
+                item_id="daemon_item_source_update",
+                repo_root=repo_root,
+                assigned_machine_key="daemon-worker-source",
+                source_commit=required_commit,
+            )
+
+        session_factory = build_session_factory(engine)
+        result = run_worker_daemon(
+            session_factory,
+            config=WorkerDaemonConfig(
+                worker=WorkerConfig(
+                    repo_root=str(repo_root),
+                    machine_key="daemon-worker-source",
+                    capabilities={"platform": "nangate45", "flow": "openroad"},
+                    capability_filter={"platform": "nangate45", "flow": "openroad"},
+                    heartbeat_seconds=1,
+                ),
+                poll_seconds=0,
+                max_polls=1,
+                auto_update_source=True,
+                restart_on_source_update=False,
+            ),
+        )
+
+        head = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True).stdout.strip()
+        assert first_commit != required_commit
+        assert head == required_commit
+        assert [row.status for row in result.results] == ["source_updated"]
+        with Session(engine) as session:
+            item = session.query(WorkItem).filter_by(item_id="daemon_item_source_update").one()
+            assert item.state == WorkItemState.READY
 
 
 def test_worker_daemon_executes_two_items_with_concurrency() -> None:

--- a/control_plane/operator_runbook.md
+++ b/control_plane/operator_runbook.md
@@ -28,6 +28,7 @@ Evaluator:
 - usually uses the shared remote PostgreSQL when `RTLCP_DB_MODE=remote`
 - runs the worker daemon
 - executes each item in a disposable clean git worktree at the task `source_commit`
+- checks the next assigned item's required source commit before leasing it; the evaluator service repo auto-fetches, updates to a commit containing that source, and re-execs the worker daemon when `RTLCP_AUTO_UPDATE_SOURCE=1`
 
 ## Required Host Environment
 
@@ -60,6 +61,26 @@ After changing these values:
 3. Notebook completion loop consumes `ARTIFACT_SYNC` items automatically.
 4. If `RTLCP_SUBMIT=1`, the notebook opens the submission PR automatically.
 5. Review and merge the PR normally.
+
+## Source Revision Contract
+
+Generated work items store the required runtime revision in two places:
+- `work_items.source_commit` / `task_requests.source_commit`
+- `task_request.request_payload.source_requirement.required_sha`
+
+The worker daemon uses that value before dispatch:
+- if the evaluator service repo already contains the required commit, the item runs normally
+- if the required commit is reachable from `origin/master`, the service repo is updated and the daemon re-execs itself before leasing the item
+- if the commit is missing or the service repo has tracked local modifications, the daemon reports a `source_blocked` or `source_reconcile_error` result instead of running with stale control-plane code
+
+The default evaluator service wrapper enables this behavior:
+```sh
+RTLCP_AUTO_UPDATE_SOURCE=1
+RTLCP_SOURCE_UPDATE_REF=origin/master
+RTLCP_RESTART_ON_SOURCE_UPDATE=1
+```
+
+Set `RTLCP_AUTO_UPDATE_SOURCE=0` only when deliberately testing stale-checkout behavior.
 
 ## Dispatch Behavior
 

--- a/control_plane/scripts/run_worker_daemon_service.sh
+++ b/control_plane/scripts/run_worker_daemon_service.sh
@@ -32,6 +32,8 @@ MAX_RETRY_ATTEMPTS="${RTLCP_MAX_RETRY_ATTEMPTS:-2}"
 EXECUTOR_KIND="${RTLCP_EXECUTOR_KIND:-local_process}"
 AUTO_PROCESS_COMPLETIONS="${RTLCP_AUTO_PROCESS_COMPLETIONS:-1}"
 COMPLETION_SUBMIT="${RTLCP_COMPLETION_SUBMIT:-1}"
+AUTO_UPDATE_SOURCE="${RTLCP_AUTO_UPDATE_SOURCE:-1}"
+SOURCE_UPDATE_REF="${RTLCP_SOURCE_UPDATE_REF:-origin/master}"
 
 repo_slug="${RTLCP_COMPLETION_REPO:-${RTLCP_REPO_SLUG:-}}"
 if [[ -z "${repo_slug}" ]]; then
@@ -61,6 +63,7 @@ cmd=(
   --poll-seconds "${POLL_SECONDS}"
   --max-items-per-poll "${MAX_ITEMS_PER_POLL}"
   --concurrency "${WORKER_CONCURRENCY}"
+  --source-update-ref "${SOURCE_UPDATE_REF}"
 )
 
 if [[ -n "${RTLCP_CAPABILITIES_JSON:-}" ]]; then
@@ -134,6 +137,14 @@ fi
 
 if [[ "${RTLCP_DISABLE_SCHEDULER_MAINTENANCE:-0}" == "1" ]]; then
   cmd+=(--no-scheduler-maintenance)
+fi
+
+if [[ "${AUTO_UPDATE_SOURCE}" == "1" ]]; then
+  cmd+=(--auto-update-source)
+fi
+
+if [[ "${RTLCP_RESTART_ON_SOURCE_UPDATE:-1}" != "1" ]]; then
+  cmd+=(--no-restart-on-source-update)
 fi
 
 exec env PYTHONPATH="${REPO_ROOT}/control_plane" "${cmd[@]}"


### PR DESCRIPTION
## Summary
- attach an explicit `source_requirement.required_sha` block to generated L1/L2 job payloads while continuing to store `work_items.source_commit`
- teach queue import to populate `source_commit` from `source_requirement.required_sha`
- add worker-daemon pre-dispatch reconciliation: before leasing a READY assigned item, fetch/update the evaluator service repo to a commit containing the required source and re-exec the daemon
- enable evaluator service auto-update by default with `RTLCP_AUTO_UPDATE_SOURCE=1`
- document the source revision contract in the operator runbook

## Validation
- `PYTHONPATH=/tmp/rtlgen-source-contract/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_worker_daemon.py control_plane/control_plane/tests/test_l1_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_queue_importer.py`

Result: `87 passed, 1 warning`.