### PR TITLE
Add resident-weight ranker fallback study

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2406,6 +2406,48 @@ def _decoder_output_projection_cadence_sensitivity_evidence(*, item_id: str) -> 
     }
 
 
+def _decoder_resident_weight_ranker_fallback_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_resident_weight_ranker_fallback__{item_id}.json"
+    report = f"{base}/decoder_resident_weight_ranker_fallback__{item_id}.md"
+    cadence_sensitivity = (
+        f"{base}/decoder_output_projection_cadence_sensitivity__"
+        "l2_decoder_output_projection_cadence_sensitivity_v1.json"
+    )
+    rank_tree = (
+        f"{base}/decoder_rank_tree_architecture__"
+        "l2_decoder_rank_tree_architecture_v1.json"
+    )
+    return {
+        "inputs": {
+            "resident_weight_ranker_fallback_out": out,
+            "resident_weight_ranker_fallback_report": report,
+            "output_projection_cadence_sensitivity": cadence_sensitivity,
+            "rank_tree_architecture": rank_tree,
+            "resident_weight_ranker_fallback_small_buffer_tiles": 32,
+            "resident_weight_ranker_fallback_scope": (
+                "Compare small waiting buffers in front of measured serial_lpc1/lpc2/lpc4 "
+                "rankers against measured r64 rank-tree fallback variants for resident-weight "
+                "producer cadences that outpace replay-proven serial ranker service."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_resident_weight_ranker_fallback",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_resident_weight_ranker_fallback.py "
+                    f"--cadence-sensitivity {cadence_sensitivity} "
+                    f"--rank-tree {rank_tree} "
+                    "--small-buffer-tiles 32 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_stage_breakdown_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_stage_breakdown__{item_id}.json"
@@ -3687,6 +3729,7 @@ def _build_payload(
         "decoder_serial_ranker_producer_replay",
         "decoder_serial_lpc1_producer_coupled_wrapper",
         "decoder_output_projection_cadence_sensitivity",
+        "decoder_resident_weight_ranker_fallback",
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
@@ -3746,6 +3789,8 @@ def _build_payload(
             decoder_evidence = _decoder_serial_lpc1_producer_coupled_wrapper_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_cadence_sensitivity":
             decoder_evidence = _decoder_output_projection_cadence_sensitivity_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_resident_weight_ranker_fallback":
+            decoder_evidence = _decoder_resident_weight_ranker_fallback_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_service":
             decoder_evidence = _decoder_output_projection_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2054,6 +2054,65 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_cadence_sensit
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_resident_weight_ranker_fallback() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_resident_weight_ranker_fallback_v1",
+                    proposal_id="prop_l2_decoder_resident_weight_ranker_fallback_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_resident_weight_ranker_fallback_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_resident_weight_ranker_fallback",
+                    expected_direction="iterate",
+                    comparison_role="producer_ranker_service",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == (
+                "estimate_decoder_resident_weight_ranker_fallback"
+            )
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_resident_weight_ranker_fallback.py" in run
+            assert "--small-buffer-tiles 32" in run
+            assert decoder_inputs["resident_weight_ranker_fallback_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_resident_weight_ranker_fallback__"
+                "l2_decoder_resident_weight_ranker_fallback_v1.json"
+            )
+            assert decoder_inputs["output_projection_cadence_sensitivity"].endswith(
+                "l2_decoder_output_projection_cadence_sensitivity_v1.json"
+            )
+            assert decoder_inputs["rank_tree_architecture"].endswith(
+                "l2_decoder_rank_tree_architecture_v1.json"
+            )
+            assert "resident-weight producer cadences" in decoder_inputs[
+                "resident_weight_ranker_fallback_scope"
+            ]
+            assert decoder_inputs["resident_weight_ranker_fallback_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_resident_weight_ranker_fallback",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_resident_weight_ranker_fallback_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_resident_weight_ranker_fallback_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_resident_weight_ranker_fallback_v1",
+  "created_utc": "2026-05-14T12:30:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_resident_weight_ranker_fallback",
+  "title": "Decoder resident-weight ranker fallback study",
+  "hypothesis": "Resident or cache-backed output-projection weights can make producer tiles arrive faster than the promoted serial_lpc1 ranker, so unsafe rows need either a bounded waiting buffer in front of a serial ranker or a measured rank-tree fallback.",
+  "direct_comparison": {
+    "primary_question": "For cadence rows that outpace the replay-proven serial ranker thresholds, is a small input buffer in front of serial_lpc4 sufficient, or should those rows fall back to the measured r64 rank-tree architecture?",
+    "include": [
+      "unsafe rows from the output-projection cadence sensitivity report",
+      "buffer-depth simulation for serial_lpc1, serial_lpc2, and serial_lpc4",
+      "single r64 rank-tree fallback for r64 producer tiles",
+      "banked r64 rank-tree fallback for producer tiles wider than r64",
+      "raw logit storage bytes for the required waiting buffer"
+    ],
+    "exclude": [
+      "new physical PPA",
+      "new producer RTL",
+      "SRAM macro sizing or FIFO control overhead beyond raw logit bytes",
+      "NoC arbitration and multi-producer traffic"
+    ]
+  },
+  "expected_benefit": [
+    "turns the resident-weight serial-ranker risk into an explicit fallback decision",
+    "separates near-threshold rows that only need a small FIFO from rows that need rank-tree throughput",
+    "uses measured ranker PPA rather than a heuristic rank-tree proxy"
+  ],
+  "risks": [
+    "the model uses fixed-II producer arrivals rather than measured burst traces",
+    "raw buffer bytes omit FIFO control and SRAM/compiler overhead",
+    "wider producer tiles are represented by r64 rank-tree banking assumptions"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_resident_weight_ranker_fallback_v1",
+      "task_type": "l2_campaign",
+      "objective": "Compare buffered serial rankers and rank-tree fallback for resident-weight producer cadences that outpace measured serial rankers.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_resident_weight_ranker_fallback",
+      "cost_class": "low",
+      "comparison_role": "producer_ranker_service",
+      "paired_baseline_item_id": "l2_decoder_output_projection_cadence_sensitivity_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_cadence_sensitivity_v1",
+        "l2_decoder_rank_tree_architecture_v1",
+        "l2_decoder_serial_ranker_producer_replay_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Choose whether resident-weight producer rows should use a buffered serial_lpc4 guard or a rank-tree fallback before implementing a producer-coupled resident-weight wrapper."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_cadence_sensitivity__l2_decoder_output_projection_cadence_sensitivity_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_rank_tree_architecture__l2_decoder_rank_tree_architecture_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_serial_ranker_producer_replay__l2_decoder_serial_ranker_producer_replay_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_resident_weight_ranker_fallback.py",
+    "tests/test_llm_decoder_resident_weight_ranker_fallback.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_resident_weight_ranker_fallback.py
+++ b/npu/eval/estimate_llm_decoder_resident_weight_ranker_fallback.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Compare buffering and rank-tree fallbacks for fast resident-weight producers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+R64_LANES = 64
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _maybe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _placed_cell_area(variant: JsonDict) -> float | None:
+    synthesis = variant.get("synthesis") if isinstance(variant.get("synthesis"), dict) else {}
+    for line in synthesis.get("log_tail", []):
+        match = re.search(r"Placed Cell Area\s+([0-9.]+)", str(line))
+        if match:
+            return float(match.group(1))
+    return None
+
+
+def _serial_thresholds(cadence: JsonDict) -> dict[str, JsonDict]:
+    return {
+        str(key): value
+        for key, value in cadence.get("ranker_zero_backpressure_thresholds", {}).items()
+        if isinstance(value, dict)
+    }
+
+
+def _serial_costs(cadence: JsonDict) -> dict[str, JsonDict]:
+    return {
+        str(key): value
+        for key, value in cadence.get("ranker_costs", {}).items()
+        if isinstance(value, dict)
+    }
+
+
+def _rank_tree_costs(rank_tree: JsonDict) -> list[JsonDict]:
+    rows: list[JsonDict] = []
+    for variant in rank_tree.get("variants", []):
+        if not isinstance(variant, dict) or variant.get("status") != "ok":
+            continue
+        metrics = variant.get("metrics_row") if isinstance(variant.get("metrics_row"), dict) else {}
+        rows.append(
+            {
+                "ranker": f"ranktree_radix{int(variant.get('radix'))}",
+                "radix": int(variant.get("radix")),
+                "pipeline_stages": int(variant.get("pipeline_stages", 0)),
+                "ranker_service_cycles": 1,
+                "critical_path_ns": _maybe_float(metrics.get("critical_path_ns")),
+                "total_power_mw": _maybe_float(metrics.get("total_power_mw")),
+                "die_area_um2": _maybe_float(metrics.get("die_area")),
+                "placed_cell_area_um2": _placed_cell_area(variant),
+            }
+        )
+    return rows
+
+
+def _required_waiting_buffer_tiles(
+    *,
+    producer_tile_count: int,
+    chunks_per_producer_tile: int,
+    producer_ii_cycles: int,
+    consumer_ii_cycles: int,
+) -> int:
+    queue = 0
+    max_queue = 0
+    next_done: int | None = None
+    for tile in range(producer_tile_count):
+        arrival = tile * producer_ii_cycles
+        while next_done is not None and next_done <= arrival:
+            if queue > 0:
+                queue -= 1
+                next_done += consumer_ii_cycles
+            else:
+                next_done = None
+                break
+        queue += chunks_per_producer_tile
+        if next_done is None and queue > 0:
+            queue -= 1
+            next_done = arrival + consumer_ii_cycles
+        max_queue = max(max_queue, queue)
+    return max_queue
+
+
+def _buffer_option(
+    *,
+    row: JsonDict,
+    ranker: str,
+    threshold: JsonDict,
+    cost: JsonDict,
+    logit_bits: int,
+) -> JsonDict:
+    producer_lanes = int(row["producer_lanes"])
+    chunks = _ceil_div(producer_lanes, R64_LANES)
+    depth_tiles = _required_waiting_buffer_tiles(
+        producer_tile_count=int(row["tile_count"]),
+        chunks_per_producer_tile=chunks,
+        producer_ii_cycles=int(row["producer_ii_cycles"]),
+        consumer_ii_cycles=int(threshold["min_zero_backpressure_ii_cycles"]),
+    )
+    return {
+        "strategy": f"buffered_{ranker}",
+        "ranker": ranker,
+        "chunks_per_producer_tile": chunks,
+        "consumer_ii_cycles": int(threshold["min_zero_backpressure_ii_cycles"]),
+        "required_buffer_r64_tiles": depth_tiles,
+        "required_buffer_bytes": depth_tiles * R64_LANES * math.ceil(logit_bits / 8),
+        "ranker_total_power_mw": cost.get("total_power_mw"),
+        "ranker_critical_path_ns": cost.get("critical_path_ns"),
+        "ranker_service_cycles": cost.get("ranker_service_cycles"),
+        "decision": "buffer_feasible",
+    }
+
+
+def _rank_tree_option(
+    *,
+    row: JsonDict,
+    tree: JsonDict,
+    integration: str,
+    logit_bits: int,
+) -> JsonDict:
+    producer_lanes = int(row["producer_lanes"])
+    chunks = _ceil_div(producer_lanes, R64_LANES)
+    banked = integration == "banked_r64_ranktrees"
+    instances = chunks if banked else 1
+    consumer_ii = 1 if banked else chunks
+    offered_units = 1 if banked else chunks
+    queued_units = _required_waiting_buffer_tiles(
+        producer_tile_count=int(row["tile_count"]),
+        chunks_per_producer_tile=offered_units,
+        producer_ii_cycles=int(row["producer_ii_cycles"]),
+        consumer_ii_cycles=consumer_ii,
+    )
+    depth_tiles = queued_units * chunks if banked else queued_units
+    power = tree.get("total_power_mw")
+    area = tree.get("placed_cell_area_um2")
+    return {
+        "strategy": f"{integration}_{tree['ranker']}",
+        "ranker": tree["ranker"],
+        "integration": integration,
+        "ranker_instances": instances,
+        "consumer_ii_cycles": consumer_ii,
+        "required_buffer_r64_tiles": depth_tiles,
+        "required_buffer_bytes": depth_tiles * R64_LANES * math.ceil(logit_bits / 8),
+        "ranker_total_power_mw": None if power is None else power * instances,
+        "ranker_placed_cell_area_um2": None if area is None else area * instances,
+        "ranker_critical_path_ns": tree.get("critical_path_ns"),
+        "ranker_service_cycles": consumer_ii,
+        "decision": "rank_tree_feasible" if depth_tiles == 0 else "rank_tree_with_buffer",
+    }
+
+
+def _choose_option(options: list[JsonDict], *, small_buffer_tiles: int) -> JsonDict:
+    small_buffers = [
+        row
+        for row in options
+        if row["strategy"].startswith("buffered_serial_lpc4")
+        and row["required_buffer_r64_tiles"] <= small_buffer_tiles
+    ]
+    if small_buffers:
+        return min(small_buffers, key=lambda row: row["required_buffer_r64_tiles"])
+    no_buffer_trees = [
+        row for row in options if row["strategy"].startswith("single_r64_ranktrees") and row["required_buffer_r64_tiles"] == 0
+    ]
+    if no_buffer_trees:
+        return min(
+            no_buffer_trees,
+            key=lambda row: (
+                row.get("ranker_total_power_mw") is None,
+                row.get("ranker_total_power_mw") if row.get("ranker_total_power_mw") is not None else math.inf,
+            ),
+        )
+    return min(
+        options,
+        key=lambda row: (
+            row["required_buffer_r64_tiles"],
+            row.get("ranker_total_power_mw") is None,
+            row.get("ranker_total_power_mw") if row.get("ranker_total_power_mw") is not None else math.inf,
+        ),
+    )
+
+
+def build_report(
+    *,
+    cadence_sensitivity: JsonDict,
+    rank_tree: JsonDict,
+    logit_bits: int,
+    small_buffer_tiles: int,
+) -> JsonDict:
+    thresholds = _serial_thresholds(cadence_sensitivity)
+    serial_costs = _serial_costs(cadence_sensitivity)
+    trees = _rank_tree_costs(rank_tree)
+    unsafe_rows = [
+        row
+        for row in cadence_sensitivity.get("cadence_sweep", [])
+        if isinstance(row, dict)
+        and (row.get("selected_ranker") or {}).get("decision") != "serial_ranker_safe"
+    ]
+    fallback_rows: list[JsonDict] = []
+    for row in unsafe_rows:
+        options: list[JsonDict] = []
+        for ranker in ("serial_lpc1", "serial_lpc2", "serial_lpc4"):
+            if ranker in thresholds:
+                options.append(
+                    _buffer_option(
+                        row=row,
+                        ranker=ranker,
+                        threshold=thresholds[ranker],
+                        cost=serial_costs.get(ranker, {}),
+                        logit_bits=logit_bits,
+                    )
+                )
+        for tree in trees:
+            options.append(
+                _rank_tree_option(
+                    row=row,
+                    tree=tree,
+                    integration="single_r64_ranktrees",
+                    logit_bits=logit_bits,
+                )
+            )
+            if int(row["producer_lanes"]) > R64_LANES:
+                options.append(
+                    _rank_tree_option(
+                        row=row,
+                        tree=tree,
+                        integration="banked_r64_ranktrees",
+                        logit_bits=logit_bits,
+                    )
+                )
+        fallback_rows.append(
+            {
+                "producer": {
+                    key: row[key]
+                    for key in (
+                        "vocab_size",
+                        "hidden_size",
+                        "producer_lanes",
+                        "tile_count",
+                        "macs_per_cycle",
+                        "memory_bandwidth_bytes_per_cycle",
+                        "weight_cache_hit_rate",
+                        "producer_ii_cycles",
+                        "service_limiter",
+                    )
+                },
+                "options": options,
+                "recommended": _choose_option(options, small_buffer_tiles=small_buffer_tiles),
+            }
+        )
+
+    rank_tree_count = sum(
+        1 for row in fallback_rows if "ranktree" in str(row["recommended"].get("strategy", ""))
+    )
+    buffered_count = len(fallback_rows) - rank_tree_count
+    return {
+        "version": 0.1,
+        "model": "decoder_resident_weight_ranker_fallback_v1",
+        "inputs": {
+            "logit_bits": logit_bits,
+            "small_buffer_tiles": small_buffer_tiles,
+        },
+        "assumptions": [
+            "Unsafe rows are producer cadence rows where prior serial replay has no zero-backpressure ranker.",
+            "Buffer depth is simulated as r64 logit-tile chunks waiting in front of the ranker, excluding the tile in service.",
+            "Rank-tree fallback reuses measured r64/k1 rank-tree variants; single_r64 handles wider producer tiles sequentially, banked_r64 duplicates r64 rankers.",
+            "The model ignores SRAM/FIFO implementation overhead beyond raw logit storage bytes.",
+        ],
+        "fallback_rows": fallback_rows,
+        "recommendation": {
+            "decision": (
+                "rank_tree_fallback_preferred_for_resident_weight"
+                if rank_tree_count >= buffered_count
+                else "small_buffered_serial_fallback_preferred"
+            ),
+            "unsafe_rows": len(fallback_rows),
+            "rank_tree_recommended_rows": rank_tree_count,
+            "buffered_serial_recommended_rows": buffered_count,
+            "next_step": (
+                "Promote a rank-tree fallback wrapper for resident-weight producer rows, while keeping buffered serial_lpc4 only for near-threshold cadence cases."
+                if rank_tree_count >= buffered_count
+                else "Evaluate a small input FIFO in front of serial_lpc4 for near-threshold resident/cache-backed producer rows."
+            ),
+        },
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    rec = payload["recommendation"]
+    lines = [
+        "# Decoder Resident-Weight Ranker Fallback",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{rec['decision']}`",
+        f"- unsafe_rows: `{rec['unsafe_rows']}`",
+        f"- rank_tree_recommended_rows: `{rec['rank_tree_recommended_rows']}`",
+        f"- buffered_serial_recommended_rows: `{rec['buffered_serial_recommended_rows']}`",
+        f"- next_step: {rec['next_step']}",
+        "",
+        "## Fallback Rows",
+        "",
+        "| vocab | hidden | W | prod II | hit | recommended | buffer r64 tiles | buffer bytes | power mW |",
+        "|---:|---:|---:|---:|---:|---|---:|---:|---:|",
+    ]
+    for row in payload["fallback_rows"][:96]:
+        producer = row["producer"]
+        selected = row["recommended"]
+        lines.append(
+            "| {vocab} | {hidden} | {lanes} | {ii} | {hit} | {strategy} | {depth} | {bytes} | {power} |".format(
+                vocab=producer["vocab_size"],
+                hidden=producer["hidden_size"],
+                lanes=producer["producer_lanes"],
+                ii=producer["producer_ii_cycles"],
+                hit=producer["weight_cache_hit_rate"],
+                strategy=selected["strategy"],
+                depth=selected["required_buffer_r64_tiles"],
+                bytes=selected["required_buffer_bytes"],
+                power=selected.get("ranker_total_power_mw"),
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--cadence-sensitivity", required=True)
+    ap.add_argument("--rank-tree", required=True)
+    ap.add_argument("--logit-bits", type=int, default=16)
+    ap.add_argument("--small-buffer-tiles", type=int, default=32)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    payload = build_report(
+        cadence_sensitivity=_load_json(args.cadence_sensitivity),
+        rank_tree=_load_json(args.rank_tree),
+        logit_bits=args.logit_bits,
+        small_buffer_tiles=args.small_buffer_tiles,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_resident_weight_ranker_fallback.py
+++ b/tests/test_llm_decoder_resident_weight_ranker_fallback.py
@@ -1,0 +1,92 @@
+from npu.eval.estimate_llm_decoder_resident_weight_ranker_fallback import build_report
+
+
+def _cadence_row(*, producer_ii: int, producer_lanes: int = 64, tile_count: int = 32) -> dict:
+    return {
+        "vocab_size": 50257,
+        "hidden_size": 768,
+        "producer_lanes": producer_lanes,
+        "tile_count": tile_count,
+        "macs_per_cycle": 32768,
+        "memory_bandwidth_bytes_per_cycle": 256,
+        "weight_cache_hit_rate": 1.0,
+        "producer_ii_cycles": producer_ii,
+        "service_limiter": "compute",
+        "selected_ranker": {"decision": "serial_ranker_not_safe_at_this_cadence"},
+    }
+
+
+def _rank_tree() -> dict:
+    return {
+        "variants": [
+            {
+                "status": "ok",
+                "radix": 4,
+                "pipeline_stages": 3,
+                "metrics_row": {
+                    "critical_path_ns": "2.9",
+                    "die_area": "800000",
+                    "total_power_mw": "0.02",
+                },
+                "synthesis": {"log_tail": ["Placed Cell Area 32000.0"]},
+            }
+        ]
+    }
+
+
+def _cadence(*rows: dict) -> dict:
+    return {
+        "ranker_zero_backpressure_thresholds": {
+            "serial_lpc1": {"min_zero_backpressure_ii_cycles": 384},
+            "serial_lpc2": {"min_zero_backpressure_ii_cycles": 65},
+            "serial_lpc4": {"min_zero_backpressure_ii_cycles": 33},
+        },
+        "ranker_costs": {
+            "serial_lpc1": {"ranker_service_cycles": 65, "total_power_mw": 0.006},
+            "serial_lpc2": {"ranker_service_cycles": 33, "total_power_mw": 0.008},
+            "serial_lpc4": {"ranker_service_cycles": 17, "total_power_mw": 0.011},
+        },
+        "cadence_sweep": list(rows),
+    }
+
+
+def test_resident_fast_row_prefers_no_buffer_rank_tree() -> None:
+    report = build_report(
+        cadence_sensitivity=_cadence(_cadence_row(producer_ii=2, tile_count=64)),
+        rank_tree=_rank_tree(),
+        logit_bits=16,
+        small_buffer_tiles=32,
+    )
+
+    selected = report["fallback_rows"][0]["recommended"]
+    assert selected["strategy"] == "single_r64_ranktrees_ranktree_radix4"
+    assert selected["required_buffer_r64_tiles"] == 0
+    assert report["recommendation"]["decision"] == "rank_tree_fallback_preferred_for_resident_weight"
+
+
+def test_near_threshold_row_prefers_small_buffered_serial_lpc4() -> None:
+    report = build_report(
+        cadence_sensitivity=_cadence(_cadence_row(producer_ii=32, tile_count=64)),
+        rank_tree=_rank_tree(),
+        logit_bits=16,
+        small_buffer_tiles=32,
+    )
+
+    selected = report["fallback_rows"][0]["recommended"]
+    assert selected["strategy"] == "buffered_serial_lpc4"
+    assert 0 < selected["required_buffer_r64_tiles"] <= 32
+    assert selected["required_buffer_bytes"] == selected["required_buffer_r64_tiles"] * 128
+
+
+def test_wide_fast_row_can_use_banked_rank_tree_without_buffer() -> None:
+    report = build_report(
+        cadence_sensitivity=_cadence(_cadence_row(producer_ii=1, producer_lanes=128, tile_count=64)),
+        rank_tree=_rank_tree(),
+        logit_bits=16,
+        small_buffer_tiles=32,
+    )
+
+    selected = report["fallback_rows"][0]["recommended"]
+    assert selected["strategy"] == "banked_r64_ranktrees_ranktree_radix4"
+    assert selected["ranker_instances"] == 2
+    assert selected["required_buffer_r64_tiles"] == 0


### PR DESCRIPTION
## Summary
- add a resident-weight ranker fallback estimator comparing buffered serial rankers with measured r64 rank-tree fallbacks
- wire the new decoder_resident_weight_ranker_fallback L2 abstraction into task generation
- add proposal and unit/generator coverage

## Validation
- python3 -m py_compile npu/eval/estimate_llm_decoder_resident_weight_ranker_fallback.py
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_resident_weight_ranker_fallback.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "cadence_sensitivity or resident_weight_ranker_fallback"
- python3 scripts/validate_runs.py --skip_eval_queue
- smoke run against merged cadence/rank-tree artifacts