### PR TITLE
Add serial_lpc1 producer wrapper promotion job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2294,6 +2294,66 @@ def _decoder_serial_ranker_producer_replay_evidence(*, item_id: str) -> dict[str
     }
 
 
+def _decoder_serial_lpc1_producer_coupled_wrapper_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_serial_lpc1_producer_coupled_wrapper__{item_id}.json"
+    report = f"{base}/decoder_serial_lpc1_producer_coupled_wrapper__{item_id}.md"
+    serial_ranker = (
+        f"{base}/decoder_serial_ranker_architecture__"
+        "l2_decoder_serial_ranker_architecture_v1.json"
+    )
+    service_compatibility = (
+        f"{base}/decoder_producer_ranker_service_compatibility__"
+        "l2_decoder_producer_ranker_service_compatibility_v1.json"
+    )
+    producer_replay = (
+        f"{base}/decoder_serial_ranker_producer_replay__"
+        "l2_decoder_serial_ranker_producer_replay_v1.json"
+    )
+    merge_config = (
+        "runs/designs/activations/candidate_stream_merge_fifo_k1_l16_t16_d16_wrapper/"
+        "config_candidate_stream_merge_fifo_k1_l16_t16_d16.json"
+    )
+    return {
+        "inputs": {
+            "serial_lpc1_producer_coupled_wrapper_out": out,
+            "serial_lpc1_producer_coupled_wrapper_report": report,
+            "serial_ranker_architecture": serial_ranker,
+            "producer_ranker_service_compatibility": service_compatibility,
+            "serial_ranker_producer_replay": producer_replay,
+            "candidate_merge_config": merge_config,
+            "serial_lpc1_producer_coupled_wrapper_scope": (
+                "Promote the measured serial_lpc1 r64/k1 ranker wrapper as the selected "
+                "output-projection producer-coupled ranker. The job runs a focused RTL replay "
+                "at the selected producer II=384, checks zero backpressure, and carries forward "
+                "measured serial_lpc1 PPA from the architecture sweep."
+            ),
+        },
+        "commands": [
+            {
+                "name": "build_generator",
+                "run": "export PATH=/oss-cad-suite/bin:$PATH && cmake -S . -B build && cmake --build build --target rtlgen",
+            },
+            {
+                "name": "promote_decoder_serial_lpc1_producer_wrapper",
+                "run": (
+                    "python3 npu/eval/promote_llm_decoder_serial_lpc1_producer_wrapper.py "
+                    f"--serial-ranker {serial_ranker} "
+                    f"--service-compatibility {service_compatibility} "
+                    f"--producer-replay {producer_replay} "
+                    f"--merge-config {merge_config} "
+                    "--lanes-per-cycle 1 "
+                    "--producer-ii-cycles 384 "
+                    "--num-tiles 6 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_stage_breakdown_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_stage_breakdown__{item_id}.json"
@@ -3573,6 +3633,7 @@ def _build_payload(
         "decoder_producer_ranker_coupled_noc",
         "decoder_producer_ranker_service_compatibility",
         "decoder_serial_ranker_producer_replay",
+        "decoder_serial_lpc1_producer_coupled_wrapper",
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
@@ -3628,6 +3689,8 @@ def _build_payload(
             decoder_evidence = _decoder_producer_ranker_service_compatibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_serial_ranker_producer_replay":
             decoder_evidence = _decoder_serial_ranker_producer_replay_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_serial_lpc1_producer_coupled_wrapper":
+            decoder_evidence = _decoder_serial_lpc1_producer_coupled_wrapper_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_service":
             decoder_evidence = _decoder_output_projection_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -1940,6 +1940,64 @@ def test_generate_l2_campaign_task_adds_decoder_serial_ranker_producer_replay() 
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_serial_lpc1_producer_coupled_wrapper() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_serial_lpc1_producer_coupled_wrapper_v1",
+                    proposal_id="prop_l2_decoder_serial_lpc1_producer_coupled_wrapper_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_serial_lpc1_producer_coupled_wrapper_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_serial_lpc1_producer_coupled_wrapper",
+                    expected_direction="iterate",
+                    comparison_role="producer_ranker_service",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:2]] == [
+                "build_generator",
+                "promote_decoder_serial_lpc1_producer_wrapper",
+            ]
+            run = work_item.command_manifest[1]["run"]
+            assert "promote_llm_decoder_serial_lpc1_producer_wrapper.py" in run
+            assert "--lanes-per-cycle 1" in run
+            assert "--producer-ii-cycles 384" in run
+            assert decoder_inputs["serial_lpc1_producer_coupled_wrapper_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_serial_lpc1_producer_coupled_wrapper__"
+                "l2_decoder_serial_lpc1_producer_coupled_wrapper_v1.json"
+            )
+            assert decoder_inputs["serial_ranker_producer_replay"].endswith(
+                "l2_decoder_serial_ranker_producer_replay_v1.json"
+            )
+            assert "selected producer II=384" in decoder_inputs[
+                "serial_lpc1_producer_coupled_wrapper_scope"
+            ]
+            assert decoder_inputs["serial_lpc1_producer_coupled_wrapper_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_serial_lpc1_producer_coupled_wrapper",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_serial_lpc1_producer_coupled_wrapper_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_serial_lpc1_producer_coupled_wrapper_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_serial_lpc1_producer_coupled_wrapper_v1",
+  "created_utc": "2026-05-14T10:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_serial_lpc1_producer_coupled_wrapper",
+  "title": "Decoder serial_lpc1 producer-coupled wrapper promotion",
+  "hypothesis": "The measured serial_lpc1 r64/k1 ranker wrapper is the best next producer-coupled ranker block for the current output-projection producer cadence because it has the lowest measured power/area and zero replay backpressure at II=384.",
+  "direct_comparison": {
+    "primary_question": "Can serial_lpc1 be promoted as the selected producer-coupled ranker wrapper under the current output-projection producer cadence assumption?",
+    "include": [
+      "measured serial_lpc1 physical metrics from the serial ranker architecture sweep",
+      "service compatibility lowest-power selection",
+      "prior producer-cadence replay at II=384",
+      "focused RTL replay at II=384 with zero-backpressure requirement",
+      "explicit assumptions for current producer cadence versus future resident-weight producer models"
+    ],
+    "exclude": [
+      "new physical PPA for the same serial_lpc1 macro",
+      "full output-projection GEMM datapath integration",
+      "wider producer tiles",
+      "NoC or SRAM arbitration"
+    ]
+  },
+  "expected_benefit": [
+    "turns the serial ranker exploration into a concrete selected producer-coupled ranker block",
+    "avoids re-measuring identical serial_lpc1 PPA while still rechecking RTL at the selected cadence",
+    "defines the next blocker as producer-cadence measurement rather than ranker architecture"
+  ],
+  "risks": [
+    "producer II=384 still comes from the analytical output-projection service model",
+    "the promoted wrapper is r64/k1 only",
+    "resident-weight or cached producers may need lpc2/lpc4 based on the replay guard rows"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_serial_lpc1_producer_coupled_wrapper_v1",
+      "task_type": "l2_campaign",
+      "objective": "Promote measured serial_lpc1 as the selected producer-coupled ranker wrapper by checking service selection, prior replay, focused II=384 RTL replay, and measured PPA availability.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_serial_lpc1_producer_coupled_wrapper",
+      "cost_class": "low",
+      "comparison_role": "producer_ranker_service",
+      "paired_baseline_item_id": "l2_decoder_producer_ranker_physical_wrapper_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_serial_ranker_architecture_v1",
+        "l2_decoder_producer_ranker_service_compatibility_v1",
+        "l2_decoder_serial_ranker_producer_replay_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If serial_lpc1 passes focused replay at II=384 and measured PPA is available, use it as the selected ranker block for the next output-projection producer wrapper. If not, fall back to lpc2/lpc4 or rank-tree guard candidates."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_serial_ranker_architecture__l2_decoder_serial_ranker_architecture_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_producer_ranker_service_compatibility__l2_decoder_producer_ranker_service_compatibility_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_serial_ranker_producer_replay__l2_decoder_serial_ranker_producer_replay_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/promote_llm_decoder_serial_lpc1_producer_wrapper.py",
+    "tests/test_llm_decoder_serial_lpc1_producer_wrapper.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/promote_llm_decoder_serial_lpc1_producer_wrapper.py
+++ b/npu/eval/promote_llm_decoder_serial_lpc1_producer_wrapper.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Promote measured serial_lpc1 ranker as the producer-coupled wrapper candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    from probe_llm_decoder_serial_ranker_producer_replay import _simulate_variant
+    from probe_llm_decoder_producer_ranker_ready_valid_equivalence import (
+        _resolve_executable,
+    )
+except ImportError:  # pragma: no cover - package-style imports in tests
+    from npu.eval.probe_llm_decoder_serial_ranker_producer_replay import _simulate_variant
+    from npu.eval.probe_llm_decoder_producer_ranker_ready_valid_equivalence import (
+        _resolve_executable,
+    )
+
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _maybe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _placed_cell_area(variant: JsonDict) -> float | None:
+    synthesis = variant.get("synthesis") if isinstance(variant.get("synthesis"), dict) else {}
+    for line in synthesis.get("log_tail", []):
+        text = str(line)
+        if "Placed Cell Area" not in text:
+            continue
+        try:
+            return float(text.split()[-1])
+        except ValueError:
+            continue
+    return None
+
+
+def _variant_by_lpc(serial_ranker: JsonDict, lanes_per_cycle: int) -> JsonDict | None:
+    for variant in serial_ranker.get("variants", []):
+        if not isinstance(variant, dict):
+            continue
+        if int(variant.get("lanes_per_cycle", -1)) == lanes_per_cycle:
+            return variant
+    return None
+
+
+def _selected_replay_row(replay: JsonDict, *, lanes_per_cycle: int, producer_ii_cycles: int) -> JsonDict | None:
+    for row in replay.get("replay_rows", []):
+        if not isinstance(row, dict):
+            continue
+        if (
+            int(row.get("lanes_per_cycle", -1)) == lanes_per_cycle
+            and int(row.get("producer_ii_cycles", -1)) == producer_ii_cycles
+        ):
+            return row
+    return None
+
+
+def _metrics_summary(variant: JsonDict | None) -> JsonDict | None:
+    if variant is None:
+        return None
+    metrics = variant.get("metrics_row") if isinstance(variant.get("metrics_row"), dict) else {}
+    return {
+        "critical_path_ns": _maybe_float(metrics.get("critical_path_ns")),
+        "die_area_um2": _maybe_float(metrics.get("die_area")),
+        "placed_cell_area_um2": _placed_cell_area(variant),
+        "total_power_mw": _maybe_float(metrics.get("total_power_mw")),
+        "stage_elapsed_seconds": _maybe_float(metrics.get("stage_elapsed_seconds")),
+        "metrics_status": metrics.get("status"),
+        "design_dir": variant.get("design_dir"),
+        "top": variant.get("top"),
+    }
+
+
+def build_report(
+    *,
+    serial_ranker: JsonDict,
+    service_compatibility: JsonDict,
+    producer_replay: JsonDict,
+    focused_rtl_sim: JsonDict | None,
+    lanes_per_cycle: int,
+    producer_ii_cycles: int,
+) -> JsonDict:
+    variant = _variant_by_lpc(serial_ranker, lanes_per_cycle)
+    replay_row = _selected_replay_row(
+        producer_replay,
+        lanes_per_cycle=lanes_per_cycle,
+        producer_ii_cycles=producer_ii_cycles,
+    )
+    lowest_power = (
+        service_compatibility.get("recommendation", {}).get("lowest_power_feasible")
+        if isinstance(service_compatibility.get("recommendation"), dict)
+        else None
+    )
+    focused_observed = (
+        focused_rtl_sim.get("observed")
+        if isinstance(focused_rtl_sim, dict) and isinstance(focused_rtl_sim.get("observed"), dict)
+        else {}
+    )
+    focused_expected = (
+        focused_rtl_sim.get("expected")
+        if isinstance(focused_rtl_sim, dict) and isinstance(focused_rtl_sim.get("expected"), dict)
+        else {}
+    )
+    replay_observed = (
+        (replay_row or {}).get("rtl_sim", {}).get("observed")
+        if isinstance((replay_row or {}).get("rtl_sim"), dict)
+        else {}
+    )
+    checks = [
+        {
+            "name": "selected_variant_exists",
+            "passed": variant is not None and variant.get("status") == "ok",
+            "observed": None if variant is None else variant.get("top"),
+        },
+        {
+            "name": "selected_variant_has_physical_metrics",
+            "passed": variant is not None and (variant.get("metrics_row") or {}).get("status") == "ok",
+            "observed": _metrics_summary(variant),
+        },
+        {
+            "name": "service_compatibility_selected_lowest_power",
+            "passed": isinstance(lowest_power, dict)
+            and str(lowest_power.get("ranker")) == f"serial_lpc{lanes_per_cycle}",
+            "observed": lowest_power,
+        },
+        {
+            "name": "prior_replay_clean_at_selected_cadence",
+            "passed": bool(replay_row)
+            and (replay_row.get("rtl_sim") or {}).get("status") == "ok"
+            and int(replay_observed.get("tb_backpressure", -1)) == 0,
+            "observed": replay_row,
+        },
+        {
+            "name": "focused_rtl_replay_matches_reference",
+            "passed": isinstance(focused_rtl_sim, dict)
+            and focused_rtl_sim.get("status") == "ok"
+            and focused_observed.get("token") == focused_expected.get("token")
+            and focused_observed.get("logit") == focused_expected.get("logit")
+            and int(focused_observed.get("tb_backpressure", -1)) == 0,
+            "observed": focused_rtl_sim,
+        },
+    ]
+    passed = all(bool(check["passed"]) for check in checks)
+    return {
+        "version": 0.1,
+        "model": "decoder_serial_lpc1_producer_coupled_wrapper_v1",
+        "target": {
+            "producer_lanes": 64,
+            "top_k": 1,
+            "lanes_per_cycle": lanes_per_cycle,
+            "producer_ii_cycles": producer_ii_cycles,
+            "wrapper_role": "selected_serial_ranker_for_output_projection_producer",
+        },
+        "selected_variant": variant,
+        "selected_metrics": _metrics_summary(variant),
+        "service_compatibility_lowest_power_feasible": lowest_power,
+        "selected_prior_replay_row": replay_row,
+        "focused_rtl_sim": focused_rtl_sim,
+        "checks": checks,
+        "decision": {
+            "decision": (
+                "serial_lpc1_producer_coupled_wrapper_promoted"
+                if passed
+                else "serial_lpc1_producer_coupled_wrapper_blocked"
+            ),
+            "next_step": (
+                "Use serial_lpc1 as the ranker block in the next output-projection producer wrapper. "
+                "The next open architectural risk is replacing the analytical producer cadence with "
+                "measured producer output statistics or a resident-weight producer model."
+                if passed
+                else "Fix the selected serial ranker metrics or focused cadence replay before producer-wrapper promotion."
+            ),
+        },
+        "assumptions": [
+            "The promoted wrapper is the measured serial_lpc1 ranker plus candidate merge FIFO, not a synthetic producer ROM.",
+            "The output-projection producer is assumed to issue r64 tiles no faster than the selected 384-cycle cadence.",
+            "The focused replay validates ready-valid behavior at the selected cadence and carries prior PPA from the serial architecture sweep.",
+            "If a resident-weight or cached producer issues faster tiles, lpc2/lpc4 remain guard candidates from the replay result.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    metrics = payload.get("selected_metrics") or {}
+    lines = [
+        "# Decoder Serial LPC1 Producer-Coupled Wrapper",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- producer_ii_cycles: `{payload['target']['producer_ii_cycles']}`",
+        f"- critical_path_ns: `{metrics.get('critical_path_ns')}`",
+        f"- placed_cell_area_um2: `{metrics.get('placed_cell_area_um2')}`",
+        f"- total_power_mw: `{metrics.get('total_power_mw')}`",
+        f"- next_step: {payload['decision']['next_step']}",
+        "",
+        "## Checks",
+        "",
+        "| check | passed | observed |",
+        "|---|---|---|",
+    ]
+    for check in payload["checks"]:
+        lines.append(f"| {check['name']} | `{check['passed']}` | `{check.get('observed')}` |")
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--serial-ranker", required=True)
+    ap.add_argument("--service-compatibility", required=True)
+    ap.add_argument("--producer-replay", required=True)
+    ap.add_argument("--merge-config", required=True)
+    ap.add_argument("--rtlgen-binary", default="build/rtlgen")
+    ap.add_argument("--lanes-per-cycle", type=int, default=1)
+    ap.add_argument("--producer-ii-cycles", type=int, default=384)
+    ap.add_argument("--num-tiles", type=int, default=6)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    serial_ranker = _load_json(args.serial_ranker)
+    service_compatibility = _load_json(args.service_compatibility)
+    producer_replay = _load_json(args.producer_replay)
+    variant = _variant_by_lpc(serial_ranker, args.lanes_per_cycle)
+    rtlgen_binary = _resolve_executable(args.rtlgen_binary)
+    focused_rtl_sim = None
+    if variant is not None:
+        focused_rtl_sim = _simulate_variant(
+            variant=variant,
+            scenario=f"selected_ii{args.producer_ii_cycles}",
+            producer_ii_cycles=args.producer_ii_cycles,
+            num_tiles=args.num_tiles,
+            merge_config=Path(args.merge_config),
+            rtlgen_binary=rtlgen_binary,
+            producer_lanes=64,
+            logit_bits=16,
+            token_id_bits=16,
+        )
+    payload = build_report(
+        serial_ranker=serial_ranker,
+        service_compatibility=service_compatibility,
+        producer_replay=producer_replay,
+        focused_rtl_sim=focused_rtl_sim,
+        lanes_per_cycle=args.lanes_per_cycle,
+        producer_ii_cycles=args.producer_ii_cycles,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_serial_lpc1_producer_wrapper.py
+++ b/tests/test_llm_decoder_serial_lpc1_producer_wrapper.py
@@ -1,0 +1,86 @@
+from npu.eval.promote_llm_decoder_serial_lpc1_producer_wrapper import build_report
+
+
+def test_promote_serial_lpc1_report_passes_with_metrics_and_clean_replay() -> None:
+    variant = {
+        "status": "ok",
+        "top": "decoder_r64_k1_serial_rank_lpc1_wrapper",
+        "design_dir": "runs/designs/activations/decoder_r64_k1_serial_rank_lpc1_wrapper",
+        "lanes_per_cycle": 1,
+        "metrics_row": {
+            "status": "ok",
+            "critical_path_ns": "2.86",
+            "die_area": "810000",
+            "total_power_mw": "0.0065",
+        },
+        "synthesis": {"log_tail": ["[INFO GPL-1002] Placed Cell Area 19304.6840"]},
+    }
+    focused = {
+        "status": "ok",
+        "expected": {"token": 5, "logit": 500},
+        "observed": {"token": 5, "logit": 500, "tb_backpressure": 0},
+    }
+
+    report = build_report(
+        serial_ranker={"variants": [variant]},
+        service_compatibility={
+            "recommendation": {
+                "lowest_power_feasible": {
+                    "ranker": "serial_lpc1",
+                    "producer_ii_cycles": 384,
+                }
+            }
+        },
+        producer_replay={
+            "replay_rows": [
+                {
+                    "lanes_per_cycle": 1,
+                    "producer_ii_cycles": 384,
+                    "rtl_sim": focused,
+                }
+            ]
+        },
+        focused_rtl_sim=focused,
+        lanes_per_cycle=1,
+        producer_ii_cycles=384,
+    )
+
+    assert report["decision"]["decision"] == "serial_lpc1_producer_coupled_wrapper_promoted"
+    assert report["selected_metrics"]["placed_cell_area_um2"] == 19304.684
+    assert all(check["passed"] for check in report["checks"])
+
+
+def test_promote_serial_lpc1_report_blocks_on_backpressure() -> None:
+    variant = {
+        "status": "ok",
+        "top": "decoder_r64_k1_serial_rank_lpc1_wrapper",
+        "lanes_per_cycle": 1,
+        "metrics_row": {"status": "ok"},
+    }
+    focused = {
+        "status": "ok",
+        "expected": {"token": 5, "logit": 500},
+        "observed": {"token": 5, "logit": 500, "tb_backpressure": 3},
+    }
+
+    report = build_report(
+        serial_ranker={"variants": [variant]},
+        service_compatibility={
+            "recommendation": {"lowest_power_feasible": {"ranker": "serial_lpc1"}}
+        },
+        producer_replay={
+            "replay_rows": [
+                {
+                    "lanes_per_cycle": 1,
+                    "producer_ii_cycles": 384,
+                    "rtl_sim": focused,
+                }
+            ]
+        },
+        focused_rtl_sim=focused,
+        lanes_per_cycle=1,
+        producer_ii_cycles=384,
+    )
+
+    assert report["decision"]["decision"] == "serial_lpc1_producer_coupled_wrapper_blocked"
+    assert report["checks"][-1]["passed"] is False


### PR DESCRIPTION
## Summary\n- add a promotion job for the selected serial_lpc1 producer-coupled ranker wrapper\n- verify focused RTL replay at producer II=384 and carry measured serial_lpc1 PPA/service metadata forward\n- wire decoder_serial_lpc1_producer_coupled_wrapper into the L2 task generator with proposal metadata and tests\n\n## Validation\n- python3 -m py_compile npu/eval/promote_llm_decoder_serial_lpc1_producer_wrapper.py\n- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_serial_lpc1_producer_wrapper.py\n- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k serial_lpc1_producer_coupled_wrapper\n- python3 scripts/validate_runs.py --skip_eval_queue\n- git diff --check\n- focused local promotion smoke at II=384