### PR TITLE
[codex] add producer synthesis boundary probe

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -437,6 +437,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("quantization_outline_out", "quantization_outline_report"),
     ("cost_proxy_out", "cost_proxy_report"),
     ("decoder_frontier_synthesis_out", "decoder_frontier_synthesis_report"),
+    ("producer_synth_boundary_out", "producer_synth_boundary_report"),
     ("attention_kv_memory_out", "attention_kv_memory_report"),
 )
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2327,6 +2327,49 @@ def _decoder_frontier_synthesis_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_output_projection_producer_synth_boundary_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_producer_synth_boundary__{item_id}.json"
+    report = f"{base}/decoder_output_projection_producer_synth_boundary__{item_id}.md"
+    configs = [
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm3_producer/config_nm3_producer.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm4_producer/config_nm4_producer.json",
+    ]
+    sweep = "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json"
+    return {
+        "inputs": {
+            "producer_synth_boundary_out": out,
+            "producer_synth_boundary_report": report,
+            "producer_synth_boundary_configs": configs,
+            "producer_synth_boundary_sweep": sweep,
+            "producer_synth_boundary_make_target": "1_2_yosys",
+            "producer_synth_boundary_scope": (
+                "Bound decoder output-projection producer synthesis by probing nm2, nm3, "
+                "and nm4 with a synth-only target and explicit timeout before retrying full PnR."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_decoder_output_projection_producer_synth_boundary",
+                "run": (
+                    "python3 npu/eval/probe_decoder_producer_synth_boundary.py "
+                    f"--configs {','.join(configs)} "
+                    f"--sweep {sweep} "
+                    "--platform nangate45 "
+                    "--top npu_top "
+                    "--make-target 1_2_yosys "
+                    "--timeout-seconds 1800 "
+                    "--stall-timeout-seconds 900 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2795,10 +2838,13 @@ def _build_payload(
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
+        "decoder_output_projection_producer_synth_boundary",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_producer_synth_boundary":
+            decoder_evidence = _decoder_output_projection_producer_synth_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_frontier_synthesis":
             decoder_evidence = _decoder_frontier_synthesis_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_memory":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1120,6 +1120,122 @@ def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> No
             assert decision_payload["source_refs"].get("decoder_attention_kv_memory_out") is None
 
 
+def test_consume_l2_result_prefers_producer_synth_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_output_projection_producer_synth_boundary_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_output_projection_producer_synth_boundary_v1",
+                        "kind": "architecture",
+                        "title": "Decoder producer synthesis boundary",
+                        "direct_comparison": {
+                            "primary_question": "Where does producer synthesis become nonviable?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_synth_boundary__"
+                "l2_decoder_output_projection_producer_synth_boundary_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_synth_boundary__"
+                "l2_decoder_output_projection_producer_synth_boundary_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 0.1,
+                        "model": "decoder_output_projection_producer_synth_boundary_v1",
+                        "diagnosis": {
+                            "decision": "producer_synth_boundary_recorded",
+                            "feasible_max_num_modules": 3,
+                            "first_nonviable_num_modules": 4,
+                            "recommended_next_step": "split the producer before full PnR",
+                        },
+                        "probe_rows": [
+                            {"num_modules": 3, "status": "ok"},
+                            {"num_modules": 4, "status": "stall_timeout"},
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# decoder producer synthesis boundary\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_decoder_output_projection_producer_synth_boundary_v1",
+                campaign_dir_rel="runs/campaigns/npu/decoder_producer_synth_boundary_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,"
+                    "critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,"
+                    "throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm3_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1",
+                comparison={"role": "producer_synth_boundary"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Record bounded producer synthesis frontier before deeper RTL jobs.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_output_projection_producer_synth_boundary",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "producer_synth_boundary_out": evidence_rel,
+                    "producer_synth_boundary_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [
+                *(work_item.expected_outputs or []),
+                evidence_rel,
+                report_rel,
+            ]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "producer_synth_boundary_recorded"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert decision_payload["evaluation_record"]["abstraction_layer"] == (
+                "decoder_output_projection_producer_synth_boundary"
+            )
+            assert decision_payload["source_refs"]["decoder_producer_synth_boundary_out"] == evidence_rel
+            assert decision_payload["source_refs"]["decoder_producer_synth_boundary_report"] == report_rel
+
+
 def test_consume_l2_result_resolves_prior_art_report_as_baseline() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1957,6 +1957,61 @@ def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_evidence() ->
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_producer_synth_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_producer_synth_boundary_v1",
+                    proposal_id="prop_l2_decoder_output_projection_producer_synth_boundary_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_producer_synth_boundary_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_producer_synth_boundary",
+                    expected_direction="iterate",
+                    comparison_role="producer_synth_boundary",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == (
+                "probe_decoder_output_projection_producer_synth_boundary"
+            )
+            run = work_item.command_manifest[0]["run"]
+            assert "probe_decoder_producer_synth_boundary.py" in run
+            assert "--make-target 1_2_yosys" in run
+            assert "--timeout-seconds 1800" in run
+            assert "npu_fp16_cpp_nm2_producer/config_nm2_producer.json" in run
+            assert "npu_fp16_cpp_nm3_producer/config_nm3_producer.json" in run
+            assert "npu_fp16_cpp_nm4_producer/config_nm4_producer.json" in run
+            assert decoder_inputs["producer_synth_boundary_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_synth_boundary__"
+                "l2_decoder_output_projection_producer_synth_boundary_v1.json"
+            )
+            assert "synth-only target" in decoder_inputs["producer_synth_boundary_scope"]
+            assert decoder_inputs["producer_synth_boundary_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_producer_synth_boundary",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending evaluation.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/design_brief.md
@@ -1,0 +1,5 @@
+# Decoder Producer Synthesis Boundary
+
+The previous output-projection producer scale job entered a long ABC synthesis phase before producing useful PPA. This job changes the question from "finish nm4/nm8/nm16 PnR" to "where does synth-only compilation stop being practical?"
+
+It probes nm2, nm3, and nm4 in increasing order using `1_2_yosys`, a total timeout, and a quiet-output timeout. The first timeout or failed synthesis stops the probe and records the largest completed point.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+Accept the job if it:
+
+- generates producer RTL for each attempted config
+- runs `npu/synth/run_block_sweep.py` with `--make_target 1_2_yosys`
+- applies both total and quiet-output timeouts per point
+- stops after the first nonviable point unless explicitly configured otherwise
+- writes JSON and Markdown reports with largest completed and first nonviable `num_modules`
+- keeps artifact paths repo-portable

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_synth_boundary_v1",
+  "source_commit": "pending",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_synth_boundary_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a bounded synth-only probe for decoder output-projection producer scale over nm2, nm3, and nm4 and report the first runtime-nonviable synthesis point.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_synth_boundary",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_frontier_synthesis_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify the largest producer scale that finishes synth-only compilation and the first point that times out or stalls, so the next producer architecture job can stay inside the explorable region."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/implementation_summary.md
@@ -1,0 +1,3 @@
+# Implementation Summary
+
+Adds `npu/eval/probe_decoder_producer_synth_boundary.py`, nm2/nm3 producer configs, a synth-boundary sweep, and a Layer 2 abstraction named `decoder_output_projection_producer_synth_boundary`.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_synth_boundary_v1",
+  "candidate_id": "l2_decoder_output_projection_producer_synth_boundary_v1",
+  "decision": "pending",
+  "reason": "Pending bounded synthesis-boundary evaluation.",
+  "evidence_refs": [],
+  "next_action": "dispatch l2_decoder_output_projection_producer_synth_boundary_v1 after merge",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_synth_boundary_v1",
+  "decision": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_synth_boundary_v1",
+  "created_utc": "2026-05-13T06:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_synth_boundary",
+  "title": "Decoder output-projection producer synthesis boundary",
+  "hypothesis": "The unbounded nm4/nm8/nm16 output-projection producer sweep stalled in ABC before producing useful PPA. A bounded synth-only probe over nm2, nm3, and nm4 can identify the practical synthesis frontier and prevent the evaluator from spending half-day cycles on nonviable scale points.",
+  "direct_comparison": {
+    "primary_question": "At what output-projection producer module count does synth-only compilation stop completing within the bounded evaluator budget?",
+    "include": [
+      "nm2, nm3, and nm4 fp16 rtlgen producer configs",
+      "Nangate45 synth-only OpenROAD target 1_2_yosys",
+      "hard total timeout and quiet-output stall timeout per point",
+      "largest completed synth point and first nonviable point"
+    ],
+    "exclude": [
+      "full placement and routing",
+      "nm8 or nm16 retries before the smaller boundary is known",
+      "final producer/ranker/attention system PPA",
+      "quality or QAT experiments"
+    ]
+  },
+  "expected_benefit": [
+    "bounds evaluator runtime before re-entering full physical implementation",
+    "separates synthesis complexity explosion from placement or IO-perimeter effects",
+    "provides a conservative near-frontier producer scale for whole-decoder extrapolation"
+  ],
+  "risks": [
+    "synth-only completion does not guarantee feasible placement or routing",
+    "the timeout boundary is evaluator-machine dependent",
+    "nm4 failure may require hierarchy or macro-hardening changes rather than abandoning the architecture"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_synth_boundary_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a bounded synth-only probe for decoder output-projection producer scale over nm2, nm3, and nm4 and report the first runtime-nonviable synthesis point.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_synth_boundary",
+      "cost_class": "bounded-medium",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_frontier_synthesis_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify the largest producer scale that finishes synth-only compilation and the first point that times out or stalls, so the next producer architecture job can stay inside the explorable region."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_frontier_synthesis_v1.json",
+    "docs/proposals/prop_l1_decoder_output_projection_producer_scale_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_decoder_producer_synth_boundary.py",
+    "npu/synth/run_block_sweep.py",
+    "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/quality_gate.md
@@ -1,0 +1,3 @@
+# Quality Gate
+
+This is a runtime-boundary report, not final PPA. It is usable if it distinguishes synth completion from timeout/stall/failure and names the next producer scale that should not be sent to full PnR without restructuring.

--- a/npu/eval/probe_decoder_producer_synth_boundary.py
+++ b/npu/eval/probe_decoder_producer_synth_boundary.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Bounded synthesis probe for decoder output-projection producer scale."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def portable_log_label(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return path.name
+
+
+def parse_configs(args: argparse.Namespace) -> list[Path]:
+    raw: list[str] = []
+    for item in args.configs or []:
+        raw.extend(part.strip() for part in str(item).split(",") if part.strip())
+    raw.extend(args.config or [])
+    paths = [(REPO_ROOT / item).resolve() if not Path(item).is_absolute() else Path(item) for item in raw]
+    if not paths:
+        raise ValueError("provide at least one --config or --configs path")
+    return paths
+
+
+def num_modules(config: dict[str, Any]) -> int:
+    compute = config.get("compute")
+    if not isinstance(compute, dict):
+        raise ValueError("config missing compute object")
+    gemm = compute.get("gemm")
+    if not isinstance(gemm, dict):
+        raise ValueError("config missing compute.gemm object")
+    return int(gemm.get("num_modules", 0))
+
+
+def tail_lines(path: Path, limit: int = 40) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except FileNotFoundError:
+        return []
+    return lines[-limit:]
+
+
+def run_logged(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    log_path: Path,
+    timeout_seconds: int,
+    stall_timeout_seconds: int,
+) -> dict[str, Any]:
+    start = time.monotonic()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as log:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            preexec_fn=os.setsid,
+        )
+        last_size = -1
+        last_activity = time.monotonic()
+        timed_out = False
+        stalled = False
+        while proc.poll() is None:
+            now = time.monotonic()
+            try:
+                size = log_path.stat().st_size
+            except FileNotFoundError:
+                size = 0
+            if size != last_size:
+                last_size = size
+                last_activity = now
+            if timeout_seconds > 0 and now - start >= timeout_seconds:
+                timed_out = True
+                break
+            if stall_timeout_seconds > 0 and now - last_activity >= stall_timeout_seconds:
+                stalled = True
+                break
+            time.sleep(2.0)
+        if timed_out or stalled:
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                proc.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                proc.wait()
+        rc = proc.returncode
+    elapsed = time.monotonic() - start
+    if timed_out:
+        status = "timeout"
+    elif stalled:
+        status = "stall_timeout"
+    elif rc == 0:
+        status = "ok"
+    else:
+        status = "failed"
+    return {
+        "status": status,
+        "returncode": rc,
+        "elapsed_seconds": elapsed,
+        "log_path": portable_log_label(log_path),
+        "log_tail": tail_lines(log_path),
+        "command": " ".join(cmd),
+    }
+
+
+def latest_metrics_row(design_dir: Path) -> dict[str, Any] | None:
+    metrics = design_dir / "metrics.csv"
+    if not metrics.exists():
+        return None
+    with metrics.open(encoding="utf-8", newline="") as f:
+        rows = list(csv.DictReader(f))
+    return dict(rows[-1]) if rows else None
+
+
+def probe_config(
+    config_path: Path,
+    *,
+    sweep: Path,
+    platform: str,
+    top: str,
+    make_target: str,
+    out_root: Path,
+    timeout_seconds: int,
+    stall_timeout_seconds: int,
+    log_dir: Path,
+) -> dict[str, Any]:
+    config = load_json(config_path)
+    modules = num_modules(config)
+    design_dir = config_path.parent
+    verilog_dir = design_dir / "verilog"
+
+    gen_cmd = [
+        sys.executable,
+        "npu/rtlgen/gen.py",
+        "--config",
+        rel(config_path),
+        "--out",
+        rel(verilog_dir),
+    ]
+    gen_result = run_logged(
+        gen_cmd,
+        cwd=REPO_ROOT,
+        log_path=log_dir / f"nm{modules}_rtlgen.log",
+        timeout_seconds=max(300, min(timeout_seconds, 900)),
+        stall_timeout_seconds=max(120, min(stall_timeout_seconds, 300)),
+    )
+    row: dict[str, Any] = {
+        "config": rel(config_path),
+        "design_dir": rel(design_dir),
+        "num_modules": modules,
+        "rtlgen": gen_result,
+        "synthesis": None,
+        "metrics_row": None,
+    }
+    if gen_result["status"] != "ok":
+        row["status"] = f"rtlgen_{gen_result['status']}"
+        return row
+
+    synth_cmd = [
+        sys.executable,
+        "npu/synth/run_block_sweep.py",
+        "--design_dir",
+        rel(design_dir),
+        "--platform",
+        platform,
+        "--top",
+        top,
+        "--sweep",
+        rel(sweep),
+        "--make_target",
+        make_target,
+        "--out_root",
+        rel(out_root),
+        "--force_copy",
+    ]
+    synth_result = run_logged(
+        synth_cmd,
+        cwd=REPO_ROOT,
+        log_path=log_dir / f"nm{modules}_{make_target}.log",
+        timeout_seconds=timeout_seconds,
+        stall_timeout_seconds=stall_timeout_seconds,
+    )
+    row["synthesis"] = synth_result
+    metrics_row = latest_metrics_row(out_root / design_dir.name)
+    if metrics_row is not None:
+        row["metrics_row"] = metrics_row
+    if synth_result["status"] != "ok":
+        row["status"] = synth_result["status"]
+    elif metrics_row and str(metrics_row.get("status", "")).strip():
+        row["status"] = str(metrics_row.get("status"))
+    else:
+        row["status"] = "ok"
+    return row
+
+
+def build_diagnosis(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    ok_rows = [row for row in rows if str(row.get("status")) == "ok"]
+    blocked_rows = [row for row in rows if str(row.get("status")) != "ok"]
+    feasible = max((int(row.get("num_modules", 0)) for row in ok_rows), default=None)
+    first_blocked = min((int(row.get("num_modules", 0)) for row in blocked_rows), default=None)
+    if first_blocked is None:
+        decision = "producer_synth_boundary_not_reached"
+        next_step = "Extend the probe to the next producer scale before launching full PnR."
+    else:
+        decision = "producer_synth_boundary_recorded"
+        next_step = (
+            "Use the largest completed synth point for near-frontier extrapolation and split or macro-harden "
+            "larger producers before retrying full physical implementation."
+        )
+    return {
+        "decision": decision,
+        "feasible_max_num_modules": feasible,
+        "first_nonviable_num_modules": first_blocked,
+        "recommended_next_step": next_step,
+    }
+
+
+def write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# Decoder Producer Synthesis Boundary",
+        "",
+        f"- make_target: `{payload['make_target']}`",
+        f"- timeout_seconds: `{payload['timeout_seconds']}`",
+        f"- stall_timeout_seconds: `{payload['stall_timeout_seconds']}`",
+        "",
+        "| num_modules | status | elapsed_s | metrics_status | result_path | log |",
+        "|---:|---|---:|---|---|---|",
+    ]
+    for row in payload["probe_rows"]:
+        synth = row.get("synthesis") or {}
+        metrics = row.get("metrics_row") or {}
+        elapsed = synth.get("elapsed_seconds")
+        elapsed_text = f"{float(elapsed):.1f}" if elapsed is not None else ""
+        lines.append(
+            "| {nm} | {status} | {elapsed} | {metrics_status} | {result_path} | {log} |".format(
+                nm=row.get("num_modules"),
+                status=row.get("status"),
+                elapsed=elapsed_text,
+                metrics_status=metrics.get("status", ""),
+                result_path=metrics.get("result_path", ""),
+                log=synth.get("log_path", ""),
+            )
+        )
+    diagnosis = payload["diagnosis"]
+    lines.extend(
+        [
+            "",
+            "## Diagnosis",
+            "",
+            f"- decision: `{diagnosis.get('decision')}`",
+            f"- feasible_max_num_modules: `{diagnosis.get('feasible_max_num_modules')}`",
+            f"- first_nonviable_num_modules: `{diagnosis.get('first_nonviable_num_modules')}`",
+            f"- recommended_next_step: {diagnosis.get('recommended_next_step')}",
+            "",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", action="append", default=[], help="Config path; repeatable")
+    ap.add_argument("--configs", action="append", default=[], help="Comma-separated config paths")
+    ap.add_argument("--sweep", required=True)
+    ap.add_argument("--platform", default="nangate45")
+    ap.add_argument("--top", default="npu_top")
+    ap.add_argument("--make-target", default="1_2_yosys")
+    ap.add_argument("--out-root", default="runs/designs/npu_blocks")
+    ap.add_argument("--timeout-seconds", type=int, default=1800)
+    ap.add_argument("--stall-timeout-seconds", type=int, default=900)
+    ap.add_argument("--continue-after-failure", action="store_true")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    configs = sorted(parse_configs(args), key=lambda path: num_modules(load_json(path)))
+    sweep = (REPO_ROOT / args.sweep).resolve() if not Path(args.sweep).is_absolute() else Path(args.sweep)
+    out = (REPO_ROOT / args.out).resolve() if not Path(args.out).is_absolute() else Path(args.out)
+    out_md = (REPO_ROOT / args.out_md).resolve() if not Path(args.out_md).is_absolute() else Path(args.out_md)
+    out_root = (
+        (REPO_ROOT / args.out_root).resolve()
+        if not Path(args.out_root).is_absolute()
+        else Path(args.out_root)
+    )
+    log_root = Path(
+        os.environ.get("RTLGEN_PRODUCER_SYNTH_BOUNDARY_LOG_DIR", "/tmp/rtlgen-producer-synth-boundary")
+    )
+    log_dir = log_root / out.stem
+
+    rows: list[dict[str, Any]] = []
+    for config_path in configs:
+        row = probe_config(
+            config_path,
+            sweep=sweep,
+            platform=args.platform,
+            top=args.top,
+            make_target=args.make_target,
+            out_root=out_root,
+            timeout_seconds=args.timeout_seconds,
+            stall_timeout_seconds=args.stall_timeout_seconds,
+            log_dir=log_dir,
+        )
+        rows.append(row)
+        if row.get("status") != "ok" and not args.continue_after_failure:
+            break
+
+    payload = {
+        "version": 0.1,
+        "model": "decoder_output_projection_producer_synth_boundary_v1",
+        "platform": args.platform,
+        "top": args.top,
+        "make_target": args.make_target,
+        "timeout_seconds": args.timeout_seconds,
+        "stall_timeout_seconds": args.stall_timeout_seconds,
+        "sweep": rel(sweep),
+        "probe_rows": rows,
+        "diagnosis": build_diagnosis(rows),
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    write_markdown(out_md, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json
+++ b/runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json
@@ -1,0 +1,29 @@
+{
+  "flow_params": {
+    "TAG": [
+      "npu_fp16_producer_synth_boundary"
+    ],
+    "FLOW_VARIANT": [
+      "producer_synth_boundary"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2200 2200"
+    ],
+    "CORE_AREA": [
+      "80 80 2120 2120"
+    ],
+    "PLACE_DENSITY": [
+      0.36
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "gemm_compute_array"
+    ]
+  },
+  "tag_prefix": "npu_fp16_producer_synth_boundary"
+}

--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "top_name": "npu_top",
+  "mmio_addr_width": 12,
+  "data_width": 32,
+  "dma_addr_width": 64,
+  "dma_data_width": 256,
+  "axi_addr_width": 64,
+  "axi_data_width": 256,
+  "axi_id_width": 4,
+  "sram_instances": [
+    {
+      "name": "activation_sram",
+      "depth": 16384,
+      "width": 256,
+      "banks": 8,
+      "read_latency": 1,
+      "byte_en": true,
+      "port": "1r1w",
+      "pdk": "sky130",
+      "tech_node_nm": 130,
+      "base_addr": "0x80000000",
+      "alignment_bytes": 64
+    }
+  ],
+  "queue_depth": 16,
+  "enable_irq": true,
+  "enable_dma_ports": true,
+  "enable_cq_mem_ports": true,
+  "enable_axi_ports": true,
+  "enable_axi_lite_wrapper": true,
+  "compute": {
+    "enabled": true,
+    "gemm": {
+      "mac_type": "fp16",
+      "lanes": 1,
+      "accum_width": 16,
+      "pipeline": 1,
+      "fp16": {
+        "semantics": "ieee_half",
+        "accumulation": "fp16",
+        "rounding": "rne",
+        "subnormals": "preserve"
+      },
+      "rtlgen_cpp": {
+        "binary_path": "build/rtlgen",
+        "module_name": "gemm_mac_fp16_ieee",
+        "total_width": 16,
+        "mantissa_width": 10
+      },
+      "num_modules": 2,
+      "lanes_per_module": 1
+    },
+    "vec": {
+      "lanes": 1,
+      "ops": [
+        "add",
+        "mul",
+        "relu"
+      ]
+    }
+  }
+}

--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm3_producer/config_nm3_producer.json
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm3_producer/config_nm3_producer.json
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "top_name": "npu_top",
+  "mmio_addr_width": 12,
+  "data_width": 32,
+  "dma_addr_width": 64,
+  "dma_data_width": 256,
+  "axi_addr_width": 64,
+  "axi_data_width": 256,
+  "axi_id_width": 4,
+  "sram_instances": [
+    {
+      "name": "activation_sram",
+      "depth": 16384,
+      "width": 256,
+      "banks": 8,
+      "read_latency": 1,
+      "byte_en": true,
+      "port": "1r1w",
+      "pdk": "sky130",
+      "tech_node_nm": 130,
+      "base_addr": "0x80000000",
+      "alignment_bytes": 64
+    }
+  ],
+  "queue_depth": 16,
+  "enable_irq": true,
+  "enable_dma_ports": true,
+  "enable_axi_ports": true,
+  "enable_cq_mem_ports": true,
+  "enable_axi_lite_wrapper": true,
+  "compute": {
+    "enabled": true,
+    "gemm": {
+      "mac_type": "fp16",
+      "lanes": 1,
+      "accum_width": 16,
+      "pipeline": 1,
+      "fp16": {
+        "semantics": "ieee_half",
+        "accumulation": "fp16",
+        "rounding": "rne",
+        "subnormals": "preserve"
+      },
+      "rtlgen_cpp": {
+        "binary_path": "build/rtlgen",
+        "module_name": "gemm_mac_fp16_ieee",
+        "total_width": 16,
+        "mantissa_width": 10
+      },
+      "num_modules": 3,
+      "lanes_per_module": 1
+    },
+    "vec": {
+      "lanes": 1,
+      "ops": [
+        "add",
+        "mul",
+        "relu"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a bounded synth-only probe for decoder output-projection producer scale
- add nm2/nm3 producer configs and a Nangate45 synth-boundary sweep
- wire a new Layer 2 abstraction/result-consumer path for `decoder_output_projection_producer_synth_boundary`
- add proposal docs for `l2_decoder_output_projection_producer_synth_boundary_v1`

## Why
The previous full producer scale job stalled in ABC before reaching useful PPA. This changes the next job into a bounded frontier probe: try nm2, nm3, then nm4 with `1_2_yosys`, stop at the first timeout/stall/failure, and report the largest completed point plus the first nonviable point.

## Validation
- `python3 -m py_compile npu/eval/probe_decoder_producer_synth_boundary.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py`
- `python3 -m json.tool ...` for added configs, sweep, and proposal JSON
- direct focused test invocation because this container Python lacks pytest: generator + consumer tests passed
- `python3 scripts/validate_runs.py --skip_eval_queue`
