### PR TITLE
Prepare attention KV tile measurement jobs

### DIFF
--- a/docs/backlog/items/item_l1_decoder_attention_kv_tile_op_v1.md
+++ b/docs/backlog/items/item_l1_decoder_attention_kv_tile_op_v1.md
@@ -1,0 +1,50 @@
+# Decoder attention/KV tile RTLGen op
+
+- item_id: `item_l1_decoder_attention_kv_tile_op_v1`
+- layer: `layer1`
+- kind: `circuit`
+- status: `promoted_to_proposal_dependency`
+- priority: `high`
+- owner: `developer_agent`
+- created_utc: `2026-05-12T02:30:00Z`
+- updated_utc: `2026-05-12T02:30:00Z`
+- proposal_id: `prop_l1_decoder_attention_kv_tile_stream_v1`
+- proposal_path: `docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/proposal.json`
+- triggered_by_proposal: `prop_l2_decoder_attention_kv_memory_v1`
+- triggering_evidence: `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_kv_memory_large_context_v2.json`
+
+## Problem
+- The current long-context decoder model says attention/KV service dominates, but RTLGen has no standalone attention/KV tile operation to measure.
+- Dispatching a Layer 1 measurement before adding that operation would only test missing-source failure handling, not architecture cost.
+
+## Candidate Idea
+- Add a bounded `attention_kv_tile` RTLGen operation that models the QK/KV read-side tile datapath used by single-token decode.
+- Keep the first operation intentionally narrow: dot-product lanes, KV width/precision parameters, a simple streaming valid/ready interface, and observable cycle/data counters for perf-sim equivalence.
+
+## Why It Might Matter
+- Converts the current analytical QK/KV bottleneck into measured timing, area, and power.
+- Provides a reusable primitive for later producer+attention+ranker composition.
+
+## Required Work
+- l1 change? `yes`: new RTLGen operation, configs, wrapper/sweep, and local tests.
+- l2 change? `no` for the source-enabling step.
+- mapper change? `no` for the source-enabling step.
+- quality gate required? `yes`: generated Verilog smoke, C++/unit tests, and perf-sim/RTL equivalence on cycle/data counters.
+
+## Evaluation Sketch
+- Local: build `rtlgen`, generate at least one `attention_kv_tile` Verilog wrapper, run unit tests.
+- Remote: after merge, dispatch `l1_decoder_attention_kv_tile_smoke_v1`.
+
+## Inputs / Sources
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_memory__l2_decoder_attention_kv_memory_large_context_v2.json`
+- `npu/eval/estimate_llm_decoder_attention_kv_memory.py`
+- `src/rtlgen/rtl_operations.cpp`
+- `src/rtlgen/config.cpp`
+- `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_kv_memory_large_context_v2.json`
+
+## Open Questions
+- Whether the first tile should include value-mix accumulation or only QK/KV read service.
+- Whether SRAM/NoC bandwidth should be represented as explicit ready throttling or as separate perf counters in the first RTL block.
+
+## Promotion Rule
+- Promote to remote measurement after the new op, configs, and local equivalence tests are merged to `master`.

--- a/docs/backlog/items/item_l1_decoder_attention_kv_tile_stream_v1.md
+++ b/docs/backlog/items/item_l1_decoder_attention_kv_tile_stream_v1.md
@@ -1,0 +1,48 @@
+# Decoder attention/KV tile stream measurement
+
+- item_id: `item_l1_decoder_attention_kv_tile_stream_v1`
+- layer: `layer1`
+- kind: `circuit`
+- status: `promoted_to_proposal`
+- priority: `high`
+- owner: `developer_agent`
+- created_utc: `2026-05-12T02:30:00Z`
+- updated_utc: `2026-05-12T02:30:00Z`
+- proposal_id: `prop_l1_decoder_attention_kv_tile_stream_v1`
+- proposal_path: `docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/proposal.json`
+- triggered_by_proposal: `prop_l2_decoder_attention_kv_memory_v1`
+- triggering_evidence: `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_kv_memory_large_context_v2.json`
+
+## Problem
+- The current attention/KV model finds all focus points dominated by `qk_score`, and long-context best cases still spend most cycles KV-limited.
+- The model is analytical; it needs a measured RTL/PPA anchor before we rely on it for memory hierarchy and NoC choices.
+
+## Candidate Idea
+- Measure a standalone attention/KV tile stream block after the RTLGen op lands.
+- Start with one smoke point, then expand to a small frontier sweep over `head_dim`, `kv_bits`, lanes, and stream width.
+
+## Why It Might Matter
+- Directly calibrates the dominant long-context bottleneck.
+- Separates real tile datapath PPA from current planning constants for shared SRAM, HBM, remote HBM, and NoC hop bandwidth.
+
+## Required Work
+- l1 change? `yes`, supplied by `item_l1_decoder_attention_kv_tile_op_v1`.
+- l2 change? `no`.
+- mapper change? `no`.
+- quality gate required? `yes`.
+
+## Evaluation Sketch
+- `l1_decoder_attention_kv_tile_smoke_v1`: one bounded macro-style Nangate45 point.
+- `l1_decoder_attention_kv_tile_frontier_v1`: follow-up sweep over selected width/precision points after smoke passes.
+
+## Inputs / Sources
+- `docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/proposal.json`
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_memory__l2_decoder_attention_kv_memory_large_context_v2.json`
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_stage_breakdown__l2_decoder_stage_breakdown_large_array_v2.json`
+
+## Open Questions
+- Whether `kv_bits=4` should use packed int4 datapath logic immediately or first use unpacked int4 lanes with equivalent bit width for timing.
+- Whether the frontier sweep should include `value_mix` in the first measured block or reserve it for a second block.
+
+## Promotion Rule
+- Promote after the proposal workspace is merged and the source-enabling RTLGen op is available on `master`.

--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/analysis_report.md
@@ -1,0 +1,11 @@
+# Analysis Report
+
+No evaluation has been consumed yet.
+
+Prepared item IDs:
+
+- `l1_decoder_attention_kv_tile_smoke_v1`
+- `l1_decoder_attention_kv_tile_frontier_v1`
+
+Current recommendation: implement the source-enabling `attention_kv_tile`
+operation before dispatch.

--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/design_brief.md
@@ -1,0 +1,43 @@
+# Design Brief
+
+- proposal_id: `prop_l1_decoder_attention_kv_tile_stream_v1`
+- title: `Decoder attention/KV tile stream measured RTL anchor`
+
+## Trigger
+
+The merged long-context attention/KV sweep found `qk_score` dominant across all
+focus rows. The best long-context configurations used shared SRAM, MQA, 4-bit
+KV, and one hop, but even those best cases still showed high KV-limited cycle
+share. The next useful step is measured RTL/PPA for the datapath behind that
+model.
+
+## Scope
+
+The first source-enabled block should model a single-token decode tile:
+
+- query vector fragment input
+- KV stream input
+- configurable `head_dim`
+- configurable `kv_bits`
+- configurable lane count
+- configurable stream width in bytes per cycle
+- cycle and byte counters for equivalence with a simple perf model
+
+The first measured block should be a macro-style circuit block, not a full chip
+or IO-pad model.
+
+## Non-Goals
+
+- full SRAM macro banking
+- NoC arbitration RTL
+- full softmax/value-mix pipeline
+- output projection or ranker integration
+- quality analysis of KV quantization
+
+## Proposed Evaluation Sequence
+
+1. Implement and merge the `attention_kv_tile` RTLGen operation and local
+   equivalence tests.
+2. Dispatch `l1_decoder_attention_kv_tile_smoke_v1`.
+3. If the smoke point passes, dispatch `l1_decoder_attention_kv_tile_frontier_v1`.
+4. Feed accepted PPA and cycle counters back into the L2 attention/KV estimator.

--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/evaluation_gate.md
@@ -1,0 +1,19 @@
+# Evaluation Gate
+
+Queue `l1_decoder_attention_kv_tile_smoke_v1` only after:
+
+- the `attention_kv_tile` RTLGen operation is merged to `master`
+- the smoke config path exists in the same source commit
+- the smoke sweep path exists in the same source commit
+- local build and RTL generation checks pass
+- perf-sim and RTL-visible counters agree for at least one smoke vector
+- the queued payload uses `developer_loop.proposal_path` equal to
+  `docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/proposal.json`
+- the queued payload includes `source_requirement.required_sha` for the merged
+  source commit
+
+Queue `l1_decoder_attention_kv_tile_frontier_v1` only after:
+
+- `l1_decoder_attention_kv_tile_smoke_v1` has merged accepted evidence
+- no timing/placement failure in the smoke point indicates that the frontier
+  should be narrowed first

--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/evaluation_requests.json
@@ -1,0 +1,60 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_kv_tile_stream_v1",
+  "source_commit": "f06837ae257cb0b813ce77c2366051cfce92f8bb",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_kv_tile_smoke_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure one bounded Nangate45 smoke point for a standalone attention/KV tile stream block after the RTLGen operation lands.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "decoder_attention_kv_tile",
+      "comparison_role": "measured_anchor",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_memory_large_context_v2",
+        "l2_decoder_stage_breakdown_large_array_v2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [
+        "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b256_wrapper/config_attention_kv_tile_hd64_kv4_l16_b256.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/attention_kv_tile/sweeps/nangate45_macro_smoke.json",
+      "expected_result": {
+        "direction": "measure",
+        "reason": "Create the first measured RTL/PPA anchor for the analytical attention/KV bottleneck model."
+      },
+      "status": "blocked_on_source",
+      "blocker": "Requires merged RTLGen attention_kv_tile operation, smoke config, smoke sweep, and local perf-sim/RTL counter equivalence tests."
+    },
+    {
+      "item_id": "l1_decoder_attention_kv_tile_frontier_v1",
+      "task_type": "l1_sweep",
+      "objective": "Sweep a bounded attention/KV tile frontier over head_dim, KV precision, lane count, and stream width after the smoke point passes.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "decoder_attention_kv_tile",
+      "comparison_role": "precision_width_frontier",
+      "paired_baseline_item_id": "l1_decoder_attention_kv_tile_smoke_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_kv_tile_smoke_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [
+        "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/config_attention_kv_tile_hd64_kv4_l16_b128.json",
+        "runs/designs/activations/attention_kv_tile_hd64_kv4_l32_b256_wrapper/config_attention_kv_tile_hd64_kv4_l32_b256.json",
+        "runs/designs/activations/attention_kv_tile_hd64_kv8_l32_b256_wrapper/config_attention_kv_tile_hd64_kv8_l32_b256.json",
+        "runs/designs/activations/attention_kv_tile_hd128_kv4_l32_b256_wrapper/config_attention_kv_tile_hd128_kv4_l32_b256.json",
+        "runs/designs/activations/attention_kv_tile_hd128_kv8_l64_b512_wrapper/config_attention_kv_tile_hd128_kv8_l64_b512.json",
+        "runs/designs/activations/attention_kv_tile_hd128_kv16_l64_b512_wrapper/config_attention_kv_tile_hd128_kv16_l64_b512.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/attention_kv_tile/sweeps/nangate45_macro_frontier.json",
+      "expected_result": {
+        "direction": "measure",
+        "reason": "Calibrate the cost surface of the current long-context attention/KV frontier after a legal smoke measurement exists."
+      },
+      "status": "blocked_on_smoke",
+      "blocker": "Requires l1_decoder_attention_kv_tile_smoke_v1 merged accepted evidence before dispatch."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/implementation_summary.md
@@ -1,0 +1,22 @@
+# Implementation Summary
+
+- proposal_id: `prop_l1_decoder_attention_kv_tile_stream_v1`
+- title: `Decoder attention/KV tile stream measured RTL anchor`
+
+## Prepared Jobs
+
+- `l1_decoder_attention_kv_tile_smoke_v1`
+- `l1_decoder_attention_kv_tile_frontier_v1`
+
+## Source Work Required Before Dispatch
+
+- Add an `attention_kv_tile` operation to RTLGen config parsing and Verilog generation.
+- Add local tests that compare a simple perf model against generated RTL-visible cycle and byte counters.
+- Add the config files listed in `proposal.json`.
+- Add the sweep files listed in `proposal.json`.
+
+## Dispatch Status
+
+The evaluation jobs are intentionally prepared but not dispatchable yet. They
+must remain blocked until the implementing source commit is merged and can be
+attached to the control-plane `source_requirement.required_sha`.

--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/promotion_decision.json
@@ -1,0 +1,12 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_kv_tile_stream_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Jobs are prepared but blocked on source-enabling RTLGen attention_kv_tile support.",
+  "evidence_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_kv_memory_large_context_v2.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_stage_breakdown_large_array_v2.json"
+  ],
+  "next_action": "implement attention_kv_tile RTLGen operation and smoke config, then queue l1_decoder_attention_kv_tile_smoke_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_kv_tile_stream_v1",
+  "decision": "iterate",
+  "pr_number": null,
+  "merge_commit": null,
+  "merged_utc": null
+}

--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/proposal.json
@@ -1,0 +1,118 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_kv_tile_stream_v1",
+  "created_utc": "2026-05-12T02:30:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "abstraction_layer": "decoder_attention_kv_tile",
+  "title": "Decoder attention/KV tile stream measured RTL anchor",
+  "hypothesis": "The long-context decoder frontier is dominated by attention QK/KV service. A measured attention/KV tile stream block will show whether the current analytical shared-SRAM, MQA, and low-bit KV conclusions remain plausible once RTL timing, area, power, and stream-control overhead are included.",
+  "direct_comparison": {
+    "primary_question": "What are the measured Nangate45 timing, area, power, and equivalent cycle/data-movement counters for a standalone QK/KV tile stream datapath across head dimension, KV precision, lane count, and stream width?",
+    "include": [
+      "standalone attention/KV tile stream RTLGen operation",
+      "QK dot-product datapath and KV read stream interface",
+      "macro-style wrapper without IO-pad assumptions",
+      "perf-sim versus RTL equivalence on tile cycle count and bytes consumed",
+      "smoke point before frontier sweep"
+    ],
+    "exclude": [
+      "full decoder integration",
+      "full NoC arbitration RTL",
+      "full SRAM macro banking layout",
+      "quality impact of KV quantization",
+      "training or prefill behavior",
+      "ranker and output-projection integration"
+    ],
+    "follow_on_broad_sweep": [
+      "after smoke passes, run a bounded frontier sweep over head_dim, kv_bits, lanes, and stream width",
+      "feed accepted PPA/cycle points back into the L2 attention/KV estimator"
+    ]
+  },
+  "expected_benefit": [
+    "replaces the current analytical attention/KV datapath proxy with measured circuit-block evidence",
+    "calibrates whether shared SRAM plus MQA plus low-bit KV remains the leading long-context frontier",
+    "creates a reusable measured block for later producer-attention-ranker composition"
+  ],
+  "risks": [
+    "the first operation may under-model SRAM/NoC arbitration if ready throttling is too simple",
+    "unpacked int4 lanes may not capture final packed-KV data movement cost",
+    "standalone block PPA may shift after integration with producer, softmax, value mix, or scheduler overlap",
+    "a full head_dim=128 and lanes=64 point may require macro perimeter/density tuning similar to prior wide-ranker runs"
+  ],
+  "needs_mapper_change": false,
+  "required_source_work": [
+    {
+      "item_id": "item_l1_decoder_attention_kv_tile_op_v1",
+      "objective": "Add the source artifacts needed before remote measurement: RTLGen attention_kv_tile operation, example configs, sweep file, and local perf-sim/RTL equivalence tests.",
+      "status": "not_started",
+      "must_merge_before_dispatch": true
+    }
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_kv_tile_smoke_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure one bounded Nangate45 smoke point for a standalone attention/KV tile stream block after the RTLGen operation lands.",
+      "config_paths": [
+        "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b256_wrapper/config_attention_kv_tile_hd64_kv4_l16_b256.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/attention_kv_tile/sweeps/nangate45_macro_smoke.json",
+      "platform": "nangate45",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "decoder_attention_kv_tile",
+      "comparison_role": "measured_anchor",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_memory_large_context_v2",
+        "l2_decoder_stage_breakdown_large_array_v2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure",
+        "reason": "Create the first measured RTL/PPA anchor for the analytical attention/KV bottleneck model."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_kv_tile_frontier_v1",
+      "task_type": "l1_sweep",
+      "objective": "Sweep a bounded attention/KV tile frontier over head_dim, KV precision, lane count, and stream width after the smoke point passes.",
+      "config_paths": [
+        "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/config_attention_kv_tile_hd64_kv4_l16_b128.json",
+        "runs/designs/activations/attention_kv_tile_hd64_kv4_l32_b256_wrapper/config_attention_kv_tile_hd64_kv4_l32_b256.json",
+        "runs/designs/activations/attention_kv_tile_hd64_kv8_l32_b256_wrapper/config_attention_kv_tile_hd64_kv8_l32_b256.json",
+        "runs/designs/activations/attention_kv_tile_hd128_kv4_l32_b256_wrapper/config_attention_kv_tile_hd128_kv4_l32_b256.json",
+        "runs/designs/activations/attention_kv_tile_hd128_kv8_l64_b512_wrapper/config_attention_kv_tile_hd128_kv8_l64_b512.json",
+        "runs/designs/activations/attention_kv_tile_hd128_kv16_l64_b512_wrapper/config_attention_kv_tile_hd128_kv16_l64_b512.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/attention_kv_tile/sweeps/nangate45_macro_frontier.json",
+      "platform": "nangate45",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "decoder_attention_kv_tile",
+      "comparison_role": "precision_width_frontier",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_kv_tile_smoke_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure",
+        "reason": "Calibrate the cost surface of the current long-context attention/KV frontier after a legal smoke measurement exists."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_kv_memory_large_context_v2.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_stage_breakdown_large_array_v2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_memory__l2_decoder_attention_kv_memory_large_context_v2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_stage_breakdown__l2_decoder_stage_breakdown_large_array_v2.json"
+  ],
+  "knowledge_refs": [
+    "src/rtlgen/config.cpp",
+    "src/rtlgen/config.hpp",
+    "src/rtlgen/rtl_operations.cpp",
+    "npu/eval/estimate_llm_decoder_attention_kv_memory.py",
+    "tests/test_llm_decoder_attention_kv_memory.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/quality_gate.md
@@ -1,0 +1,12 @@
+# Quality Gate
+
+Required before source-enabling PR merge:
+
+- `cmake --build /workspaces/RTLGen/build` or equivalent local build succeeds
+- generated Verilog exists for the smoke config
+- generated Verilog exposes stable cycle and byte counters or equivalent
+  observable signals
+- local tests cover at least one deterministic vector for the perf model and RTL
+  counter contract
+- no evaluator dispatch is attempted before the required config and sweep paths
+  exist in a merged commit

--- a/docs/workflows/developer_loop.md
+++ b/docs/workflows/developer_loop.md
@@ -98,3 +98,21 @@ is exported, the artifact PR must be self-contained: the PR body's
 `reviewer_first_read` paths must exist in that PR branch, including the
 proposal scaffold. The submission path resolves `proposal_path` to a single
 `proposal.json` and packages files from that proposal directory.
+
+## Source-enabling evaluation rule
+
+Some proposed measurements require source artifacts that do not exist yet, such
+as a new RTLGen operation, a new config family, or a new sweep file. In that
+case, record the evaluator item in the proposal workspace with a blocked status,
+but do not dispatch it.
+
+Before dispatching such an item:
+
+- the source-enabling implementation must be merged to `master`
+- every referenced config and sweep path must exist in that merged commit
+- local quality gates must pass
+- the queued item must carry `source_requirement.required_sha` for the merged
+  source-enabling commit
+
+This keeps the evaluator deterministic: it should run prepared source, not infer
+or implement missing architecture blocks.


### PR DESCRIPTION
## Summary
- add proposal workspace for the attention/KV tile measured RTL anchor
- prepare smoke and frontier L1 item IDs with blocked statuses until source support lands
- add backlog entries for the source-enabling RTLGen op and measurement sequence
- document the source-enabling evaluation rule so missing-source jobs are not dispatched prematurely

## Verification
- python -m json.tool on proposal/evaluation/promotion JSON files
- git diff --check

## Dispatch note
No evaluator dispatch is intended from this PR. The prepared items are blocked until the attention_kv_tile RTLGen op, configs, sweep files, and local equivalence checks are merged.