### PR TITLE
[codex] Add decoder serial ranker architecture probe

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2670,6 +2670,79 @@ def _decoder_rank_tree_architecture_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_serial_ranker_architecture_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_serial_ranker_architecture__{item_id}.json"
+    report = f"{base}/decoder_serial_ranker_architecture__{item_id}.md"
+    merge_config = (
+        "runs/designs/activations/candidate_stream_merge_fifo_k1_l16_t16_d16_wrapper/"
+        "config_candidate_stream_merge_fifo_k1_l16_t16_d16.json"
+    )
+    ready_valid_equivalence = (
+        f"{base}/decoder_producer_ranker_ready_valid_equivalence__"
+        "l2_decoder_producer_ranker_ready_valid_equivalence_v1_r2.json"
+    )
+    rank_tree = (
+        f"{base}/decoder_rank_tree_architecture__"
+        "l2_decoder_rank_tree_architecture_v1.json"
+    )
+    sweep = "runs/campaigns/npu/decoder_serial_ranker_architecture/sweeps/nangate45_r64_serial.json"
+    design_root = "runs/designs/activations"
+    lane_counts = [1, 2, 4, 8, 16]
+    tops = [f"decoder_r64_k1_serial_rank_lpc{lanes}_wrapper" for lanes in lane_counts]
+    return {
+        "inputs": {
+            "serial_ranker_architecture_out": out,
+            "serial_ranker_architecture_report": report,
+            "serial_ranker_architecture_sweep": sweep,
+            "serial_ranker_architecture_make_target": "3_3_place_gp",
+            "serial_ranker_architecture_lanes_per_cycle": lane_counts,
+            "candidate_merge_config": merge_config,
+            "ready_valid_equivalence": ready_valid_equivalence,
+            "rank_tree_architecture": rank_tree,
+            "serial_ranker_architecture_scope": (
+                "Explore area-conservative r64/k1 running-best rankers after the fully parallel "
+                "rank-tree sweep. Variants consume 1, 2, 4, 8, or 16 logits per cycle, "
+                "backpressure during tile scan, and preserve deterministic top-1 ready-valid output."
+            ),
+        },
+        "commands": [
+            {
+                "name": "build_generator",
+                "run": "export PATH=/oss-cad-suite/bin:$PATH && cmake -S . -B build && cmake --build build --target rtlgen",
+            },
+            {
+                "name": "probe_decoder_serial_ranker_architecture",
+                "run": (
+                    "python3 npu/eval/probe_llm_decoder_serial_ranker_architecture.py "
+                    f"--merge-config {merge_config} "
+                    f"--ready-valid-equivalence {ready_valid_equivalence} "
+                    f"--design-root {design_root} "
+                    "--lanes-per-cycle 1,2,4,8,16 "
+                    f"--sweep {sweep} "
+                    "--platform nangate45 "
+                    "--make-target 3_3_place_gp "
+                    "--timeout-seconds 1800 "
+                    "--stall-timeout-seconds 900 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+            {
+                "name": "build_runs_index",
+                "run": "python3 scripts/build_runs_index.py",
+            },
+        ],
+        "expected_outputs": [
+            out,
+            report,
+            "runs/index.csv",
+            *[f"{design_root}/{top}/metrics.csv" for top in tops],
+            *[f"{design_root}/{top}/verilog/{top}.v" for top in tops],
+        ],
+    }
+
+
 def _decoder_output_projection_producer_synth_boundary_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_producer_synth_boundary__{item_id}.json"
@@ -3407,6 +3480,7 @@ def _build_payload(
         "decoder_producer_ranker_physical_wrapper",
         "decoder_pipelined_ranker_architecture",
         "decoder_rank_tree_architecture",
+        "decoder_serial_ranker_architecture",
         "decoder_output_projection_producer_pnr_feasibility",
         "decoder_output_projection_producer_synth_boundary",
         "decoder_output_projection_producer_isolated_synth",
@@ -3441,6 +3515,8 @@ def _build_payload(
             decoder_evidence = _decoder_pipelined_ranker_architecture_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_rank_tree_architecture":
             decoder_evidence = _decoder_rank_tree_architecture_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_serial_ranker_architecture":
+            decoder_evidence = _decoder_serial_ranker_architecture_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_memory":
             decoder_evidence = _decoder_attention_kv_memory_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_stage_breakdown":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2233,6 +2233,56 @@ def test_generate_l2_campaign_task_adds_decoder_rank_tree_architecture() -> None
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_serial_ranker_architecture() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_serial_ranker_architecture_v1",
+                    proposal_id="prop_l2_decoder_serial_ranker_architecture_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_serial_ranker_architecture_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_serial_ranker_architecture",
+                    expected_direction="iterate",
+                    comparison_role="ranker_pipeline_architecture",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:3]] == [
+                "build_generator",
+                "probe_decoder_serial_ranker_architecture",
+                "build_runs_index",
+            ]
+            run = work_item.command_manifest[1]["run"]
+            assert "probe_llm_decoder_serial_ranker_architecture.py" in run
+            assert "--lanes-per-cycle 1,2,4,8,16" in run
+            assert "decoder_serial_ranker_architecture" in decoder_inputs[
+                "serial_ranker_architecture_sweep"
+            ]
+            assert decoder_inputs["rank_tree_architecture"].endswith(
+                "l2_decoder_rank_tree_architecture_v1.json"
+            )
+            assert "runs/index.csv" in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_serial_ranker_architecture",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_producer_synth_boundary_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_serial_ranker_architecture_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_serial_ranker_architecture_v1/proposal.json
@@ -1,0 +1,73 @@
+{
+  "proposal_id": "prop_l2_decoder_serial_ranker_architecture_v1",
+  "created_utc": "2026-05-14T09:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_serial_ranker_architecture",
+  "title": "Decoder serial ranker architecture space",
+  "hypothesis": "The fully parallel r64/k1 rank trees improved timing but still assume the ranker consumes all 64 logits at once. For larger LLMs, output projection and memory traffic are likely to dominate service time, so a serial or partially-serial running-best ranker may reduce area and power while staying off the critical throughput path.",
+  "direct_comparison": {
+    "primary_question": "How much ranker area/power can be saved by scanning fewer logits per cycle before ranker service time exceeds producer cadence?",
+    "include": [
+      "lanes_per_cycle 1, 2, 4, 8, and 16 over the same 64-logit tile",
+      "running-best top-1 with deterministic token tie-break",
+      "ready-valid simulation against the deterministic decoder ranker reference",
+      "bounded nangate45 physical sweep through 3_3_place_gp",
+      "comparison against the fully parallel radix-2/radix-4 rank-tree anchors"
+    ],
+    "exclude": [
+      "full producer coupling",
+      "r128 or wider ranker tiles",
+      "shared SRAM or NoC arbitration",
+      "quality or probability recovery"
+    ]
+  },
+  "expected_benefit": [
+    "adds the area-conservative side of the ranker design space",
+    "separates tile service time from ranker critical path",
+    "creates candidates for producer-coupled evaluation where producer cadence is slower than one full tile per cycle"
+  ],
+  "risks": [
+    "the wrapper intentionally backpressures while scanning a tile and may be unsuitable for a producer that emits one full 64-logit tile every cycle",
+    "the current standalone macro-style wrapper does not yet model producer overlap or buffering",
+    "reported die_area remains fixed by the macro floorplan, so placed cell area from logs may be needed for nuanced area comparison"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_serial_ranker_architecture_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure r64/k1 serial running-best ranker wrappers with lanes_per_cycle 1, 2, 4, 8, and 16.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_serial_ranker_architecture",
+      "cost_class": "medium",
+      "comparison_role": "ranker_pipeline_architecture",
+      "paired_baseline_item_id": "l2_decoder_rank_tree_architecture_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_rank_tree_architecture_v1",
+        "l2_decoder_pipelined_ranker_architecture_v1",
+        "l2_decoder_producer_ranker_ready_valid_equivalence_v1_r2",
+        "l1_decoder_logit_rank_datapath_v1_r2",
+        "l1_decoder_candidate_stream_merge_fifo_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If a serial point has much lower power/area and its tile scan cycles fit under the producer cadence, promote it to producer-coupled timing. If all serial points are dominated, keep radix-4/radix-2 rank trees for coupling."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_rank_tree_architecture__l2_decoder_rank_tree_architecture_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_pipelined_ranker_architecture__l2_decoder_pipelined_ranker_architecture_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_producer_ranker_ready_valid_equivalence__l2_decoder_producer_ranker_ready_valid_equivalence_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_llm_decoder_serial_ranker_architecture.py",
+    "runs/campaigns/npu/decoder_serial_ranker_architecture/sweeps/nangate45_r64_serial.json",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "tests/test_llm_decoder_serial_ranker_architecture.py"
+  ]
+}

--- a/npu/eval/probe_llm_decoder_serial_ranker_architecture.py
+++ b/npu/eval/probe_llm_decoder_serial_ranker_architecture.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Explore serial/partially-serial r64/k1 decoder ranker wrappers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    from probe_llm_decoder_pipelined_ranker_architecture import (
+        _ceil_log2_at_least_one,
+        _rank_config,
+        _simulate_variant,
+        _sv_signed_literal,
+        _write_json,
+    )
+    from probe_llm_decoder_producer_ranker_physical_wrapper import (
+        REPO_ROOT,
+        _latest_metrics_row,
+        _portable_metrics_row,
+        _rel,
+        _run_logged,
+    )
+    from probe_llm_decoder_producer_ranker_ready_valid_equivalence import (
+        _as_int,
+        _load_json,
+        _operation_options,
+        _resolve_executable,
+        _run,
+    )
+except ImportError:  # pragma: no cover - package-style imports in tests
+    from npu.eval.probe_llm_decoder_pipelined_ranker_architecture import (
+        _ceil_log2_at_least_one,
+        _rank_config,
+        _simulate_variant,
+        _sv_signed_literal,
+        _write_json,
+    )
+    from npu.eval.probe_llm_decoder_producer_ranker_physical_wrapper import (
+        REPO_ROOT,
+        _latest_metrics_row,
+        _portable_metrics_row,
+        _rel,
+        _run_logged,
+    )
+    from npu.eval.probe_llm_decoder_producer_ranker_ready_valid_equivalence import (
+        _as_int,
+        _load_json,
+        _operation_options,
+        _resolve_executable,
+        _run,
+    )
+
+
+JsonDict = dict[str, Any]
+
+
+def _bus_range(index: int, width: int) -> str:
+    return f"{index * width} +: {width}"
+
+
+def _write_serial_wrapper(
+    path: Path,
+    *,
+    top: str,
+    rank_module: str,
+    merge_module: str,
+    producer_lanes: int,
+    lanes_per_cycle: int,
+    logit_bits: int,
+    token_id_bits: int,
+) -> None:
+    chunks = producer_lanes // lanes_per_cycle
+    if chunks * lanes_per_cycle != producer_lanes:
+        raise ValueError("lanes_per_cycle must divide producer_lanes")
+    logit_width = producer_lanes * logit_bits
+    chunk_logit_width = lanes_per_cycle * logit_bits
+    chunk_index_bits = _ceil_log2_at_least_one(chunks)
+    local_index_bits = _ceil_log2_at_least_one(lanes_per_cycle)
+    min_logit = -(2 ** (logit_bits - 1))
+    lines = [
+        "`timescale 1ns/1ps",
+        f"module {top}(",
+        "  input clk,",
+        "  input rst_n,",
+        "  input in_valid,",
+        "  output in_ready,",
+        "  input in_last,",
+        f"  input [{token_id_bits - 1}:0] in_base_token_id,",
+        f"  input [{producer_lanes - 1}:0] in_lane_valid,",
+        f"  input signed [{logit_width - 1}:0] in_logits,",
+        "  output out_valid,",
+        "  input out_ready,",
+        "  output out_valid_mask,",
+        f"  output [{token_id_bits - 1}:0] out_token_ids,",
+        f"  output signed [{logit_bits - 1}:0] out_logits,",
+        "  output [31:0] accepted_group_count,",
+        "  output [31:0] producer_stall_cycles,",
+        "  output [31:0] fifo_max_occupancy,",
+        "  output [31:0] final_completion_cycle",
+        ");",
+        f"  wire signed [{logit_width - 1}:0] masked_logits;",
+    ]
+    for lane in range(producer_lanes):
+        lines.append(
+            f"  assign masked_logits[{_bus_range(lane, logit_bits)}] = "
+            f"in_lane_valid[{lane}] ? in_logits[{_bus_range(lane, logit_bits)}] : "
+            f"{_sv_signed_literal(logit_bits, min_logit)};"
+        )
+
+    lines.extend(
+        [
+            "  localparam STATE_IDLE = 2'd0;",
+            "  localparam STATE_SCAN = 2'd1;",
+            "  localparam STATE_EMIT = 2'd2;",
+            "  reg [1:0] state;",
+            f"  reg signed [{logit_width - 1}:0] tile_logits;",
+            f"  reg [{token_id_bits - 1}:0] tile_base_token_id;",
+            "  reg tile_last;",
+            f"  reg [{chunk_index_bits - 1}:0] chunk_index;",
+            "  reg best_valid;",
+            f"  reg signed [{logit_bits - 1}:0] best_logit;",
+            f"  reg [{token_id_bits - 1}:0] best_token_id;",
+            f"  reg signed [{chunk_logit_width - 1}:0] chunk_logits;",
+            f"  reg [{token_id_bits - 1}:0] chunk_base_token_id;",
+            "  wire merge_in_ready;",
+            "  wire accept_input = in_valid && in_ready;",
+            "  wire emit_done = (state == STATE_EMIT) && merge_in_ready;",
+            "  assign in_ready = (state == STATE_IDLE);",
+            "",
+            "  always @* begin",
+            "    chunk_logits = '0;",
+            "    chunk_base_token_id = tile_base_token_id;",
+            "    case (chunk_index)",
+        ]
+    )
+    for chunk in range(chunks):
+        lane_base = chunk * lanes_per_cycle
+        lines.extend(
+            [
+                f"      {chunk_index_bits}'d{chunk}: begin",
+                f"        chunk_logits = tile_logits[{lane_base * logit_bits} +: {chunk_logit_width}];",
+                f"        chunk_base_token_id = tile_base_token_id + {token_id_bits}'d{lane_base};",
+                "      end",
+            ]
+        )
+    lines.extend(
+        [
+            "      default: begin",
+            f"        chunk_logits = tile_logits[0 +: {chunk_logit_width}];",
+            "        chunk_base_token_id = tile_base_token_id;",
+            "      end",
+            "    endcase",
+            "  end",
+            f"  wire [{local_index_bits - 1}:0] chunk_top_index;",
+            f"  wire signed [{logit_bits - 1}:0] chunk_top_logit;",
+            f"  {rank_module} chunk_rank (",
+            "    .logits(chunk_logits),",
+            "    .top_indices(chunk_top_index),",
+            "    .top_logits(chunk_top_logit)",
+            "  );",
+            f"  wire [{token_id_bits - 1}:0] chunk_top_token_id = "
+            f"chunk_base_token_id + {{ {token_id_bits - local_index_bits}'d0, chunk_top_index }};",
+            "  wire chunk_beats_best = !best_valid || (chunk_top_logit > best_logit) || "
+            "((chunk_top_logit == best_logit) && (chunk_top_token_id < best_token_id));",
+            "",
+            "  always @(posedge clk or negedge rst_n) begin",
+            "    if (!rst_n) begin",
+            "      state <= STATE_IDLE;",
+            "      tile_logits <= '0;",
+            "      tile_base_token_id <= '0;",
+            "      tile_last <= 1'b0;",
+            "      chunk_index <= '0;",
+            "      best_valid <= 1'b0;",
+            "      best_logit <= '0;",
+            "      best_token_id <= '0;",
+            "    end else begin",
+            "      case (state)",
+            "        STATE_IDLE: begin",
+            "          if (accept_input) begin",
+            "            tile_logits <= masked_logits;",
+            "            tile_base_token_id <= in_base_token_id;",
+            "            tile_last <= in_last;",
+            "            chunk_index <= '0;",
+            "            best_valid <= 1'b0;",
+            "            best_logit <= '0;",
+            "            best_token_id <= '0;",
+            "            state <= STATE_SCAN;",
+            "          end",
+            "        end",
+            "        STATE_SCAN: begin",
+            "          if (chunk_beats_best) begin",
+            "            best_valid <= 1'b1;",
+            "            best_logit <= chunk_top_logit;",
+            "            best_token_id <= chunk_top_token_id;",
+            "          end",
+            f"          if (chunk_index == {chunk_index_bits}'d{chunks - 1}) begin",
+            "            state <= STATE_EMIT;",
+            "          end else begin",
+            "            chunk_index <= chunk_index + 1'b1;",
+            "          end",
+            "        end",
+            "        STATE_EMIT: begin",
+            "          if (emit_done) begin",
+            "            state <= STATE_IDLE;",
+            "          end",
+            "        end",
+            "        default: state <= STATE_IDLE;",
+            "      endcase",
+            "    end",
+            "  end",
+            f"  {merge_module} merger (",
+            "    .clk(clk),",
+            "    .rst_n(rst_n),",
+            "    .in_valid(state == STATE_EMIT),",
+            "    .in_ready(merge_in_ready),",
+            "    .in_last(tile_last),",
+            "    .in_valid_mask(1'b1),",
+            "    .in_token_ids(best_token_id),",
+            "    .in_logits(best_logit),",
+            "    .out_valid(out_valid),",
+            "    .out_ready(out_ready),",
+            "    .out_valid_mask(out_valid_mask),",
+            "    .out_token_ids(out_token_ids),",
+            "    .out_logits(out_logits),",
+            "    .accepted_group_count(accepted_group_count),",
+            "    .producer_stall_cycles(producer_stall_cycles),",
+            "    .fifo_max_occupancy(fifo_max_occupancy),",
+            "    .final_completion_cycle(final_completion_cycle)",
+            "  );",
+            "endmodule",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _prepare_variant(
+    *,
+    rtlgen_binary: str,
+    merge_config: Path,
+    design_root: Path,
+    lanes_per_cycle: int,
+    producer_lanes: int,
+    logit_bits: int,
+    token_id_bits: int,
+) -> JsonDict:
+    top = f"decoder_r64_k1_serial_rank_lpc{lanes_per_cycle}_wrapper"
+    design_dir = design_root / top
+    verilog_dir = design_dir / "verilog"
+    config_dir = design_dir / "generated_configs"
+    verilog_dir.mkdir(parents=True, exist_ok=True)
+    for old in verilog_dir.glob("*.v"):
+        old.unlink()
+    rank_config = config_dir / f"config_logit_rank_r{lanes_per_cycle}_l{logit_bits}_k1.json"
+    _write_json(rank_config, _rank_config(lanes_per_cycle, logit_bits))
+    rank_cmd = _run([rtlgen_binary, str(rank_config.resolve())], cwd=verilog_dir)
+    merge_cmd = _run([rtlgen_binary, str(merge_config.resolve())], cwd=verilog_dir)
+    if rank_cmd.returncode == 0 and merge_cmd.returncode == 0:
+        _write_serial_wrapper(
+            verilog_dir / f"{top}.v",
+            top=top,
+            rank_module=f"logit_rank_r{lanes_per_cycle}_l{logit_bits}_k1",
+            merge_module="candidate_stream_merge_fifo_k1_l16_t16_d16",
+            producer_lanes=producer_lanes,
+            lanes_per_cycle=lanes_per_cycle,
+            logit_bits=logit_bits,
+            token_id_bits=token_id_bits,
+        )
+
+    chunks = producer_lanes // lanes_per_cycle
+    manifest = {
+        "version": 0.1,
+        "top": top,
+        "producer_lanes": producer_lanes,
+        "lanes_per_cycle": lanes_per_cycle,
+        "tile_scan_cycles": chunks,
+        "ii_goal_cycles": chunks + 1,
+        "architecture": "serial_running_best",
+        "logit_bits": logit_bits,
+        "token_id_bits": token_id_bits,
+        "generated_configs": [_rel(rank_config)],
+    }
+    _write_json(design_dir / f"config_{top}.json", manifest)
+    return {
+        "top": top,
+        "design_dir": _rel(design_dir),
+        "verilog_dir": _rel(verilog_dir),
+        "lanes_per_cycle": lanes_per_cycle,
+        "tile_scan_cycles": chunks,
+        "ii_goal_cycles": chunks + 1,
+        "status": "ok" if rank_cmd.returncode == 0 and merge_cmd.returncode == 0 else "rtlgen_failed",
+        "returncodes": {"rank": rank_cmd.returncode, "merge": merge_cmd.returncode},
+        "generated_verilog": sorted(_rel(path) for path in verilog_dir.glob("*.v")),
+        "config_manifest": _rel(design_dir / f"config_{top}.json"),
+    }
+
+
+def _run_physical_variant(
+    variant: JsonDict,
+    *,
+    sweep: str,
+    platform: str,
+    make_target: str,
+    timeout_seconds: int,
+    stall_timeout_seconds: int,
+) -> tuple[JsonDict, JsonDict | None]:
+    top = str(variant["top"])
+    log_dir = REPO_ROOT / "control_plane/runtime_logs/decoder_serial_ranker_architecture"
+    cmd = [
+        "python3",
+        "npu/synth/run_block_sweep.py",
+        "--design_dir",
+        str(variant["design_dir"]),
+        "--platform",
+        platform,
+        "--top",
+        top,
+        "--sweep",
+        sweep,
+        "--make_target",
+        make_target,
+        "--out_root",
+        "runs/designs/activations",
+        "--force_copy",
+    ]
+    synthesis = _run_logged(
+        cmd,
+        cwd=REPO_ROOT,
+        log_path=log_dir / f"{top}_{make_target}.log",
+        timeout_seconds=timeout_seconds,
+        stall_timeout_seconds=stall_timeout_seconds,
+    )
+    metrics = _portable_metrics_row(_latest_metrics_row(REPO_ROOT / str(variant["design_dir"]) / "metrics.csv"))
+    return synthesis, metrics
+
+
+def build_report(*, variants: list[JsonDict], sweep: str, make_target: str) -> JsonDict:
+    measured = [row for row in variants if (row.get("metrics_row") or {}).get("status") == "ok"]
+
+    def metric(row: JsonDict, key: str) -> float:
+        return float((row.get("metrics_row") or {}).get(key, "inf"))
+
+    best_area = min(measured, key=lambda row: metric(row, "total_power_mw"), default=None)
+    best_timing = min(measured, key=lambda row: metric(row, "critical_path_ns"), default=None)
+    return {
+        "version": 0.1,
+        "model": "decoder_serial_ranker_architecture_v1",
+        "target": {
+            "producer_lanes": 64,
+            "top_k": 1,
+            "architecture": "serial_running_best",
+            "explored_lanes_per_cycle": [row["lanes_per_cycle"] for row in variants],
+            "sweep": sweep,
+            "make_target": make_target,
+        },
+        "variants": variants,
+        "best_timing_variant": (
+            {
+                "top": best_timing.get("top"),
+                "lanes_per_cycle": best_timing.get("lanes_per_cycle"),
+                "tile_scan_cycles": best_timing.get("tile_scan_cycles"),
+                "critical_path_ns": (best_timing.get("metrics_row") or {}).get("critical_path_ns"),
+                "die_area": (best_timing.get("metrics_row") or {}).get("die_area"),
+                "total_power_mw": (best_timing.get("metrics_row") or {}).get("total_power_mw"),
+            }
+            if best_timing
+            else None
+        ),
+        "lowest_power_variant": (
+            {
+                "top": best_area.get("top"),
+                "lanes_per_cycle": best_area.get("lanes_per_cycle"),
+                "tile_scan_cycles": best_area.get("tile_scan_cycles"),
+                "critical_path_ns": (best_area.get("metrics_row") or {}).get("critical_path_ns"),
+                "die_area": (best_area.get("metrics_row") or {}).get("die_area"),
+                "total_power_mw": (best_area.get("metrics_row") or {}).get("total_power_mw"),
+            }
+            if best_area
+            else None
+        ),
+        "decision": {
+            "decision": "serial_ranker_architecture_measured" if measured else "serial_ranker_architecture_blocked",
+            "next_step": (
+                "Compare serial service time against producer output cadence, then choose a ranker point for producer coupling."
+                if measured
+                else "Fix RTL generation, simulation, or physical constraints before using serial ranker costs."
+            ),
+        },
+        "assumptions": [
+            "All variants preserve a 64-logit tile and top-k=1 stream contract.",
+            "The serial wrapper backpressures the producer while scanning one tile; it is intended for producer cadences slower than one full 64-logit tile per cycle.",
+            "The measured PPA isolates ranker area/timing and must be compared against producer service time before promotion.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Serial Ranker Architecture",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- next_step: {payload['decision']['next_step']}",
+        "",
+        "## Variants",
+        "",
+        "| lanes_per_cycle | scan_cycles | materialized | sim | synth | metrics | critical_path_ns | die_area | power_mw |",
+        "|---:|---:|---|---|---|---|---:|---:|---:|",
+    ]
+    for row in payload["variants"]:
+        metrics = row.get("metrics_row") or {}
+        lines.append(
+            "| {lpc} | {cycles} | `{mat}` | `{sim}` | `{syn}` | `{met}` | {cp} | {area} | {power} |".format(
+                lpc=row.get("lanes_per_cycle"),
+                cycles=row.get("tile_scan_cycles"),
+                mat=row.get("status"),
+                sim=(row.get("simulation") or {}).get("status"),
+                syn=(row.get("synthesis") or {}).get("status"),
+                met=metrics.get("status"),
+                cp=metrics.get("critical_path_ns", ""),
+                area=metrics.get("die_area", ""),
+                power=metrics.get("total_power_mw", ""),
+            )
+        )
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Explore serial r64/k1 ranker architecture variants")
+    ap.add_argument("--merge-config", required=True)
+    ap.add_argument("--ready-valid-equivalence")
+    ap.add_argument("--rtlgen-binary", default="build/rtlgen")
+    ap.add_argument("--design-root", default="runs/designs/activations")
+    ap.add_argument("--lanes-per-cycle", default="1,2,4,8,16")
+    ap.add_argument("--sweep", required=True)
+    ap.add_argument("--platform", default="nangate45")
+    ap.add_argument("--make-target", default="3_3_place_gp")
+    ap.add_argument("--timeout-seconds", type=int, default=1800)
+    ap.add_argument("--stall-timeout-seconds", type=int, default=900)
+    ap.add_argument("--skip-physical", action="store_true")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    rtlgen_binary = _resolve_executable(args.rtlgen_binary)
+    lane_counts = [int(x) for x in args.lanes_per_cycle.split(",") if x.strip()]
+    if rtlgen_binary is None:
+        variants = [
+            {
+                "status": "rtlgen_binary_missing",
+                "requested": args.rtlgen_binary,
+                "lanes_per_cycle": lanes,
+                "tile_scan_cycles": 64 // lanes,
+            }
+            for lanes in lane_counts
+        ]
+    else:
+        merge_config = Path(args.merge_config)
+        merge_opts = _operation_options(_load_json(merge_config))
+        producer_lanes = 64
+        logit_bits = _as_int(merge_opts.get("logit_bits"), 16)
+        token_id_bits = _as_int(merge_opts.get("token_id_bits"), 16)
+        variants = []
+        for lanes in lane_counts:
+            variant = _prepare_variant(
+                rtlgen_binary=rtlgen_binary,
+                merge_config=merge_config,
+                design_root=REPO_ROOT / args.design_root,
+                lanes_per_cycle=lanes,
+                producer_lanes=producer_lanes,
+                logit_bits=logit_bits,
+                token_id_bits=token_id_bits,
+            )
+            if variant["status"] == "ok":
+                variant["simulation"] = _simulate_variant(
+                    variant,
+                    producer_lanes=producer_lanes,
+                    logit_bits=logit_bits,
+                    token_id_bits=token_id_bits,
+                )
+            if (
+                variant["status"] == "ok"
+                and (variant.get("simulation") or {}).get("status") == "ok"
+                and not args.skip_physical
+            ):
+                synthesis, metrics = _run_physical_variant(
+                    variant,
+                    sweep=args.sweep,
+                    platform=args.platform,
+                    make_target=args.make_target,
+                    timeout_seconds=args.timeout_seconds,
+                    stall_timeout_seconds=args.stall_timeout_seconds,
+                )
+                variant["synthesis"] = synthesis
+                variant["metrics_row"] = metrics
+            variants.append(variant)
+
+    payload = build_report(variants=variants, sweep=args.sweep, make_target=args.make_target)
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/decoder_serial_ranker_architecture/sweeps/nangate45_r64_serial.json
+++ b/runs/campaigns/npu/decoder_serial_ranker_architecture/sweeps/nangate45_r64_serial.json
@@ -1,0 +1,29 @@
+{
+  "flow_params": {
+    "TAG": [
+      "decoder_r64_k1_serial_ranker"
+    ],
+    "FLOW_VARIANT": [
+      "decoder_r64_k1_serial_ranker"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 900 900"
+    ],
+    "CORE_AREA": [
+      "40 40 860 860"
+    ],
+    "PLACE_DENSITY": [
+      0.36
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "candidate_stream_merge_fifo_k1_l16_t16_d16"
+    ]
+  },
+  "tag_prefix": "decoder_r64_k1_serial_ranker"
+}

--- a/tests/test_llm_decoder_serial_ranker_architecture.py
+++ b/tests/test_llm_decoder_serial_ranker_architecture.py
@@ -1,0 +1,55 @@
+from npu.eval.probe_llm_decoder_serial_ranker_architecture import build_report
+
+
+def test_serial_ranker_report_selects_best_timing_and_power_variants() -> None:
+    report = build_report(
+        variants=[
+            {
+                "top": "decoder_r64_k1_serial_rank_lpc1_wrapper",
+                "lanes_per_cycle": 1,
+                "tile_scan_cycles": 64,
+                "metrics_row": {
+                    "status": "ok",
+                    "critical_path_ns": "3.1",
+                    "die_area": "810000",
+                    "total_power_mw": "0.04",
+                },
+            },
+            {
+                "top": "decoder_r64_k1_serial_rank_lpc8_wrapper",
+                "lanes_per_cycle": 8,
+                "tile_scan_cycles": 8,
+                "metrics_row": {
+                    "status": "ok",
+                    "critical_path_ns": "4.5",
+                    "die_area": "810000",
+                    "total_power_mw": "0.02",
+                },
+            },
+        ],
+        sweep="runs/campaigns/npu/decoder_serial_ranker_architecture/sweeps/nangate45_r64_serial.json",
+        make_target="3_3_place_gp",
+    )
+
+    assert report["decision"]["decision"] == "serial_ranker_architecture_measured"
+    assert report["best_timing_variant"]["lanes_per_cycle"] == 1
+    assert report["lowest_power_variant"]["lanes_per_cycle"] == 8
+
+
+def test_serial_ranker_report_blocks_without_metrics() -> None:
+    report = build_report(
+        variants=[
+            {
+                "top": "decoder_r64_k1_serial_rank_lpc4_wrapper",
+                "lanes_per_cycle": 4,
+                "tile_scan_cycles": 16,
+                "metrics_row": {"status": "failed"},
+            }
+        ],
+        sweep="sweep.json",
+        make_target="3_3_place_gp",
+    )
+
+    assert report["decision"]["decision"] == "serial_ranker_architecture_blocked"
+    assert report["best_timing_variant"] is None
+    assert report["lowest_power_variant"] is None


### PR DESCRIPTION
## Summary
- add `probe_llm_decoder_serial_ranker_architecture.py` for r64/k1 running-best serial rankers
- sweep `lanes_per_cycle` 1, 2, 4, 8, and 16 with ready-valid backpressure while scanning a tile
- add L2 generator wiring, proposal metadata, sweep config, and focused tests

## Why
The existing rank-tree measurements cover fully parallel rankers. This adds the area-conservative side of the space for cases where the ranker service time can hide under larger LLM producer and memory latency.

## Validation
- `python3 -m py_compile npu/eval/probe_llm_decoder_serial_ranker_architecture.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_serial_ranker_architecture.py tests/test_llm_decoder_rank_tree_architecture.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'serial_ranker_architecture or rank_tree_architecture'`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
- skip-physical RTL smoke for lanes_per_cycle 1, 2, 4, 8, and 16; all passed ready-valid simulation
