### PR TITLE
docs: propose measured attention kv memory refresh

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/analysis_report.md
@@ -1,0 +1,7 @@
+# Analysis Report
+
+No evaluation has been merged yet.
+
+- proposal_id: `prop_l2_decoder_attention_kv_memory_measured_tile_v1`
+- pending item: `l2_decoder_attention_kv_memory_measured_tile_v1`
+- expected result: calibrated Layer 2 attention/KV memory report

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/design_brief.md
@@ -1,0 +1,15 @@
+# Design Brief
+
+The prior attention/KV memory reports were analytical. PR #478 added measured
+Layer 1 PPA for six standalone `attention_kv_tile` frontier points, and PR #480
+made the Layer 2 estimator able to ingest those metrics.
+
+This job reruns the attention/KV memory report with the measured tile metrics
+explicitly attached. It should not be read as a full integrated decoder
+measurement. The purpose is to decide whether standalone datapath cost changes
+the next priority, or whether the frontier still requires producer, memory
+hierarchy, and NoC coupling.
+
+The expected next step after this refresh is a bounded producer/memory/NoC
+coupled attention job if the measured tile evidence does not invalidate that
+direction.

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+- Run `l2_decoder_attention_kv_memory_measured_tile_v1`.
+- Confirm the JSON report includes `measured_attention_kv_tile_frontier`.
+- Confirm the measured frontier records six best design points and twelve raw
+  accepted rows from the merged Layer 1 metrics.
+- Confirm the markdown report includes the measured tile table.
+- Treat the result as a calibrated analytical report, not integrated RTL PPA.
+- Use the result to choose whether the next job should be producer/memory/NoC
+  coupled attention work.

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_memory_measured_tile_v1",
+  "source_commit": "1227040b3707ba4606496f6452bdfe75fc954199",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_memory_measured_tile_v1",
+      "task_type": "l2_campaign",
+      "objective": "Refresh the decoder attention/KV memory hierarchy report with the merged measured attention/KV tile frontier as explicit calibration evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_memory",
+      "comparison_role": "calibrated_refresh",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_memory_large_context_v2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_memory_large_context_v2",
+        "l1_decoder_attention_kv_tile_frontier_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should confirm whether measured tile PPA changes the attention/KV bottleneck map before producer/memory/NoC coupled RTL work is queued."
+      },
+      "status": "pending",
+      "notes": "Dispatch after PR #480 is merged so the estimator accepts measured tile metrics."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/implementation_summary.md
@@ -1,0 +1,21 @@
+# Implementation Summary
+
+## Scope
+
+- Reuse the existing `decoder_attention_kv_memory` Layer 2 generator hook.
+- Require the estimator support merged in PR #480.
+- Feed the six merged `attention_kv_tile` frontier metrics files into the report.
+- Keep the job low cost; no new RTL or physical implementation is requested.
+
+## Evidence Inputs
+
+- `l1_decoder_attention_kv_tile_frontier_v1`
+- `l2_decoder_attention_kv_memory_large_context_v2`
+- `runs/index.csv` entries from PR #478
+
+## Out Of Scope
+
+- measured SRAM macro banking
+- measured NoC arbitration
+- producer-coupled attention RTL
+- quality impact of KV precision or sharing

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_memory_measured_tile_v1",
+  "candidate_id": "l2_decoder_attention_kv_memory_measured_tile_v1",
+  "decision": "pending",
+  "reason": "Awaiting calibrated Layer 2 attention/KV memory refresh.",
+  "evidence_refs": [],
+  "next_action": "dispatch l2_decoder_attention_kv_memory_measured_tile_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_memory_measured_tile_v1",
+  "decision": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_memory_measured_tile_v1",
+  "created_utc": "2026-05-13T01:30:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_memory",
+  "title": "Decoder attention/KV memory model with measured tile calibration",
+  "hypothesis": "The standalone attention/KV tile frontier now provides measured PPA anchors. Feeding those anchors into the decoder attention/KV memory report should clarify whether the next architecture frontier remains producer, memory hierarchy, and NoC coupling rather than only standalone tile datapath scaling.",
+  "direct_comparison": {
+    "primary_question": "Do the accepted Layer 1 attention/KV tile measurements materially change the Layer 2 attention/KV memory bottleneck map and next-job priority?",
+    "include": [
+      "previous decoder_attention_kv_memory analytical sweep shape",
+      "merged attention_kv_tile frontier metrics from l1_decoder_attention_kv_tile_frontier_v1",
+      "measured tile critical path, area, power, cycle-floor, and scaling summary",
+      "large-context memory tiers, NoC hops, KV precision, and MHA/GQA/MQA sharing"
+    ],
+    "exclude": [
+      "new RTL implementation",
+      "measured SRAM macro banking",
+      "measured NoC arbitration",
+      "producer-coupled attention RTL",
+      "quality impact of KV quantization"
+    ]
+  },
+  "expected_benefit": [
+    "records the accepted attention/KV tile PPA directly inside the Layer 2 attention/KV report",
+    "keeps the next architecture choice grounded in measured datapath cost instead of a purely analytical proxy",
+    "sets up the following producer/memory/NoC-coupled attention job with a clearer standalone datapath baseline"
+  ],
+  "risks": [
+    "the measured tile is still standalone and does not include SRAM arbitration, producer overlap, softmax, or value-mix integration",
+    "the current calibration summarizes PPA and cycle-floor scaling but does not yet replace the full analytical latency model",
+    "larger LLM shapes may shift the balance once producer scheduling and memory hierarchy are measured together"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_memory_measured_tile_v1",
+      "task_type": "l2_campaign",
+      "objective": "Refresh the decoder attention/KV memory hierarchy report with the merged measured attention/KV tile frontier as explicit calibration evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_memory",
+      "cost_class": "low",
+      "comparison_role": "calibrated_refresh",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_memory_large_context_v2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_memory_large_context_v2",
+        "l1_decoder_attention_kv_tile_frontier_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should confirm whether measured tile PPA changes the attention/KV bottleneck map before producer/memory/NoC coupled RTL work is queued."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_attention_kv_memory_v1/proposal.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_kv_memory_large_context_v2.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_kv_tile_frontier_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_memory.py",
+    "tests/test_llm_decoder_attention_kv_memory.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/metrics.csv",
+    "runs/designs/activations/attention_kv_tile_hd128_kv16_l64_b512_wrapper/metrics.csv"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_memory_measured_tile_v1/quality_gate.md
@@ -1,0 +1,8 @@
+# Quality Gate
+
+- The estimator must run from committed repository inputs only.
+- The committed JSON output must keep full analytical sweep detail compact.
+- The measured tile section must identify its source metrics paths.
+- The measured tile section must not claim full SRAM, NoC, softmax, or
+  producer-coupled calibration.
+- `scripts/validate_runs.py --skip_eval_queue` must pass after artifact merge.


### PR DESCRIPTION
## Summary
- add proposal workspace for `prop_l2_decoder_attention_kv_memory_measured_tile_v1`
- define follow-on item `l2_decoder_attention_kv_memory_measured_tile_v1`
- scope the job as a low-cost calibrated L2 refresh using the merged attention/KV tile frontier metrics

## Purpose
This stages the next job after the measured L1 attention/KV tile frontier. The job should confirm whether adding measured tile PPA changes the L2 attention/KV memory bottleneck map before we queue producer/memory/NoC-coupled RTL work.

## Validation
- `python3 -m json.tool` over the proposal JSON files
- `python3 scripts/validate_runs.py --skip_eval_queue`
