### PR TITLE
[codex] Add integrated decoder frontier synthesis job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2862,6 +2862,64 @@ def _decoder_frontier_synthesis_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_frontier_synthesis_integrated_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    stage = _decoder_stage_breakdown_evidence(item_id=item_id)
+    attention = _decoder_attention_kv_memory_evidence(item_id=item_id)
+    producer = _decoder_producer_ranker_coupled_noc_evidence(item_id=item_id)
+    integration = _decoder_output_projection_producer_ranker_integration_evidence(item_id=item_id)
+    out = f"{base}/decoder_frontier_synthesis__{item_id}.json"
+    report = f"{base}/decoder_frontier_synthesis__{item_id}.md"
+
+    stage_out = stage["inputs"]["stage_breakdown_out"]
+    attention_out = attention["inputs"]["attention_kv_memory_out"]
+    producer_out = producer["inputs"]["producer_ranker_coupled_out"]
+    integration_out = integration["inputs"]["output_projection_producer_ranker_integration_out"]
+    commands = [
+        *stage["commands"],
+        *attention["commands"],
+        *producer["commands"],
+        *integration["commands"],
+        {
+            "name": "synthesize_decoder_frontier",
+            "run": (
+                "python3 npu/eval/synthesize_llm_decoder_frontier.py "
+                f"--stage-breakdown {stage_out} "
+                f"--attention-kv-memory {attention_out} "
+                f"--producer-ranker-coupled {producer_out} "
+                f"--producer-ranker-integration {integration_out} "
+                f"--out {out} "
+                f"--out-md {report}"
+            ),
+        },
+    ]
+    return {
+        "inputs": {
+            **stage["inputs"],
+            **attention["inputs"],
+            **producer["inputs"],
+            **integration["inputs"],
+            "decoder_frontier_synthesis_out": out,
+            "decoder_frontier_synthesis_report": report,
+            "decoder_frontier_synthesis_scope": (
+                "Combine whole-decoder stage breakdown, measured attention/KV tile-calibrated "
+                "memory pressure, producer/ranker NoC coupling, and measured additive "
+                "producer/ranker integration accounting to identify the dominant frontier "
+                "before queueing deeper RTL blocks."
+            ),
+        },
+        "commands": commands,
+        "expected_outputs": [
+            *stage["expected_outputs"],
+            *attention["expected_outputs"],
+            *producer["expected_outputs"],
+            *integration["expected_outputs"],
+            out,
+            report,
+        ],
+    }
+
+
 def _decoder_producer_ranker_memory_integration_plan_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_producer_ranker_memory_integration_plan__{item_id}.json"
@@ -4004,6 +4062,7 @@ def _build_payload(
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
+        "decoder_frontier_synthesis_integrated",
         "decoder_producer_ranker_memory_integration_plan",
         "decoder_producer_ranker_ready_valid_equivalence",
         "decoder_producer_ranker_physical_wrapper",
@@ -4034,6 +4093,8 @@ def _build_payload(
             decoder_evidence = _decoder_output_projection_producer_synth_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_frontier_synthesis":
             decoder_evidence = _decoder_frontier_synthesis_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_frontier_synthesis_integrated":
+            decoder_evidence = _decoder_frontier_synthesis_integrated_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_producer_ranker_memory_integration_plan":
             decoder_evidence = _decoder_producer_ranker_memory_integration_plan_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_producer_ranker_ready_valid_equivalence":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2552,6 +2552,57 @@ def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_evidence() ->
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_integrated_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_frontier_synthesis_integrated_v1",
+                    proposal_id="prop_l2_decoder_frontier_synthesis_integrated_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_frontier_synthesis_integrated_v1/proposal.json",
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_frontier_synthesis_integrated",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert command_names[:5] == [
+                "estimate_decoder_stage_breakdown",
+                "estimate_decoder_attention_kv_memory",
+                "estimate_decoder_producer_ranker_coupled_noc",
+                "estimate_decoder_output_projection_producer_ranker_integration",
+                "synthesize_decoder_frontier",
+            ]
+            synth_run = work_item.command_manifest[4]["run"]
+            assert "--producer-ranker-integration" in synth_run
+            assert decoder_inputs["decoder_frontier_synthesis_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_frontier_synthesis__l2_decoder_frontier_synthesis_integrated_v1.json"
+            )
+            assert "measured additive" in decoder_inputs["decoder_frontier_synthesis_scope"]
+            assert decoder_inputs["output_projection_producer_ranker_integration_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_frontier_synthesis_integrated",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_producer_ranker_memory_integration_plan() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_frontier_synthesis_integrated_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_frontier_synthesis_integrated_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_frontier_synthesis_integrated_v1",
+  "created_utc": "2026-05-15T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_frontier_synthesis_integrated",
+  "title": "Decoder frontier synthesis with producer/ranker integration accounting",
+  "hypothesis": "The latest measured producer/ranker integration accounting can be carried into the whole-decoder frontier synthesis as PPA context without replacing the existing analytical producer/ranker latency model.",
+  "direct_comparison": {
+    "primary_question": "After adding measured additive producer/ranker integration PPA context, is the next measured RTL frontier still producer/ranker, or does attention/KV memory dominate larger contexts?",
+    "include": [
+      "whole-decoder large-array stage breakdown",
+      "attention/KV memory hierarchy report calibrated by measured tile PPA",
+      "producer/ranker NoC coupling latency model",
+      "producer/ranker integration accounting from measured producer and ranker-wrapper PPA",
+      "dominant component ranking across shape and context points"
+    ],
+    "exclude": [
+      "new physical RTL implementation",
+      "routed monolithic producer-plus-ranker macro",
+      "measured SRAM/NoC subsystem",
+      "quality impact of KV quantization or GQA/MQA"
+    ]
+  },
+  "expected_benefit": [
+    "keeps the newly measured producer/ranker wrapper overhead visible in frontier selection",
+    "prevents additive PPA evidence from being confused with the producer/ranker latency model",
+    "selects a better next RTL job across attention/KV and producer/ranker candidates"
+  ],
+  "risks": [
+    "the synthesis remains analytical and inherits assumptions from its input reports",
+    "producer/ranker integration accounting is additive and may understate monolithic routing interaction",
+    "attention/KV hierarchy remains modeled rather than a routed memory or NoC implementation"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_frontier_synthesis_integrated_v1",
+      "task_type": "l2_campaign",
+      "objective": "Refresh decoder frontier synthesis with measured producer/ranker integration accounting as PPA context.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_frontier_synthesis_integrated",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_frontier_synthesis_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_stage_breakdown_large_array_v2",
+        "l2_decoder_attention_kv_memory_measured_tile_v1",
+        "l2_decoder_producer_ranker_coupled_noc_v1",
+        "l2_decoder_output_projection_producer_ranker_integration_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the refreshed synthesis to choose whether the next measured RTL job should target attention/KV memory hierarchy, producer/ranker integration, or another whole-decoder bottleneck."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_frontier_synthesis_v1.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_output_projection_producer_ranker_integration_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/synthesize_llm_decoder_frontier.py",
+    "npu/eval/estimate_llm_decoder_output_projection_integrated_breakdown.py",
+    "tests/test_llm_decoder_frontier_synthesis.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/synthesize_llm_decoder_frontier.py
+++ b/npu/eval/synthesize_llm_decoder_frontier.py
@@ -69,7 +69,39 @@ def _dominant_component(components: dict[str, float]) -> tuple[str, float]:
     return name, round(share, 6)
 
 
-def build_report(*, stage_breakdown: JsonDict, attention_kv: JsonDict, producer_ranker: JsonDict) -> JsonDict:
+def _integration_summary(payload: JsonDict | None) -> JsonDict | None:
+    if not payload:
+        return None
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    rows = payload.get("integrations") if isinstance(payload.get("integrations"), list) else []
+    return {
+        "model": payload.get("model"),
+        "decision": (payload.get("decision") or {}).get("decision"),
+        "ok_integrations": summary.get("ok_integrations"),
+        "total_integrations": summary.get("total_integrations"),
+        "max_ranker_area_over_producer": summary.get("max_ranker_area_over_producer"),
+        "max_ranker_power_over_producer": summary.get("max_ranker_power_over_producer"),
+        "timing_bottlenecks": [
+            {
+                "arch_id": row.get("arch_id"),
+                "macro_mode": row.get("macro_mode"),
+                "producer_lanes": row.get("producer_lanes"),
+                "timing_bottleneck": (row.get("integrated_accounting") or {}).get("timing_bottleneck"),
+                "critical_path_ns": (row.get("integrated_accounting") or {}).get("critical_path_ns_max"),
+            }
+            for row in rows
+            if isinstance(row, dict)
+        ],
+    }
+
+
+def build_report(
+    *,
+    stage_breakdown: JsonDict,
+    attention_kv: JsonDict,
+    producer_ranker: JsonDict,
+    producer_ranker_integration: JsonDict | None = None,
+) -> JsonDict:
     attention_best = _best_attention_by_label_seq(attention_kv)
     producer_best = _best_producer_by_shape(producer_ranker)
     rows: list[JsonDict] = []
@@ -142,6 +174,7 @@ def build_report(*, stage_breakdown: JsonDict, attention_kv: JsonDict, producer_
         dominant_counts[row["dominant_component"]] = dominant_counts.get(row["dominant_component"], 0) + 1
 
     tile_frontier = attention_kv.get("measured_attention_kv_tile_frontier", {})
+    integration_summary = _integration_summary(producer_ranker_integration)
     return {
         "version": 0.1,
         "model": "llm_decoder_frontier_synthesis_v1",
@@ -149,8 +182,12 @@ def build_report(*, stage_breakdown: JsonDict, attention_kv: JsonDict, producer_
             "stage_breakdown_model": stage_breakdown.get("model"),
             "attention_kv_model": attention_kv.get("model"),
             "producer_ranker_model": producer_ranker.get("model"),
+            "producer_ranker_integration_model": (
+                producer_ranker_integration.get("model") if producer_ranker_integration else None
+            ),
             "producer_control_boundary": producer_ranker.get("producer_control_boundary"),
             "producer_physical_boundary": producer_ranker.get("producer_physical_boundary"),
+            "producer_ranker_integration_accounting": integration_summary,
         },
         "measured_attention_kv_tile_summary": tile_frontier.get("scaling_summary", {}),
         "dominant_component_counts": dominant_counts,
@@ -164,6 +201,7 @@ def build_report(*, stage_breakdown: JsonDict, attention_kv: JsonDict, producer_
             "Attention/KV uses the best latency row per shape and sequence from the calibrated attention/KV report.",
             "Producer/ranker uses the best FIFO-valid coupled row per hidden/vocab shape.",
             "Producer physical-boundary evidence is carried as feasibility/PPA context; it does not replace the analytical producer/ranker latency model.",
+            "Producer/ranker integration accounting is carried as measured additive PPA context; it does not replace the analytical coupled latency model.",
             "MLP and norm are resident-weight estimates from the whole-decoder stage breakdown.",
             "Use this report to choose the next measured RTL frontier, not as final PPA accounting.",
         ],
@@ -240,6 +278,33 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
                 f"- result_path: `{physical_boundary.get('result_path')}`",
             ]
         )
+    integration = payload.get("inputs", {}).get("producer_ranker_integration_accounting")
+    if integration:
+        lines.extend(
+            [
+                "",
+                "## Producer/Ranker Integration Accounting",
+                "",
+                f"- decision: `{integration.get('decision')}`",
+                f"- ok_integrations: `{integration.get('ok_integrations')}`",
+                f"- total_integrations: `{integration.get('total_integrations')}`",
+                f"- max_ranker_area_over_producer: `{integration.get('max_ranker_area_over_producer')}`",
+                f"- max_ranker_power_over_producer: `{integration.get('max_ranker_power_over_producer')}`",
+                "",
+                "| arch | macro | lanes | bottleneck | cp ns |",
+                "|---|---|---:|---|---:|",
+            ]
+        )
+        for row in integration.get("timing_bottlenecks", []):
+            lines.append(
+                "| {arch} | {macro} | {lanes} | {bottleneck} | {cp} |".format(
+                    arch=row.get("arch_id"),
+                    macro=row.get("macro_mode"),
+                    lanes=row.get("producer_lanes"),
+                    bottleneck=row.get("timing_bottleneck"),
+                    cp=row.get("critical_path_ns"),
+                )
+            )
     lines.extend(["", "## Assumptions", ""])
     for item in payload["assumptions"]:
         lines.append(f"- {item}")
@@ -251,6 +316,7 @@ def main() -> int:
     ap.add_argument("--stage-breakdown", required=True)
     ap.add_argument("--attention-kv-memory", required=True)
     ap.add_argument("--producer-ranker-coupled", required=True)
+    ap.add_argument("--producer-ranker-integration")
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
     args = ap.parse_args()
@@ -258,6 +324,9 @@ def main() -> int:
         stage_breakdown=_load_json(args.stage_breakdown),
         attention_kv=_load_json(args.attention_kv_memory),
         producer_ranker=_load_json(args.producer_ranker_coupled),
+        producer_ranker_integration=(
+            _load_json(args.producer_ranker_integration) if args.producer_ranker_integration else None
+        ),
     )
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_llm_decoder_frontier_synthesis.py
+++ b/tests/test_llm_decoder_frontier_synthesis.py
@@ -67,3 +67,90 @@ def test_frontier_synthesis_carries_producer_physical_boundary() -> None:
 
     assert report["inputs"]["producer_physical_boundary"] == physical_boundary
     assert "feasibility/PPA context" in report["assumptions"][3]
+
+
+def test_frontier_synthesis_carries_producer_ranker_integration_accounting() -> None:
+    stage_breakdown = {
+        "model": "stage_model",
+        "breakdown_sweep": [
+            {
+                "label": "gpt2_small",
+                "sequence_length": 128,
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "macs_per_cycle": 32768,
+                "memory_bandwidth_bytes_per_cycle": 256,
+                "weight_residency": "resident_weights",
+                "stage_shares": {"mlp": 0.2, "norm_residual": 0.01},
+                "total_latency_us": 100.0,
+            }
+        ],
+    }
+    attention_kv = {
+        "model": "attention_model",
+        "focus_summary": [
+            {
+                "label": "gpt2_small",
+                "sequence_length": 128,
+                "total_latency_us": 25.0,
+                "kv_memory_tier": "shared_sram",
+                "kv_sharing": "gqa4",
+                "kv_bits": 8,
+                "noc_hops": 1,
+                "dominant_substage": "kv_read",
+                "kv_limited_cycle_share": 0.5,
+            }
+        ],
+        "measured_attention_kv_tile_frontier": {"scaling_summary": {"best": "tile"}},
+    }
+    producer_ranker = {
+        "model": "producer_ranker_model",
+        "coupled_ranker_sweep": [
+            {
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "producer_lanes": 64,
+                "top_k": 1,
+                "memory_share": 1.0,
+                "producer_ii_cycles": 24,
+                "service_limiter": "weight_memory",
+                "ranker_traffic_reduction_vs_materialized": 0.99,
+                "ranker_fifo_capacity_ok": True,
+                "coupled_latency_us_per_token": 10.0,
+            }
+        ],
+    }
+    integration = {
+        "model": "decoder_output_projection_producer_ranker_integration_v1",
+        "decision": {"decision": "producer_output_ranker_integration_accounting_passed"},
+        "summary": {
+            "ok_integrations": 1,
+            "total_integrations": 1,
+            "max_ranker_area_over_producer": 0.12,
+            "max_ranker_power_over_producer": 0.14,
+        },
+        "integrations": [
+            {
+                "arch_id": "fp16_nm2",
+                "macro_mode": "flat_nomacro",
+                "producer_lanes": 128,
+                "integrated_accounting": {
+                    "timing_bottleneck": "producer",
+                    "critical_path_ns_max": 5.7,
+                },
+            }
+        ],
+    }
+
+    report = build_report(
+        stage_breakdown=stage_breakdown,
+        attention_kv=attention_kv,
+        producer_ranker=producer_ranker,
+        producer_ranker_integration=integration,
+    )
+
+    accounting = report["inputs"]["producer_ranker_integration_accounting"]
+    assert accounting["decision"] == "producer_output_ranker_integration_accounting_passed"
+    assert accounting["max_ranker_area_over_producer"] == 0.12
+    assert accounting["timing_bottlenecks"][0]["timing_bottleneck"] == "producer"
+    assert "measured additive PPA context" in report["assumptions"][4]


### PR DESCRIPTION
## Summary

Adds `decoder_frontier_synthesis_integrated`, a frontier synthesis variant that carries the latest producer/ranker integration accounting into the whole-decoder synthesis report.

The existing frontier latency model is preserved: producer/ranker integration accounting is included as measured additive PPA context, not as a replacement for the analytical producer/ranker coupled latency model.

## Validation

- `python3 -m py_compile npu/eval/synthesize_llm_decoder_frontier.py`
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_frontier_synthesis.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "frontier_synthesis"`
- local synthesis smoke with `--producer-ranker-integration` using merged artifacts
- `python3 scripts/validate_runs.py --skip_eval_queue`
