### PR TITLE
[codex] Guard infeasible synth entries by source signature

### DIFF
--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_post_scoreboard_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_post_scoreboard_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_synth_boundary_post_scoreboard_v1",
+  "created_utc": "2026-05-14T05:30:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_synth_boundary",
+  "title": "Post-scoreboard decoder output-projection producer synthesis boundary",
+  "hypothesis": "The previous nm2 full-producer synth timeout was tied to the pre-scoreboard RTL structure that used a wide dynamic event_state vector. After replacing that structure with a bounded EVENT scoreboard, the producer parallelism boundary should be remeasured instead of treating nm1 as the practical limit.",
+  "direct_comparison": {
+    "primary_question": "After the bounded EVENT scoreboard fix, what is the largest decoder output-projection producer module count that completes bounded synth-only compilation?",
+    "include": [
+      "nm2, nm3, and nm4 fp16 producer configs",
+      "full npu_top producer wrapper rather than isolated GEMM-only top",
+      "Nangate45 synth-only OpenROAD target 1_2_yosys",
+      "hard total timeout and quiet-output stall timeout per point",
+      "comparison against the pre-scoreboard synth-boundary timeout record",
+      "explicit report of whether each point was skipped, completed, timed out, or failed"
+    ],
+    "exclude": [
+      "full placement and routing",
+      "nm8 or nm16 retries before nm2 through nm4 are bounded",
+      "quality or QAT experiments",
+      "new producer/ranker NoC implementation changes"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the small bounded-scoreboard RTL change recovers producer parallelism beyond nm1",
+    "prevents an invalidated pre-scoreboard timeout from suppressing post-fix exploration",
+    "separates remaining synthesis scaling problems from the already-fixed wide EVENT state register"
+  ],
+  "risks": [
+    "synth-only completion still does not prove placement or routing feasibility",
+    "nm2 may still time out because of a different wide mux, generated-control, or hierarchy issue",
+    "the bounded EVENT scoreboard preserves current descriptor-stream semantics but does not make the event namespace unbounded"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_synth_boundary_post_scoreboard_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the bounded synth-only decoder output-projection producer scale probe after the bounded EVENT scoreboard fix and source-conditional infeasible-registry guard.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_synth_boundary",
+      "cost_class": "bounded-medium",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_synth_boundary_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_event_scoreboard_v1",
+        "l2_decoder_frontier_synthesis_scoreboard_boundary_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The result should identify whether nm2 now completes after removing the wide event_state vector, and if not, preserve the exact new failure signature for the next small RTL change."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_v1/proposal.json",
+    "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__l2_decoder_output_projection_producer_synth_boundary_v1_r2/report.md",
+    "runs/knowledge/infeasible_designs.json"
+  ],
+  "knowledge_refs": [
+    "npu/rtlgen/gen.py",
+    "npu/eval/probe_decoder_producer_synth_boundary.py",
+    "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json",
+    "docs/proposals/prop_l2_decoder_output_projection_producer_event_scoreboard_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_frontier_synthesis_scoreboard_boundary_v1/proposal.json",
+    "tests/test_decoder_producer_synth_infeasible_registry.py",
+    "tests/test_npu_contract_equivalence.py"
+  ]
+}

--- a/npu/eval/probe_decoder_producer_synth_boundary.py
+++ b/npu/eval/probe_decoder_producer_synth_boundary.py
@@ -95,6 +95,27 @@ def load_infeasible_registry(path: Path | None) -> list[dict[str, Any]]:
     return entries
 
 
+def repo_text_requirements_satisfied(entry: dict[str, Any]) -> bool:
+    requirements = entry.get("requires_repo_text") or []
+    if not isinstance(requirements, list):
+        raise ValueError(f"infeasible registry entry has invalid requires_repo_text: {entry.get('id')}")
+    for requirement in requirements:
+        if not isinstance(requirement, dict):
+            raise ValueError(f"infeasible registry entry has invalid text requirement: {entry.get('id')}")
+        raw_path = str(requirement.get("path", "")).strip()
+        needle = str(requirement.get("contains", ""))
+        if not raw_path or not needle:
+            raise ValueError(f"infeasible registry text requirement missing path/contains: {entry.get('id')}")
+        path = REPO_ROOT / raw_path
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except FileNotFoundError:
+            return False
+        if needle not in text:
+            return False
+    return True
+
+
 def find_infeasible_match(
     registry: list[dict[str, Any]],
     *,
@@ -118,6 +139,8 @@ def find_infeasible_match(
         if match.get("make_target") is not None and str(match.get("make_target")) != make_target:
             continue
         if match.get("num_modules") is not None and int(match.get("num_modules")) != modules:
+            continue
+        if not repo_text_requirements_satisfied(entry):
             continue
         return entry
     return None

--- a/runs/knowledge/README.md
+++ b/runs/knowledge/README.md
@@ -7,3 +7,7 @@ control loop from repeating already-known expensive failures.
 that previously consumed the bounded evaluator budget without producing useful
 PPA. Entries should be narrow enough not to block diagnostic variants or
 structurally changed RTL.
+
+Use `requires_repo_text` when the failure is tied to a specific old RTL
+structure. This keeps the registry from suppressing a retry after the source has
+changed in a way that may invalidate the failure.

--- a/runs/knowledge/infeasible_designs.json
+++ b/runs/knowledge/infeasible_designs.json
@@ -17,6 +17,16 @@
       "top": "npu_top",
       "make_target": "1_2_yosys",
       "num_modules": 2
+    },
+    "requires_repo_text": [
+      {
+        "path": "npu/rtlgen/gen.py",
+        "contains": "event_state"
+      }
+    ],
+    "invalidated_by": {
+      "commit": "dbad5522be1193b3abffbfe96a37d1df59e5cf6f",
+      "reason": "The bounded EVENT scoreboard change removed the wide event_state vector from generated RTL."
     }
   }
 ]

--- a/tests/test_decoder_producer_synth_infeasible_registry.py
+++ b/tests/test_decoder_producer_synth_infeasible_registry.py
@@ -26,8 +26,7 @@ def test_infeasible_registry_matches_exact_known_timeout() -> None:
         make_target="1_2_yosys",
     )
 
-    assert match is not None
-    assert match["id"] == "npu_fp16_nm2_producer_npu_top_yosys_timeout_20260513"
+    assert match is None
 
 
 def test_infeasible_registry_does_not_match_diagnostic_top_or_target() -> None:
@@ -59,7 +58,22 @@ def test_infeasible_registry_does_not_match_diagnostic_top_or_target() -> None:
 
 
 def test_probe_config_skips_known_infeasible_without_synth(tmp_path: Path) -> None:
-    registry = load_infeasible_registry(REGISTRY)
+    registry = [
+        {
+            "id": "test_infeasible",
+            "reason": "test",
+            "source_evidence": {
+                "item_id": "l2_decoder_output_projection_producer_synth_boundary_v1_r2"
+            },
+            "match": {
+                "config": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json",
+                "platform": "nangate45",
+                "top": "npu_top",
+                "make_target": "1_2_yosys",
+                "num_modules": 2,
+            },
+        }
+    ]
 
     row = probe_config(
         NM2_CONFIG,
@@ -79,3 +93,42 @@ def test_probe_config_skips_known_infeasible_without_synth(tmp_path: Path) -> No
     assert row["known_infeasible"]["source_evidence"]["item_id"] == (
         "l2_decoder_output_projection_producer_synth_boundary_v1_r2"
     )
+
+
+def test_infeasible_registry_matches_when_required_source_text_exists(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "npu/rtlgen/gen.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("reg [65535:0] event_state;\n", encoding="utf-8")
+    monkeypatch.setattr("npu.eval.probe_decoder_producer_synth_boundary.REPO_ROOT", tmp_path)
+
+    registry = [
+        {
+            "id": "old_event_state_timeout",
+            "match": {
+                "config": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json",
+                "platform": "nangate45",
+                "top": "npu_top",
+                "make_target": "1_2_yosys",
+                "num_modules": 2,
+            },
+            "requires_repo_text": [
+                {
+                    "path": "npu/rtlgen/gen.py",
+                    "contains": "event_state",
+                }
+            ],
+        }
+    ]
+    config = load_json(NM2_CONFIG)
+    config_path = tmp_path / "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json"
+
+    match = find_infeasible_match(
+        registry,
+        config_path=config_path,
+        config=config,
+        platform="nangate45",
+        top="npu_top",
+        make_target="1_2_yosys",
+    )
+
+    assert match is not None


### PR DESCRIPTION
## Summary
- gate known-infeasible synthesis registry entries on optional repo text signatures
- mark the old nm2 producer timeout as tied to the removed wide event_state RTL structure
- add a post-scoreboard producer synth-boundary proposal so nm2/nm3/nm4 are retried instead of accepting nm1 as the limit

## Root cause
The infeasible registry matched the old producer timeout by config/top/platform only. That made pre-scoreboard evidence suppress a post-scoreboard retry even though the wide event_state vector was removed.

## Validation
- python3 -m py_compile npu/eval/probe_decoder_producer_synth_boundary.py
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_decoder_producer_synth_infeasible_registry.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py tests/test_decoder_producer_synth_infeasible_registry.py
- python3 scripts/validate_runs.py --skip_eval_queue