### PR TITLE
Promote resident-weight rank-tree fallback job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2448,6 +2448,46 @@ def _decoder_resident_weight_ranker_fallback_evidence(*, item_id: str) -> dict[s
     }
 
 
+def _decoder_resident_ranktree_fallback_promotion_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_resident_ranktree_fallback_promotion__{item_id}.json"
+    report = f"{base}/decoder_resident_ranktree_fallback_promotion__{item_id}.md"
+    fallback = (
+        f"{base}/decoder_resident_weight_ranker_fallback__"
+        "l2_decoder_resident_weight_ranker_fallback_v1.json"
+    )
+    rank_tree = (
+        f"{base}/decoder_rank_tree_architecture__"
+        "l2_decoder_rank_tree_architecture_v1.json"
+    )
+    return {
+        "inputs": {
+            "resident_ranktree_fallback_promotion_out": out,
+            "resident_ranktree_fallback_promotion_report": report,
+            "resident_weight_ranker_fallback": fallback,
+            "rank_tree_architecture": rank_tree,
+            "resident_ranktree_fallback_promotion_scope": (
+                "Promote the resident-weight output-projection fallback policy to the measured "
+                "radix-4 r64 rank-tree: one instance for r64 producer tiles and banked r64 "
+                "instances for wider resident-weight producer tiles."
+            ),
+        },
+        "commands": [
+            {
+                "name": "promote_decoder_resident_ranktree_fallback",
+                "run": (
+                    "python3 npu/eval/promote_llm_decoder_resident_ranktree_fallback.py "
+                    f"--fallback {fallback} "
+                    f"--rank-tree {rank_tree} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_stage_breakdown_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_stage_breakdown__{item_id}.json"
@@ -3730,6 +3770,7 @@ def _build_payload(
         "decoder_serial_lpc1_producer_coupled_wrapper",
         "decoder_output_projection_cadence_sensitivity",
         "decoder_resident_weight_ranker_fallback",
+        "decoder_resident_ranktree_fallback_promotion",
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
@@ -3791,6 +3832,8 @@ def _build_payload(
             decoder_evidence = _decoder_output_projection_cadence_sensitivity_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_resident_weight_ranker_fallback":
             decoder_evidence = _decoder_resident_weight_ranker_fallback_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_resident_ranktree_fallback_promotion":
+            decoder_evidence = _decoder_resident_ranktree_fallback_promotion_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_service":
             decoder_evidence = _decoder_output_projection_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2113,6 +2113,64 @@ def test_generate_l2_campaign_task_adds_decoder_resident_weight_ranker_fallback(
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_resident_ranktree_fallback_promotion() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_resident_ranktree_fallback_promotion_v1",
+                    proposal_id="prop_l2_decoder_resident_ranktree_fallback_promotion_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_resident_ranktree_fallback_promotion_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_resident_ranktree_fallback_promotion",
+                    expected_direction="promote",
+                    comparison_role="producer_ranker_service",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == (
+                "promote_decoder_resident_ranktree_fallback"
+            )
+            run = work_item.command_manifest[0]["run"]
+            assert "promote_llm_decoder_resident_ranktree_fallback.py" in run
+            assert decoder_inputs["resident_ranktree_fallback_promotion_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_resident_ranktree_fallback_promotion__"
+                "l2_decoder_resident_ranktree_fallback_promotion_v1.json"
+            )
+            assert decoder_inputs["resident_weight_ranker_fallback"].endswith(
+                "l2_decoder_resident_weight_ranker_fallback_v1.json"
+            )
+            assert decoder_inputs["rank_tree_architecture"].endswith(
+                "l2_decoder_rank_tree_architecture_v1.json"
+            )
+            assert "radix-4 r64 rank-tree" in decoder_inputs[
+                "resident_ranktree_fallback_promotion_scope"
+            ]
+            assert decoder_inputs["resident_ranktree_fallback_promotion_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_resident_ranktree_fallback_promotion",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_resident_ranktree_fallback_promotion_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_resident_ranktree_fallback_promotion_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_resident_ranktree_fallback_promotion_v1",
+  "created_utc": "2026-05-14T10:35:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_resident_ranktree_fallback_promotion",
+  "title": "Decoder resident-weight rank-tree fallback promotion",
+  "hypothesis": "The resident-weight output-projection rows that outpace serial rankers can be covered by the measured radix-4 r64 rank-tree without an input waiting buffer, using one instance for r64 tiles and banked instances for r128 tiles.",
+  "direct_comparison": {
+    "primary_question": "Can the resident-weight ranker fallback policy be promoted to the measured radix-4 r64 rank-tree while preserving RTL simulation evidence, physical metrics, and zero-buffer service coverage?",
+    "include": [
+      "rank-tree fallback recommendations from the resident-weight fallback study",
+      "measured r64/k1 rank-tree RTL simulation status",
+      "measured rank-tree critical path, placed cell area, and power",
+      "single-r64 and banked-r64 producer coupling modes",
+      "zero waiting-buffer promotion gate"
+    ],
+    "exclude": [
+      "new physical synthesis",
+      "new producer RTL",
+      "NoC or SRAM arbitration",
+      "larger-than-r128 producer tiles"
+    ]
+  },
+  "expected_benefit": [
+    "turns the resident-weight fallback recommendation into a concrete producer-coupled ranker policy",
+    "keeps the promotion anchored to measured RTL and PPA rather than heuristic costs",
+    "separates r64 single-instance and r128 banked-instance integration assumptions before implementing the wrapper"
+  ],
+  "risks": [
+    "the producer traffic is still fixed-II planning data rather than measured burst traces",
+    "banked r64 instances assume independent 64-lane chunks can be routed and reduced without extra arbitration overhead",
+    "future wider producer tiles may require a second-level reduction or a broader rank-tree measurement"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_resident_ranktree_fallback_promotion_v1",
+      "task_type": "l2_campaign",
+      "objective": "Promote the measured radix-4 r64 rank-tree as the resident-weight output-projection fallback policy for unsafe producer cadences.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_resident_ranktree_fallback_promotion",
+      "cost_class": "low",
+      "comparison_role": "producer_ranker_service",
+      "paired_baseline_item_id": "l2_decoder_resident_weight_ranker_fallback_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_resident_weight_ranker_fallback_v1",
+        "l2_decoder_rank_tree_architecture_v1",
+        "l2_decoder_output_projection_cadence_sensitivity_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "promote",
+        "reason": "If all unsafe resident-weight rows use zero-buffer rank-tree recommendations and the selected radix has clean RTL simulation plus measured PPA, use it as the producer-coupled fallback implementation target."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_resident_weight_ranker_fallback__l2_decoder_resident_weight_ranker_fallback_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_rank_tree_architecture__l2_decoder_rank_tree_architecture_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_cadence_sensitivity__l2_decoder_output_projection_cadence_sensitivity_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/promote_llm_decoder_resident_ranktree_fallback.py",
+    "tests/test_llm_decoder_resident_ranktree_fallback_promotion.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/promote_llm_decoder_resident_ranktree_fallback.py
+++ b/npu/eval/promote_llm_decoder_resident_ranktree_fallback.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Promote the resident-weight output-projection rank-tree fallback policy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+R64_LANES = 64
+STRATEGY_RE = re.compile(r"^(single|banked)_r64_ranktrees_ranktree_radix(?P<radix>\d+)$")
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _maybe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _placed_cell_area(variant: JsonDict | None) -> float | None:
+    if not isinstance(variant, dict):
+        return None
+    synthesis = variant.get("synthesis") if isinstance(variant.get("synthesis"), dict) else {}
+    for line in synthesis.get("log_tail", []):
+        match = re.search(r"Placed Cell Area\s+([0-9.]+)", str(line))
+        if match:
+            return float(match.group(1))
+    return None
+
+
+def _variant_by_radix(rank_tree: JsonDict, radix: int) -> JsonDict | None:
+    for variant in rank_tree.get("variants", []):
+        if not isinstance(variant, dict):
+            continue
+        if int(variant.get("radix", -1)) == radix:
+            return variant
+    return None
+
+
+def _metrics_summary(variant: JsonDict | None) -> JsonDict | None:
+    if not isinstance(variant, dict):
+        return None
+    metrics = variant.get("metrics_row") if isinstance(variant.get("metrics_row"), dict) else {}
+    return {
+        "top": variant.get("top"),
+        "radix": variant.get("radix"),
+        "pipeline_stages": variant.get("pipeline_stages"),
+        "critical_path_ns": _maybe_float(metrics.get("critical_path_ns")),
+        "die_area_um2": _maybe_float(metrics.get("die_area")),
+        "placed_cell_area_um2": _placed_cell_area(variant),
+        "total_power_mw": _maybe_float(metrics.get("total_power_mw")),
+        "metrics_status": metrics.get("status"),
+        "simulation_status": (variant.get("simulation") or {}).get("status")
+        if isinstance(variant.get("simulation"), dict)
+        else None,
+        "design_dir": variant.get("design_dir"),
+    }
+
+
+def _recommended_rows(fallback: JsonDict) -> list[JsonDict]:
+    rows: list[JsonDict] = []
+    for row in fallback.get("fallback_rows", []):
+        if isinstance(row, dict) and isinstance(row.get("recommended"), dict):
+            rows.append(row)
+    return rows
+
+
+def _selected_strategy(row: JsonDict) -> str:
+    return str((row.get("recommended") or {}).get("strategy", ""))
+
+
+def _strategy_radix(strategy: str) -> int | None:
+    match = STRATEGY_RE.match(strategy)
+    if not match:
+        return None
+    return int(match.group("radix"))
+
+
+def _producer_mode(row: JsonDict) -> str:
+    producer = row.get("producer") if isinstance(row.get("producer"), dict) else {}
+    lanes = int(producer.get("producer_lanes", R64_LANES))
+    return "single_r64_ranktree" if lanes <= R64_LANES else "banked_r64_ranktrees"
+
+
+def _mode_summaries(rows: list[JsonDict], *, selected_radix: int, selected_metrics: JsonDict | None) -> list[JsonDict]:
+    summaries: list[JsonDict] = []
+    power = (selected_metrics or {}).get("total_power_mw")
+    area = (selected_metrics or {}).get("placed_cell_area_um2")
+    for mode in ("single_r64_ranktree", "banked_r64_ranktrees"):
+        mode_rows = [row for row in rows if _producer_mode(row) == mode]
+        if not mode_rows:
+            continue
+        lane_values = sorted(
+            {
+                int((row.get("producer") or {}).get("producer_lanes", R64_LANES))
+                for row in mode_rows
+            }
+        )
+        max_lanes = max(lane_values)
+        instances = math.ceil(max_lanes / R64_LANES)
+        summaries.append(
+            {
+                "mode": mode,
+                "recommended_strategy_count": len(mode_rows),
+                "producer_lanes": lane_values,
+                "ranktree_radix": selected_radix,
+                "ranker_instances": instances,
+                "consumer_ii_cycles": 1,
+                "max_required_buffer_r64_tiles": max(
+                    int((row.get("recommended") or {}).get("required_buffer_r64_tiles", 0))
+                    for row in mode_rows
+                ),
+                "producer_ii_cycles_min": min(
+                    int((row.get("producer") or {}).get("producer_ii_cycles", 0))
+                    for row in mode_rows
+                ),
+                "producer_ii_cycles_max": max(
+                    int((row.get("producer") or {}).get("producer_ii_cycles", 0))
+                    for row in mode_rows
+                ),
+                "ranker_total_power_mw": None if power is None else power * instances,
+                "ranker_placed_cell_area_um2": None if area is None else area * instances,
+            }
+        )
+    return summaries
+
+
+def build_report(*, fallback: JsonDict, rank_tree: JsonDict) -> JsonDict:
+    rows = _recommended_rows(fallback)
+    strategy_counts = Counter(_selected_strategy(row) for row in rows)
+    selected_radices = sorted(
+        {
+            radix
+            for radix in (_strategy_radix(strategy) for strategy in strategy_counts)
+            if radix is not None
+        }
+    )
+    selected_radix = selected_radices[0] if len(selected_radices) == 1 else None
+    selected_variant = _variant_by_radix(rank_tree, selected_radix) if selected_radix is not None else None
+    selected_metrics = _metrics_summary(selected_variant)
+    all_rank_tree = bool(rows) and all(_strategy_radix(_selected_strategy(row)) is not None for row in rows)
+    max_buffer = max(
+        (int((row.get("recommended") or {}).get("required_buffer_r64_tiles", 0)) for row in rows),
+        default=None,
+    )
+    fallback_rec = fallback.get("recommendation") if isinstance(fallback.get("recommendation"), dict) else {}
+    checks = [
+        {
+            "name": "fallback_prefers_rank_tree",
+            "passed": fallback_rec.get("decision") == "rank_tree_fallback_preferred_for_resident_weight",
+            "observed": fallback_rec,
+        },
+        {
+            "name": "all_unsafe_rows_have_rank_tree_strategy",
+            "passed": all_rank_tree,
+            "observed": dict(strategy_counts),
+        },
+        {
+            "name": "rank_tree_strategy_has_single_radix",
+            "passed": selected_radix is not None,
+            "observed": selected_radices,
+        },
+        {
+            "name": "selected_rank_tree_variant_has_clean_rtl_sim",
+            "passed": isinstance(selected_variant, dict)
+            and selected_variant.get("status") == "ok"
+            and (selected_variant.get("simulation") or {}).get("status") == "ok",
+            "observed": None if selected_variant is None else selected_variant.get("simulation"),
+        },
+        {
+            "name": "selected_rank_tree_variant_has_physical_metrics",
+            "passed": isinstance(selected_variant, dict)
+            and (selected_variant.get("metrics_row") or {}).get("status") == "ok",
+            "observed": selected_metrics,
+        },
+        {
+            "name": "promotion_requires_no_waiting_buffer",
+            "passed": max_buffer == 0,
+            "observed": max_buffer,
+        },
+    ]
+    passed = all(bool(check["passed"]) for check in checks)
+    return {
+        "version": 0.1,
+        "model": "decoder_resident_ranktree_fallback_promotion_v1",
+        "target": {
+            "producer_role": "resident_weight_output_projection",
+            "producer_lanes_supported": sorted(
+                {
+                    int((row.get("producer") or {}).get("producer_lanes", R64_LANES))
+                    for row in rows
+                }
+            ),
+            "top_k": 1,
+            "selected_radix": selected_radix,
+            "wrapper_role": "rank_tree_fallback_for_resident_weight_output_projection",
+        },
+        "coverage": {
+            "unsafe_rows": len(rows),
+            "strategy_counts": dict(strategy_counts),
+            "max_required_buffer_r64_tiles": max_buffer,
+        },
+        "selected_ranktree_variant": selected_variant,
+        "selected_metrics": selected_metrics,
+        "producer_modes": (
+            []
+            if selected_radix is None
+            else _mode_summaries(rows, selected_radix=selected_radix, selected_metrics=selected_metrics)
+        ),
+        "checks": checks,
+        "decision": {
+            "decision": (
+                "resident_weight_ranktree_fallback_promoted"
+                if passed
+                else "resident_weight_ranktree_fallback_blocked"
+            ),
+            "next_step": (
+                "Implement or instantiate the radix-4 r64 rank-tree fallback in the resident-weight "
+                "output-projection producer wrapper: one instance for r64 producer tiles and two "
+                "banked instances for r128 producer tiles."
+                if passed
+                else "Resolve fallback coverage, RTL simulation, or physical metric gaps before promoting the resident-weight rank-tree fallback."
+            ),
+        },
+        "assumptions": [
+            "The fallback policy is for resident/cache-backed output-projection rows that outpace the replay-proven serial ranker thresholds.",
+            "Single-r64 mode uses one measured r64/k1 rank-tree instance at II=1.",
+            "Banked-r64 mode duplicates the measured r64/k1 rank-tree per 64-lane chunk so r128 producer tiles still drain at II=1.",
+            "This promotion carries measured rank-tree PPA and RTL simulation status; it does not model FIFO/SRAM overhead because the selected current rows require no waiting buffer.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    metrics = payload.get("selected_metrics") or {}
+    lines = [
+        "# Decoder Resident Rank-Tree Fallback Promotion",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- selected_radix: `{payload['target']['selected_radix']}`",
+        f"- unsafe_rows: `{payload['coverage']['unsafe_rows']}`",
+        f"- max_required_buffer_r64_tiles: `{payload['coverage']['max_required_buffer_r64_tiles']}`",
+        f"- critical_path_ns: `{metrics.get('critical_path_ns')}`",
+        f"- placed_cell_area_um2: `{metrics.get('placed_cell_area_um2')}`",
+        f"- total_power_mw: `{metrics.get('total_power_mw')}`",
+        f"- next_step: {payload['decision']['next_step']}",
+        "",
+        "## Producer Modes",
+        "",
+        "| mode | lanes | instances | II | rows | max buffer r64 | power mW | area um2 |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["producer_modes"]:
+        lines.append(
+            "| {mode} | {lanes} | {instances} | {ii} | {rows} | {buf} | {power} | {area} |".format(
+                mode=row["mode"],
+                lanes=",".join(str(x) for x in row["producer_lanes"]),
+                instances=row["ranker_instances"],
+                ii=row["consumer_ii_cycles"],
+                rows=row["recommended_strategy_count"],
+                buf=row["max_required_buffer_r64_tiles"],
+                power=row.get("ranker_total_power_mw"),
+                area=row.get("ranker_placed_cell_area_um2"),
+            )
+        )
+    lines.extend(["", "## Checks", "", "| check | passed | observed |", "|---|---|---|"])
+    for check in payload["checks"]:
+        lines.append(f"| {check['name']} | `{check['passed']}` | `{check.get('observed')}` |")
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--fallback", required=True)
+    ap.add_argument("--rank-tree", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    payload = build_report(fallback=_load_json(args.fallback), rank_tree=_load_json(args.rank_tree))
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_resident_ranktree_fallback_promotion.py
+++ b/tests/test_llm_decoder_resident_ranktree_fallback_promotion.py
@@ -1,0 +1,95 @@
+from npu.eval.promote_llm_decoder_resident_ranktree_fallback import build_report
+
+
+def _variant(*, simulation_status: str = "ok", metrics_status: str = "ok") -> dict:
+    return {
+        "status": "ok",
+        "top": "decoder_r64_k1_ranktree_radix4_pipe3_wrapper",
+        "design_dir": "runs/designs/activations/decoder_r64_k1_ranktree_radix4_pipe3_wrapper",
+        "radix": 4,
+        "pipeline_stages": 3,
+        "simulation": {"status": simulation_status, "expected": {"token": 5, "logit": 500}},
+        "metrics_row": {
+            "status": metrics_status,
+            "critical_path_ns": "4.35",
+            "die_area": "810000",
+            "total_power_mw": "0.011",
+        },
+        "synthesis": {"log_tail": ["[INFO GPL-1002] Placed Cell Area 32000.0"]},
+    }
+
+
+def _fallback_row(*, lanes: int, strategy: str, buffer_tiles: int = 0) -> dict:
+    return {
+        "producer": {
+            "producer_lanes": lanes,
+            "producer_ii_cycles": 2 if lanes == 64 else 3,
+        },
+        "recommended": {
+            "strategy": strategy,
+            "required_buffer_r64_tiles": buffer_tiles,
+            "required_buffer_bytes": buffer_tiles * 128,
+        },
+    }
+
+
+def _fallback(*rows: dict) -> dict:
+    return {
+        "recommendation": {
+            "decision": "rank_tree_fallback_preferred_for_resident_weight",
+            "unsafe_rows": len(rows),
+            "rank_tree_recommended_rows": len(rows),
+            "buffered_serial_recommended_rows": 0,
+        },
+        "fallback_rows": list(rows),
+    }
+
+
+def test_promotes_radix4_single_and_banked_ranktree_fallback() -> None:
+    report = build_report(
+        fallback=_fallback(
+            _fallback_row(lanes=64, strategy="single_r64_ranktrees_ranktree_radix4"),
+            _fallback_row(lanes=128, strategy="banked_r64_ranktrees_ranktree_radix4"),
+        ),
+        rank_tree={"variants": [_variant()]},
+    )
+
+    assert report["decision"]["decision"] == "resident_weight_ranktree_fallback_promoted"
+    assert report["target"]["selected_radix"] == 4
+    assert report["coverage"]["max_required_buffer_r64_tiles"] == 0
+    assert report["selected_metrics"]["placed_cell_area_um2"] == 32000.0
+    assert [row["mode"] for row in report["producer_modes"]] == [
+        "single_r64_ranktree",
+        "banked_r64_ranktrees",
+    ]
+    assert report["producer_modes"][1]["ranker_instances"] == 2
+    assert report["producer_modes"][1]["ranker_total_power_mw"] == 0.022
+    assert all(check["passed"] for check in report["checks"])
+
+
+def test_blocks_when_ranktree_fallback_needs_waiting_buffer() -> None:
+    report = build_report(
+        fallback=_fallback(
+            _fallback_row(
+                lanes=64,
+                strategy="single_r64_ranktrees_ranktree_radix4",
+                buffer_tiles=1,
+            )
+        ),
+        rank_tree={"variants": [_variant()]},
+    )
+
+    assert report["decision"]["decision"] == "resident_weight_ranktree_fallback_blocked"
+    assert report["checks"][-1]["name"] == "promotion_requires_no_waiting_buffer"
+    assert report["checks"][-1]["passed"] is False
+
+
+def test_blocks_when_selected_ranktree_lacks_clean_simulation() -> None:
+    report = build_report(
+        fallback=_fallback(_fallback_row(lanes=64, strategy="single_r64_ranktrees_ranktree_radix4")),
+        rank_tree={"variants": [_variant(simulation_status="failed")]},
+    )
+
+    assert report["decision"]["decision"] == "resident_weight_ranktree_fallback_blocked"
+    assert report["checks"][3]["name"] == "selected_rank_tree_variant_has_clean_rtl_sim"
+    assert report["checks"][3]["passed"] is False


### PR DESCRIPTION
## Summary
- add a promotion estimator for resident-weight output-projection rank-tree fallback policy
- wire decoder_resident_ranktree_fallback_promotion into L2 task generation
- add proposal and unit/generator coverage

## Validation
- python3 -m py_compile npu/eval/promote_llm_decoder_resident_ranktree_fallback.py
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_resident_ranktree_fallback_promotion.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "resident_ranktree_fallback_promotion or resident_weight_ranker_fallback"
- python3 scripts/validate_runs.py --skip_eval_queue
- smoke run against merged fallback/rank-tree artifacts