### PR TITLE
[codex] Add nm16 producer PnR feasibility probe

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2394,8 +2394,9 @@ def _decoder_output_projection_producer_pnr_feasibility_evidence(*, item_id: str
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_producer_pnr_feasibility__{item_id}.json"
     report = f"{base}/decoder_output_projection_producer_pnr_feasibility__{item_id}.md"
+    num_modules = 16 if "nm16" in item_id else 8
     configs = [
-        "runs/designs/npu_blocks/npu_fp16_cpp_nm8_producer/config_nm8_producer.json",
+        f"runs/designs/npu_blocks/npu_fp16_cpp_nm{num_modules}_producer/config_nm{num_modules}_producer.json",
     ]
     sweep = "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json"
     return {
@@ -2406,9 +2407,9 @@ def _decoder_output_projection_producer_pnr_feasibility_evidence(*, item_id: str
             "producer_synth_boundary_sweep": sweep,
             "producer_synth_boundary_make_target": "3_3_place_gp",
             "producer_synth_boundary_scope": (
-                "Probe full physical implementation feasibility for the post-scoreboard nm8 "
+                f"Probe full physical implementation feasibility for the post-scoreboard nm{num_modules} "
                 "decoder output-projection producer using the same bounded producer floorplan "
-                "before attempting nm16 PnR."
+                "before attempting a larger or more integrated physical implementation."
             ),
         },
         "commands": [

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2113,6 +2113,50 @@ def test_generate_l2_campaign_task_adds_decoder_producer_pnr_feasibility_evidenc
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_producer_nm16_pnr_feasibility_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_producer_pnr_nm16_v1",
+                    proposal_id="prop_l2_decoder_output_projection_producer_pnr_nm16_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_producer_pnr_nm16_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_producer_pnr_feasibility",
+                    expected_direction="iterate",
+                    comparison_role="producer_pnr_feasibility",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            run = work_item.command_manifest[0]["run"]
+            assert "npu_fp16_cpp_nm16_producer/config_nm16_producer.json" in run
+            assert "npu_fp16_cpp_nm8_producer/config_nm8_producer.json" not in run
+            assert "post-scoreboard nm16" in decoder_inputs["producer_synth_boundary_scope"]
+            assert decoder_inputs["producer_synth_boundary_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_pnr_feasibility__"
+                "l2_decoder_output_projection_producer_pnr_nm16_v1.json"
+            )
+
+
 def test_generate_l2_campaign_task_adds_decoder_producer_isolated_synth_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_pnr_nm16_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_pnr_nm16_v1/proposal.json
@@ -1,0 +1,72 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_pnr_nm16_v1",
+  "created_utc": "2026-05-14T05:50:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_pnr_feasibility",
+  "title": "Decoder output-projection producer nm16 physical feasibility",
+  "hypothesis": "The post-scoreboard nm8 producer completed bounded physical implementation after the full producer wrapper synthesized through nm16. Testing nm16 with the same bounded 3_3_place_gp target will show whether producer parallelism remains physically feasible at the largest currently generated point or whether floorplan/hierarchy work is needed before larger integration.",
+  "direct_comparison": {
+    "primary_question": "Can the post-scoreboard nm16 decoder output-projection producer complete the bounded Nangate45 3_3_place_gp physical target?",
+    "include": [
+      "nm16 fp16 producer config",
+      "full npu_top producer wrapper",
+      "Nangate45 OpenROAD target 3_3_place_gp",
+      "same producer floorplan parameters used for nm8 physical feasibility",
+      "hard total timeout and quiet-output stall timeout"
+    ],
+    "exclude": [
+      "new floorplan or hierarchy changes",
+      "full route closure beyond the existing target",
+      "quality or QAT experiments",
+      "producer/ranker NoC implementation changes"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the largest generated producer module count is physically feasible after the EVENT scoreboard repair",
+    "separates physical floorplan pressure from remaining system-level producer/ranker/memory coupling questions",
+    "provides a high-parallelism physical anchor for the next decoder frontier update"
+  ],
+  "risks": [
+    "nm16 may fail placement even though nm8 passes, requiring floorplan, hierarchy, or macro-hardening follow-up",
+    "3_3_place_gp is not full route closure",
+    "a successful isolated producer physical point still does not include shared NoC or memory hierarchy contention"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_pnr_nm16_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a bounded physical feasibility probe for the post-scoreboard nm16 decoder output-projection producer using OpenROAD target 3_3_place_gp.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_pnr_feasibility",
+      "cost_class": "bounded-high",
+      "comparison_role": "producer_pnr_feasibility",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_pnr_nm8_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_pnr_nm8_v1",
+        "l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The result should report whether nm16 completes bounded physical implementation or identify the first placement-stage blocker for a floorplan or hierarchy follow-up."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_output_projection_producer_pnr_nm8_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_pnr_feasibility__l2_decoder_output_projection_producer_pnr_nm8_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_pnr_feasibility__l2_decoder_output_projection_producer_pnr_nm8_v1.md",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_synth_boundary__l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_decoder_producer_synth_boundary.py",
+    "npu/synth/run_block_sweep.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "runs/campaigns/npu/output_projection_producer_scale/sweeps/nangate45_synth_boundary.json",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- extend producer PnR feasibility generation to select nm16 by item id
- add the nm16 physical feasibility proposal after the successful nm8 PnR result
- add task-generator coverage for the nm16 PnR command contract

## Why
The post-scoreboard producer now synthesizes through nm16, and nm8 completes bounded physical implementation. The next bounded question is whether nm16 can also reach 3_3_place_gp under the current floorplan.

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 -m json.tool docs/proposals/prop_l2_decoder_output_projection_producer_pnr_nm16_v1/proposal.json >/dev/null