### PR TITLE
Add output-projection ranker wrapper contract job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2534,6 +2534,63 @@ def _decoder_output_projection_ranker_policy_evidence(*, item_id: str) -> dict[s
     }
 
 
+def _decoder_output_projection_ranker_wrapper_contract_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_ranker_wrapper_contract__{item_id}.json"
+    report = f"{base}/decoder_output_projection_ranker_wrapper_contract__{item_id}.md"
+    policy = (
+        f"{base}/decoder_output_projection_ranker_policy__"
+        "l2_decoder_output_projection_ranker_policy_v1.json"
+    )
+    serial_wrapper = (
+        f"{base}/decoder_serial_lpc1_producer_coupled_wrapper__"
+        "l2_decoder_serial_lpc1_producer_coupled_wrapper_v1.json"
+    )
+    ranktree_promotion = (
+        f"{base}/decoder_resident_ranktree_fallback_promotion__"
+        "l2_decoder_resident_ranktree_fallback_promotion_v1.json"
+    )
+    merge_config = (
+        "runs/designs/activations/candidate_stream_merge_fifo_k1_l16_t16_d16_wrapper/"
+        "config_candidate_stream_merge_fifo_k1_l16_t16_d16.json"
+    )
+    return {
+        "inputs": {
+            "output_projection_ranker_wrapper_contract_out": out,
+            "output_projection_ranker_wrapper_contract_report": report,
+            "output_projection_ranker_policy": policy,
+            "serial_lpc1_producer_coupled_wrapper": serial_wrapper,
+            "resident_ranktree_fallback_promotion": ranktree_promotion,
+            "candidate_merge_config": merge_config,
+            "output_projection_ranker_wrapper_contract_scope": (
+                "Check representative wrapper-policy cases before implementing final RTL mux/control: "
+                "fresh serial_lpc1 RTL replay, r64 rank-tree primitive RTL equivalence, and r128 "
+                "banked-r64 composition against the full-tile perf reference."
+            ),
+        },
+        "commands": [
+            {
+                "name": "build_generator",
+                "run": "export PATH=/oss-cad-suite/bin:$PATH && cmake -S . -B build && cmake --build build --target rtlgen",
+            },
+            {
+                "name": "probe_decoder_output_projection_ranker_wrapper_contract",
+                "run": (
+                    "python3 npu/eval/probe_llm_decoder_output_projection_ranker_wrapper_contract.py "
+                    f"--policy {policy} "
+                    f"--serial-wrapper {serial_wrapper} "
+                    f"--ranktree-promotion {ranktree_promotion} "
+                    f"--merge-config {merge_config} "
+                    "--num-tiles 6 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_stage_breakdown_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_stage_breakdown__{item_id}.json"
@@ -3818,6 +3875,7 @@ def _build_payload(
         "decoder_resident_weight_ranker_fallback",
         "decoder_resident_ranktree_fallback_promotion",
         "decoder_output_projection_ranker_policy",
+        "decoder_output_projection_ranker_wrapper_contract",
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
@@ -3883,6 +3941,8 @@ def _build_payload(
             decoder_evidence = _decoder_resident_ranktree_fallback_promotion_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_ranker_policy":
             decoder_evidence = _decoder_output_projection_ranker_policy_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_ranker_wrapper_contract":
+            decoder_evidence = _decoder_output_projection_ranker_wrapper_contract_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_service":
             decoder_evidence = _decoder_output_projection_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2229,6 +2229,65 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_ranker_policy(
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_output_projection_ranker_wrapper_contract() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_ranker_wrapper_contract_v1",
+                    proposal_id="prop_l2_decoder_output_projection_ranker_wrapper_contract_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_ranker_wrapper_contract_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_ranker_wrapper_contract",
+                    expected_direction="iterate",
+                    comparison_role="producer_ranker_service",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:2]] == [
+                "build_generator",
+                "probe_decoder_output_projection_ranker_wrapper_contract",
+            ]
+            run = work_item.command_manifest[1]["run"]
+            assert "probe_llm_decoder_output_projection_ranker_wrapper_contract.py" in run
+            assert decoder_inputs["output_projection_ranker_wrapper_contract_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_ranker_wrapper_contract__"
+                "l2_decoder_output_projection_ranker_wrapper_contract_v1.json"
+            )
+            assert decoder_inputs["output_projection_ranker_policy"].endswith(
+                "l2_decoder_output_projection_ranker_policy_v1.json"
+            )
+            assert decoder_inputs["serial_lpc1_producer_coupled_wrapper"].endswith(
+                "l2_decoder_serial_lpc1_producer_coupled_wrapper_v1.json"
+            )
+            assert "banked-r64 composition" in decoder_inputs[
+                "output_projection_ranker_wrapper_contract_scope"
+            ]
+            assert decoder_inputs["output_projection_ranker_wrapper_contract_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_ranker_wrapper_contract",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_ranker_wrapper_contract_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_ranker_wrapper_contract_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_ranker_wrapper_contract_v1",
+  "created_utc": "2026-05-14T10:55:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_ranker_wrapper_contract",
+  "title": "Decoder output-projection ranker wrapper contract",
+  "hypothesis": "The promoted ranker policy can be implemented by a wrapper that selects serial_lpc1 for slow r64 streams, a single radix-4 r64 rank-tree for fast r64 streams, and two banked radix-4 r64 rank-trees for fast r128 streams while preserving top-1 equivalence to the perf reference.",
+  "direct_comparison": {
+    "primary_question": "Do representative serial, rank-tree r64, and banked rank-tree r128 cases satisfy the promoted policy contract before implementing final wrapper mux/control RTL?",
+    "include": [
+      "fresh RTL replay of the promoted serial_lpc1 wrapper at the policy threshold",
+      "promoted r64 rank-tree primitive RTL simulation result",
+      "banked r128 composition against a full r128 perf reference",
+      "deterministic lower-token tie-break across banks",
+      "representative policy rows for each selected path"
+    ],
+    "exclude": [
+      "new physical synthesis",
+      "full producer GEMM RTL",
+      "NoC or SRAM arbitration",
+      "new measured producer burst traces"
+    ]
+  },
+  "expected_benefit": [
+    "establishes the exact functional contract the next wrapper RTL must implement",
+    "keeps serial and rank-tree primitive equivalence tied to RTL evidence",
+    "checks the banked r128 composition before adding wrapper control and mux logic"
+  ],
+  "risks": [
+    "banked r128 is checked as a composition contract rather than a monolithic RTL wrapper",
+    "final wrapper mux/control timing is not measured in this job",
+    "future producer burst traces may need additional buffering around the policy boundary"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_ranker_wrapper_contract_v1",
+      "task_type": "l2_campaign",
+      "objective": "Check representative RTL/perf equivalence cases for the promoted output-projection ranker wrapper policy before final RTL wrapper implementation.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_ranker_wrapper_contract",
+      "cost_class": "low",
+      "comparison_role": "producer_ranker_service",
+      "paired_baseline_item_id": "l2_decoder_output_projection_ranker_policy_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_ranker_policy_v1",
+        "l2_decoder_serial_lpc1_producer_coupled_wrapper_v1",
+        "l2_decoder_resident_ranktree_fallback_promotion_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If the representative serial, r64 rank-tree, and banked r128 contract cases pass, implement the final wrapper mux/control RTL and then run a physical wrapper sweep."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_ranker_policy__l2_decoder_output_projection_ranker_policy_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_serial_lpc1_producer_coupled_wrapper__l2_decoder_serial_lpc1_producer_coupled_wrapper_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_resident_ranktree_fallback_promotion__l2_decoder_resident_ranktree_fallback_promotion_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_llm_decoder_output_projection_ranker_wrapper_contract.py",
+    "tests/test_llm_decoder_output_projection_ranker_wrapper_contract.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/probe_llm_decoder_output_projection_ranker_wrapper_contract.py
+++ b/npu/eval/probe_llm_decoder_output_projection_ranker_wrapper_contract.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Check the output-projection ranker wrapper policy contract on representative cases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+try:
+    from probe_llm_decoder_serial_ranker_producer_replay import (
+        _make_tile_values,
+        _reference_top1,
+        _simulate_variant as _simulate_serial_variant,
+    )
+    from probe_llm_decoder_producer_ranker_ready_valid_equivalence import _resolve_executable
+except ImportError:  # pragma: no cover - package-style imports in tests
+    from npu.eval.probe_llm_decoder_serial_ranker_producer_replay import (
+        _make_tile_values,
+        _reference_top1,
+        _simulate_variant as _simulate_serial_variant,
+    )
+    from npu.eval.probe_llm_decoder_producer_ranker_ready_valid_equivalence import _resolve_executable
+
+
+JsonDict = dict[str, Any]
+R64_LANES = 64
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _ranktree_result_from_log(sim: JsonDict) -> JsonDict:
+    for line in sim.get("log_tail", []):
+        match = re.search(
+            r"RESULT token=(?P<token>\d+) logit=(?P<logit>-?\d+) accepted=(?P<accepted>\d+) "
+            r"stalls=(?P<stalls>\d+) fifo_max=(?P<fifo_max>\d+) final_cycle=(?P<final_cycle>\d+)",
+            str(line),
+        )
+        if match:
+            return {key: int(value) for key, value in match.groupdict().items()}
+    return {}
+
+
+def _policy_rows(policy: JsonDict, selected_path: str) -> list[JsonDict]:
+    return [
+        row
+        for row in policy.get("policy_rows", [])
+        if isinstance(row, dict) and row.get("selected_path") == selected_path
+    ]
+
+
+def _representative_policy_row(policy: JsonDict, selected_path: str) -> JsonDict | None:
+    rows = _policy_rows(policy, selected_path)
+    if not rows:
+        return None
+    return min(rows, key=lambda row: int((row.get("producer") or {}).get("producer_ii_cycles", 10**9)))
+
+
+def _banked_r64_reference(*, producer_lanes: int, num_tiles: int) -> JsonDict:
+    tiles = _make_tile_values(num_tiles=num_tiles, producer_lanes=producer_lanes)
+    full_reference = _reference_top1(tiles, producer_lanes=producer_lanes)
+    bank_results: list[JsonDict] = []
+    for bank_id, lane_base in enumerate(range(0, producer_lanes, R64_LANES)):
+        bank_tiles = [row[lane_base : lane_base + R64_LANES] for row in tiles]
+        bank_ref = _reference_top1(bank_tiles, producer_lanes=R64_LANES)
+        bank_results.append(
+            {
+                "bank": bank_id,
+                "local_token": bank_ref["token"],
+                "global_token": int(bank_ref["token"]) + lane_base,
+                "logit": bank_ref["logit"],
+            }
+        )
+    selected = min(
+        bank_results,
+        key=lambda row: (-int(row["logit"]), int(row["global_token"])),
+    )
+    banked_reference = {"token": selected["global_token"], "logit": selected["logit"]}
+    return {
+        "producer_lanes": producer_lanes,
+        "num_tiles": num_tiles,
+        "bank_results": bank_results,
+        "banked_reference": banked_reference,
+        "full_reference": full_reference,
+        "equivalent": banked_reference == full_reference,
+    }
+
+
+def _serial_case(
+    *,
+    policy: JsonDict,
+    serial_wrapper: JsonDict,
+    merge_config: Path,
+    rtlgen_binary: str | None,
+    num_tiles: int,
+) -> JsonDict:
+    row = _representative_policy_row(policy, "serial_lpc1")
+    variant = serial_wrapper.get("selected_variant") if isinstance(serial_wrapper.get("selected_variant"), dict) else None
+    threshold = (policy.get("policy") or {}).get("serial_lpc1_min_ii_cycles")
+    sim = None
+    if variant is not None and threshold is not None:
+        sim = _simulate_serial_variant(
+            variant=variant,
+            scenario="policy_serial_lpc1",
+            producer_ii_cycles=int(threshold),
+            num_tiles=num_tiles,
+            merge_config=merge_config,
+            rtlgen_binary=rtlgen_binary,
+            producer_lanes=R64_LANES,
+            logit_bits=16,
+            token_id_bits=16,
+        )
+    observed = (sim or {}).get("observed") if isinstance((sim or {}).get("observed"), dict) else {}
+    expected = (sim or {}).get("expected") if isinstance((sim or {}).get("expected"), dict) else {}
+    passed = (
+        row is not None
+        and isinstance(sim, dict)
+        and sim.get("status") == "ok"
+        and observed.get("token") == expected.get("token")
+        and observed.get("logit") == expected.get("logit")
+        and int(observed.get("tb_backpressure", -1)) == 0
+    )
+    return {
+        "case": "streaming_serial_lpc1_r64",
+        "policy_row": row,
+        "rtl_sim": sim,
+        "passed": passed,
+        "reason": "serial RTL replay matches perf reference with zero backpressure" if passed else "serial RTL replay failed or policy row missing",
+    }
+
+
+def _ranktree_r64_case(*, policy: JsonDict, ranktree_promotion: JsonDict) -> JsonDict:
+    row = _representative_policy_row(policy, "single_r64_ranktree")
+    variant = (
+        ranktree_promotion.get("selected_ranktree_variant")
+        if isinstance(ranktree_promotion.get("selected_ranktree_variant"), dict)
+        else {}
+    )
+    sim = variant.get("simulation") if isinstance(variant.get("simulation"), dict) else {}
+    observed = _ranktree_result_from_log(sim)
+    expected = sim.get("expected") if isinstance(sim.get("expected"), dict) else {}
+    passed = (
+        row is not None
+        and sim.get("status") == "ok"
+        and observed.get("token") == expected.get("token")
+        and observed.get("logit") == expected.get("logit")
+    )
+    return {
+        "case": "resident_ranktree_r64",
+        "policy_row": row,
+        "primitive_rtl_sim": sim,
+        "observed": observed,
+        "passed": passed,
+        "reason": "rank-tree r64 RTL primitive matches perf reference" if passed else "rank-tree r64 primitive failed or policy row missing",
+    }
+
+
+def _ranktree_r128_case(*, policy: JsonDict, ranktree_promotion: JsonDict, num_tiles: int) -> JsonDict:
+    row = _representative_policy_row(policy, "banked_r64_ranktrees")
+    modes = {
+        str(mode.get("mode")): mode
+        for mode in ranktree_promotion.get("producer_modes", [])
+        if isinstance(mode, dict)
+    }
+    banked_mode = modes.get("banked_r64_ranktrees")
+    composition = _banked_r64_reference(producer_lanes=128, num_tiles=num_tiles)
+    primitive_status = (
+        (ranktree_promotion.get("selected_ranktree_variant") or {}).get("simulation") or {}
+    ).get("status")
+    passed = (
+        row is not None
+        and isinstance(banked_mode, dict)
+        and int(banked_mode.get("ranker_instances", 0)) == 2
+        and int(banked_mode.get("consumer_ii_cycles", 0)) == 1
+        and primitive_status == "ok"
+        and bool(composition["equivalent"])
+    )
+    return {
+        "case": "resident_ranktree_banked_r128",
+        "policy_row": row,
+        "banked_mode": banked_mode,
+        "primitive_rtl_status": primitive_status,
+        "composition_reference": composition,
+        "passed": passed,
+        "reason": "banked r64 composition matches full r128 perf reference" if passed else "banked r128 composition failed or policy row missing",
+    }
+
+
+def build_report(
+    *,
+    policy: JsonDict,
+    serial_wrapper: JsonDict,
+    ranktree_promotion: JsonDict,
+    merge_config: Path,
+    rtlgen_binary: str | None,
+    num_tiles: int,
+) -> JsonDict:
+    policy_decision = (policy.get("decision") or {}).get("decision") if isinstance(policy.get("decision"), dict) else None
+    cases = [
+        _serial_case(
+            policy=policy,
+            serial_wrapper=serial_wrapper,
+            merge_config=merge_config,
+            rtlgen_binary=rtlgen_binary,
+            num_tiles=num_tiles,
+        ),
+        _ranktree_r64_case(policy=policy, ranktree_promotion=ranktree_promotion),
+        _ranktree_r128_case(policy=policy, ranktree_promotion=ranktree_promotion, num_tiles=num_tiles),
+    ]
+    checks = [
+        {
+            "name": "ranker_policy_promoted",
+            "passed": policy_decision == "output_projection_ranker_policy_promoted",
+            "observed": policy_decision,
+        },
+        {
+            "name": "representative_cases_passed",
+            "passed": all(bool(case.get("passed")) for case in cases),
+            "observed": {case["case"]: case.get("passed") for case in cases},
+        },
+    ]
+    passed = all(bool(check["passed"]) for check in checks)
+    return {
+        "version": 0.1,
+        "model": "decoder_output_projection_ranker_wrapper_contract_v1",
+        "target": {
+            "paths": ["serial_lpc1", "single_r64_ranktree", "banked_r64_ranktrees"],
+            "producer_lanes": [64, 128],
+            "num_tiles": num_tiles,
+            "top_k": 1,
+        },
+        "representative_cases": cases,
+        "checks": checks,
+        "decision": {
+            "decision": (
+                "output_projection_ranker_wrapper_contract_passed"
+                if passed
+                else "output_projection_ranker_wrapper_contract_blocked"
+            ),
+            "next_step": (
+                "Implement the wrapper RTL mux/control around the verified serial_lpc1 and rank-tree primitive paths, then run a physical wrapper sweep."
+                if passed
+                else "Fix the failing representative wrapper contract case before RTL wrapper implementation."
+            ),
+        },
+        "assumptions": [
+            "The serial path is checked by a fresh RTL replay of the promoted serial_lpc1 wrapper at the policy threshold.",
+            "The r64 rank-tree path reuses the promoted rank-tree primitive RTL simulation from the rank-tree architecture sweep.",
+            "The r128 banked path is a composition contract: two proven r64 primitives plus deterministic lower-token tie-break across banks.",
+            "This job does not synthesize the final wrapper mux/control; it establishes the contract that the next RTL wrapper must implement.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Output-Projection Ranker Wrapper Contract",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- next_step: {payload['decision']['next_step']}",
+        "",
+        "## Representative Cases",
+        "",
+        "| case | passed | reason |",
+        "|---|---|---|",
+    ]
+    for case in payload["representative_cases"]:
+        lines.append(f"| {case['case']} | `{case['passed']}` | {case['reason']} |")
+    lines.extend(["", "## Checks", "", "| check | passed | observed |", "|---|---|---|"])
+    for check in payload["checks"]:
+        lines.append(f"| {check['name']} | `{check['passed']}` | `{check.get('observed')}` |")
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--policy", required=True)
+    ap.add_argument("--serial-wrapper", required=True)
+    ap.add_argument("--ranktree-promotion", required=True)
+    ap.add_argument("--merge-config", required=True)
+    ap.add_argument("--rtlgen-binary", default="build/rtlgen")
+    ap.add_argument("--num-tiles", type=int, default=6)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    payload = build_report(
+        policy=_load_json(args.policy),
+        serial_wrapper=_load_json(args.serial_wrapper),
+        ranktree_promotion=_load_json(args.ranktree_promotion),
+        merge_config=Path(args.merge_config),
+        rtlgen_binary=_resolve_executable(args.rtlgen_binary),
+        num_tiles=args.num_tiles,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    write_markdown(out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": str(out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_output_projection_ranker_wrapper_contract.py
+++ b/tests/test_llm_decoder_output_projection_ranker_wrapper_contract.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+from npu.eval.probe_llm_decoder_output_projection_ranker_wrapper_contract import (
+    _banked_r64_reference,
+    build_report,
+)
+
+
+def _policy() -> dict:
+    return {
+        "decision": {"decision": "output_projection_ranker_policy_promoted"},
+        "policy": {"serial_lpc1_min_ii_cycles": 384},
+        "policy_rows": [
+            {
+                "selected_path": "serial_lpc1",
+                "producer": {"producer_lanes": 64, "producer_ii_cycles": 384},
+                "coverage_status": "covered",
+            },
+            {
+                "selected_path": "single_r64_ranktree",
+                "producer": {"producer_lanes": 64, "producer_ii_cycles": 6},
+                "coverage_status": "covered",
+            },
+            {
+                "selected_path": "banked_r64_ranktrees",
+                "producer": {"producer_lanes": 128, "producer_ii_cycles": 3},
+                "coverage_status": "covered",
+            },
+        ],
+    }
+
+
+def _serial_wrapper() -> dict:
+    return {
+        "selected_variant": {"top": "missing", "design_dir": "missing", "lanes_per_cycle": 1},
+    }
+
+
+def _ranktree_promotion() -> dict:
+    return {
+        "selected_ranktree_variant": {
+            "simulation": {
+                "status": "ok",
+                "expected": {"token": 5, "logit": 500},
+                "log_tail": ["RESULT token=5 logit=500 accepted=3 stalls=0 fifo_max=1 final_cycle=10"],
+            }
+        },
+        "producer_modes": [
+            {"mode": "single_r64_ranktree", "consumer_ii_cycles": 1, "ranker_instances": 1},
+            {"mode": "banked_r64_ranktrees", "consumer_ii_cycles": 1, "ranker_instances": 2},
+        ],
+    }
+
+
+def test_banked_r64_reference_matches_full_r128_reference() -> None:
+    result = _banked_r64_reference(producer_lanes=128, num_tiles=6)
+
+    assert result["equivalent"] is True
+    assert result["banked_reference"] == result["full_reference"]
+    assert len(result["bank_results"]) == 2
+
+
+def test_wrapper_contract_blocks_when_serial_rtl_cannot_run() -> None:
+    report = build_report(
+        policy=_policy(),
+        serial_wrapper=_serial_wrapper(),
+        ranktree_promotion=_ranktree_promotion(),
+        merge_config=Path("missing.json"),
+        rtlgen_binary=None,
+        num_tiles=6,
+    )
+
+    assert report["decision"]["decision"] == "output_projection_ranker_wrapper_contract_blocked"
+    assert report["representative_cases"][0]["case"] == "streaming_serial_lpc1_r64"
+    assert report["representative_cases"][0]["passed"] is False
+    assert report["representative_cases"][1]["passed"] is True
+    assert report["representative_cases"][2]["passed"] is True
+
+
+def test_wrapper_contract_blocks_without_promoted_policy() -> None:
+    policy = _policy()
+    policy["decision"] = {"decision": "output_projection_ranker_policy_blocked"}
+
+    report = build_report(
+        policy=policy,
+        serial_wrapper=_serial_wrapper(),
+        ranktree_promotion=_ranktree_promotion(),
+        merge_config=Path("missing.json"),
+        rtlgen_binary=None,
+        num_tiles=6,
+    )
+
+    assert report["decision"]["decision"] == "output_projection_ranker_wrapper_contract_blocked"
+    assert report["checks"][0]["name"] == "ranker_policy_promoted"
+    assert report["checks"][0]["passed"] is False


### PR DESCRIPTION
## Summary
- add representative wrapper-contract probe for the promoted output-projection ranker policy
- fresh RTL replay for serial_lpc1, reuse promoted r64 rank-tree RTL primitive, and check r128 banked composition against the full perf reference
- wire decoder_output_projection_ranker_wrapper_contract into L2 task generation with proposal and tests

## Validation
- python3 -m py_compile npu/eval/probe_llm_decoder_output_projection_ranker_wrapper_contract.py
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_output_projection_ranker_wrapper_contract.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "output_projection_ranker_wrapper_contract or output_projection_ranker_policy"
- cmake -S . -B build && cmake --build build --target rtlgen
- python3 scripts/validate_runs.py --skip_eval_queue
- smoke run against merged policy/serial/ranktree artifacts