### PR TITLE
[codex] Add producer output-ranker integration accounting job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2666,6 +2666,54 @@ def _decoder_output_projection_ranker_wrapper_physical_evidence(*, item_id: str)
     }
 
 
+def _decoder_output_projection_producer_ranker_integration_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_producer_ranker_integration__{item_id}.json"
+    report = f"{base}/decoder_output_projection_producer_ranker_integration__{item_id}.md"
+    producer_summary = (
+        "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__"
+        "l2_decoder_producer_ranker_physical_wrapper_v1/summary.csv"
+    )
+    ranker_wrapper_physical = (
+        f"{base}/decoder_output_projection_ranker_wrapper_physical__"
+        "l2_decoder_output_projection_ranker_wrapper_physical_v1.json"
+    )
+    policy = (
+        f"{base}/decoder_output_projection_ranker_policy__"
+        "l2_decoder_output_projection_ranker_policy_v1.json"
+    )
+    return {
+        "inputs": {
+            "output_projection_producer_ranker_integration_out": out,
+            "output_projection_producer_ranker_integration_report": report,
+            "output_projection_producer_summary": producer_summary,
+            "output_projection_ranker_wrapper_physical": ranker_wrapper_physical,
+            "output_projection_ranker_policy": policy,
+            "output_projection_producer_ranker_integration_scope": (
+                "Additively account independently measured output-projection producer PPA "
+                "and measured output-ranker policy-wrapper PPA. Report timing bottleneck, "
+                "area/power overhead, and serial versus rank-tree service behavior before "
+                "requesting a heavier routed monolithic wrapper."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_output_projection_producer_ranker_integration",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_output_projection_integrated_breakdown.py "
+                    f"--producer-summary {producer_summary} "
+                    f"--ranker-wrapper-physical {ranker_wrapper_physical} "
+                    f"--policy {policy} "
+                    "--lane-map fp16_nm1=64,fp16_nm2=128 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_stage_breakdown_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_stage_breakdown__{item_id}.json"
@@ -3952,6 +4000,7 @@ def _build_payload(
         "decoder_output_projection_ranker_policy",
         "decoder_output_projection_ranker_wrapper_contract",
         "decoder_output_projection_ranker_wrapper_physical",
+        "decoder_output_projection_producer_ranker_integration",
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
@@ -4021,6 +4070,8 @@ def _build_payload(
             decoder_evidence = _decoder_output_projection_ranker_wrapper_contract_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_ranker_wrapper_physical":
             decoder_evidence = _decoder_output_projection_ranker_wrapper_physical_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_producer_ranker_integration":
+            decoder_evidence = _decoder_output_projection_producer_ranker_integration_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_service":
             decoder_evidence = _decoder_output_projection_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2346,6 +2346,62 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_ranker_wrapper
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_output_projection_producer_ranker_integration() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_producer_ranker_integration_v1",
+                    proposal_id="prop_l2_decoder_output_projection_producer_ranker_integration_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_producer_ranker_integration_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_producer_ranker_integration",
+                    expected_direction="iterate",
+                    comparison_role="producer_ranker_service",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_output_projection_producer_ranker_integration",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_output_projection_integrated_breakdown.py" in run
+            assert "--lane-map fp16_nm1=64,fp16_nm2=128" in run
+            assert decoder_inputs["output_projection_producer_ranker_integration_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_producer_ranker_integration__"
+                "l2_decoder_output_projection_producer_ranker_integration_v1.json"
+            )
+            assert decoder_inputs["output_projection_ranker_wrapper_physical"].endswith(
+                "l2_decoder_output_projection_ranker_wrapper_physical_v1.json"
+            )
+            assert "Additively account" in decoder_inputs[
+                "output_projection_producer_ranker_integration_scope"
+            ]
+            assert decoder_inputs["output_projection_producer_ranker_integration_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_producer_ranker_integration",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_producer_ranker_integration_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_producer_ranker_integration_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_producer_ranker_integration_v1",
+  "created_utc": "2026-05-15T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_producer_ranker_integration",
+  "title": "Decoder output-projection producer/ranker integration accounting",
+  "hypothesis": "The measured output-ranker policy wrapper can be integrated with the measured output-projection producer without becoming the timing bottleneck, while its area and power overhead stay small enough to use as the next producer-side baseline.",
+  "direct_comparison": {
+    "primary_question": "When independently measured producer and output-ranker wrapper PPA are accounted together, does the ranker wrapper materially change the producer-side timing, area, or power picture?",
+    "include": [
+      "aggregate producer PPA rows from the current producer/ranker physical-wrapper campaign",
+      "measured r64 and r128 output-ranker policy-wrapper PPA",
+      "policy coverage summary for serial_lpc1 versus rank-tree selected rows",
+      "additive timing, area, and power breakdown for fp16_nm1 and fp16_nm2 producer points"
+    ],
+    "exclude": [
+      "routed monolithic producer-plus-ranker macro",
+      "clock gating for inactive ranker paths",
+      "NoC, SRAM arbitration, or attention/KV-memory integration"
+    ]
+  },
+  "expected_benefit": [
+    "turns the independently measured ranker wrapper into a producer-side accounting baseline",
+    "shows whether the wrapper is timing-dominated by the producer or needs path splitting",
+    "quantifies first-order area and power overhead before requesting a heavier routed integration"
+  ],
+  "risks": [
+    "additive accounting may understate routing interaction in a monolithic macro",
+    "wrapper power includes inactive path overhead because clock gating is not modeled",
+    "fp16_nm1 to r64 and fp16_nm2 to r128 lane mapping is an architectural convention that should be revisited for larger arrays"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_producer_ranker_integration_v1",
+      "task_type": "l2_campaign",
+      "objective": "Account measured output-projection producer PPA together with the measured output-ranker policy-wrapper PPA and report timing/area/power overhead.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_producer_ranker_integration",
+      "cost_class": "small",
+      "comparison_role": "producer_ranker_service",
+      "paired_baseline_item_id": "l2_decoder_producer_ranker_physical_wrapper_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_producer_ranker_physical_wrapper_v1",
+        "l2_decoder_output_projection_ranker_policy_v1",
+        "l2_decoder_output_projection_ranker_wrapper_physical_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If accounting shows low overhead and producer-dominated timing, use it as the producer-side integration baseline; otherwise split/gate the wrapper before monolithic integration."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__l2_decoder_producer_ranker_physical_wrapper_v1/summary.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_ranker_policy__l2_decoder_output_projection_ranker_policy_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_ranker_wrapper_physical__l2_decoder_output_projection_ranker_wrapper_physical_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_output_projection_integrated_breakdown.py",
+    "tests/test_llm_decoder_output_projection_integrated_breakdown.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_output_projection_integrated_breakdown.py
+++ b/npu/eval/estimate_llm_decoder_output_projection_integrated_breakdown.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Account for producer plus output-ranker wrapper PPA and service behavior."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    with Path(path).open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    if value in (None, ""):
+        return default
+    return float(value)
+
+
+def _int(value: Any, default: int = 0) -> int:
+    if value in (None, ""):
+        return default
+    return int(float(value))
+
+
+def _read_aggregate_rows(path: str | Path) -> list[JsonDict]:
+    with Path(path).open(encoding="utf-8", newline="") as f:
+        rows = [dict(row) for row in csv.DictReader(f)]
+    return [row for row in rows if row.get("scope") == "aggregate"]
+
+
+def _parse_lane_map(raw: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        key, sep, value = part.partition("=")
+        if not sep:
+            raise ValueError(f"lane map entry must be arch=lanes: {part}")
+        out[key.strip()] = int(value)
+    return out
+
+
+def _ranker_by_lane(wrapper_physical: JsonDict) -> dict[int, JsonDict]:
+    variants = wrapper_physical.get("variants")
+    if not isinstance(variants, list):
+        raise ValueError("wrapper physical JSON missing variants list")
+    out: dict[int, JsonDict] = {}
+    for variant in variants:
+        if isinstance(variant, dict):
+            out[_int(variant.get("producer_lanes"))] = variant
+    return out
+
+
+def _policy_summary(policy: JsonDict) -> dict[int, JsonDict]:
+    rows = policy.get("policy_rows")
+    if not isinstance(rows, list):
+        return {}
+    summary: dict[int, JsonDict] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        producer = row.get("producer")
+        if not isinstance(producer, dict):
+            continue
+        lanes = _int(producer.get("producer_lanes"))
+        entry = summary.setdefault(
+            lanes,
+            {
+                "producer_lanes": lanes,
+                "rows": 0,
+                "serial_lpc1_rows": 0,
+                "ranktree_rows": 0,
+                "producer_ii_cycles_min": None,
+                "producer_ii_cycles_max": None,
+            },
+        )
+        entry["rows"] += 1
+        selected = str(row.get("selected_path", ""))
+        if selected == "serial_lpc1":
+            entry["serial_lpc1_rows"] += 1
+        elif "ranktree" in selected:
+            entry["ranktree_rows"] += 1
+        ii = _int(producer.get("producer_ii_cycles"))
+        entry["producer_ii_cycles_min"] = ii if entry["producer_ii_cycles_min"] is None else min(entry["producer_ii_cycles_min"], ii)
+        entry["producer_ii_cycles_max"] = ii if entry["producer_ii_cycles_max"] is None else max(entry["producer_ii_cycles_max"], ii)
+    return summary
+
+
+def _simulation_cycles(variant: JsonDict, name: str) -> int:
+    simulations = variant.get("simulations")
+    if not isinstance(simulations, dict):
+        return 0
+    sim = simulations.get(name)
+    if not isinstance(sim, dict):
+        return 0
+    observed = sim.get("observed")
+    if not isinstance(observed, dict):
+        return 0
+    return _int(observed.get("final_cycle"))
+
+
+def build_report(
+    *,
+    producer_rows: list[JsonDict],
+    wrapper_physical: JsonDict,
+    policy: JsonDict,
+    lane_map: dict[str, int],
+    source_refs: JsonDict,
+) -> JsonDict:
+    rankers = _ranker_by_lane(wrapper_physical)
+    policy_by_lane = _policy_summary(policy)
+    integrations: list[JsonDict] = []
+    checks: list[JsonDict] = [
+        {
+            "name": "ranker_wrapper_physical_measured",
+            "passed": (wrapper_physical.get("decision") or {}).get("decision")
+            == "output_projection_ranker_wrapper_physical_measured",
+            "observed": (wrapper_physical.get("decision") or {}).get("decision"),
+        },
+        {
+            "name": "ranker_policy_promoted",
+            "passed": (policy.get("decision") or {}).get("decision")
+            == "output_projection_ranker_policy_promoted",
+            "observed": (policy.get("decision") or {}).get("decision"),
+        },
+    ]
+
+    for producer in producer_rows:
+        arch_id = str(producer.get("arch_id", ""))
+        lanes = lane_map.get(arch_id)
+        ranker = rankers.get(lanes or -1)
+        if ranker is None:
+            integrations.append(
+                {
+                    "arch_id": arch_id,
+                    "macro_mode": producer.get("macro_mode"),
+                    "producer_lanes": lanes,
+                    "status": "missing_ranker_lane_mapping",
+                }
+            )
+            continue
+        ranker_metrics = ranker.get("metrics_row") if isinstance(ranker.get("metrics_row"), dict) else {}
+        producer_cp = _float(producer.get("critical_path_ns_mean"))
+        ranker_cp = _float(ranker_metrics.get("critical_path_ns"))
+        producer_area = _float(producer.get("die_area_um2_mean"))
+        ranker_area = _float(ranker_metrics.get("die_area"))
+        producer_power = _float(producer.get("total_power_mw_mean"))
+        ranker_power = _float(ranker_metrics.get("total_power_mw"))
+        integrated_cp = max(producer_cp, ranker_cp)
+        serial_cycles = _simulation_cycles(ranker, "serial")
+        ranktree_cycles = _simulation_cycles(ranker, "ranktree")
+        row = {
+            "arch_id": arch_id,
+            "macro_mode": producer.get("macro_mode"),
+            "producer_lanes": lanes,
+            "status": "ok",
+            "producer": {
+                "critical_path_ns": producer_cp,
+                "area_um2": producer_area,
+                "power_mw": producer_power,
+                "latency_ms_mean": _float(producer.get("latency_ms_mean")),
+                "energy_mj_mean": _float(producer.get("energy_mj_mean")),
+                "flow_elapsed_s_mean": _float(producer.get("flow_elapsed_s_mean")),
+            },
+            "ranker_wrapper": {
+                "critical_path_ns": ranker_cp,
+                "area_um2": ranker_area,
+                "power_mw": ranker_power,
+                "serial_final_cycle": serial_cycles,
+                "ranktree_final_cycle": ranktree_cycles,
+                "serial_service_ns_at_ranker_cp": serial_cycles * ranker_cp,
+                "ranktree_service_ns_at_ranker_cp": ranktree_cycles * ranker_cp,
+                "policy_summary": policy_by_lane.get(lanes or -1, {}),
+            },
+            "integrated_accounting": {
+                "critical_path_ns_max": integrated_cp,
+                "timing_bottleneck": "ranker_wrapper" if ranker_cp > producer_cp else "producer",
+                "area_um2_sum": producer_area + ranker_area,
+                "ranker_area_over_producer": ranker_area / producer_area if producer_area else None,
+                "power_mw_sum": producer_power + ranker_power,
+                "ranker_power_over_producer": ranker_power / producer_power if producer_power else None,
+            },
+        }
+        integrations.append(row)
+
+    ok_rows = [row for row in integrations if row.get("status") == "ok"]
+    area_overheads = [
+        float(row["integrated_accounting"]["ranker_area_over_producer"])
+        for row in ok_rows
+        if row.get("integrated_accounting", {}).get("ranker_area_over_producer") is not None
+    ]
+    power_overheads = [
+        float(row["integrated_accounting"]["ranker_power_over_producer"])
+        for row in ok_rows
+        if row.get("integrated_accounting", {}).get("ranker_power_over_producer") is not None
+    ]
+    checks.append(
+        {
+            "name": "all_producer_arches_have_ranker_mapping",
+            "passed": len(ok_rows) == len(integrations) and bool(integrations),
+            "observed": {"ok": len(ok_rows), "total": len(integrations)},
+        }
+    )
+    checks.append(
+        {
+            "name": "ranker_not_timing_bottleneck",
+            "passed": all(row.get("integrated_accounting", {}).get("timing_bottleneck") == "producer" for row in ok_rows),
+            "observed": [
+                {
+                    "arch_id": row.get("arch_id"),
+                    "macro_mode": row.get("macro_mode"),
+                    "timing_bottleneck": row.get("integrated_accounting", {}).get("timing_bottleneck"),
+                }
+                for row in ok_rows
+            ],
+        }
+    )
+
+    max_area_overhead = max(area_overheads) if area_overheads else None
+    max_power_overhead = max(power_overheads) if power_overheads else None
+    low_overhead = (
+        max_area_overhead is not None
+        and max_power_overhead is not None
+        and max_area_overhead <= 0.15
+        and max_power_overhead <= 0.20
+    )
+    checks.append(
+        {
+            "name": "ranker_overhead_within_first_order_budget",
+            "passed": low_overhead,
+            "observed": {
+                "max_ranker_area_over_producer": max_area_overhead,
+                "max_ranker_power_over_producer": max_power_overhead,
+                "budget": {"area": 0.15, "power": 0.20},
+            },
+        }
+    )
+
+    decision = (
+        "producer_output_ranker_integration_accounting_passed"
+        if all(check["passed"] for check in checks)
+        else "producer_output_ranker_integration_needs_refinement"
+    )
+    return {
+        "version": 0.1,
+        "model": "decoder_output_projection_producer_ranker_integration_v1",
+        "source_refs": source_refs,
+        "assumptions": [
+            "This is an additive accounting model over independently measured producer and ranker-wrapper macros; it is not a routed monolithic integration.",
+            "The default lane map treats fp16_nm1 as a 64-lane output tile producer and fp16_nm2 as a 128-lane output tile producer.",
+            "Wrapper power includes inactive serial or rank-tree path because no clock gating was modeled in the physical wrapper measurement.",
+        ],
+        "checks": checks,
+        "integrations": integrations,
+        "summary": {
+            "ok_integrations": len(ok_rows),
+            "total_integrations": len(integrations),
+            "max_ranker_area_over_producer": max_area_overhead,
+            "max_ranker_power_over_producer": max_power_overhead,
+        },
+        "decision": {
+            "decision": decision,
+            "next_step": (
+                "Use the additive breakdown as the producer-side integration baseline, then decide whether to add clock/path gating or a monolithic routed wrapper."
+                if decision.endswith("_passed")
+                else "Refine lane mapping, split serial/rank-tree wrappers, or add gating before treating the wrapper as producer-integrated."
+            ),
+        },
+    }
+
+
+def write_markdown(path: str | Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Output Projection Producer/Ranker Integration",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- next_step: {payload['decision']['next_step']}",
+        "",
+        "## Integration Rows",
+        "",
+        "| arch | macro | lanes | bottleneck | cp ns | ranker area/prod | ranker power/prod | serial cycles | ranktree cycles |",
+        "|---|---|---:|---|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["integrations"]:
+        acct = row.get("integrated_accounting") or {}
+        ranker = row.get("ranker_wrapper") or {}
+        lines.append(
+            "| {arch} | {macro} | {lanes} | {bottleneck} | {cp:.4f} | {area:.4f} | {power:.4f} | {serial} | {ranktree} |".format(
+                arch=row.get("arch_id"),
+                macro=row.get("macro_mode"),
+                lanes=row.get("producer_lanes"),
+                bottleneck=acct.get("timing_bottleneck"),
+                cp=_float(acct.get("critical_path_ns_max")),
+                area=_float(acct.get("ranker_area_over_producer")),
+                power=_float(acct.get("ranker_power_over_producer")),
+                serial=ranker.get("serial_final_cycle"),
+                ranktree=ranker.get("ranktree_final_cycle"),
+            )
+        )
+    lines.extend(["", "## Checks", "", "| check | passed | observed |", "|---|---|---|"])
+    for check in payload["checks"]:
+        lines.append(f"| {check['name']} | `{check['passed']}` | `{check.get('observed')}` |")
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--producer-summary", required=True)
+    ap.add_argument("--ranker-wrapper-physical", required=True)
+    ap.add_argument("--policy", required=True)
+    ap.add_argument("--lane-map", default="fp16_nm1=64,fp16_nm2=128")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    source_refs = {
+        "producer_summary": args.producer_summary,
+        "ranker_wrapper_physical": args.ranker_wrapper_physical,
+        "policy": args.policy,
+        "lane_map": args.lane_map,
+    }
+    payload = build_report(
+        producer_rows=_read_aggregate_rows(args.producer_summary),
+        wrapper_physical=_load_json(args.ranker_wrapper_physical),
+        policy=_load_json(args.policy),
+        lane_map=_parse_lane_map(args.lane_map),
+        source_refs=source_refs,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "out": args.out, "out_md": args.out_md}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_output_projection_integrated_breakdown.py
+++ b/tests/test_llm_decoder_output_projection_integrated_breakdown.py
@@ -1,0 +1,107 @@
+from npu.eval.estimate_llm_decoder_output_projection_integrated_breakdown import build_report
+
+
+def _producer_rows():
+    return [
+        {
+            "scope": "aggregate",
+            "arch_id": "fp16_nm1",
+            "macro_mode": "flat_nomacro",
+            "critical_path_ns_mean": "5.5",
+            "die_area_um2_mean": "1000",
+            "total_power_mw_mean": "0.10",
+            "latency_ms_mean": "0.01",
+            "energy_mj_mean": "0.001",
+            "flow_elapsed_s_mean": "10",
+        },
+        {
+            "scope": "aggregate",
+            "arch_id": "fp16_nm2",
+            "macro_mode": "flat_nomacro",
+            "critical_path_ns_mean": "5.7",
+            "die_area_um2_mean": "2000",
+            "total_power_mw_mean": "0.20",
+            "latency_ms_mean": "0.02",
+            "energy_mj_mean": "0.002",
+            "flow_elapsed_s_mean": "20",
+        },
+    ]
+
+
+def _ranker_payload():
+    return {
+        "decision": {"decision": "output_projection_ranker_wrapper_physical_measured"},
+        "variants": [
+            {
+                "producer_lanes": 64,
+                "metrics_row": {
+                    "status": "ok",
+                    "critical_path_ns": "4.4",
+                    "die_area": "100",
+                    "total_power_mw": "0.01",
+                },
+                "simulations": {
+                    "serial": {"observed": {"final_cycle": 1987}},
+                    "ranktree": {"observed": {"final_cycle": 35}},
+                },
+            },
+            {
+                "producer_lanes": 128,
+                "metrics_row": {
+                    "status": "ok",
+                    "critical_path_ns": "4.5",
+                    "die_area": "240",
+                    "total_power_mw": "0.03",
+                },
+                "simulations": {
+                    "serial": {"observed": {"final_cycle": 1987}},
+                    "ranktree": {"observed": {"final_cycle": 20}},
+                },
+            },
+        ],
+    }
+
+
+def _policy_payload():
+    return {
+        "decision": {"decision": "output_projection_ranker_policy_promoted"},
+        "policy_rows": [
+            {
+                "selected_path": "serial_lpc1",
+                "producer": {"producer_lanes": 64, "producer_ii_cycles": 512},
+            },
+            {
+                "selected_path": "single_r64_ranktree",
+                "producer": {"producer_lanes": 128, "producer_ii_cycles": 128},
+            },
+        ],
+    }
+
+
+def test_build_report_passes_for_additive_low_overhead() -> None:
+    report = build_report(
+        producer_rows=_producer_rows(),
+        wrapper_physical=_ranker_payload(),
+        policy=_policy_payload(),
+        lane_map={"fp16_nm1": 64, "fp16_nm2": 128},
+        source_refs={},
+    )
+
+    assert report["decision"]["decision"] == "producer_output_ranker_integration_accounting_passed"
+    assert report["summary"]["ok_integrations"] == 2
+    assert report["integrations"][0]["integrated_accounting"]["timing_bottleneck"] == "producer"
+    assert report["integrations"][1]["ranker_wrapper"]["ranktree_final_cycle"] == 20
+    assert report["summary"]["max_ranker_area_over_producer"] == 0.12
+
+
+def test_build_report_flags_missing_lane_mapping() -> None:
+    report = build_report(
+        producer_rows=_producer_rows(),
+        wrapper_physical=_ranker_payload(),
+        policy=_policy_payload(),
+        lane_map={"fp16_nm1": 64},
+        source_refs={},
+    )
+
+    assert report["decision"]["decision"] == "producer_output_ranker_integration_needs_refinement"
+    assert report["integrations"][1]["status"] == "missing_ranker_lane_mapping"


### PR DESCRIPTION
## Summary

Adds a small L2 job that accounts measured output-projection producer PPA together with the measured output-ranker policy-wrapper PPA. The job reports producer/ranker timing bottleneck, additive area and power overhead, policy coverage, and serial versus rank-tree service-cycle behavior.

This is intentionally an additive accounting model over independently measured macros, not a routed monolithic producer-plus-ranker macro.

## Validation

- `python3 -m py_compile npu/eval/estimate_llm_decoder_output_projection_integrated_breakdown.py`
- `python3 npu/eval/estimate_llm_decoder_output_projection_integrated_breakdown.py --producer-summary runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__l2_decoder_producer_ranker_physical_wrapper_v1/summary.csv --ranker-wrapper-physical runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_ranker_wrapper_physical__l2_decoder_output_projection_ranker_wrapper_physical_v1.json --policy runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_ranker_policy__l2_decoder_output_projection_ranker_policy_v1.json --lane-map fp16_nm1=64,fp16_nm2=128 --out /tmp/output-producer-ranker-integration.json --out-md /tmp/output-producer-ranker-integration.md`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_output_projection_integrated_breakdown.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "output_projection_producer_ranker_integration or output_projection_ranker_wrapper_physical"`
- `python3 scripts/validate_runs.py --skip_eval_queue`
