### PR TITLE
[codex] Add producer ranker policy calibration job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2714,6 +2714,53 @@ def _decoder_output_projection_producer_ranker_integration_evidence(*, item_id: 
     }
 
 
+def _decoder_producer_ranker_policy_calibration_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_producer_ranker_policy_calibration__{item_id}.json"
+    report = f"{base}/decoder_producer_ranker_policy_calibration__{item_id}.md"
+    coupled = (
+        f"{base}/decoder_producer_ranker_coupled_noc__"
+        "l2_decoder_frontier_synthesis_integrated_v1.json"
+    )
+    ranker_wrapper_physical = (
+        f"{base}/decoder_output_projection_ranker_wrapper_physical__"
+        "l2_decoder_output_projection_ranker_wrapper_physical_v1.json"
+    )
+    policy = (
+        f"{base}/decoder_output_projection_ranker_policy__"
+        "l2_decoder_output_projection_ranker_policy_v1.json"
+    )
+    return {
+        "inputs": {
+            "producer_ranker_policy_calibration_out": out,
+            "producer_ranker_policy_calibration_report": report,
+            "producer_ranker_coupled_report": coupled,
+            "output_projection_ranker_wrapper_physical": ranker_wrapper_physical,
+            "output_projection_ranker_policy": policy,
+            "producer_ranker_policy_calibration_scope": (
+                "Recompute producer/ranker coupling with measured output-ranker policy-wrapper "
+                "service latency. This preserves the old coupled report as baseline evidence while "
+                "checking whether the reported output-projection domination came from stale ranker "
+                "hierarchy latency rather than measured policy-wrapper service."
+            ),
+        },
+        "commands": [
+            {
+                "name": "calibrate_decoder_producer_ranker_policy_service",
+                "run": (
+                    "python3 npu/eval/calibrate_llm_decoder_producer_ranker_policy_service.py "
+                    f"--coupled-report {coupled} "
+                    f"--wrapper-physical {ranker_wrapper_physical} "
+                    f"--policy {policy} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_stage_breakdown_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_stage_breakdown__{item_id}.json"
@@ -4059,6 +4106,7 @@ def _build_payload(
         "decoder_output_projection_ranker_wrapper_contract",
         "decoder_output_projection_ranker_wrapper_physical",
         "decoder_output_projection_producer_ranker_integration",
+        "decoder_producer_ranker_policy_calibration",
         "decoder_stage_breakdown",
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
@@ -4133,6 +4181,8 @@ def _build_payload(
             decoder_evidence = _decoder_output_projection_ranker_wrapper_physical_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_ranker_integration":
             decoder_evidence = _decoder_output_projection_producer_ranker_integration_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_producer_ranker_policy_calibration":
+            decoder_evidence = _decoder_producer_ranker_policy_calibration_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_service":
             decoder_evidence = _decoder_output_projection_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_logit_rank_streaming_producer_integrated":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2402,6 +2402,60 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_producer_ranke
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_producer_ranker_policy_calibration() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_producer_ranker_policy_calibration_v1",
+                    proposal_id="prop_l2_decoder_producer_ranker_policy_calibration_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_producer_ranker_policy_calibration_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_producer_ranker_policy_calibration",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "calibrate_decoder_producer_ranker_policy_service",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "calibrate_llm_decoder_producer_ranker_policy_service.py" in run
+            assert "--coupled-report" in run
+            assert "l2_decoder_frontier_synthesis_integrated_v1.json" in run
+            assert decoder_inputs["producer_ranker_policy_calibration_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_producer_ranker_policy_calibration__"
+                "l2_decoder_producer_ranker_policy_calibration_v1.json"
+            )
+            assert "stale ranker hierarchy latency" in decoder_inputs[
+                "producer_ranker_policy_calibration_scope"
+            ]
+            assert decoder_inputs["producer_ranker_policy_calibration_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_producer_ranker_policy_calibration",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_producer_ranker_policy_calibration_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_producer_ranker_policy_calibration_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_producer_ranker_policy_calibration_v1",
+  "created_utc": "2026-05-15T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_producer_ranker_policy_calibration",
+  "title": "Decoder producer/ranker policy-service latency calibration",
+  "hypothesis": "The current producer/ranker coupled frontier is dominated by an older streaming ranker hierarchy latency estimate; replacing that ranker service with measured output-ranker policy-wrapper service may move the bottleneck back to producer output-projection service.",
+  "direct_comparison": {
+    "primary_question": "Does measured policy-wrapper ranker service still dominate producer/ranker coupling, or was the previous frontier dominated by stale ranker hierarchy latency?",
+    "include": [
+      "existing producer/ranker coupled NoC report from the integrated frontier synthesis",
+      "measured r64 and r128 output-ranker policy-wrapper service cycles and clock",
+      "output-ranker policy rows for serial_lpc1 versus rank-tree selection",
+      "old versus calibrated coupled latency best rows",
+      "producer-dominant versus ranker-dominant row counts after calibration"
+    ],
+    "exclude": [
+      "new routed RTL implementation",
+      "new producer physical synthesis",
+      "measured SRAM or NoC arbitration",
+      "quality or training recovery effects"
+    ]
+  },
+  "expected_benefit": [
+    "separates stale analytical ranker latency from measured policy-wrapper ranker service",
+    "prevents the next frontier choice from chasing a ranker bottleneck that may already be resolved",
+    "identifies whether the immediate RTL target should be producer memory/cache hierarchy or whole-decoder attention/KV breakdown"
+  ],
+  "risks": [
+    "producer latency and initiation interval still come from the prior analytical service model",
+    "policy-wrapper measurements are standalone and do not include NoC/SRAM contention",
+    "exact policy matching can fall back to a threshold if a coupled row is missing from the policy report"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_producer_ranker_policy_calibration_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recompute producer/ranker coupling using measured output-ranker policy-wrapper service instead of the older streaming ranker hierarchy latency.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_producer_ranker_policy_calibration",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_frontier_synthesis_integrated_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_integrated_v1",
+        "l2_decoder_output_projection_ranker_wrapper_physical_v1",
+        "l2_decoder_output_projection_ranker_policy_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If calibrated producer/ranker latency no longer dominates, refresh frontier synthesis with calibrated latency; otherwise target producer weight-memory/cache hierarchy."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_producer_ranker_coupled_noc__l2_decoder_frontier_synthesis_integrated_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_ranker_wrapper_physical__l2_decoder_output_projection_ranker_wrapper_physical_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_ranker_policy__l2_decoder_output_projection_ranker_policy_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/calibrate_llm_decoder_producer_ranker_policy_service.py",
+    "tests/test_llm_decoder_producer_ranker_policy_calibration.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/calibrate_llm_decoder_producer_ranker_policy_service.py
+++ b/npu/eval/calibrate_llm_decoder_producer_ranker_policy_service.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Calibrate producer/ranker coupling with measured policy-wrapper service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    with Path(path).open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if value in (None, ""):
+        return default
+    return int(float(value))
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    if value in (None, ""):
+        return default
+    return float(value)
+
+
+def _wrapper_by_lanes(wrapper_physical: JsonDict) -> dict[int, JsonDict]:
+    out: dict[int, JsonDict] = {}
+    for row in wrapper_physical.get("variants", []):
+        if isinstance(row, dict):
+            out[_as_int(row.get("producer_lanes"))] = row
+    return out
+
+
+def _policy_index(policy: JsonDict) -> dict[tuple[int, int, int, int, float, int], JsonDict]:
+    index: dict[tuple[int, int, int, int, float, int], JsonDict] = {}
+    for row in policy.get("policy_rows", []):
+        if not isinstance(row, dict):
+            continue
+        producer = row.get("producer")
+        if not isinstance(producer, dict):
+            continue
+        key = (
+            _as_int(producer.get("vocab_size")),
+            _as_int(producer.get("hidden_size")),
+            _as_int(producer.get("producer_lanes")),
+            _as_int(producer.get("macs_per_cycle")),
+            _as_float(producer.get("memory_bandwidth_bytes_per_cycle")),
+            _as_int(producer.get("producer_ii_cycles")),
+        )
+        index[key] = row
+    return index
+
+
+def _scenario_from_policy(row: JsonDict | None, *, producer_ii_cycles: int) -> tuple[str, str]:
+    if row is not None:
+        selected = str(row.get("selected_path") or "")
+        if selected == "serial_lpc1":
+            return "serial", selected
+        if "ranktree" in selected:
+            return "ranktree", selected
+    return ("serial", "threshold_serial_lpc1") if producer_ii_cycles >= 384 else ("ranktree", "threshold_ranktree")
+
+
+def _simulation_cycles(wrapper: JsonDict, scenario: str) -> int:
+    simulations = wrapper.get("simulations") if isinstance(wrapper.get("simulations"), dict) else {}
+    sim = simulations.get(scenario) if isinstance(simulations.get(scenario), dict) else {}
+    observed = sim.get("observed") if isinstance(sim.get("observed"), dict) else {}
+    return _as_int(observed.get("final_cycle"))
+
+
+def _wrapper_clock_ns(wrapper: JsonDict) -> float:
+    metrics = wrapper.get("metrics_row") if isinstance(wrapper.get("metrics_row"), dict) else {}
+    return _as_float(metrics.get("critical_path_ns"))
+
+
+def _best(rows: list[JsonDict], key: str) -> JsonDict | None:
+    ok = [row for row in rows if row.get("status") == "ok"]
+    if not ok:
+        return None
+    return min(
+        ok,
+        key=lambda row: (
+            _as_float(row.get(key), float("inf")),
+            _as_float(row.get("calibrated_candidate_memory_bytes"), float("inf")),
+            _as_int(row.get("producer_lanes"), 10**9),
+        ),
+    )
+
+
+def build_report(
+    *,
+    coupled_report: JsonDict,
+    wrapper_physical: JsonDict,
+    policy: JsonDict,
+) -> JsonDict:
+    wrappers = _wrapper_by_lanes(wrapper_physical)
+    policies = _policy_index(policy)
+    calibrated_rows: list[JsonDict] = []
+
+    for row in coupled_report.get("coupled_ranker_sweep", []):
+        if not isinstance(row, dict):
+            continue
+        lanes = _as_int(row.get("producer_lanes"))
+        wrapper = wrappers.get(lanes)
+        if wrapper is None:
+            calibrated_rows.append({**row, "status": "missing_wrapper_physical"})
+            continue
+        key = (
+            _as_int(row.get("vocab_size")),
+            _as_int(row.get("hidden_size")),
+            lanes,
+            _as_int(row.get("macs_per_cycle")),
+            _as_float(row.get("memory_bandwidth_bytes_per_cycle")),
+            _as_int(row.get("producer_ii_cycles")),
+        )
+        policy_row = policies.get(key)
+        scenario, selected_path = _scenario_from_policy(
+            policy_row,
+            producer_ii_cycles=_as_int(row.get("producer_ii_cycles")),
+        )
+        cycles = _simulation_cycles(wrapper, scenario)
+        clock_ns = _wrapper_clock_ns(wrapper)
+        if cycles <= 0 or clock_ns <= 0.0:
+            calibrated_rows.append(
+                {
+                    **row,
+                    "status": "missing_wrapper_service_measurement",
+                    "policy_match": policy_row is not None,
+                    "calibrated_selected_path": selected_path,
+                    "calibrated_scenario": scenario,
+                    "calibrated_ranker_cycles": cycles,
+                    "calibrated_ranker_clock_ns": clock_ns,
+                }
+            )
+            continue
+        measured_ranker_us = cycles * clock_ns / 1000.0
+        producer_us = _as_float(row.get("producer_latency_us_per_token"))
+        calibrated_us = max(producer_us, measured_ranker_us)
+        calibrated_rows.append(
+            {
+                **row,
+                "status": "ok",
+                "policy_match": policy_row is not None,
+                "calibrated_selected_path": selected_path,
+                "calibrated_scenario": scenario,
+                "calibrated_ranker_cycles": cycles,
+                "calibrated_ranker_clock_ns": clock_ns,
+                "calibrated_ranker_latency_us_per_token": round(measured_ranker_us, 6),
+                "calibrated_coupled_latency_us_per_token": round(calibrated_us, 6),
+                "old_ranker_latency_us_per_token": row.get("ranker_latency_us_per_token"),
+                "old_coupled_latency_us_per_token": row.get("coupled_latency_us_per_token"),
+                "calibrated_dominant_term": "ranker_policy_wrapper" if measured_ranker_us > producer_us else "producer",
+                "calibrated_candidate_memory_bytes": row.get("ranker_candidate_memory_bytes"),
+            }
+        )
+
+    old_best = _best(calibrated_rows, "coupled_latency_us_per_token")
+    calibrated_best = _best(calibrated_rows, "calibrated_coupled_latency_us_per_token")
+    speedup = None
+    if old_best and calibrated_best:
+        old_us = _as_float(old_best.get("coupled_latency_us_per_token"))
+        new_us = _as_float(calibrated_best.get("calibrated_coupled_latency_us_per_token"))
+        speedup = round(old_us / new_us, 6) if new_us > 0 else None
+
+    producer_dominant = [
+        row for row in calibrated_rows if row.get("status") == "ok" and row.get("calibrated_dominant_term") == "producer"
+    ]
+    ok_count = sum(1 for row in calibrated_rows if row.get("status") == "ok")
+    missing_wrapper_count = sum(1 for row in calibrated_rows if row.get("status") == "missing_wrapper_physical")
+    bad_measurement_count = sum(
+        1 for row in calibrated_rows if row.get("status") == "missing_wrapper_service_measurement"
+    )
+    return {
+        "version": 0.1,
+        "model": "decoder_output_projection_producer_ranker_policy_calibration_v1",
+        "inputs": {
+            "coupled_model": coupled_report.get("model"),
+            "wrapper_model": wrapper_physical.get("model"),
+            "policy_model": policy.get("model"),
+        },
+        "checks": [
+            {
+                "name": "wrapper_physical_measured",
+                "passed": (wrapper_physical.get("decision") or {}).get("decision")
+                == "output_projection_ranker_wrapper_physical_measured",
+                "observed": (wrapper_physical.get("decision") or {}).get("decision"),
+            },
+            {
+                "name": "policy_promoted",
+                "passed": (policy.get("decision") or {}).get("decision")
+                == "output_projection_ranker_policy_promoted",
+                "observed": (policy.get("decision") or {}).get("decision"),
+            },
+            {
+                "name": "measured_wrapper_lane_rows_calibrated",
+                "passed": ok_count > 0 and bad_measurement_count == 0,
+                "observed": {
+                    "ok": ok_count,
+                    "missing_wrapper_physical": missing_wrapper_count,
+                    "missing_wrapper_service_measurement": bad_measurement_count,
+                    "total": len(calibrated_rows),
+                },
+            },
+        ],
+        "old_best": old_best,
+        "calibrated_best": calibrated_best,
+        "summary": {
+            "row_count": len(calibrated_rows),
+            "calibrated_row_count": ok_count,
+            "missing_wrapper_physical_rows": missing_wrapper_count,
+            "missing_wrapper_service_measurement_rows": bad_measurement_count,
+            "producer_dominant_rows": len(producer_dominant),
+            "ranker_dominant_rows": sum(
+                1 for row in calibrated_rows if row.get("status") == "ok" and row.get("calibrated_dominant_term") != "producer"
+            ),
+            "old_to_calibrated_best_latency_speedup": speedup,
+        },
+        "calibrated_coupled_ranker_sweep": calibrated_rows,
+        "decision": {
+            "decision": "producer_ranker_policy_calibration_completed",
+            "next_step": (
+                "Refresh frontier synthesis with calibrated producer/ranker latency; if output projection still dominates, "
+                "measure producer weight-memory/cache hierarchy rather than the ranker wrapper."
+            ),
+        },
+        "assumptions": [
+            "The measured policy wrapper service is used only for ranker service after a producer tile reaches the ranker.",
+            "Producer latency and II remain from the existing output-projection service model.",
+            "Exact policy rows are used when available; otherwise the serial_lpc1 threshold is applied conservatively.",
+            "This calibration replaces the older streaming ranker hierarchy latency for output-projection policy-wrapper coupling.",
+        ],
+    }
+
+
+def write_markdown(path: str | Path, payload: JsonDict) -> None:
+    old_best = payload.get("old_best") or {}
+    new_best = payload.get("calibrated_best") or {}
+    lines = [
+        "# Decoder Producer/Ranker Policy Calibration",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- old_best_us: `{old_best.get('coupled_latency_us_per_token')}`",
+        f"- calibrated_best_us: `{new_best.get('calibrated_coupled_latency_us_per_token')}`",
+        f"- old_to_calibrated_speedup: `{payload['summary'].get('old_to_calibrated_best_latency_speedup')}`",
+        f"- producer_dominant_rows: `{payload['summary'].get('producer_dominant_rows')}`",
+        f"- ranker_dominant_rows: `{payload['summary'].get('ranker_dominant_rows')}`",
+        "",
+        "## Best Row",
+        "",
+        "| metric | old | calibrated |",
+        "|---|---:|---:|",
+        f"| coupled_us | {old_best.get('coupled_latency_us_per_token')} | {new_best.get('calibrated_coupled_latency_us_per_token')} |",
+        f"| producer_us | {old_best.get('producer_latency_us_per_token')} | {new_best.get('producer_latency_us_per_token')} |",
+        f"| ranker_us | {old_best.get('ranker_latency_us_per_token')} | {new_best.get('calibrated_ranker_latency_us_per_token')} |",
+        f"| lanes | {old_best.get('producer_lanes')} | {new_best.get('producer_lanes')} |",
+        f"| selected_path |  | {new_best.get('calibrated_selected_path')} |",
+        "",
+        "## Checks",
+        "",
+        "| check | passed | observed |",
+        "|---|---|---|",
+    ]
+    for check in payload["checks"]:
+        lines.append(f"| {check['name']} | `{check['passed']}` | `{check.get('observed')}` |")
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--coupled-report", required=True)
+    ap.add_argument("--wrapper-physical", required=True)
+    ap.add_argument("--policy", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    payload = build_report(
+        coupled_report=_load_json(args.coupled_report),
+        wrapper_physical=_load_json(args.wrapper_physical),
+        policy=_load_json(args.policy),
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "out": args.out, "out_md": args.out_md}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_producer_ranker_policy_calibration.py
+++ b/tests/test_llm_decoder_producer_ranker_policy_calibration.py
@@ -1,0 +1,99 @@
+from npu.eval.calibrate_llm_decoder_producer_ranker_policy_service import build_report
+
+
+def _coupled_row(**overrides: object) -> dict:
+    row = {
+        "vocab_size": 50257,
+        "hidden_size": 768,
+        "producer_lanes": 64,
+        "macs_per_cycle": 32768,
+        "memory_bandwidth_bytes_per_cycle": 256,
+        "producer_ii_cycles": 512,
+        "producer_latency_us_per_token": 300.0,
+        "ranker_latency_us_per_token": 1000.0,
+        "coupled_latency_us_per_token": 1000.0,
+        "ranker_candidate_memory_bytes": 1024,
+    }
+    row.update(overrides)
+    return row
+
+
+def _wrapper(*, lanes: int = 64) -> dict:
+    return {
+        "producer_lanes": lanes,
+        "metrics_row": {"critical_path_ns": "2.0"},
+        "simulations": {
+            "serial": {"observed": {"final_cycle": 1000}},
+            "ranktree": {"observed": {"final_cycle": 10}},
+        },
+    }
+
+
+def test_calibration_replaces_old_ranker_latency_with_measured_serial_service() -> None:
+    report = build_report(
+        coupled_report={"model": "coupled", "coupled_ranker_sweep": [_coupled_row()]},
+        wrapper_physical={
+            "model": "wrapper",
+            "decision": {"decision": "output_projection_ranker_wrapper_physical_measured"},
+            "variants": [_wrapper()],
+        },
+        policy={
+            "model": "policy",
+            "decision": {"decision": "output_projection_ranker_policy_promoted"},
+            "policy_rows": [],
+        },
+    )
+
+    best = report["calibrated_best"]
+    assert best["calibrated_selected_path"] == "threshold_serial_lpc1"
+    assert best["calibrated_ranker_latency_us_per_token"] == 2.0
+    assert best["calibrated_coupled_latency_us_per_token"] == 300.0
+    assert best["calibrated_dominant_term"] == "producer"
+    assert report["summary"]["old_to_calibrated_best_latency_speedup"] == 3.333333
+
+
+def test_calibration_uses_exact_policy_ranktree_row_when_available() -> None:
+    row = _coupled_row(producer_ii_cycles=128)
+    policy_row = {
+        "producer": {
+            "vocab_size": 50257,
+            "hidden_size": 768,
+            "producer_lanes": 64,
+            "macs_per_cycle": 32768,
+            "memory_bandwidth_bytes_per_cycle": 256,
+            "producer_ii_cycles": 128,
+        },
+        "selected_path": "resident_ranktree_r64",
+    }
+    report = build_report(
+        coupled_report={"coupled_ranker_sweep": [row]},
+        wrapper_physical={
+            "decision": {"decision": "output_projection_ranker_wrapper_physical_measured"},
+            "variants": [_wrapper()],
+        },
+        policy={
+            "decision": {"decision": "output_projection_ranker_policy_promoted"},
+            "policy_rows": [policy_row],
+        },
+    )
+
+    best = report["calibrated_best"]
+    assert best["policy_match"] is True
+    assert best["calibrated_selected_path"] == "resident_ranktree_r64"
+    assert best["calibrated_scenario"] == "ranktree"
+    assert best["calibrated_ranker_latency_us_per_token"] == 0.02
+
+
+def test_calibration_marks_rows_without_wrapper_measurements() -> None:
+    report = build_report(
+        coupled_report={"coupled_ranker_sweep": [_coupled_row(producer_lanes=128)]},
+        wrapper_physical={
+            "decision": {"decision": "output_projection_ranker_wrapper_physical_measured"},
+            "variants": [_wrapper(lanes=64)],
+        },
+        policy={"decision": {"decision": "output_projection_ranker_policy_promoted"}, "policy_rows": []},
+    )
+
+    assert report["calibrated_coupled_ranker_sweep"][0]["status"] == "missing_wrapper_physical"
+    assert report["checks"][2]["passed"] is False
+    assert report["summary"]["missing_wrapper_physical_rows"] == 1


### PR DESCRIPTION
## Summary
- add a decoder producer/ranker policy-service calibration script
- register `decoder_producer_ranker_policy_calibration` in the L2 task generator
- add proposal metadata and tests for the report logic and generator contract

## Why
The integrated frontier synthesis was still dominated by producer/ranker latency, but that latency came from the older streaming ranker hierarchy model. This job recalibrates the coupled report with measured output-ranker policy-wrapper service so the next architecture step does not chase a stale ranker bottleneck.

## Validation
- `PYTHONPATH=/tmp/rtlgen-producer-ranker-calibration:/tmp/rtlgen-producer-ranker-calibration/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_producer_ranker_policy_calibration.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_producer_ranker_policy_calibration -q`
- `PYTHONPATH=/tmp/rtlgen-producer-ranker-calibration:/tmp/rtlgen-producer-ranker-calibration/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -q`
- smoke ran the new calibration script against current merged artifacts
