### PR TITLE
[codex] Carry producer control boundary into frontier synthesis

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2135,6 +2135,11 @@ def _decoder_producer_ranker_coupled_noc_evidence(*, item_id: str) -> dict[str, 
         "control_plane/shadow_exports/l1_promotions/"
         "l1_decoder_logit_rank_r128_k1_pin_perimeter_bound_v1.json"
     )
+    producer_control_boundary = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_output_projection_producer_softmax_event_ablation__"
+        "l2_decoder_output_projection_producer_event_scoreboard_v1.json"
+    )
     sram_metrics_json = "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json"
     return {
         "inputs": {
@@ -2144,11 +2149,13 @@ def _decoder_producer_ranker_coupled_noc_evidence(*, item_id: str) -> dict[str, 
             "rank_scale_ppa": scale_ppa,
             "candidate_merge_ppa": candidate_merge_ppa,
             "boundary_ppa": boundary_ppa,
+            "producer_control_boundary": producer_control_boundary,
             "sram_metrics_json": sram_metrics_json,
             "producer_ranker_coupled_scope": (
                 "Couple stage-serialized output-projection producer service curves to the "
                 "producer-integrated ready-valid ranker frontier, including shared NoC/memory "
-                "bandwidth shares for contention sensitivity."
+                "bandwidth shares for contention sensitivity and bounded SOFTMAX/EVENT "
+                "producer-control synthesis evidence."
             ),
             "memory_share_list": [1.0, 0.5, 0.25],
         },
@@ -2162,6 +2169,7 @@ def _decoder_producer_ranker_coupled_noc_evidence(*, item_id: str) -> dict[str, 
                     f"--scale-ppa {scale_ppa} "
                     f"--candidate-merge-ppa {candidate_merge_ppa} "
                     f"--boundary-ppa {boundary_ppa} "
+                    f"--producer-control-boundary {producer_control_boundary} "
                     f"--sram-metrics-json {sram_metrics_json} "
                     "--vocab-size-list 50257,100000,200000 "
                     "--hidden-size-list 768,1024,2048 "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1796,11 +1796,19 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_coupled_noc_evid
             run = work_item.command_manifest[0]["run"]
             assert "--mode coupled_noc" in run
             assert "--memory-share-list 1.0,0.5,0.25" in run
+            assert "--producer-control-boundary" in run
+            assert "l2_decoder_output_projection_producer_event_scoreboard_v1.json" in run
             assert decoder_inputs["producer_ranker_coupled_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_producer_ranker_coupled_noc__l2_decoder_producer_ranker_coupled_noc_v1.json"
             )
             assert "shared NoC/memory bandwidth shares" in decoder_inputs["producer_ranker_coupled_scope"]
+            assert "producer-control synthesis evidence" in decoder_inputs["producer_ranker_coupled_scope"]
+            assert decoder_inputs["producer_control_boundary"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_softmax_event_ablation__"
+                "l2_decoder_output_projection_producer_event_scoreboard_v1.json"
+            )
             assert decoder_inputs["producer_ranker_coupled_out"] in work_item.expected_outputs
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "decoder_producer_ranker_coupled_noc",

--- a/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/design_brief.md
@@ -1,0 +1,11 @@
+# Decoder Frontier Synthesis With Bounded Producer Control
+
+Refresh the whole-decoder frontier view after the bounded EVENT scoreboard fix.
+
+The producer/ranker model still estimates output-projection service from
+compute and memory bandwidth. The new SOFTMAX/EVENT guard result should be
+carried as producer-control feasibility evidence, not folded into token
+latency as if it measured the full producer.
+
+The expected decision is still `iterate`: choose the next measured RTL frontier
+from the updated evidence.

--- a/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+Accept the job if it:
+
+- reruns stage breakdown, attention/KV memory, producer/ranker coupling, and frontier synthesis
+- includes `producer_control_boundary` in the producer/ranker JSON
+- reports the SOFTMAX/EVENT guard decision and synth status in the frontier markdown
+- keeps the previous frontier synthesis result as the paired baseline
+- keeps generated artifact paths repo-portable

--- a/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1",
+  "source_commit": "b866a3bad1e33bba4301d13aa1d7fd38f043c239",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_frontier_synthesis_scoreboard_boundary_v1",
+      "task_type": "l2_campaign",
+      "objective": "Refresh decoder frontier synthesis after the bounded EVENT scoreboard result and include SOFTMAX/EVENT guard metrics as producer-control feasibility evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_frontier_synthesis",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_frontier_synthesis_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_v1",
+        "l2_decoder_output_projection_producer_event_scoreboard_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify whether the bounded producer-control result changes the next architecture frontier or simply validates continued producer/ranker modeling."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/implementation_summary.md
@@ -1,0 +1,10 @@
+# Implementation Summary
+
+Adds an optional `--producer-control-boundary` input to the producer/ranker
+coupling estimator. The Layer 2 frontier synthesis command now passes the
+bounded SOFTMAX/EVENT guard artifact from
+`l2_decoder_output_projection_producer_event_scoreboard_v1`.
+
+The refreshed frontier report surfaces this boundary separately from producer
+latency so the architecture decision does not confuse control-path feasibility
+with output-projection service.

--- a/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1",
+  "created_utc": "2026-05-14T03:05:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_frontier_synthesis",
+  "title": "Decoder frontier synthesis with bounded producer control evidence",
+  "hypothesis": "The previous decoder frontier synthesis should be refreshed now that the SOFTMAX/EVENT producer control path has a bounded scoreboard implementation and confirmed synth result. The dominant-frontier view should explicitly separate producer service latency from producer-control synthesis feasibility before choosing the next RTL target.",
+  "direct_comparison": {
+    "primary_question": "Does the whole-decoder frontier conclusion change when the producer/ranker coupling report carries the bounded SOFTMAX/EVENT guard result as control-path feasibility evidence?",
+    "include": [
+      "whole-decoder resident-weight stage breakdown",
+      "measured attention/KV tile-calibrated memory report",
+      "producer/ranker shared NoC coupling report",
+      "bounded SOFTMAX/EVENT producer-control guard result from l2_decoder_output_projection_producer_event_scoreboard_v1",
+      "focus rows for GPT-2 small and medium proxy shapes"
+    ],
+    "exclude": [
+      "new physical RTL implementation",
+      "new ranker datapath synthesis",
+      "quality or QAT experiments",
+      "full SRAM/NoC arbitration PPA"
+    ]
+  },
+  "expected_benefit": [
+    "updates the system-level frontier using the repaired producer control path",
+    "keeps the scorecard honest by treating the guard result as feasibility evidence rather than as a replacement for producer latency modeling",
+    "chooses whether the next measured RTL job should remain producer/ranker-focused or shift toward attention/KV hierarchy"
+  ],
+  "risks": [
+    "the producer service model remains analytical and weight-memory dominated",
+    "the SOFTMAX/EVENT guard is a synth-only bounded probe, not full placement and routing",
+    "attention/KV memory hierarchy is still modeled from measured tiles rather than a complete shared-memory subsystem"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_frontier_synthesis_scoreboard_boundary_v1",
+      "task_type": "l2_campaign",
+      "objective": "Refresh decoder frontier synthesis after the bounded EVENT scoreboard result and include SOFTMAX/EVENT guard metrics as producer-control feasibility evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_frontier_synthesis",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_frontier_synthesis_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_v1",
+        "l2_decoder_output_projection_producer_event_scoreboard_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should identify whether the bounded producer-control result changes the next architecture frontier or simply validates continued producer/ranker modeling."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_frontier_synthesis_v1.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_output_projection_producer_event_scoreboard_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_softmax_event_ablation__l2_decoder_output_projection_producer_event_scoreboard_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_producer_ranker_coupling.py",
+    "npu/eval/synthesize_llm_decoder_frontier.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "tests/test_llm_decoder_producer_ranker_coupling.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/quality_gate.md
@@ -1,0 +1,7 @@
+# Quality Gate
+
+This is a planning-quality refresh, not final PPA.
+
+The result is usable if it clearly states that the bounded SOFTMAX/EVENT guard
+proves producer-control synth feasibility while the output-projection latency
+and memory pressure remain modeled separately.

--- a/npu/eval/estimate_llm_decoder_producer_ranker_coupling.py
+++ b/npu/eval/estimate_llm_decoder_producer_ranker_coupling.py
@@ -47,6 +47,44 @@ def _ceil_div(a: int, b: int) -> int:
     return (a + b - 1) // b
 
 
+def _load_producer_control_boundary(path: Path | None) -> JsonDict | None:
+    if path is None:
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    diagnosis = payload.get("diagnosis") if isinstance(payload.get("diagnosis"), dict) else {}
+    guard = None
+    for row in payload.get("probe_rows", []):
+        if isinstance(row, dict) and row.get("variant") == "cq_v1_softmax_event_guard":
+            guard = row
+            break
+    if guard is None:
+        return {
+            "source": str(path),
+            "status": "missing_guard_variant",
+            "decision": diagnosis.get("decision"),
+        }
+    synthesis = guard.get("synthesis") if isinstance(guard.get("synthesis"), dict) else {}
+    static_stats = (
+        guard.get("static_verilog_stats")
+        if isinstance(guard.get("static_verilog_stats"), dict)
+        else {}
+    )
+    metrics = guard.get("metrics_row") if isinstance(guard.get("metrics_row"), dict) else {}
+    return {
+        "source": str(path),
+        "status": guard.get("status"),
+        "decision": diagnosis.get("decision"),
+        "guard_variant": guard.get("variant"),
+        "synthesis_status": synthesis.get("status"),
+        "synthesis_elapsed_seconds": synthesis.get("elapsed_seconds"),
+        "flow_elapsed_seconds": metrics.get("flow_elapsed_seconds"),
+        "stage_elapsed_seconds": metrics.get("stage_elapsed_seconds"),
+        "verilog_kb": round(float(static_stats.get("verilog_bytes", 0) or 0) / 1024.0, 3),
+        "reg_bits_est": static_stats.get("reg_bit_count_est"),
+        "wire_bits_est": static_stats.get("wire_bit_count_est"),
+    }
+
+
 def _producer_service_row(
     *,
     scenario: str,
@@ -111,6 +149,7 @@ def build_coupling_report(
     scale_ppa_path: Path | None,
     candidate_merge_ppa_path: Path | None,
     boundary_ppa_path: Path | None,
+    producer_control_boundary_path: Path | None,
     sram_metrics_json_path: Path | None,
     vocab_size_list: list[int],
     hidden_size_list: list[int],
@@ -123,6 +162,7 @@ def build_coupling_report(
     activation_bits: int,
     clock_ns: float,
 ) -> JsonDict:
+    producer_control_boundary = _load_producer_control_boundary(producer_control_boundary_path)
     scenarios = (
         ["shared_gemm_stage_serial"]
         if mode == "producer_service"
@@ -259,6 +299,7 @@ def build_coupling_report(
             "activation_bits": activation_bits,
             "clock_ns": clock_ns,
         },
+        "producer_control_boundary": producer_control_boundary,
         "assumptions": [
             "Producer means only the final decoder output-projection logit source.",
             "Shared GEMM is stage-serialized: attention/MLP have completed before output projection starts.",
@@ -266,6 +307,7 @@ def build_coupling_report(
             "Hidden vector load is charged once per token; output projection weights are streamed per vocabulary tile.",
             "shared_noc_contention reduces effective producer memory bandwidth by memory_share.",
             "Ranker coupling reuses the ready-valid logit-rank model and preserves its equivalence observables.",
+            "If producer_control_boundary is present, it is control-path synthesis feasibility evidence; it does not replace the output-projection service model.",
         ],
         "producer_service_sweep": producer_rows,
         "coupled_ranker_sweep": coupled_rows,
@@ -304,6 +346,15 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         lines.append(
             f"- coupled_best: `{best['scenario']} w{best['producer_lanes']} k{best['top_k']} "
             f"ii{best['producer_ii_cycles']}`"
+        )
+    if payload.get("producer_control_boundary"):
+        boundary = payload["producer_control_boundary"]
+        lines.extend(
+            [
+                f"- producer_control_boundary: `{boundary.get('decision')} "
+                f"{boundary.get('guard_variant')} {boundary.get('synthesis_status')}`",
+                f"- producer_control_boundary_elapsed_s: `{boundary.get('synthesis_elapsed_seconds')}`",
+            ]
         )
     lines.extend(
         [
@@ -372,6 +423,7 @@ def main() -> int:
     ap.add_argument("--scale-ppa", help="rank scale PPA JSON")
     ap.add_argument("--candidate-merge-ppa", help="candidate merge PPA JSON")
     ap.add_argument("--boundary-ppa", help="boundary diagnostic PPA JSON")
+    ap.add_argument("--producer-control-boundary", help="bounded producer control-path evidence JSON")
     ap.add_argument("--sram-metrics-json", help="SRAM metrics JSON")
     ap.add_argument("--vocab-size-list", type=_int_list, default=[50257, 100000, 200000])
     ap.add_argument("--hidden-size-list", type=_int_list, default=[768, 1024, 2048])
@@ -392,6 +444,7 @@ def main() -> int:
         scale_ppa_path=Path(args.scale_ppa) if args.scale_ppa else None,
         candidate_merge_ppa_path=Path(args.candidate_merge_ppa) if args.candidate_merge_ppa else None,
         boundary_ppa_path=Path(args.boundary_ppa) if args.boundary_ppa else None,
+        producer_control_boundary_path=Path(args.producer_control_boundary) if args.producer_control_boundary else None,
         sram_metrics_json_path=Path(args.sram_metrics_json) if args.sram_metrics_json else None,
         vocab_size_list=args.vocab_size_list,
         hidden_size_list=args.hidden_size_list,

--- a/npu/eval/synthesize_llm_decoder_frontier.py
+++ b/npu/eval/synthesize_llm_decoder_frontier.py
@@ -149,6 +149,7 @@ def build_report(*, stage_breakdown: JsonDict, attention_kv: JsonDict, producer_
             "stage_breakdown_model": stage_breakdown.get("model"),
             "attention_kv_model": attention_kv.get("model"),
             "producer_ranker_model": producer_ranker.get("model"),
+            "producer_control_boundary": producer_ranker.get("producer_control_boundary"),
         },
         "measured_attention_kv_tile_summary": tile_frontier.get("scaling_summary", {}),
         "dominant_component_counts": dominant_counts,
@@ -205,6 +206,21 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
     lines.extend(["", "## Measured Attention/KV Tile Summary", ""])
     for key, value in payload["measured_attention_kv_tile_summary"].items():
         lines.append(f"- {key}: `{value}`")
+    control_boundary = payload.get("inputs", {}).get("producer_control_boundary")
+    if control_boundary:
+        lines.extend(
+            [
+                "",
+                "## Producer Control Boundary",
+                "",
+                f"- decision: `{control_boundary.get('decision')}`",
+                f"- guard_variant: `{control_boundary.get('guard_variant')}`",
+                f"- synthesis_status: `{control_boundary.get('synthesis_status')}`",
+                f"- synthesis_elapsed_seconds: `{control_boundary.get('synthesis_elapsed_seconds')}`",
+                f"- reg_bits_est: `{control_boundary.get('reg_bits_est')}`",
+                f"- wire_bits_est: `{control_boundary.get('wire_bits_est')}`",
+            ]
+        )
     lines.extend(["", "## Assumptions", ""])
     for item in payload["assumptions"]:
         lines.append(f"- {item}")

--- a/tests/test_llm_decoder_producer_ranker_coupling.py
+++ b/tests/test_llm_decoder_producer_ranker_coupling.py
@@ -10,6 +10,7 @@ def test_producer_service_derives_integer_ii_from_compute_and_memory() -> None:
         scale_ppa_path=None,
         candidate_merge_ppa_path=None,
         boundary_ppa_path=None,
+        producer_control_boundary_path=None,
         sram_metrics_json_path=None,
         vocab_size_list=[256],
         hidden_size_list=[64],
@@ -38,6 +39,7 @@ def test_coupled_noc_reports_ranker_rows(tmp_path: Path) -> None:
         scale_ppa_path=None,
         candidate_merge_ppa_path=None,
         boundary_ppa_path=None,
+        producer_control_boundary_path=None,
         sram_metrics_json_path=None,
         vocab_size_list=[256],
         hidden_size_list=[64],
@@ -59,3 +61,55 @@ def test_coupled_noc_reports_ranker_rows(tmp_path: Path) -> None:
     assert "ranker_latency_us_per_token" in row
     assert row["coupled_latency_us_per_token"] >= row["producer_latency_us_per_token"]
     assert report["recommendation"]["coupled_best"] is not None
+
+
+def test_coupling_report_carries_producer_control_boundary(tmp_path: Path) -> None:
+    boundary = tmp_path / "softmax_event.json"
+    boundary.write_text(
+        """
+{
+  "diagnosis": {"decision": "softmax_event_guard_synth_ok_under_bound"},
+  "probe_rows": [
+    {
+      "variant": "cq_v1_softmax_event_guard",
+      "status": "ok",
+      "static_verilog_stats": {
+        "verilog_bytes": 57181,
+        "reg_bit_count_est": 2634,
+        "wire_bit_count_est": 3864
+      },
+      "synthesis": {"status": "ok", "elapsed_seconds": 196.2},
+      "metrics_row": {"flow_elapsed_seconds": "195.14"}
+    }
+  ]
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_coupling_report(
+        mode="producer_service",
+        rank_ppa_path=None,
+        scale_ppa_path=None,
+        candidate_merge_ppa_path=None,
+        boundary_ppa_path=None,
+        producer_control_boundary_path=boundary,
+        sram_metrics_json_path=None,
+        vocab_size_list=[256],
+        hidden_size_list=[64],
+        producer_lanes_list=[64],
+        macs_per_cycle_list=[4096],
+        memory_bandwidth_bytes_per_cycle_list=[128.0],
+        memory_share_list=[1.0],
+        top_k_list=[1],
+        weight_bits=16,
+        activation_bits=16,
+        clock_ns=1.0,
+    )
+
+    control = report["producer_control_boundary"]
+    assert control["decision"] == "softmax_event_guard_synth_ok_under_bound"
+    assert control["guard_variant"] == "cq_v1_softmax_event_guard"
+    assert control["synthesis_status"] == "ok"
+    assert control["reg_bits_est"] == 2634


### PR DESCRIPTION
## Summary

Feeds the bounded SOFTMAX/EVENT guard result into the producer/ranker coupling and decoder frontier synthesis flow as producer-control feasibility evidence.

The output-projection producer latency model remains separate: the new field records that the control path synthesizes under the bounded scoreboard guard, but it does not replace the weight-memory dominated producer service model.

## Changes

- Add `--producer-control-boundary` to `estimate_llm_decoder_producer_ranker_coupling.py`.
- Surface the guard decision/status/size estimates in the coupled producer/ranker report.
- Carry the boundary into `synthesize_llm_decoder_frontier.py` markdown and JSON.
- Update the Layer 2 `decoder_frontier_synthesis` contract to pass the merged scoreboard result artifact.
- Add proposal `prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1` for the next evaluator job.

## Validation

- `python3 -m py_compile npu/eval/estimate_llm_decoder_producer_ranker_coupling.py npu/eval/synthesize_llm_decoder_frontier.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_producer_ranker_coupling.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- smoke ran producer/ranker coupling and frontier synthesis with the merged scoreboard artifact
