### PR TITLE
npu: calibrate attention kv memory with tile metrics

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2239,6 +2239,14 @@ def _decoder_attention_kv_memory_evidence(*, item_id: str) -> dict[str, Any]:
                 "kv_bits_list": [8, 16],
                 "noc_hops_list": [0, 1, 2, 4],
             },
+            "measured_tile_metrics": [
+                "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/metrics.csv",
+                "runs/designs/activations/attention_kv_tile_hd64_kv4_l32_b256_wrapper/metrics.csv",
+                "runs/designs/activations/attention_kv_tile_hd64_kv8_l32_b256_wrapper/metrics.csv",
+                "runs/designs/activations/attention_kv_tile_hd128_kv4_l32_b256_wrapper/metrics.csv",
+                "runs/designs/activations/attention_kv_tile_hd128_kv8_l64_b512_wrapper/metrics.csv",
+                "runs/designs/activations/attention_kv_tile_hd128_kv16_l64_b512_wrapper/metrics.csv",
+            ],
         },
         "commands": [
             {
@@ -2252,6 +2260,13 @@ def _decoder_attention_kv_memory_evidence(*, item_id: str) -> dict[str, Any]:
                     "--kv-bits-list 8,16 "
                     "--noc-hops-list 1,2,4 "
                     "--noc-bandwidth-bytes-per-cycle 256 "
+                    "--measured-tile-metrics "
+                    "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/metrics.csv,"
+                    "runs/designs/activations/attention_kv_tile_hd64_kv4_l32_b256_wrapper/metrics.csv,"
+                    "runs/designs/activations/attention_kv_tile_hd64_kv8_l32_b256_wrapper/metrics.csv,"
+                    "runs/designs/activations/attention_kv_tile_hd128_kv4_l32_b256_wrapper/metrics.csv,"
+                    "runs/designs/activations/attention_kv_tile_hd128_kv8_l64_b512_wrapper/metrics.csv,"
+                    "runs/designs/activations/attention_kv_tile_hd128_kv16_l64_b512_wrapper/metrics.csv "
                     f"--out {out} "
                     f"--out-md {report}"
                 ),

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1887,11 +1887,17 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence() -
             assert "--sequence-length-list 128,512,2048,8192,32768" in run
             assert "--kv-memory-tier-list local_sram,shared_sram,hbm,remote_hbm" in run
             assert "--kv-sharing-list mha,gqa4,mqa" in run
+            assert "--measured-tile-metrics " in run
+            assert "attention_kv_tile_hd128_kv16_l64_b512_wrapper/metrics.csv" in run
             assert decoder_inputs["attention_kv_memory_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_kv_memory__l2_decoder_attention_kv_memory_v1.json"
             )
             assert "KV-cache memory tier" in decoder_inputs["attention_kv_memory_scope"]
+            assert (
+                "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/metrics.csv"
+                in decoder_inputs["measured_tile_metrics"]
+            )
             assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "decoder_attention_kv_memory",

--- a/npu/eval/estimate_llm_decoder_attention_kv_memory.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_memory.py
@@ -4,12 +4,18 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import math
 from pathlib import Path
+import re
 from typing import Any
 
 JsonDict = dict[str, Any]
+
+_ATTENTION_KV_TILE_RE = re.compile(
+    r"^attention_kv_tile_hd(?P<head_dim>\d+)_kv(?P<kv_bits>\d+)_l(?P<lanes>\d+)_b(?P<stream_bytes_per_cycle>\d+)_wrapper$"
+)
 
 
 def _int_list(value: str) -> list[int]:
@@ -45,6 +51,121 @@ def _byte_width(bits: int) -> int:
 
 def _ceil_div(numerator: float, denominator: float) -> int:
     return int(math.ceil(numerator / denominator)) if numerator else 0
+
+
+def _parse_attention_kv_tile_design(design: str) -> JsonDict | None:
+    match = _ATTENTION_KV_TILE_RE.match(design)
+    if match is None:
+        return None
+    return {key: int(value) for key, value in match.groupdict().items()}
+
+
+def _load_measured_tile_frontier(paths: list[str]) -> JsonDict | None:
+    if not paths:
+        return None
+
+    rows: list[JsonDict] = []
+    for path_text in paths:
+        path = Path(path_text)
+        if not path.exists():
+            raise FileNotFoundError(f"measured tile metrics not found: {path}")
+        with path.open(newline="", encoding="utf-8") as fh:
+            for row in csv.DictReader(fh):
+                if str(row.get("status", "")).strip() != "ok":
+                    continue
+                design = str(row.get("design", "")).strip()
+                parsed = _parse_attention_kv_tile_design(design)
+                if parsed is None:
+                    continue
+                kv_byte_width = _byte_width(parsed["kv_bits"])
+                accepted_bytes_per_tile = 2 * parsed["head_dim"] * kv_byte_width
+                stream_cycles_per_tile = _ceil_div(
+                    accepted_bytes_per_tile,
+                    parsed["stream_bytes_per_cycle"],
+                )
+                lane_cycles_per_tile = _ceil_div(parsed["head_dim"], parsed["lanes"])
+                pipeline_cycle_floor = max(stream_cycles_per_tile, lane_cycles_per_tile)
+                critical_path_ns = float(row["critical_path_ns"])
+                die_area = float(row["die_area"])
+                total_power_mw = float(row["total_power_mw"])
+                rows.append(
+                    {
+                        "metrics_csv": str(path),
+                        "design": design,
+                        **parsed,
+                        "param_hash": str(row.get("param_hash", "")).strip(),
+                        "tag": str(row.get("tag", "")).strip(),
+                        "critical_path_ns": critical_path_ns,
+                        "frequency_mhz": round(1000.0 / critical_path_ns, 6) if critical_path_ns > 0.0 else 0.0,
+                        "die_area_um2": die_area,
+                        "total_power_mw": total_power_mw,
+                        "accepted_bytes_per_tile": accepted_bytes_per_tile,
+                        "stream_cycles_per_tile": stream_cycles_per_tile,
+                        "lane_cycles_per_tile": lane_cycles_per_tile,
+                        "pipeline_cycle_floor": pipeline_cycle_floor,
+                        "area_per_lane_um2": round(die_area / parsed["lanes"], 6),
+                        "power_per_lane_mw": round(total_power_mw / parsed["lanes"], 6),
+                        "area_per_stream_byte_um2": round(die_area / parsed["stream_bytes_per_cycle"], 6),
+                    }
+                )
+
+    best_by_design: dict[str, JsonDict] = {}
+    for row in rows:
+        current = best_by_design.get(row["design"])
+        if current is None or (
+            row["critical_path_ns"],
+            row["die_area_um2"],
+            row["total_power_mw"],
+        ) < (
+            current["critical_path_ns"],
+            current["die_area_um2"],
+            current["total_power_mw"],
+        ):
+            best_by_design[row["design"]] = row
+
+    best_rows = sorted(
+        best_by_design.values(),
+        key=lambda row: (
+            row["head_dim"],
+            row["kv_bits"],
+            row["lanes"],
+            row["stream_bytes_per_cycle"],
+        ),
+    )
+    if not best_rows:
+        return {
+            "source_metrics": paths,
+            "raw_ok_row_count": 0,
+            "best_row_count": 0,
+            "best_by_design": [],
+            "scaling_summary": {},
+        }
+
+    fastest = min(best_rows, key=lambda row: row["critical_path_ns"])
+    smallest = min(best_rows, key=lambda row: row["die_area_um2"])
+    largest = max(best_rows, key=lambda row: row["die_area_um2"])
+    return {
+        "source_metrics": paths,
+        "raw_ok_row_count": len(rows),
+        "best_row_count": len(best_rows),
+        "selection": "best row per design by critical_path_ns, then die_area_um2, then total_power_mw",
+        "calibration_scope": (
+            "standalone attention_kv_tile RTL/PPA anchor; not a full producer, SRAM, NoC, "
+            "softmax, or value-mix integration model"
+        ),
+        "best_by_design": best_rows,
+        "scaling_summary": {
+            "fastest_design": fastest["design"],
+            "fastest_critical_path_ns": fastest["critical_path_ns"],
+            "smallest_design": smallest["design"],
+            "smallest_die_area_um2": smallest["die_area_um2"],
+            "largest_design": largest["design"],
+            "largest_die_area_um2": largest["die_area_um2"],
+            "area_growth_largest_vs_smallest": round(largest["die_area_um2"] / smallest["die_area_um2"], 6)
+            if smallest["die_area_um2"]
+            else 0.0,
+        },
+    }
 
 
 def _kv_heads(*, attention_heads: int, kv_sharing: str) -> int:
@@ -355,6 +476,7 @@ def build_report(
     weight_bandwidth_bytes_per_cycle: float,
     activation_bandwidth_bytes_per_cycle: float,
     noc_bandwidth_bytes_per_cycle: float,
+    measured_tile_metrics: list[str] | None = None,
     include_detail: bool = False,
 ) -> JsonDict:
     shapes = [
@@ -443,6 +565,7 @@ def build_report(
             "weight_bandwidth_bytes_per_cycle": weight_bandwidth_bytes_per_cycle,
             "activation_bandwidth_bytes_per_cycle": activation_bandwidth_bytes_per_cycle,
             "noc_bandwidth_bytes_per_cycle": noc_bandwidth_bytes_per_cycle,
+            "measured_tile_metrics": measured_tile_metrics or [],
         },
         "assumptions": [
             "This is an analytical single-token decode attention model, not measured RTL.",
@@ -452,6 +575,7 @@ def build_report(
             "NoC contention is represented by effective KV bandwidth min(tier_bandwidth, noc_bandwidth / hops) for non-local tiers.",
             "GQA/MQA reduce KV-cache width but not query/output projection width.",
             "streaming_weights charges attention projection weights each token; resident_weights exposes KV and compute pressure.",
+            "Measured attention_kv_tile frontier rows calibrate standalone datapath PPA only; memory hierarchy and producer coupling remain analytical.",
         ],
         "detail_policy": {
             "attention_kv_sweep": "compact scalar rows for the decision-focused slice only; full sweep rows are summarized by counts",
@@ -502,6 +626,9 @@ def build_report(
             ),
         ),
     }
+    measured_frontier = _load_measured_tile_frontier(measured_tile_metrics or [])
+    if measured_frontier is not None:
+        payload["measured_attention_kv_tile_frontier"] = measured_frontier
     if include_detail:
         payload["attention_kv_sweep_detail"] = rows
     return payload
@@ -537,6 +664,35 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
             )
         )
 
+    measured_frontier = payload.get("measured_attention_kv_tile_frontier")
+    if isinstance(measured_frontier, dict):
+        lines.extend(
+            [
+                "",
+                "## Measured Attention/KV Tile Frontier",
+                "",
+                f"- calibration_scope: {measured_frontier.get('calibration_scope', '')}",
+                f"- best_row_count: `{measured_frontier.get('best_row_count', 0)}`",
+                "",
+                "| design | hd | kv_bits | lanes | stream_B/cyc | crit_ns | area_um2 | power_mw | cycle_floor |",
+                "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for row in measured_frontier.get("best_by_design", []):
+            lines.append(
+                "| {design} | {hd} | {kv_bits} | {lanes} | {stream} | {crit} | {area} | {power} | {floor} |".format(
+                    design=row["design"],
+                    hd=row["head_dim"],
+                    kv_bits=row["kv_bits"],
+                    lanes=row["lanes"],
+                    stream=row["stream_bytes_per_cycle"],
+                    crit=row["critical_path_ns"],
+                    area=row["die_area_um2"],
+                    power=row["total_power_mw"],
+                    floor=row["pipeline_cycle_floor"],
+                )
+            )
+
     lines.extend(["", "## Assumptions", ""])
     for item in payload["assumptions"]:
         lines.append(f"- {item}")
@@ -559,6 +715,7 @@ def main() -> int:
     ap.add_argument("--weight-bandwidth-bytes-per-cycle", type=float, default=256.0)
     ap.add_argument("--activation-bandwidth-bytes-per-cycle", type=float, default=512.0)
     ap.add_argument("--noc-bandwidth-bytes-per-cycle", type=float, default=256.0)
+    ap.add_argument("--measured-tile-metrics", type=_str_list, default=[])
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
     ap.add_argument("--detail-out")
@@ -579,6 +736,7 @@ def main() -> int:
         weight_bandwidth_bytes_per_cycle=args.weight_bandwidth_bytes_per_cycle,
         activation_bandwidth_bytes_per_cycle=args.activation_bandwidth_bytes_per_cycle,
         noc_bandwidth_bytes_per_cycle=args.noc_bandwidth_bytes_per_cycle,
+        measured_tile_metrics=args.measured_tile_metrics,
         include_detail=bool(args.detail_out),
     )
 

--- a/tests/test_llm_decoder_attention_kv_memory.py
+++ b/tests/test_llm_decoder_attention_kv_memory.py
@@ -114,3 +114,47 @@ def test_attention_kv_memory_detail_rows_are_opt_in() -> None:
     assert "attention_kv_sweep_detail" in detailed
     assert "stages" not in compact["attention_kv_sweep"][0]
     assert "stages" in detailed["attention_kv_sweep_detail"][0]
+
+
+def test_attention_kv_memory_loads_measured_tile_frontier(tmp_path) -> None:
+    metrics = tmp_path / "metrics.csv"
+    metrics.write_text(
+        "\n".join(
+            [
+                "design,platform,config_hash,param_hash,tag,status,critical_path_ns,die_area,total_power_mw,params_json,result_path",
+                'attention_kv_tile_hd64_kv4_l16_b128_wrapper,nangate45,cfg,slow,tag,ok,4.8,12000,0.42,"{}",result.json',
+                'attention_kv_tile_hd64_kv4_l16_b128_wrapper,nangate45,cfg,fast,tag,ok,4.5,13000,0.45,"{}",result.json',
+                'attention_kv_tile_hd128_kv16_l64_b512_wrapper,nangate45,cfg,wide,tag,ok,5.9,225000,2.4,"{}",result.json',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_report(
+        sequence_length_list=[128],
+        macs_per_cycle_list=[32768],
+        kv_memory_tier_list=["local_sram"],
+        kv_sharing_list=["mha"],
+        kv_bits_list=[8],
+        noc_hops_list=[0],
+        clock_ns=1.0,
+        weight_bits=16,
+        activation_bits=16,
+        score_bits=16,
+        vector_ops_per_cycle=32768,
+        weight_bandwidth_bytes_per_cycle=256.0,
+        activation_bandwidth_bytes_per_cycle=512.0,
+        noc_bandwidth_bytes_per_cycle=256.0,
+        measured_tile_metrics=[str(metrics)],
+    )
+
+    frontier = report["measured_attention_kv_tile_frontier"]
+    assert frontier["raw_ok_row_count"] == 3
+    assert frontier["best_row_count"] == 2
+    compact = frontier["best_by_design"][0]
+    assert compact["design"] == "attention_kv_tile_hd64_kv4_l16_b128_wrapper"
+    assert compact["param_hash"] == "fast"
+    assert compact["accepted_bytes_per_tile"] == 128
+    assert compact["pipeline_cycle_floor"] == 4
+    assert frontier["scaling_summary"]["area_growth_largest_vs_smallest"] > 10.0


### PR DESCRIPTION
## Summary
- add an explicit measured attention/KV tile frontier section to the L2 decoder attention/KV memory estimator
- parse committed L1 `attention_kv_tile_*` metrics to expose best per design PPA, frequency, stream/lane cycle floor, and scaling summary
- pass the merged frontier metrics into generated L2 attention/KV jobs so refresh artifacts record the L1 evidence they used

## Scope
This calibrates the L2 report with standalone datapath PPA. It does not yet replace producer, SRAM, NoC, softmax, or value-mix integration with measured RTL.

## Validation
- `PYTHONPATH=/tmp/rtlgen-source-contract/control_plane:/tmp/rtlgen-source-contract /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_attention_kv_memory.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence`
- `PYTHONPATH=/tmp/rtlgen-source-contract/control_plane:/tmp/rtlgen-source-contract /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile npu/eval/estimate_llm_decoder_attention_kv_memory.py control_plane/control_plane/services/l2_task_generator.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
