### PR TITLE
[codex] Add nm8 producer PnR feasibility probe

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2390,6 +2390,48 @@ def _decoder_output_projection_producer_synth_boundary_evidence(*, item_id: str)
     }
 
 
+def _decoder_output_projection_producer_pnr_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_producer_pnr_feasibility__{item_id}.json"
+    report = f"{base}/decoder_output_projection_producer_pnr_feasibility__{item_id}.md"
+    configs = [
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm8_producer/config_nm8_producer.json",
+    ]
+    sweep = "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json"
+    return {
+        "inputs": {
+            "producer_synth_boundary_out": out,
+            "producer_synth_boundary_report": report,
+            "producer_synth_boundary_configs": configs,
+            "producer_synth_boundary_sweep": sweep,
+            "producer_synth_boundary_make_target": "3_3_place_gp",
+            "producer_synth_boundary_scope": (
+                "Probe full physical implementation feasibility for the post-scoreboard nm8 "
+                "decoder output-projection producer using the same bounded producer floorplan "
+                "before attempting nm16 PnR."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_decoder_output_projection_producer_pnr_feasibility",
+                "run": (
+                    "python3 npu/eval/probe_decoder_producer_synth_boundary.py "
+                    f"--configs {','.join(configs)} "
+                    f"--sweep {sweep} "
+                    "--platform nangate45 "
+                    "--top npu_top "
+                    "--make-target 3_3_place_gp "
+                    "--timeout-seconds 3600 "
+                    "--stall-timeout-seconds 1200 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_output_projection_producer_isolated_synth_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_producer_isolated_synth__{item_id}.json"
@@ -3024,6 +3066,7 @@ def _build_payload(
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
+        "decoder_output_projection_producer_pnr_feasibility",
         "decoder_output_projection_producer_synth_boundary",
         "decoder_output_projection_producer_isolated_synth",
         "decoder_output_projection_producer_top_ablation",
@@ -3041,6 +3084,8 @@ def _build_payload(
             decoder_evidence = _decoder_output_projection_producer_top_ablation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_isolated_synth":
             decoder_evidence = _decoder_output_projection_producer_isolated_synth_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_producer_pnr_feasibility":
+            decoder_evidence = _decoder_output_projection_producer_pnr_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_synth_boundary":
             decoder_evidence = _decoder_output_projection_producer_synth_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_frontier_synthesis":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2060,6 +2060,59 @@ def test_generate_l2_campaign_task_adds_decoder_producer_extended_synth_boundary
             assert "nm8 and nm16" in decoder_inputs["producer_synth_boundary_scope"]
 
 
+def test_generate_l2_campaign_task_adds_decoder_producer_pnr_feasibility_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_producer_pnr_nm8_v1",
+                    proposal_id="prop_l2_decoder_output_projection_producer_pnr_nm8_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_producer_pnr_nm8_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_producer_pnr_feasibility",
+                    expected_direction="iterate",
+                    comparison_role="producer_pnr_feasibility",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            run = work_item.command_manifest[0]["run"]
+            assert work_item.command_manifest[0]["name"] == (
+                "probe_decoder_output_projection_producer_pnr_feasibility"
+            )
+            assert "--make-target 3_3_place_gp" in run
+            assert "--timeout-seconds 3600" in run
+            assert "npu_fp16_cpp_nm8_producer/config_nm8_producer.json" in run
+            assert "npu_fp16_cpp_nm16_producer/config_nm16_producer.json" not in run
+            assert decoder_inputs["producer_synth_boundary_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_pnr_feasibility__"
+                "l2_decoder_output_projection_producer_pnr_nm8_v1.json"
+            )
+            assert decoder_inputs["producer_synth_boundary_make_target"] == "3_3_place_gp"
+            assert "full physical implementation" in decoder_inputs["producer_synth_boundary_scope"]
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_producer_pnr_feasibility",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_producer_isolated_synth_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_pnr_nm8_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_pnr_nm8_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_pnr_nm8_v1",
+  "created_utc": "2026-05-14T05:20:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_pnr_feasibility",
+  "title": "Decoder output-projection producer nm8 physical feasibility",
+  "hypothesis": "The bounded EVENT scoreboard fix moved the full producer-wrapper synthesis boundary beyond nm16. The next practical question is whether a useful high-parallelism point, nm8, can complete bounded placement and global placement under the existing producer floorplan before estimating larger producer/ranker/memory coupling.",
+  "direct_comparison": {
+    "primary_question": "Can the post-scoreboard nm8 decoder output-projection producer complete the bounded Nangate45 3_3_place_gp physical target?",
+    "include": [
+      "nm8 fp16 producer config",
+      "full npu_top producer wrapper",
+      "Nangate45 OpenROAD target 3_3_place_gp",
+      "same producer floorplan parameters used for the synth-boundary sweep",
+      "hard total timeout and quiet-output stall timeout"
+    ],
+    "exclude": [
+      "nm16 PnR before nm8 physical feasibility is known",
+      "new floorplan or hierarchy changes",
+      "quality or QAT experiments",
+      "producer/ranker NoC implementation changes"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the recovered producer parallelism is useful beyond synth-only evidence",
+    "identifies whether the next blocker is placement/floorplan pressure rather than RTL synthesis",
+    "provides a measured high-parallelism physical anchor for producer/ranker and memory-coupled estimates"
+  ],
+  "risks": [
+    "the reused producer floorplan may be too coarse for nm8 and fail despite a fixable physical implementation",
+    "3_3_place_gp is still not full route closure",
+    "a successful nm8 point may not extrapolate to nm16 without floorplan or hierarchy changes"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_pnr_nm8_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a bounded physical feasibility probe for the post-scoreboard nm8 decoder output-projection producer using OpenROAD target 3_3_place_gp.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_pnr_feasibility",
+      "cost_class": "bounded-high",
+      "comparison_role": "producer_pnr_feasibility",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The result should report whether nm8 completes bounded physical implementation or identify the first placement-stage blocker for a floorplan or hierarchy follow-up."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_synth_boundary__l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_synth_boundary__l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1.md"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_decoder_producer_synth_boundary.py",
+    "npu/synth/run_block_sweep.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm8_producer/config_nm8_producer.json"
+  ]
+}

--- a/npu/eval/probe_decoder_producer_synth_boundary.py
+++ b/npu/eval/probe_decoder_producer_synth_boundary.py
@@ -465,35 +465,50 @@ def probe_config(
     return row
 
 
-def build_diagnosis(rows: list[dict[str, Any]]) -> dict[str, Any]:
+def boundary_kind(make_target: str) -> str:
+    return "synth" if make_target == "1_2_yosys" else "physical"
+
+
+def build_diagnosis(rows: list[dict[str, Any]], *, make_target: str) -> dict[str, Any]:
+    kind = boundary_kind(make_target)
+    prefix = "producer_synth_boundary" if kind == "synth" else "producer_physical_boundary"
     if rows and str(rows[0].get("status")) == "setup_failed":
         return {
-            "decision": "producer_synth_boundary_setup_failed",
+            "decision": f"{prefix}_setup_failed",
             "feasible_max_num_modules": None,
             "first_nonviable_num_modules": None,
-            "recommended_next_step": "Fix evaluator tool setup before interpreting producer synthesis scale.",
+            "recommended_next_step": f"Fix evaluator tool setup before interpreting producer {kind} scale.",
         }
     tool_failures = [row for row in rows if str(row.get("status", "")).startswith("rtlgen_")]
     if tool_failures:
         return {
-            "decision": "producer_synth_boundary_setup_failed",
+            "decision": f"{prefix}_setup_failed",
             "feasible_max_num_modules": None,
             "first_nonviable_num_modules": None,
-            "recommended_next_step": "Fix RTL generation before interpreting producer synthesis scale.",
+            "recommended_next_step": f"Fix RTL generation before interpreting producer {kind} scale.",
         }
     ok_rows = [row for row in rows if str(row.get("status")) == "ok"]
     blocked_rows = [row for row in rows if str(row.get("status")) != "ok"]
     feasible = max((int(row.get("num_modules", 0)) for row in ok_rows), default=None)
     first_blocked = min((int(row.get("num_modules", 0)) for row in blocked_rows), default=None)
     if first_blocked is None:
-        decision = "producer_synth_boundary_not_reached"
-        next_step = "Extend the probe to the next producer scale before launching full PnR."
+        decision = f"{prefix}_not_reached"
+        if kind == "synth":
+            next_step = "Extend the probe to the next producer scale before launching full PnR."
+        else:
+            next_step = "Use the largest completed physical point for near-frontier extrapolation or extend cautiously."
     else:
-        decision = "producer_synth_boundary_recorded"
-        next_step = (
-            "Use the largest completed synth point for near-frontier extrapolation and split or macro-harden "
-            "larger producers before retrying full physical implementation."
-        )
+        decision = f"{prefix}_recorded"
+        if kind == "synth":
+            next_step = (
+                "Use the largest completed synth point for near-frontier extrapolation and split or macro-harden "
+                "larger producers before retrying full physical implementation."
+            )
+        else:
+            next_step = (
+                "Use the largest completed physical point for near-frontier extrapolation and adjust floorplan, "
+                "hierarchy, or macro hardening before retrying larger producers."
+            )
     return {
         "decision": decision,
         "feasible_max_num_modules": feasible,
@@ -503,8 +518,10 @@ def build_diagnosis(rows: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    kind = payload.get("boundary_kind") or boundary_kind(str(payload.get("make_target", "")))
+    title = "Decoder Producer Synthesis Boundary" if kind == "synth" else "Decoder Producer Physical Boundary"
     lines = [
-        "# Decoder Producer Synthesis Boundary",
+        f"# {title}",
         "",
         f"- make_target: `{payload['make_target']}`",
         f"- timeout_seconds: `{payload['timeout_seconds']}`",
@@ -654,13 +671,14 @@ def main() -> int:
         "platform": args.platform,
         "top": args.top,
         "make_target": args.make_target,
+        "boundary_kind": boundary_kind(args.make_target),
         "timeout_seconds": args.timeout_seconds,
         "stall_timeout_seconds": args.stall_timeout_seconds,
         "infeasible_registry": rel(registry_path) if registry_path is not None else None,
         "rtlgen_setup": setup,
         "sweep": rel(sweep),
         "probe_rows": rows,
-        "diagnosis": build_diagnosis(rows),
+        "diagnosis": build_diagnosis(rows, make_target=args.make_target),
     }
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/tests/test_decoder_producer_synth_infeasible_registry.py
+++ b/tests/test_decoder_producer_synth_infeasible_registry.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from npu.eval.probe_decoder_producer_synth_boundary import (
     REPO_ROOT,
+    build_diagnosis,
     find_infeasible_match,
     load_infeasible_registry,
     load_json,
@@ -148,3 +149,13 @@ def test_portable_metrics_row_prefers_repo_relative_work_result_for_external_res
     assert row["result_path"] == "runs/designs/npu_blocks/demo/work/abcd/result.json"
     assert row["work_result_json"] == "runs/designs/npu_blocks/demo/work/abcd/result.json"
     assert row["synth_script_path"] == ""
+
+
+def test_build_diagnosis_uses_physical_boundary_for_place_target() -> None:
+    diagnosis = build_diagnosis(
+        [{"num_modules": 8, "status": "ok"}],
+        make_target="3_3_place_gp",
+    )
+
+    assert diagnosis["decision"] == "producer_physical_boundary_not_reached"
+    assert diagnosis["feasible_max_num_modules"] == 8


### PR DESCRIPTION
## Summary
- add a decoder output-projection producer PnR feasibility abstraction for nm8
- route the job through the bounded producer probe with OpenROAD target 3_3_place_gp
- label non-synth targets as physical-boundary results in the focused evidence

## Why
The post-scoreboard full producer wrapper now synthesizes through nm16. Before assuming that parallelism is practically useful, we need a bounded physical implementation check at nm8.

## Validation
- python3 -m py_compile npu/eval/probe_decoder_producer_synth_boundary.py
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_decoder_producer_synth_infeasible_registry.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py tests/test_decoder_producer_synth_infeasible_registry.py
- python3 scripts/validate_runs.py --skip_eval_queue