### PR TITLE
[codex] update attention kv tile frontier dispatch metadata

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_kv_tile_stream_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_decoder_attention_kv_tile_stream_v1",
-  "source_commit": "4deca89f916e647c2a85f55a955db682792ebf4f",
+  "source_commit": "0eaa71e464ef15616e3741e79e53ed86ffed9126",
   "requested_items": [
     {
       "item_id": "l1_decoder_attention_kv_tile_smoke_v1",
@@ -57,9 +57,8 @@
         "direction": "measure",
         "reason": "Calibrate the cost surface of the current long-context attention/KV frontier after a legal smoke measurement exists."
       },
-      "status": "ready_to_queue",
-      "blocker": "Requires l1_decoder_attention_kv_tile_smoke_v1 merged accepted evidence before dispatch.",
-      "notes": "Prerequisites are merged; item is ready to queue."
+      "status": "pending",
+      "notes": "Dispatched after l1_decoder_attention_kv_tile_smoke_v1 merged accepted evidence."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update `prop_l1_decoder_attention_kv_tile_stream_v1` evaluation metadata to the source commit used for the frontier dispatch
- mark `l1_decoder_attention_kv_tile_frontier_v1` as pending after smoke evidence merged and frontier was dispatched

## Validation
- DB item `l1_decoder_attention_kv_tile_frontier_v1` is RUNNING with run key `l1_decoder_attention_kv_tile_frontier_v1_run_4a4455181bf10099`
- assigned evaluator: `eval-daemon-b7c2d9c80c1c`
- checkout commit: `0eaa71e464ef15616e3741e79e53ed86ffed9126`