### PR TITLE
[codex] Add nm16 physical anchor to decoder frontier

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2140,6 +2140,11 @@ def _decoder_producer_ranker_coupled_noc_evidence(*, item_id: str) -> dict[str, 
         "decoder_output_projection_producer_softmax_event_ablation__"
         "l2_decoder_output_projection_producer_event_scoreboard_v1.json"
     )
+    producer_physical_boundary = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_output_projection_producer_pnr_feasibility__"
+        "l2_decoder_output_projection_producer_pnr_nm16_v1.json"
+    )
     sram_metrics_json = "runs/designs/sram/minimal_v0_2_draft/sram_metrics.json"
     return {
         "inputs": {
@@ -2150,12 +2155,14 @@ def _decoder_producer_ranker_coupled_noc_evidence(*, item_id: str) -> dict[str, 
             "candidate_merge_ppa": candidate_merge_ppa,
             "boundary_ppa": boundary_ppa,
             "producer_control_boundary": producer_control_boundary,
+            "producer_physical_boundary": producer_physical_boundary,
             "sram_metrics_json": sram_metrics_json,
             "producer_ranker_coupled_scope": (
                 "Couple stage-serialized output-projection producer service curves to the "
                 "producer-integrated ready-valid ranker frontier, including shared NoC/memory "
                 "bandwidth shares for contention sensitivity and bounded SOFTMAX/EVENT "
-                "producer-control synthesis evidence."
+                "producer-control synthesis evidence plus nm16 producer-wrapper physical "
+                "feasibility/PPA evidence."
             ),
             "memory_share_list": [1.0, 0.5, 0.25],
         },
@@ -2170,6 +2177,7 @@ def _decoder_producer_ranker_coupled_noc_evidence(*, item_id: str) -> dict[str, 
                     f"--candidate-merge-ppa {candidate_merge_ppa} "
                     f"--boundary-ppa {boundary_ppa} "
                     f"--producer-control-boundary {producer_control_boundary} "
+                    f"--producer-physical-boundary {producer_physical_boundary} "
                     f"--sram-metrics-json {sram_metrics_json} "
                     "--vocab-size-list 50257,100000,200000 "
                     "--hidden-size-list 768,1024,2048 "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1798,16 +1798,24 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_coupled_noc_evid
             assert "--memory-share-list 1.0,0.5,0.25" in run
             assert "--producer-control-boundary" in run
             assert "l2_decoder_output_projection_producer_event_scoreboard_v1.json" in run
+            assert "--producer-physical-boundary" in run
+            assert "l2_decoder_output_projection_producer_pnr_nm16_v1.json" in run
             assert decoder_inputs["producer_ranker_coupled_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_producer_ranker_coupled_noc__l2_decoder_producer_ranker_coupled_noc_v1.json"
             )
             assert "shared NoC/memory bandwidth shares" in decoder_inputs["producer_ranker_coupled_scope"]
             assert "producer-control synthesis evidence" in decoder_inputs["producer_ranker_coupled_scope"]
+            assert "nm16 producer-wrapper physical" in decoder_inputs["producer_ranker_coupled_scope"]
             assert decoder_inputs["producer_control_boundary"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_output_projection_producer_softmax_event_ablation__"
                 "l2_decoder_output_projection_producer_event_scoreboard_v1.json"
+            )
+            assert decoder_inputs["producer_physical_boundary"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_pnr_feasibility__"
+                "l2_decoder_output_projection_producer_pnr_nm16_v1.json"
             )
             assert decoder_inputs["producer_ranker_coupled_out"] in work_item.expected_outputs
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {

--- a/docs/proposals/prop_l2_decoder_frontier_synthesis_nm16_physical_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_frontier_synthesis_nm16_physical_v1/proposal.json
@@ -1,0 +1,73 @@
+{
+  "proposal_id": "prop_l2_decoder_frontier_synthesis_nm16_physical_v1",
+  "created_utc": "2026-05-14T08:20:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_frontier_synthesis",
+  "title": "Decoder frontier synthesis with nm16 producer physical anchor",
+  "hypothesis": "The decoder frontier synthesis should be refreshed now that the post-scoreboard nm16 output-projection producer has completed a bounded physical placement target. The refreshed report should keep producer service and NoC contention analytical while carrying measured nm16 producer-wrapper PPA as feasibility context for the next larger decoder point.",
+  "direct_comparison": {
+    "primary_question": "Does the current decoder frontier conclusion remain valid when the producer/ranker coupling report carries the largest measured producer physical anchor?",
+    "include": [
+      "whole-decoder resident-weight stage breakdown",
+      "measured attention/KV tile-calibrated memory report",
+      "producer/ranker shared NoC coupling report",
+      "bounded SOFTMAX/EVENT producer-control guard evidence",
+      "nm16 producer-wrapper 3_3_place_gp physical feasibility and PPA evidence"
+    ],
+    "exclude": [
+      "new producer RTL generation",
+      "new ranker datapath synthesis",
+      "full route closure beyond the existing nm16 target",
+      "shared SRAM/NoC arbitration implementation",
+      "quality or QAT experiments"
+    ]
+  },
+  "expected_benefit": [
+    "ties the whole-decoder frontier scorecard to the largest measured producer physical point",
+    "separates analytical producer latency assumptions from measured producer feasibility and PPA",
+    "chooses whether the next measured job should extend producer parallelism, add producer/ranker/memory integration, or move toward attention/KV hierarchy"
+  ],
+  "risks": [
+    "the producer service latency model remains analytical and weight-memory dominated",
+    "the nm16 evidence is a bounded placement target, not final route closure",
+    "the measured producer block is isolated and does not include shared NoC or memory hierarchy arbitration"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_frontier_synthesis_nm16_physical_v1",
+      "task_type": "l2_campaign",
+      "objective": "Refresh decoder frontier synthesis after the nm16 producer physical feasibility result and include that measured PPA anchor in the producer/ranker coupling and final scorecard.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_frontier_synthesis",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_frontier_synthesis_scoreboard_boundary_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_scoreboard_boundary_v1",
+        "l2_decoder_output_projection_producer_synth_boundary_nm8_nm16_v1",
+        "l2_decoder_output_projection_producer_pnr_nm16_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output should show whether the nm16 physical anchor changes the next architecture frontier or simply validates continued producer/ranker/memory exploration."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_frontier_synthesis_scoreboard_boundary_v1.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_output_projection_producer_pnr_nm16_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_pnr_feasibility__l2_decoder_output_projection_producer_pnr_nm16_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_producer_ranker_coupling.py",
+    "npu/eval/synthesize_llm_decoder_frontier.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "tests/test_llm_decoder_producer_ranker_coupling.py",
+    "tests/test_llm_decoder_frontier_synthesis.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_producer_ranker_coupling.py
+++ b/npu/eval/estimate_llm_decoder_producer_ranker_coupling.py
@@ -85,6 +85,63 @@ def _load_producer_control_boundary(path: Path | None) -> JsonDict | None:
     }
 
 
+def _maybe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_producer_physical_boundary(path: Path | None) -> JsonDict | None:
+    if path is None:
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    diagnosis = payload.get("diagnosis") if isinstance(payload.get("diagnosis"), dict) else {}
+    probe_rows = [row for row in payload.get("probe_rows", []) if isinstance(row, dict)]
+    ok_rows = [row for row in probe_rows if row.get("status") == "ok"]
+    boundary_row = max(ok_rows, key=lambda row: int(row.get("num_modules", 0) or 0), default=None)
+    if boundary_row is None:
+        return {
+            "source": str(path),
+            "status": "missing_ok_probe_row",
+            "decision": diagnosis.get("decision"),
+            "feasible_max_num_modules": diagnosis.get("feasible_max_num_modules"),
+            "first_nonviable_num_modules": diagnosis.get("first_nonviable_num_modules"),
+        }
+    synthesis = (
+        boundary_row.get("synthesis")
+        if isinstance(boundary_row.get("synthesis"), dict)
+        else {}
+    )
+    metrics = (
+        boundary_row.get("metrics_row")
+        if isinstance(boundary_row.get("metrics_row"), dict)
+        else {}
+    )
+    return {
+        "source": str(path),
+        "status": boundary_row.get("status"),
+        "decision": diagnosis.get("decision"),
+        "feasible_max_num_modules": diagnosis.get("feasible_max_num_modules"),
+        "first_nonviable_num_modules": diagnosis.get("first_nonviable_num_modules"),
+        "recommended_next_step": diagnosis.get("recommended_next_step"),
+        "make_target": payload.get("make_target"),
+        "boundary_kind": payload.get("boundary_kind"),
+        "num_modules": boundary_row.get("num_modules"),
+        "design_dir": boundary_row.get("design_dir"),
+        "synthesis_status": synthesis.get("status"),
+        "synthesis_elapsed_seconds": synthesis.get("elapsed_seconds"),
+        "critical_path_ns": _maybe_float(metrics.get("critical_path_ns")),
+        "die_area_um2": _maybe_float(metrics.get("die_area")),
+        "total_power_mw": _maybe_float(metrics.get("total_power_mw")),
+        "flow_elapsed_seconds": _maybe_float(metrics.get("flow_elapsed_seconds")),
+        "stage_elapsed_seconds": _maybe_float(metrics.get("stage_elapsed_seconds")),
+        "result_path": metrics.get("result_path") or metrics.get("work_result_json"),
+    }
+
+
 def _producer_service_row(
     *,
     scenario: str,
@@ -150,6 +207,7 @@ def build_coupling_report(
     candidate_merge_ppa_path: Path | None,
     boundary_ppa_path: Path | None,
     producer_control_boundary_path: Path | None,
+    producer_physical_boundary_path: Path | None,
     sram_metrics_json_path: Path | None,
     vocab_size_list: list[int],
     hidden_size_list: list[int],
@@ -163,6 +221,7 @@ def build_coupling_report(
     clock_ns: float,
 ) -> JsonDict:
     producer_control_boundary = _load_producer_control_boundary(producer_control_boundary_path)
+    producer_physical_boundary = _load_producer_physical_boundary(producer_physical_boundary_path)
     scenarios = (
         ["shared_gemm_stage_serial"]
         if mode == "producer_service"
@@ -300,6 +359,7 @@ def build_coupling_report(
             "clock_ns": clock_ns,
         },
         "producer_control_boundary": producer_control_boundary,
+        "producer_physical_boundary": producer_physical_boundary,
         "assumptions": [
             "Producer means only the final decoder output-projection logit source.",
             "Shared GEMM is stage-serialized: attention/MLP have completed before output projection starts.",
@@ -308,6 +368,7 @@ def build_coupling_report(
             "shared_noc_contention reduces effective producer memory bandwidth by memory_share.",
             "Ranker coupling reuses the ready-valid logit-rank model and preserves its equivalence observables.",
             "If producer_control_boundary is present, it is control-path synthesis feasibility evidence; it does not replace the output-projection service model.",
+            "If producer_physical_boundary is present, it is measured producer-wrapper physical feasibility/PPA evidence; latency and memory-coupling rows remain analytical service estimates.",
         ],
         "producer_service_sweep": producer_rows,
         "coupled_ranker_sweep": coupled_rows,
@@ -354,6 +415,18 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
                 f"- producer_control_boundary: `{boundary.get('decision')} "
                 f"{boundary.get('guard_variant')} {boundary.get('synthesis_status')}`",
                 f"- producer_control_boundary_elapsed_s: `{boundary.get('synthesis_elapsed_seconds')}`",
+            ]
+        )
+    if payload.get("producer_physical_boundary"):
+        boundary = payload["producer_physical_boundary"]
+        lines.extend(
+            [
+                f"- producer_physical_boundary: `{boundary.get('decision')} "
+                f"nm{boundary.get('num_modules')} {boundary.get('make_target')}`",
+                f"- producer_physical_boundary_critical_path_ns: `{boundary.get('critical_path_ns')}`",
+                f"- producer_physical_boundary_area_um2: `{boundary.get('die_area_um2')}`",
+                f"- producer_physical_boundary_power_mw: `{boundary.get('total_power_mw')}`",
+                f"- producer_physical_boundary_elapsed_s: `{boundary.get('synthesis_elapsed_seconds')}`",
             ]
         )
     lines.extend(
@@ -424,6 +497,7 @@ def main() -> int:
     ap.add_argument("--candidate-merge-ppa", help="candidate merge PPA JSON")
     ap.add_argument("--boundary-ppa", help="boundary diagnostic PPA JSON")
     ap.add_argument("--producer-control-boundary", help="bounded producer control-path evidence JSON")
+    ap.add_argument("--producer-physical-boundary", help="bounded producer physical feasibility evidence JSON")
     ap.add_argument("--sram-metrics-json", help="SRAM metrics JSON")
     ap.add_argument("--vocab-size-list", type=_int_list, default=[50257, 100000, 200000])
     ap.add_argument("--hidden-size-list", type=_int_list, default=[768, 1024, 2048])
@@ -445,6 +519,7 @@ def main() -> int:
         candidate_merge_ppa_path=Path(args.candidate_merge_ppa) if args.candidate_merge_ppa else None,
         boundary_ppa_path=Path(args.boundary_ppa) if args.boundary_ppa else None,
         producer_control_boundary_path=Path(args.producer_control_boundary) if args.producer_control_boundary else None,
+        producer_physical_boundary_path=Path(args.producer_physical_boundary) if args.producer_physical_boundary else None,
         sram_metrics_json_path=Path(args.sram_metrics_json) if args.sram_metrics_json else None,
         vocab_size_list=args.vocab_size_list,
         hidden_size_list=args.hidden_size_list,

--- a/npu/eval/synthesize_llm_decoder_frontier.py
+++ b/npu/eval/synthesize_llm_decoder_frontier.py
@@ -150,6 +150,7 @@ def build_report(*, stage_breakdown: JsonDict, attention_kv: JsonDict, producer_
             "attention_kv_model": attention_kv.get("model"),
             "producer_ranker_model": producer_ranker.get("model"),
             "producer_control_boundary": producer_ranker.get("producer_control_boundary"),
+            "producer_physical_boundary": producer_ranker.get("producer_physical_boundary"),
         },
         "measured_attention_kv_tile_summary": tile_frontier.get("scaling_summary", {}),
         "dominant_component_counts": dominant_counts,
@@ -162,6 +163,7 @@ def build_report(*, stage_breakdown: JsonDict, attention_kv: JsonDict, producer_
             "This is a synthesis of existing analytical reports, not a new RTL measurement.",
             "Attention/KV uses the best latency row per shape and sequence from the calibrated attention/KV report.",
             "Producer/ranker uses the best FIFO-valid coupled row per hidden/vocab shape.",
+            "Producer physical-boundary evidence is carried as feasibility/PPA context; it does not replace the analytical producer/ranker latency model.",
             "MLP and norm are resident-weight estimates from the whole-decoder stage breakdown.",
             "Use this report to choose the next measured RTL frontier, not as final PPA accounting.",
         ],
@@ -219,6 +221,23 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
                 f"- synthesis_elapsed_seconds: `{control_boundary.get('synthesis_elapsed_seconds')}`",
                 f"- reg_bits_est: `{control_boundary.get('reg_bits_est')}`",
                 f"- wire_bits_est: `{control_boundary.get('wire_bits_est')}`",
+            ]
+        )
+    physical_boundary = payload.get("inputs", {}).get("producer_physical_boundary")
+    if physical_boundary:
+        lines.extend(
+            [
+                "",
+                "## Producer Physical Boundary",
+                "",
+                f"- decision: `{physical_boundary.get('decision')}`",
+                f"- make_target: `{physical_boundary.get('make_target')}`",
+                f"- num_modules: `{physical_boundary.get('num_modules')}`",
+                f"- critical_path_ns: `{physical_boundary.get('critical_path_ns')}`",
+                f"- die_area_um2: `{physical_boundary.get('die_area_um2')}`",
+                f"- total_power_mw: `{physical_boundary.get('total_power_mw')}`",
+                f"- synthesis_elapsed_seconds: `{physical_boundary.get('synthesis_elapsed_seconds')}`",
+                f"- result_path: `{physical_boundary.get('result_path')}`",
             ]
         )
     lines.extend(["", "## Assumptions", ""])

--- a/tests/test_llm_decoder_frontier_synthesis.py
+++ b/tests/test_llm_decoder_frontier_synthesis.py
@@ -1,0 +1,69 @@
+from npu.eval.synthesize_llm_decoder_frontier import build_report
+
+
+def test_frontier_synthesis_carries_producer_physical_boundary() -> None:
+    stage_breakdown = {
+        "model": "stage_model",
+        "breakdown_sweep": [
+            {
+                "label": "gpt2_small",
+                "sequence_length": 128,
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "macs_per_cycle": 32768,
+                "memory_bandwidth_bytes_per_cycle": 256,
+                "weight_residency": "resident_weights",
+                "stage_shares": {"mlp": 0.2, "norm_residual": 0.01},
+                "total_latency_us": 100.0,
+            }
+        ],
+    }
+    attention_kv = {
+        "model": "attention_model",
+        "focus_summary": [
+            {
+                "label": "gpt2_small",
+                "sequence_length": 128,
+                "total_latency_us": 25.0,
+                "kv_memory_tier": "shared_sram",
+                "kv_sharing": "gqa4",
+                "kv_bits": 8,
+                "noc_hops": 1,
+                "dominant_substage": "kv_read",
+                "kv_limited_cycle_share": 0.5,
+            }
+        ],
+        "measured_attention_kv_tile_frontier": {"scaling_summary": {"best": "tile"}},
+    }
+    physical_boundary = {
+        "decision": "producer_physical_boundary_not_reached",
+        "num_modules": 16,
+        "critical_path_ns": 6.104,
+    }
+    producer_ranker = {
+        "model": "producer_ranker_model",
+        "producer_physical_boundary": physical_boundary,
+        "coupled_ranker_sweep": [
+            {
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "producer_lanes": 64,
+                "top_k": 1,
+                "memory_share": 1.0,
+                "producer_ii_cycles": 24,
+                "service_limiter": "weight_memory",
+                "ranker_traffic_reduction_vs_materialized": 0.99,
+                "ranker_fifo_capacity_ok": True,
+                "coupled_latency_us_per_token": 10.0,
+            }
+        ],
+    }
+
+    report = build_report(
+        stage_breakdown=stage_breakdown,
+        attention_kv=attention_kv,
+        producer_ranker=producer_ranker,
+    )
+
+    assert report["inputs"]["producer_physical_boundary"] == physical_boundary
+    assert "feasibility/PPA context" in report["assumptions"][3]

--- a/tests/test_llm_decoder_producer_ranker_coupling.py
+++ b/tests/test_llm_decoder_producer_ranker_coupling.py
@@ -11,6 +11,7 @@ def test_producer_service_derives_integer_ii_from_compute_and_memory() -> None:
         candidate_merge_ppa_path=None,
         boundary_ppa_path=None,
         producer_control_boundary_path=None,
+        producer_physical_boundary_path=None,
         sram_metrics_json_path=None,
         vocab_size_list=[256],
         hidden_size_list=[64],
@@ -40,6 +41,7 @@ def test_coupled_noc_reports_ranker_rows(tmp_path: Path) -> None:
         candidate_merge_ppa_path=None,
         boundary_ppa_path=None,
         producer_control_boundary_path=None,
+        producer_physical_boundary_path=None,
         sram_metrics_json_path=None,
         vocab_size_list=[256],
         hidden_size_list=[64],
@@ -95,6 +97,7 @@ def test_coupling_report_carries_producer_control_boundary(tmp_path: Path) -> No
         candidate_merge_ppa_path=None,
         boundary_ppa_path=None,
         producer_control_boundary_path=boundary,
+        producer_physical_boundary_path=None,
         sram_metrics_json_path=None,
         vocab_size_list=[256],
         hidden_size_list=[64],
@@ -113,3 +116,81 @@ def test_coupling_report_carries_producer_control_boundary(tmp_path: Path) -> No
     assert control["guard_variant"] == "cq_v1_softmax_event_guard"
     assert control["synthesis_status"] == "ok"
     assert control["reg_bits_est"] == 2634
+
+
+def test_coupling_report_carries_producer_physical_boundary(tmp_path: Path) -> None:
+    boundary = tmp_path / "producer_pnr.json"
+    boundary.write_text(
+        """
+{
+  "make_target": "3_3_place_gp",
+  "boundary_kind": "physical",
+  "diagnosis": {
+    "decision": "producer_physical_boundary_not_reached",
+    "feasible_max_num_modules": 16,
+    "first_nonviable_num_modules": null,
+    "recommended_next_step": "Use the largest completed physical point."
+  },
+  "probe_rows": [
+    {
+      "num_modules": 8,
+      "status": "ok",
+      "synthesis": {"status": "ok", "elapsed_seconds": 662.7},
+      "metrics_row": {
+        "critical_path_ns": "5.66",
+        "die_area": "4840000.0",
+        "total_power_mw": "0.209",
+        "flow_elapsed_seconds": "660.0",
+        "stage_elapsed_seconds": "300.0",
+        "result_path": "runs/designs/nm8/result.json"
+      }
+    },
+    {
+      "num_modules": 16,
+      "status": "ok",
+      "design_dir": "runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer",
+      "synthesis": {"status": "ok", "elapsed_seconds": 822.8},
+      "metrics_row": {
+        "critical_path_ns": "6.104",
+        "die_area": "4840000.0",
+        "total_power_mw": "0.254",
+        "flow_elapsed_seconds": "819.27",
+        "stage_elapsed_seconds": "397.0",
+        "result_path": "runs/designs/nm16/result.json"
+      }
+    }
+  ]
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_coupling_report(
+        mode="producer_service",
+        rank_ppa_path=None,
+        scale_ppa_path=None,
+        candidate_merge_ppa_path=None,
+        boundary_ppa_path=None,
+        producer_control_boundary_path=None,
+        producer_physical_boundary_path=boundary,
+        sram_metrics_json_path=None,
+        vocab_size_list=[256],
+        hidden_size_list=[64],
+        producer_lanes_list=[64],
+        macs_per_cycle_list=[4096],
+        memory_bandwidth_bytes_per_cycle_list=[128.0],
+        memory_share_list=[1.0],
+        top_k_list=[1],
+        weight_bits=16,
+        activation_bits=16,
+        clock_ns=1.0,
+    )
+
+    physical = report["producer_physical_boundary"]
+    assert physical["decision"] == "producer_physical_boundary_not_reached"
+    assert physical["num_modules"] == 16
+    assert physical["make_target"] == "3_3_place_gp"
+    assert physical["critical_path_ns"] == 6.104
+    assert physical["die_area_um2"] == 4840000.0
+    assert physical["total_power_mw"] == 0.254


### PR DESCRIPTION
## Summary
- add optional producer physical-boundary evidence to the producer/ranker coupling estimator
- carry the nm16 producer PnR anchor into decoder frontier synthesis outputs and Markdown
- add the `l2_decoder_frontier_synthesis_nm16_physical_v1` proposal and focused tests

## Why
The previous frontier synthesis used analytical producer/ranker latency plus producer control-path synth evidence. The nm16 producer wrapper now has bounded `3_3_place_gp` physical evidence, so the next scorecard should expose that PPA/feasibility anchor while keeping the service model assumptions explicit.

## Validation
- `python3 -m py_compile npu/eval/estimate_llm_decoder_producer_ranker_coupling.py npu/eval/synthesize_llm_decoder_frontier.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_producer_ranker_coupling.py tests/test_llm_decoder_frontier_synthesis.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'producer_ranker_coupled_noc or frontier_synthesis'`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- smoke-ran the producer/ranker estimator against the actual nm16 PnR artifact
