### PR TITLE
[codex] Add extended producer synth boundary probe

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2339,11 +2339,26 @@ def _decoder_output_projection_producer_synth_boundary_evidence(*, item_id: str)
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_producer_synth_boundary__{item_id}.json"
     report = f"{base}/decoder_output_projection_producer_synth_boundary__{item_id}.md"
-    configs = [
-        "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json",
-        "runs/designs/npu_blocks/npu_fp16_cpp_nm3_producer/config_nm3_producer.json",
-        "runs/designs/npu_blocks/npu_fp16_cpp_nm4_producer/config_nm4_producer.json",
-    ]
+    if "nm8_nm16" in item_id:
+        configs = [
+            "runs/designs/npu_blocks/npu_fp16_cpp_nm8_producer/config_nm8_producer.json",
+            "runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json",
+        ]
+        scope = (
+            "Extend the post-scoreboard decoder output-projection producer synthesis boundary "
+            "by probing nm8 and nm16 with a synth-only target and explicit timeout before "
+            "retrying full PnR."
+        )
+    else:
+        configs = [
+            "runs/designs/npu_blocks/npu_fp16_cpp_nm2_producer/config_nm2_producer.json",
+            "runs/designs/npu_blocks/npu_fp16_cpp_nm3_producer/config_nm3_producer.json",
+            "runs/designs/npu_blocks/npu_fp16_cpp_nm4_producer/config_nm4_producer.json",
+        ]
+        scope = (
+            "Bound decoder output-projection producer synthesis by probing nm2, nm3, "
+            "and nm4 with a synth-only target and explicit timeout before retrying full PnR."
+        )
     sweep = "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json"
     return {
         "inputs": {
@@ -2352,10 +2367,7 @@ def _decoder_output_projection_producer_synth_boundary_evidence(*, item_id: str)
             "producer_synth_boundary_configs": configs,
             "producer_synth_boundary_sweep": sweep,
             "producer_synth_boundary_make_target": "1_2_yosys",
-            "producer_synth_boundary_scope": (
-                "Bound decoder output-projection producer synthesis by probing nm2, nm3, "
-                "and nm4 with a synth-only target and explicit timeout before retrying full PnR."
-            ),
+            "producer_synth_boundary_scope": scope,
         },
         "commands": [
             {

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2020,6 +2020,46 @@ def test_generate_l2_campaign_task_adds_decoder_producer_synth_boundary_evidence
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_producer_extended_synth_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1",
+                    proposal_id="prop_l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_producer_synth_boundary",
+                    expected_direction="iterate",
+                    comparison_role="producer_synth_boundary",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            run = work_item.command_manifest[0]["run"]
+            assert "npu_fp16_cpp_nm8_producer/config_nm8_producer.json" in run
+            assert "npu_fp16_cpp_nm16_producer/config_nm16_producer.json" in run
+            assert "npu_fp16_cpp_nm4_producer/config_nm4_producer.json" not in run
+            assert "nm8 and nm16" in decoder_inputs["producer_synth_boundary_scope"]
+
+
 def test_generate_l2_campaign_task_adds_decoder_producer_isolated_synth_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1",
+  "created_utc": "2026-05-14T05:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_synth_boundary",
+  "title": "Extended decoder output-projection producer synthesis boundary",
+  "hypothesis": "After the bounded EVENT scoreboard fix, the full decoder output-projection producer wrapper completes synth-only compilation through nm4. The next boundary should be measured at nm8 and nm16 before attempting full PnR or concluding that practical producer parallelism is limited.",
+  "direct_comparison": {
+    "primary_question": "Does the post-scoreboard full producer wrapper remain synth-feasible at nm8 and nm16 under the same bounded synth-only target?",
+    "include": [
+      "nm8 and nm16 fp16 producer configs",
+      "full npu_top producer wrapper rather than isolated GEMM-only top",
+      "Nangate45 synth-only OpenROAD target 1_2_yosys",
+      "hard total timeout and quiet-output stall timeout per point",
+      "comparison against the merged nm2/nm3/nm4 post-scoreboard boundary result"
+    ],
+    "exclude": [
+      "full placement and routing",
+      "new RTL architecture changes",
+      "quality or QAT experiments",
+      "producer/ranker NoC implementation changes"
+    ]
+  },
+  "expected_benefit": [
+    "identifies whether the repaired producer control path scales to practically useful module counts",
+    "finds the next synthesis explosion boundary with bounded evaluator time",
+    "provides a better scale target for subsequent producer/ranker and memory-hierarchy coupling estimates"
+  ],
+  "risks": [
+    "nm8 or nm16 may still timeout and require hierarchy or macro hardening before PnR",
+    "synth-only completion does not prove placement or routing feasibility",
+    "the larger probe can consume significant evaluator time if the next boundary is below nm16"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1",
+      "task_type": "l2_campaign",
+      "objective": "Extend the post-scoreboard bounded synth-only decoder output-projection producer scale probe to nm8 and nm16.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_synth_boundary",
+      "cost_class": "bounded-high",
+      "comparison_role": "producer_synth_boundary",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_synth_boundary_post_scoreboard_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_synth_boundary_post_scoreboard_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The result should report whether nm8 and nm16 complete synth-only compilation or record the first nonviable module count for the next hierarchy or macro-hardening change."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_post_scoreboard_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_synth_boundary__l2_decoder_output_projection_producer_synth_boundary_post_scoreboard_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_synth_boundary__l2_decoder_output_projection_producer_synth_boundary_post_scoreboard_v1.md"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_decoder_producer_synth_boundary.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm8_producer/config_nm8_producer.json",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json"
+  ]
+}

--- a/npu/eval/probe_decoder_producer_synth_boundary.py
+++ b/npu/eval/probe_decoder_producer_synth_boundary.py
@@ -51,6 +51,39 @@ def portable_log_label(path: Path) -> str:
         return path.name
 
 
+def repo_portable_path_text(raw: Any) -> str:
+    text = str(raw or "").strip()
+    if not text:
+        return ""
+    path = Path(text)
+    if not path.is_absolute():
+        return text
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return ""
+
+
+def portable_metrics_row(row: dict[str, Any]) -> dict[str, Any]:
+    portable = dict(row)
+    work_result = repo_portable_path_text(portable.get("work_result_json"))
+    if work_result:
+        portable["work_result_json"] = work_result
+    result_path = repo_portable_path_text(portable.get("result_path"))
+    if result_path:
+        portable["result_path"] = result_path
+    elif work_result:
+        portable["result_path"] = work_result
+    else:
+        portable["result_path"] = ""
+    synth_script = repo_portable_path_text(portable.get("synth_script_path"))
+    if synth_script:
+        portable["synth_script_path"] = synth_script
+    elif "synth_script_path" in portable:
+        portable["synth_script_path"] = ""
+    return portable
+
+
 def parse_configs(args: argparse.Namespace) -> list[Path]:
     raw: list[str] = []
     for item in args.configs or []:
@@ -422,7 +455,7 @@ def probe_config(
     row["synthesis"] = synth_result
     metrics_row = latest_metrics_row(out_root / design_dir.name)
     if metrics_row is not None:
-        row["metrics_row"] = metrics_row
+        row["metrics_row"] = portable_metrics_row(metrics_row)
     if synth_result["status"] != "ok":
         row["status"] = synth_result["status"]
     elif metrics_row and str(metrics_row.get("status", "")).strip():

--- a/tests/test_decoder_producer_synth_infeasible_registry.py
+++ b/tests/test_decoder_producer_synth_infeasible_registry.py
@@ -5,6 +5,7 @@ from npu.eval.probe_decoder_producer_synth_boundary import (
     find_infeasible_match,
     load_infeasible_registry,
     load_json,
+    portable_metrics_row,
     probe_config,
 )
 
@@ -132,3 +133,18 @@ def test_infeasible_registry_matches_when_required_source_text_exists(tmp_path: 
     )
 
     assert match is not None
+
+
+def test_portable_metrics_row_prefers_repo_relative_work_result_for_external_result_path() -> None:
+    row = portable_metrics_row(
+        {
+            "status": "ok",
+            "result_path": "/orfs/flow/results/nangate45/demo/1_2_yosys.v",
+            "work_result_json": "runs/designs/npu_blocks/demo/work/abcd/result.json",
+            "synth_script_path": "/orfs/flow/scripts/synth.tcl",
+        }
+    )
+
+    assert row["result_path"] == "runs/designs/npu_blocks/demo/work/abcd/result.json"
+    assert row["work_result_json"] == "runs/designs/npu_blocks/demo/work/abcd/result.json"
+    assert row["synth_script_path"] == ""


### PR DESCRIPTION
## Summary
- add an nm8/nm16 producer synth-boundary mode for the L2 task generator
- add the proposal for the next post-scoreboard producer parallelism boundary job
- make focused synth-boundary metrics rows prefer repo-relative result paths instead of evaluator-local flow paths

## Why
The post-scoreboard boundary result showed full producer-wrapper synthesis now completes through nm4. The next practical NPU parallelism question is whether nm8 and nm16 remain synth-feasible under the same bounded guard.

## Validation
- python3 -m py_compile npu/eval/probe_decoder_producer_synth_boundary.py
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_decoder_producer_synth_infeasible_registry.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py tests/test_decoder_producer_synth_infeasible_registry.py
- python3 scripts/validate_runs.py --skip_eval_queue