### PR TITLE
[codex] Add decoder rank tree architecture probe

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2594,6 +2594,82 @@ def _decoder_pipelined_ranker_architecture_evidence(*, item_id: str) -> dict[str
     }
 
 
+def _decoder_rank_tree_architecture_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_rank_tree_architecture__{item_id}.json"
+    report = f"{base}/decoder_rank_tree_architecture__{item_id}.md"
+    merge_config = (
+        "runs/designs/activations/candidate_stream_merge_fifo_k1_l16_t16_d16_wrapper/"
+        "config_candidate_stream_merge_fifo_k1_l16_t16_d16.json"
+    )
+    ready_valid_equivalence = (
+        f"{base}/decoder_producer_ranker_ready_valid_equivalence__"
+        "l2_decoder_producer_ranker_ready_valid_equivalence_v1_r2.json"
+    )
+    pipelined_ranker = (
+        f"{base}/decoder_pipelined_ranker_architecture__"
+        "l2_decoder_pipelined_ranker_architecture_v1.json"
+    )
+    sweep = "runs/campaigns/npu/decoder_rank_tree_architecture/sweeps/nangate45_r64_ranktree.json"
+    design_root = "runs/designs/activations"
+    tops = [
+        "decoder_r64_k1_ranktree_radix2_pipe6_wrapper",
+        "decoder_r64_k1_ranktree_radix4_pipe3_wrapper",
+        "decoder_r64_k1_ranktree_radix8_pipe2_wrapper",
+    ]
+    return {
+        "inputs": {
+            "rank_tree_architecture_out": out,
+            "rank_tree_architecture_report": report,
+            "rank_tree_architecture_sweep": sweep,
+            "rank_tree_architecture_make_target": "3_3_place_gp",
+            "rank_tree_architecture_radices": [2, 4, 8],
+            "candidate_merge_config": merge_config,
+            "ready_valid_equivalence": ready_valid_equivalence,
+            "pipelined_ranker_architecture": pipelined_ranker,
+            "rank_tree_architecture_scope": (
+                "Explore deeper r64/k1 rank trees after the two-stage radix-8/local-lanes-8 "
+                "wrapper measured a 6.6 ns critical path. Variants use radix 2, 4, and 8, "
+                "register after every rank level, and preserve II=1 ready-valid semantics."
+            ),
+        },
+        "commands": [
+            {
+                "name": "build_generator",
+                "run": "export PATH=/oss-cad-suite/bin:$PATH && cmake -S . -B build && cmake --build build --target rtlgen",
+            },
+            {
+                "name": "probe_decoder_rank_tree_architecture",
+                "run": (
+                    "python3 npu/eval/probe_llm_decoder_rank_tree_architecture.py "
+                    f"--merge-config {merge_config} "
+                    f"--ready-valid-equivalence {ready_valid_equivalence} "
+                    f"--design-root {design_root} "
+                    "--radices 2,4,8 "
+                    f"--sweep {sweep} "
+                    "--platform nangate45 "
+                    "--make-target 3_3_place_gp "
+                    "--timeout-seconds 1800 "
+                    "--stall-timeout-seconds 900 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+            {
+                "name": "build_runs_index",
+                "run": "python3 scripts/build_runs_index.py",
+            },
+        ],
+        "expected_outputs": [
+            out,
+            report,
+            "runs/index.csv",
+            *[f"{design_root}/{top}/metrics.csv" for top in tops],
+            *[f"{design_root}/{top}/verilog/{top}.v" for top in tops],
+        ],
+    }
+
+
 def _decoder_output_projection_producer_synth_boundary_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_producer_synth_boundary__{item_id}.json"
@@ -3330,6 +3406,7 @@ def _build_payload(
         "decoder_producer_ranker_ready_valid_equivalence",
         "decoder_producer_ranker_physical_wrapper",
         "decoder_pipelined_ranker_architecture",
+        "decoder_rank_tree_architecture",
         "decoder_output_projection_producer_pnr_feasibility",
         "decoder_output_projection_producer_synth_boundary",
         "decoder_output_projection_producer_isolated_synth",
@@ -3362,6 +3439,8 @@ def _build_payload(
             decoder_evidence = _decoder_producer_ranker_physical_wrapper_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_pipelined_ranker_architecture":
             decoder_evidence = _decoder_pipelined_ranker_architecture_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_rank_tree_architecture":
+            decoder_evidence = _decoder_rank_tree_architecture_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_memory":
             decoder_evidence = _decoder_attention_kv_memory_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_stage_breakdown":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2183,6 +2183,56 @@ def test_generate_l2_campaign_task_adds_decoder_pipelined_ranker_architecture() 
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_rank_tree_architecture() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_rank_tree_architecture_v1",
+                    proposal_id="prop_l2_decoder_rank_tree_architecture_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_rank_tree_architecture_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_rank_tree_architecture",
+                    expected_direction="iterate",
+                    comparison_role="ranker_pipeline_architecture",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:3]] == [
+                "build_generator",
+                "probe_decoder_rank_tree_architecture",
+                "build_runs_index",
+            ]
+            run = work_item.command_manifest[1]["run"]
+            assert "probe_llm_decoder_rank_tree_architecture.py" in run
+            assert "--radices 2,4,8" in run
+            assert "decoder_rank_tree_architecture" in decoder_inputs[
+                "rank_tree_architecture_sweep"
+            ]
+            assert decoder_inputs["pipelined_ranker_architecture"].endswith(
+                "l2_decoder_pipelined_ranker_architecture_v1.json"
+            )
+            assert "runs/index.csv" in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_rank_tree_architecture",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_producer_synth_boundary_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_rank_tree_architecture_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_rank_tree_architecture_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_rank_tree_architecture_v1",
+  "created_utc": "2026-05-14T08:30:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_rank_tree_architecture",
+  "title": "Decoder deeper pipelined rank-tree architecture",
+  "hypothesis": "The r64/k1 two-stage segmented ranker improved the standalone wrapper from about 32 ns to 6.6 ns, but the remaining path may still be dominated by ranker fan-in. A deeper rank tree with smaller radix and a register after every rank level should trade additional latency and registers for lower critical path while preserving II=1 ready-valid semantics.",
+  "direct_comparison": {
+    "primary_question": "Which rank-tree radix gives the best r64/k1 timing/PPA tradeoff after registering every rank level?",
+    "include": [
+      "radix 2, 4, and 8 trees over the same 64-logit tile",
+      "a ready-valid register cut after every rank level",
+      "generated RTL simulation against the deterministic ready-valid reference",
+      "bounded nangate45 physical sweep through 3_3_place_gp",
+      "comparison against the measured two-stage radix-8/local-lanes-8 anchor"
+    ],
+    "exclude": [
+      "r128 or wider ranker tiles",
+      "full output-projection producer timing",
+      "shared SRAM or NoC arbitration",
+      "probability recovery or training"
+    ]
+  },
+  "expected_benefit": [
+    "identifies whether the 6.6 ns r64 ranker anchor is limited by radix-8 fan-in",
+    "exposes the latency versus critical-path tradeoff before scaling ranker width",
+    "keeps stream equivalence explicit before coupling the ranker to the producer"
+  ],
+  "risks": [
+    "deeper trees add latency and more rank-level registers even if throughput remains II=1",
+    "radix-2 may increase register and routing overhead enough to lose PPA despite shorter local logic",
+    "the standalone 64-logit wrapper still retains macro-style pin pressure not present inside a larger producer"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_rank_tree_architecture_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure r64/k1 rank-tree wrappers with radix 2, 4, and 8 plus a register after every rank level.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_rank_tree_architecture",
+      "cost_class": "medium",
+      "comparison_role": "ranker_pipeline_architecture",
+      "paired_baseline_item_id": "l2_decoder_pipelined_ranker_architecture_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_pipelined_ranker_architecture_v1",
+        "l2_decoder_producer_ranker_ready_valid_equivalence_v1_r2",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_candidate_stream_merge_fifo_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If a smaller radix improves timing enough to justify latency/register overhead, use it as the r64 anchor for producer-coupled timing and r128 scaling. If radix 8 remains best, keep the two-stage shape and move to producer coupling."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_pipelined_ranker_architecture__l2_decoder_pipelined_ranker_architecture_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_producer_ranker_ready_valid_equivalence__l2_decoder_producer_ranker_ready_valid_equivalence_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_llm_decoder_rank_tree_architecture.py",
+    "runs/campaigns/npu/decoder_rank_tree_architecture/sweeps/nangate45_r64_ranktree.json",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "tests/test_llm_decoder_rank_tree_architecture.py"
+  ]
+}

--- a/npu/eval/probe_llm_decoder_rank_tree_architecture.py
+++ b/npu/eval/probe_llm_decoder_rank_tree_architecture.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Explore deeper pipelined r64/k1 decoder rank-tree wrappers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    from probe_llm_decoder_pipelined_ranker_architecture import (
+        _ceil_log2_at_least_one,
+        _rank_config,
+        _simulate_variant,
+        _sv_signed_literal,
+        _write_json,
+    )
+    from probe_llm_decoder_producer_ranker_physical_wrapper import (
+        REPO_ROOT,
+        _latest_metrics_row,
+        _portable_metrics_row,
+        _rel,
+        _run_logged,
+    )
+    from probe_llm_decoder_producer_ranker_ready_valid_equivalence import (
+        _as_int,
+        _load_json,
+        _operation_options,
+        _resolve_executable,
+        _run,
+    )
+except ImportError:  # pragma: no cover - package-style imports in tests
+    from npu.eval.probe_llm_decoder_pipelined_ranker_architecture import (
+        _ceil_log2_at_least_one,
+        _rank_config,
+        _simulate_variant,
+        _sv_signed_literal,
+        _write_json,
+    )
+    from npu.eval.probe_llm_decoder_producer_ranker_physical_wrapper import (
+        REPO_ROOT,
+        _latest_metrics_row,
+        _portable_metrics_row,
+        _rel,
+        _run_logged,
+    )
+    from npu.eval.probe_llm_decoder_producer_ranker_ready_valid_equivalence import (
+        _as_int,
+        _load_json,
+        _operation_options,
+        _resolve_executable,
+        _run,
+    )
+
+
+JsonDict = dict[str, Any]
+
+
+def _rank_tree_levels(producer_lanes: int, radix: int) -> list[dict[str, int]]:
+    if radix <= 1:
+        raise ValueError("radix must be greater than one")
+    levels: list[dict[str, int]] = []
+    source_count = producer_lanes
+    while source_count > 1:
+        if source_count % radix != 0:
+            raise ValueError(f"producer_lanes={producer_lanes} is not an exact radix-{radix} tree")
+        levels.append(
+            {
+                "level": len(levels),
+                "source_count": source_count,
+                "dest_count": source_count // radix,
+            }
+        )
+        source_count //= radix
+    return levels
+
+
+def _bus_range(index: int, width: int) -> str:
+    return f"{index * width} +: {width}"
+
+
+def _write_rank_tree_wrapper(
+    path: Path,
+    *,
+    top: str,
+    rank_module: str,
+    merge_module: str,
+    producer_lanes: int,
+    radix: int,
+    logit_bits: int,
+    token_id_bits: int,
+) -> None:
+    levels = _rank_tree_levels(producer_lanes, radix)
+    logit_width = producer_lanes * logit_bits
+    rank_index_bits = _ceil_log2_at_least_one(radix)
+    min_logit = -(2 ** (logit_bits - 1))
+    lines = [
+        "`timescale 1ns/1ps",
+        f"module {top}(",
+        "  input clk,",
+        "  input rst_n,",
+        "  input in_valid,",
+        "  output in_ready,",
+        "  input in_last,",
+        f"  input [{token_id_bits - 1}:0] in_base_token_id,",
+        f"  input [{producer_lanes - 1}:0] in_lane_valid,",
+        f"  input signed [{logit_width - 1}:0] in_logits,",
+        "  output out_valid,",
+        "  input out_ready,",
+        "  output out_valid_mask,",
+        f"  output [{token_id_bits - 1}:0] out_token_ids,",
+        f"  output signed [{logit_bits - 1}:0] out_logits,",
+        "  output [31:0] accepted_group_count,",
+        "  output [31:0] producer_stall_cycles,",
+        "  output [31:0] fifo_max_occupancy,",
+        "  output [31:0] final_completion_cycle",
+        ");",
+        f"  wire signed [{logit_width - 1}:0] masked_logits;",
+    ]
+    for lane in range(producer_lanes):
+        lines.append(
+            f"  assign masked_logits[{_bus_range(lane, logit_bits)}] = "
+            f"in_lane_valid[{lane}] ? in_logits[{_bus_range(lane, logit_bits)}] : "
+            f"{_sv_signed_literal(logit_bits, min_logit)};"
+        )
+
+    lines.append("  wire merge_in_ready;")
+    for register_index, level in enumerate(levels, start=1):
+        count = level["dest_count"]
+        lines.extend(
+            [
+                f"  reg stage{register_index}_valid;",
+                f"  reg stage{register_index}_last;",
+                f"  reg signed [{count * logit_bits - 1}:0] stage{register_index}_logits;",
+                f"  reg [{count * token_id_bits - 1}:0] stage{register_index}_token_ids;",
+            ]
+        )
+
+    final_stage = len(levels)
+    lines.append(f"  wire stage{final_stage}_ready = !stage{final_stage}_valid || merge_in_ready;")
+    for register_index in range(final_stage - 1, 0, -1):
+        lines.append(
+            f"  wire stage{register_index}_ready = !stage{register_index}_valid || stage{register_index + 1}_ready;"
+        )
+    lines.extend(["  assign in_ready = stage1_ready;", ""])
+
+    for level in levels:
+        level_index = level["level"]
+        source_count = level["source_count"]
+        dest_count = level["dest_count"]
+        source_prefix = "masked" if level_index == 0 else f"stage{level_index}"
+        dest_prefix = f"level{level_index}"
+        lines.extend(
+            [
+                f"  wire signed [{dest_count * logit_bits - 1}:0] {dest_prefix}_logits;",
+                f"  reg [{dest_count * token_id_bits - 1}:0] {dest_prefix}_token_ids;",
+            ]
+        )
+        for group in range(dest_count):
+            source_base = group * radix
+            source_logit_bus = (
+                "masked_logits"
+                if level_index == 0
+                else f"stage{level_index}_logits"
+            )
+            source_token_bus = "" if level_index == 0 else f"stage{level_index}_token_ids"
+            lines.extend(
+                [
+                    f"  wire [{rank_index_bits - 1}:0] {dest_prefix}_index_{group};",
+                    f"  {rank_module} rank_l{level_index}_g{group} (",
+                    f"    .logits({source_logit_bus}[{source_base * logit_bits} +: {radix * logit_bits}]),",
+                    f"    .top_indices({dest_prefix}_index_{group}),",
+                    f"    .top_logits({dest_prefix}_logits[{_bus_range(group, logit_bits)}])",
+                    "  );",
+                    "  always @* begin",
+                ]
+            )
+            lines.append(f"    case ({dest_prefix}_index_{group})")
+            for choice in range(radix):
+                if level_index == 0:
+                    token_expr = f"in_base_token_id + {token_id_bits}'d{source_base + choice}"
+                else:
+                    token_expr = f"{source_token_bus}[{_bus_range(source_base + choice, token_id_bits)}]"
+                lines.append(
+                    f"      {rank_index_bits}'d{choice}: {dest_prefix}_token_ids[{_bus_range(group, token_id_bits)}] = {token_expr};"
+                )
+            fallback = (
+                f"in_base_token_id + {token_id_bits}'d{source_base}"
+                if level_index == 0
+                else f"{source_token_bus}[{_bus_range(source_base, token_id_bits)}]"
+            )
+            lines.extend(
+                [
+                    f"      default: {dest_prefix}_token_ids[{_bus_range(group, token_id_bits)}] = {fallback};",
+                    "    endcase",
+                    "  end",
+                ]
+            )
+
+        source_valid = "in_valid" if level_index == 0 else f"stage{level_index}_valid"
+        source_last = "in_last" if level_index == 0 else f"stage{level_index}_last"
+        dest_register = level_index + 1
+        dest_ready = f"stage{dest_register}_ready"
+        lines.extend(
+            [
+                f"  always @(posedge clk or negedge rst_n) begin",
+                "    if (!rst_n) begin",
+                f"      stage{dest_register}_valid <= 1'b0;",
+                f"      stage{dest_register}_last <= 1'b0;",
+                f"      stage{dest_register}_logits <= '0;",
+                f"      stage{dest_register}_token_ids <= '0;",
+                f"    end else if ({dest_ready}) begin",
+                f"      stage{dest_register}_valid <= {source_valid};",
+                f"      stage{dest_register}_last <= {source_last};",
+                f"      stage{dest_register}_logits <= {dest_prefix}_logits;",
+                f"      stage{dest_register}_token_ids <= {dest_prefix}_token_ids;",
+                "    end",
+                "  end",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            f"  {merge_module} merger (",
+            "    .clk(clk),",
+            "    .rst_n(rst_n),",
+            f"    .in_valid(stage{final_stage}_valid),",
+            "    .in_ready(merge_in_ready),",
+            f"    .in_last(stage{final_stage}_last),",
+            "    .in_valid_mask(1'b1),",
+            f"    .in_token_ids(stage{final_stage}_token_ids[0 +: {token_id_bits}]),",
+            f"    .in_logits(stage{final_stage}_logits[0 +: {logit_bits}]),",
+            "    .out_valid(out_valid),",
+            "    .out_ready(out_ready),",
+            "    .out_valid_mask(out_valid_mask),",
+            "    .out_token_ids(out_token_ids),",
+            "    .out_logits(out_logits),",
+            "    .accepted_group_count(accepted_group_count),",
+            "    .producer_stall_cycles(producer_stall_cycles),",
+            "    .fifo_max_occupancy(fifo_max_occupancy),",
+            "    .final_completion_cycle(final_completion_cycle)",
+            "  );",
+            "endmodule",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _prepare_variant(
+    *,
+    rtlgen_binary: str,
+    merge_config: Path,
+    design_root: Path,
+    radix: int,
+    producer_lanes: int,
+    logit_bits: int,
+    token_id_bits: int,
+) -> JsonDict:
+    levels = _rank_tree_levels(producer_lanes, radix)
+    top = f"decoder_r64_k1_ranktree_radix{radix}_pipe{len(levels)}_wrapper"
+    design_dir = design_root / top
+    verilog_dir = design_dir / "verilog"
+    config_dir = design_dir / "generated_configs"
+    verilog_dir.mkdir(parents=True, exist_ok=True)
+    for old in verilog_dir.glob("*.v"):
+        old.unlink()
+
+    rank_config = config_dir / f"config_logit_rank_r{radix}_l{logit_bits}_k1.json"
+    _write_json(rank_config, _rank_config(radix, logit_bits))
+    rank_cmd = _run([rtlgen_binary, str(rank_config.resolve())], cwd=verilog_dir)
+    merge_cmd = _run([rtlgen_binary, str(merge_config.resolve())], cwd=verilog_dir)
+    if rank_cmd.returncode == 0 and merge_cmd.returncode == 0:
+        _write_rank_tree_wrapper(
+            verilog_dir / f"{top}.v",
+            top=top,
+            rank_module=f"logit_rank_r{radix}_l{logit_bits}_k1",
+            merge_module="candidate_stream_merge_fifo_k1_l16_t16_d16",
+            producer_lanes=producer_lanes,
+            radix=radix,
+            logit_bits=logit_bits,
+            token_id_bits=token_id_bits,
+        )
+
+    manifest = {
+        "version": 0.1,
+        "top": top,
+        "producer_lanes": producer_lanes,
+        "rank_tree_radix": radix,
+        "rank_tree_levels": levels,
+        "pipeline_register_cuts": ["after_each_rank_level"],
+        "ii_goal": 1,
+        "logit_bits": logit_bits,
+        "token_id_bits": token_id_bits,
+        "generated_configs": [_rel(rank_config)],
+    }
+    _write_json(design_dir / f"config_{top}.json", manifest)
+    return {
+        "top": top,
+        "design_dir": _rel(design_dir),
+        "verilog_dir": _rel(verilog_dir),
+        "radix": radix,
+        "pipeline_stages": len(levels),
+        "levels": levels,
+        "status": "ok" if rank_cmd.returncode == 0 and merge_cmd.returncode == 0 else "rtlgen_failed",
+        "returncodes": {
+            "rank": rank_cmd.returncode,
+            "merge": merge_cmd.returncode,
+        },
+        "generated_verilog": sorted(_rel(path) for path in verilog_dir.glob("*.v")),
+        "config_manifest": _rel(design_dir / f"config_{top}.json"),
+    }
+
+
+def _run_physical_variant(
+    variant: JsonDict,
+    *,
+    sweep: str,
+    platform: str,
+    make_target: str,
+    timeout_seconds: int,
+    stall_timeout_seconds: int,
+) -> tuple[JsonDict, JsonDict | None]:
+    top = str(variant["top"])
+    log_dir = REPO_ROOT / "control_plane/runtime_logs/decoder_rank_tree_architecture"
+    cmd = [
+        "python3",
+        "npu/synth/run_block_sweep.py",
+        "--design_dir",
+        str(variant["design_dir"]),
+        "--platform",
+        platform,
+        "--top",
+        top,
+        "--sweep",
+        sweep,
+        "--make_target",
+        make_target,
+        "--out_root",
+        "runs/designs/activations",
+        "--force_copy",
+    ]
+    synthesis = _run_logged(
+        cmd,
+        cwd=REPO_ROOT,
+        log_path=log_dir / f"{top}_{make_target}.log",
+        timeout_seconds=timeout_seconds,
+        stall_timeout_seconds=stall_timeout_seconds,
+    )
+    metrics = _portable_metrics_row(_latest_metrics_row(REPO_ROOT / str(variant["design_dir"]) / "metrics.csv"))
+    return synthesis, metrics
+
+
+def build_report(*, variants: list[JsonDict], sweep: str, make_target: str) -> JsonDict:
+    measured = [row for row in variants if (row.get("metrics_row") or {}).get("status") == "ok"]
+
+    def metric(row: JsonDict, key: str) -> float:
+        return float((row.get("metrics_row") or {}).get(key, "inf"))
+
+    best_timing = min(measured, key=lambda row: metric(row, "critical_path_ns"), default=None)
+    return {
+        "version": 0.1,
+        "model": "decoder_rank_tree_architecture_v1",
+        "target": {
+            "producer_lanes": 64,
+            "top_k": 1,
+            "pipeline_register_cuts": ["after_each_rank_level"],
+            "explored_radices": [row["radix"] for row in variants],
+            "sweep": sweep,
+            "make_target": make_target,
+        },
+        "variants": variants,
+        "best_timing_variant": (
+            {
+                "top": best_timing.get("top"),
+                "radix": best_timing.get("radix"),
+                "pipeline_stages": best_timing.get("pipeline_stages"),
+                "critical_path_ns": (best_timing.get("metrics_row") or {}).get("critical_path_ns"),
+                "die_area": (best_timing.get("metrics_row") or {}).get("die_area"),
+                "total_power_mw": (best_timing.get("metrics_row") or {}).get("total_power_mw"),
+            }
+            if best_timing
+            else None
+        ),
+        "decision": {
+            "decision": "rank_tree_architecture_measured" if measured else "rank_tree_architecture_blocked",
+            "next_step": (
+                "Use the best radix as the r64 ranker anchor, then test producer-coupled timing and r128 scaling."
+                if measured
+                else "Fix RTL generation, simulation, or physical constraints before using rank-tree costs."
+            ),
+        },
+        "assumptions": [
+            "All variants preserve a 64-logit tile and top-k=1 stream contract.",
+            "Every rank level is separated by a ready-valid register cut, so added latency is tolerated while II=1 is preserved.",
+            "The radix controls ranker fan-in and pipeline depth: radix 8 reproduces the prior two-stage 8x8 shape, radix 4 and 2 test deeper trees.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Rank Tree Architecture",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- next_step: {payload['decision']['next_step']}",
+        "",
+        "## Variants",
+        "",
+        "| radix | stages | materialized | sim | synth | metrics | critical_path_ns | die_area | power_mw |",
+        "|---:|---:|---|---|---|---|---:|---:|---:|",
+    ]
+    for row in payload["variants"]:
+        metrics = row.get("metrics_row") or {}
+        lines.append(
+            "| {radix} | {stages} | `{mat}` | `{sim}` | `{syn}` | `{met}` | {cp} | {area} | {power} |".format(
+                radix=row.get("radix"),
+                stages=row.get("pipeline_stages"),
+                mat=row.get("status"),
+                sim=(row.get("simulation") or {}).get("status"),
+                syn=(row.get("synthesis") or {}).get("status"),
+                met=metrics.get("status"),
+                cp=metrics.get("critical_path_ns", ""),
+                area=metrics.get("die_area", ""),
+                power=metrics.get("total_power_mw", ""),
+            )
+        )
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Explore deeper pipelined r64/k1 rank-tree architecture variants")
+    ap.add_argument("--merge-config", required=True)
+    ap.add_argument("--ready-valid-equivalence")
+    ap.add_argument("--rtlgen-binary", default="build/rtlgen")
+    ap.add_argument("--design-root", default="runs/designs/activations")
+    ap.add_argument("--radices", default="2,4,8")
+    ap.add_argument("--sweep", required=True)
+    ap.add_argument("--platform", default="nangate45")
+    ap.add_argument("--make-target", default="3_3_place_gp")
+    ap.add_argument("--timeout-seconds", type=int, default=1800)
+    ap.add_argument("--stall-timeout-seconds", type=int, default=900)
+    ap.add_argument("--skip-physical", action="store_true")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    rtlgen_binary = _resolve_executable(args.rtlgen_binary)
+    radices = [int(x) for x in args.radices.split(",") if x.strip()]
+    if rtlgen_binary is None:
+        variants = [
+            {
+                "status": "rtlgen_binary_missing",
+                "requested": args.rtlgen_binary,
+                "radix": radix,
+                "pipeline_stages": len(_rank_tree_levels(64, radix)),
+            }
+            for radix in radices
+        ]
+    else:
+        merge_config = Path(args.merge_config)
+        merge_opts = _operation_options(_load_json(merge_config))
+        producer_lanes = 64
+        logit_bits = _as_int(merge_opts.get("logit_bits"), 16)
+        token_id_bits = _as_int(merge_opts.get("token_id_bits"), 16)
+        variants = []
+        for radix in radices:
+            variant = _prepare_variant(
+                rtlgen_binary=rtlgen_binary,
+                merge_config=merge_config,
+                design_root=REPO_ROOT / args.design_root,
+                radix=radix,
+                producer_lanes=producer_lanes,
+                logit_bits=logit_bits,
+                token_id_bits=token_id_bits,
+            )
+            if variant["status"] == "ok":
+                variant["simulation"] = _simulate_variant(
+                    variant,
+                    producer_lanes=producer_lanes,
+                    logit_bits=logit_bits,
+                    token_id_bits=token_id_bits,
+                )
+            if (
+                variant["status"] == "ok"
+                and (variant.get("simulation") or {}).get("status") == "ok"
+                and not args.skip_physical
+            ):
+                synthesis, metrics = _run_physical_variant(
+                    variant,
+                    sweep=args.sweep,
+                    platform=args.platform,
+                    make_target=args.make_target,
+                    timeout_seconds=args.timeout_seconds,
+                    stall_timeout_seconds=args.stall_timeout_seconds,
+                )
+                variant["synthesis"] = synthesis
+                variant["metrics_row"] = metrics
+            variants.append(variant)
+
+    payload = build_report(variants=variants, sweep=args.sweep, make_target=args.make_target)
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/decoder_rank_tree_architecture/sweeps/nangate45_r64_ranktree.json
+++ b/runs/campaigns/npu/decoder_rank_tree_architecture/sweeps/nangate45_r64_ranktree.json
@@ -1,0 +1,29 @@
+{
+  "flow_params": {
+    "TAG": [
+      "decoder_r64_k1_ranktree"
+    ],
+    "FLOW_VARIANT": [
+      "decoder_r64_k1_ranktree"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 900 900"
+    ],
+    "CORE_AREA": [
+      "40 40 860 860"
+    ],
+    "PLACE_DENSITY": [
+      0.36
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "candidate_stream_merge_fifo_k1_l16_t16_d16"
+    ]
+  },
+  "tag_prefix": "decoder_r64_k1_ranktree"
+}

--- a/tests/test_llm_decoder_rank_tree_architecture.py
+++ b/tests/test_llm_decoder_rank_tree_architecture.py
@@ -1,0 +1,54 @@
+from npu.eval.probe_llm_decoder_rank_tree_architecture import build_report
+
+
+def test_rank_tree_report_selects_best_timing_variant() -> None:
+    report = build_report(
+        variants=[
+            {
+                "top": "decoder_r64_k1_ranktree_radix2_pipe6_wrapper",
+                "radix": 2,
+                "pipeline_stages": 6,
+                "metrics_row": {
+                    "status": "ok",
+                    "critical_path_ns": "5.2",
+                    "die_area": "810000",
+                    "total_power_mw": "0.7",
+                },
+            },
+            {
+                "top": "decoder_r64_k1_ranktree_radix4_pipe3_wrapper",
+                "radix": 4,
+                "pipeline_stages": 3,
+                "metrics_row": {
+                    "status": "ok",
+                    "critical_path_ns": "4.8",
+                    "die_area": "810000",
+                    "total_power_mw": "0.5",
+                },
+            },
+        ],
+        sweep="runs/campaigns/npu/decoder_rank_tree_architecture/sweeps/nangate45_r64_ranktree.json",
+        make_target="3_3_place_gp",
+    )
+
+    assert report["decision"]["decision"] == "rank_tree_architecture_measured"
+    assert report["best_timing_variant"]["radix"] == 4
+    assert report["best_timing_variant"]["critical_path_ns"] == "4.8"
+
+
+def test_rank_tree_report_blocks_without_metrics() -> None:
+    report = build_report(
+        variants=[
+            {
+                "top": "decoder_r64_k1_ranktree_radix4_pipe3_wrapper",
+                "radix": 4,
+                "pipeline_stages": 3,
+                "metrics_row": {"status": "failed"},
+            }
+        ],
+        sweep="sweep.json",
+        make_target="3_3_place_gp",
+    )
+
+    assert report["decision"]["decision"] == "rank_tree_architecture_blocked"
+    assert report["best_timing_variant"] is None


### PR DESCRIPTION
## Summary
- add `probe_llm_decoder_rank_tree_architecture.py` for r64/k1 radix 2, 4, and 8 rank trees
- register every rank level while preserving the existing ready-valid merge contract
- add L2 task-generator wiring, proposal metadata, sweep config, and focused tests

## Why
The two-stage ranker reduced the measured r64/k1 wrapper from ~32 ns to ~6.6 ns, but it still leaves radix-8 rank fan-in in the critical path. This PR prepares the next evaluator job to measure whether deeper radix-4 or radix-2 trees improve timing enough to justify extra latency/registers.

## Validation
- `python3 -m py_compile npu/eval/probe_llm_decoder_rank_tree_architecture.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_rank_tree_architecture.py tests/test_llm_decoder_pipelined_ranker_architecture.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'rank_tree_architecture or pipelined_ranker_architecture'`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
- skip-physical RTL smoke for radices 2, 4, and 8; all passed ready-valid simulation
