### PR TITLE
[codex] allow attention kv tile l1 dispatch

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -420,6 +420,7 @@ def _read_config_target(
             "score_tie_rank",
             "logit_rank",
             "candidate_stream_merge_fifo",
+            "attention_kv_tile",
         }:
             raise Layer1TaskGenerationError(f"unsupported single-operation design type in {config_path}: {op_type}")
         module_name = entry["module_name"]

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -256,6 +256,47 @@ def _write_candidate_stream_merge_fifo_config(repo_root: Path) -> str:
     return str(config_path.relative_to(repo_root))
 
 
+def _write_attention_kv_tile_config(repo_root: Path) -> str:
+    config_path = repo_root / "examples" / "config_attention_kv_tile.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "operands": [
+                    {
+                        "name": "kv_fragment",
+                        "dimensions": 1,
+                        "bit_width": 4,
+                        "signed": True,
+                        "kind": "int",
+                    }
+                ],
+                "operations": [
+                    {
+                        "type": "attention_kv_tile",
+                        "module_name": "attention_kv_tile_hd8_kv4_l4_b16",
+                        "operand": "kv_fragment",
+                        "options": {
+                            "head_dim": 8,
+                            "kv_bits": 4,
+                            "lanes": 4,
+                            "stream_bytes_per_cycle": 16,
+                            "accum_bits": 24,
+                            "counter_bits": 16,
+                            "signed_inputs": True,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
 def _init_git_repo(repo_root: Path) -> str:
     origin_root = repo_root.parent / "origin.git"
     subprocess.run(["git", "init", "--bare", str(origin_root)], check=True, capture_output=True, text=True)
@@ -589,6 +630,39 @@ def test_generate_l1_sweep_task_supports_candidate_stream_merge_fifo_wrapper_con
             assert result.status == "applied"
             assert work_item.expected_outputs == [
                 "runs/designs/activations/candidate_stream_merge_fifo_k2_l16_t8_d2_wrapper/metrics.csv",
+            ]
+
+
+def test_generate_l1_sweep_task_supports_attention_kv_tile_wrapper_config() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _, sweep_path = _write_example_repo(repo_root)
+        config_path = _write_attention_kv_tile_config(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    item_id="l1_demo_attention_kv_tile",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_tile",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert work_item.expected_outputs == [
+                "runs/designs/activations/attention_kv_tile_hd8_kv4_l4_b16_wrapper/metrics.csv",
             ]
 
 


### PR DESCRIPTION
## Summary
- allow `attention_kv_tile` configs through the Layer 1 sweep task generator
- add regression coverage that verifies expected metrics output path creation for an attention/KV tile wrapper

## Why
PR #466 added the RTLGen source operation and run configs, but the control-plane task generator had an independent single-operation allowlist. Without this, dispatching `l1_decoder_attention_kv_tile_smoke_v1` would fail before reaching the evaluator.

## Validation
- `PYTHONPATH=/tmp/rtlgen-source-contract/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_supports_attention_kv_tile_wrapper_config control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_supports_candidate_stream_merge_fifo_wrapper_config`