### PR TITLE
[codex] add attention kv tile rtlgen op

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,9 @@ set_tests_properties(test_mac_pp_feedback PROPERTIES WORKING_DIRECTORY ${PROJECT
 add_test(NAME test_candidate_stream_merge_fifo COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_candidate_stream_merge_fifo.sh)
 set_tests_properties(test_candidate_stream_merge_fifo PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
+add_test(NAME test_attention_kv_tile COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_attention_kv_tile.sh)
+set_tests_properties(test_attention_kv_tile PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
 if(RTLGEN_BUILD_FLOPOCO)
     set(FLOPOCO_STAGED_BIN ${PROJECT_SOURCE_DIR}/bin/flopoco)
     set(FLOPOCO_READY OFF)

--- a/apps/rtlgen_main.cpp
+++ b/apps/rtlgen_main.cpp
@@ -197,7 +197,9 @@ int main(int argc, char** argv) {
               << config.score_tie_rank_operations.size() << " score tie-rank block(s), "
               << config.logit_rank_operations.size() << " logit-rank block(s), "
               << config.candidate_stream_merge_fifo_operations.size()
-              << " candidate-stream merge FIFO block(s)\n";
+              << " candidate-stream merge FIFO block(s), "
+              << config.attention_kv_tile_operations.size()
+              << " attention/KV tile block(s)\n";
 
     try {
         std::filesystem::path flopocoPath;
@@ -345,6 +347,16 @@ int main(int argc, char** argv) {
                       << ", token_id_bits=" << merge.token_id_bits
                       << ", fifo_depth_groups=" << merge.fifo_depth_groups << ")\n";
             emitCandidateStreamMergeFifoModule(merge, operandDef);
+        }
+
+        for (const auto &tile : config.attention_kv_tile_operations) {
+            OperandDefinition operandDef = resolveOperand(config, tile.operand);
+            std::cout << "[INFO] Generating attention/KV tile " << tile.module_name
+                      << " (head_dim=" << tile.head_dim
+                      << ", kv_bits=" << tile.kv_bits
+                      << ", lanes=" << tile.lanes
+                      << ", stream_bytes_per_cycle=" << tile.stream_bytes_per_cycle << ")\n";
+            emitAttentionKvTileModule(tile, operandDef);
         }
 
         for (const auto &fp : config.fp_operations) {

--- a/examples/about_config.md
+++ b/examples/about_config.md
@@ -392,6 +392,37 @@ Reference helper:
 
 - `python3 scripts/softmax_rowwise_ref.py --config examples/config_softmax_rowwise_int8.json --row 0,0,0,0`
 
+## Attention/KV Tile Units
+
+Decoder attention/KV tile candidates use a streaming valid/ready interface so
+Layer 1 measurements can model producer-coupled behavior without assuming chip
+IO pads. Each accepted tile consumes packed query/key fragments, computes a
+lane-parallel integer dot-product partial sum, and accumulates until
+`tile_last` emits one score.
+
+Each tile unit is an `operations[]` entry with:
+
+- `type`: `"attention_kv_tile"`
+- `module_name`: generated Verilog module name
+- `operand`: integer operand reference used for the default element width
+- `options`: tile geometry and counter widths
+
+Supported options:
+
+- `head_dim`: attention head dimension represented by the complete stream
+- `kv_bits`: query/key lane precision
+- `lanes`: lane pairs consumed per accepted tile
+- `stream_bytes_per_cycle`: byte-service assumption for accepted tile counters
+- `accum_bits`: score accumulator width
+- `counter_bits`: observable counter width
+- `signed_inputs`: signed query/key lane multiplication when true
+
+Generated observables include `accepted_tile_count`, `accepted_byte_count`,
+`producer_stall_cycles`, `cycle_count`, and `final_completion_cycle` for
+perf-sim/RTL counter equivalence.
+
+See `examples/config_attention_kv_tile.json` for a minimal smoke configuration.
+
 ## Vector-Op Approximation Notes (NPU Phase-2)
 
 This section documents how `vec_op` math is currently approximated.

--- a/examples/config_attention_kv_tile.json
+++ b/examples/config_attention_kv_tile.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "kv_fragment",
+      "dimensions": 1,
+      "bit_width": 4,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "attention_kv_tile",
+      "module_name": "attention_kv_tile_hd8_kv4_l4_b16",
+      "operand": "kv_fragment",
+      "options": {
+        "head_dim": 8,
+        "kv_bits": 4,
+        "lanes": 4,
+        "stream_bytes_per_cycle": 16,
+        "accum_bits": 24,
+        "counter_bits": 16,
+        "signed_inputs": true
+      }
+    }
+  ]
+}

--- a/runs/campaigns/activations/attention_kv_tile/sweeps/nangate45_macro_frontier.json
+++ b/runs/campaigns/activations/attention_kv_tile/sweeps/nangate45_macro_frontier.json
@@ -1,0 +1,12 @@
+{
+  "tag_prefix": "attention_kv_tile_nangate45_macro_frontier",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.5],
+    "CORE_UTILIZATION": [60, 50],
+    "PLACE_DENSITY": [0.68],
+    "SYNTH_MEMORY_MAX_BITS": [32768],
+    "IO_PLACER_H": ["metal3 metal5"],
+    "IO_PLACER_V": ["metal4 metal6"],
+    "PLACE_PINS_ARGS": ["-min_distance 1"]
+  }
+}

--- a/runs/campaigns/activations/attention_kv_tile/sweeps/nangate45_macro_smoke.json
+++ b/runs/campaigns/activations/attention_kv_tile/sweeps/nangate45_macro_smoke.json
@@ -1,0 +1,12 @@
+{
+  "tag_prefix": "attention_kv_tile_nangate45_macro_smoke",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.5],
+    "CORE_UTILIZATION": [60, 50],
+    "PLACE_DENSITY": [0.68],
+    "SYNTH_MEMORY_MAX_BITS": [32768],
+    "IO_PLACER_H": ["metal3 metal5"],
+    "IO_PLACER_V": ["metal4 metal6"],
+    "PLACE_PINS_ARGS": ["-min_distance 1"]
+  }
+}

--- a/runs/designs/activations/attention_kv_tile_hd128_kv16_l64_b512_wrapper/config_attention_kv_tile_hd128_kv16_l64_b512.json
+++ b/runs/designs/activations/attention_kv_tile_hd128_kv16_l64_b512_wrapper/config_attention_kv_tile_hd128_kv16_l64_b512.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "kv_fragment",
+      "dimensions": 1,
+      "bit_width": 16,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "attention_kv_tile",
+      "module_name": "attention_kv_tile_hd128_kv16_l64_b512",
+      "operand": "kv_fragment",
+      "options": {
+        "head_dim": 128,
+        "kv_bits": 16,
+        "lanes": 64,
+        "stream_bytes_per_cycle": 512,
+        "accum_bits": 48,
+        "counter_bits": 32,
+        "signed_inputs": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/attention_kv_tile_hd128_kv4_l32_b256_wrapper/config_attention_kv_tile_hd128_kv4_l32_b256.json
+++ b/runs/designs/activations/attention_kv_tile_hd128_kv4_l32_b256_wrapper/config_attention_kv_tile_hd128_kv4_l32_b256.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "kv_fragment",
+      "dimensions": 1,
+      "bit_width": 4,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "attention_kv_tile",
+      "module_name": "attention_kv_tile_hd128_kv4_l32_b256",
+      "operand": "kv_fragment",
+      "options": {
+        "head_dim": 128,
+        "kv_bits": 4,
+        "lanes": 32,
+        "stream_bytes_per_cycle": 256,
+        "accum_bits": 48,
+        "counter_bits": 32,
+        "signed_inputs": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/attention_kv_tile_hd128_kv8_l64_b512_wrapper/config_attention_kv_tile_hd128_kv8_l64_b512.json
+++ b/runs/designs/activations/attention_kv_tile_hd128_kv8_l64_b512_wrapper/config_attention_kv_tile_hd128_kv8_l64_b512.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "kv_fragment",
+      "dimensions": 1,
+      "bit_width": 8,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "attention_kv_tile",
+      "module_name": "attention_kv_tile_hd128_kv8_l64_b512",
+      "operand": "kv_fragment",
+      "options": {
+        "head_dim": 128,
+        "kv_bits": 8,
+        "lanes": 64,
+        "stream_bytes_per_cycle": 512,
+        "accum_bits": 48,
+        "counter_bits": 32,
+        "signed_inputs": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/config_attention_kv_tile_hd64_kv4_l16_b128.json
+++ b/runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/config_attention_kv_tile_hd64_kv4_l16_b128.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "kv_fragment",
+      "dimensions": 1,
+      "bit_width": 4,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "attention_kv_tile",
+      "module_name": "attention_kv_tile_hd64_kv4_l16_b128",
+      "operand": "kv_fragment",
+      "options": {
+        "head_dim": 64,
+        "kv_bits": 4,
+        "lanes": 16,
+        "stream_bytes_per_cycle": 128,
+        "accum_bits": 48,
+        "counter_bits": 32,
+        "signed_inputs": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b256_wrapper/config_attention_kv_tile_hd64_kv4_l16_b256.json
+++ b/runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b256_wrapper/config_attention_kv_tile_hd64_kv4_l16_b256.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "kv_fragment",
+      "dimensions": 1,
+      "bit_width": 4,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "attention_kv_tile",
+      "module_name": "attention_kv_tile_hd64_kv4_l16_b256",
+      "operand": "kv_fragment",
+      "options": {
+        "head_dim": 64,
+        "kv_bits": 4,
+        "lanes": 16,
+        "stream_bytes_per_cycle": 256,
+        "accum_bits": 48,
+        "counter_bits": 32,
+        "signed_inputs": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/attention_kv_tile_hd64_kv4_l32_b256_wrapper/config_attention_kv_tile_hd64_kv4_l32_b256.json
+++ b/runs/designs/activations/attention_kv_tile_hd64_kv4_l32_b256_wrapper/config_attention_kv_tile_hd64_kv4_l32_b256.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "kv_fragment",
+      "dimensions": 1,
+      "bit_width": 4,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "attention_kv_tile",
+      "module_name": "attention_kv_tile_hd64_kv4_l32_b256",
+      "operand": "kv_fragment",
+      "options": {
+        "head_dim": 64,
+        "kv_bits": 4,
+        "lanes": 32,
+        "stream_bytes_per_cycle": 256,
+        "accum_bits": 48,
+        "counter_bits": 32,
+        "signed_inputs": true
+      }
+    }
+  ]
+}

--- a/runs/designs/activations/attention_kv_tile_hd64_kv8_l32_b256_wrapper/config_attention_kv_tile_hd64_kv8_l32_b256.json
+++ b/runs/designs/activations/attention_kv_tile_hd64_kv8_l32_b256_wrapper/config_attention_kv_tile_hd64_kv8_l32_b256.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "kv_fragment",
+      "dimensions": 1,
+      "bit_width": 8,
+      "signed": true,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "attention_kv_tile",
+      "module_name": "attention_kv_tile_hd64_kv8_l32_b256",
+      "operand": "kv_fragment",
+      "options": {
+        "head_dim": 64,
+        "kv_bits": 8,
+        "lanes": 32,
+        "stream_bytes_per_cycle": 256,
+        "accum_bits": 48,
+        "counter_bits": 32,
+        "signed_inputs": true
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -203,6 +203,38 @@ def identify_design(config):
             "logit_signed": bool(options.get("logit_signed", True)),
             "include_mg_cpa": False,
         }
+    if op_type == "attention_kv_tile":
+        options = entry.get("options", {})
+        kv_bits = int(options.get("kv_bits", bit_width) or bit_width)
+        head_dim = int(options.get("head_dim", 64))
+        lanes = int(options.get("lanes", 16))
+        stream_bytes_per_cycle = int(options.get("stream_bytes_per_cycle", 256))
+        accum_bits = int(options.get("accum_bits", 48))
+        counter_bits = int(options.get("counter_bits", 32))
+        if head_dim <= 0:
+            raise ValueError("attention_kv_tile head_dim must be positive")
+        if kv_bits <= 0:
+            raise ValueError("attention_kv_tile kv_bits must be positive")
+        if lanes <= 0 or lanes > head_dim:
+            raise ValueError("attention_kv_tile lanes must be in [1, head_dim]")
+        if stream_bytes_per_cycle <= 0:
+            raise ValueError("attention_kv_tile stream_bytes_per_cycle must be positive")
+        if stream_bytes_per_cycle * 8 < lanes * kv_bits * 2:
+            raise ValueError("attention_kv_tile stream_bytes_per_cycle cannot carry query+key lane payload")
+        if accum_bits <= 0:
+            raise ValueError("attention_kv_tile accum_bits must be positive")
+        if counter_bits <= 0:
+            raise ValueError("attention_kv_tile counter_bits must be positive")
+        return {
+            "kind": "attention_kv_tile",
+            "module_name": module_name,
+            "wrapper_name": f"{module_name}_wrapper",
+            "fragment_width": lanes * kv_bits,
+            "accum_bits": accum_bits,
+            "counter_bits": counter_bits,
+            "signed_inputs": bool(options.get("signed_inputs", True)),
+            "include_mg_cpa": False,
+        }
     raise ValueError(f"generate_design.py does not support operation type: {op_type}")
 
 
@@ -529,6 +561,50 @@ module {wrapper_name}(
     .accepted_group_count(accepted_group_count),
     .producer_stall_cycles(producer_stall_cycles),
     .fifo_max_occupancy(fifo_max_occupancy),
+    .final_completion_cycle(final_completion_cycle)
+  );
+
+endmodule
+"""
+    elif design["kind"] == "attention_kv_tile":
+        fragment_width = int(design["fragment_width"])
+        accum_bits = int(design["accum_bits"])
+        counter_bits = int(design["counter_bits"])
+        signed_kw = "signed " if design.get("signed_inputs", True) else ""
+        wrapper_content = f"""
+module {wrapper_name}(
+  input clk,
+  input rst_n,
+  input tile_valid,
+  output tile_ready,
+  input tile_last,
+  input [{fragment_width-1}:0] query_fragment,
+  input [{fragment_width-1}:0] key_fragment,
+  input score_ready,
+  output score_valid,
+  output {signed_kw}[{accum_bits-1}:0] score,
+  output [{counter_bits-1}:0] accepted_tile_count,
+  output [{counter_bits-1}:0] accepted_byte_count,
+  output [{counter_bits-1}:0] producer_stall_cycles,
+  output [{counter_bits-1}:0] cycle_count,
+  output [{counter_bits-1}:0] final_completion_cycle
+);
+
+  {module_name} dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .tile_valid(tile_valid),
+    .tile_ready(tile_ready),
+    .tile_last(tile_last),
+    .query_fragment(query_fragment),
+    .key_fragment(key_fragment),
+    .score_ready(score_ready),
+    .score_valid(score_valid),
+    .score(score),
+    .accepted_tile_count(accepted_tile_count),
+    .accepted_byte_count(accepted_byte_count),
+    .producer_stall_cycles(producer_stall_cycles),
+    .cycle_count(cycle_count),
     .final_completion_cycle(final_completion_cycle)
   );
 

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -135,6 +135,7 @@ def read_design_names(config_path: Path) -> Tuple[str, str]:
             "score_tie_rank",
             "logit_rank",
             "candidate_stream_merge_fifo",
+            "attention_kv_tile",
         ):
             raise ValueError(f"Unsupported single-operation design type in {config_path}: {entry['type']}")
         module_name = entry["module_name"]

--- a/src/rtlgen/config.cpp
+++ b/src/rtlgen/config.cpp
@@ -63,6 +63,7 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
         config.score_tie_rank_operations.clear();
         config.logit_rank_operations.clear();
         config.candidate_stream_merge_fifo_operations.clear();
+        config.attention_kv_tile_operations.clear();
         config.onnx_model.reset();
 
         if (j.contains("operand")) {
@@ -486,6 +487,43 @@ bool readConfig(const std::string& filename, CircuitConfig& config) {
                         throw std::runtime_error("candidate_stream_merge_fifo counter_bits must be in [1, 64] for " + merge.module_name);
                     }
                     config.candidate_stream_merge_fifo_operations.push_back(merge);
+                } else if (type == "attention_kv_tile") {
+                    const json &options = entry.contains("options") ? entry["options"] : entry;
+                    AttentionKvTileOperationConfig tile;
+                    tile.module_name = module_name;
+                    tile.operand = operand_name;
+                    tile.head_dim = options.value("head_dim", 64);
+                    tile.kv_bits = options.value("kv_bits", 8);
+                    tile.lanes = options.value("lanes", 16);
+                    tile.stream_bytes_per_cycle = options.value("stream_bytes_per_cycle", 256);
+                    tile.accum_bits = options.value("accum_bits", 48);
+                    tile.counter_bits = options.value("counter_bits", 32);
+                    tile.signed_inputs = options.value("signed_inputs", true);
+                    if (tile.head_dim <= 0 || tile.head_dim > 4096) {
+                        throw std::runtime_error("attention_kv_tile head_dim must be in [1, 4096] for " + tile.module_name);
+                    }
+                    if (tile.kv_bits <= 0 || tile.kv_bits > 32) {
+                        throw std::runtime_error("attention_kv_tile kv_bits must be in [1, 32] for " + tile.module_name);
+                    }
+                    if (tile.lanes <= 0 || tile.lanes > 256) {
+                        throw std::runtime_error("attention_kv_tile lanes must be in [1, 256] for " + tile.module_name);
+                    }
+                    if (tile.lanes > tile.head_dim) {
+                        throw std::runtime_error("attention_kv_tile lanes must not exceed head_dim for " + tile.module_name);
+                    }
+                    if (tile.stream_bytes_per_cycle <= 0 || tile.stream_bytes_per_cycle > 4096) {
+                        throw std::runtime_error("attention_kv_tile stream_bytes_per_cycle must be in [1, 4096] for " + tile.module_name);
+                    }
+                    if (tile.accum_bits < 8 || tile.accum_bits > 128) {
+                        throw std::runtime_error("attention_kv_tile accum_bits must be in [8, 128] for " + tile.module_name);
+                    }
+                    if (tile.counter_bits <= 0 || tile.counter_bits > 64) {
+                        throw std::runtime_error("attention_kv_tile counter_bits must be in [1, 64] for " + tile.module_name);
+                    }
+                    if (tile.stream_bytes_per_cycle * 8 < tile.lanes * tile.kv_bits * 2) {
+                        throw std::runtime_error("attention_kv_tile stream_bytes_per_cycle cannot carry query+key lane payload for " + tile.module_name);
+                    }
+                    config.attention_kv_tile_operations.push_back(tile);
                 } else {
                     throw std::runtime_error("Unknown operation type: " + type);
                 }

--- a/src/rtlgen/config.hpp
+++ b/src/rtlgen/config.hpp
@@ -247,6 +247,18 @@ struct CandidateStreamMergeFifoOperationConfig {
     bool logit_signed{true};
 };
 
+struct AttentionKvTileOperationConfig {
+    std::string module_name;
+    std::string operand;
+    int head_dim{64};
+    int kv_bits{8};
+    int lanes{16};
+    int stream_bytes_per_cycle{256};
+    int accum_bits{48};
+    int counter_bits{32};
+    bool signed_inputs{true};
+};
+
 struct CircuitConfig {
     OperandConfig operand;
     std::vector<OperandDefinition> operands;
@@ -263,6 +275,7 @@ struct CircuitConfig {
     std::vector<ScoreTieRankOperationConfig> score_tie_rank_operations;
     std::vector<LogitRankOperationConfig> logit_rank_operations;
     std::vector<CandidateStreamMergeFifoOperationConfig> candidate_stream_merge_fifo_operations;
+    std::vector<AttentionKvTileOperationConfig> attention_kv_tile_operations;
     std::optional<std::string> onnx_model; // Added ONNX model path
 };
 

--- a/src/rtlgen/rtl_operations.cpp
+++ b/src/rtlgen/rtl_operations.cpp
@@ -1639,3 +1639,137 @@ void emitCandidateStreamMergeFifoModule(const CandidateStreamMergeFifoOperationC
     os << "  end\n";
     os << "endmodule\n";
 }
+
+void emitAttentionKvTileModule(const AttentionKvTileOperationConfig &config,
+                               const OperandDefinition &operand) {
+    const int data_bits = config.kv_bits > 0 ? config.kv_bits : operand.bit_width;
+    if (config.head_dim <= 0 || config.head_dim > 4096) {
+        throw std::runtime_error("attention_kv_tile head_dim must be in [1, 4096]");
+    }
+    if (data_bits <= 0 || data_bits > 32) {
+        throw std::runtime_error("attention_kv_tile kv_bits must be in [1, 32]");
+    }
+    if (config.lanes <= 0 || config.lanes > 256 || config.lanes > config.head_dim) {
+        throw std::runtime_error("attention_kv_tile lanes must be in [1, min(256, head_dim)]");
+    }
+    if (config.stream_bytes_per_cycle <= 0 || config.stream_bytes_per_cycle > 4096) {
+        throw std::runtime_error("attention_kv_tile stream_bytes_per_cycle must be in [1, 4096]");
+    }
+    if (config.counter_bits <= 0 || config.counter_bits > 64) {
+        throw std::runtime_error("attention_kv_tile counter_bits must be in [1, 64]");
+    }
+    if (config.stream_bytes_per_cycle * 8 < config.lanes * data_bits * 2) {
+        throw std::runtime_error("attention_kv_tile stream_bytes_per_cycle cannot carry query+key lane payload");
+    }
+
+    const int product_width = 2 * data_bits;
+    const int min_accum_bits = product_width +
+        std::max(1, ceilLog2U64(static_cast<unsigned long long>(config.head_dim))) + 1;
+    if (config.accum_bits < min_accum_bits || config.accum_bits > 128) {
+        std::ostringstream oss;
+        oss << "attention_kv_tile accum_bits must be in [" << min_accum_bits
+            << ", 128] for this head_dim/kv_bits";
+        throw std::runtime_error(oss.str());
+    }
+
+    const int fragment_width = config.lanes * data_bits;
+    const int expected_tiles = (config.head_dim + config.lanes - 1) / config.lanes;
+    const std::string signed_kw = config.signed_inputs ? "signed " : "";
+
+    std::string filename = config.module_name + ".v";
+    std::ofstream os(filename);
+    if (!os) {
+        throw std::runtime_error("Failed to open " + filename + " for writing");
+    }
+
+    os << "`timescale 1ns/1ps\n\n";
+    os << "module " << config.module_name << "(\n";
+    os << "  input  clk,\n";
+    os << "  input  rst_n,\n";
+    os << "  input  tile_valid,\n";
+    os << "  output tile_ready,\n";
+    os << "  input  tile_last,\n";
+    os << "  input  [" << (fragment_width - 1) << ":0] query_fragment,\n";
+    os << "  input  [" << (fragment_width - 1) << ":0] key_fragment,\n";
+    os << "  output reg score_valid,\n";
+    os << "  input  score_ready,\n";
+    os << "  output reg " << signed_kw << "[" << (config.accum_bits - 1) << ":0] score,\n";
+    os << "  output reg [" << (config.counter_bits - 1) << ":0] accepted_tile_count,\n";
+    os << "  output reg [" << (config.counter_bits - 1) << ":0] accepted_byte_count,\n";
+    os << "  output reg [" << (config.counter_bits - 1) << ":0] producer_stall_cycles,\n";
+    os << "  output reg [" << (config.counter_bits - 1) << ":0] cycle_count,\n";
+    os << "  output reg [" << (config.counter_bits - 1) << ":0] final_completion_cycle\n";
+    os << ");\n\n";
+    os << "  // Attention/KV tile stream primitive for single-token decoder exploration.\n";
+    os << "  // Each accepted tile consumes LANES query/key pairs, accumulates their dot product,\n";
+    os << "  // and emits one score when tile_last closes the head fragment stream.\n";
+    os << "  localparam integer HEAD_DIM = " << config.head_dim << ";\n";
+    os << "  localparam integer DATA_W = " << data_bits << ";\n";
+    os << "  localparam integer LANES = " << config.lanes << ";\n";
+    os << "  localparam integer PRODUCT_W = " << product_width << ";\n";
+    os << "  localparam integer ACCUM_W = " << config.accum_bits << ";\n";
+    os << "  localparam integer COUNT_W = " << config.counter_bits << ";\n";
+    os << "  localparam integer EXPECTED_TILES = " << expected_tiles << ";\n";
+    os << "  localparam [COUNT_W-1:0] STREAM_BYTES_PER_TILE = "
+       << config.counter_bits << "'d" << config.stream_bytes_per_cycle << ";\n\n";
+    os << "  reg " << signed_kw << "[ACCUM_W-1:0] running_sum;\n";
+    os << "  reg [COUNT_W-1:0] tile_count_in_score;\n";
+    std::vector<std::string> lane_terms;
+    lane_terms.reserve(static_cast<std::size_t>(config.lanes));
+    for (int lane = 0; lane < config.lanes; ++lane) {
+        const std::string product_name = "lane_product_" + std::to_string(lane);
+        const std::string term_name = "lane_term_" + std::to_string(lane);
+        os << "  wire " << signed_kw << "[PRODUCT_W-1:0] " << product_name << " = ";
+        if (config.signed_inputs) {
+            os << "$signed(query_fragment[(" << lane << "*DATA_W) +: DATA_W]) * "
+               << "$signed(key_fragment[(" << lane << "*DATA_W) +: DATA_W]);\n";
+            os << "  wire signed [ACCUM_W-1:0] " << term_name
+               << " = {{(ACCUM_W-PRODUCT_W){" << product_name << "[PRODUCT_W-1]}}, "
+               << product_name << "};\n";
+        } else {
+            os << "query_fragment[(" << lane << "*DATA_W) +: DATA_W] * "
+               << "key_fragment[(" << lane << "*DATA_W) +: DATA_W];\n";
+            os << "  wire [ACCUM_W-1:0] " << term_name
+               << " = {{(ACCUM_W-PRODUCT_W){1'b0}}, " << product_name << "};\n";
+        }
+        lane_terms.push_back(term_name);
+    }
+    const std::string partial_expr = emitSumChain(os, lane_terms, "partial_sum_chain",
+                                                  config.signed_inputs, config.accum_bits);
+    os << "  wire " << signed_kw << "[ACCUM_W-1:0] partial_sum = " << partial_expr << ";\n\n";
+    os << "  assign tile_ready = !score_valid || score_ready;\n\n";
+    os << "  always @(posedge clk or negedge rst_n) begin\n";
+    os << "    if (!rst_n) begin\n";
+    os << "      running_sum <= {ACCUM_W{1'b0}};\n";
+    os << "      score <= {ACCUM_W{1'b0}};\n";
+    os << "      score_valid <= 1'b0;\n";
+    os << "      accepted_tile_count <= {COUNT_W{1'b0}};\n";
+    os << "      accepted_byte_count <= {COUNT_W{1'b0}};\n";
+    os << "      producer_stall_cycles <= {COUNT_W{1'b0}};\n";
+    os << "      cycle_count <= {COUNT_W{1'b0}};\n";
+    os << "      final_completion_cycle <= {COUNT_W{1'b0}};\n";
+    os << "      tile_count_in_score <= {COUNT_W{1'b0}};\n";
+    os << "    end else begin\n";
+    os << "      cycle_count <= cycle_count + {{(COUNT_W-1){1'b0}}, 1'b1};\n\n";
+    os << "      if (score_valid && score_ready)\n";
+    os << "        score_valid <= 1'b0;\n\n";
+    os << "      if (tile_valid && !tile_ready)\n";
+    os << "        producer_stall_cycles <= producer_stall_cycles + {{(COUNT_W-1){1'b0}}, 1'b1};\n\n";
+    os << "      if (tile_valid && tile_ready) begin\n";
+    os << "        accepted_tile_count <= accepted_tile_count + {{(COUNT_W-1){1'b0}}, 1'b1};\n";
+    os << "        accepted_byte_count <= accepted_byte_count + STREAM_BYTES_PER_TILE;\n";
+    os << "        if (tile_last) begin\n";
+    os << "          score <= running_sum + partial_sum;\n";
+    os << "          score_valid <= 1'b1;\n";
+    os << "          running_sum <= {ACCUM_W{1'b0}};\n";
+    os << "          tile_count_in_score <= {COUNT_W{1'b0}};\n";
+    os << "          final_completion_cycle <= cycle_count + {{(COUNT_W-1){1'b0}}, 1'b1};\n";
+    os << "        end else begin\n";
+    os << "          running_sum <= running_sum + partial_sum;\n";
+    os << "          tile_count_in_score <= tile_count_in_score + {{(COUNT_W-1){1'b0}}, 1'b1};\n";
+    os << "        end\n";
+    os << "      end\n";
+    os << "    end\n";
+    os << "  end\n";
+    os << "endmodule\n";
+}

--- a/src/rtlgen/rtl_operations.hpp
+++ b/src/rtlgen/rtl_operations.hpp
@@ -11,3 +11,5 @@ void emitScoreTieRankModule(const ScoreTieRankOperationConfig &config, const Ope
 void emitLogitRankModule(const LogitRankOperationConfig &config, const OperandDefinition &operand);
 void emitCandidateStreamMergeFifoModule(const CandidateStreamMergeFifoOperationConfig &config,
                                         const OperandDefinition &operand);
+void emitAttentionKvTileModule(const AttentionKvTileOperationConfig &config,
+                               const OperandDefinition &operand);

--- a/tests/attention_kv_tile_tb.v
+++ b/tests/attention_kv_tile_tb.v
@@ -1,0 +1,115 @@
+`timescale 1ns/1ps
+
+module attention_kv_tile_tb;
+  reg clk;
+  reg rst_n;
+  reg tile_valid;
+  wire tile_ready;
+  reg tile_last;
+  reg [15:0] query_fragment;
+  reg [15:0] key_fragment;
+  wire score_valid;
+  reg score_ready;
+  wire signed [23:0] score;
+  wire [15:0] accepted_tile_count;
+  wire [15:0] accepted_byte_count;
+  wire [15:0] producer_stall_cycles;
+  wire [15:0] cycle_count;
+  wire [15:0] final_completion_cycle;
+
+  attention_kv_tile_hd8_kv4_l4_b16 dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .tile_valid(tile_valid),
+    .tile_ready(tile_ready),
+    .tile_last(tile_last),
+    .query_fragment(query_fragment),
+    .key_fragment(key_fragment),
+    .score_valid(score_valid),
+    .score_ready(score_ready),
+    .score(score),
+    .accepted_tile_count(accepted_tile_count),
+    .accepted_byte_count(accepted_byte_count),
+    .producer_stall_cycles(producer_stall_cycles),
+    .cycle_count(cycle_count),
+    .final_completion_cycle(final_completion_cycle)
+  );
+
+  always #5 clk = ~clk;
+
+  task send_tile;
+    input last;
+    input [15:0] query_bits;
+    input [15:0] key_bits;
+    begin
+      @(negedge clk);
+      while (tile_ready !== 1'b1) begin
+        @(negedge clk);
+      end
+      tile_valid = 1'b1;
+      tile_last = last;
+      query_fragment = query_bits;
+      key_fragment = key_bits;
+      @(negedge clk);
+      tile_valid = 1'b0;
+      tile_last = 1'b0;
+      query_fragment = 16'h0000;
+      key_fragment = 16'h0000;
+    end
+  endtask
+
+  initial begin
+    #1000;
+    $display("FAIL attention_kv_tile: simulation timeout");
+    $fatal;
+  end
+
+  initial begin
+    clk = 1'b0;
+    rst_n = 1'b1;
+    tile_valid = 1'b0;
+    tile_last = 1'b0;
+    query_fragment = 16'h0000;
+    key_fragment = 16'h0000;
+    score_ready = 1'b0;
+
+    #1 rst_n = 1'b0;
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+
+    // Tile 0 lanes: q=[1,2,-1,3], k=[2,-1,4,1] => -1.
+    send_tile(1'b0, 16'h3f21, 16'h14f2);
+    // Tile 1 lanes: q=[-2,1,0,4], k=[3,2,-1,-2] => -12.
+    send_tile(1'b1, 16'h401e, 16'hef23);
+
+    repeat (2) @(negedge clk);
+    if (!score_valid) begin
+      $display("FAIL attention_kv_tile: score_valid was not asserted");
+      $fatal;
+    end
+    if (score !== -24'sd13) begin
+      $display("FAIL attention_kv_tile: score=%0d expected=-13", score);
+      $fatal;
+    end
+    if (accepted_tile_count !== 16'd2 || accepted_byte_count !== 16'd32 ||
+        producer_stall_cycles !== 16'd0 || cycle_count === 16'd0 ||
+        final_completion_cycle === 16'd0) begin
+      $display(
+        "FAIL attention_kv_tile observables: tiles=%0d bytes=%0d stalls=%0d cycles=%0d final=%0d",
+        accepted_tile_count,
+        accepted_byte_count,
+        producer_stall_cycles,
+        cycle_count,
+        final_completion_cycle
+      );
+      $fatal;
+    end
+
+    score_ready = 1'b1;
+    @(negedge clk);
+    score_ready = 1'b0;
+
+    $display("All attention/KV tile tests passed.");
+    $finish;
+  end
+endmodule

--- a/tests/test_attention_kv_tile.sh
+++ b/tests/test_attention_kv_tile.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+cp "$ROOT/examples/config_attention_kv_tile.json" "$TMP/config.json"
+
+pushd "$TMP" >/dev/null
+"$ROOT/build/rtlgen" config.json
+
+grep -q "module attention_kv_tile_hd8_kv4_l4_b16" attention_kv_tile_hd8_kv4_l4_b16.v
+grep -q "Attention/KV tile stream primitive" attention_kv_tile_hd8_kv4_l4_b16.v
+grep -q "accepted_byte_count" attention_kv_tile_hd8_kv4_l4_b16.v
+grep -q "final_completion_cycle" attention_kv_tile_hd8_kv4_l4_b16.v
+
+YOSYS_BIN="${YOSYS_BIN:-}"
+if [[ -z "$YOSYS_BIN" ]]; then
+  if command -v yosys >/dev/null 2>&1; then
+    YOSYS_BIN="$(command -v yosys)"
+  elif [[ -x /oss-cad-suite/bin/yosys ]]; then
+    YOSYS_BIN=/oss-cad-suite/bin/yosys
+  fi
+fi
+if [[ -n "$YOSYS_BIN" ]]; then
+  "$YOSYS_BIN" -q -p "read_verilog attention_kv_tile_hd8_kv4_l4_b16.v; hierarchy -top attention_kv_tile_hd8_kv4_l4_b16; proc"
+fi
+
+iverilog -g2012 -s attention_kv_tile_tb -o sim \
+  attention_kv_tile_hd8_kv4_l4_b16.v "$ROOT/tests/attention_kv_tile_tb.v"
+vvp sim
+
+WRAP_DIR="$TMP/wrapper"
+mkdir -p "$WRAP_DIR"
+PYTHONPATH="$ROOT/scripts" python3 - "$ROOT/examples/config_attention_kv_tile.json" "$WRAP_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from generate_design import generate_wrapper, identify_design
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+design = identify_design(config)
+assert design["kind"] == "attention_kv_tile"
+assert design["fragment_width"] == 16
+generate_wrapper(config, sys.argv[2], design)
+PY
+iverilog -g2012 -s attention_kv_tile_hd8_kv4_l4_b16_wrapper -t null \
+  attention_kv_tile_hd8_kv4_l4_b16.v \
+  "$WRAP_DIR/attention_kv_tile_hd8_kv4_l4_b16_wrapper.v"
+
+python3 "$ROOT/scripts/run_sweep.py" \
+  --configs "$ROOT/examples/config_attention_kv_tile.json" \
+  --platform nangate45 \
+  --sweep "$ROOT/runs/campaigns/activations/attention_kv_tile/sweeps/nangate45_macro_smoke.json" \
+  --out_root "$TMP/runs" \
+  --dry_run
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add an `attention_kv_tile` RTLGen operation with streaming valid/ready query/key fragments, lane-parallel dot-product accumulation, and observable perf counters
- add wrapper/sweep support plus smoke and frontier Nangate45 macro configs for the prepared Layer 1 jobs
- add local Verilog simulation coverage and register it in CTest

## Why
This unblocks `l1_decoder_attention_kv_tile_smoke_v1` from proposal-only preparation by adding the source artifacts the evaluator needs to generate and measure the tile primitive.

## Validation
- `cmake -S . -B build`
- `cmake --build build -j2`
- `tests/test_attention_kv_tile.sh`
- `python3 -m py_compile scripts/generate_design.py scripts/run_sweep.py`
- generated all seven `runs/designs/activations/attention_kv_tile_*` configs with `build/rtlgen`
- `ctest --test-dir build --output-on-failure`
- `ctest --test-dir build -R test_attention_kv_tile --output-on-failure`