### PR TITLE
[codex] Prefer decoder synthesis evidence in L2 consumer

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -436,8 +436,13 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("bitwidth_boundary_out", "bitwidth_boundary_report"),
     ("quantization_outline_out", "quantization_outline_report"),
     ("cost_proxy_out", "cost_proxy_report"),
+    ("decoder_frontier_synthesis_out", "decoder_frontier_synthesis_report"),
     ("attention_kv_memory_out", "attention_kv_memory_report"),
 )
+
+
+def _decoder_source_ref_key(key: str) -> str:
+    return key if key.startswith("decoder_") else f"decoder_{key}"
 
 
 def _decoder_evidence_paths(
@@ -452,7 +457,7 @@ def _decoder_evidence_paths(
     for ref_key in ("dataset_manifest", "sample_file", "validation_out", "quality_out", "candidate_sweep_out"):
         value = str(decoder_contract.get(ref_key, "")).strip()
         if value:
-            source_refs[f"decoder_{ref_key}"] = value
+            source_refs[_decoder_source_ref_key(ref_key)] = value
     for out_key, report_key in _DECODER_EVIDENCE_OUTPUT_KEYS:
         out_rel = str(decoder_contract.get(out_key, "")).strip()
         if not out_rel:
@@ -460,10 +465,10 @@ def _decoder_evidence_paths(
         out_path = _resolve_path(repo_root=repo_root, path_text=out_rel)
         if not out_path.exists():
             continue
-        source_refs[f"decoder_{out_key}"] = out_rel
+        source_refs[_decoder_source_ref_key(out_key)] = out_rel
         report_rel = str(decoder_contract.get(report_key, "")).strip()
         if report_rel and _resolve_path(repo_root=repo_root, path_text=report_rel).exists():
-            source_refs[f"decoder_{report_key}"] = report_rel
+            source_refs[_decoder_source_ref_key(report_key)] = report_rel
         return out_rel, source_refs
     return None, source_refs
 
@@ -492,7 +497,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
     diagnosis = evidence_payload.get("diagnosis")
     diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
     decision = str(diagnosis_dict.get("decision", "")).strip() or "decoder_evidence_recorded"
-    parts = [f"Decoder quality evidence recorded from {evidence_ref}: decision={decision}"]
+    parts = [f"Decoder evidence recorded from {evidence_ref}: decision={decision}"]
     if "exact_safe_after_recovery" in diagnosis_dict:
         parts.append(f"exact_safe_after_recovery={bool(diagnosis_dict.get('exact_safe_after_recovery'))}")
     if "recovered_count" in diagnosis_dict:

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -991,6 +991,135 @@ def test_consume_l2_result_frontier_attention_kv_uses_decoder_evidence() -> None
             assert decision_payload["source_refs"]["decoder_attention_kv_memory_report"] == report_rel
 
 
+def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_decoder_frontier_synthesis_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_frontier_synthesis_v1",
+                        "kind": "architecture",
+                        "title": "Decoder frontier synthesis",
+                        "direct_comparison": {
+                            "primary_question": "Which measured decoder components dominate the frontier?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            synthesis_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_frontier_synthesis__l2_decoder_frontier_synthesis_v1.json"
+            )
+            synthesis_report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_frontier_synthesis__l2_decoder_frontier_synthesis_v1.md"
+            )
+            attention_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_memory__l2_decoder_frontier_synthesis_v1.json"
+            )
+            attention_report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_memory__l2_decoder_frontier_synthesis_v1.md"
+            )
+            _write(
+                repo_root / synthesis_rel,
+                json.dumps(
+                    {
+                        "version": 0.1,
+                        "model": "llm_decoder_frontier_synthesis_v1",
+                        "diagnosis": {
+                            "decision": "decoder_frontier_synthesis_recorded",
+                            "recommended_next_step": "measure producer/ranker RTL",
+                        },
+                        "dominant_component_counts": {
+                            "output_projection_producer_ranker": 8,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / synthesis_report_rel, "# decoder frontier synthesis\n")
+            _write(
+                repo_root / attention_rel,
+                json.dumps(
+                    {
+                        "version": 0.1,
+                        "diagnosis": {
+                            "decision": "attention_kv_bottleneck_recorded",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / attention_report_rel, "# attention kv\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_decoder_frontier_synthesis_v1",
+                campaign_dir_rel="runs/campaigns/npu/decoder_frontier_synthesis_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_decoder_frontier_synthesis_v1",
+                comparison={"role": "ranking"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use measured decoder frontier synthesis evidence for next architecture selection.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_frontier_synthesis",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "decoder_frontier_synthesis_out": synthesis_rel,
+                    "decoder_frontier_synthesis_report": synthesis_report_rel,
+                    "attention_kv_memory_out": attention_rel,
+                    "attention_kv_memory_report": attention_report_rel,
+                }
+            }
+            work_item.expected_outputs = [
+                *(work_item.expected_outputs or []),
+                synthesis_rel,
+                synthesis_report_rel,
+                attention_rel,
+                attention_report_rel,
+            ]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "decoder_frontier_synthesis_recorded"
+            assert assessment["decoder_evidence_ref"] == synthesis_rel
+            assert decision_payload["evaluation_record"]["abstraction_layer"] == "decoder_frontier_synthesis"
+            assert decision_payload["source_refs"]["decoder_frontier_synthesis_out"] == synthesis_rel
+            assert decision_payload["source_refs"]["decoder_frontier_synthesis_report"] == synthesis_report_rel
+            assert decision_payload["source_refs"].get("decoder_attention_kv_memory_out") is None
+
+
 def test_consume_l2_result_resolves_prior_art_report_as_baseline() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- teach the L2 result consumer to select decoder frontier synthesis evidence before attention/KV evidence
- keep decoder-prefixed source ref keys stable without producing `decoder_decoder_*`
- add regression coverage where both synthesis and attention/KV artifacts exist in one decoder contract

## Validation
- `PYTHONPATH=/tmp/rtlgen-source-contract/control_plane:/tmp/rtlgen-source-contract /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py`
