### PR TITLE
[codex] Select smallest integration planning target

### DIFF
--- a/npu/eval/plan_llm_decoder_producer_ranker_memory_integration.py
+++ b/npu/eval/plan_llm_decoder_producer_ranker_memory_integration.py
@@ -239,7 +239,16 @@ def build_report(
             }
         )
 
-    first_target = rows[0] if rows else {}
+    first_target = min(
+        rows,
+        key=lambda row: (
+            _as_int(row.get("hidden_size")),
+            _as_int(row.get("vocab_size")),
+            _as_int(row.get("sequence_length")),
+            str(row.get("label", "")),
+        ),
+        default={},
+    )
     area_basis = physical.get("placed_cell_area_um2") or physical.get("die_area_um2") or 0.0
     clusters = (
         first_target.get("nm16_mac_projection", {}).get("equivalent_nm16_clusters_for_analytical_macs")

--- a/tests/test_llm_decoder_producer_ranker_memory_integration.py
+++ b/tests/test_llm_decoder_producer_ranker_memory_integration.py
@@ -6,6 +6,19 @@ def test_integration_plan_separates_mac_modules_from_tile_lanes() -> None:
         "model": "frontier",
         "focus_summary": [
             {
+                "label": "gpt2_medium_proxy",
+                "sequence_length": 128,
+                "hidden_size": 1024,
+                "vocab_size": 50257,
+                "dominant_component": "output_projection_producer_ranker",
+                "producer_choice": {
+                    "producer_lanes": 64,
+                    "top_k": 1,
+                    "memory_share": 1.0,
+                    "producer_ii_cycles": 512,
+                },
+            },
+            {
                 "label": "gpt2_small",
                 "sequence_length": 128,
                 "hidden_size": 768,
@@ -25,6 +38,18 @@ def test_integration_plan_separates_mac_modules_from_tile_lanes() -> None:
         "producer_service_sweep": [
             {
                 "scenario": "shared_gemm_stage_serial",
+                "hidden_size": 1024,
+                "vocab_size": 50257,
+                "producer_lanes": 64,
+                "macs_per_cycle": 8192,
+                "memory_share": 1.0,
+                "producer_ii_cycles": 512,
+                "compute_cycles_per_tile": 8,
+                "weight_cycles_per_tile": 512,
+                "hidden_load_cycles": 8,
+            },
+            {
+                "scenario": "shared_gemm_stage_serial",
                 "hidden_size": 768,
                 "vocab_size": 50257,
                 "producer_lanes": 64,
@@ -37,6 +62,22 @@ def test_integration_plan_separates_mac_modules_from_tile_lanes() -> None:
             }
         ],
         "coupled_ranker_sweep": [
+            {
+                "scenario": "shared_gemm_stage_serial",
+                "hidden_size": 1024,
+                "vocab_size": 50257,
+                "producer_lanes": 64,
+                "top_k": 1,
+                "macs_per_cycle": 8192,
+                "memory_share": 1.0,
+                "producer_ii_cycles": 512,
+                "producer_latency_us_per_token": 401.936,
+                "ranker_latency_us_per_token": 6728.322951,
+                "coupled_latency_us_per_token": 6728.322951,
+                "ranker_fifo_capacity_ok": True,
+                "ranker_required_fifo_depth_groups": 1,
+                "ranker_candidate_memory_bytes": 6292,
+            },
             {
                 "scenario": "shared_gemm_stage_serial",
                 "hidden_size": 768,
@@ -88,10 +129,11 @@ def test_integration_plan_separates_mac_modules_from_tile_lanes() -> None:
     )
 
     assert report["producer_config_summary"]["mac_lanes_per_cycle"] == 16
-    row = report["integration_rows"][0]
+    row = next(item for item in report["integration_rows"] if item["label"] == "gpt2_small")
     assert row["producer_choice"]["producer_lanes"] == 64
     assert row["nm16_mac_projection"]["measured_compute_cycles_per_tile"] == 3072
     assert row["nm16_mac_projection"]["equivalent_nm16_clusters_for_analytical_macs"] == 512
     assert row["bottleneck_if_nm16_model_clock"] == "ranker"
     assert row["bottleneck_if_nm16_physical_clock"] == "producer_mac_limited"
     assert report["recommendation"]["next_target"]["name"] == "r64_k1_nm16_ready_valid_equivalence"
+    assert report["recommendation"]["next_target"]["hidden_size"] == 768


### PR DESCRIPTION
## Summary
- select the smallest focus row explicitly for the producer/ranker integration target
- extend the unit test so a medium row appearing first cannot mask the target selection

## Why
The first evaluator run for the integration planner produced useful rows, but the recommendation used the first focus row from the frontier report. That happened to be `gpt2_medium_proxy`, contradicting the text that says the first implementation target should be the smallest dominating focus row.

## Validation
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_producer_ranker_memory_integration.py`
- smoke-ran `plan_llm_decoder_producer_ranker_memory_integration.py` against the merged nm16 frontier artifacts and confirmed `hidden_size=768`, `vocab_size=50257`
- `python3 scripts/validate_runs.py --skip_eval_queue`
