### PR TITLE
[codex] Bound EVENT scoreboard storage

### DIFF
--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/evaluation_gate.md
@@ -1,0 +1,5 @@
+# Evaluation Gate
+
+Dispatch `l2_decoder_output_projection_producer_event_scoreboard_v1` after the bounded EVENT scoreboard RTL generator change is merged.
+
+The gate passes if the evaluator reruns the SOFTMAX/EVENT ablation on the merged commit and records whether the prior EVENT_WAIT timeout moved to a bounded synth result.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_event_scoreboard_v1",
+  "source_commit": "257045a723785a364aeec841fff29f8fd8a52bde",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_event_scoreboard_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the bounded nm2 SOFTMAX/EVENT CQ ablation after replacing the wide event_state vector with a bounded scoreboard.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_softmax_event_ablation",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_event_wait_staged_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_event_wait_staged_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "promote",
+        "reason": "EVENT_WAIT-only, full EVENT, and SOFTMAX/EVENT guard variants should move from timeout to bounded synth result once the wide dynamic event_state vector is removed."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/implementation_summary.md
@@ -1,0 +1,7 @@
+# Implementation Summary
+
+Replaces the wide `event_state[65535:0]` vector in `npu/rtlgen/gen.py` with a bounded associative EVENT scoreboard controlled by `event_scoreboard_entries`.
+
+Updates EVENT_SIGNAL to insert or refresh a scoreboard entry, and EVENT_WAIT to latch the event id then clear the matching scoreboard entry when it appears.
+
+Updates RTL shell diagnostics and generator tests to reference the bounded scoreboard and confirm no production generated RTL contains `event_state`.

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_event_scoreboard_v1",
+  "created_utc": "2026-05-14T02:20:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_softmax_event_ablation",
+  "title": "Decoder output-projection producer bounded EVENT scoreboard",
+  "hypothesis": "The staged EVENT_WAIT rerun still timed out because the wait service retained a dynamic read over the wide 65536-bit event_state vector. Replacing that vector with a small bounded event scoreboard should preserve EVENT_SIGNAL/EVENT_WAIT ordering for the descriptor streams under exploration while avoiding the large random-access mux that appears to explode synthesis.",
+  "direct_comparison": {
+    "primary_question": "Does a bounded EVENT scoreboard make the prior EVENT_WAIT-only, full EVENT, and SOFTMAX/EVENT guard variants synthesize under the nm2 bounded probe?",
+    "include": [
+      "nm2 fp16 producer base config",
+      "existing SOFTMAX/EVENT command-queue ablation variants",
+      "bounded Nangate45 synth-only target 1_2_yosys",
+      "static generated-RTL size counters per variant",
+      "perf-vs-RTL EVENT/DMA contract regression"
+    ],
+    "exclude": [
+      "full placement and routing",
+      "producer scale beyond nm2",
+      "unbounded 16-bit EVENT namespace storage",
+      "quality or QAT experiments"
+    ]
+  },
+  "expected_benefit": [
+    "removes the wide dynamic event_state read/write structure from production EVENT paths",
+    "keeps multiple outstanding signaled events through a bounded associative table",
+    "preserves command ordering and EVENT_WAIT consumption semantics for the current producer command streams"
+  ],
+  "risks": [
+    "the EVENT namespace becomes bounded by event_scoreboard_entries rather than all 65536 IDs being simultaneously resident",
+    "descriptor streams with more unique signaled-but-unwaited events than the scoreboard depth will now report an EVENT scoreboard full error",
+    "if the timeout persists, the remaining issue is likely loop/control structure or hierarchy rather than event storage width"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_event_scoreboard_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the bounded nm2 SOFTMAX/EVENT CQ ablation after replacing the wide event_state vector with a bounded scoreboard.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_softmax_event_ablation",
+      "cost_class": "bounded-medium",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_event_wait_staged_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_event_wait_staged_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "promote",
+        "reason": "EVENT_WAIT-only, full EVENT, and SOFTMAX/EVENT guard variants should move from timeout to bounded synth result once the wide dynamic event_state vector is removed."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_output_projection_producer_event_wait_staged_v1/analysis_report.md",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_softmax_event_ablation__l2_decoder_output_projection_producer_event_wait_staged_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/rtlgen/gen.py",
+    "npu/eval/probe_decoder_producer_softmax_event_ablation.py",
+    "tests/test_npu_contract_equivalence.py",
+    "tests/test_npu_rtlgen_event_wait.py",
+    "npu/sim/rtl/tb_npu_shell.sv"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/quality_gate.md
@@ -1,0 +1,9 @@
+# Quality Gate
+
+The result is acceptable if:
+
+- generated RTL for full and EVENT diagnostic modes contains no `event_state` vector
+- perf-vs-RTL EVENT/DMA contract tests pass
+- `cq_v1_event_wait_only` no longer times out under the bounded nm2 synth-only probe
+- `cq_v1_event_only` and `cq_v1_softmax_event_guard` record bounded results or a new clearly classified non-scoreboard failure
+- static RTL counters are included for every variant

--- a/npu/eval/probe_decoder_producer_softmax_event_ablation.py
+++ b/npu/eval/probe_decoder_producer_softmax_event_ablation.py
@@ -51,19 +51,19 @@ VARIANTS: list[dict[str, Any]] = [
     {
         "name": "cq_v1_event_signal_only",
         "top": "npu_top",
-        "description": "EVENT_SIGNAL path with busy gating, dynamic event_state set, and optional IRQ.",
+        "description": "EVENT_SIGNAL path with busy gating, bounded event scoreboard set, and optional IRQ.",
         "updates": {"cq_mem_ablation_mode": "v1_event_signal_only"},
     },
     {
         "name": "cq_v1_event_wait_only",
         "top": "npu_top",
-        "description": "EVENT_WAIT path with staged event id latch, pending wait, and indexed event_state clear.",
+        "description": "EVENT_WAIT path with staged event id latch, pending wait, and bounded scoreboard clear.",
         "updates": {"cq_mem_ablation_mode": "v1_event_wait_only"},
     },
     {
         "name": "cq_v1_event_index_only",
         "top": "npu_top",
-        "description": "Dynamic event_state index read/write only, without EVENT busy gating or stall behavior.",
+        "description": "Bounded event scoreboard set/clear only, without EVENT busy gating or stall behavior.",
         "updates": {"cq_mem_ablation_mode": "v1_event_index_only"},
     },
     {

--- a/npu/rtlgen/gen.py
+++ b/npu/rtlgen/gen.py
@@ -80,9 +80,16 @@ module {top_name} (
   reg [31:0] dma_size;
   reg        cq_stage_valid;
   reg        dma_pending;
-  reg [65535:0] event_state;
+  reg [{event_scoreboard_entries_minus1}:0] event_scoreboard_valid;
+  reg [15:0] event_scoreboard_id [0:{event_scoreboard_entries_minus1}];
   reg        event_wait_pending;
   reg [15:0] event_wait_id;
+  reg        event_wait_match;
+  reg [{event_slot_idx_width_minus1}:0] event_wait_match_slot;
+  reg        event_signal_match;
+  reg        event_signal_free;
+  reg [{event_slot_idx_width_minus1}:0] event_signal_slot;
+  integer    event_i;
   reg [2:0]  dma_state;
 {gemm_state_regs}
 {compute_state_regs}
@@ -100,6 +107,7 @@ module {top_name} (
   localparam STATUS_ERR  = 32'h4;
 
   localparam integer AXI_BEAT_BYTES = {axi_beat_bytes};
+  localparam integer EVENT_SCOREBOARD_ENTRIES = {event_scoreboard_entries};
 
   localparam IRQ_CQ_EMPTY    = 0;
   localparam IRQ_EVENT       = 1;
@@ -201,9 +209,17 @@ module {top_name} (
       dma_size <= 0;
       cq_stage_valid <= 0;
       dma_pending <= 0;
-      event_state <= 0;
+      event_scoreboard_valid <= 0;
+      for (event_i = 0; event_i < EVENT_SCOREBOARD_ENTRIES; event_i = event_i + 1) begin
+        event_scoreboard_id[event_i] <= 0;
+      end
       event_wait_pending <= 0;
       event_wait_id <= 0;
+      event_wait_match <= 0;
+      event_wait_match_slot <= 0;
+      event_signal_match <= 0;
+      event_signal_free <= 0;
+      event_signal_slot <= 0;
       dma_state <= 0;
 {gemm_reset}
 {compute_reset}
@@ -2296,6 +2312,12 @@ endmodule
     enable_dma_ports = bool(cfg.get("enable_dma_ports", False))
     enable_cq_mem_ports = bool(cfg.get("enable_cq_mem_ports", False))
     cq_mem_ablation_mode = str(cfg.get("cq_mem_ablation_mode", "full")).lower()
+    event_scoreboard_entries = int(cfg.get("event_scoreboard_entries", 16))
+    if event_scoreboard_entries < 1 or event_scoreboard_entries > 64:
+        die("event_scoreboard_entries must be in [1, 64]")
+    event_slot_idx_width = max(1, math.ceil(math.log2(event_scoreboard_entries)))
+    event_slot_idx_width_minus1 = event_slot_idx_width - 1
+    event_scoreboard_entries_minus1 = event_scoreboard_entries - 1
     valid_cq_mem_ablation_modes = {
         "full",
         "fetch_only",
@@ -2399,8 +2421,16 @@ endmodule
       end
       gemm_pending <= (gemm_slot_valid != {gemm_slot_valid_zero});"""
 
-    event_wait_service_block = """        if (event_state[event_wait_id]) begin
-          event_state[event_wait_id] <= 1'b0;
+    event_wait_service_block = """        event_wait_match = 1'b0;
+        event_wait_match_slot = 0;
+        for (event_i = 0; event_i < EVENT_SCOREBOARD_ENTRIES; event_i = event_i + 1) begin
+          if (event_scoreboard_valid[event_i] && (event_scoreboard_id[event_i] == event_wait_id)) begin
+            event_wait_match = 1'b1;
+            event_wait_match_slot = event_i;
+          end
+        end
+        if (event_wait_match) begin
+          event_scoreboard_valid[event_wait_match_slot] <= 1'b0;
           event_wait_pending <= 1'b0;
           cq_head <= cq_head + 32;
           if (cq_count == 1) begin
@@ -2413,6 +2443,28 @@ endmodule
               event_wait_id <= cq_mem_rdata[47:32];
               event_wait_pending <= 1'b1;
               cq_stage_valid <= 1'b0;"""
+
+    event_signal_block = """                event_signal_match = 1'b0;
+                event_signal_free = 1'b0;
+                event_signal_slot = 0;
+                for (event_i = 0; event_i < EVENT_SCOREBOARD_ENTRIES; event_i = event_i + 1) begin
+                  if (event_scoreboard_valid[event_i] && (event_scoreboard_id[event_i] == cq_mem_rdata[47:32])) begin
+                    event_signal_match = 1'b1;
+                    event_signal_slot = event_i;
+                  end else if (!event_scoreboard_valid[event_i] && !event_signal_free) begin
+                    event_signal_free = 1'b1;
+                    event_signal_slot = event_i;
+                  end
+                end
+                if (!event_signal_match && !event_signal_free) begin
+                  error_code <= 32'hb; // EVENT scoreboard full
+                end else begin
+                  event_scoreboard_valid[event_signal_slot] <= 1'b1;
+                  event_scoreboard_id[event_signal_slot] <= cq_mem_rdata[47:32];
+                  if (cq_mem_rdata[8]) begin
+                    irq_status[IRQ_EVENT] <= 1'b1;
+                  end
+                end"""
 
     if enable_cq_mem_ports:
         cq_mem_ports = f""",
@@ -2538,10 +2590,7 @@ endmodule
               if (dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
                 consume_desc = 1'b0;
               end else begin
-                event_state[cq_mem_rdata[47:32]] <= 1'b1;
-                if (cq_mem_rdata[8]) begin
-                  irq_status[IRQ_EVENT] <= 1'b1;
-                end
+{event_signal_block}
               end
             end else if (cq_mem_rdata[7:0] == 8'h21) begin
               // EVENT_WAIT: stall command retirement until the event is signaled.
@@ -2883,10 +2932,7 @@ endmodule
             if (dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
               consume_desc = 1'b0;
             end else begin
-              event_state[cq_mem_rdata[47:32]] <= 1'b1;
-              if (cq_mem_rdata[8]) begin
-                irq_status[IRQ_EVENT] <= 1'b1;
-              end
+{event_signal_block}
             end
           end else if (cq_mem_rdata[7:0] == 8'h21) begin
 {event_wait_latch_block}
@@ -3031,10 +3077,7 @@ endmodule
             if (dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
               consume_desc = 1'b0;
             end else begin
-              event_state[cq_mem_rdata[47:32]] <= 1'b1;
-              if (cq_mem_rdata[8]) begin
-                irq_status[IRQ_EVENT] <= 1'b1;
-              end
+{event_signal_block}
             end
           end
           if (consume_desc) begin
@@ -3095,10 +3138,18 @@ endmodule
           last_size <= cq_mem_rdata[223:192];
           last_op_uid <= 0;
           if (cq_mem_rdata[7:0] == 8'h20) begin
-            event_state[cq_mem_rdata[47:32]] <= 1'b1;
+{event_signal_block}
           end else if (cq_mem_rdata[7:0] == 8'h21) begin
-            if (event_state[cq_mem_rdata[47:32]]) begin
-              event_state[cq_mem_rdata[47:32]] <= 1'b0;
+            event_wait_match = 1'b0;
+            event_wait_match_slot = 0;
+            for (event_i = 0; event_i < EVENT_SCOREBOARD_ENTRIES; event_i = event_i + 1) begin
+              if (event_scoreboard_valid[event_i] && (event_scoreboard_id[event_i] == cq_mem_rdata[47:32])) begin
+                event_wait_match = 1'b1;
+                event_wait_match_slot = event_i;
+              end
+            end
+            if (event_wait_match) begin
+              event_scoreboard_valid[event_wait_match_slot] <= 1'b0;
             end
           end
           cq_head <= cq_head + 32;
@@ -3132,10 +3183,7 @@ endmodule
             if (dma_pending || vec_pending || softmax_pending || {gemm_slots_busy_expr}) begin
               consume_desc = 1'b0;
             end else begin
-              event_state[cq_mem_rdata[47:32]] <= 1'b1;
-              if (cq_mem_rdata[8]) begin
-                irq_status[IRQ_EVENT] <= 1'b1;
-              end
+{event_signal_block}
             end
           end else if (cq_mem_rdata[7:0] == 8'h21) begin
 {event_wait_latch_block}
@@ -3335,6 +3383,9 @@ endmodule
         axi_data_width_minus1=axi_data_width_minus1,
         axi_strb_width_minus1=axi_strb_width_minus1,
         axi_beat_bytes=(1 << axi_size),
+        event_scoreboard_entries=event_scoreboard_entries,
+        event_scoreboard_entries_minus1=event_scoreboard_entries_minus1,
+        event_slot_idx_width_minus1=event_slot_idx_width_minus1,
         vec_en_add=vec_en_add,
         vec_en_mul=vec_en_mul,
         vec_en_relu=vec_en_relu,

--- a/npu/sim/rtl/tb_npu_shell.sv
+++ b/npu/sim/rtl/tb_npu_shell.sv
@@ -756,8 +756,8 @@ module tb_npu_shell;
       end
       if (dma_req_valid !== 1'b1) begin
         mmio_read(OFF_CQ_HEAD, cq_head);
-        $display("ERROR: expected dma_req_valid in contract_gemm_event_dma_test head=%h tail=%h last_opcode=%h event0=%b dma_pending=%b",
-                 cq_head, cq_tail, dut.last_opcode, dut.event_state[0], dut.dma_pending);
+        $display("ERROR: expected dma_req_valid in contract_gemm_event_dma_test head=%h tail=%h last_opcode=%h event_valid=0x%h dma_pending=%b",
+                 cq_head, cq_tail, dut.last_opcode, dut.event_scoreboard_valid, dut.dma_pending);
         $finish(1);
       end
       dma_req_ready = 1'b1;
@@ -774,8 +774,8 @@ module tb_npu_shell;
       end
       if (dma_req_valid !== 1'b1) begin
         mmio_read(OFF_CQ_HEAD, cq_head);
-        $display("ERROR: expected dma_req_valid in event_dma_test head=%h tail=%h last_opcode=%h event0=%b dma_pending=%b bvalid=%b",
-                 cq_head, cq_tail, dut.last_opcode, dut.event_state[0], dut.dma_pending, saw_bvalid);
+        $display("ERROR: expected dma_req_valid in event_dma_test head=%h tail=%h last_opcode=%h event_valid=0x%h dma_pending=%b bvalid=%b",
+                 cq_head, cq_tail, dut.last_opcode, dut.event_scoreboard_valid, dut.dma_pending, saw_bvalid);
         $finish(1);
       end
       if (dma_req_src !== expected_dma_src) begin
@@ -824,8 +824,8 @@ module tb_npu_shell;
       end
       if (dma_req_count != 2) begin
         mmio_read(OFF_CQ_HEAD, cq_head);
-        $display("ERROR: expected 2 DMA requests in event_dma_test, saw %0d head=%h tail=%h last_opcode=%h event0=%b dma_pending=%b bvalid=%b",
-                 dma_req_count, cq_head, cq_tail, dut.last_opcode, dut.event_state[0], dut.dma_pending, saw_bvalid);
+        $display("ERROR: expected 2 DMA requests in event_dma_test, saw %0d head=%h tail=%h last_opcode=%h event_valid=0x%h dma_pending=%b bvalid=%b",
+                 dma_req_count, cq_head, cq_tail, dut.last_opcode, dut.event_scoreboard_valid, dut.dma_pending, saw_bvalid);
         $finish(1);
       end
       if (second_dma_seen_before_first_bvalid) begin

--- a/tests/test_npu_rtlgen_event_wait.py
+++ b/tests/test_npu_rtlgen_event_wait.py
@@ -32,12 +32,15 @@ def _generate_top(tmp_path: Path, mode: str = "full") -> str:
 def test_full_cq_event_wait_latches_id_before_stalling(tmp_path: Path) -> None:
     top = _generate_top(tmp_path)
 
+    assert "reg [15:0] event_scoreboard_id [0:15];" in top
+    assert "reg [15:0] event_scoreboard_valid;" in top
     assert "reg        event_wait_pending;" in top
     assert "reg [15:0] event_wait_id;" in top
     assert "event_wait_id <= cq_mem_rdata[47:32];" in top
     assert "event_wait_pending <= 1'b1;" in top
-    assert "if (!event_state[cq_mem_rdata[47:32]])" not in top
-    assert "event_state[event_wait_id] <= 1'b0;" in top
+    assert "event_scoreboard_id[event_i] == event_wait_id" in top
+    assert "event_scoreboard_valid[event_wait_match_slot] <= 1'b0;" in top
+    assert "event_state" not in top
 
 
 @pytest.mark.parametrize("mode", ["v1_softmax_event_only", "v1_event_wait_only", "v1_event_only"])
@@ -46,12 +49,14 @@ def test_event_wait_diagnostic_modes_use_staged_wait(tmp_path: Path, mode: str) 
 
     assert "event_wait_id <= cq_mem_rdata[47:32];" in top
     assert "if (event_wait_pending) begin" in top
-    assert "event_state[event_wait_id] <= 1'b0;" in top
-    assert "if (!event_state[cq_mem_rdata[47:32]])" not in top
+    assert "event_scoreboard_id[event_i] == event_wait_id" in top
+    assert "event_scoreboard_valid[event_wait_match_slot] <= 1'b0;" in top
+    assert "event_state" not in top
 
 
-def test_event_index_diagnostic_mode_keeps_direct_dynamic_access(tmp_path: Path) -> None:
+def test_event_index_diagnostic_mode_uses_bounded_scoreboard(tmp_path: Path) -> None:
     top = _generate_top(tmp_path, "v1_event_index_only")
 
     assert "event_wait_id <= cq_mem_rdata[47:32];" not in top
-    assert "event_state[cq_mem_rdata[47:32]]" in top
+    assert "event_scoreboard_id[event_i] == cq_mem_rdata[47:32]" in top
+    assert "event_state" not in top


### PR DESCRIPTION
## Summary

Replaces the wide generated `event_state[65535:0]` EVENT storage with a configurable bounded scoreboard (`event_scoreboard_entries`, default 16). EVENT_SIGNAL now inserts or refreshes an event id in the scoreboard, while staged EVENT_WAIT clears the matching entry once it appears.

This targets the root cause seen in the SOFTMAX/EVENT ablation after PR #508: staging the wait id removed one part of the dynamic path, but synthesis still timed out because the generated RTL retained a dynamic read over the 65536-bit event vector.

## Impact

- Keeps the current command-stream EVENT_SIGNAL/EVENT_WAIT ordering model.
- Bounds synthesized EVENT storage and associative search width.
- Reports `0x0000000b` if more unique signaled-but-unwaited event ids are resident than the configured scoreboard depth.
- Adds a proposal to rerun the bounded nm2 SOFTMAX/EVENT ablation against the prior staged baseline.

## Validation

- `python3 -m py_compile npu/rtlgen/gen.py npu/eval/probe_decoder_producer_softmax_event_ablation.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_npu_rtlgen_event_wait.py tests/test_npu_contract_equivalence.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
