### PR TITLE
[codex] Handle rtlgen setup for ready-valid probe

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2427,6 +2427,10 @@ def _decoder_producer_ranker_ready_valid_equivalence_evidence(*, item_id: str) -
         },
         "commands": [
             {
+                "name": "build_generator",
+                "run": "export PATH=/oss-cad-suite/bin:$PATH && cmake -S . -B build && cmake --build build --target rtlgen",
+            },
+            {
                 "name": "probe_decoder_producer_ranker_ready_valid_equivalence",
                 "run": (
                     "python3 npu/eval/probe_llm_decoder_producer_ranker_ready_valid_equivalence.py "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2055,8 +2055,15 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_ready_valid_equi
 
             work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
             decoder_inputs = work_item.input_manifest["decoder_contract"]
-            assert work_item.command_manifest[0]["name"] == "probe_decoder_producer_ranker_ready_valid_equivalence"
-            run = work_item.command_manifest[0]["run"]
+            assert [command["name"] for command in work_item.command_manifest[:2]] == [
+                "build_generator",
+                "probe_decoder_producer_ranker_ready_valid_equivalence",
+            ]
+            assert work_item.command_manifest[0]["run"] == (
+                "export PATH=/oss-cad-suite/bin:$PATH && "
+                "cmake -S . -B build && cmake --build build --target rtlgen"
+            )
+            run = work_item.command_manifest[1]["run"]
             assert "probe_llm_decoder_producer_ranker_ready_valid_equivalence.py" in run
             assert "--run-rtl-sim" in run
             assert "logit_rank_r64_l16_k1" in run

--- a/npu/eval/probe_llm_decoder_producer_ranker_ready_valid_equivalence.py
+++ b/npu/eval/probe_llm_decoder_producer_ranker_ready_valid_equivalence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 import re
 import shutil
@@ -311,7 +312,47 @@ def _write_testbench(
 
 
 def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(cmd, 127, stdout=str(exc))
+
+
+def _resolve_executable(requested: str) -> str | None:
+    candidate_paths: list[Path] = []
+    requested_path = Path(requested)
+    if requested_path.is_absolute():
+        candidate_paths.append(requested_path)
+    elif "/" in requested or "\\" in requested:
+        candidate_paths.append((Path.cwd() / requested_path).resolve())
+    else:
+        found = shutil.which(requested)
+        if found is not None:
+            candidate_paths.append(Path(found))
+
+    env_path = os.environ.get("RTLGEN_BINARY")
+    if env_path:
+        candidate_paths.append(Path(env_path).expanduser())
+
+    repo_root = Path(__file__).resolve().parents[2]
+    candidate_paths.extend(
+        [
+            Path.cwd() / "build" / "rtlgen",
+            repo_root / "build" / "rtlgen",
+            Path("/workspaces/RTLGen/build/rtlgen"),
+        ]
+    )
+    for candidate in candidate_paths:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate.resolve())
+    return None
 
 
 def _run_rtl_sim(
@@ -538,17 +579,26 @@ def main() -> int:
         if iverilog is None or vvp is None:
             rtl_sim = {"status": "simulator_missing", "iverilog": iverilog, "vvp": vvp}
         else:
-            rtl_sim = _run_rtl_sim(
-                rtlgen_binary=args.rtlgen_binary,
-                iverilog_binary=iverilog,
-                vvp_binary=vvp,
-                logit_rank_config=Path(args.logit_rank_config).resolve(),
-                merge_config=Path(args.merge_config).resolve(),
-                producer_lanes=_as_int(rank_opts.get("row_elems")),
-                logit_bits=_as_int(rank_opts.get("logit_bits")),
-                token_id_bits=_as_int(merge_opts.get("token_id_bits")),
-                top_k=_as_int(rank_opts.get("top_k")),
-            )
+            rtlgen_binary = _resolve_executable(args.rtlgen_binary)
+            if rtlgen_binary is None:
+                rtl_sim = {
+                    "status": "rtlgen_binary_missing",
+                    "requested": args.rtlgen_binary,
+                    "rtlgen_binary_env": os.environ.get("RTLGEN_BINARY"),
+                }
+            else:
+                rtl_sim = _run_rtl_sim(
+                    rtlgen_binary=rtlgen_binary,
+                    iverilog_binary=iverilog,
+                    vvp_binary=vvp,
+                    logit_rank_config=Path(args.logit_rank_config).resolve(),
+                    merge_config=Path(args.merge_config).resolve(),
+                    producer_lanes=_as_int(rank_opts.get("row_elems")),
+                    logit_bits=_as_int(rank_opts.get("logit_bits")),
+                    token_id_bits=_as_int(merge_opts.get("token_id_bits")),
+                    top_k=_as_int(rank_opts.get("top_k")),
+                )
+                rtl_sim["rtlgen_binary"] = rtlgen_binary
     payload = build_report(
         producer_config=producer_config,
         logit_rank_config=logit_rank_config,

--- a/tests/test_llm_decoder_producer_ranker_ready_valid_equivalence.py
+++ b/tests/test_llm_decoder_producer_ranker_ready_valid_equivalence.py
@@ -1,4 +1,10 @@
-from npu.eval.probe_llm_decoder_producer_ranker_ready_valid_equivalence import build_report
+from pathlib import Path
+
+from npu.eval.probe_llm_decoder_producer_ranker_ready_valid_equivalence import (
+    _resolve_executable,
+    _run,
+    build_report,
+)
 
 
 def test_ready_valid_equivalence_report_requires_r64_k1_and_rtl_match() -> None:
@@ -46,3 +52,20 @@ def test_ready_valid_equivalence_report_requires_r64_k1_and_rtl_match() -> None:
     assert report["target"]["top_k"] == 1
     assert report["producer_config_summary"]["mac_lanes_per_cycle"] == 16
     assert report["decision"]["decision"] == "ready_valid_equivalence_passed"
+
+
+def test_missing_tool_execution_is_reportable(tmp_path: Path) -> None:
+    result = _run([str(tmp_path / "missing-rtlgen")], cwd=tmp_path)
+
+    assert result.returncode == 127
+    assert "No such file or directory" in result.stdout
+
+
+def test_resolve_executable_handles_repo_relative_build_path(tmp_path: Path, monkeypatch) -> None:
+    binary = tmp_path / "build" / "rtlgen"
+    binary.parent.mkdir()
+    binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    binary.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+
+    assert _resolve_executable("build/rtlgen") == str(binary.resolve())


### PR DESCRIPTION
## Summary

Fix the r64/k1 producer-ranker ready-valid equivalence job setup.

The failed evaluator run crashed before producing a report because the probe launched `build/rtlgen` from a temporary simulation directory. A relative binary path that exists at the repository root is not valid from that temp directory.

This PR:
- adds an explicit `build_generator` step before the ready-valid probe command
- resolves `build/rtlgen` to an executable path before entering the tempdir
- reports missing external executables as structured blocked evidence instead of raising `FileNotFoundError`
- adds regression coverage for the command manifest and executable handling

## Validation

- `python3 -m py_compile npu/eval/probe_llm_decoder_producer_ranker_ready_valid_equivalence.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_producer_ranker_ready_valid_equivalence.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'ready_valid_equivalence'`
- local probe smoke with default `build/rtlgen` path
- `python3 scripts/validate_runs.py --skip_eval_queue`
