### PR TITLE
control_plane: quarantine source checkout blockers

### DIFF
--- a/control_plane/control_plane/services/source_reconciler.py
+++ b/control_plane/control_plane/services/source_reconciler.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
+import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -37,6 +40,7 @@ class SourceReconciliationResult:
     source_commit_relation: str | None = None
     message: str | None = None
     restart_required: bool = False
+    quarantine_paths: tuple[str, ...] = ()
 
 
 def _run_git(repo_root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -209,21 +213,114 @@ def _recover_stale_git_index_lock(repo_root: Path) -> bool:
         raise SourceReconciliationError(f"failed to remove stale git index lock {index_lock}: {exc}") from exc
 
 
-def _checkout_source_target(repo_root: Path, target: str) -> None:
-    try:
-        _run_git(repo_root, "checkout", "--detach", target)
-    except (OSError, subprocess.CalledProcessError) as exc:
-        stderr = getattr(exc, "stderr", "") or ""
-        if "index.lock" not in stderr:
-            raise SourceReconciliationError(f"failed to checkout source target {target}: {exc}") from exc
-        if not _recover_stale_git_index_lock(repo_root):
-            raise SourceReconciliationError(f"failed to checkout source target {target}: {exc}") from exc
+def _checkout_blocking_untracked_paths(stderr: str) -> list[str]:
+    marker = "The following untracked working tree files would be overwritten by checkout:"
+    paths: list[str] = []
+    collecting = False
+    for line in stderr.splitlines():
+        text = line.strip()
+        if marker in text:
+            collecting = True
+            continue
+        if not collecting:
+            continue
+        if not text:
+            continue
+        if text.startswith("Please ") or text == "Aborting":
+            break
+        if text.startswith("error:"):
+            continue
+        paths.append(text)
+    return paths
+
+
+def _safe_repo_relative_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute() or not path.parts or any(part in {"", ".", ".."} for part in path.parts):
+        raise SourceReconciliationError(f"unsafe checkout blocker path reported by git: {raw_path}")
+    return path
+
+
+def _source_quarantine_root() -> Path:
+    root = os.environ.get("RTLCP_SOURCE_QUARANTINE_ROOT", "/tmp")
+    return Path(root).resolve()
+
+
+def _quarantine_untracked_checkout_blockers(repo_root: Path, paths: list[str], target: str) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    quarantine_dir = _source_quarantine_root() / f"{repo_root.name}-checkout-blockers-{stamp}-{os.getpid()}"
+    moved: list[dict[str, str]] = []
+    for raw_path in paths:
+        rel_path = _safe_repo_relative_path(raw_path)
+        if _git_success(repo_root, "ls-files", "--error-unmatch", "--", str(rel_path)):
+            raise SourceReconciliationError(f"checkout blocker is tracked in current service repo: {rel_path}")
+        source = (repo_root / rel_path).resolve()
+        try:
+            source.relative_to(repo_root)
+        except ValueError as exc:
+            raise SourceReconciliationError(f"checkout blocker escapes service repo: {rel_path}") from exc
+        if not source.exists():
+            continue
+        destination = quarantine_dir / rel_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(destination))
+        moved.append({"source": str(rel_path), "quarantined_to": str(destination)})
+
+    if not moved:
+        raise SourceReconciliationError(
+            "git reported untracked checkout blockers, but none could be found to quarantine"
+        )
+    manifest = {
+        "repo_root": str(repo_root),
+        "target": target,
+        "moved": moved,
+        "created_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    quarantine_dir.mkdir(parents=True, exist_ok=True)
+    (quarantine_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return quarantine_dir
+
+
+def _checkout_error_message(target: str, exc: Exception, context: str | None = None) -> str:
+    stderr = str(getattr(exc, "stderr", "") or "").strip()
+    prefix = f"failed to checkout source target {target}"
+    if context:
+        prefix = f"{prefix} {context}"
+    if stderr:
+        return f"{prefix}: {stderr}"
+    return f"{prefix}: {exc}"
+
+
+def _checkout_source_target(repo_root: Path, target: str) -> tuple[Path, ...]:
+    quarantine_dirs: list[Path] = []
+    recovered_index_lock = False
+    quarantine_attempts = 0
+
+    while True:
         try:
             _run_git(repo_root, "checkout", "--detach", target)
-        except (OSError, subprocess.CalledProcessError) as retry_exc:
-            raise SourceReconciliationError(
-                f"failed to checkout source target {target} after stale index lock recovery: {retry_exc}"
-            ) from retry_exc
+            return tuple(quarantine_dirs)
+        except (OSError, subprocess.CalledProcessError) as exc:
+            stderr = getattr(exc, "stderr", "") or ""
+            if "index.lock" in stderr and not recovered_index_lock:
+                recovered_index_lock = True
+                if not _recover_stale_git_index_lock(repo_root):
+                    raise SourceReconciliationError(_checkout_error_message(target, exc)) from exc
+                continue
+
+            blocker_paths = _checkout_blocking_untracked_paths(stderr)
+            if blocker_paths and quarantine_attempts < 3:
+                quarantine_attempts += 1
+                quarantine_dirs.append(_quarantine_untracked_checkout_blockers(repo_root, blocker_paths, target))
+                continue
+
+            context = None
+            if recovered_index_lock:
+                context = "after stale index lock recovery"
+            if quarantine_dirs:
+                paths = ", ".join(str(path) for path in quarantine_dirs)
+                context = f"after quarantining untracked blockers at {paths}"
+            raise SourceReconciliationError(_checkout_error_message(target, exc, context)) from exc
 
 
 def _current_head(repo_root: Path) -> str | None:
@@ -377,7 +474,7 @@ def _reconcile_service_repo_source_locked(
             message="service repo has tracked local modifications; refusing automatic checkout",
         )
 
-    _checkout_source_target(repo_path, target)
+    quarantine_paths = _checkout_source_target(repo_path, target)
 
     new_head = _current_head(repo_path)
     new_relation = _source_relation(repo_path, required, new_head)
@@ -390,13 +487,18 @@ def _reconcile_service_repo_source_locked(
             message=f"updated service repo does not satisfy required source commit: {required}",
         )
 
+    message = f"service repo updated to {target}"
+    if quarantine_paths:
+        message = f"{message}; quarantined untracked checkout blockers at {', '.join(str(path) for path in quarantine_paths)}"
+
     return SourceReconciliationResult(
         status="updated",
         required_sha=required,
         current_sha=new_head,
         source_commit_relation=new_relation,
         restart_required=True,
-        message=f"service repo updated to {target}",
+        message=message,
+        quarantine_paths=tuple(str(path) for path in quarantine_paths),
     )
 
 

--- a/control_plane/control_plane/tests/test_source_reconciler.py
+++ b/control_plane/control_plane/tests/test_source_reconciler.py
@@ -82,3 +82,46 @@ def test_reconcile_service_repo_keeps_index_lock_when_git_process_appears_active
         )
 
     assert index_lock.exists()
+
+
+def test_reconcile_service_repo_quarantines_untracked_checkout_blockers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    first, _second = _init_repo_with_stale_head(repo_root)
+    blocker_rel = Path("runs/designs/activations/demo_wrapper/metrics.csv")
+    _run("git", "-C", str(repo_root), "checkout", "master")
+    tracked_blocker = repo_root / blocker_rel
+    tracked_blocker.parent.mkdir(parents=True, exist_ok=True)
+    tracked_blocker.write_text("tracked,new\n", encoding="utf-8")
+    _run("git", "-C", str(repo_root), "add", str(blocker_rel))
+    _run("git", "-C", str(repo_root), "commit", "-m", "track generated metric")
+    _run("git", "-C", str(repo_root), "push", "origin", "HEAD:master")
+    required = _run("git", "-C", str(repo_root), "rev-parse", "HEAD")
+    _run("git", "-C", str(repo_root), "checkout", "--detach", first)
+    blocker = repo_root / blocker_rel
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    blocker.write_text("generated,old\n", encoding="utf-8")
+    monkeypatch.setenv("RTLCP_SOURCE_QUARANTINE_ROOT", str(tmp_path / "quarantine"))
+
+    result = reconcile_service_repo_source(
+        repo_root=str(repo_root),
+        required_sha=required,
+        update_ref="origin/master",
+        allow_update=True,
+    )
+
+    assert result.status == "updated"
+    assert result.required_sha == required
+    assert _run("git", "-C", str(repo_root), "rev-parse", "HEAD") == required
+    assert first != required
+    assert blocker.exists()
+    assert blocker.read_text(encoding="utf-8") != "generated,old\n"
+    assert len(result.quarantine_paths) == 1
+    quarantine_dir = Path(result.quarantine_paths[0])
+    assert quarantine_dir.is_dir()
+    assert (quarantine_dir / blocker_rel).read_text(encoding="utf-8") == "generated,old\n"
+    assert (quarantine_dir / "manifest.json").exists()
+    assert "quarantined untracked checkout blockers" in (result.message or "")

--- a/control_plane/operator_runbook.md
+++ b/control_plane/operator_runbook.md
@@ -72,6 +72,7 @@ The worker daemon uses that value before dispatch:
 - if the evaluator service repo already contains the required commit, the item runs normally
 - if the required commit is reachable from `origin/master`, the service repo is updated and the daemon re-execs itself before leasing the item
 - if the commit is missing or the service repo has tracked local modifications, the daemon reports a `source_blocked` or `source_reconcile_error` result instead of running with stale control-plane code
+- if Git reports untracked generated files that would be overwritten by the update, the daemon quarantines those files under `/tmp/<repo>-checkout-blockers-*`, writes a `manifest.json`, retries the checkout, and includes the quarantine path in the source reconciliation log
 
 The default evaluator service wrapper enables this behavior:
 ```sh


### PR DESCRIPTION
## Summary
- quarantine Git-reported untracked files that block evaluator service checkout updates
- retry source checkout after quarantine while preserving tracked-modification refusal
- record quarantine directories in the source reconciliation result/message
- document the behavior in the operator runbook

## Validation
- `PYTHONPATH=/tmp/rtlgen-source-contract/control_plane:/tmp/rtlgen-source-contract /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_source_reconciler.py`
- `PYTHONPATH=/tmp/rtlgen-source-contract/control_plane:/tmp/rtlgen-source-contract /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_worker_daemon.py control_plane/control_plane/tests/test_source_reconciler.py`
- `PYTHONPATH=/tmp/rtlgen-source-contract/control_plane:/tmp/rtlgen-source-contract /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile control_plane/control_plane/services/source_reconciler.py control_plane/control_plane/services/worker_daemon.py control_plane/control_plane/cli/run_worker_daemon.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
