### PR TITLE
Add producer CQ synthesis ablation probe

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -439,6 +439,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("decoder_frontier_synthesis_out", "decoder_frontier_synthesis_report"),
     ("producer_synth_boundary_out", "producer_synth_boundary_report"),
     ("producer_top_ablation_out", "producer_top_ablation_report"),
+    ("producer_cq_ablation_out", "producer_cq_ablation_report"),
     ("attention_kv_memory_out", "attention_kv_memory_report"),
 )
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2456,6 +2456,46 @@ def _decoder_output_projection_producer_top_ablation_evidence(*, item_id: str) -
     }
 
 
+def _decoder_output_projection_producer_cq_ablation_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_producer_cq_ablation__{item_id}.json"
+    report = f"{base}/decoder_output_projection_producer_cq_ablation__{item_id}.md"
+    base_config = "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json"
+    sweep = "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json"
+    return {
+        "inputs": {
+            "producer_cq_ablation_out": out,
+            "producer_cq_ablation_report": report,
+            "producer_cq_ablation_base_config": base_config,
+            "producer_cq_ablation_sweep": sweep,
+            "producer_cq_ablation_make_target": "1_2_yosys",
+            "producer_cq_ablation_scope": (
+                "Probe nm2 npu_top CQ subpaths with diagnostic generator modes: fetch-only, "
+                "v0.1 header, DMA_COPY, GEMM issue, VEC validation, SOFTMAX/EVENT, and "
+                "v0.2 extension GEMM. The default full CQ path remains unchanged."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_decoder_output_projection_producer_cq_ablation",
+                "run": (
+                    "python3 npu/eval/probe_decoder_producer_cq_ablation.py "
+                    f"--base-config {base_config} "
+                    f"--sweep {sweep} "
+                    "--platform nangate45 "
+                    "--make-target 1_2_yosys "
+                    "--timeout-seconds 900 "
+                    "--stall-timeout-seconds 450 "
+                    "--continue-after-failure "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2927,10 +2967,13 @@ def _build_payload(
         "decoder_output_projection_producer_synth_boundary",
         "decoder_output_projection_producer_isolated_synth",
         "decoder_output_projection_producer_top_ablation",
+        "decoder_output_projection_producer_cq_ablation",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_producer_cq_ablation":
+            decoder_evidence = _decoder_output_projection_producer_cq_ablation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_top_ablation":
             decoder_evidence = _decoder_output_projection_producer_top_ablation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_isolated_synth":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2122,6 +2122,57 @@ def test_generate_l2_campaign_task_adds_decoder_producer_top_ablation_evidence()
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_producer_cq_ablation_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_producer_cq_ablation_v1",
+                    proposal_id="prop_l2_decoder_output_projection_producer_cq_ablation_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_producer_cq_ablation_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_producer_cq_ablation",
+                    expected_direction="iterate",
+                    comparison_role="producer_synth_boundary",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == (
+                "probe_decoder_output_projection_producer_cq_ablation"
+            )
+            run = work_item.command_manifest[0]["run"]
+            assert "probe_decoder_producer_cq_ablation.py" in run
+            assert "--timeout-seconds 900" in run
+            assert decoder_inputs["producer_cq_ablation_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_cq_ablation__"
+                "l2_decoder_output_projection_producer_cq_ablation_v1.json"
+            )
+            assert "CQ subpaths" in decoder_inputs["producer_cq_ablation_scope"]
+            assert decoder_inputs["producer_cq_ablation_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_producer_cq_ablation",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/evaluation_gate.md
@@ -1,0 +1,5 @@
+# Evaluation Gate
+
+Dispatch `l2_decoder_output_projection_producer_cq_ablation_v1` after `l2_decoder_output_projection_producer_top_ablation_v1` is merged and finalized.
+
+The gate passes if the result records each attempted CQ subpath variant with either a bounded synth result or a clear generation/synthesis failure classification.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/evaluation_requests.json
@@ -1,0 +1,24 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_cq_ablation_v1",
+  "source_commit": "0da220bfa4c0110d07f273dd0bc0043682166145",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_cq_ablation_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded synth-only nm2 npu_top command-queue subpath ablations to isolate the descriptor decode/issue logic responsible for the whole-top synthesis timeout.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_cq_ablation",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_top_ablation_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_top_ablation_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify the first CQ subpath that becomes nonviable, or show that each individual subpath is viable and a pairwise interaction probe is required."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/implementation_summary.md
@@ -1,0 +1,7 @@
+# Implementation Summary
+
+Adds diagnostic `cq_mem_ablation_mode` support to `npu/rtlgen/gen.py`, defaulting to the existing full command-queue decode path.
+
+Adds `npu/eval/probe_decoder_producer_cq_ablation.py` and wires it into the L2 task generator as `decoder_output_projection_producer_cq_ablation`.
+
+The probe writes temporary variant configs under `runs/designs/npu_blocks`, generates RTL, captures static Verilog size counters, and runs bounded synth-only OpenROAD flow per CQ subpath variant.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/proposal.json
@@ -1,0 +1,72 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_cq_ablation_v1",
+  "created_utc": "2026-05-13T22:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_cq_ablation",
+  "title": "Decoder output-projection producer command-queue synthesis ablation",
+  "hypothesis": "The nm2 whole npu_top timeout was bracketed to the command-queue memory fetch, descriptor decode, and issue logic. Splitting that CQ path into fetch, v0.1 header, DMA, GEMM, VEC, SOFTMAX/EVENT, and v0.2 extension subpaths should identify whether a single decode expression or a subpath interaction triggers the Yosys pre-ABC expansion.",
+  "direct_comparison": {
+    "primary_question": "Which command-queue subpath first changes the nm2 producer top from synth-viable to synth-nonviable?",
+    "include": [
+      "nm2 fp16 producer base config",
+      "known-passing no_cq_mem_ports anchor",
+      "diagnostic generator modes for CQ fetch-only, v0.1 header, DMA_COPY, GEMM issue, VEC validation, SOFTMAX/EVENT, and v0.2 GEMM extension paths",
+      "bounded Nangate45 synth-only target 1_2_yosys",
+      "static generated-RTL size counters per variant"
+    ],
+    "exclude": [
+      "full placement and routing",
+      "producer scale beyond nm2",
+      "quality or QAT experiments",
+      "changing the default full CQ RTL behavior",
+      "changing perf-simulator semantics"
+    ]
+  },
+  "expected_benefit": [
+    "turns the broad CQ-memory culprit from the previous ablation into a specific RTL generator subpath",
+    "distinguishes isolated expression explosion from multi-branch decode interaction",
+    "provides evidence for a targeted fix such as staged decode, hierarchy preservation, or narrower arithmetic expressions"
+  ],
+  "risks": [
+    "the diagnostic modes are not intended as production RTL modes and only preserve the default full mode behavior",
+    "several subpaths may be individually viable, requiring a follow-on pairwise interaction matrix",
+    "bounded timeout values classify synth nonviability for exploration rather than proving absolute impossibility"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_cq_ablation_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded synth-only nm2 npu_top command-queue subpath ablations to isolate the descriptor decode/issue logic responsible for the whole-top synthesis timeout.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_cq_ablation",
+      "cost_class": "bounded-medium",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_top_ablation_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_top_ablation_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify the first CQ subpath that becomes nonviable, or show that each individual subpath is viable and a pairwise interaction probe is required."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_output_projection_producer_top_ablation_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_top_ablation__l2_decoder_output_projection_producer_top_ablation_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_isolated_synth__l2_decoder_output_projection_producer_isolated_synth_scale_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_decoder_producer_cq_ablation.py",
+    "npu/eval/probe_decoder_producer_top_ablation.py",
+    "npu/rtlgen/gen.py",
+    "npu/synth/run_block_sweep.py",
+    "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_cq_ablation_v1/quality_gate.md
@@ -1,0 +1,10 @@
+# Quality Gate
+
+The result is acceptable if:
+
+- all variants use the nm2 producer base config
+- default `cq_mem_ablation_mode=full` preserves the existing full CQ RTL path
+- the probe continues after failed variants
+- each row includes static RTL counters
+- timeout and stall classifications are preserved without retry loops
+- the result compares against the prior top-level ablation that identified CQ memory/decode as the broad culprit

--- a/npu/eval/probe_decoder_producer_cq_ablation.py
+++ b/npu/eval/probe_decoder_producer_cq_ablation.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Bounded command-queue path ablation probe for decoder producer synth."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT_FOR_IMPORT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT_FOR_IMPORT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT_FOR_IMPORT))
+
+from npu.eval.probe_decoder_producer_top_ablation import (  # noqa: E402
+    REPO_ROOT,
+    ensure_rtlgen_binaries,
+    probe_variant,
+    rel,
+    write_variant_config,
+)
+
+
+VARIANTS: list[dict[str, Any]] = [
+    {
+        "name": "no_cq_mem_ports",
+        "top": "npu_top",
+        "description": "Known-passing anchor with CQ memory fetch and descriptor decode removed.",
+        "updates": {"enable_cq_mem_ports": False},
+    },
+    {
+        "name": "cq_fetch_only",
+        "top": "npu_top",
+        "description": "CQ memory port, address generation, one-word fetch, and descriptor retirement only.",
+        "updates": {"cq_mem_ablation_mode": "fetch_only"},
+    },
+    {
+        "name": "cq_v1_header_only",
+        "top": "npu_top",
+        "description": "CQ v0.1 header field capture without opcode issue logic.",
+        "updates": {"cq_mem_ablation_mode": "v1_header_only"},
+    },
+    {
+        "name": "cq_v1_dma_only",
+        "top": "npu_top",
+        "description": "CQ v0.1 DMA_COPY decode plus DMA request bookkeeping only.",
+        "updates": {"cq_mem_ablation_mode": "v1_dma_only"},
+    },
+    {
+        "name": "cq_v1_gemm_only",
+        "top": "npu_top",
+        "description": "CQ v0.1 GEMM opcode decode and GEMM slot issue chain only.",
+        "updates": {"cq_mem_ablation_mode": "v1_gemm_only"},
+    },
+    {
+        "name": "cq_v2_gemm_only",
+        "top": "npu_top",
+        "description": "CQ v0.2 extension fetch and GEMM slot issue chain only.",
+        "updates": {"cq_mem_ablation_mode": "v2_gemm_only"},
+    },
+    {
+        "name": "cq_v1_vec_only",
+        "top": "npu_top",
+        "description": "CQ v0.1 VEC_OP dtype/op validation and issue path only.",
+        "updates": {"cq_mem_ablation_mode": "v1_vec_only"},
+    },
+    {
+        "name": "cq_v1_softmax_event_only",
+        "top": "npu_top",
+        "description": "CQ v0.1 SOFTMAX and EVENT_SIGNAL/EVENT_WAIT paths only.",
+        "updates": {"cq_mem_ablation_mode": "v1_softmax_event_only"},
+    },
+    {
+        "name": "full_reference_guard",
+        "top": "npu_top",
+        "description": "Full CQ decode/issue reference, included as a bounded timeout guard.",
+        "updates": {},
+    },
+]
+
+
+def build_cq_ablation_diagnosis(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    ok = [row for row in rows if row.get("status") == "ok"]
+    bad = [row for row in rows if row.get("status") != "ok"]
+    first_bad = bad[0]["variant"] if bad else None
+    full = next((row for row in rows if row.get("variant") == "full_reference_guard"), None)
+    if full and full.get("status") == "ok":
+        decision = "cq_reference_synth_ok_under_guard"
+        next_step = "Use the full-reference metrics as an updated boundary before changing RTL."
+    elif first_bad:
+        decision = "cq_subpath_culprit_bracketed"
+        next_step = (
+            "Compare the first non-OK CQ subpath against the preceding OK subpath and "
+            "stage or preserve hierarchy around that decode/issue expression."
+        )
+    else:
+        decision = "cq_subpaths_individually_viable"
+        next_step = (
+            "Probe pairwise combinations of the individually viable CQ subpaths to isolate "
+            "the interaction that triggers Yosys expansion."
+        )
+    return {
+        "decision": decision,
+        "ok_variants": [row.get("variant") for row in ok],
+        "non_ok_variants": [row.get("variant") for row in bad],
+        "first_non_ok_variant": first_bad,
+        "recommended_next_step": next_step,
+    }
+
+
+def write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# Decoder Producer CQ Ablation",
+        "",
+        f"- base_config: `{payload['base_config']}`",
+        f"- make_target: `{payload['make_target']}`",
+        f"- timeout_seconds: `{payload['timeout_seconds']}`",
+        f"- stall_timeout_seconds: `{payload['stall_timeout_seconds']}`",
+        "",
+        "| variant | top | status | elapsed_s | verilog_kb | reg_bits_est | wire_bits_est | log |",
+        "|---|---|---|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["probe_rows"]:
+        synth = row.get("synthesis") or {}
+        stats = row.get("static_verilog_stats") or {}
+        elapsed = synth.get("elapsed_seconds")
+        elapsed_text = f"{float(elapsed):.1f}" if elapsed is not None else ""
+        lines.append(
+            "| {variant} | {top} | {status} | {elapsed} | {kb:.1f} | {reg_bits} | {wire_bits} | {log} |".format(
+                variant=row.get("variant"),
+                top=row.get("top"),
+                status=row.get("status"),
+                elapsed=elapsed_text,
+                kb=float(stats.get("verilog_bytes") or 0) / 1024.0,
+                reg_bits=stats.get("reg_bit_count_est", ""),
+                wire_bits=stats.get("wire_bit_count_est", ""),
+                log=synth.get("log_path", ""),
+            )
+        )
+    diagnosis = payload["diagnosis"]
+    lines.extend(
+        [
+            "",
+            "## Diagnosis",
+            "",
+            f"- decision: `{diagnosis.get('decision')}`",
+            f"- ok_variants: `{diagnosis.get('ok_variants')}`",
+            f"- non_ok_variants: `{diagnosis.get('non_ok_variants')}`",
+            f"- first_non_ok_variant: `{diagnosis.get('first_non_ok_variant')}`",
+            f"- recommended_next_step: {diagnosis.get('recommended_next_step')}",
+            "",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-config", required=True)
+    ap.add_argument("--sweep", required=True)
+    ap.add_argument("--platform", default="nangate45")
+    ap.add_argument("--make-target", default="1_2_yosys")
+    ap.add_argument("--out-root", default="runs/designs/npu_blocks")
+    ap.add_argument("--timeout-seconds", type=int, default=900)
+    ap.add_argument("--stall-timeout-seconds", type=int, default=450)
+    ap.add_argument("--rtlgen-build-timeout-seconds", type=int, default=900)
+    ap.add_argument("--skip-rtlgen-build", action="store_true")
+    ap.add_argument("--continue-after-failure", action="store_true")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    base_config = (REPO_ROOT / args.base_config).resolve() if not Path(args.base_config).is_absolute() else Path(args.base_config)
+    sweep = (REPO_ROOT / args.sweep).resolve() if not Path(args.sweep).is_absolute() else Path(args.sweep)
+    out = (REPO_ROOT / args.out).resolve() if not Path(args.out).is_absolute() else Path(args.out)
+    out_md = (REPO_ROOT / args.out_md).resolve() if not Path(args.out_md).is_absolute() else Path(args.out_md)
+    out_root = (REPO_ROOT / args.out_root).resolve() if not Path(args.out_root).is_absolute() else Path(args.out_root)
+    log_root = Path(os.environ.get("RTLGEN_PRODUCER_CQ_ABLATION_LOG_DIR", "/tmp/rtlgen-producer-cq-ablation"))
+    log_dir = log_root / out.stem
+
+    config_paths = [write_variant_config(base_config, variant, out_root) for variant in VARIANTS]
+    setup = ensure_rtlgen_binaries(
+        config_paths,
+        log_dir=log_dir,
+        build_timeout_seconds=args.rtlgen_build_timeout_seconds,
+        stall_timeout_seconds=max(120, min(args.stall_timeout_seconds, 300)),
+        skip_build=args.skip_rtlgen_build,
+    )
+    rows: list[dict[str, Any]] = []
+    if setup["status"] != "ok":
+        rows.append({"status": "setup_failed", "variant": "setup", "rtlgen_setup": setup})
+    else:
+        for variant, config_path in zip(VARIANTS, config_paths):
+            row = probe_variant(
+                config_path,
+                variant=variant,
+                sweep=sweep,
+                platform=args.platform,
+                make_target=args.make_target,
+                out_root=out_root,
+                timeout_seconds=args.timeout_seconds,
+                stall_timeout_seconds=args.stall_timeout_seconds,
+                log_dir=log_dir,
+            )
+            rows.append(row)
+            if row.get("status") != "ok" and not args.continue_after_failure:
+                break
+
+    payload = {
+        "version": 0.1,
+        "model": "decoder_output_projection_producer_cq_ablation_v1",
+        "platform": args.platform,
+        "base_config": rel(base_config),
+        "make_target": args.make_target,
+        "timeout_seconds": args.timeout_seconds,
+        "stall_timeout_seconds": args.stall_timeout_seconds,
+        "rtlgen_setup": setup,
+        "sweep": rel(sweep),
+        "probe_rows": rows,
+        "diagnosis": build_cq_ablation_diagnosis(rows),
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    write_markdown(out_md, payload)
+    return 2 if setup["status"] != "ok" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/config_spec.md
+++ b/npu/rtlgen/config_spec.md
@@ -43,6 +43,7 @@ can later be extended without breaking v0.1.
   "enable_irq": true,
   "enable_dma_ports": true,
   "enable_cq_mem_ports": true,
+  "cq_mem_ablation_mode": "full",
   "enable_axi_ports": true,
   "enable_axi_lite_wrapper": false,
   "compute": {
@@ -95,6 +96,10 @@ can later be extended without breaking v0.1.
 - `enable_irq` (bool): include IRQ output.
 - `enable_dma_ports` (bool): include a stub DMA/memory interface.
 - `enable_cq_mem_ports` (bool): include a command queue memory read port.
+- `cq_mem_ablation_mode` (string, optional): diagnostic-only command-queue
+  subpath selector for synthesis probes. Default `full` preserves the normal
+  generated CQ fetch/decode/issue RTL. Other values are not production RTL
+  modes; they are used to isolate synthesis behavior.
 - `enable_axi_ports` (bool): include AXI4-like memory interface ports (stub).
 - `enable_axi_lite_wrapper` (bool): emit an AXI-Lite wrapper module for MMIO.
 - `compute` (object, optional): Phase 1 compute generation controls.

--- a/npu/rtlgen/gen.py
+++ b/npu/rtlgen/gen.py
@@ -2291,6 +2291,22 @@ endmodule
 
     enable_dma_ports = bool(cfg.get("enable_dma_ports", False))
     enable_cq_mem_ports = bool(cfg.get("enable_cq_mem_ports", False))
+    cq_mem_ablation_mode = str(cfg.get("cq_mem_ablation_mode", "full")).lower()
+    valid_cq_mem_ablation_modes = {
+        "full",
+        "fetch_only",
+        "v1_header_only",
+        "v1_dma_only",
+        "v1_gemm_only",
+        "v1_vec_only",
+        "v1_softmax_event_only",
+        "v2_gemm_only",
+    }
+    if cq_mem_ablation_mode not in valid_cq_mem_ablation_modes:
+        die(
+            "cq_mem_ablation_mode must be one of "
+            + ", ".join(sorted(valid_cq_mem_ablation_modes))
+        )
     enable_axi_ports = bool(cfg.get("enable_axi_ports", False))
     sram_instances = cfg.get("sram_instances", [])
     if enable_dma_ports:
@@ -2599,6 +2615,309 @@ endmodule
               end
             end else begin
               error_code <= 32'h1;
+            end
+            if (cq_count <= cq_word0_size) begin
+              irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+            end
+            cq_head <= cq_head + (cq_word0_size * 32);
+            cq_count <= cq_count - cq_word0_size;
+            cq_stage_valid <= 1'b0;
+            cq_pending_ext <= 1'b0;
+          end
+        end
+      end"""
+        if cq_mem_ablation_mode == "fetch_only":
+            cq_block = f"""      // CQ diagnostic ablation: fetch and consume one 32B descriptor word only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+          cq_stage_valid <= 1'b0;
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_header_only":
+            cq_block = f"""      // CQ diagnostic ablation: decode v0.1 descriptor header fields only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[23:16] >= 8'h02) begin
+            error_code <= 32'hd; // v0.2 extension intentionally excluded by ablation
+          end
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+          cq_stage_valid <= 1'b0;
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_dma_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 DMA_COPY issue path only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h01) begin
+            dma_req_valid <= 1'b1;
+            dma_req_src <= cq_mem_rdata[127:64];
+            dma_req_dst <= cq_mem_rdata[191:128];
+            dma_req_bytes <= cq_mem_rdata[223:192];
+            dma_src <= cq_mem_rdata[127:64];
+            dma_dst <= cq_mem_rdata[191:128];
+            dma_size <= cq_mem_rdata[223:192];
+            dma_beats <= {dma_beats_expr};
+            dma_arlen <= {dma_arlen_expr};
+            dma_pending <= 1'b1;
+          end
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+          cq_stage_valid <= 1'b0;
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_gemm_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 GEMM issue path only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h10) begin
+{gemm_issue_chain_v1}
+          end
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+          cq_stage_valid <= 1'b0;
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_vec_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 VEC_OP validation and issue path only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h11) begin
+            if (vec_pending) begin
+              error_code <= 32'h3;
+            end else begin
+              vec_in0 <= cq_mem_rdata[{vec_a_hi}:64];
+              vec_in1 <= cq_mem_rdata[{vec_b_hi}:128];
+              vec_op_sel <= cq_mem_rdata[11:8];
+              vec_dtype_sel <= cq_mem_rdata[15:12];
+              if (((cq_mem_rdata[15:12] == VEC_DTYPE_FP16) && !VEC_FP16_ENABLED) ||
+                  ((cq_mem_rdata[15:12] != VEC_DTYPE_INT8) && (cq_mem_rdata[15:12] != VEC_DTYPE_FP16)) ||
+                  ((cq_mem_rdata[15:12] == VEC_DTYPE_FP16) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_RELU) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_ADD) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_MUL) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_GELU) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_SOFTMAX) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_LAYERNORM) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_DRELU) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_DGELU) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_DSOFTMAX) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_DLAYERNORM) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_SIGMOID) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_TANH) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_HARDSIGMOID) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_HARDTANH)) ||
+                  (cq_mem_rdata[11:8] == VEC_OP_ADD       && !VEC_EN_ADD)       ||
+                  (cq_mem_rdata[11:8] == VEC_OP_MUL       && !VEC_EN_MUL)       ||
+                  (cq_mem_rdata[11:8] == VEC_OP_RELU      && !VEC_EN_RELU)      ||
+                  (cq_mem_rdata[11:8] == VEC_OP_GELU      && !VEC_EN_GELU)      ||
+                  (cq_mem_rdata[11:8] == VEC_OP_SOFTMAX   && !VEC_EN_SOFTMAX)   ||
+                  (cq_mem_rdata[11:8] == VEC_OP_LAYERNORM && !VEC_EN_LAYERNORM) ||
+                  (cq_mem_rdata[11:8] == VEC_OP_DRELU     && !VEC_EN_DRELU)     ||
+                  (cq_mem_rdata[11:8] == VEC_OP_DGELU     && !VEC_EN_DGELU)     ||
+                  (cq_mem_rdata[11:8] == VEC_OP_DSOFTMAX  && !VEC_EN_DSOFTMAX)  ||
+                  (cq_mem_rdata[11:8] == VEC_OP_DLAYERNORM&& !VEC_EN_DLAYERNORM)||
+                  (cq_mem_rdata[11:8] == VEC_OP_SIGMOID   && !VEC_EN_SIGMOID)   ||
+                  (cq_mem_rdata[11:8] == VEC_OP_TANH      && !VEC_EN_TANH)      ||
+                  (cq_mem_rdata[11:8] == VEC_OP_HARDSIGMOID && !VEC_EN_HARDSIGMOID) ||
+                  (cq_mem_rdata[11:8] == VEC_OP_HARDTANH  && !VEC_EN_HARDTANH)  ||
+                  ((cq_mem_rdata[11:8] != VEC_OP_RELU)      &&
+                   (cq_mem_rdata[11:8] != VEC_OP_ADD)       &&
+                   (cq_mem_rdata[11:8] != VEC_OP_MUL)       &&
+                   (cq_mem_rdata[11:8] != VEC_OP_GELU)      &&
+                   (cq_mem_rdata[11:8] != VEC_OP_SOFTMAX)   &&
+                   (cq_mem_rdata[11:8] != VEC_OP_LAYERNORM) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_DRELU)     &&
+                   (cq_mem_rdata[11:8] != VEC_OP_DGELU)     &&
+                   (cq_mem_rdata[11:8] != VEC_OP_DSOFTMAX)  &&
+                   (cq_mem_rdata[11:8] != VEC_OP_DLAYERNORM)&&
+                   (cq_mem_rdata[11:8] != VEC_OP_SIGMOID)   &&
+                   (cq_mem_rdata[11:8] != VEC_OP_TANH)      &&
+                   (cq_mem_rdata[11:8] != VEC_OP_HARDSIGMOID) &&
+                   (cq_mem_rdata[11:8] != VEC_OP_HARDTANH))) begin
+                error_code <= 32'h6;
+              end else begin
+                vec_pending <= 1'b1;
+              end
+            end
+          end
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+          cq_stage_valid <= 1'b0;
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_softmax_event_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 SOFTMAX and EVENT descriptor paths only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          reg consume_desc;
+          consume_desc = 1'b1;
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h12) begin
+            last_size <= (cq_mem_rdata[207:192] * cq_mem_rdata[223:208]);
+            if (!SOFTMAX_DESC_ENABLED) begin
+              error_code <= 32'h7;
+            end else if (softmax_pending) begin
+              error_code <= 32'h8;
+            end else if (cq_mem_rdata[15:12] != 4'h0) begin
+              error_code <= 32'h9;
+            end else if (cq_mem_rdata[207:192] != SOFTMAX_ROW_BYTES) begin
+              error_code <= 32'ha;
+            end else begin
+              softmax_in_row <= cq_mem_rdata[{softmax_seed_hi}:64];
+              softmax_last_result <= 0;
+              softmax_row_bytes_reg <= cq_mem_rdata[207:192];
+              softmax_rows_remaining <= cq_mem_rdata[223:208];
+              softmax_cycles_remaining <= (cq_mem_rdata[223:208] == 0) ? 1 : (cq_mem_rdata[223:208] + 1);
+              softmax_pending <= 1'b1;
+            end
+          end else if (cq_mem_rdata[7:0] == 8'h20) begin
+            if (dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
+              consume_desc = 1'b0;
+            end else begin
+              event_state[cq_mem_rdata[47:32]] <= 1'b1;
+              if (cq_mem_rdata[8]) begin
+                irq_status[IRQ_EVENT] <= 1'b1;
+              end
+            end
+          end else if (cq_mem_rdata[7:0] == 8'h21) begin
+            if (!event_state[cq_mem_rdata[47:32]]) begin
+              consume_desc = 1'b0;
+            end else begin
+              event_state[cq_mem_rdata[47:32]] <= 1'b0;
+            end
+          end
+          if (consume_desc) begin
+            cq_head <= cq_head + 32;
+            if (cq_count == 1) begin
+              irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+            end
+            cq_count <= cq_count - 1;
+            cq_stage_valid <= 1'b0;
+          end
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v2_gemm_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.2 extension fetch and GEMM issue path only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid && !cq_pending_ext) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else if (cq_stage_valid && !cq_pending_ext) begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          if (cq_mem_rdata[23:16] >= 8'h02) begin
+            cq_pending_ext <= 1'b1;
+            cq_stage_valid <= 1'b0;
+          end else begin
+            last_opcode <= cq_mem_rdata[7:0];
+            last_tag <= cq_mem_rdata[63:32];
+            last_src <= cq_mem_rdata[127:64];
+            last_dst <= cq_mem_rdata[191:128];
+            last_size <= cq_mem_rdata[223:192];
+            last_op_uid <= 0;
+            cq_head <= cq_head + 32;
+            if (cq_count == 1) begin
+              irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+            end
+            cq_count <= cq_count - 1;
+            cq_stage_valid <= 1'b0;
+          end
+        end else if (cq_pending_ext) begin
+          if (!cq_stage_valid) begin
+            cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head + 32;
+            cq_stage_valid <= 1'b1;
+          end else begin
+            last_opcode <= cq_word0[7:0];
+            last_tag <= cq_word0[63:32];
+            last_src <= cq_word0[127:64];
+            last_dst <= cq_word0[191:128];
+            last_size <= cq_mem_rdata[31:0];
+            last_op_uid <= cq_mem_rdata[255:192];
+            if (cq_word0[7:0] == 8'h10) begin
+{gemm_issue_chain_v2}
             end
             if (cq_count <= cq_word0_size) begin
               irq_status[IRQ_CQ_EMPTY] <= 1'b1;


### PR DESCRIPTION
## Summary
- add diagnostic `cq_mem_ablation_mode` options with default `full` preserving the existing CQ RTL path
- add `probe_decoder_producer_cq_ablation.py` to split CQ fetch/header/DMA/GEMM/VEC/SOFTMAX/EVENT/v0.2 paths
- wire the new `decoder_output_projection_producer_cq_ablation` abstraction into L2 task generation/result consumption
- add proposal `prop_l2_decoder_output_projection_producer_cq_ablation_v1`

## Validation
- `python3 -m py_compile npu/rtlgen/gen.py npu/eval/probe_decoder_producer_cq_ablation.py npu/eval/probe_decoder_producer_top_ablation.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- generated RTL smoke for all CQ diagnostic modes using existing `/workspaces/RTLGen/build/rtlgen`
