### PR TITLE
[codex] Stage EVENT_WAIT CQ retirement

### DIFF
--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/evaluation_gate.md
@@ -1,0 +1,5 @@
+# Evaluation Gate
+
+Dispatch `l2_decoder_output_projection_producer_event_wait_staged_v1` after the staged EVENT_WAIT RTL generator change is merged.
+
+The gate passes if the evaluator runs the existing SOFTMAX/EVENT ablation on the merged commit and records whether the prior EVENT_WAIT timeout moved to a bounded synth result.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_event_wait_staged_v1",
+  "source_commit": "c10ca39fe34ed359daa7cdcbcebc43b3ade67a93",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_event_wait_staged_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the bounded nm2 SOFTMAX/EVENT CQ ablation after staging EVENT_WAIT to confirm the prior timeout is removed and the combined guard remains explorable.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_softmax_event_ablation",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_softmax_event_ablation_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_softmax_event_ablation_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "promote",
+        "reason": "EVENT_WAIT-only and full EVENT variants should move from timeout to bounded synth result after staging the descriptor-indexed event_state access."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/implementation_summary.md
@@ -1,0 +1,7 @@
+# Implementation Summary
+
+Stages EVENT_WAIT retirement in `npu/rtlgen/gen.py` by latching `event_wait_id`, holding `event_wait_pending`, and servicing the wait before fetching the next command.
+
+Updates the RTL shell event-DMA testbench to wait for the second DMA issue instead of treating the EVENT IRQ from EVENT_SIGNAL as proof that EVENT_WAIT already retired.
+
+Adds `tests/test_npu_rtlgen_event_wait.py` to guard the generated full and diagnostic EVENT_WAIT paths.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_event_wait_staged_v1",
+  "created_utc": "2026-05-14T00:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_softmax_event_ablation",
+  "title": "Decoder output-projection producer staged EVENT_WAIT confirmation",
+  "hypothesis": "The SOFTMAX/EVENT ablation identified EVENT_WAIT as the first nm2 command-queue synthesis timeout. Staging EVENT_WAIT by latching the event id and servicing the wait from a small pending state should remove the direct descriptor-indexed event_state read from the retire branch while preserving perf-vs-RTL ordering.",
+  "direct_comparison": {
+    "primary_question": "Does the staged EVENT_WAIT RTL make the prior EVENT_WAIT and combined SOFTMAX/EVENT CQ variants synthesize under the bounded nm2 probe?",
+    "include": [
+      "nm2 fp16 producer base config",
+      "existing SOFTMAX/EVENT command-queue ablation variants",
+      "bounded Nangate45 synth-only target 1_2_yosys",
+      "static generated-RTL size counters per variant",
+      "perf-vs-RTL event-DMA contract regression"
+    ],
+    "exclude": [
+      "full placement and routing",
+      "producer scale beyond nm2",
+      "changing command ordering semantics",
+      "quality or QAT experiments"
+    ]
+  },
+  "expected_benefit": [
+    "confirms whether staged EVENT_WAIT eliminates the prior synthesis explosion",
+    "keeps the diagnostic event_index_only mode as the remaining direct dynamic-index reference",
+    "preserves the existing command-queue/perf-simulator contract except for an allowed one-cycle RTL staging latency"
+  ],
+  "risks": [
+    "bounded synthesis success does not prove larger producer configurations are viable",
+    "the staged wait adds a cycle between EVENT_WAIT decode and retirement",
+    "the combined SOFTMAX/EVENT path may still expose a separate interaction after EVENT_WAIT is fixed"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_event_wait_staged_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the bounded nm2 SOFTMAX/EVENT CQ ablation after staging EVENT_WAIT to confirm the prior timeout is removed and the combined guard remains explorable.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_softmax_event_ablation",
+      "cost_class": "bounded-medium",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_softmax_event_ablation_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_softmax_event_ablation_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "promote",
+        "reason": "The expected result is that EVENT_WAIT-only and full EVENT variants move from timeout to bounded synth result, validating the RTL staging fix before broader producer exploration resumes."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_output_projection_producer_softmax_event_ablation_v1/analysis_report.md",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_softmax_event_ablation__l2_decoder_output_projection_producer_softmax_event_ablation_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/rtlgen/gen.py",
+    "npu/eval/probe_decoder_producer_softmax_event_ablation.py",
+    "tests/test_npu_contract_equivalence.py",
+    "tests/test_npu_rtlgen_event_wait.py",
+    "npu/sim/rtl/tb_npu_shell.sv"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/quality_gate.md
@@ -1,0 +1,9 @@
+# Quality Gate
+
+The result is acceptable if:
+
+- `cq_v1_event_wait_only` no longer times out under the bounded nm2 synth-only probe
+- `cq_v1_event_only` and `cq_v1_softmax_event_guard` record bounded results or a new clearly classified non-EVENT_WAIT failure
+- `cq_v1_event_index_only` remains the direct dynamic-index diagnostic reference
+- static RTL counters are included for every variant
+- perf-vs-RTL event-DMA ordering remains equivalent

--- a/npu/eval/probe_decoder_producer_softmax_event_ablation.py
+++ b/npu/eval/probe_decoder_producer_softmax_event_ablation.py
@@ -57,7 +57,7 @@ VARIANTS: list[dict[str, Any]] = [
     {
         "name": "cq_v1_event_wait_only",
         "top": "npu_top",
-        "description": "EVENT_WAIT path with dynamic event_state read, stall, and clear.",
+        "description": "EVENT_WAIT path with staged event id latch, pending wait, and indexed event_state clear.",
         "updates": {"cq_mem_ablation_mode": "v1_event_wait_only"},
     },
     {

--- a/npu/rtlgen/gen.py
+++ b/npu/rtlgen/gen.py
@@ -81,6 +81,8 @@ module {top_name} (
   reg        cq_stage_valid;
   reg        dma_pending;
   reg [65535:0] event_state;
+  reg        event_wait_pending;
+  reg [15:0] event_wait_id;
   reg [2:0]  dma_state;
 {gemm_state_regs}
 {compute_state_regs}
@@ -200,6 +202,8 @@ module {top_name} (
       cq_stage_valid <= 0;
       dma_pending <= 0;
       event_state <= 0;
+      event_wait_pending <= 0;
+      event_wait_id <= 0;
       dma_state <= 0;
 {gemm_reset}
 {compute_reset}
@@ -249,7 +253,7 @@ module {top_name} (
         status <= STATUS_ERR;
         irq_status[IRQ_ERROR] <= 1'b1;
       end else if (!(mmio_we && mmio_addr == OFF_DOORBELL)) begin
-        if ((cq_count != 0) || cq_stage_valid || dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
+        if ((cq_count != 0) || cq_stage_valid || event_wait_pending || dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
           status <= STATUS_BUSY;
         end else begin
           status <= STATUS_IDLE;
@@ -2395,6 +2399,21 @@ endmodule
       end
       gemm_pending <= (gemm_slot_valid != {gemm_slot_valid_zero});"""
 
+    event_wait_service_block = """        if (event_state[event_wait_id]) begin
+          event_state[event_wait_id] <= 1'b0;
+          event_wait_pending <= 1'b0;
+          cq_head <= cq_head + 32;
+          if (cq_count == 1) begin
+            irq_status[IRQ_CQ_EMPTY] <= 1'b1;
+          end
+          cq_count <= cq_count - 1;
+        end"""
+
+    event_wait_latch_block = """              consume_desc = 1'b0;
+              event_wait_id <= cq_mem_rdata[47:32];
+              event_wait_pending <= 1'b1;
+              cq_stage_valid <= 1'b0;"""
+
     if enable_cq_mem_ports:
         cq_mem_ports = f""",
     output reg  [{dma_addr_width_minus1}:0] cq_mem_addr,
@@ -2402,7 +2421,9 @@ endmodule
 """
         cq_block = f"""      // Command queue fetch (supports v0.1 32B and v0.2 64B descriptors).
       if (cq_count != 0) begin
-        if (!cq_stage_valid && !cq_pending_ext) begin
+        if (event_wait_pending) begin
+{event_wait_service_block}
+        end else if (!cq_stage_valid && !cq_pending_ext) begin
           cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
           cq_stage_valid <= 1'b1;
         end else if (cq_stage_valid && !cq_pending_ext) begin
@@ -2524,11 +2545,7 @@ endmodule
               end
             end else if (cq_mem_rdata[7:0] == 8'h21) begin
               // EVENT_WAIT: stall command retirement until the event is signaled.
-              if (!event_state[cq_mem_rdata[47:32]]) begin
-                consume_desc = 1'b0;
-              end else begin
-                event_state[cq_mem_rdata[47:32]] <= 1'b0;
-              end
+{event_wait_latch_block}
             end else begin
               error_code <= 32'h1;
             end
@@ -2828,7 +2845,9 @@ endmodule
         elif cq_mem_ablation_mode == "v1_softmax_event_only":
             cq_block = f"""      // CQ diagnostic ablation: v0.1 SOFTMAX and EVENT descriptor paths only.
       if (cq_count != 0) begin
-        if (!cq_stage_valid) begin
+        if (event_wait_pending) begin
+{event_wait_service_block}
+        end else if (!cq_stage_valid) begin
           cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
           cq_stage_valid <= 1'b1;
         end else begin
@@ -2870,11 +2889,7 @@ endmodule
               end
             end
           end else if (cq_mem_rdata[7:0] == 8'h21) begin
-            if (!event_state[cq_mem_rdata[47:32]]) begin
-              consume_desc = 1'b0;
-            end else begin
-              event_state[cq_mem_rdata[47:32]] <= 1'b0;
-            end
+{event_wait_latch_block}
           end
           if (consume_desc) begin
             cq_head <= cq_head + 32;
@@ -3035,7 +3050,9 @@ endmodule
         elif cq_mem_ablation_mode == "v1_event_wait_only":
             cq_block = f"""      // CQ diagnostic ablation: v0.1 EVENT_WAIT path only.
       if (cq_count != 0) begin
-        if (!cq_stage_valid) begin
+        if (event_wait_pending) begin
+{event_wait_service_block}
+        end else if (!cq_stage_valid) begin
           cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
           cq_stage_valid <= 1'b1;
         end else begin
@@ -3050,11 +3067,7 @@ endmodule
           last_size <= cq_mem_rdata[223:192];
           last_op_uid <= 0;
           if (cq_mem_rdata[7:0] == 8'h21) begin
-            if (!event_state[cq_mem_rdata[47:32]]) begin
-              consume_desc = 1'b0;
-            end else begin
-              event_state[cq_mem_rdata[47:32]] <= 1'b0;
-            end
+{event_wait_latch_block}
           end
           if (consume_desc) begin
             cq_head <= cq_head + 32;
@@ -3099,7 +3112,9 @@ endmodule
         elif cq_mem_ablation_mode == "v1_event_only":
             cq_block = f"""      // CQ diagnostic ablation: v0.1 EVENT_SIGNAL and EVENT_WAIT paths only.
       if (cq_count != 0) begin
-        if (!cq_stage_valid) begin
+        if (event_wait_pending) begin
+{event_wait_service_block}
+        end else if (!cq_stage_valid) begin
           cq_mem_addr <= {{cq_base_hi, cq_base_lo}} + cq_head;
           cq_stage_valid <= 1'b1;
         end else begin
@@ -3123,11 +3138,7 @@ endmodule
               end
             end
           end else if (cq_mem_rdata[7:0] == 8'h21) begin
-            if (!event_state[cq_mem_rdata[47:32]]) begin
-              consume_desc = 1'b0;
-            end else begin
-              event_state[cq_mem_rdata[47:32]] <= 1'b0;
-            end
+{event_wait_latch_block}
           end
           if (consume_desc) begin
             cq_head <= cq_head + 32;

--- a/npu/sim/rtl/axi_mem_router.sv
+++ b/npu/sim/rtl/axi_mem_router.sv
@@ -25,7 +25,7 @@ module axi_mem_router (
   output reg [255:0] m_axi_rdata,
   output reg         m_axi_rlast
 );
-  `include "npu/rtlgen/out/sram_map.vh"
+  `include "sram_map.vh"
 
   reg [7:0] mem [0:2097151];
   reg [63:0] aw_addr_q;

--- a/npu/sim/rtl/tb_axi_lite_mmio.sv
+++ b/npu/sim/rtl/tb_axi_lite_mmio.sv
@@ -2,7 +2,7 @@
 
 module tb_axi_lite_mmio;
   localparam CLK_PERIOD = 10;
-  `include "npu/rtlgen/out/mmio_map.vh"
+  `include "mmio_map.vh"
 
   reg clk;
   reg rst_n;
@@ -156,7 +156,7 @@ module tb_axi_lite_mmio;
   reg checked_dma;
   reg sram_test;
   reg event_test;
-  `include "npu/rtlgen/out/sram_map.vh"
+  `include "sram_map.vh"
   localparam [63:0] MEM_DST_BASE = 64'h0000_0000_0001_0000;
 
   initial begin

--- a/npu/sim/rtl/tb_axi_lite_multi.sv
+++ b/npu/sim/rtl/tb_axi_lite_multi.sv
@@ -2,7 +2,7 @@
 
 module tb_axi_lite_multi;
   localparam CLK_PERIOD = 10;
-  `include "npu/rtlgen/out/mmio_map.vh"
+  `include "mmio_map.vh"
 
   reg clk;
   reg rst_n;
@@ -156,7 +156,7 @@ module tb_axi_lite_multi;
   reg checked_dma;
   reg sram_test;
   reg event_test;
-  `include "npu/rtlgen/out/sram_map.vh"
+  `include "sram_map.vh"
   localparam [63:0] MEM_DST_BASE = 64'h0000_0000_0001_0000;
 
   initial begin

--- a/npu/sim/rtl/tb_npu_shell.sv
+++ b/npu/sim/rtl/tb_npu_shell.sv
@@ -5,7 +5,7 @@ module tb_npu_shell;
   localparam MMIO_ADDR_W = 12;
   localparam DATA_W = 32;
 
-  `include "npu/rtlgen/out/mmio_map.vh"
+  `include "mmio_map.vh"
 
   reg clk;
   reg rst_n;
@@ -218,7 +218,7 @@ module tb_npu_shell;
   reg [DATA_W-1:0] cq_head_prev_mon;
   integer dma_complete_index;
   string bin_path;
-  `include "npu/rtlgen/out/sram_map.vh"
+  `include "sram_map.vh"
   localparam [63:0] MEM_DST_BASE = 64'h0000_0000_0001_0000;
 
   initial begin
@@ -814,6 +814,14 @@ module tb_npu_shell;
         $finish(1);
       end
     end else if (event_dma_test) begin
+      begin : wait_second_dma_after_event
+        integer t4;
+        for (t4 = 0; t4 < 600; t4 = t4 + 1) begin
+          @(posedge clk);
+          if (dma_req_count >= 2)
+            disable wait_second_dma_after_event;
+        end
+      end
       if (dma_req_count != 2) begin
         mmio_read(OFF_CQ_HEAD, cq_head);
         $display("ERROR: expected 2 DMA requests in event_dma_test, saw %0d head=%h tail=%h last_opcode=%h event0=%b dma_pending=%b bvalid=%b",

--- a/tests/test_npu_rtlgen_event_wait.py
+++ b/tests/test_npu_rtlgen_event_wait.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""RTLGen coverage for staged EVENT_WAIT CQ decode."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _generate_top(tmp_path: Path, mode: str = "full") -> str:
+    cfg = json.loads((REPO_ROOT / "npu/rtlgen/examples/minimal.json").read_text(encoding="utf-8"))
+    cfg["enable_axi_lite_wrapper"] = False
+    cfg["cq_mem_ablation_mode"] = mode
+    cfg_path = tmp_path / f"{mode}.json"
+    out_dir = tmp_path / mode
+    cfg_path.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    subprocess.run(
+        [sys.executable, "npu/rtlgen/gen.py", "--config", str(cfg_path), "--out", str(out_dir)],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return (out_dir / "top.v").read_text(encoding="utf-8")
+
+
+def test_full_cq_event_wait_latches_id_before_stalling(tmp_path: Path) -> None:
+    top = _generate_top(tmp_path)
+
+    assert "reg        event_wait_pending;" in top
+    assert "reg [15:0] event_wait_id;" in top
+    assert "event_wait_id <= cq_mem_rdata[47:32];" in top
+    assert "event_wait_pending <= 1'b1;" in top
+    assert "if (!event_state[cq_mem_rdata[47:32]])" not in top
+    assert "event_state[event_wait_id] <= 1'b0;" in top
+
+
+@pytest.mark.parametrize("mode", ["v1_softmax_event_only", "v1_event_wait_only", "v1_event_only"])
+def test_event_wait_diagnostic_modes_use_staged_wait(tmp_path: Path, mode: str) -> None:
+    top = _generate_top(tmp_path, mode)
+
+    assert "event_wait_id <= cq_mem_rdata[47:32];" in top
+    assert "if (event_wait_pending) begin" in top
+    assert "event_state[event_wait_id] <= 1'b0;" in top
+    assert "if (!event_state[cq_mem_rdata[47:32]])" not in top
+
+
+def test_event_index_diagnostic_mode_keeps_direct_dynamic_access(tmp_path: Path) -> None:
+    top = _generate_top(tmp_path, "v1_event_index_only")
+
+    assert "event_wait_id <= cq_mem_rdata[47:32];" not in top
+    assert "event_state[cq_mem_rdata[47:32]]" in top


### PR DESCRIPTION
## Summary

Stages EVENT_WAIT CQ retirement by latching the descriptor event id into a small pending state before checking and clearing `event_state`. This removes the direct descriptor-indexed EVENT_WAIT read from full CQ and the relevant diagnostic modes while keeping `v1_event_index_only` as the direct dynamic-index reference.

Also fixes RTL simulation include paths to use the configured `-I` generated RTL directory, and updates the event-DMA testbench wait so the staged one-cycle EVENT_WAIT retire preserves the perf-vs-RTL ordering contract.

Adds the follow-up proposal `prop_l2_decoder_output_projection_producer_event_wait_staged_v1` to rerun the bounded SOFTMAX/EVENT ablation after merge.

## Validation

- `python3 -m py_compile npu/rtlgen/gen.py npu/eval/probe_decoder_producer_softmax_event_ablation.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_npu_rtlgen_event_wait.py tests/test_npu_contract_equivalence.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- deleted ignored `npu/rtlgen/out` and reran `tests/test_npu_contract_equivalence.py` to verify temp-generated include behavior
