### PR TITLE
[codex] Plan output projection producer scale sweep

### DIFF
--- a/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending evaluation.

--- a/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/design_brief.md
@@ -1,0 +1,14 @@
+# Output-Projection Producer Scale
+
+The merged decoder frontier synthesis says the current dominant component is
+`output_projection_producer_ranker`. The best synthesis rows use producer width
+64 and integer producer II values of 384 to 512 cycles, but the measured
+producer-side PPA anchors are currently much smaller.
+
+This proposal measures fp16 GEMM producer blocks at `num_modules=4`, `8`, and
+`16` with the `gemm_compute_array` hierarchy preserved. These points should be
+used as producer-side scaling anchors before selecting the first combined
+producer/ranker macro.
+
+The result is not final decoder PPA. It does not yet include vocabulary weight
+SRAM, shared NoC arbitration, or the global top-k merge path.

--- a/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+Accept the job if it:
+
+- runs all three producer configs at `num_modules=4`, `8`, and `16`
+- keeps `SYNTH_HIERARCHICAL=1` and preserves `gemm_compute_array`
+- reports per-config `metrics.csv` with timing, area, and power
+- clearly separates producer-side block PPA from final combined producer/ranker
+  macro PPA

--- a/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/evaluation_requests.json
@@ -1,0 +1,32 @@
+{
+  "proposal_id": "prop_l1_decoder_output_projection_producer_scale_v1",
+  "source_commit": "",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_output_projection_producer_scale_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure hierarchical Nangate45 PPA for fp16 output-projection producer blocks at num_modules=4, 8, and 16.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "producer_scale_anchor",
+      "configs": [
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm4_producer/config_nm4_producer.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm8_producer/config_nm8_producer.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_hier_macro.json",
+      "out_root": "runs/designs/npu_blocks",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_v1",
+        "l2_decoder_output_projection_service_v1",
+        "l2_decoder_producer_ranker_coupled_noc_v1"
+      ],
+      "requires_merged_inputs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the measured producer scale curve to decide the first combined producer/ranker macro shape and to bound extrapolation toward the w64 frontier."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/implementation_summary.md
@@ -1,0 +1,8 @@
+# Implementation Summary
+
+- Add three fp16 NPU producer block configs with `compute.gemm.num_modules`
+  set to 4, 8, and 16.
+- Add a hierarchy-preserving Nangate45 sweep that keeps `gemm_compute_array`
+  as the measured producer boundary.
+- Queue one Layer 1 sweep item to collect timing, area, and power for the
+  producer scaling curve.

--- a/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_decoder_output_projection_producer_scale_v1",
+  "candidate_id": "",
+  "decision": "pending",
+  "reason": "Pending evaluation.",
+  "evidence_refs": [],
+  "next_action": "run l1_decoder_output_projection_producer_scale_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l1_decoder_output_projection_producer_scale_v1",
+  "decision": "pending"
+}

--- a/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/proposal.json
@@ -1,0 +1,77 @@
+{
+  "proposal_id": "prop_l1_decoder_output_projection_producer_scale_v1",
+  "created_utc": "2026-05-13T02:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "title": "Output-projection producer GEMM-array scaling anchor",
+  "hypothesis": "The decoder frontier synthesis result is dominated by output_projection_producer_ranker because producer service is weight-memory limited. Before implementing a combined producer/ranker macro, the producer-side GEMM array needs measured Nangate45 scaling points beyond the existing one- and two-module anchors.",
+  "direct_comparison": {
+    "primary_question": "How do fp16 GEMM producer blocks with 4, 8, and 16 modules scale in timing, area, and power when preserved hierarchically for the decoder output-projection producer?",
+    "include": [
+      "hierarchical Nangate45 PPA for num_modules=4, 8, and 16",
+      "gemm_compute_array preserved as a hierarchy boundary",
+      "comparison against existing num_modules=1 and num_modules=2 producer anchors",
+      "explicit caveat that this is producer-side block PPA, not the final combined producer/ranker macro"
+    ],
+    "exclude": [
+      "full vocabulary SRAM/NoC integration",
+      "top-k ranker merge RTL changes",
+      "final decoder end-to-end PPA",
+      "probability sampling path"
+    ]
+  },
+  "expected_benefit": [
+    "replaces a large part of the producer service extrapolation with measured PPA",
+    "checks whether scaling toward the w64 producer frontier remains physically plausible",
+    "feeds the follow-on combined producer/ranker macro target selection"
+  ],
+  "risks": [
+    "the measured NPU block still includes wrapper/control structure around the internal producer array",
+    "num_modules=16 is the current rtlgen generator limit and still far below a full 64-lane producer",
+    "memory and NoC bandwidth remain modeled until a shared-memory producer/ranker macro is implemented"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_output_projection_producer_scale_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure hierarchical Nangate45 PPA for fp16 output-projection producer blocks at num_modules=4, 8, and 16.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "producer_scale_anchor",
+      "configs": [
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm4_producer/config_nm4_producer.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm8_producer/config_nm8_producer.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_hier_macro.json",
+      "out_root": "runs/designs/npu_blocks",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_v1",
+        "l2_decoder_output_projection_service_v1",
+        "l2_decoder_producer_ranker_coupled_noc_v1"
+      ],
+      "requires_merged_inputs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the measured producer scale curve to decide the first combined producer/ranker macro shape and to bound extrapolation toward the w64 frontier."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_frontier_synthesis_v1.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_output_projection_service_v1.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_producer_ranker_coupled_noc_v1.json",
+    "runs/designs/npu_macros/gemm_compute_array_fp16_nm1_c250/macro_manifest.json",
+    "runs/designs/npu_macros/gemm_compute_array_fp16_2slot_c300/macro_manifest.json"
+  ],
+  "knowledge_refs": [
+    "npu/rtlgen/gen.py",
+    "npu/rtlgen/config_spec.md",
+    "npu/eval/synthesize_llm_decoder_frontier.py",
+    "npu/eval/estimate_llm_decoder_producer_ranker_coupling.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/quality_gate.md
@@ -1,0 +1,6 @@
+# Quality Gate
+
+The result is useful if it provides a monotonic or explainable producer PPA
+curve that can be compared with the existing num_modules=1 and num_modules=2
+anchors. The next architectural step should use that curve to choose a combined
+producer/ranker RTL target.

--- a/runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_hier_macro.json
+++ b/runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_hier_macro.json
@@ -1,0 +1,29 @@
+{
+  "flow_params": {
+    "TAG": [
+      "npu_fp16_producer_scale_hier"
+    ],
+    "FLOW_VARIANT": [
+      "producer_scale_hier"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2200 2200"
+    ],
+    "CORE_AREA": [
+      "80 80 2120 2120"
+    ],
+    "PLACE_DENSITY": [
+      0.36
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "gemm_compute_array"
+    ]
+  },
+  "tag_prefix": "npu_fp16_producer_scale"
+}

--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "top_name": "npu_top",
+  "mmio_addr_width": 12,
+  "data_width": 32,
+  "dma_addr_width": 64,
+  "dma_data_width": 256,
+  "axi_addr_width": 64,
+  "axi_data_width": 256,
+  "axi_id_width": 4,
+  "sram_instances": [
+    {
+      "name": "activation_sram",
+      "depth": 16384,
+      "width": 256,
+      "banks": 8,
+      "read_latency": 1,
+      "byte_en": true,
+      "port": "1r1w",
+      "pdk": "sky130",
+      "tech_node_nm": 130,
+      "base_addr": "0x80000000",
+      "alignment_bytes": 64
+    }
+  ],
+  "queue_depth": 16,
+  "enable_irq": true,
+  "enable_dma_ports": true,
+  "enable_cq_mem_ports": true,
+  "enable_axi_ports": true,
+  "enable_axi_lite_wrapper": true,
+  "compute": {
+    "enabled": true,
+    "gemm": {
+      "mac_type": "fp16",
+      "lanes": 1,
+      "accum_width": 16,
+      "pipeline": 1,
+      "fp16": {
+        "semantics": "ieee_half",
+        "accumulation": "fp16",
+        "rounding": "rne",
+        "subnormals": "preserve"
+      },
+      "rtlgen_cpp": {
+        "binary_path": "build/rtlgen",
+        "module_name": "gemm_mac_fp16_ieee",
+        "total_width": 16,
+        "mantissa_width": 10
+      },
+      "num_modules": 16,
+      "lanes_per_module": 1
+    },
+    "vec": {
+      "lanes": 1,
+      "ops": [
+        "add",
+        "mul",
+        "relu"
+      ]
+    }
+  }
+}

--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm4_producer/config_nm4_producer.json
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm4_producer/config_nm4_producer.json
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "top_name": "npu_top",
+  "mmio_addr_width": 12,
+  "data_width": 32,
+  "dma_addr_width": 64,
+  "dma_data_width": 256,
+  "axi_addr_width": 64,
+  "axi_data_width": 256,
+  "axi_id_width": 4,
+  "sram_instances": [
+    {
+      "name": "activation_sram",
+      "depth": 16384,
+      "width": 256,
+      "banks": 8,
+      "read_latency": 1,
+      "byte_en": true,
+      "port": "1r1w",
+      "pdk": "sky130",
+      "tech_node_nm": 130,
+      "base_addr": "0x80000000",
+      "alignment_bytes": 64
+    }
+  ],
+  "queue_depth": 16,
+  "enable_irq": true,
+  "enable_dma_ports": true,
+  "enable_cq_mem_ports": true,
+  "enable_axi_ports": true,
+  "enable_axi_lite_wrapper": true,
+  "compute": {
+    "enabled": true,
+    "gemm": {
+      "mac_type": "fp16",
+      "lanes": 1,
+      "accum_width": 16,
+      "pipeline": 1,
+      "fp16": {
+        "semantics": "ieee_half",
+        "accumulation": "fp16",
+        "rounding": "rne",
+        "subnormals": "preserve"
+      },
+      "rtlgen_cpp": {
+        "binary_path": "build/rtlgen",
+        "module_name": "gemm_mac_fp16_ieee",
+        "total_width": 16,
+        "mantissa_width": 10
+      },
+      "num_modules": 4,
+      "lanes_per_module": 1
+    },
+    "vec": {
+      "lanes": 1,
+      "ops": [
+        "add",
+        "mul",
+        "relu"
+      ]
+    }
+  }
+}

--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm8_producer/config_nm8_producer.json
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm8_producer/config_nm8_producer.json
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "top_name": "npu_top",
+  "mmio_addr_width": 12,
+  "data_width": 32,
+  "dma_addr_width": 64,
+  "dma_data_width": 256,
+  "axi_addr_width": 64,
+  "axi_data_width": 256,
+  "axi_id_width": 4,
+  "sram_instances": [
+    {
+      "name": "activation_sram",
+      "depth": 16384,
+      "width": 256,
+      "banks": 8,
+      "read_latency": 1,
+      "byte_en": true,
+      "port": "1r1w",
+      "pdk": "sky130",
+      "tech_node_nm": 130,
+      "base_addr": "0x80000000",
+      "alignment_bytes": 64
+    }
+  ],
+  "queue_depth": 16,
+  "enable_irq": true,
+  "enable_dma_ports": true,
+  "enable_cq_mem_ports": true,
+  "enable_axi_ports": true,
+  "enable_axi_lite_wrapper": true,
+  "compute": {
+    "enabled": true,
+    "gemm": {
+      "mac_type": "fp16",
+      "lanes": 1,
+      "accum_width": 16,
+      "pipeline": 1,
+      "fp16": {
+        "semantics": "ieee_half",
+        "accumulation": "fp16",
+        "rounding": "rne",
+        "subnormals": "preserve"
+      },
+      "rtlgen_cpp": {
+        "binary_path": "build/rtlgen",
+        "module_name": "gemm_mac_fp16_ieee",
+        "total_width": 16,
+        "mantissa_width": 10
+      },
+      "num_modules": 8,
+      "lanes_per_module": 1
+    },
+    "vec": {
+      "lanes": 1,
+      "ops": [
+        "add",
+        "mul",
+        "relu"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Layer 1 proposal for output-projection producer GEMM scaling after the decoder frontier synthesis result
- add fp16 producer configs at `num_modules=4`, `8`, and `16`
- add a hierarchy-preserving Nangate45 sweep that keeps `gemm_compute_array` intact

## Validation
- `jq empty` on new JSON configs/proposal files
- `python3 npu/rtlgen/gen.py --config runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json --out /tmp/rtlgen-nm16-producer-validate`
- direct `generate_l1_sweep_task` smoke with sqlite in-memory DB
- `PYTHONPATH=/tmp/rtlgen-source-contract/control_plane:/tmp/rtlgen-source-contract /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py`
