### PR TITLE
[codex] Skip known infeasible producer synth points

### DIFF
--- a/npu/eval/probe_decoder_producer_synth_boundary.py
+++ b/npu/eval/probe_decoder_producer_synth_boundary.py
@@ -26,6 +26,17 @@ def load_json(path: Path) -> dict[str, Any]:
     return data
 
 
+def load_json_list(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError(f"expected JSON array: {path}")
+    entries = [entry for entry in data if isinstance(entry, dict)]
+    if len(entries) != len(data):
+        raise ValueError(f"expected only JSON objects in {path}")
+    return entries
+
+
 def rel(path: Path) -> str:
     try:
         return str(path.resolve().relative_to(REPO_ROOT))
@@ -59,6 +70,57 @@ def num_modules(config: dict[str, Any]) -> int:
     if not isinstance(gemm, dict):
         raise ValueError("config missing compute.gemm object")
     return int(gemm.get("num_modules", 0))
+
+
+def normalize_repo_path(path: str | Path | None) -> str | None:
+    if path is None:
+        return None
+    raw = str(path).strip()
+    if not raw:
+        return None
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = REPO_ROOT / candidate
+    return rel(candidate)
+
+
+def load_infeasible_registry(path: Path | None) -> list[dict[str, Any]]:
+    if path is None or not path.exists():
+        return []
+    entries = load_json_list(path)
+    for entry in entries:
+        match = entry.get("match")
+        if not isinstance(match, dict):
+            raise ValueError(f"infeasible registry entry missing match object: {entry.get('id')}")
+    return entries
+
+
+def find_infeasible_match(
+    registry: list[dict[str, Any]],
+    *,
+    config_path: Path,
+    config: dict[str, Any],
+    platform: str,
+    top: str,
+    make_target: str,
+) -> dict[str, Any] | None:
+    normalized_config = rel(config_path)
+    modules = num_modules(config)
+    for entry in registry:
+        match = entry.get("match") or {}
+        match_config = normalize_repo_path(match.get("config"))
+        if match_config is not None and match_config != normalized_config:
+            continue
+        if match.get("platform") is not None and str(match.get("platform")) != platform:
+            continue
+        if match.get("top") is not None and str(match.get("top")) != top:
+            continue
+        if match.get("make_target") is not None and str(match.get("make_target")) != make_target:
+            continue
+        if match.get("num_modules") is not None and int(match.get("num_modules")) != modules:
+            continue
+        return entry
+    return None
 
 
 def rtlgen_binary_paths(configs: list[Path]) -> list[Path]:
@@ -245,11 +307,43 @@ def probe_config(
     timeout_seconds: int,
     stall_timeout_seconds: int,
     log_dir: Path,
+    infeasible_registry: list[dict[str, Any]],
 ) -> dict[str, Any]:
     config = load_json(config_path)
     modules = num_modules(config)
     design_dir = config_path.parent
     verilog_dir = design_dir / "verilog"
+    infeasible = find_infeasible_match(
+        infeasible_registry,
+        config_path=config_path,
+        config=config,
+        platform=platform,
+        top=top,
+        make_target=make_target,
+    )
+    if infeasible is not None:
+        return {
+            "config": rel(config_path),
+            "design_dir": rel(design_dir),
+            "num_modules": modules,
+            "rtlgen": None,
+            "synthesis": {
+                "status": "known_infeasible",
+                "returncode": None,
+                "elapsed_seconds": 0.0,
+                "log_path": "",
+                "log_tail": [],
+                "command": "",
+            },
+            "metrics_row": None,
+            "status": "known_infeasible",
+            "known_infeasible": {
+                "id": infeasible.get("id"),
+                "reason": infeasible.get("reason"),
+                "source_evidence": infeasible.get("source_evidence"),
+                "recorded_utc": infeasible.get("recorded_utc"),
+            },
+        }
 
     gen_cmd = [
         sys.executable,
@@ -409,6 +503,11 @@ def main() -> int:
     ap.add_argument("--rtlgen-build-timeout-seconds", type=int, default=900)
     ap.add_argument("--skip-rtlgen-build", action="store_true")
     ap.add_argument("--continue-after-failure", action="store_true")
+    ap.add_argument(
+        "--infeasible-registry",
+        default="runs/knowledge/infeasible_designs.json",
+        help="JSON registry of exact synth points to skip before launching long-running tools",
+    )
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
     args = ap.parse_args()
@@ -426,14 +525,42 @@ def main() -> int:
         os.environ.get("RTLGEN_PRODUCER_SYNTH_BOUNDARY_LOG_DIR", "/tmp/rtlgen-producer-synth-boundary")
     )
     log_dir = log_root / out.stem
+    registry_path = (
+        (REPO_ROOT / args.infeasible_registry).resolve()
+        if args.infeasible_registry and not Path(args.infeasible_registry).is_absolute()
+        else Path(args.infeasible_registry).resolve()
+        if args.infeasible_registry
+        else None
+    )
+    infeasible_registry = load_infeasible_registry(registry_path)
+
+    configs_requiring_tools: list[Path] = []
+    for config_path in configs:
+        config = load_json(config_path)
+        if find_infeasible_match(
+            infeasible_registry,
+            config_path=config_path,
+            config=config,
+            platform=args.platform,
+            top=args.top,
+            make_target=args.make_target,
+        ) is None:
+            configs_requiring_tools.append(config_path)
 
     setup = ensure_rtlgen_binaries(
-        configs,
+        configs_requiring_tools,
         log_dir=log_dir,
         build_timeout_seconds=args.rtlgen_build_timeout_seconds,
         stall_timeout_seconds=max(120, min(args.stall_timeout_seconds, 300)),
         skip_build=args.skip_rtlgen_build,
-    )
+    ) if configs_requiring_tools else {
+        "status": "ok",
+        "required_binaries": [],
+        "missing_before_build": [],
+        "configure": None,
+        "build": None,
+        "skipped": "all requested configs matched infeasible registry",
+    }
     rows: list[dict[str, Any]] = []
     if setup["status"] != "ok":
         rows.append(
@@ -459,6 +586,7 @@ def main() -> int:
                 timeout_seconds=args.timeout_seconds,
                 stall_timeout_seconds=args.stall_timeout_seconds,
                 log_dir=log_dir,
+                infeasible_registry=infeasible_registry,
             )
             rows.append(row)
             if row.get("status") != "ok" and not args.continue_after_failure:
@@ -472,6 +600,7 @@ def main() -> int:
         "make_target": args.make_target,
         "timeout_seconds": args.timeout_seconds,
         "stall_timeout_seconds": args.stall_timeout_seconds,
+        "infeasible_registry": rel(registry_path) if registry_path is not None else None,
         "rtlgen_setup": setup,
         "sweep": rel(sweep),
         "probe_rows": rows,

--- a/runs/knowledge/README.md
+++ b/runs/knowledge/README.md
@@ -1,0 +1,9 @@
+# Run Knowledge
+
+This directory stores small, reviewable knowledge artifacts that prevent the
+control loop from repeating already-known expensive failures.
+
+`infeasible_designs.json` is an exact-match skip registry for synthesis points
+that previously consumed the bounded evaluator budget without producing useful
+PPA. Entries should be narrow enough not to block diagnostic variants or
+structurally changed RTL.

--- a/runs/knowledge/infeasible_designs.json
+++ b/runs/knowledge/infeasible_designs.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "npu_fp16_nm2_producer_npu_top_yosys_timeout_20260513",
+    "recorded_utc": "2026-05-14T04:00:00Z",
+    "scope": "decoder_output_projection_producer_synth_boundary",
+    "reason": "Full npu_top output-projection producer synthesis for nm2 timed out in the bounded producer synth-boundary probe. Do not relaunch this exact point without a structural RTL change or explicit override.",
+    "source_evidence": {
+      "item_id": "l2_decoder_output_projection_producer_synth_boundary_v1_r2",
+      "proposal_id": "prop_l2_decoder_output_projection_producer_synth_boundary_v1",
+      "dataset": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_synth_boundary__l2_decoder_output_projection_producer_synth_boundary_v1_r2.json",
+      "status": "timeout",
+      "elapsed_seconds": 1801.7644507059886
+    },
+    "match": {
+      "config": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json",
+      "platform": "nangate45",
+      "top": "npu_top",
+      "make_target": "1_2_yosys",
+      "num_modules": 2
+    }
+  }
+]

--- a/tests/test_decoder_producer_synth_infeasible_registry.py
+++ b/tests/test_decoder_producer_synth_infeasible_registry.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+from npu.eval.probe_decoder_producer_synth_boundary import (
+    REPO_ROOT,
+    find_infeasible_match,
+    load_infeasible_registry,
+    load_json,
+    probe_config,
+)
+
+
+REGISTRY = REPO_ROOT / "runs/knowledge/infeasible_designs.json"
+NM2_CONFIG = REPO_ROOT / "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json"
+
+
+def test_infeasible_registry_matches_exact_known_timeout() -> None:
+    registry = load_infeasible_registry(REGISTRY)
+    config = load_json(NM2_CONFIG)
+
+    match = find_infeasible_match(
+        registry,
+        config_path=NM2_CONFIG,
+        config=config,
+        platform="nangate45",
+        top="npu_top",
+        make_target="1_2_yosys",
+    )
+
+    assert match is not None
+    assert match["id"] == "npu_fp16_nm2_producer_npu_top_yosys_timeout_20260513"
+
+
+def test_infeasible_registry_does_not_match_diagnostic_top_or_target() -> None:
+    registry = load_infeasible_registry(REGISTRY)
+    config = load_json(NM2_CONFIG)
+
+    assert (
+        find_infeasible_match(
+            registry,
+            config_path=NM2_CONFIG,
+            config=config,
+            platform="nangate45",
+            top="gemm_compute_array",
+            make_target="1_2_yosys",
+        )
+        is None
+    )
+    assert (
+        find_infeasible_match(
+            registry,
+            config_path=NM2_CONFIG,
+            config=config,
+            platform="nangate45",
+            top="npu_top",
+            make_target="2_1_floorplan",
+        )
+        is None
+    )
+
+
+def test_probe_config_skips_known_infeasible_without_synth(tmp_path: Path) -> None:
+    registry = load_infeasible_registry(REGISTRY)
+
+    row = probe_config(
+        NM2_CONFIG,
+        sweep=REPO_ROOT / "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json",
+        platform="nangate45",
+        top="npu_top",
+        make_target="1_2_yosys",
+        out_root=tmp_path,
+        timeout_seconds=1,
+        stall_timeout_seconds=1,
+        log_dir=tmp_path,
+        infeasible_registry=registry,
+    )
+
+    assert row["status"] == "known_infeasible"
+    assert row["synthesis"]["elapsed_seconds"] == 0.0
+    assert row["known_infeasible"]["source_evidence"]["item_id"] == (
+        "l2_decoder_output_projection_producer_synth_boundary_v1_r2"
+    )


### PR DESCRIPTION
## Summary

Adds an exact-match infeasible synthesis registry and teaches the decoder producer synth-boundary probe to skip known long-running failure points before launching RTL generation or synthesis.

The first recorded entry is the full `npu_top` nm2 output-projection producer synth-only point that timed out in `l2_decoder_output_projection_producer_synth_boundary_v1_r2`. The match is deliberately narrow: config path, platform, top, make target, and `num_modules` all have to match, so successful diagnostic probes like the SOFTMAX/EVENT guard are not blocked.

## Behavior

- Default registry path: `runs/knowledge/infeasible_designs.json`.
- A matched point records `status: known_infeasible` and zero synth elapsed time.
- If all requested configs are registry-matched, the probe skips even the rtlgen C++ binary preparation step.
- Passing a different registry path, or an empty/missing registry, preserves current behavior.

## Validation

- `python3 -m py_compile npu/eval/probe_decoder_producer_synth_boundary.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_decoder_producer_synth_infeasible_registry.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py tests/test_decoder_producer_synth_infeasible_registry.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- smoke: known nm2 full-producer point returned `known_infeasible` without running synth
