### PR TITLE
[codex] extend isolated producer synth probe

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2377,6 +2377,8 @@ def _decoder_output_projection_producer_isolated_synth_evidence(*, item_id: str)
     configs = [
         "runs/designs/npu_blocks/npu_fp16_cpp_nm1_producer/config_nm1_producer.json",
         "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm3_producer/config_nm3_producer.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm4_producer/config_nm4_producer.json",
     ]
     sweep = "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_isolated_synth.json"
     return {
@@ -2388,9 +2390,9 @@ def _decoder_output_projection_producer_isolated_synth_evidence(*, item_id: str)
             "producer_synth_boundary_make_target": "1_2_yosys",
             "producer_synth_boundary_top": "gemm_compute_array",
             "producer_synth_boundary_scope": (
-                "Probe the isolated generated gemm_compute_array producer submodule for nm1 and nm2 "
-                "with a clockless synth-only target, separating compute-array synthesis from npu_top "
-                "control/MMIO/queue synthesis."
+                "Probe the isolated generated gemm_compute_array producer submodule for nm1 through "
+                "nm4 with a clockless synth-only target, separating compute-array synthesis from "
+                "npu_top control/MMIO/queue synthesis."
             ),
         },
         "commands": [

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2054,12 +2054,15 @@ def test_generate_l2_campaign_task_adds_decoder_producer_isolated_synth_evidence
             assert "--make-target 1_2_yosys" in run
             assert "npu_fp16_cpp_nm1_producer/config_nm1_producer.json" in run
             assert "npu_fp16_cpp_nm2_producer/config_nm2_producer.json" in run
+            assert "npu_fp16_cpp_nm3_producer/config_nm3_producer.json" in run
+            assert "npu_fp16_cpp_nm4_producer/config_nm4_producer.json" in run
             assert decoder_inputs["producer_synth_boundary_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_output_projection_producer_isolated_synth__"
                 "l2_decoder_output_projection_producer_isolated_synth_v1.json"
             )
             assert decoder_inputs["producer_synth_boundary_top"] == "gemm_compute_array"
+            assert "nm1 through nm4" in decoder_inputs["producer_synth_boundary_scope"]
             assert "separating compute-array synthesis" in decoder_inputs["producer_synth_boundary_scope"]
             assert decoder_inputs["producer_synth_boundary_out"] in work_item.expected_outputs
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/design_brief.md
@@ -1,0 +1,14 @@
+# Design Brief
+
+## Goal
+Extend the isolated decoder output-projection producer synth probe from nm1/nm2 to nm1 through nm4.
+
+## Rationale
+The prior isolated probe showed that `gemm_compute_array` synth is viable at nm1 and nm2, while the whole `npu_top` producer probe timed out at nm2. The next boundary question is whether the arithmetic array itself remains easy to synthesize at nm3/nm4.
+
+## Evaluation
+- top: `gemm_compute_array`
+- flow target: `1_2_yosys`
+- configs: `npu_fp16_cpp_nm1_producer` through `npu_fp16_cpp_nm4_producer`
+- sweep: `runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_isolated_synth.json`
+

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/evaluation_gate.md
@@ -1,0 +1,6 @@
+# Evaluation Gate
+
+Dispatch `l2_decoder_output_projection_producer_isolated_synth_scale_v1` only after `l2_decoder_output_projection_producer_isolated_synth_v1` is merged and finalized.
+
+The expected output is the isolated producer synth boundary report with `feasible_max_num_modules` and `first_nonviable_num_modules` for nm1 through nm4.
+

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1",
+  "source_commit": null,
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_isolated_synth_scale_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a bounded synth-only probe for the isolated generated gemm_compute_array producer submodule over nm1 through nm4.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_isolated_synth",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_isolated_synth_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_isolated_synth_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should show whether the isolated producer arithmetic-array synth boundary appears before nm4 or whether the next blocker is still whole npu_top integration."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/implementation_summary.md
@@ -1,0 +1,6 @@
+# Implementation Summary
+
+The L2 task generator now includes nm3 and nm4 producer configs in `decoder_output_projection_producer_isolated_synth` evidence generation.
+
+This keeps the previous isolated synth flow intact and only expands the producer scale set.
+

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1",
+  "created_utc": "2026-05-13T10:35:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_isolated_synth",
+  "title": "Extended isolated decoder output-projection producer synthesis scale probe",
+  "hypothesis": "The isolated generated gemm_compute_array producer submodule completed synth-only compilation at nm1 and nm2, while whole npu_top synthesis timed out at nm2. Extending the isolated probe through nm3 and nm4 will distinguish a near-term arithmetic-array synthesis boundary from wrapper/top-level integration cost.",
+  "direct_comparison": {
+    "primary_question": "Can the isolated generated gemm_compute_array producer submodule complete synth-only compilation for nm1 through nm4 within the evaluator budget?",
+    "include": [
+      "nm1, nm2, nm3, and nm4 fp16 rtlgen producer configs",
+      "generated gemm_compute_array as the OpenROAD top module",
+      "clockless Nangate45 synth-only target 1_2_yosys",
+      "same rtlgen binary setup check and timeout policy used by the prior isolated producer probe"
+    ],
+    "exclude": [
+      "whole npu_top synthesis",
+      "full placement and routing",
+      "nm8 or nm16 before the nm4 isolated boundary is known",
+      "system-level producer/ranker/attention coupling"
+    ]
+  },
+  "expected_benefit": [
+    "establishes whether isolated arithmetic-array synth remains cheap beyond nm2",
+    "identifies the first nonviable isolated producer scale if nm3 or nm4 stalls",
+    "prevents premature full-PnR runs at scales whose arithmetic synth is already outside the explorable region"
+  ],
+  "risks": [
+    "isolated synth completion still does not prove whole producer integration is feasible",
+    "clockless synth-only timing is not final PPA",
+    "the timeout boundary remains evaluator-machine dependent"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_isolated_synth_scale_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a bounded synth-only probe for the isolated generated gemm_compute_array producer submodule over nm1 through nm4.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_isolated_synth",
+      "cost_class": "bounded-medium",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_isolated_synth_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_isolated_synth_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should show whether the isolated producer arithmetic-array synth boundary appears before nm4 or whether the next blocker is still whole npu_top integration."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_output_projection_producer_isolated_synth_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_isolated_synth__l2_decoder_output_projection_producer_isolated_synth_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_decoder_producer_synth_boundary.py",
+    "npu/rtlgen/gen.py",
+    "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_isolated_synth.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/quality_gate.md
@@ -1,0 +1,9 @@
+# Quality Gate
+
+The run is acceptable if:
+
+- the command manifest uses `--top gemm_compute_array`
+- the config list includes nm1, nm2, nm3, and nm4 producer configs
+- the report records per-point status and elapsed time
+- timeout or stall classifications are preserved as evidence rather than retried indefinitely
+


### PR DESCRIPTION
## Summary
- extend the isolated producer synth evidence generator from nm1/nm2 to nm1 through nm4
- add the follow-on proposal for the producer isolated synth scale probe
- update the focused generator test to assert nm3/nm4 coverage

## Verification
- PYTHONPATH=control_plane python3 - <<'PY'
from control_plane.tests.test_l2_task_generator import test_generate_l2_campaign_task_adds_decoder_producer_isolated_synth_evidence
test_generate_l2_campaign_task_adds_decoder_producer_isolated_synth_evidence()
print('focused isolated synth generator test passed')
PY
- python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 -m json.tool docs/proposals/prop_l2_decoder_output_projection_producer_isolated_synth_scale_v1/proposal.json
- python3 scripts/validate_runs.py --skip_eval_queue