### PR TITLE
Add output-projection ranker policy job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2488,6 +2488,52 @@ def _decoder_resident_ranktree_fallback_promotion_evidence(*, item_id: str) -> d
     }
 
 
+def _decoder_output_projection_ranker_policy_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_ranker_policy__{item_id}.json"
+    report = f"{base}/decoder_output_projection_ranker_policy__{item_id}.md"
+    serial_wrapper = (
+        f"{base}/decoder_serial_lpc1_producer_coupled_wrapper__"
+        "l2_decoder_serial_lpc1_producer_coupled_wrapper_v1.json"
+    )
+    cadence_sensitivity = (
+        f"{base}/decoder_output_projection_cadence_sensitivity__"
+        "l2_decoder_output_projection_cadence_sensitivity_v1.json"
+    )
+    ranktree_promotion = (
+        f"{base}/decoder_resident_ranktree_fallback_promotion__"
+        "l2_decoder_resident_ranktree_fallback_promotion_v1.json"
+    )
+    return {
+        "inputs": {
+            "output_projection_ranker_policy_out": out,
+            "output_projection_ranker_policy_report": report,
+            "serial_lpc1_producer_coupled_wrapper": serial_wrapper,
+            "output_projection_cadence_sensitivity": cadence_sensitivity,
+            "resident_ranktree_fallback_promotion": ranktree_promotion,
+            "output_projection_ranker_policy_scope": (
+                "Promote the output-projection ranker selection policy: serial_lpc1 for "
+                "producer cadences at or above the replay-proven lpc1 threshold, and radix-4 "
+                "rank-tree fallback for faster resident/cache-backed producer cadences."
+            ),
+        },
+        "commands": [
+            {
+                "name": "promote_decoder_output_projection_ranker_policy",
+                "run": (
+                    "python3 npu/eval/promote_llm_decoder_output_projection_ranker_policy.py "
+                    f"--serial-wrapper {serial_wrapper} "
+                    f"--cadence-sensitivity {cadence_sensitivity} "
+                    f"--ranktree-promotion {ranktree_promotion} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_stage_breakdown_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_stage_breakdown__{item_id}.json"
@@ -3771,6 +3817,7 @@ def _build_payload(
         "decoder_output_projection_cadence_sensitivity",
         "decoder_resident_weight_ranker_fallback",
         "decoder_resident_ranktree_fallback_promotion",
+        "decoder_output_projection_ranker_policy",
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
@@ -3834,6 +3881,8 @@ def _build_payload(
             decoder_evidence = _decoder_resident_weight_ranker_fallback_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_resident_ranktree_fallback_promotion":
             decoder_evidence = _decoder_resident_ranktree_fallback_promotion_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_ranker_policy":
+            decoder_evidence = _decoder_output_projection_ranker_policy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_service":
             decoder_evidence = _decoder_output_projection_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2171,6 +2171,64 @@ def test_generate_l2_campaign_task_adds_decoder_resident_ranktree_fallback_promo
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_output_projection_ranker_policy() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_ranker_policy_v1",
+                    proposal_id="prop_l2_decoder_output_projection_ranker_policy_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_ranker_policy_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_ranker_policy",
+                    expected_direction="promote",
+                    comparison_role="producer_ranker_service",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.command_manifest[0]["name"] == (
+                "promote_decoder_output_projection_ranker_policy"
+            )
+            run = work_item.command_manifest[0]["run"]
+            assert "promote_llm_decoder_output_projection_ranker_policy.py" in run
+            assert decoder_inputs["output_projection_ranker_policy_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_ranker_policy__"
+                "l2_decoder_output_projection_ranker_policy_v1.json"
+            )
+            assert decoder_inputs["serial_lpc1_producer_coupled_wrapper"].endswith(
+                "l2_decoder_serial_lpc1_producer_coupled_wrapper_v1.json"
+            )
+            assert decoder_inputs["resident_ranktree_fallback_promotion"].endswith(
+                "l2_decoder_resident_ranktree_fallback_promotion_v1.json"
+            )
+            assert "ranker selection policy" in decoder_inputs[
+                "output_projection_ranker_policy_scope"
+            ]
+            assert decoder_inputs["output_projection_ranker_policy_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_ranker_policy",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_ranker_policy_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_ranker_policy_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_ranker_policy_v1",
+  "created_utc": "2026-05-14T10:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_ranker_policy",
+  "title": "Decoder output-projection ranker selection policy",
+  "hypothesis": "The output-projection producer can use the low-power serial_lpc1 ranker for streaming or otherwise slow producer cadences, and switch to the promoted radix-4 rank-tree fallback for resident or cache-backed cadences that exceed the serial_lpc1 replay threshold.",
+  "direct_comparison": {
+    "primary_question": "Does a simple producer-II policy cover the full cadence sweep using only promoted artifacts: serial_lpc1 for II >= the replay-proven threshold and radix-4 rank-tree fallback for faster rows?",
+    "include": [
+      "promoted serial_lpc1 producer-coupled wrapper",
+      "output-projection cadence sensitivity rows",
+      "promoted resident-weight rank-tree fallback",
+      "coverage over r64 and r128 producer lanes",
+      "explicit conservative routing of lpc2/lpc4-safe rows to rank-tree unless lpc1 is also safe"
+    ],
+    "exclude": [
+      "new RTL synthesis",
+      "new producer burst traces",
+      "NoC or SRAM arbitration",
+      "training or probability quality effects"
+    ]
+  },
+  "expected_benefit": [
+    "converts separate serial and resident-ranktree promotions into one implementation policy",
+    "keeps the selection boundary tied to replay-observed ready-valid behavior",
+    "avoids depending on unpromoted lpc2/lpc4 rankers for near-threshold cache-backed cases"
+  ],
+  "risks": [
+    "the fixed-II policy may be too conservative for lpc2/lpc4-safe cache-backed rows",
+    "measured producer bursts may need hysteresis or buffering near the threshold",
+    "banked rank-tree routing cost is still represented by duplicated measured r64 instances"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_ranker_policy_v1",
+      "task_type": "l2_campaign",
+      "objective": "Promote a combined output-projection ranker selection policy using serial_lpc1 for slow producer cadences and radix-4 rank-tree fallback for faster resident/cache-backed cadences.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_ranker_policy",
+      "cost_class": "low",
+      "comparison_role": "producer_ranker_service",
+      "paired_baseline_item_id": "l2_decoder_resident_ranktree_fallback_promotion_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_serial_lpc1_producer_coupled_wrapper_v1",
+        "l2_decoder_output_projection_cadence_sensitivity_v1",
+        "l2_decoder_resident_ranktree_fallback_promotion_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "promote",
+        "reason": "If the promoted serial and rank-tree artifacts cover every cadence row, use this policy as the contract for the next output-projection producer wrapper implementation."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_serial_lpc1_producer_coupled_wrapper__l2_decoder_serial_lpc1_producer_coupled_wrapper_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_cadence_sensitivity__l2_decoder_output_projection_cadence_sensitivity_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_resident_ranktree_fallback_promotion__l2_decoder_resident_ranktree_fallback_promotion_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/promote_llm_decoder_output_projection_ranker_policy.py",
+    "tests/test_llm_decoder_output_projection_ranker_policy.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/promote_llm_decoder_output_projection_ranker_policy.py
+++ b/npu/eval/promote_llm_decoder_output_projection_ranker_policy.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Promote output-projection ranker selection policy across streaming and resident weights."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+R64_LANES = 64
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _serial_lpc1_threshold(cadence: JsonDict, serial_wrapper: JsonDict) -> int | None:
+    thresholds = cadence.get("ranker_zero_backpressure_thresholds")
+    if isinstance(thresholds, dict) and isinstance(thresholds.get("serial_lpc1"), dict):
+        value = thresholds["serial_lpc1"].get("min_zero_backpressure_ii_cycles")
+        if value is not None:
+            return int(value)
+    target = serial_wrapper.get("target") if isinstance(serial_wrapper.get("target"), dict) else {}
+    value = target.get("producer_ii_cycles")
+    return None if value is None else int(value)
+
+
+def _ranktree_mode_for_lanes(lanes: int) -> str:
+    return "single_r64_ranktree" if lanes <= R64_LANES else "banked_r64_ranktrees"
+
+
+def _ranktree_modes(ranktree_promotion: JsonDict) -> dict[str, JsonDict]:
+    modes: dict[str, JsonDict] = {}
+    for row in ranktree_promotion.get("producer_modes", []):
+        if isinstance(row, dict) and row.get("mode"):
+            modes[str(row["mode"])] = row
+    return modes
+
+
+def _policy_row(
+    row: JsonDict,
+    *,
+    serial_threshold: int,
+    ranktree_modes: dict[str, JsonDict],
+) -> JsonDict:
+    producer_lanes = int(row["producer_lanes"])
+    producer_ii = int(row["producer_ii_cycles"])
+    base = {
+        key: row[key]
+        for key in (
+            "vocab_size",
+            "hidden_size",
+            "producer_lanes",
+            "tile_count",
+            "macs_per_cycle",
+            "memory_bandwidth_bytes_per_cycle",
+            "weight_cache_hit_rate",
+            "producer_ii_cycles",
+            "service_limiter",
+        )
+    }
+    if producer_ii >= serial_threshold:
+        return {
+            "producer": base,
+            "selected_path": "serial_lpc1",
+            "selection_reason": "producer_ii_meets_serial_lpc1_zero_backpressure_threshold",
+            "consumer_ii_cycles": serial_threshold,
+            "ranker_instances": 1,
+            "coverage_status": "covered",
+        }
+    mode = _ranktree_mode_for_lanes(producer_lanes)
+    promoted = ranktree_modes.get(mode)
+    return {
+        "producer": base,
+        "selected_path": mode,
+        "selection_reason": "producer_ii_is_faster_than_serial_lpc1_threshold",
+        "consumer_ii_cycles": None if promoted is None else promoted.get("consumer_ii_cycles"),
+        "ranker_instances": None if promoted is None else promoted.get("ranker_instances"),
+        "ranktree_radix": None if promoted is None else promoted.get("ranktree_radix"),
+        "coverage_status": "covered" if promoted is not None else "uncovered_ranktree_mode",
+    }
+
+
+def build_report(
+    *,
+    serial_wrapper: JsonDict,
+    cadence_sensitivity: JsonDict,
+    ranktree_promotion: JsonDict,
+) -> JsonDict:
+    serial_threshold = _serial_lpc1_threshold(cadence_sensitivity, serial_wrapper)
+    ranktree_modes = _ranktree_modes(ranktree_promotion)
+    rows: list[JsonDict] = []
+    if serial_threshold is not None:
+        for row in cadence_sensitivity.get("cadence_sweep", []):
+            if isinstance(row, dict):
+                rows.append(_policy_row(row, serial_threshold=serial_threshold, ranktree_modes=ranktree_modes))
+    path_counts = Counter(row["selected_path"] for row in rows)
+    uncovered = [row for row in rows if row["coverage_status"] != "covered"]
+    serial_decision = (
+        serial_wrapper.get("decision", {}).get("decision")
+        if isinstance(serial_wrapper.get("decision"), dict)
+        else None
+    )
+    ranktree_decision = (
+        ranktree_promotion.get("decision", {}).get("decision")
+        if isinstance(ranktree_promotion.get("decision"), dict)
+        else None
+    )
+    checks = [
+        {
+            "name": "serial_lpc1_wrapper_promoted",
+            "passed": serial_decision == "serial_lpc1_producer_coupled_wrapper_promoted",
+            "observed": serial_decision,
+        },
+        {
+            "name": "resident_ranktree_fallback_promoted",
+            "passed": ranktree_decision == "resident_weight_ranktree_fallback_promoted",
+            "observed": ranktree_decision,
+        },
+        {
+            "name": "serial_lpc1_threshold_available",
+            "passed": serial_threshold is not None,
+            "observed": serial_threshold,
+        },
+        {
+            "name": "all_cadence_rows_covered",
+            "passed": bool(rows) and not uncovered,
+            "observed": {"total_rows": len(rows), "uncovered_rows": len(uncovered)},
+        },
+        {
+            "name": "ranktree_has_single_and_banked_modes",
+            "passed": {"single_r64_ranktree", "banked_r64_ranktrees"}.issubset(ranktree_modes),
+            "observed": sorted(ranktree_modes),
+        },
+    ]
+    passed = all(bool(check["passed"]) for check in checks)
+    return {
+        "version": 0.1,
+        "model": "decoder_output_projection_ranker_policy_v1",
+        "policy": {
+            "serial_lpc1_min_ii_cycles": serial_threshold,
+            "rule": (
+                "Use serial_lpc1 when producer_ii_cycles is at least the replay-proven "
+                "serial_lpc1 zero-backpressure threshold; otherwise use the promoted radix-4 "
+                "rank-tree fallback mode selected by producer_lanes."
+            ),
+            "ranktree_mode_by_lanes": {
+                "producer_lanes <= 64": "single_r64_ranktree",
+                "producer_lanes > 64": "banked_r64_ranktrees",
+            },
+        },
+        "path_summary": {
+            "total_rows": len(rows),
+            "path_counts": dict(path_counts),
+            "uncovered_rows": len(uncovered),
+            "serial_lpc1_rows": path_counts.get("serial_lpc1", 0),
+            "ranktree_rows": sum(count for path, count in path_counts.items() if path != "serial_lpc1"),
+        },
+        "selected_artifacts": {
+            "serial_lpc1": {
+                "decision": serial_decision,
+                "metrics": serial_wrapper.get("selected_metrics"),
+                "target": serial_wrapper.get("target"),
+            },
+            "ranktree_fallback": {
+                "decision": ranktree_decision,
+                "metrics": ranktree_promotion.get("selected_metrics"),
+                "producer_modes": ranktree_promotion.get("producer_modes"),
+            },
+        },
+        "policy_rows": rows,
+        "uncovered_rows": uncovered,
+        "checks": checks,
+        "decision": {
+            "decision": (
+                "output_projection_ranker_policy_promoted"
+                if passed
+                else "output_projection_ranker_policy_blocked"
+            ),
+            "next_step": (
+                "Implement the output-projection producer wrapper policy with a serial_lpc1 path for "
+                "streaming/slow producer cadences and a radix-4 rank-tree fallback path for faster "
+                "resident/cache-backed cadences."
+                if passed
+                else "Resolve missing serial or rank-tree promotion coverage before implementing the output-projection producer wrapper policy."
+            ),
+        },
+        "assumptions": [
+            "The policy is conservative: lpc2/lpc4 rows that were analytically safe are routed to the promoted rank-tree unless lpc1 is also safe.",
+            "The rank-tree fallback uses one r64 rank-tree for producer_lanes <= 64 and banked r64 rank-trees for wider producer tiles.",
+            "The selection boundary is replay-observed ready-valid backpressure, not only analytical ranker service cycles.",
+            "Future measured producer burst traces may add hysteresis or buffering around this fixed-II policy boundary.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Output-Projection Ranker Policy",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- serial_lpc1_min_ii_cycles: `{payload['policy']['serial_lpc1_min_ii_cycles']}`",
+        f"- total_rows: `{payload['path_summary']['total_rows']}`",
+        f"- serial_lpc1_rows: `{payload['path_summary']['serial_lpc1_rows']}`",
+        f"- ranktree_rows: `{payload['path_summary']['ranktree_rows']}`",
+        f"- uncovered_rows: `{payload['path_summary']['uncovered_rows']}`",
+        f"- next_step: {payload['decision']['next_step']}",
+        "",
+        "## Path Counts",
+        "",
+        "| path | rows |",
+        "|---|---:|",
+    ]
+    for path_name, count in sorted(payload["path_summary"]["path_counts"].items()):
+        lines.append(f"| {path_name} | {count} |")
+    lines.extend(["", "## Checks", "", "| check | passed | observed |", "|---|---|---|"])
+    for check in payload["checks"]:
+        lines.append(f"| {check['name']} | `{check['passed']}` | `{check.get('observed')}` |")
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--serial-wrapper", required=True)
+    ap.add_argument("--cadence-sensitivity", required=True)
+    ap.add_argument("--ranktree-promotion", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    payload = build_report(
+        serial_wrapper=_load_json(args.serial_wrapper),
+        cadence_sensitivity=_load_json(args.cadence_sensitivity),
+        ranktree_promotion=_load_json(args.ranktree_promotion),
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_output_projection_ranker_policy.py
+++ b/tests/test_llm_decoder_output_projection_ranker_policy.py
@@ -1,0 +1,95 @@
+from npu.eval.promote_llm_decoder_output_projection_ranker_policy import build_report
+
+
+def _cadence_row(*, lanes: int, ii: int, hit: float) -> dict:
+    return {
+        "vocab_size": 50257,
+        "hidden_size": 768,
+        "producer_lanes": lanes,
+        "tile_count": 786,
+        "macs_per_cycle": 8192,
+        "memory_bandwidth_bytes_per_cycle": 64,
+        "weight_cache_hit_rate": hit,
+        "producer_ii_cycles": ii,
+        "service_limiter": "weight_memory" if hit < 1.0 else "compute_array",
+    }
+
+
+def _serial_wrapper() -> dict:
+    return {
+        "decision": {"decision": "serial_lpc1_producer_coupled_wrapper_promoted"},
+        "target": {"producer_ii_cycles": 384},
+        "selected_metrics": {"total_power_mw": 0.0065},
+    }
+
+
+def _ranktree_promotion() -> dict:
+    return {
+        "decision": {"decision": "resident_weight_ranktree_fallback_promoted"},
+        "selected_metrics": {"total_power_mw": 0.0114},
+        "producer_modes": [
+            {"mode": "single_r64_ranktree", "consumer_ii_cycles": 1, "ranker_instances": 1},
+            {"mode": "banked_r64_ranktrees", "consumer_ii_cycles": 1, "ranker_instances": 2},
+        ],
+    }
+
+
+def test_policy_routes_streaming_to_serial_and_fast_rows_to_ranktree() -> None:
+    report = build_report(
+        serial_wrapper=_serial_wrapper(),
+        cadence_sensitivity={
+            "ranker_zero_backpressure_thresholds": {
+                "serial_lpc1": {"min_zero_backpressure_ii_cycles": 384}
+            },
+            "cadence_sweep": [
+                _cadence_row(lanes=64, ii=384, hit=0.0),
+                _cadence_row(lanes=64, ii=154, hit=0.9),
+                _cadence_row(lanes=128, ii=8, hit=1.0),
+            ],
+        },
+        ranktree_promotion=_ranktree_promotion(),
+    )
+
+    assert report["decision"]["decision"] == "output_projection_ranker_policy_promoted"
+    assert report["path_summary"]["path_counts"] == {
+        "serial_lpc1": 1,
+        "single_r64_ranktree": 1,
+        "banked_r64_ranktrees": 1,
+    }
+    assert report["policy_rows"][0]["selected_path"] == "serial_lpc1"
+    assert report["policy_rows"][1]["selected_path"] == "single_r64_ranktree"
+    assert report["policy_rows"][2]["selected_path"] == "banked_r64_ranktrees"
+    assert all(check["passed"] for check in report["checks"])
+
+
+def test_policy_blocks_when_banked_ranktree_mode_missing() -> None:
+    ranktree = _ranktree_promotion()
+    ranktree["producer_modes"] = [ranktree["producer_modes"][0]]
+    report = build_report(
+        serial_wrapper=_serial_wrapper(),
+        cadence_sensitivity={
+            "ranker_zero_backpressure_thresholds": {
+                "serial_lpc1": {"min_zero_backpressure_ii_cycles": 384}
+            },
+            "cadence_sweep": [_cadence_row(lanes=128, ii=8, hit=1.0)],
+        },
+        ranktree_promotion=ranktree,
+    )
+
+    assert report["decision"]["decision"] == "output_projection_ranker_policy_blocked"
+    assert report["path_summary"]["uncovered_rows"] == 1
+    assert report["policy_rows"][0]["coverage_status"] == "uncovered_ranktree_mode"
+
+
+def test_policy_blocks_when_serial_wrapper_not_promoted() -> None:
+    serial = _serial_wrapper()
+    serial["decision"] = {"decision": "serial_lpc1_producer_coupled_wrapper_blocked"}
+    report = build_report(
+        serial_wrapper=serial,
+        cadence_sensitivity={"cadence_sweep": [_cadence_row(lanes=64, ii=384, hit=0.0)]},
+        ranktree_promotion=_ranktree_promotion(),
+    )
+
+    assert report["decision"]["decision"] == "output_projection_ranker_policy_blocked"
+    assert report["checks"][0]["name"] == "serial_lpc1_wrapper_promoted"
+    assert report["checks"][0]["passed"] is False


### PR DESCRIPTION
## Summary
- add a promotion estimator for output-projection ranker selection policy
- route producer cadences at or above the serial_lpc1 threshold to serial_lpc1 and faster rows to promoted rank-tree fallback modes
- wire decoder_output_projection_ranker_policy into L2 task generation with proposal and tests

## Validation
- python3 -m py_compile npu/eval/promote_llm_decoder_output_projection_ranker_policy.py
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_output_projection_ranker_policy.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "output_projection_ranker_policy or resident_ranktree_fallback_promotion"
- python3 scripts/validate_runs.py --skip_eval_queue
- smoke run against merged serial/cadence/ranktree-promotion artifacts