### PR TITLE
Add serial ranker producer replay job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2241,6 +2241,59 @@ def _decoder_producer_ranker_service_compatibility_evidence(*, item_id: str) -> 
     }
 
 
+def _decoder_serial_ranker_producer_replay_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_serial_ranker_producer_replay__{item_id}.json"
+    report = f"{base}/decoder_serial_ranker_producer_replay__{item_id}.md"
+    serial_ranker = (
+        f"{base}/decoder_serial_ranker_architecture__"
+        "l2_decoder_serial_ranker_architecture_v1.json"
+    )
+    service_compatibility = (
+        f"{base}/decoder_producer_ranker_service_compatibility__"
+        "l2_decoder_producer_ranker_service_compatibility_v1.json"
+    )
+    merge_config = (
+        "runs/designs/activations/candidate_stream_merge_fifo_k1_l16_t16_d16_wrapper/"
+        "config_candidate_stream_merge_fifo_k1_l16_t16_d16.json"
+    )
+    return {
+        "inputs": {
+            "serial_ranker_producer_replay_out": out,
+            "serial_ranker_producer_replay_report": report,
+            "serial_ranker_architecture": serial_ranker,
+            "producer_ranker_service_compatibility": service_compatibility,
+            "candidate_merge_config": merge_config,
+            "serial_ranker_producer_replay_scope": (
+                "Replay fixed producer tile issue intervals through the measured serial-ranker "
+                "RTL wrappers for lpc1, lpc2, and lpc4. The harness checks full-token top-1 "
+                "equivalence and records ready-valid backpressure at aggressive and producer-model cadences."
+            ),
+        },
+        "commands": [
+            {
+                "name": "build_generator",
+                "run": "export PATH=/oss-cad-suite/bin:$PATH && cmake -S . -B build && cmake --build build --target rtlgen",
+            },
+            {
+                "name": "probe_decoder_serial_ranker_producer_replay",
+                "run": (
+                    "python3 npu/eval/probe_llm_decoder_serial_ranker_producer_replay.py "
+                    f"--serial-ranker {serial_ranker} "
+                    f"--service-compatibility {service_compatibility} "
+                    f"--merge-config {merge_config} "
+                    "--lanes-per-cycle 1,2,4 "
+                    "--producer-ii-cycles 16,33,65,384 "
+                    "--num-tiles 6 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_stage_breakdown_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_stage_breakdown__{item_id}.json"
@@ -3519,6 +3572,7 @@ def _build_payload(
         "decoder_output_projection_service",
         "decoder_producer_ranker_coupled_noc",
         "decoder_producer_ranker_service_compatibility",
+        "decoder_serial_ranker_producer_replay",
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
@@ -3572,6 +3626,8 @@ def _build_payload(
             decoder_evidence = _decoder_producer_ranker_coupled_noc_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_producer_ranker_service_compatibility":
             decoder_evidence = _decoder_producer_ranker_service_compatibility_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_serial_ranker_producer_replay":
+            decoder_evidence = _decoder_serial_ranker_producer_replay_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_service":
             decoder_evidence = _decoder_output_projection_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1881,6 +1881,65 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_service_compatib
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_serial_ranker_producer_replay() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_serial_ranker_producer_replay_v1",
+                    proposal_id="prop_l2_decoder_serial_ranker_producer_replay_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_serial_ranker_producer_replay_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_serial_ranker_producer_replay",
+                    expected_direction="iterate",
+                    comparison_role="producer_ranker_service",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:2]] == [
+                "build_generator",
+                "probe_decoder_serial_ranker_producer_replay"
+            ]
+            run = work_item.command_manifest[1]["run"]
+            assert "probe_llm_decoder_serial_ranker_producer_replay.py" in run
+            assert "--merge-config" in run
+            assert "--lanes-per-cycle 1,2,4" in run
+            assert "--producer-ii-cycles 16,33,65,384" in run
+            assert decoder_inputs["serial_ranker_producer_replay_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_serial_ranker_producer_replay__"
+                "l2_decoder_serial_ranker_producer_replay_v1.json"
+            )
+            assert decoder_inputs["producer_ranker_service_compatibility"].endswith(
+                "l2_decoder_producer_ranker_service_compatibility_v1.json"
+            )
+            assert "full-token top-1 equivalence" in decoder_inputs[
+                "serial_ranker_producer_replay_scope"
+            ]
+            assert decoder_inputs["serial_ranker_producer_replay_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_serial_ranker_producer_replay",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_serial_ranker_producer_replay_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_serial_ranker_producer_replay_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l2_decoder_serial_ranker_producer_replay_v1",
+  "created_utc": "2026-05-14T09:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_serial_ranker_producer_replay",
+  "title": "Decoder serial ranker producer-cadence RTL replay",
+  "hypothesis": "The low-power serial r64/k1 ranker remains a valid producer-coupled candidate if the same RTL wrapper preserves top-1 equivalence and avoids backpressure at output-projection producer cadences.",
+  "direct_comparison": {
+    "primary_question": "Do serial_lpc1, serial_lpc2, and serial_lpc4 preserve RTL equivalence and show the expected backpressure boundary when driven by producer-like tile cadence?",
+    "include": [
+      "measured serial ranker RTL wrappers from the architecture sweep",
+      "producer issue intervals 16, 33, 65, and 384 cycles",
+      "full-token top-1 reference with deterministic lower-token tie-break",
+      "ready-valid backpressure counted by the testbench",
+      "service-compatibility result as the planning baseline"
+    ],
+    "exclude": [
+      "new physical PPA",
+      "wider-than-r64 producer tiles",
+      "new ranker RTL architecture",
+      "full NoC or SRAM arbitration"
+    ]
+  },
+  "expected_benefit": [
+    "confirms that the service-compatible serial choice also behaves correctly in RTL under producer cadence",
+    "separates real ready-valid backpressure from analytical service-cycle estimates",
+    "creates evidence for promoting serial_lpc1 into the next producer-coupled wrapper"
+  ],
+  "risks": [
+    "the producer is represented by a deterministic cadence replay, not the real output-projection datapath",
+    "only r64/k1 top-1 is tested",
+    "the aggressive intervals are synthetic guard cases, not measured resident-weight producer output"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_serial_ranker_producer_replay_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replay producer-like tile cadences through measured serial r64/k1 ranker RTL wrappers and compare against the full-token top-1 reference.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_serial_ranker_producer_replay",
+      "cost_class": "low",
+      "comparison_role": "producer_ranker_service",
+      "paired_baseline_item_id": "l2_decoder_producer_ranker_service_compatibility_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_serial_ranker_architecture_v1",
+        "l2_decoder_producer_ranker_service_compatibility_v1",
+        "l2_decoder_producer_ranker_ready_valid_equivalence_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If lpc1 preserves RTL equivalence and has no backpressure at producer-model cadence, promote it to the next producer-coupled wrapper. If guard cadences expose unexpected stalls, use lpc2/lpc4 or rank-tree points."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_serial_ranker_architecture__l2_decoder_serial_ranker_architecture_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_producer_ranker_service_compatibility__l2_decoder_producer_ranker_service_compatibility_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_llm_decoder_serial_ranker_producer_replay.py",
+    "tests/test_llm_decoder_serial_ranker_producer_replay.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/probe_llm_decoder_serial_ranker_producer_replay.py
+++ b/npu/eval/probe_llm_decoder_serial_ranker_producer_replay.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Replay producer-like tile cadence through measured serial ranker RTL wrappers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import shutil
+import tempfile
+from typing import Any
+
+try:
+    from probe_llm_decoder_pipelined_ranker_architecture import _rank_config
+    from probe_llm_decoder_producer_ranker_ready_valid_equivalence import (
+        _as_int,
+        _resolve_executable,
+        _run,
+        _sv_signed_literal,
+    )
+    from probe_llm_decoder_producer_ranker_physical_wrapper import REPO_ROOT
+except ImportError:  # pragma: no cover - package-style imports in tests
+    from npu.eval.probe_llm_decoder_pipelined_ranker_architecture import _rank_config
+    from npu.eval.probe_llm_decoder_producer_ranker_ready_valid_equivalence import (
+        _as_int,
+        _resolve_executable,
+        _run,
+        _sv_signed_literal,
+    )
+    from npu.eval.probe_llm_decoder_producer_ranker_physical_wrapper import REPO_ROOT
+
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _make_tile_values(*, num_tiles: int, producer_lanes: int) -> list[list[int]]:
+    tiles: list[list[int]] = []
+    for tile in range(num_tiles):
+        row = []
+        for lane in range(producer_lanes):
+            row.append(((tile + 3) * 23 + lane * 7) % 257 - 128)
+        tiles.append(row)
+    if num_tiles:
+        tiles[0][5] = 500
+    if num_tiles > 1:
+        tiles[1][2] = 499
+    if num_tiles > 2:
+        tiles[2][7] = 500
+    if num_tiles > 4:
+        tiles[4][11] = 498
+    return tiles
+
+
+def _reference_top1(tiles: list[list[int]], *, producer_lanes: int) -> JsonDict:
+    best_token = None
+    best_logit = None
+    for tile_id, logits in enumerate(tiles):
+        for lane, logit in enumerate(logits):
+            token = tile_id * producer_lanes + lane
+            if best_logit is None or logit > best_logit or (
+                logit == best_logit and token < int(best_token)
+            ):
+                best_token = token
+                best_logit = logit
+    return {"token": best_token, "logit": best_logit}
+
+
+def _write_cadence_testbench(
+    path: Path,
+    *,
+    wrapper_name: str,
+    producer_lanes: int,
+    logit_bits: int,
+    token_id_bits: int,
+    tiles: list[list[int]],
+    expected: JsonDict,
+    producer_ii_cycles: int,
+    scenario: str,
+    lanes_per_cycle: int,
+) -> None:
+    logit_width = producer_lanes * logit_bits
+    num_tiles = len(tiles)
+    wait_limit = producer_ii_cycles * max(4, num_tiles * 2) + 512
+    lines = [
+        "`timescale 1ns/1ps",
+        "module decoder_serial_ranker_producer_replay_tb;",
+        "  reg clk;",
+        "  reg rst_n;",
+        "  reg in_valid;",
+        "  wire in_ready;",
+        "  reg in_last;",
+        f"  reg [{token_id_bits - 1}:0] in_base_token_id;",
+        f"  reg [{producer_lanes - 1}:0] in_lane_valid;",
+        f"  reg signed [{logit_width - 1}:0] in_logits;",
+        "  wire out_valid;",
+        "  reg out_ready;",
+        "  wire out_valid_mask;",
+        f"  wire [{token_id_bits - 1}:0] out_token_ids;",
+        f"  wire signed [{logit_bits - 1}:0] out_logits;",
+        "  wire [31:0] accepted_group_count;",
+        "  wire [31:0] producer_stall_cycles;",
+        "  wire [31:0] fifo_max_occupancy;",
+        "  wire [31:0] final_completion_cycle;",
+        "  integer cycle;",
+        "  integer tile_id;",
+        "  integer wait_cycles;",
+        "  integer next_issue_cycle;",
+        "  integer tb_backpressure_cycles;",
+        f"  {wrapper_name} dut (",
+        "    .clk(clk), .rst_n(rst_n), .in_valid(in_valid), .in_ready(in_ready),",
+        "    .in_last(in_last), .in_base_token_id(in_base_token_id),",
+        "    .in_lane_valid(in_lane_valid), .in_logits(in_logits),",
+        "    .out_valid(out_valid), .out_ready(out_ready), .out_valid_mask(out_valid_mask),",
+        "    .out_token_ids(out_token_ids), .out_logits(out_logits),",
+        "    .accepted_group_count(accepted_group_count),",
+        "    .producer_stall_cycles(producer_stall_cycles),",
+        "    .fifo_max_occupancy(fifo_max_occupancy),",
+        "    .final_completion_cycle(final_completion_cycle)",
+        "  );",
+        "  always #5 clk = ~clk;",
+        "  always @(posedge clk or negedge rst_n) begin",
+        "    if (!rst_n) cycle <= 0;",
+        "    else cycle <= cycle + 1;",
+        "  end",
+        "  task clear_logits;",
+        "    integer i;",
+        "    begin",
+        f"      for (i = 0; i < {producer_lanes}; i = i + 1) begin",
+        f"        in_logits[i*{logit_bits} +: {logit_bits}] = {logit_bits}'sd0;",
+        "      end",
+        "    end",
+        "  endtask",
+        "  task drive_tile;",
+        "    input [31:0] tid;",
+        "    input last;",
+        "    begin",
+        "      in_valid = 1'b1;",
+        "      in_last = last;",
+        f"      in_base_token_id = tid * {producer_lanes};",
+        f"      in_lane_valid = {{{producer_lanes}{{1'b1}}}};",
+        "      clear_logits();",
+    ]
+    for tile_id, logits in enumerate(tiles):
+        lines.append(f"      if (tid == {tile_id}) begin")
+        for lane, value in enumerate(logits):
+            lines.append(
+                f"        in_logits[{lane * logit_bits} +: {logit_bits}] = "
+                f"{_sv_signed_literal(logit_bits, value)};"
+            )
+        lines.append("      end")
+    lines.extend(
+        [
+            "      while (!in_ready) begin",
+            "        tb_backpressure_cycles = tb_backpressure_cycles + 1;",
+            "        @(negedge clk);",
+            "      end",
+            "      @(negedge clk);",
+            "      in_valid = 1'b0;",
+            "      in_last = 1'b0;",
+            "      in_base_token_id = 0;",
+            "      in_lane_valid = 0;",
+            "      clear_logits();",
+            "    end",
+            "  endtask",
+            "  initial begin",
+            "    clk = 1'b0;",
+            "    rst_n = 1'b0;",
+            "    in_valid = 1'b0;",
+            "    in_last = 1'b0;",
+            "    in_base_token_id = 0;",
+            "    in_lane_valid = 0;",
+            "    out_ready = 1'b0;",
+            "    tb_backpressure_cycles = 0;",
+            "    next_issue_cycle = 0;",
+            "    clear_logits();",
+            "    repeat (3) @(negedge clk);",
+            "    rst_n = 1'b1;",
+            f"    for (tile_id = 0; tile_id < {num_tiles}; tile_id = tile_id + 1) begin",
+            "      while (cycle < next_issue_cycle) begin",
+            "        @(negedge clk);",
+            "      end",
+            f"      drive_tile(tile_id, tile_id == ({num_tiles} - 1));",
+            f"      next_issue_cycle = next_issue_cycle + {producer_ii_cycles};",
+            "    end",
+            "    wait_cycles = 0;",
+            f"    while (!out_valid && wait_cycles < {wait_limit}) begin",
+            "      wait_cycles = wait_cycles + 1;",
+            "      @(negedge clk);",
+            "    end",
+            "    if (!out_valid) begin",
+            "      $display(\"FAIL no out_valid wait=%0d\", wait_cycles);",
+            "      $fatal;",
+            "    end",
+            f"    if (out_valid_mask !== 1'b1 || out_token_ids !== {token_id_bits}'d{expected['token']} || "
+            f"$signed(out_logits) !== {_sv_signed_literal(logit_bits, int(expected['logit']))}) begin",
+            "      $display(\"FAIL result token=%0d logit=%0d mask=%b\", out_token_ids, $signed(out_logits), out_valid_mask);",
+            "      $fatal;",
+            "    end",
+            f"    $display(\"RESULT scenario={scenario} lpc={lanes_per_cycle} producer_ii={producer_ii_cycles} token=%0d logit=%0d accepted=%0d tb_backpressure=%0d dut_stalls=%0d fifo_max=%0d final_cycle=%0d\",",
+            "      out_token_ids, $signed(out_logits), accepted_group_count, tb_backpressure_cycles,",
+            "      producer_stall_cycles, fifo_max_occupancy, final_completion_cycle);",
+            "    out_ready = 1'b1;",
+            "    @(negedge clk);",
+            "    out_ready = 1'b0;",
+            "    $finish;",
+            "  end",
+            "endmodule",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _simulate_variant(
+    *,
+    variant: JsonDict,
+    scenario: str,
+    producer_ii_cycles: int,
+    num_tiles: int,
+    merge_config: Path,
+    rtlgen_binary: str | None,
+    producer_lanes: int,
+    logit_bits: int,
+    token_id_bits: int,
+) -> JsonDict:
+    iverilog = shutil.which("iverilog")
+    vvp = shutil.which("vvp")
+    if iverilog is None or vvp is None:
+        return {"status": "simulator_missing", "iverilog": iverilog, "vvp": vvp}
+    top = str(variant["top"])
+    design_dir = REPO_ROOT / str(variant["design_dir"])
+    rank_module = f"logit_rank_r{variant['lanes_per_cycle']}_l{logit_bits}_k1"
+    merge_module = "candidate_stream_merge_fifo_k1_l16_t16_d16"
+    wrapper = design_dir / "verilog" / f"{top}.v"
+    if not wrapper.is_file():
+        return {"status": "wrapper_missing", "wrapper": str(wrapper)}
+    tiles = _make_tile_values(num_tiles=num_tiles, producer_lanes=producer_lanes)
+    expected = _reference_top1(tiles, producer_lanes=producer_lanes)
+    with tempfile.TemporaryDirectory() as td:
+        work = Path(td)
+        if rtlgen_binary is None:
+            return {
+                "status": "rtlgen_binary_missing",
+                "required_modules": [rank_module, merge_module],
+            }
+        generated_config = work / f"config_{rank_module}.json"
+        generated_config.write_text(
+            json.dumps(_rank_config(int(variant["lanes_per_cycle"]), logit_bits), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        rank_cmd = _run([rtlgen_binary, str(generated_config.resolve())], cwd=work)
+        merge_cmd = _run([rtlgen_binary, str(merge_config.resolve())], cwd=work)
+        if rank_cmd.returncode != 0 or merge_cmd.returncode != 0:
+            return {
+                "status": "rtlgen_failed",
+                "rank_returncode": rank_cmd.returncode,
+                "merge_returncode": merge_cmd.returncode,
+                "rank_log_tail": rank_cmd.stdout.splitlines()[-20:],
+                "merge_log_tail": merge_cmd.stdout.splitlines()[-20:],
+            }
+        tb = work / f"tb_{top}_producer_replay_{scenario}.v"
+        _write_cadence_testbench(
+            tb,
+            wrapper_name=top,
+            producer_lanes=producer_lanes,
+            logit_bits=logit_bits,
+            token_id_bits=token_id_bits,
+            tiles=tiles,
+            expected=expected,
+            producer_ii_cycles=producer_ii_cycles,
+            scenario=scenario,
+            lanes_per_cycle=int(variant["lanes_per_cycle"]),
+        )
+        sim_path = work / f"sim_producer_replay_{scenario}"
+        sources = [
+            str(wrapper),
+            str(work / f"{rank_module}.v"),
+            str(work / f"{merge_module}.v"),
+            str(tb),
+        ]
+        compile_cmd = _run(
+            [
+                "iverilog",
+                "-g2012",
+                "-s",
+                "decoder_serial_ranker_producer_replay_tb",
+                "-o",
+                str(sim_path),
+                *sources,
+            ],
+            cwd=REPO_ROOT,
+        )
+        if compile_cmd.returncode != 0:
+            return {
+                "status": "iverilog_failed",
+                "returncode": compile_cmd.returncode,
+                "log_tail": compile_cmd.stdout.splitlines()[-40:],
+            }
+        sim_cmd = _run(["vvp", str(sim_path)], cwd=REPO_ROOT)
+    result: JsonDict = {
+        "status": "ok" if sim_cmd.returncode == 0 else "vvp_failed",
+        "returncode": sim_cmd.returncode,
+        "expected": expected,
+        "log_tail": sim_cmd.stdout.splitlines()[-40:],
+    }
+    match = re.search(
+        r"RESULT scenario=(?P<scenario>\S+) lpc=(?P<lpc>\d+) producer_ii=(?P<producer_ii>\d+) "
+        r"token=(?P<token>\d+) logit=(?P<logit>-?\d+) accepted=(?P<accepted>\d+) "
+        r"tb_backpressure=(?P<tb_backpressure>\d+) dut_stalls=(?P<dut_stalls>\d+) "
+        r"fifo_max=(?P<fifo_max>\d+) final_cycle=(?P<final_cycle>\d+)",
+        sim_cmd.stdout,
+    )
+    if match:
+        result["observed"] = {key: int(value) if value.lstrip("-").isdigit() else value for key, value in match.groupdict().items()}
+    return result
+
+
+def _variant_by_lanes(serial_ranker: JsonDict) -> dict[int, JsonDict]:
+    return {
+        int(variant["lanes_per_cycle"]): variant
+        for variant in serial_ranker.get("variants", [])
+        if isinstance(variant, dict) and variant.get("status") == "ok" and "lanes_per_cycle" in variant
+    }
+
+
+def _service_cycles(variant: JsonDict) -> int:
+    return _as_int(variant.get("ii_goal_cycles"), _as_int(variant.get("tile_scan_cycles"), 0) + 1)
+
+
+def build_report(
+    *,
+    serial_ranker: JsonDict,
+    service_compatibility: JsonDict | None,
+    replay_rows: list[JsonDict],
+    producer_ii_cycles: list[int],
+    lanes_per_cycle: list[int],
+    num_tiles: int,
+) -> JsonDict:
+    passed_rows = [
+        row
+        for row in replay_rows
+        if (row.get("rtl_sim") or {}).get("status") == "ok"
+        and (row.get("rtl_sim") or {}).get("observed", {}).get("token")
+        == (row.get("rtl_sim") or {}).get("expected", {}).get("token")
+        and (row.get("rtl_sim") or {}).get("observed", {}).get("logit")
+        == (row.get("rtl_sim") or {}).get("expected", {}).get("logit")
+    ]
+    throughput_safe = [
+        row
+        for row in replay_rows
+        if row.get("expected_throughput_ok") and (row.get("rtl_sim") or {}).get("observed", {}).get("tb_backpressure") == 0
+    ]
+    lowest_power = (
+        (service_compatibility or {}).get("recommendation", {}).get("lowest_power_feasible")
+        if isinstance(service_compatibility, dict)
+        else None
+    )
+    return {
+        "version": 0.1,
+        "model": "decoder_serial_ranker_producer_replay_v1",
+        "target": {
+            "producer_lanes": 64,
+            "top_k": 1,
+            "lanes_per_cycle": lanes_per_cycle,
+            "producer_ii_cycles": producer_ii_cycles,
+            "num_tiles": num_tiles,
+            "serial_ranker_model": serial_ranker.get("model"),
+            "service_compatibility_model": (
+                service_compatibility.get("model") if isinstance(service_compatibility, dict) else None
+            ),
+        },
+        "service_compatibility_lowest_power_feasible": lowest_power,
+        "replay_rows": replay_rows,
+        "decision": {
+            "decision": (
+                "producer_cadence_replay_passed"
+                if len(passed_rows) == len(replay_rows) and replay_rows
+                else "producer_cadence_replay_blocked"
+            ),
+            "throughput_safe_rows": len(throughput_safe),
+            "total_rows": len(replay_rows),
+            "next_step": (
+                "Promote serial_lpc1 into a producer-coupled RTL wrapper if the chosen producer cadence "
+                "matches the output-projection service model; keep lpc2/lpc4 as guard points for faster "
+                "resident-weight producer assumptions."
+                if len(passed_rows) == len(replay_rows) and replay_rows
+                else "Fix replay RTL failures before promoting a serial ranker into producer-coupled RTL."
+            ),
+        },
+        "assumptions": [
+            "The replay uses the same generated serial-ranker RTL wrappers measured in the architecture sweep.",
+            "Producer tiles are released at fixed issue intervals; if the ranker is busy, the testbench holds valid and counts backpressure.",
+            "The RTL output is checked against a full-token top-1 reference with deterministic lower-token tie-break.",
+            "This validates stream behavior and cadence tolerance; it is not a new physical PPA measurement.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Serial Ranker Producer Replay",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- throughput_safe_rows: `{payload['decision']['throughput_safe_rows']}/{payload['decision']['total_rows']}`",
+        f"- next_step: {payload['decision']['next_step']}",
+        "",
+        "## Replay Rows",
+        "",
+        "| lpc | scenario | producer II | service | expected ok | rtl | token | logit | backpressure | final cycle |",
+        "|---:|---|---:|---:|---|---|---:|---:|---:|---:|",
+    ]
+    for row in payload["replay_rows"]:
+        sim = row.get("rtl_sim") or {}
+        observed = sim.get("observed") if isinstance(sim.get("observed"), dict) else {}
+        lines.append(
+            "| {lpc} | {scenario} | {ii} | {service} | `{ok}` | `{rtl}` | {token} | {logit} | {bp} | {cycle} |".format(
+                lpc=row.get("lanes_per_cycle"),
+                scenario=row.get("scenario"),
+                ii=row.get("producer_ii_cycles"),
+                service=row.get("ranker_service_cycles"),
+                ok=row.get("expected_throughput_ok"),
+                rtl=sim.get("status"),
+                token=observed.get("token", ""),
+                logit=observed.get("logit", ""),
+                bp=observed.get("tb_backpressure", ""),
+                cycle=observed.get("final_cycle", ""),
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Replay producer cadence through serial ranker RTL wrappers")
+    ap.add_argument("--serial-ranker", required=True)
+    ap.add_argument("--service-compatibility")
+    ap.add_argument("--merge-config", required=True)
+    ap.add_argument("--rtlgen-binary", default="build/rtlgen")
+    ap.add_argument("--lanes-per-cycle", default="1,2,4")
+    ap.add_argument("--producer-ii-cycles", default="16,33,65,384")
+    ap.add_argument("--num-tiles", type=int, default=6)
+    ap.add_argument("--logit-bits", type=int, default=16)
+    ap.add_argument("--token-id-bits", type=int, default=16)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    serial_ranker = _load_json(args.serial_ranker)
+    service_compatibility = _load_json(args.service_compatibility) if args.service_compatibility else None
+    rtlgen_binary = _resolve_executable(args.rtlgen_binary)
+    variants = _variant_by_lanes(serial_ranker)
+    lane_counts = [int(x) for x in args.lanes_per_cycle.split(",") if x.strip()]
+    producer_iis = [int(x) for x in args.producer_ii_cycles.split(",") if x.strip()]
+    replay_rows: list[JsonDict] = []
+    for lanes in lane_counts:
+        variant = variants.get(lanes)
+        if variant is None:
+            replay_rows.append(
+                {
+                    "lanes_per_cycle": lanes,
+                    "status": "variant_missing",
+                    "rtl_sim": {"status": "variant_missing"},
+                }
+            )
+            continue
+        service = _service_cycles(variant)
+        for producer_ii in producer_iis:
+            scenario = f"ii{producer_ii}"
+            row: JsonDict = {
+                "lanes_per_cycle": lanes,
+                "scenario": scenario,
+                "producer_ii_cycles": producer_ii,
+                "ranker_service_cycles": service,
+                "expected_throughput_ok": service <= producer_ii,
+            }
+            row["rtl_sim"] = _simulate_variant(
+                variant=variant,
+                scenario=scenario,
+                producer_ii_cycles=producer_ii,
+                num_tiles=args.num_tiles,
+                merge_config=Path(args.merge_config),
+                rtlgen_binary=rtlgen_binary,
+                producer_lanes=64,
+                logit_bits=args.logit_bits,
+                token_id_bits=args.token_id_bits,
+            )
+            replay_rows.append(row)
+
+    payload = build_report(
+        serial_ranker=serial_ranker,
+        service_compatibility=service_compatibility,
+        replay_rows=replay_rows,
+        producer_ii_cycles=producer_iis,
+        lanes_per_cycle=lane_counts,
+        num_tiles=args.num_tiles,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_serial_ranker_producer_replay.py
+++ b/tests/test_llm_decoder_serial_ranker_producer_replay.py
@@ -1,0 +1,62 @@
+from npu.eval.probe_llm_decoder_serial_ranker_producer_replay import (
+    _make_tile_values,
+    _reference_top1,
+    build_report,
+)
+
+
+def test_reference_top1_uses_lower_token_tie_break() -> None:
+    tiles = _make_tile_values(num_tiles=3, producer_lanes=64)
+
+    assert _reference_top1(tiles, producer_lanes=64) == {"token": 5, "logit": 500}
+
+
+def test_replay_report_passes_when_all_rtl_rows_match_reference() -> None:
+    report = build_report(
+        serial_ranker={"model": "decoder_serial_ranker_architecture_v1"},
+        service_compatibility={
+            "model": "decoder_producer_ranker_service_compatibility_v1",
+            "recommendation": {"lowest_power_feasible": {"ranker": "serial_lpc1"}},
+        },
+        replay_rows=[
+            {
+                "lanes_per_cycle": 1,
+                "scenario": "ii65",
+                "producer_ii_cycles": 65,
+                "ranker_service_cycles": 65,
+                "expected_throughput_ok": True,
+                "rtl_sim": {
+                    "status": "ok",
+                    "expected": {"token": 5, "logit": 500},
+                    "observed": {
+                        "token": 5,
+                        "logit": 500,
+                        "tb_backpressure": 0,
+                    },
+                },
+            },
+            {
+                "lanes_per_cycle": 1,
+                "scenario": "ii16",
+                "producer_ii_cycles": 16,
+                "ranker_service_cycles": 65,
+                "expected_throughput_ok": False,
+                "rtl_sim": {
+                    "status": "ok",
+                    "expected": {"token": 5, "logit": 500},
+                    "observed": {
+                        "token": 5,
+                        "logit": 500,
+                        "tb_backpressure": 100,
+                    },
+                },
+            },
+        ],
+        producer_ii_cycles=[16, 65],
+        lanes_per_cycle=[1],
+        num_tiles=6,
+    )
+
+    assert report["decision"]["decision"] == "producer_cadence_replay_passed"
+    assert report["decision"]["throughput_safe_rows"] == 1
+    assert report["service_compatibility_lowest_power_feasible"]["ranker"] == "serial_lpc1"


### PR DESCRIPTION
## Summary\n- add an RTL replay harness for measured serial ranker wrappers under fixed producer tile cadences\n- wire the decoder_serial_ranker_producer_replay L2 abstraction into the task generator\n- add proposal metadata and focused tests\n\n## Validation\n- python3 -m py_compile npu/eval/probe_llm_decoder_serial_ranker_producer_replay.py\n- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_serial_ranker_producer_replay.py\n- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k serial_ranker_producer_replay\n- python3 scripts/validate_runs.py --skip_eval_queue\n- git diff --check\n- local replay smoke with lpc 1,2,4 and producer II 16,33,65,384