### PR TITLE
control_plane: allow pending follow-on submissions

### DIFF
--- a/control_plane/control_plane/services/operator_submission.py
+++ b/control_plane/control_plane/services/operator_submission.py
@@ -302,6 +302,10 @@ def _latest_submission_failure_reason(session: Session, *, run_id: str) -> str |
     return reason or None
 
 
+def _is_cached_eligibility_failure(reason: str | None) -> bool:
+    return bool(reason and " is not eligible for submission:" in reason)
+
+
 def _proposal_linkage_reason(*, repo_root: Path, work_item: WorkItem) -> str | None:
     payload = (work_item.task_request.request_payload or {}) if work_item.task_request is not None else {}
     developer_loop = payload.get("developer_loop")
@@ -336,8 +340,32 @@ def _terminal_proposal_reason(*, repo_root: Path, work_item: WorkItem) -> str | 
         return None
     decision = str(promotion_result.get("decision", "")).strip().lower()
     if decision in {"promote", "promoted", "superseded", "closed", "rejected"}:
+        if _is_pending_requested_evaluation(proposal_json=proposal_json, item_id=work_item.item_id):
+            return None
         return f"proposal already finalized with decision={decision}"
     return None
+
+
+def _is_pending_requested_evaluation(*, proposal_json: Path, item_id: str) -> bool:
+    evaluation_requests_path = proposal_json.parent / "evaluation_requests.json"
+    if not evaluation_requests_path.exists():
+        return False
+    try:
+        payload = json.loads(evaluation_requests_path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    requested_items = payload.get("requested_items")
+    if not isinstance(requested_items, list):
+        return False
+    active_statuses = {"", "pending", "queued", "ready", "running", "artifact_sync", "awaiting_review"}
+    for entry in requested_items:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("item_id", "")).strip() != item_id:
+            continue
+        status = str(entry.get("status", "")).strip().lower()
+        return status in active_statuses
+    return False
 
 
 def _ensure_review_artifact_materialized(
@@ -471,8 +499,6 @@ def assess_submission_eligibility(
         submission_failure_reason = _latest_submission_failure_reason(session, run_id=latest_run.id)
         if not required_kind:
             reason = f"unsupported_task_type={work_item.task_type}"
-        elif submission_failure_reason is not None:
-            reason = submission_failure_reason
         elif repo_root is not None:
             proposal_linkage_reason = _proposal_linkage_reason(repo_root=repo_root, work_item=work_item)
             terminal_reason = _terminal_proposal_reason(repo_root=repo_root, work_item=work_item)
@@ -500,6 +526,12 @@ def assess_submission_eligibility(
             reason = f"missing {required_kind} artifact"
         elif not _has_canonical_runs_evidence(work_item):
             reason = "missing canonical runs evidence outputs"
+        if (
+            reason is None
+            and submission_failure_reason is not None
+            and not _is_cached_eligibility_failure(submission_failure_reason)
+        ):
+            reason = submission_failure_reason
 
     return SubmissionEligibility(
         item_id=work_item.item_id,

--- a/control_plane/control_plane/tests/test_submission_status.py
+++ b/control_plane/control_plane/tests/test_submission_status.py
@@ -524,7 +524,7 @@ def test_assess_submission_eligibility_reports_terminal_proposal() -> None:
             payload = dict(work_item.task_request.request_payload or {})
             payload["developer_loop"] = {
                 "proposal_id": "prop_terminal_demo",
-                "proposal_path": "docs/proposals/prop_terminal_demo",
+                "proposal_path": "docs/proposals/prop_terminal_demo/proposal.json",
             }
             work_item.task_request.request_payload = payload
             session.commit()
@@ -533,6 +533,68 @@ def test_assess_submission_eligibility_reports_terminal_proposal() -> None:
             status = assess_submission_eligibility(session, work_item=work_item, run=run, repo_root=repo_root)
             assert status.eligible is False
             assert status.reason == "proposal already finalized with decision=promote"
+
+
+def test_assess_submission_eligibility_allows_pending_followon_after_promotion() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        proposal_dir = repo_root / "docs" / "proposals" / "prop_terminal_demo"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        _write(
+            proposal_dir / "proposal.json",
+            json.dumps({"proposal_id": "prop_terminal_demo"}, indent=2) + "\n",
+        )
+        _write(
+            proposal_dir / "evaluation_requests.json",
+            json.dumps(
+                {
+                    "proposal_id": "prop_terminal_demo",
+                    "requested_items": [
+                        {
+                            "item_id": "l1_status_demo",
+                            "task_type": "l1_sweep",
+                            "status": "pending",
+                        }
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+        _write(
+            proposal_dir / "promotion_result.json",
+            json.dumps(
+                {
+                    "proposal_id": "prop_terminal_demo",
+                    "decision": "promote",
+                    "pr_number": 114,
+                    "merge_commit": "deadbeef",
+                    "merged_utc": "2026-03-27T03:10:07Z",
+                },
+                indent=2,
+            ) + "\n",
+        )
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, run_key = _seed_l1_reviewable(session, repo_root)
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = dict(work_item.task_request.request_payload or {})
+            payload["developer_loop"] = {
+                "proposal_id": "prop_terminal_demo",
+                "proposal_path": "docs/proposals/prop_terminal_demo/proposal.json",
+            }
+            work_item.task_request.request_payload = payload
+            session.commit()
+            run = session.query(Run).filter_by(run_key=run_key).one()
+
+            status = assess_submission_eligibility(session, work_item=work_item, run=run, repo_root=repo_root)
+            assert status.eligible is True
+            assert status.reason is None
 
 
 def test_assess_submission_eligibility_prefers_terminal_proposal_over_missing_review_file() -> None:


### PR DESCRIPTION
## Summary
- allow a finalized proposal to submit a still-pending follow-on evaluation listed in evaluation_requests.json
- recompute cached eligibility submission failures so stale policy errors do not keep artifact_sync blocked after the policy/state is fixed
- add submission eligibility regression coverage for terminal proposals and pending follow-ons

## Root Cause
The artifact-sync eligibility check treated any proposal with promotion_result.json decision=promote as terminal. That blocked l1_decoder_attention_kv_tile_frontier_v1 even though the same proposal explicitly queued it as pending follow-on work after the smoke result. Existing submission_failed events then cached the old eligibility message and kept future attempts blocked.

## Validation
- PYTHONPATH=/tmp/rtlgen-source-contract/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_submission_status.py::test_assess_submission_eligibility_reports_terminal_proposal control_plane/control_plane/tests/test_submission_status.py::test_assess_submission_eligibility_allows_pending_followon_after_promotion control_plane/control_plane/tests/test_submission_status.py::test_assess_submission_eligibility_prefers_terminal_proposal_over_missing_review_file control_plane/control_plane/tests/test_completion_service.py::test_process_completed_items_submission_failure_keeps_artifact_sync control_plane/control_plane/tests/test_completion_service.py::test_process_completed_items_continues_after_submission_failure
