### PR TITLE
[codex] Plan producer/ranker memory integration

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2343,6 +2343,58 @@ def _decoder_frontier_synthesis_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_producer_ranker_memory_integration_plan_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_producer_ranker_memory_integration_plan__{item_id}.json"
+    report = f"{base}/decoder_producer_ranker_memory_integration_plan__{item_id}.md"
+    frontier = (
+        f"{base}/decoder_frontier_synthesis__"
+        "l2_decoder_frontier_synthesis_nm16_physical_v1.json"
+    )
+    producer_ranker = (
+        f"{base}/decoder_producer_ranker_coupled_noc__"
+        "l2_decoder_frontier_synthesis_nm16_physical_v1.json"
+    )
+    producer_physical = (
+        f"{base}/decoder_output_projection_producer_pnr_feasibility__"
+        "l2_decoder_output_projection_producer_pnr_nm16_v1.json"
+    )
+    producer_config = "runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json"
+    stream_contract = "npu/docs/decoder_logit_rank_streaming_hierarchy.md"
+    return {
+        "inputs": {
+            "integration_plan_out": out,
+            "integration_plan_report": report,
+            "frontier_synthesis": frontier,
+            "producer_ranker_coupled": producer_ranker,
+            "producer_physical_boundary": producer_physical,
+            "producer_config": producer_config,
+            "stream_contract": stream_contract,
+            "integration_plan_scope": (
+                "Reconcile the nm16 measured producer MAC lanes with the W64/W128 "
+                "producer/ranker frontier, shared memory assumptions, and ready-valid "
+                "stream equivalence requirements before queueing an integrated RTL macro."
+            ),
+        },
+        "commands": [
+            {
+                "name": "plan_decoder_producer_ranker_memory_integration",
+                "run": (
+                    "python3 npu/eval/plan_llm_decoder_producer_ranker_memory_integration.py "
+                    f"--frontier-synthesis {frontier} "
+                    f"--producer-ranker-coupled {producer_ranker} "
+                    f"--producer-physical-boundary {producer_physical} "
+                    f"--producer-config {producer_config} "
+                    f"--stream-contract {stream_contract} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_output_projection_producer_synth_boundary_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_producer_synth_boundary__{item_id}.json"
@@ -3075,6 +3127,7 @@ def _build_payload(
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
+        "decoder_producer_ranker_memory_integration_plan",
         "decoder_output_projection_producer_pnr_feasibility",
         "decoder_output_projection_producer_synth_boundary",
         "decoder_output_projection_producer_isolated_synth",
@@ -3099,6 +3152,8 @@ def _build_payload(
             decoder_evidence = _decoder_output_projection_producer_synth_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_frontier_synthesis":
             decoder_evidence = _decoder_frontier_synthesis_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_producer_ranker_memory_integration_plan":
+            decoder_evidence = _decoder_producer_ranker_memory_integration_plan_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_memory":
             decoder_evidence = _decoder_attention_kv_memory_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_stage_breakdown":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1973,6 +1973,58 @@ def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_evidence() ->
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_producer_ranker_memory_integration_plan() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_producer_ranker_memory_integration_plan_v1",
+                    proposal_id="prop_l2_decoder_producer_ranker_memory_integration_plan_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_producer_ranker_memory_integration_plan_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_producer_ranker_memory_integration_plan",
+                    expected_direction="iterate",
+                    comparison_role="integration_plan",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == "plan_decoder_producer_ranker_memory_integration"
+            run = work_item.command_manifest[0]["run"]
+            assert "plan_llm_decoder_producer_ranker_memory_integration.py" in run
+            assert "--frontier-synthesis" in run
+            assert "--producer-ranker-coupled" in run
+            assert "--producer-physical-boundary" in run
+            assert "--producer-config" in run
+            assert decoder_inputs["integration_plan_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_producer_ranker_memory_integration_plan__"
+                "l2_decoder_producer_ranker_memory_integration_plan_v1.json"
+            )
+            assert "ready-valid stream equivalence" in decoder_inputs["integration_plan_scope"]
+            assert decoder_inputs["producer_config"] == (
+                "runs/designs/npu_blocks/npu_fp16_cpp_nm16_producer/config_nm16_producer.json"
+            )
+            assert decoder_inputs["integration_plan_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_producer_ranker_memory_integration_plan",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_producer_synth_boundary_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_producer_ranker_memory_integration_plan_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_producer_ranker_memory_integration_plan_v1/proposal.json
@@ -1,0 +1,72 @@
+{
+  "proposal_id": "prop_l2_decoder_producer_ranker_memory_integration_plan_v1",
+  "created_utc": "2026-05-14T06:55:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_producer_ranker_memory_integration_plan",
+  "title": "Decoder producer/ranker memory integration plan",
+  "hypothesis": "The nm16 producer physical result should not be treated as proof of the full analytical 8192-MAC output-projection frontier. A focused integration-planning pass should reconcile measured nm16 MAC lanes, W64/W128 ranker tile widths, memory service assumptions, and ready-valid equivalence requirements before queueing an expensive producer/ranker/memory RTL macro.",
+  "direct_comparison": {
+    "primary_question": "Which first producer-to-ranker memory-interface target should be implemented after the nm16 physical producer anchor, and how large is the gap between measured nm16 MAC capacity and the analytical producer service rows?",
+    "include": [
+      "nm16 producer physical feasibility/PPA evidence",
+      "nm16 producer RTLGen config and measured MAC-lane count",
+      "decoder frontier synthesis with nm16 physical anchor",
+      "producer/ranker coupled NoC report",
+      "ready-valid LogitTileStream and CandidateStream equivalence requirements"
+    ],
+    "exclude": [
+      "new integrated RTL implementation",
+      "new OpenROAD PnR run",
+      "final SRAM/NoC arbitration PPA",
+      "training-time recovery or quality sweeps"
+    ]
+  },
+  "expected_benefit": [
+    "prevents charging the isolated nm16 producer as if it were the full analytical 8192-MAC producer",
+    "selects a concrete first r64/k1 producer-to-ranker integration target",
+    "keeps perf-sim/RTL stream equivalence requirements explicit before PPA is used in rankings"
+  ],
+  "risks": [
+    "the result is a planning report, not a new physical measurement",
+    "the extrapolation uses existing memory-service assumptions",
+    "placed-cell area is only available when present in the physical log tail; padded floorplan area remains diagnostic-only"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_producer_ranker_memory_integration_plan_v1",
+      "task_type": "l2_campaign",
+      "objective": "Reconcile nm16 producer physical MAC capacity with the W64/W128 producer/ranker memory-coupling frontier and choose the first ready-valid integration target.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_producer_ranker_memory_integration_plan",
+      "cost_class": "low",
+      "comparison_role": "integration_plan",
+      "paired_baseline_item_id": "l2_decoder_frontier_synthesis_nm16_physical_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_nm16_physical_v1",
+        "l2_decoder_output_projection_producer_pnr_nm16_v1",
+        "l2_decoder_logit_rank_streaming_producer_integrated_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The report should identify the first integrated producer/ranker/memory target and quantify the physical/analytical MAC-capacity gap before implementation."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_frontier_synthesis_nm16_physical_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_frontier_synthesis__l2_decoder_frontier_synthesis_nm16_physical_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_pnr_feasibility__l2_decoder_output_projection_producer_pnr_nm16_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/plan_llm_decoder_producer_ranker_memory_integration.py",
+    "npu/docs/decoder_logit_rank_streaming_hierarchy.md",
+    "npu/eval/estimate_llm_decoder_producer_ranker_coupling.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "tests/test_llm_decoder_producer_ranker_memory_integration.py"
+  ]
+}

--- a/npu/eval/plan_llm_decoder_producer_ranker_memory_integration.py
+++ b/npu/eval/plan_llm_decoder_producer_ranker_memory_integration.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Plan the next decoder producer/ranker/memory integration point."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import re
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _producer_mac_lanes(config: JsonDict) -> JsonDict:
+    gemm = config.get("compute", {}).get("gemm", {})
+    num_modules = _as_int(gemm.get("num_modules"), 1)
+    lanes_per_module = _as_int(gemm.get("lanes_per_module", gemm.get("lanes")), 1)
+    return {
+        "num_modules": num_modules,
+        "lanes_per_module": lanes_per_module,
+        "mac_lanes_per_cycle": num_modules * lanes_per_module,
+        "mac_type": gemm.get("mac_type"),
+        "mac_source": gemm.get("mac_source", gemm.get("rtlgen_cpp", {}).get("module_name")),
+    }
+
+
+def _physical_boundary_summary(payload: JsonDict) -> JsonDict:
+    diagnosis = payload.get("diagnosis") if isinstance(payload.get("diagnosis"), dict) else {}
+    ok_rows = [
+        row
+        for row in payload.get("probe_rows", [])
+        if isinstance(row, dict) and row.get("status") == "ok"
+    ]
+    row = max(ok_rows, key=lambda item: _as_int(item.get("num_modules")), default={})
+    metrics = row.get("metrics_row") if isinstance(row.get("metrics_row"), dict) else {}
+    synthesis = row.get("synthesis") if isinstance(row.get("synthesis"), dict) else {}
+    log_tail = synthesis.get("log_tail") if isinstance(synthesis.get("log_tail"), list) else []
+    placed_cell_area = None
+    for line in log_tail:
+        match = re.search(r"Placed Cell Area\s+([0-9.]+)", str(line))
+        if match:
+            placed_cell_area = _as_float(match.group(1))
+            break
+    return {
+        "source_decision": diagnosis.get("decision"),
+        "make_target": payload.get("make_target"),
+        "boundary_kind": payload.get("boundary_kind"),
+        "num_modules": row.get("num_modules"),
+        "critical_path_ns": _as_float(metrics.get("critical_path_ns")),
+        "die_area_um2": _as_float(metrics.get("die_area")),
+        "placed_cell_area_um2": placed_cell_area,
+        "total_power_mw": _as_float(metrics.get("total_power_mw")),
+        "synthesis_elapsed_seconds": synthesis.get("elapsed_seconds"),
+        "result_path": metrics.get("result_path") or metrics.get("work_result_json"),
+        "die_area_note": "die_area is the bounded floorplan area; placed_cell_area is preferred for extrapolation when present.",
+    }
+
+
+def _service_rows_by_key(coupling: JsonDict) -> dict[tuple[Any, ...], JsonDict]:
+    keyed: dict[tuple[Any, ...], JsonDict] = {}
+    for row in coupling.get("producer_service_sweep", []):
+        key = (
+            row.get("scenario"),
+            row.get("hidden_size"),
+            row.get("vocab_size"),
+            row.get("producer_lanes"),
+            row.get("macs_per_cycle"),
+            row.get("memory_share"),
+            row.get("producer_ii_cycles"),
+        )
+        keyed[key] = row
+    return keyed
+
+
+def _match_coupled_row(
+    coupling: JsonDict,
+    *,
+    hidden_size: int,
+    vocab_size: int,
+    producer_choice: JsonDict,
+) -> JsonDict | None:
+    candidates = []
+    for row in coupling.get("coupled_ranker_sweep", []):
+        if int(row.get("hidden_size", 0) or 0) != hidden_size:
+            continue
+        if int(row.get("vocab_size", 0) or 0) != vocab_size:
+            continue
+        if row.get("producer_lanes") != producer_choice.get("producer_lanes"):
+            continue
+        if row.get("top_k") != producer_choice.get("top_k"):
+            continue
+        if row.get("producer_ii_cycles") != producer_choice.get("producer_ii_cycles"):
+            continue
+        candidates.append(row)
+    if not candidates:
+        return None
+    return min(candidates, key=lambda row: _as_float(row.get("coupled_latency_us_per_token")))
+
+
+def _projection_with_measured_mac_lanes(
+    *,
+    service: JsonDict,
+    measured_mac_lanes: int,
+    physical_clock_ns: float,
+) -> JsonDict:
+    vocab_size = _as_int(service.get("vocab_size"))
+    hidden_size = _as_int(service.get("hidden_size"))
+    producer_lanes = _as_int(service.get("producer_lanes"))
+    tile_count = _ceil_div(vocab_size, producer_lanes)
+    macs_per_tile = producer_lanes * hidden_size
+    measured_compute_cycles_per_tile = _ceil_div(macs_per_tile, measured_mac_lanes)
+    memory_cycles_per_tile = _as_int(service.get("weight_cycles_per_tile"))
+    hidden_load_cycles = _as_int(service.get("hidden_load_cycles"))
+    measured_ii_cycles = max(1, measured_compute_cycles_per_tile, memory_cycles_per_tile)
+    measured_total_cycles = (
+        hidden_load_cycles
+        + measured_compute_cycles_per_tile
+        + max(0, tile_count - 1) * measured_ii_cycles
+    )
+    analytical_macs_per_cycle = _as_int(service.get("macs_per_cycle"))
+    equivalent_clusters = _ceil_div(analytical_macs_per_cycle, measured_mac_lanes)
+    return {
+        "measured_mac_lanes_per_cycle": measured_mac_lanes,
+        "analytical_macs_per_cycle": analytical_macs_per_cycle,
+        "equivalent_nm16_clusters_for_analytical_macs": equivalent_clusters,
+        "tile_count": tile_count,
+        "macs_per_tile": macs_per_tile,
+        "analytical_compute_cycles_per_tile": service.get("compute_cycles_per_tile"),
+        "measured_compute_cycles_per_tile": measured_compute_cycles_per_tile,
+        "weight_cycles_per_tile": memory_cycles_per_tile,
+        "hidden_load_cycles": hidden_load_cycles,
+        "measured_ii_cycles": measured_ii_cycles,
+        "model_clock_latency_us_per_token": round(measured_total_cycles * 1.0 / 1000.0, 6),
+        "physical_clock_latency_us_per_token": round(measured_total_cycles * physical_clock_ns / 1000.0, 6),
+    }
+
+
+def build_report(
+    *,
+    frontier: JsonDict,
+    coupling: JsonDict,
+    producer_physical: JsonDict,
+    producer_config: JsonDict,
+    stream_contract_path: str,
+) -> JsonDict:
+    mac_summary = _producer_mac_lanes(producer_config)
+    physical = _physical_boundary_summary(producer_physical)
+    service_by_key = _service_rows_by_key(coupling)
+    rows: list[JsonDict] = []
+    for focus in frontier.get("focus_summary", []):
+        producer_choice = focus.get("producer_choice") if isinstance(focus.get("producer_choice"), dict) else {}
+        coupled = _match_coupled_row(
+            coupling,
+            hidden_size=_as_int(focus.get("hidden_size")),
+            vocab_size=_as_int(focus.get("vocab_size")),
+            producer_choice=producer_choice,
+        )
+        if coupled is None:
+            continue
+        service = service_by_key.get(
+            (
+                coupled.get("scenario"),
+                coupled.get("hidden_size"),
+                coupled.get("vocab_size"),
+                coupled.get("producer_lanes"),
+                coupled.get("macs_per_cycle"),
+                coupled.get("memory_share"),
+                coupled.get("producer_ii_cycles"),
+            )
+        )
+        if service is None:
+            continue
+        projection = _projection_with_measured_mac_lanes(
+            service=service,
+            measured_mac_lanes=mac_summary["mac_lanes_per_cycle"],
+            physical_clock_ns=physical["critical_path_ns"] or 1.0,
+        )
+        ranker_us = _as_float(coupled.get("ranker_latency_us_per_token"))
+        model_clock_limiter = (
+            "producer_mac_limited"
+            if projection["model_clock_latency_us_per_token"] > ranker_us
+            else "ranker"
+        )
+        physical_clock_limiter = (
+            "producer_mac_limited"
+            if projection["physical_clock_latency_us_per_token"] > ranker_us
+            else "ranker"
+        )
+        rows.append(
+            {
+                "label": focus.get("label"),
+                "sequence_length": focus.get("sequence_length"),
+                "hidden_size": focus.get("hidden_size"),
+                "vocab_size": focus.get("vocab_size"),
+                "frontier_dominant_component": focus.get("dominant_component"),
+                "producer_choice": producer_choice,
+                "coupled_model": {
+                    "scenario": coupled.get("scenario"),
+                    "macs_per_cycle": coupled.get("macs_per_cycle"),
+                    "memory_share": coupled.get("memory_share"),
+                    "producer_latency_us_per_token": coupled.get("producer_latency_us_per_token"),
+                    "ranker_latency_us_per_token": coupled.get("ranker_latency_us_per_token"),
+                    "coupled_latency_us_per_token": coupled.get("coupled_latency_us_per_token"),
+                    "ranker_fifo_capacity_ok": coupled.get("ranker_fifo_capacity_ok"),
+                    "ranker_required_fifo_depth_groups": coupled.get("ranker_required_fifo_depth_groups"),
+                    "ranker_candidate_memory_bytes": coupled.get("ranker_candidate_memory_bytes"),
+                },
+                "nm16_mac_projection": projection,
+                "bottleneck_if_nm16_model_clock": model_clock_limiter,
+                "bottleneck_if_nm16_physical_clock": physical_clock_limiter,
+            }
+        )
+
+    first_target = rows[0] if rows else {}
+    area_basis = physical.get("placed_cell_area_um2") or physical.get("die_area_um2") or 0.0
+    clusters = (
+        first_target.get("nm16_mac_projection", {}).get("equivalent_nm16_clusters_for_analytical_macs")
+        if first_target
+        else None
+    )
+    return {
+        "version": 0.1,
+        "model": "decoder_producer_ranker_memory_integration_plan_v1",
+        "inputs": {
+            "frontier_model": frontier.get("model"),
+            "coupling_model": coupling.get("model"),
+            "stream_contract": stream_contract_path,
+        },
+        "producer_physical_anchor": physical,
+        "producer_config_summary": mac_summary,
+        "integration_rows": rows,
+        "recommendation": {
+            "next_target": {
+                "name": "r64_k1_nm16_ready_valid_equivalence",
+                "reason": "Use the smallest focus row that already dominates the frontier before attempting larger producer parallelism.",
+                "producer_lanes": first_target.get("producer_choice", {}).get("producer_lanes"),
+                "top_k": first_target.get("producer_choice", {}).get("top_k"),
+                "hidden_size": first_target.get("hidden_size"),
+                "vocab_size": first_target.get("vocab_size"),
+                "measured_mac_lanes_per_cycle": mac_summary["mac_lanes_per_cycle"],
+            },
+            "implementation_order": [
+                "add producer-to-ranker LogitTileStream/CandidateStream ready-valid equivalence harness",
+                "measure a macro-style r64/k1 wrapper with one-entry skid buffers and no exposed scalar logit pins",
+                "only then scale producer MAC parallelism or shared-memory/NoC arbitration",
+            ],
+            "large_array_gap": {
+                "analytical_macs_per_cycle": first_target.get("coupled_model", {}).get("macs_per_cycle"),
+                "equivalent_nm16_clusters": clusters,
+                "area_basis_um2_per_nm16_cluster": area_basis,
+                "area_basis_kind": (
+                    "placed_cell_area" if physical.get("placed_cell_area_um2") else "floorplan_die_area"
+                ),
+                "do_not_charge_padded_die_area_blindly": True,
+            },
+        },
+        "assumptions": [
+            "Producer num_modules and producer_lanes are different axes: num_modules is measured FP16 MAC parallelism, producer_lanes is logit tile width.",
+            "The nm16 physical anchor proves bounded feasibility for the current generated producer wrapper, not an 8192-MAC output-projection array.",
+            "Latency rows are recalculated with the same weight-memory model but with measured nm16 MAC lanes to expose the physical/analytical gap.",
+            "Ready/valid stream equivalence must be validated before integrated RTL PPA is used in rankings.",
+        ],
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    rec = payload["recommendation"]
+    phys = payload["producer_physical_anchor"]
+    cfg = payload["producer_config_summary"]
+    lines = [
+        "# Decoder Producer/Ranker/Memory Integration Plan",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- measured_mac_lanes_per_cycle: `{cfg['mac_lanes_per_cycle']}`",
+        f"- physical_anchor: `nm{phys.get('num_modules')} {phys.get('make_target')} cp={phys.get('critical_path_ns')}ns`",
+        f"- next_target: `{rec['next_target']['name']}`",
+        "",
+        "## Integration Rows",
+        "",
+        "| shape | W | top_k | model MAC/cyc | ranker_us | nm16_model_us | nm16_physical_us | model limiter | physical limiter | clusters |",
+        "|---|---:|---:|---:|---:|---:|---:|---|---|---:|",
+    ]
+    for row in payload["integration_rows"]:
+        prod = row["producer_choice"]
+        coupled = row["coupled_model"]
+        proj = row["nm16_mac_projection"]
+        lines.append(
+            "| {label} | {w} | {k} | {macs} | {ranker_us} | {model_us} | {physical_us} | {model_limiter} | {physical_limiter} | {clusters} |".format(
+                label=row["label"],
+                w=prod.get("producer_lanes"),
+                k=prod.get("top_k"),
+                macs=coupled.get("macs_per_cycle"),
+                ranker_us=coupled.get("ranker_latency_us_per_token"),
+                model_us=proj.get("model_clock_latency_us_per_token"),
+                physical_us=proj.get("physical_clock_latency_us_per_token"),
+                model_limiter=row["bottleneck_if_nm16_model_clock"],
+                physical_limiter=row["bottleneck_if_nm16_physical_clock"],
+                clusters=proj.get("equivalent_nm16_clusters_for_analytical_macs"),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Recommendation",
+            "",
+        ]
+    )
+    for item in rec["implementation_order"]:
+        lines.append(f"- {item}")
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Plan decoder producer/ranker/memory integration")
+    ap.add_argument("--frontier-synthesis", required=True)
+    ap.add_argument("--producer-ranker-coupled", required=True)
+    ap.add_argument("--producer-physical-boundary", required=True)
+    ap.add_argument("--producer-config", required=True)
+    ap.add_argument("--stream-contract", default="npu/docs/decoder_logit_rank_streaming_hierarchy.md")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+    payload = build_report(
+        frontier=_load_json(args.frontier_synthesis),
+        coupling=_load_json(args.producer_ranker_coupled),
+        producer_physical=_load_json(args.producer_physical_boundary),
+        producer_config=_load_json(args.producer_config),
+        stream_contract_path=args.stream_contract,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    _write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_producer_ranker_memory_integration.py
+++ b/tests/test_llm_decoder_producer_ranker_memory_integration.py
@@ -1,0 +1,97 @@
+from npu.eval.plan_llm_decoder_producer_ranker_memory_integration import build_report
+
+
+def test_integration_plan_separates_mac_modules_from_tile_lanes() -> None:
+    frontier = {
+        "model": "frontier",
+        "focus_summary": [
+            {
+                "label": "gpt2_small",
+                "sequence_length": 128,
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "dominant_component": "output_projection_producer_ranker",
+                "producer_choice": {
+                    "producer_lanes": 64,
+                    "top_k": 1,
+                    "memory_share": 1.0,
+                    "producer_ii_cycles": 384,
+                },
+            }
+        ],
+    }
+    coupling = {
+        "model": "coupling",
+        "producer_service_sweep": [
+            {
+                "scenario": "shared_gemm_stage_serial",
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "producer_lanes": 64,
+                "macs_per_cycle": 8192,
+                "memory_share": 1.0,
+                "producer_ii_cycles": 384,
+                "compute_cycles_per_tile": 6,
+                "weight_cycles_per_tile": 384,
+                "hidden_load_cycles": 6,
+            }
+        ],
+        "coupled_ranker_sweep": [
+            {
+                "scenario": "shared_gemm_stage_serial",
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "producer_lanes": 64,
+                "top_k": 1,
+                "macs_per_cycle": 8192,
+                "memory_share": 1.0,
+                "producer_ii_cycles": 384,
+                "producer_latency_us_per_token": 301.452,
+                "ranker_latency_us_per_token": 5046.275694,
+                "coupled_latency_us_per_token": 5046.275694,
+                "ranker_fifo_capacity_ok": True,
+                "ranker_required_fifo_depth_groups": 1,
+                "ranker_candidate_memory_bytes": 6292,
+            }
+        ],
+    }
+    producer_physical = {
+        "make_target": "3_3_place_gp",
+        "boundary_kind": "physical",
+        "diagnosis": {"decision": "producer_physical_boundary_not_reached"},
+        "probe_rows": [
+            {
+                "num_modules": 16,
+                "status": "ok",
+                "synthesis": {
+                    "elapsed_seconds": 822.8,
+                    "log_tail": ["[INFO GPL-1002] Placed Cell Area            597643.1212"],
+                },
+                "metrics_row": {
+                    "critical_path_ns": "6.104",
+                    "die_area": "4840000.0",
+                    "total_power_mw": "0.254",
+                },
+            }
+        ],
+    }
+    producer_config = {
+        "compute": {"gemm": {"mac_type": "fp16", "num_modules": 16, "lanes_per_module": 1}}
+    }
+
+    report = build_report(
+        frontier=frontier,
+        coupling=coupling,
+        producer_physical=producer_physical,
+        producer_config=producer_config,
+        stream_contract_path="npu/docs/decoder_logit_rank_streaming_hierarchy.md",
+    )
+
+    assert report["producer_config_summary"]["mac_lanes_per_cycle"] == 16
+    row = report["integration_rows"][0]
+    assert row["producer_choice"]["producer_lanes"] == 64
+    assert row["nm16_mac_projection"]["measured_compute_cycles_per_tile"] == 3072
+    assert row["nm16_mac_projection"]["equivalent_nm16_clusters_for_analytical_macs"] == 512
+    assert row["bottleneck_if_nm16_model_clock"] == "ranker"
+    assert row["bottleneck_if_nm16_physical_clock"] == "producer_mac_limited"
+    assert report["recommendation"]["next_target"]["name"] == "r64_k1_nm16_ready_valid_equivalence"


### PR DESCRIPTION
## Summary
- add a producer/ranker/memory integration planning estimator
- wire a new `decoder_producer_ranker_memory_integration_plan` Layer 2 evidence job
- add proposal and focused tests for the next integration-planning task

## Why
The nm16 producer physical anchor has 16 measured FP16 MAC lanes, while the current frontier model uses analytical producer rows such as W64/k1 with 8192 MAC/cycle. This report makes that gap explicit before we queue an integrated producer/ranker/memory RTL macro.

## Local smoke result
Against the merged nm16 physical frontier artifacts, the planner reports:
- measured producer MAC lanes/cycle: 16
- next target: `r64_k1_nm16_ready_valid_equivalence`
- analytical 8192 MAC/cycle corresponds to 512 nm16 clusters
- W64/k1 remains ranker-limited at a 1 ns model clock, but becomes producer-MAC-limited at the measured 6.104 ns physical clock

## Validation
- `python3 -m py_compile npu/eval/plan_llm_decoder_producer_ranker_memory_integration.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_producer_ranker_memory_integration.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'producer_ranker_memory_integration_plan'`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_producer_ranker_memory_integration.py tests/test_llm_decoder_producer_ranker_coupling.py tests/test_llm_decoder_frontier_synthesis.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
