### PR TITLE
Fix top-level run-worker forwarding

### DIFF
--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -738,8 +738,6 @@ def main(argv: list[str] | None = None) -> int:
             str(args.lease_seconds),
             "--machine-role",
             str(args.machine_role),
-            "--machine-role",
-            str(args.machine_role),
             "--heartbeat-seconds",
             str(args.heartbeat_seconds),
             "--max-retry-attempts",
@@ -749,7 +747,6 @@ def main(argv: list[str] | None = None) -> int:
         ]
         for key, value in [
             ("--hostname", args.hostname),
-            ("--slot-capacity", args.slot_capacity),
             ("--slot-capacity", args.slot_capacity),
             ("--capabilities-json", args.capabilities_json),
             ("--capability-filter-json", args.capability_filter_json),
@@ -768,7 +765,6 @@ def main(argv: list[str] | None = None) -> int:
             ("--completion-worktree-root", args.completion_worktree_root),
             ("--completion-commit-message", args.completion_commit_message),
             ("--completion-pr-base", args.completion_pr_base),
-            ("--source-update-ref", args.source_update_ref),
         ]:
             if value is not None:
                 argv2.extend([key, str(value)])

--- a/control_plane/control_plane/tests/test_cli_generate_l1.py
+++ b/control_plane/control_plane/tests/test_cli_generate_l1.py
@@ -50,3 +50,32 @@ def test_top_level_generate_l1_forwards_extended_generation_flags() -> None:
     assert forwarded[forwarded.index("--trial-count") + 1] == "3"
     assert forwarded[forwarded.index("--seed-start") + 1] == "100"
     assert forwarded[forwarded.index("--stop-after-failures") + 1] == "2"
+
+
+def test_top_level_run_worker_forwards_only_worker_flags() -> None:
+    with patch("control_plane.cli.main.run_worker_main", return_value=0) as worker:
+        result = main(
+            [
+                "run-worker",
+                "--database-url",
+                "sqlite+pysqlite:///:memory:",
+                "--repo-root",
+                "/repo",
+                "--machine-key",
+                "eval-daemon",
+                "--machine-role",
+                "evaluator",
+                "--slot-capacity",
+                "1",
+                "--max-items",
+                "1",
+            ]
+        )
+
+    assert result == 0
+    forwarded = worker.call_args.args[0]
+    assert "--source-update-ref" not in forwarded
+    assert forwarded.count("--machine-role") == 1
+    assert forwarded.count("--slot-capacity") == 1
+    assert forwarded[forwarded.index("--machine-role") + 1] == "evaluator"
+    assert forwarded[forwarded.index("--slot-capacity") + 1] == "1"


### PR DESCRIPTION
## Summary
- stop forwarding daemon-only --source-update-ref from the top-level run-worker wrapper
- remove duplicate --machine-role and --slot-capacity forwarding
- add CLI regression coverage for run-worker forwarding

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_cli_generate_l1.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python control_plane/control_plane/cli/main.py run-worker --database-url sqlite+pysqlite:///:memory: --repo-root /tmp/rtlgen-worker-cli-fix --machine-key eval-daemon --max-items 0