### PR TITLE
Add producer SOFTMAX/EVENT CQ ablation probe

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -440,6 +440,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("producer_synth_boundary_out", "producer_synth_boundary_report"),
     ("producer_top_ablation_out", "producer_top_ablation_report"),
     ("producer_cq_ablation_out", "producer_cq_ablation_report"),
+    ("producer_softmax_event_ablation_out", "producer_softmax_event_ablation_report"),
     ("attention_kv_memory_out", "attention_kv_memory_report"),
 )
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2496,6 +2496,46 @@ def _decoder_output_projection_producer_cq_ablation_evidence(*, item_id: str) ->
     }
 
 
+def _decoder_output_projection_producer_softmax_event_ablation_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_producer_softmax_event_ablation__{item_id}.json"
+    report = f"{base}/decoder_output_projection_producer_softmax_event_ablation__{item_id}.md"
+    base_config = "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json"
+    sweep = "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json"
+    return {
+        "inputs": {
+            "producer_softmax_event_ablation_out": out,
+            "producer_softmax_event_ablation_report": report,
+            "producer_softmax_event_ablation_base_config": base_config,
+            "producer_softmax_event_ablation_sweep": sweep,
+            "producer_softmax_event_ablation_make_target": "1_2_yosys",
+            "producer_softmax_event_ablation_scope": (
+                "Probe the prior failing nm2 CQ SOFTMAX/EVENT slice with diagnostic generator "
+                "modes for SOFTMAX checks, SOFTMAX issue, full SOFTMAX, EVENT_SIGNAL, "
+                "EVENT_WAIT, dynamic event_state index/update, full EVENT, and combined guard."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_decoder_output_projection_producer_softmax_event_ablation",
+                "run": (
+                    "python3 npu/eval/probe_decoder_producer_softmax_event_ablation.py "
+                    f"--base-config {base_config} "
+                    f"--sweep {sweep} "
+                    "--platform nangate45 "
+                    "--make-target 1_2_yosys "
+                    "--timeout-seconds 900 "
+                    "--stall-timeout-seconds 450 "
+                    "--continue-after-failure "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_distilgpt2_prompt_stress_evidence(*, item_id: str) -> dict[str, Any]:
     return _decoder_distilgpt2_quality_evidence_for_dataset(
         item_id=item_id,
@@ -2968,10 +3008,13 @@ def _build_payload(
         "decoder_output_projection_producer_isolated_synth",
         "decoder_output_projection_producer_top_ablation",
         "decoder_output_projection_producer_cq_ablation",
+        "decoder_output_projection_producer_softmax_event_ablation",
         "decoder_quantization_outline",
     }:
         if abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_producer_softmax_event_ablation":
+            decoder_evidence = _decoder_output_projection_producer_softmax_event_ablation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_cq_ablation":
             decoder_evidence = _decoder_output_projection_producer_cq_ablation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_top_ablation":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2173,6 +2173,57 @@ def test_generate_l2_campaign_task_adds_decoder_producer_cq_ablation_evidence() 
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_producer_softmax_event_ablation_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_producer_softmax_event_ablation_v1",
+                    proposal_id="prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_producer_softmax_event_ablation",
+                    expected_direction="iterate",
+                    comparison_role="producer_synth_boundary",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == (
+                "probe_decoder_output_projection_producer_softmax_event_ablation"
+            )
+            run = work_item.command_manifest[0]["run"]
+            assert "probe_decoder_producer_softmax_event_ablation.py" in run
+            assert "--stall-timeout-seconds 450" in run
+            assert decoder_inputs["producer_softmax_event_ablation_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_softmax_event_ablation__"
+                "l2_decoder_output_projection_producer_softmax_event_ablation_v1.json"
+            )
+            assert "SOFTMAX/EVENT slice" in decoder_inputs["producer_softmax_event_ablation_scope"]
+            assert decoder_inputs["producer_softmax_event_ablation_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_producer_softmax_event_ablation",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/evaluation_gate.md
@@ -1,0 +1,5 @@
+# Evaluation Gate
+
+Dispatch `l2_decoder_output_projection_producer_softmax_event_ablation_v1` after `l2_decoder_output_projection_producer_cq_ablation_v1` is merged and finalized.
+
+The gate passes if each SOFTMAX/EVENT subpath variant records either a bounded synth result or a clear generation/synthesis failure classification.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/evaluation_requests.json
@@ -1,0 +1,24 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1",
+  "source_commit": "4bb6457756ff7044e59f45b4153b1914bfe0f70f",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_softmax_event_ablation_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded synth-only nm2 npu_top SOFTMAX/EVENT command-queue subpath ablations to isolate the descriptor logic responsible for the prior CQ slice timeout.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_softmax_event_ablation",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_cq_ablation_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_cq_ablation_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify whether SOFTMAX checks, SOFTMAX issue, EVENT signal, EVENT wait, dynamic event_state indexing, or their combination causes the synthesis timeout."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/implementation_summary.md
@@ -1,0 +1,7 @@
+# Implementation Summary
+
+Extends diagnostic `cq_mem_ablation_mode` support in `npu/rtlgen/gen.py` with finer SOFTMAX/EVENT descriptor branch modes.
+
+Adds `npu/eval/probe_decoder_producer_softmax_event_ablation.py` and wires it into the L2 task generator as `decoder_output_projection_producer_softmax_event_ablation`.
+
+The probe writes temporary variant configs under `runs/designs/npu_blocks`, generates RTL, captures static Verilog size counters, and runs bounded synth-only OpenROAD flow per SOFTMAX/EVENT subpath variant.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/proposal.json
@@ -1,0 +1,73 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1",
+  "created_utc": "2026-05-13T23:05:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_softmax_event_ablation",
+  "title": "Decoder output-projection producer SOFTMAX/EVENT CQ synthesis ablation",
+  "hypothesis": "The prior CQ ablation identified `cq_v1_softmax_event_only` as the first non-OK nm2 synthesis slice while fetch, header, DMA, GEMM, and VEC slices were viable. Splitting SOFTMAX and EVENT into checks, issue/update, signal, wait, dynamic event_state index/update, and combined guard variants should identify whether the timeout is caused by SOFTMAX descriptor logic, the 65536-bit dynamic EVENT state access, or their interaction.",
+  "direct_comparison": {
+    "primary_question": "Which SOFTMAX/EVENT CQ subpath causes the nm2 producer top synthesis timeout?",
+    "include": [
+      "nm2 fp16 producer base config",
+      "known-passing cq_v1_vec_only anchor",
+      "SOFTMAX checks-only, issue-only, and full SOFTMAX variants",
+      "EVENT_SIGNAL-only, EVENT_WAIT-only, dynamic event_state index/update-only, and full EVENT variants",
+      "combined SOFTMAX/EVENT guard",
+      "bounded Nangate45 synth-only target 1_2_yosys",
+      "static generated-RTL size counters per variant"
+    ],
+    "exclude": [
+      "full placement and routing",
+      "producer scale beyond nm2",
+      "changing the default full CQ RTL behavior",
+      "changing perf-simulator semantics"
+    ]
+  },
+  "expected_benefit": [
+    "distinguishes SOFTMAX descriptor arithmetic/check logic from EVENT state indexing as the synthesis blocker",
+    "shows whether the combined SOFTMAX/EVENT branch fails only as an interaction",
+    "provides evidence for a targeted RTL generator fix such as staging event index decode or replacing the wide event_state vector"
+  ],
+  "risks": [
+    "diagnostic modes are not production RTL modes and only preserve default behavior when unset",
+    "a bounded timeout classifies exploration viability rather than absolute synthesis impossibility",
+    "if all individual variants pass, a follow-on pairwise interaction probe may still be required"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_softmax_event_ablation_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded synth-only nm2 npu_top SOFTMAX/EVENT command-queue subpath ablations to isolate the descriptor logic responsible for the prior CQ slice timeout.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_softmax_event_ablation",
+      "cost_class": "bounded-medium",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_cq_ablation_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_cq_ablation_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify whether SOFTMAX checks, SOFTMAX issue, EVENT signal, EVENT wait, dynamic event_state indexing, or their combination causes the synthesis timeout."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_output_projection_producer_cq_ablation_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_cq_ablation__l2_decoder_output_projection_producer_cq_ablation_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_top_ablation__l2_decoder_output_projection_producer_top_ablation_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_decoder_producer_softmax_event_ablation.py",
+    "npu/eval/probe_decoder_producer_cq_ablation.py",
+    "npu/rtlgen/gen.py",
+    "npu/synth/run_block_sweep.py",
+    "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/quality_gate.md
@@ -1,0 +1,10 @@
+# Quality Gate
+
+The result is acceptable if:
+
+- all variants use the nm2 producer base config
+- default `cq_mem_ablation_mode=full` preserves the existing full CQ RTL path
+- the probe continues after failed variants
+- each row includes static RTL counters
+- timeout and stall classifications are preserved without retry loops
+- the result compares against the prior CQ ablation that identified `cq_v1_softmax_event_only` as the first non-OK slice

--- a/npu/eval/probe_decoder_producer_softmax_event_ablation.py
+++ b/npu/eval/probe_decoder_producer_softmax_event_ablation.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Bounded SOFTMAX/EVENT command-queue ablation probe for decoder producer synth."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT_FOR_IMPORT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT_FOR_IMPORT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT_FOR_IMPORT))
+
+from npu.eval.probe_decoder_producer_top_ablation import (  # noqa: E402
+    REPO_ROOT,
+    ensure_rtlgen_binaries,
+    probe_variant,
+    rel,
+    write_variant_config,
+)
+
+
+VARIANTS: list[dict[str, Any]] = [
+    {
+        "name": "cq_v1_vec_only_anchor",
+        "top": "npu_top",
+        "description": "Known-passing anchor immediately before the prior failing SOFTMAX/EVENT slice.",
+        "updates": {"cq_mem_ablation_mode": "v1_vec_only"},
+    },
+    {
+        "name": "cq_v1_softmax_checks_only",
+        "top": "npu_top",
+        "description": "SOFTMAX descriptor opcode, size, dtype, row-width, and busy checks only.",
+        "updates": {"cq_mem_ablation_mode": "v1_softmax_checks_only"},
+    },
+    {
+        "name": "cq_v1_softmax_issue_only",
+        "top": "npu_top",
+        "description": "SOFTMAX descriptor issue/update registers only, without descriptor checks.",
+        "updates": {"cq_mem_ablation_mode": "v1_softmax_issue_only"},
+    },
+    {
+        "name": "cq_v1_softmax_only",
+        "top": "npu_top",
+        "description": "Full SOFTMAX descriptor path without EVENT_SIGNAL/EVENT_WAIT.",
+        "updates": {"cq_mem_ablation_mode": "v1_softmax_only"},
+    },
+    {
+        "name": "cq_v1_event_signal_only",
+        "top": "npu_top",
+        "description": "EVENT_SIGNAL path with busy gating, dynamic event_state set, and optional IRQ.",
+        "updates": {"cq_mem_ablation_mode": "v1_event_signal_only"},
+    },
+    {
+        "name": "cq_v1_event_wait_only",
+        "top": "npu_top",
+        "description": "EVENT_WAIT path with dynamic event_state read, stall, and clear.",
+        "updates": {"cq_mem_ablation_mode": "v1_event_wait_only"},
+    },
+    {
+        "name": "cq_v1_event_index_only",
+        "top": "npu_top",
+        "description": "Dynamic event_state index read/write only, without EVENT busy gating or stall behavior.",
+        "updates": {"cq_mem_ablation_mode": "v1_event_index_only"},
+    },
+    {
+        "name": "cq_v1_event_only",
+        "top": "npu_top",
+        "description": "Full EVENT_SIGNAL/EVENT_WAIT paths without SOFTMAX.",
+        "updates": {"cq_mem_ablation_mode": "v1_event_only"},
+    },
+    {
+        "name": "cq_v1_softmax_event_guard",
+        "top": "npu_top",
+        "description": "Prior failing combined SOFTMAX and EVENT slice as a guard.",
+        "updates": {"cq_mem_ablation_mode": "v1_softmax_event_only"},
+    },
+]
+
+
+def build_diagnosis(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    ok = [row for row in rows if row.get("status") == "ok"]
+    bad = [row for row in rows if row.get("status") != "ok"]
+    first_bad = bad[0]["variant"] if bad else None
+    guard = next((row for row in rows if row.get("variant") == "cq_v1_softmax_event_guard"), None)
+    individual_rows = [row for row in rows if row.get("variant") != "cq_v1_softmax_event_guard"]
+    individual_bad = [row for row in individual_rows if row.get("status") != "ok"]
+    if guard and guard.get("status") == "ok":
+        decision = "softmax_event_guard_synth_ok_under_bound"
+        next_step = "Use the guard metrics as an updated synthesis boundary before changing RTL."
+    elif individual_bad:
+        decision = "softmax_event_subpath_culprit_bracketed"
+        next_step = (
+            "Inspect the first non-OK SOFTMAX/EVENT subpath and replace the failing "
+            "expression with staged decode or preserved hierarchy."
+        )
+    elif guard and guard.get("status") != "ok":
+        decision = "softmax_event_combination_culprit"
+        next_step = (
+            "Probe the interaction between the individually viable SOFTMAX and EVENT paths, "
+            "then stage the combined CQ branch boundary."
+        )
+    else:
+        decision = "softmax_event_subpaths_individually_viable"
+        next_step = "Run a combined guard with a longer bound or compare static RTL before changing RTL."
+    return {
+        "decision": decision,
+        "ok_variants": [row.get("variant") for row in ok],
+        "non_ok_variants": [row.get("variant") for row in bad],
+        "first_non_ok_variant": first_bad,
+        "recommended_next_step": next_step,
+    }
+
+
+def write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# Decoder Producer SOFTMAX/EVENT CQ Ablation",
+        "",
+        f"- base_config: `{payload['base_config']}`",
+        f"- make_target: `{payload['make_target']}`",
+        f"- timeout_seconds: `{payload['timeout_seconds']}`",
+        f"- stall_timeout_seconds: `{payload['stall_timeout_seconds']}`",
+        "",
+        "| variant | top | status | elapsed_s | verilog_kb | reg_bits_est | wire_bits_est | log |",
+        "|---|---|---|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["probe_rows"]:
+        synth = row.get("synthesis") or {}
+        stats = row.get("static_verilog_stats") or {}
+        elapsed = synth.get("elapsed_seconds")
+        elapsed_text = f"{float(elapsed):.1f}" if elapsed is not None else ""
+        lines.append(
+            "| {variant} | {top} | {status} | {elapsed} | {kb:.1f} | {reg_bits} | {wire_bits} | {log} |".format(
+                variant=row.get("variant"),
+                top=row.get("top"),
+                status=row.get("status"),
+                elapsed=elapsed_text,
+                kb=float(stats.get("verilog_bytes") or 0) / 1024.0,
+                reg_bits=stats.get("reg_bit_count_est", ""),
+                wire_bits=stats.get("wire_bit_count_est", ""),
+                log=synth.get("log_path", ""),
+            )
+        )
+    diagnosis = payload["diagnosis"]
+    lines.extend(
+        [
+            "",
+            "## Diagnosis",
+            "",
+            f"- decision: `{diagnosis.get('decision')}`",
+            f"- ok_variants: `{diagnosis.get('ok_variants')}`",
+            f"- non_ok_variants: `{diagnosis.get('non_ok_variants')}`",
+            f"- first_non_ok_variant: `{diagnosis.get('first_non_ok_variant')}`",
+            f"- recommended_next_step: {diagnosis.get('recommended_next_step')}",
+            "",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-config", required=True)
+    ap.add_argument("--sweep", required=True)
+    ap.add_argument("--platform", default="nangate45")
+    ap.add_argument("--make-target", default="1_2_yosys")
+    ap.add_argument("--out-root", default="runs/designs/npu_blocks")
+    ap.add_argument("--timeout-seconds", type=int, default=900)
+    ap.add_argument("--stall-timeout-seconds", type=int, default=450)
+    ap.add_argument("--rtlgen-build-timeout-seconds", type=int, default=900)
+    ap.add_argument("--skip-rtlgen-build", action="store_true")
+    ap.add_argument("--continue-after-failure", action="store_true")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    base_config = (REPO_ROOT / args.base_config).resolve() if not Path(args.base_config).is_absolute() else Path(args.base_config)
+    sweep = (REPO_ROOT / args.sweep).resolve() if not Path(args.sweep).is_absolute() else Path(args.sweep)
+    out = (REPO_ROOT / args.out).resolve() if not Path(args.out).is_absolute() else Path(args.out)
+    out_md = (REPO_ROOT / args.out_md).resolve() if not Path(args.out_md).is_absolute() else Path(args.out_md)
+    out_root = (REPO_ROOT / args.out_root).resolve() if not Path(args.out_root).is_absolute() else Path(args.out_root)
+    log_root = Path(os.environ.get("RTLGEN_PRODUCER_SOFTMAX_EVENT_ABLATION_LOG_DIR", "/tmp/rtlgen-producer-softmax-event-ablation"))
+    log_dir = log_root / out.stem
+
+    config_paths = [write_variant_config(base_config, variant, out_root) for variant in VARIANTS]
+    setup = ensure_rtlgen_binaries(
+        config_paths,
+        log_dir=log_dir,
+        build_timeout_seconds=args.rtlgen_build_timeout_seconds,
+        stall_timeout_seconds=max(120, min(args.stall_timeout_seconds, 300)),
+        skip_build=args.skip_rtlgen_build,
+    )
+    rows: list[dict[str, Any]] = []
+    if setup["status"] != "ok":
+        rows.append({"status": "setup_failed", "variant": "setup", "rtlgen_setup": setup})
+    else:
+        for variant, config_path in zip(VARIANTS, config_paths):
+            row = probe_variant(
+                config_path,
+                variant=variant,
+                sweep=sweep,
+                platform=args.platform,
+                make_target=args.make_target,
+                out_root=out_root,
+                timeout_seconds=args.timeout_seconds,
+                stall_timeout_seconds=args.stall_timeout_seconds,
+                log_dir=log_dir,
+            )
+            rows.append(row)
+            if row.get("status") != "ok" and not args.continue_after_failure:
+                break
+
+    payload = {
+        "version": 0.1,
+        "model": "decoder_output_projection_producer_softmax_event_ablation_v1",
+        "platform": args.platform,
+        "base_config": rel(base_config),
+        "make_target": args.make_target,
+        "timeout_seconds": args.timeout_seconds,
+        "stall_timeout_seconds": args.stall_timeout_seconds,
+        "rtlgen_setup": setup,
+        "sweep": rel(sweep),
+        "probe_rows": rows,
+        "diagnosis": build_diagnosis(rows),
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    write_markdown(out_md, payload)
+    return 2 if setup["status"] != "ok" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/config_spec.md
+++ b/npu/rtlgen/config_spec.md
@@ -99,7 +99,8 @@ can later be extended without breaking v0.1.
 - `cq_mem_ablation_mode` (string, optional): diagnostic-only command-queue
   subpath selector for synthesis probes. Default `full` preserves the normal
   generated CQ fetch/decode/issue RTL. Other values are not production RTL
-  modes; they are used to isolate synthesis behavior.
+  modes; they are used to isolate synthesis behavior, including finer
+  SOFTMAX/EVENT descriptor branch splits.
 - `enable_axi_ports` (bool): include AXI4-like memory interface ports (stub).
 - `enable_axi_lite_wrapper` (bool): emit an AXI-Lite wrapper module for MMIO.
 - `compute` (object, optional): Phase 1 compute generation controls.

--- a/npu/rtlgen/gen.py
+++ b/npu/rtlgen/gen.py
@@ -2300,6 +2300,13 @@ endmodule
         "v1_gemm_only",
         "v1_vec_only",
         "v1_softmax_event_only",
+        "v1_softmax_checks_only",
+        "v1_softmax_issue_only",
+        "v1_softmax_only",
+        "v1_event_signal_only",
+        "v1_event_wait_only",
+        "v1_event_index_only",
+        "v1_event_only",
         "v2_gemm_only",
     }
     if cq_mem_ablation_mode not in valid_cq_mem_ablation_modes:
@@ -2854,6 +2861,259 @@ endmodule
               softmax_pending <= 1'b1;
             end
           end else if (cq_mem_rdata[7:0] == 8'h20) begin
+            if (dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
+              consume_desc = 1'b0;
+            end else begin
+              event_state[cq_mem_rdata[47:32]] <= 1'b1;
+              if (cq_mem_rdata[8]) begin
+                irq_status[IRQ_EVENT] <= 1'b1;
+              end
+            end
+          end else if (cq_mem_rdata[7:0] == 8'h21) begin
+            if (!event_state[cq_mem_rdata[47:32]]) begin
+              consume_desc = 1'b0;
+            end else begin
+              event_state[cq_mem_rdata[47:32]] <= 1'b0;
+            end
+          end
+          if (consume_desc) begin
+            cq_head <= cq_head + 32;
+            if (cq_count == 1) begin
+              irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+            end
+            cq_count <= cq_count - 1;
+            cq_stage_valid <= 1'b0;
+          end
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_softmax_checks_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 SOFTMAX descriptor checks only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h12) begin
+            last_size <= (cq_mem_rdata[207:192] * cq_mem_rdata[223:208]);
+            if (!SOFTMAX_DESC_ENABLED) begin
+              error_code <= 32'h7;
+            end else if (softmax_pending) begin
+              error_code <= 32'h8;
+            end else if (cq_mem_rdata[15:12] != 4'h0) begin
+              error_code <= 32'h9;
+            end else if (cq_mem_rdata[207:192] != SOFTMAX_ROW_BYTES) begin
+              error_code <= 32'ha;
+            end
+          end
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+          cq_stage_valid <= 1'b0;
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_softmax_issue_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 SOFTMAX issue/update path only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h12) begin
+            last_size <= (cq_mem_rdata[207:192] * cq_mem_rdata[223:208]);
+            softmax_in_row <= cq_mem_rdata[{softmax_seed_hi}:64];
+            softmax_last_result <= 0;
+            softmax_row_bytes_reg <= cq_mem_rdata[207:192];
+            softmax_rows_remaining <= cq_mem_rdata[223:208];
+            softmax_cycles_remaining <= (cq_mem_rdata[223:208] == 0) ? 1 : (cq_mem_rdata[223:208] + 1);
+            softmax_pending <= 1'b1;
+          end
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+          cq_stage_valid <= 1'b0;
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_softmax_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 SOFTMAX descriptor path only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h12) begin
+            last_size <= (cq_mem_rdata[207:192] * cq_mem_rdata[223:208]);
+            if (!SOFTMAX_DESC_ENABLED) begin
+              error_code <= 32'h7;
+            end else if (softmax_pending) begin
+              error_code <= 32'h8;
+            end else if (cq_mem_rdata[15:12] != 4'h0) begin
+              error_code <= 32'h9;
+            end else if (cq_mem_rdata[207:192] != SOFTMAX_ROW_BYTES) begin
+              error_code <= 32'ha;
+            end else begin
+              softmax_in_row <= cq_mem_rdata[{softmax_seed_hi}:64];
+              softmax_last_result <= 0;
+              softmax_row_bytes_reg <= cq_mem_rdata[207:192];
+              softmax_rows_remaining <= cq_mem_rdata[223:208];
+              softmax_cycles_remaining <= (cq_mem_rdata[223:208] == 0) ? 1 : (cq_mem_rdata[223:208] + 1);
+              softmax_pending <= 1'b1;
+            end
+          end
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+          cq_stage_valid <= 1'b0;
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_event_signal_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 EVENT_SIGNAL path only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          reg consume_desc;
+          consume_desc = 1'b1;
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h20) begin
+            if (dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
+              consume_desc = 1'b0;
+            end else begin
+              event_state[cq_mem_rdata[47:32]] <= 1'b1;
+              if (cq_mem_rdata[8]) begin
+                irq_status[IRQ_EVENT] <= 1'b1;
+              end
+            end
+          end
+          if (consume_desc) begin
+            cq_head <= cq_head + 32;
+            if (cq_count == 1) begin
+              irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+            end
+            cq_count <= cq_count - 1;
+            cq_stage_valid <= 1'b0;
+          end
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_event_wait_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 EVENT_WAIT path only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          reg consume_desc;
+          consume_desc = 1'b1;
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h21) begin
+            if (!event_state[cq_mem_rdata[47:32]]) begin
+              consume_desc = 1'b0;
+            end else begin
+              event_state[cq_mem_rdata[47:32]] <= 1'b0;
+            end
+          end
+          if (consume_desc) begin
+            cq_head <= cq_head + 32;
+            if (cq_count == 1) begin
+              irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+            end
+            cq_count <= cq_count - 1;
+            cq_stage_valid <= 1'b0;
+          end
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_event_index_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 EVENT dynamic state index/update only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h20) begin
+            event_state[cq_mem_rdata[47:32]] <= 1'b1;
+          end else if (cq_mem_rdata[7:0] == 8'h21) begin
+            if (event_state[cq_mem_rdata[47:32]]) begin
+              event_state[cq_mem_rdata[47:32]] <= 1'b0;
+            end
+          end
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+          cq_stage_valid <= 1'b0;
+        end
+      end"""
+        elif cq_mem_ablation_mode == "v1_event_only":
+            cq_block = f"""      // CQ diagnostic ablation: v0.1 EVENT_SIGNAL and EVENT_WAIT paths only.
+      if (cq_count != 0) begin
+        if (!cq_stage_valid) begin
+          cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
+          cq_stage_valid <= 1'b1;
+        end else begin
+          reg consume_desc;
+          consume_desc = 1'b1;
+          cq_word0 <= cq_mem_rdata;
+          cq_word0_size <= cq_mem_rdata[23:16];
+          last_opcode <= cq_mem_rdata[7:0];
+          last_tag <= cq_mem_rdata[63:32];
+          last_src <= cq_mem_rdata[127:64];
+          last_dst <= cq_mem_rdata[191:128];
+          last_size <= cq_mem_rdata[223:192];
+          last_op_uid <= 0;
+          if (cq_mem_rdata[7:0] == 8'h20) begin
             if (dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
               consume_desc = 1'b0;
             end else begin


### PR DESCRIPTION
## Summary
- add finer diagnostic `cq_mem_ablation_mode` values for the failing CQ SOFTMAX/EVENT slice
- add `probe_decoder_producer_softmax_event_ablation.py` to split SOFTMAX checks, SOFTMAX issue, EVENT signal, EVENT wait, dynamic event_state access, and combined guard
- wire the new `decoder_output_projection_producer_softmax_event_ablation` abstraction into L2 task generation/result consumption
- add proposal `prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1`

## Validation
- `python3 -m py_compile npu/rtlgen/gen.py npu/eval/probe_decoder_producer_softmax_event_ablation.py npu/eval/probe_decoder_producer_cq_ablation.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- generated RTL smoke for all new SOFTMAX/EVENT diagnostic modes using existing `/workspaces/RTLGen/build/rtlgen`
