### PR TITLE
[codex] Add calibrated frontier synthesis job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2967,6 +2967,56 @@ def _decoder_frontier_synthesis_integrated_evidence(*, item_id: str) -> dict[str
     }
 
 
+def _decoder_frontier_synthesis_policy_calibrated_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_frontier_synthesis__{item_id}.json"
+    report = f"{base}/decoder_frontier_synthesis__{item_id}.md"
+    stage_out = f"{base}/decoder_stage_breakdown__l2_decoder_frontier_synthesis_integrated_v1.json"
+    attention_out = f"{base}/decoder_attention_kv_memory__l2_decoder_frontier_synthesis_integrated_v1.json"
+    producer_out = f"{base}/decoder_producer_ranker_coupled_noc__l2_decoder_frontier_synthesis_integrated_v1.json"
+    integration_out = (
+        f"{base}/decoder_output_projection_producer_ranker_integration__"
+        "l2_decoder_frontier_synthesis_integrated_v1.json"
+    )
+    calibration_out = (
+        f"{base}/decoder_producer_ranker_policy_calibration__"
+        "l2_decoder_producer_ranker_policy_calibration_v1.json"
+    )
+    return {
+        "inputs": {
+            "stage_breakdown_out": stage_out,
+            "attention_kv_memory_out": attention_out,
+            "producer_ranker_coupled_out": producer_out,
+            "output_projection_producer_ranker_integration_out": integration_out,
+            "producer_ranker_policy_calibration_out": calibration_out,
+            "decoder_frontier_synthesis_out": out,
+            "decoder_frontier_synthesis_report": report,
+            "decoder_frontier_synthesis_scope": (
+                "Refresh whole-decoder frontier synthesis with the measured policy-wrapper "
+                "producer/ranker latency calibration. This replaces the older streaming ranker "
+                "hierarchy latency in the ranking while preserving the coupled and additive "
+                "integration reports as context."
+            ),
+        },
+        "commands": [
+            {
+                "name": "synthesize_decoder_frontier_policy_calibrated",
+                "run": (
+                    "python3 npu/eval/synthesize_llm_decoder_frontier.py "
+                    f"--stage-breakdown {stage_out} "
+                    f"--attention-kv-memory {attention_out} "
+                    f"--producer-ranker-coupled {producer_out} "
+                    f"--producer-ranker-integration {integration_out} "
+                    f"--producer-ranker-policy-calibration {calibration_out} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_producer_ranker_memory_integration_plan_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_producer_ranker_memory_integration_plan__{item_id}.json"
@@ -4111,6 +4161,7 @@ def _build_payload(
         "decoder_attention_kv_memory",
         "decoder_frontier_synthesis",
         "decoder_frontier_synthesis_integrated",
+        "decoder_frontier_synthesis_policy_calibrated",
         "decoder_producer_ranker_memory_integration_plan",
         "decoder_producer_ranker_ready_valid_equivalence",
         "decoder_producer_ranker_physical_wrapper",
@@ -4143,6 +4194,8 @@ def _build_payload(
             decoder_evidence = _decoder_frontier_synthesis_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_frontier_synthesis_integrated":
             decoder_evidence = _decoder_frontier_synthesis_integrated_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_frontier_synthesis_policy_calibrated":
+            decoder_evidence = _decoder_frontier_synthesis_policy_calibrated_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_producer_ranker_memory_integration_plan":
             decoder_evidence = _decoder_producer_ranker_memory_integration_plan_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_producer_ranker_ready_valid_equivalence":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2657,6 +2657,56 @@ def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_integrated_ev
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_policy_calibrated() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_frontier_synthesis_policy_calibrated_v1",
+                    proposal_id="prop_l2_decoder_frontier_synthesis_policy_calibrated_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_frontier_synthesis_policy_calibrated_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_frontier_synthesis_policy_calibrated",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "synthesize_decoder_frontier_policy_calibrated",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "--producer-ranker-policy-calibration" in run
+            assert "l2_decoder_producer_ranker_policy_calibration_v1.json" in run
+            assert decoder_inputs["decoder_frontier_synthesis_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_frontier_synthesis__l2_decoder_frontier_synthesis_policy_calibrated_v1.json"
+            )
+            assert "measured policy-wrapper" in decoder_inputs["decoder_frontier_synthesis_scope"]
+            assert decoder_inputs["decoder_frontier_synthesis_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_frontier_synthesis_policy_calibrated",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_producer_ranker_memory_integration_plan() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_frontier_synthesis_policy_calibrated_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_frontier_synthesis_policy_calibrated_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l2_decoder_frontier_synthesis_policy_calibrated_v1",
+  "created_utc": "2026-05-15T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_frontier_synthesis_policy_calibrated",
+  "title": "Decoder frontier synthesis with calibrated producer/ranker service",
+  "hypothesis": "Replacing the older streaming ranker hierarchy latency with measured policy-wrapper ranker service will move the whole-decoder frontier away from ranker-dominated output projection and expose whether producer output projection, attention/KV memory, or MLP is the next measured bottleneck.",
+  "direct_comparison": {
+    "primary_question": "After substituting calibrated producer/ranker latency, what component dominates the focused whole-decoder rows?",
+    "include": [
+      "integrated frontier stage breakdown and attention/KV evidence",
+      "prior producer/ranker coupled NoC report as baseline context",
+      "producer/ranker integration PPA accounting",
+      "producer/ranker policy-service latency calibration",
+      "dominant component counts and focused row latency breakdowns"
+    ],
+    "exclude": [
+      "new routed RTL implementation",
+      "new producer or ranker physical synthesis",
+      "measured SRAM/NoC arbitration",
+      "model-quality or training recovery effects"
+    ]
+  },
+  "expected_benefit": [
+    "uses measured ranker-wrapper service in the frontier ranking rather than only as side evidence",
+    "prevents the next job from targeting a ranker bottleneck that calibration already removed",
+    "selects a more defensible next architecture point across producer memory/cache and attention/KV hierarchy"
+  ],
+  "risks": [
+    "producer service latency and initiation interval remain analytical",
+    "r256 rows remain outside the measured wrapper calibration",
+    "attention/KV and MLP costs still come from coarse synthesis models rather than full routed subsystems"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_frontier_synthesis_policy_calibrated_v1",
+      "task_type": "l2_campaign",
+      "objective": "Refresh decoder frontier synthesis using calibrated producer/ranker policy-wrapper service latency.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_frontier_synthesis_policy_calibrated",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_frontier_synthesis_integrated_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_frontier_synthesis_integrated_v1",
+        "l2_decoder_producer_ranker_policy_calibration_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If output projection still dominates after calibrated ranker service, target producer memory/cache hierarchy; otherwise move to the newly dominant decoder component."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_frontier_synthesis__l2_decoder_frontier_synthesis_integrated_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_producer_ranker_policy_calibration__l2_decoder_producer_ranker_policy_calibration_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/synthesize_llm_decoder_frontier.py",
+    "tests/test_llm_decoder_frontier_synthesis.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/synthesize_llm_decoder_frontier.py
+++ b/npu/eval/synthesize_llm_decoder_frontier.py
@@ -35,26 +35,34 @@ def _best_attention_by_label_seq(payload: JsonDict) -> dict[tuple[str, int], Jso
     return best
 
 
+def _producer_latency_us(row: JsonDict) -> float:
+    return float(
+        row.get("calibrated_coupled_latency_us_per_token")
+        or row.get("coupled_latency_us_per_token")
+        or row.get("producer_latency_us_per_token")
+        or 0.0
+    )
+
+
 def _best_producer_by_shape(payload: JsonDict) -> dict[tuple[int, int], JsonDict]:
     best: dict[tuple[int, int], JsonDict] = {}
-    rows = payload.get("coupled_ranker_sweep") or payload.get("producer_service_sweep") or []
+    rows = (
+        payload.get("calibrated_coupled_ranker_sweep")
+        or payload.get("coupled_ranker_sweep")
+        or payload.get("producer_service_sweep")
+        or []
+    )
     for row in rows:
+        if row.get("status") not in (None, "ok"):
+            continue
         if row.get("ranker_fifo_capacity_ok") is False:
             continue
         key = (int(row.get("hidden_size", 0) or 0), int(row.get("vocab_size", 0) or 0))
         if key[0] <= 0 or key[1] <= 0:
             continue
         current = best.get(key)
-        latency = float(
-            row.get("coupled_latency_us_per_token")
-            or row.get("producer_latency_us_per_token")
-            or 0.0
-        )
-        current_latency = float(
-            current.get("coupled_latency_us_per_token")
-            or current.get("producer_latency_us_per_token")
-            or 0.0
-        ) if current else 0.0
+        latency = _producer_latency_us(row)
+        current_latency = _producer_latency_us(current) if current else 0.0
         if current is None or latency < current_latency:
             best[key] = row
     return best
@@ -95,15 +103,38 @@ def _integration_summary(payload: JsonDict | None) -> JsonDict | None:
     }
 
 
+def _calibration_summary(payload: JsonDict | None) -> JsonDict | None:
+    if not payload:
+        return None
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    best = payload.get("calibrated_best") if isinstance(payload.get("calibrated_best"), dict) else {}
+    old_best = payload.get("old_best") if isinstance(payload.get("old_best"), dict) else {}
+    return {
+        "model": payload.get("model"),
+        "decision": (payload.get("decision") or {}).get("decision"),
+        "row_count": summary.get("row_count"),
+        "calibrated_row_count": summary.get("calibrated_row_count"),
+        "missing_wrapper_physical_rows": summary.get("missing_wrapper_physical_rows"),
+        "producer_dominant_rows": summary.get("producer_dominant_rows"),
+        "ranker_dominant_rows": summary.get("ranker_dominant_rows"),
+        "old_to_calibrated_best_latency_speedup": summary.get("old_to_calibrated_best_latency_speedup"),
+        "old_best_us": old_best.get("coupled_latency_us_per_token"),
+        "calibrated_best_us": best.get("calibrated_coupled_latency_us_per_token"),
+        "calibrated_best_dominant_term": best.get("calibrated_dominant_term"),
+    }
+
+
 def build_report(
     *,
     stage_breakdown: JsonDict,
     attention_kv: JsonDict,
     producer_ranker: JsonDict,
     producer_ranker_integration: JsonDict | None = None,
+    producer_ranker_policy_calibration: JsonDict | None = None,
 ) -> JsonDict:
     attention_best = _best_attention_by_label_seq(attention_kv)
-    producer_best = _best_producer_by_shape(producer_ranker)
+    producer_source = producer_ranker_policy_calibration or producer_ranker
+    producer_best = _best_producer_by_shape(producer_source)
     rows: list[JsonDict] = []
 
     for row in stage_breakdown.get("breakdown_sweep", []):
@@ -119,11 +150,7 @@ def build_report(
         producer = producer_best.get((hidden_size, vocab_size))
         if attention is None or producer is None:
             continue
-        producer_us = float(
-            producer.get("coupled_latency_us_per_token")
-            or producer.get("producer_latency_us_per_token")
-            or 0.0
-        )
+        producer_us = _producer_latency_us(producer)
         components = {
             "attention_kv_best": float(attention.get("total_latency_us", 0.0) or 0.0),
             "mlp_resident": _stage_component_us(row, "mlp"),
@@ -157,6 +184,11 @@ def build_report(
                     "producer_ii_cycles": producer.get("producer_ii_cycles"),
                     "service_limiter": producer.get("service_limiter"),
                     "traffic_reduction_vs_materialized": producer.get("ranker_traffic_reduction_vs_materialized"),
+                    "calibrated_selected_path": producer.get("calibrated_selected_path"),
+                    "calibrated_ranker_latency_us_per_token": producer.get(
+                        "calibrated_ranker_latency_us_per_token"
+                    ),
+                    "old_coupled_latency_us_per_token": producer.get("old_coupled_latency_us_per_token"),
                 },
             }
         )
@@ -175,9 +207,14 @@ def build_report(
 
     tile_frontier = attention_kv.get("measured_attention_kv_tile_frontier", {})
     integration_summary = _integration_summary(producer_ranker_integration)
+    calibration_summary = _calibration_summary(producer_ranker_policy_calibration)
     return {
         "version": 0.1,
-        "model": "llm_decoder_frontier_synthesis_v1",
+        "model": (
+            "llm_decoder_frontier_synthesis_policy_calibrated_v1"
+            if producer_ranker_policy_calibration
+            else "llm_decoder_frontier_synthesis_v1"
+        ),
         "inputs": {
             "stage_breakdown_model": stage_breakdown.get("model"),
             "attention_kv_model": attention_kv.get("model"),
@@ -185,9 +222,13 @@ def build_report(
             "producer_ranker_integration_model": (
                 producer_ranker_integration.get("model") if producer_ranker_integration else None
             ),
+            "producer_ranker_policy_calibration_model": (
+                producer_ranker_policy_calibration.get("model") if producer_ranker_policy_calibration else None
+            ),
             "producer_control_boundary": producer_ranker.get("producer_control_boundary"),
             "producer_physical_boundary": producer_ranker.get("producer_physical_boundary"),
             "producer_ranker_integration_accounting": integration_summary,
+            "producer_ranker_policy_calibration": calibration_summary,
         },
         "measured_attention_kv_tile_summary": tile_frontier.get("scaling_summary", {}),
         "dominant_component_counts": dominant_counts,
@@ -202,6 +243,7 @@ def build_report(
             "Producer/ranker uses the best FIFO-valid coupled row per hidden/vocab shape.",
             "Producer physical-boundary evidence is carried as feasibility/PPA context; it does not replace the analytical producer/ranker latency model.",
             "Producer/ranker integration accounting is carried as measured additive PPA context; it does not replace the analytical coupled latency model.",
+            "When producer/ranker policy calibration is provided, calibrated coupled latency replaces the older streaming ranker hierarchy latency for frontier ranking.",
             "MLP and norm are resident-weight estimates from the whole-decoder stage breakdown.",
             "Use this report to choose the next measured RTL frontier, not as final PPA accounting.",
         ],
@@ -305,6 +347,23 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
                     cp=row.get("critical_path_ns"),
                 )
             )
+    calibration = payload.get("inputs", {}).get("producer_ranker_policy_calibration")
+    if calibration:
+        lines.extend(
+            [
+                "",
+                "## Producer/Ranker Policy Calibration",
+                "",
+                f"- decision: `{calibration.get('decision')}`",
+                f"- calibrated_row_count: `{calibration.get('calibrated_row_count')}`",
+                f"- missing_wrapper_physical_rows: `{calibration.get('missing_wrapper_physical_rows')}`",
+                f"- producer_dominant_rows: `{calibration.get('producer_dominant_rows')}`",
+                f"- ranker_dominant_rows: `{calibration.get('ranker_dominant_rows')}`",
+                f"- old_best_us: `{calibration.get('old_best_us')}`",
+                f"- calibrated_best_us: `{calibration.get('calibrated_best_us')}`",
+                f"- old_to_calibrated_best_latency_speedup: `{calibration.get('old_to_calibrated_best_latency_speedup')}`",
+            ]
+        )
     lines.extend(["", "## Assumptions", ""])
     for item in payload["assumptions"]:
         lines.append(f"- {item}")
@@ -317,6 +376,7 @@ def main() -> int:
     ap.add_argument("--attention-kv-memory", required=True)
     ap.add_argument("--producer-ranker-coupled", required=True)
     ap.add_argument("--producer-ranker-integration")
+    ap.add_argument("--producer-ranker-policy-calibration")
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
     args = ap.parse_args()
@@ -326,6 +386,11 @@ def main() -> int:
         producer_ranker=_load_json(args.producer_ranker_coupled),
         producer_ranker_integration=(
             _load_json(args.producer_ranker_integration) if args.producer_ranker_integration else None
+        ),
+        producer_ranker_policy_calibration=(
+            _load_json(args.producer_ranker_policy_calibration)
+            if args.producer_ranker_policy_calibration
+            else None
         ),
     )
     out = Path(args.out)

--- a/tests/test_llm_decoder_frontier_synthesis.py
+++ b/tests/test_llm_decoder_frontier_synthesis.py
@@ -154,3 +154,103 @@ def test_frontier_synthesis_carries_producer_ranker_integration_accounting() -> 
     assert accounting["max_ranker_area_over_producer"] == 0.12
     assert accounting["timing_bottlenecks"][0]["timing_bottleneck"] == "producer"
     assert "measured additive PPA context" in report["assumptions"][4]
+
+
+def test_frontier_synthesis_uses_policy_calibrated_producer_latency() -> None:
+    stage_breakdown = {
+        "model": "stage_model",
+        "breakdown_sweep": [
+            {
+                "label": "gpt2_small",
+                "sequence_length": 128,
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "macs_per_cycle": 32768,
+                "memory_bandwidth_bytes_per_cycle": 256,
+                "weight_residency": "resident_weights",
+                "stage_shares": {"mlp": 0.2, "norm_residual": 0.01},
+                "total_latency_us": 100.0,
+            }
+        ],
+    }
+    attention_kv = {
+        "model": "attention_model",
+        "focus_summary": [
+            {
+                "label": "gpt2_small",
+                "sequence_length": 128,
+                "total_latency_us": 25.0,
+                "kv_memory_tier": "shared_sram",
+                "kv_sharing": "gqa4",
+                "kv_bits": 8,
+                "noc_hops": 1,
+                "dominant_substage": "kv_read",
+                "kv_limited_cycle_share": 0.5,
+            }
+        ],
+        "measured_attention_kv_tile_frontier": {"scaling_summary": {"best": "tile"}},
+    }
+    producer_ranker = {
+        "model": "producer_ranker_model",
+        "coupled_ranker_sweep": [
+            {
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "producer_lanes": 64,
+                "top_k": 1,
+                "memory_share": 1.0,
+                "producer_ii_cycles": 384,
+                "service_limiter": "ranker",
+                "ranker_fifo_capacity_ok": True,
+                "coupled_latency_us_per_token": 1000.0,
+            }
+        ],
+    }
+    calibration = {
+        "model": "decoder_output_projection_producer_ranker_policy_calibration_v1",
+        "decision": {"decision": "producer_ranker_policy_calibration_completed"},
+        "summary": {
+            "row_count": 1,
+            "calibrated_row_count": 1,
+            "missing_wrapper_physical_rows": 0,
+            "producer_dominant_rows": 1,
+            "ranker_dominant_rows": 0,
+            "old_to_calibrated_best_latency_speedup": 100.0,
+        },
+        "old_best": {"coupled_latency_us_per_token": 1000.0},
+        "calibrated_best": {
+            "calibrated_coupled_latency_us_per_token": 10.0,
+            "calibrated_dominant_term": "producer",
+        },
+        "calibrated_coupled_ranker_sweep": [
+            {
+                "status": "ok",
+                "hidden_size": 768,
+                "vocab_size": 50257,
+                "producer_lanes": 128,
+                "top_k": 1,
+                "memory_share": 1.0,
+                "producer_ii_cycles": 768,
+                "service_limiter": "weight_memory",
+                "ranker_fifo_capacity_ok": True,
+                "calibrated_coupled_latency_us_per_token": 10.0,
+                "calibrated_ranker_latency_us_per_token": 0.2,
+                "calibrated_selected_path": "threshold_serial_lpc1",
+                "old_coupled_latency_us_per_token": 1000.0,
+            }
+        ],
+    }
+
+    report = build_report(
+        stage_breakdown=stage_breakdown,
+        attention_kv=attention_kv,
+        producer_ranker=producer_ranker,
+        producer_ranker_policy_calibration=calibration,
+    )
+
+    row = report["focus_summary"][0]
+    assert report["model"] == "llm_decoder_frontier_synthesis_policy_calibrated_v1"
+    assert row["dominant_component"] == "attention_kv_best"
+    assert row["component_latency_us"]["output_projection_producer_ranker"] == 10.0
+    assert row["producer_choice"]["calibrated_selected_path"] == "threshold_serial_lpc1"
+    assert report["inputs"]["producer_ranker_policy_calibration"]["producer_dominant_rows"] == 1


### PR DESCRIPTION
## Summary
- add `decoder_frontier_synthesis_policy_calibrated` as a dispatchable L2 abstraction
- teach the frontier synthesizer to rank producer/ranker rows on calibrated policy-wrapper service latency when provided
- add proposal metadata plus tests for the calibrated frontier path

## Why
The policy-service calibration showed the previous ranker latency was stale. This refresh lets the frontier synthesis consume that calibration directly so the next architecture job is selected from the current bottleneck rather than the old streaming ranker hierarchy estimate.

## Smoke Result
Using current merged artifacts, the calibrated frontier still has output projection as the focused-row bottleneck, now because producer service dominates:
- `gpt2_small`: producer/ranker `301.065 us`, dominant share `0.991542`
- `gpt2_medium_proxy`: producer/ranker `401.42 us`, dominant share `0.979733`

## Validation
- `PYTHONPATH=/tmp/rtlgen-producer-ranker-calibration:/tmp/rtlgen-producer-ranker-calibration/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_frontier_synthesis.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_policy_calibrated -q`
- `PYTHONPATH=/tmp/rtlgen-producer-ranker-calibration:/tmp/rtlgen-producer-ranker-calibration/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_frontier_synthesis.py -q`
- smoke ran `synthesize_llm_decoder_frontier.py` with `--producer-ranker-policy-calibration`
