### PR TITLE
[codex] add producer top ablation probe

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -438,6 +438,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("cost_proxy_out", "cost_proxy_report"),
     ("decoder_frontier_synthesis_out", "decoder_frontier_synthesis_report"),
     ("producer_synth_boundary_out", "producer_synth_boundary_report"),
+    ("producer_top_ablation_out", "producer_top_ablation_report"),
     ("attention_kv_memory_out", "attention_kv_memory_report"),
 )
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2416,6 +2416,46 @@ def _decoder_output_projection_producer_isolated_synth_evidence(*, item_id: str)
     }
 
 
+def _decoder_output_projection_producer_top_ablation_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_producer_top_ablation__{item_id}.json"
+    report = f"{base}/decoder_output_projection_producer_top_ablation__{item_id}.md"
+    base_config = "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json"
+    sweep = "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json"
+    return {
+        "inputs": {
+            "producer_top_ablation_out": out,
+            "producer_top_ablation_report": report,
+            "producer_top_ablation_base_config": base_config,
+            "producer_top_ablation_sweep": sweep,
+            "producer_top_ablation_make_target": "1_2_yosys",
+            "producer_top_ablation_scope": (
+                "Probe nm2 whole-top variants that progressively remove AXI-Lite wrapper files, "
+                "SRAM side models, AXI ports, command-queue fetch/decode, and external ports while "
+                "recording static RTL size signals and bounded synth status."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_decoder_output_projection_producer_top_ablation",
+                "run": (
+                    "python3 npu/eval/probe_decoder_producer_top_ablation.py "
+                    f"--base-config {base_config} "
+                    f"--sweep {sweep} "
+                    "--platform nangate45 "
+                    "--make-target 1_2_yosys "
+                    "--timeout-seconds 1800 "
+                    "--stall-timeout-seconds 900 "
+                    "--continue-after-failure "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2886,10 +2926,13 @@ def _build_payload(
         "decoder_frontier_synthesis",
         "decoder_output_projection_producer_synth_boundary",
         "decoder_output_projection_producer_isolated_synth",
+        "decoder_output_projection_producer_top_ablation",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_producer_top_ablation":
+            decoder_evidence = _decoder_output_projection_producer_top_ablation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_isolated_synth":
             decoder_evidence = _decoder_output_projection_producer_isolated_synth_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_synth_boundary":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2070,6 +2070,58 @@ def test_generate_l2_campaign_task_adds_decoder_producer_isolated_synth_evidence
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_producer_top_ablation_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_producer_top_ablation_v1",
+                    proposal_id="prop_l2_decoder_output_projection_producer_top_ablation_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_producer_top_ablation_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_producer_top_ablation",
+                    expected_direction="iterate",
+                    comparison_role="producer_synth_boundary",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == (
+                "probe_decoder_output_projection_producer_top_ablation"
+            )
+            run = work_item.command_manifest[0]["run"]
+            assert "probe_decoder_producer_top_ablation.py" in run
+            assert "--base-config runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json" in run
+            assert "--continue-after-failure" in run
+            assert decoder_inputs["producer_top_ablation_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_top_ablation__"
+                "l2_decoder_output_projection_producer_top_ablation_v1.json"
+            )
+            assert "bounded synth status" in decoder_inputs["producer_top_ablation_scope"]
+            assert decoder_inputs["producer_top_ablation_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_producer_top_ablation",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/design_brief.md
@@ -1,0 +1,18 @@
+# Design Brief
+
+## Goal
+Find why whole `npu_top` producer synthesis timed out even though isolated `gemm_compute_array` synthesis is viable through nm4.
+
+## Method
+Use the nm2 producer config as a base and synthesize bounded whole-top variants:
+
+- full reference
+- no AXI-Lite wrapper files
+- no SRAM side models
+- no AXI ports
+- no command-queue memory/decode ports
+- external ports off
+- AXI-Lite wrapper top
+
+Each variant records static generated-RTL counters and synth-only status.
+

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/evaluation_gate.md
@@ -1,0 +1,6 @@
+# Evaluation Gate
+
+Dispatch `l2_decoder_output_projection_producer_top_ablation_v1` after the isolated producer scale probe is merged and finalized.
+
+The gate passes if the result records every attempted variant with either a bounded synth result or a clear generation/synthesis failure classification.
+

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_top_ablation_v1",
+  "source_commit": null,
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_top_ablation_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded synth-only nm2 npu_top ablations to identify the feature that causes whole-top synthesis to become nonviable.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_top_ablation",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_isolated_synth_scale_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_isolated_synth_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify the first top-level feature delta that changes nm2 whole-top synth from viable to nonviable, or show that a broader interaction matrix is required."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/implementation_summary.md
@@ -1,0 +1,6 @@
+# Implementation Summary
+
+Adds `npu/eval/probe_decoder_producer_top_ablation.py` and wires it into the L2 task generator as `decoder_output_projection_producer_top_ablation`.
+
+The script writes temporary variant configs under `runs/designs/npu_blocks`, generates RTL, captures static Verilog size counters, and runs bounded synth-only OpenROAD flow per variant.
+

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/proposal.json
@@ -1,0 +1,72 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_top_ablation_v1",
+  "created_utc": "2026-05-13T10:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_top_ablation",
+  "title": "Decoder output-projection producer top-level synthesis ablation",
+  "hypothesis": "The isolated gemm_compute_array producer submodule completes synth-only compilation through nm4, while whole npu_top timed out at nm2. The true blocker is therefore likely in npu_top integration logic, interface wiring, command-queue decode, wrapper files, or an interaction between those features and the generated compute state.",
+  "direct_comparison": {
+    "primary_question": "Which top-level npu_top feature first causes the nm2 producer synth-only run to become nonviable?",
+    "include": [
+      "nm2 fp16 producer base config",
+      "full npu_top reference",
+      "variants removing AXI-Lite wrapper files, SRAM side models, AXI ports, command-queue memory/decode, and external ports",
+      "one wrapper-top variant using npu_top_axi",
+      "static generated-RTL size counters per variant",
+      "bounded Nangate45 synth-only target 1_2_yosys"
+    ],
+    "exclude": [
+      "full placement and routing",
+      "producer scale beyond nm2",
+      "quality or QAT experiments",
+      "changing the isolated gemm_compute_array arithmetic implementation"
+    ]
+  },
+  "expected_benefit": [
+    "identifies whether the nm2 timeout belongs to shell/control/interface logic or a feature interaction",
+    "prevents further full-top retries without knowing which generated feature is responsible",
+    "provides concrete evidence for the next RTL generator fix or macro-level evaluation boundary"
+  ],
+  "risks": [
+    "some variants may fail due to invalid feature combinations; these failures are still diagnostic",
+    "static RTL counters are approximate and supplement, not replace, synthesis logs",
+    "a two-feature interaction may require a follow-on matrix after this one-dimensional ablation"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_top_ablation_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded synth-only nm2 npu_top ablations to identify the feature that causes whole-top synthesis to become nonviable.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_top_ablation",
+      "cost_class": "bounded-medium",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_isolated_synth_scale_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_isolated_synth_scale_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify the first top-level feature delta that changes nm2 whole-top synth from viable to nonviable, or show that a broader interaction matrix is required."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_output_projection_producer_isolated_synth_scale_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_isolated_synth__l2_decoder_output_projection_producer_isolated_synth_scale_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_synth_boundary__l2_decoder_output_projection_producer_synth_boundary_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_decoder_producer_top_ablation.py",
+    "npu/eval/probe_decoder_producer_synth_boundary.py",
+    "npu/rtlgen/gen.py",
+    "npu/synth/run_block_sweep.py",
+    "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_top_ablation_v1/quality_gate.md
@@ -1,0 +1,10 @@
+# Quality Gate
+
+The result is acceptable if:
+
+- all variants use the nm2 producer base config
+- full reference preserves `npu_top`
+- the probe continues after failed variants
+- each row includes static RTL counters
+- timeout and stall classifications are preserved without retry loops
+

--- a/npu/eval/probe_decoder_producer_top_ablation.py
+++ b/npu/eval/probe_decoder_producer_top_ablation.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Bounded npu_top ablation probe for decoder output-projection producer synth."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT_FOR_IMPORT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT_FOR_IMPORT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT_FOR_IMPORT))
+
+from npu.eval.probe_decoder_producer_synth_boundary import (
+    REPO_ROOT,
+    ensure_rtlgen_binaries,
+    latest_metrics_row,
+    load_json,
+    rel,
+    run_logged,
+)
+
+
+VARIANTS: list[dict[str, Any]] = [
+    {
+        "name": "full_reference",
+        "top": "npu_top",
+        "description": "Full nm2 producer top as generated today.",
+        "updates": {},
+    },
+    {
+        "name": "no_axi_lite_wrapper",
+        "top": "npu_top",
+        "description": "Remove the unused AXI-Lite wrapper files while keeping npu_top interfaces.",
+        "updates": {"enable_axi_lite_wrapper": False},
+    },
+    {
+        "name": "no_sram_instances",
+        "top": "npu_top",
+        "description": "Remove generated SRAM side models and SRAM map entries.",
+        "updates": {"sram_instances": []},
+    },
+    {
+        "name": "no_axi_ports",
+        "top": "npu_top",
+        "description": "Remove AXI4 memory-interface ports and AXI DMA FSM logic from npu_top.",
+        "updates": {"enable_axi_ports": False, "enable_axi_lite_wrapper": False},
+    },
+    {
+        "name": "no_cq_mem_ports",
+        "top": "npu_top",
+        "description": "Remove command-queue memory fetch ports and descriptor decode/issue logic.",
+        "updates": {"enable_cq_mem_ports": False},
+    },
+    {
+        "name": "external_ports_off",
+        "top": "npu_top",
+        "description": "Keep compute state inside npu_top but remove CQ memory, DMA, AXI, AXI-Lite, and SRAM side features.",
+        "updates": {
+            "enable_dma_ports": False,
+            "enable_cq_mem_ports": False,
+            "enable_axi_ports": False,
+            "enable_axi_lite_wrapper": False,
+            "sram_instances": [],
+        },
+    },
+    {
+        "name": "axi_lite_wrapper_top",
+        "top": "npu_top_axi",
+        "description": "Synthesize the generated AXI-Lite wrapper top instead of npu_top.",
+        "updates": {"enable_axi_lite_wrapper": True},
+    },
+]
+
+
+def apply_updates(config: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    out = copy.deepcopy(config)
+    for key, value in updates.items():
+        out[key] = value
+    return out
+
+
+def write_variant_config(base_config_path: Path, variant: dict[str, Any], out_root: Path) -> Path:
+    base = load_json(base_config_path)
+    config = apply_updates(base, variant.get("updates", {}))
+    config["top_name"] = "npu_top"
+    variant_dir = out_root / f"npu_fp16_cpp_nm2_top_ablate_{variant['name']}"
+    variant_dir.mkdir(parents=True, exist_ok=True)
+    config_path = variant_dir / "config.json"
+    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    return config_path
+
+
+def _width_of_decl(decl: str) -> int:
+    match = re.search(r"\[(\d+)\s*:\s*(\d+)\]", decl)
+    if not match:
+        return 1
+    hi = int(match.group(1))
+    lo = int(match.group(2))
+    return abs(hi - lo) + 1
+
+
+def _module_body(text: str, module_name: str) -> str:
+    match = re.search(rf"\bmodule\s+{re.escape(module_name)}\b(?P<body>.*?)(?=\nendmodule\b)", text, re.S)
+    if not match:
+        return ""
+    return match.group("body")
+
+
+def static_verilog_stats(verilog_dir: Path, top: str) -> dict[str, Any]:
+    files = sorted(verilog_dir.glob("*.v"))
+    text_by_file = {path.name: path.read_text(encoding="utf-8", errors="ignore") for path in files}
+    all_text = "\n".join(text_by_file.values())
+    top_body = _module_body(all_text, top)
+    decls = re.findall(r"\b(?:input|output|inout)\b[^;,\n]*(?:[,;]|\n)", top_body)
+    reg_decls = re.findall(r"\breg\b[^;]*;", all_text)
+    wire_decls = re.findall(r"\bwire\b[^;]*;", all_text)
+    return {
+        "verilog_file_count": len(files),
+        "verilog_bytes": sum(path.stat().st_size for path in files),
+        "verilog_lines": sum(text.count("\n") + 1 for text in text_by_file.values()),
+        "module_count": len(re.findall(r"^\s*module\s+", all_text, re.M)),
+        "top_found": bool(top_body),
+        "top_port_decl_count_est": len(decls),
+        "reg_decl_count": len(reg_decls),
+        "reg_bit_count_est": sum(_width_of_decl(decl) for decl in reg_decls),
+        "wire_decl_count": len(wire_decls),
+        "wire_bit_count_est": sum(_width_of_decl(decl) for decl in wire_decls),
+        "always_count": len(re.findall(r"\balways\b", all_text)),
+        "assign_count": len(re.findall(r"\bassign\b", all_text)),
+        "case_count": len(re.findall(r"\bcase\s*\(", all_text)),
+        "ternary_count": all_text.count("?"),
+        "multiply_operator_count": all_text.count("*"),
+        "divide_operator_count": all_text.count("/"),
+        "files": [
+            {
+                "path": rel(path),
+                "bytes": path.stat().st_size,
+                "lines": text_by_file[path.name].count("\n") + 1,
+            }
+            for path in files
+        ],
+    }
+
+
+def probe_variant(
+    config_path: Path,
+    *,
+    variant: dict[str, Any],
+    sweep: Path,
+    platform: str,
+    make_target: str,
+    out_root: Path,
+    timeout_seconds: int,
+    stall_timeout_seconds: int,
+    log_dir: Path,
+) -> dict[str, Any]:
+    design_dir = config_path.parent
+    verilog_dir = design_dir / "verilog"
+    top = str(variant["top"])
+    gen_result = run_logged(
+        [
+            sys.executable,
+            "npu/rtlgen/gen.py",
+            "--config",
+            rel(config_path),
+            "--out",
+            rel(verilog_dir),
+        ],
+        cwd=REPO_ROOT,
+        log_path=log_dir / f"{variant['name']}_rtlgen.log",
+        timeout_seconds=max(300, min(timeout_seconds, 900)),
+        stall_timeout_seconds=max(120, min(stall_timeout_seconds, 300)),
+    )
+    row: dict[str, Any] = {
+        "variant": variant["name"],
+        "description": variant["description"],
+        "top": top,
+        "config": rel(config_path),
+        "design_dir": rel(design_dir),
+        "updates": variant.get("updates", {}),
+        "rtlgen": gen_result,
+        "static_verilog_stats": None,
+        "synthesis": None,
+        "metrics_row": None,
+    }
+    if gen_result["status"] != "ok":
+        row["status"] = f"rtlgen_{gen_result['status']}"
+        return row
+
+    row["static_verilog_stats"] = static_verilog_stats(verilog_dir, top)
+    synth_result = run_logged(
+        [
+            sys.executable,
+            "npu/synth/run_block_sweep.py",
+            "--design_dir",
+            rel(design_dir),
+            "--platform",
+            platform,
+            "--top",
+            top,
+            "--sweep",
+            rel(sweep),
+            "--make_target",
+            make_target,
+            "--out_root",
+            rel(out_root),
+            "--force_copy",
+        ],
+        cwd=REPO_ROOT,
+        log_path=log_dir / f"{variant['name']}_{top}_{make_target}.log",
+        timeout_seconds=timeout_seconds,
+        stall_timeout_seconds=stall_timeout_seconds,
+    )
+    row["synthesis"] = synth_result
+    metrics_row = latest_metrics_row(out_root / design_dir.name)
+    if metrics_row is not None:
+        row["metrics_row"] = metrics_row
+    if synth_result["status"] != "ok":
+        row["status"] = synth_result["status"]
+    elif metrics_row and str(metrics_row.get("status", "")).strip():
+        row["status"] = str(metrics_row.get("status"))
+    else:
+        row["status"] = "ok"
+    return row
+
+
+def build_top_ablation_diagnosis(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    full = next((row for row in rows if row.get("variant") == "full_reference"), None)
+    ok = [row for row in rows if row.get("status") == "ok"]
+    bad = [row for row in rows if row.get("status") != "ok"]
+    first_bad = bad[0]["variant"] if bad else None
+    if full and full.get("status") == "ok":
+        decision = "producer_top_reference_synth_ok"
+        next_step = "Retry larger whole npu_top or full-PnR points with bounded staging."
+    elif ok:
+        decision = "producer_top_culprit_bracketed"
+        next_step = "Compare the last passing ablation against the full reference to isolate the added top-level feature."
+    else:
+        decision = "producer_top_all_variants_nonviable"
+        next_step = "Inspect RTL generation and Yosys logs before adding more architecture variants."
+    return {
+        "decision": decision,
+        "ok_variants": [row.get("variant") for row in ok],
+        "non_ok_variants": [row.get("variant") for row in bad],
+        "first_non_ok_variant": first_bad,
+        "recommended_next_step": next_step,
+    }
+
+
+def write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# Decoder Producer Top Ablation",
+        "",
+        f"- base_config: `{payload['base_config']}`",
+        f"- make_target: `{payload['make_target']}`",
+        f"- timeout_seconds: `{payload['timeout_seconds']}`",
+        f"- stall_timeout_seconds: `{payload['stall_timeout_seconds']}`",
+        "",
+        "| variant | top | status | elapsed_s | verilog_kb | reg_bits_est | wire_bits_est | log |",
+        "|---|---|---|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["probe_rows"]:
+        synth = row.get("synthesis") or {}
+        stats = row.get("static_verilog_stats") or {}
+        elapsed = synth.get("elapsed_seconds")
+        elapsed_text = f"{float(elapsed):.1f}" if elapsed is not None else ""
+        lines.append(
+            "| {variant} | {top} | {status} | {elapsed} | {kb:.1f} | {reg_bits} | {wire_bits} | {log} |".format(
+                variant=row.get("variant"),
+                top=row.get("top"),
+                status=row.get("status"),
+                elapsed=elapsed_text,
+                kb=float(stats.get("verilog_bytes") or 0) / 1024.0,
+                reg_bits=stats.get("reg_bit_count_est", ""),
+                wire_bits=stats.get("wire_bit_count_est", ""),
+                log=synth.get("log_path", ""),
+            )
+        )
+    diagnosis = payload["diagnosis"]
+    lines.extend(
+        [
+            "",
+            "## Diagnosis",
+            "",
+            f"- decision: `{diagnosis.get('decision')}`",
+            f"- ok_variants: `{diagnosis.get('ok_variants')}`",
+            f"- non_ok_variants: `{diagnosis.get('non_ok_variants')}`",
+            f"- first_non_ok_variant: `{diagnosis.get('first_non_ok_variant')}`",
+            f"- recommended_next_step: {diagnosis.get('recommended_next_step')}",
+            "",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-config", required=True)
+    ap.add_argument("--sweep", required=True)
+    ap.add_argument("--platform", default="nangate45")
+    ap.add_argument("--make-target", default="1_2_yosys")
+    ap.add_argument("--out-root", default="runs/designs/npu_blocks")
+    ap.add_argument("--timeout-seconds", type=int, default=1800)
+    ap.add_argument("--stall-timeout-seconds", type=int, default=900)
+    ap.add_argument("--rtlgen-build-timeout-seconds", type=int, default=900)
+    ap.add_argument("--skip-rtlgen-build", action="store_true")
+    ap.add_argument("--continue-after-failure", action="store_true")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    base_config = (REPO_ROOT / args.base_config).resolve() if not Path(args.base_config).is_absolute() else Path(args.base_config)
+    sweep = (REPO_ROOT / args.sweep).resolve() if not Path(args.sweep).is_absolute() else Path(args.sweep)
+    out = (REPO_ROOT / args.out).resolve() if not Path(args.out).is_absolute() else Path(args.out)
+    out_md = (REPO_ROOT / args.out_md).resolve() if not Path(args.out_md).is_absolute() else Path(args.out_md)
+    out_root = (REPO_ROOT / args.out_root).resolve() if not Path(args.out_root).is_absolute() else Path(args.out_root)
+    log_root = Path(os.environ.get("RTLGEN_PRODUCER_TOP_ABLATION_LOG_DIR", "/tmp/rtlgen-producer-top-ablation"))
+    log_dir = log_root / out.stem
+
+    config_paths = [write_variant_config(base_config, variant, out_root) for variant in VARIANTS]
+    setup = ensure_rtlgen_binaries(
+        config_paths,
+        log_dir=log_dir,
+        build_timeout_seconds=args.rtlgen_build_timeout_seconds,
+        stall_timeout_seconds=max(120, min(args.stall_timeout_seconds, 300)),
+        skip_build=args.skip_rtlgen_build,
+    )
+    rows: list[dict[str, Any]] = []
+    if setup["status"] != "ok":
+        rows.append({"status": "setup_failed", "variant": "setup", "rtlgen_setup": setup})
+    else:
+        for variant, config_path in zip(VARIANTS, config_paths):
+            row = probe_variant(
+                config_path,
+                variant=variant,
+                sweep=sweep,
+                platform=args.platform,
+                make_target=args.make_target,
+                out_root=out_root,
+                timeout_seconds=args.timeout_seconds,
+                stall_timeout_seconds=args.stall_timeout_seconds,
+                log_dir=log_dir,
+            )
+            rows.append(row)
+            if row.get("status") != "ok" and not args.continue_after_failure:
+                break
+
+    payload = {
+        "version": 0.1,
+        "model": "decoder_output_projection_producer_top_ablation_v1",
+        "platform": args.platform,
+        "base_config": rel(base_config),
+        "make_target": args.make_target,
+        "timeout_seconds": args.timeout_seconds,
+        "stall_timeout_seconds": args.stall_timeout_seconds,
+        "rtlgen_setup": setup,
+        "sweep": rel(sweep),
+        "probe_rows": rows,
+        "diagnosis": build_top_ablation_diagnosis(rows),
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    write_markdown(out_md, payload)
+    return 2 if setup["status"] != "ok" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a bounded nm2 npu_top ablation probe for producer synth diagnosis
- wire the new decoder_output_projection_producer_top_ablation abstraction into L2 generation and result consumption
- add proposal docs and a focused generator test

## Verification
- python3 -m py_compile npu/eval/probe_decoder_producer_top_ablation.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 npu/eval/probe_decoder_producer_top_ablation.py --help
- PYTHONPATH=control_plane python3 - <<'PY'
from control_plane.tests.test_l2_task_generator import test_generate_l2_campaign_task_adds_decoder_producer_top_ablation_evidence
test_generate_l2_campaign_task_adds_decoder_producer_top_ablation_evidence()
print('focused top ablation generator test passed')
PY
- python3 scripts/validate_runs.py --skip_eval_queue