### PR TITLE
[codex] update attention kv tile dispatch metadata

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_decoder_attention_kv_tile_stream_v1",
-  "source_commit": "f06837ae257cb0b813ce77c2366051cfce92f8bb",
+  "source_commit": "4deca89f916e647c2a85f55a955db682792ebf4f",
   "requested_items": [
     {
       "item_id": "l1_decoder_attention_kv_tile_smoke_v1",
@@ -24,8 +24,7 @@
         "direction": "measure",
         "reason": "Create the first measured RTL/PPA anchor for the analytical attention/KV bottleneck model."
       },
-      "status": "blocked_on_source",
-      "blocker": "Requires merged RTLGen attention_kv_tile operation, smoke config, smoke sweep, and local perf-sim/RTL counter equivalence tests."
+      "status": "pending"
     },
     {
       "item_id": "l1_decoder_attention_kv_tile_frontier_v1",


### PR DESCRIPTION
## Summary
- update the attention/KV tile proposal evaluation request to the merged source commit used for the queued smoke job
- move the smoke item from `blocked_on_source` to `pending` now that PRs #466 and #467 are merged

## Validation
- `l1_decoder_attention_kv_tile_smoke_v1` was generated in the control-plane DB with source commit `4deca89f916e647c2a85f55a955db682792ebf4f` and assigned to `eval-daemon-b7c2d9c80c1c`