### PR TITLE
[codex] Add output projection weight store feasibility job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3064,6 +3064,44 @@ def _decoder_output_projection_producer_memory_hierarchy_evidence(*, item_id: st
     }
 
 
+def _decoder_output_projection_weight_store_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_output_projection_weight_store_feasibility__{item_id}.json"
+    report = f"{base}/decoder_output_projection_weight_store_feasibility__{item_id}.md"
+    memory_hierarchy = (
+        f"{base}/decoder_output_projection_producer_memory_hierarchy__"
+        "l2_decoder_output_projection_producer_memory_hierarchy_v1.json"
+    )
+    return {
+        "inputs": {
+            "weight_store_feasibility_out": out,
+            "weight_store_feasibility_report": report,
+            "producer_memory_hierarchy": memory_hierarchy,
+            "weight_store_feasibility_scope": (
+                "Convert the resident output-projection producer weight requirement into a bounded "
+                "banking, bandwidth, read-width, and proxy storage-area envelope before queueing "
+                "a routed weight-store interface wrapper."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_output_projection_weight_store_feasibility",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_output_projection_weight_store_feasibility.py "
+                    f"--memory-hierarchy {memory_hierarchy} "
+                    "--bank-capacity-mb-list 0.5,1,2,4,8 "
+                    "--bank-read-width-bits-list 256,512,1024,2048 "
+                    "--read-ports-per-bank-list 1,2 "
+                    "--area-budget-mm2-list 25,100,400 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_producer_ranker_memory_integration_plan_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_producer_ranker_memory_integration_plan__{item_id}.json"
@@ -4210,6 +4248,7 @@ def _build_payload(
         "decoder_frontier_synthesis_integrated",
         "decoder_frontier_synthesis_policy_calibrated",
         "decoder_output_projection_producer_memory_hierarchy",
+        "decoder_output_projection_weight_store_feasibility",
         "decoder_producer_ranker_memory_integration_plan",
         "decoder_producer_ranker_ready_valid_equivalence",
         "decoder_producer_ranker_physical_wrapper",
@@ -4246,6 +4285,8 @@ def _build_payload(
             decoder_evidence = _decoder_frontier_synthesis_policy_calibrated_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_memory_hierarchy":
             decoder_evidence = _decoder_output_projection_producer_memory_hierarchy_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_output_projection_weight_store_feasibility":
+            decoder_evidence = _decoder_output_projection_weight_store_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_producer_ranker_memory_integration_plan":
             decoder_evidence = _decoder_producer_ranker_memory_integration_plan_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_producer_ranker_ready_valid_equivalence":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2759,6 +2759,58 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_producer_memor
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_feasibility() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_output_projection_weight_store_feasibility_v1",
+                    proposal_id="prop_l2_decoder_output_projection_weight_store_feasibility_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_output_projection_weight_store_feasibility_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_output_projection_weight_store_feasibility",
+                    expected_direction="iterate",
+                    comparison_role="producer_memory_hierarchy",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_output_projection_weight_store_feasibility",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_output_projection_weight_store_feasibility.py" in run
+            assert "--bank-read-width-bits-list 256,512,1024,2048" in run
+            assert "l2_decoder_output_projection_producer_memory_hierarchy_v1.json" in run
+            assert decoder_inputs["weight_store_feasibility_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_output_projection_weight_store_feasibility__"
+                "l2_decoder_output_projection_weight_store_feasibility_v1.json"
+            )
+            assert "banking, bandwidth" in decoder_inputs["weight_store_feasibility_scope"]
+            assert decoder_inputs["weight_store_feasibility_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_output_projection_weight_store_feasibility",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_producer_ranker_memory_integration_plan() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_output_projection_weight_store_feasibility_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_output_projection_weight_store_feasibility_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l2_decoder_output_projection_weight_store_feasibility_v1",
+  "created_utc": "2026-05-15T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_output_projection_weight_store_feasibility",
+  "title": "Decoder output-projection resident weight-store feasibility",
+  "hypothesis": "The producer memory-hierarchy speedup requires a resident/sharded weight store with very high aggregate local read bandwidth. A bounded banking and proxy storage-area estimate can decide whether a routed weight-store interface wrapper is worth measuring next.",
+  "direct_comparison": {
+    "primary_question": "Can the required resident output-projection weights and local read bandwidth be satisfied by a plausible number of SRAM banks and read ports under a coarse area envelope?",
+    "include": [
+      "resident weight capacity targets from producer memory-hierarchy results",
+      "local-cache bandwidth targets from best parallel producer rows",
+      "bank capacity sweep",
+      "bank read-width and read-port sweep",
+      "proxy storage-area budget sweep",
+      "aggregate read-width pressure"
+    ],
+    "exclude": [
+      "generated SRAM macro or CACTI invocation",
+      "routed producer datapath",
+      "NoC refill protocol",
+      "model quality or training effects"
+    ]
+  },
+  "expected_benefit": [
+    "turns the 74-99 MB resident-weight requirement into concrete bank-count and read-width targets",
+    "shows whether the next measured RTL block should be a sharded weight-store interface wrapper",
+    "prevents queueing a full producer integration if the storage and local bandwidth envelope is already implausible"
+  ],
+  "risks": [
+    "proxy area uses a coarse bitcell-area assumption and does not replace SRAM compiler output",
+    "aggregate read bandwidth assumes independent banks and a distributed producer fabric",
+    "the interface-width pressure may require floorplanning or NoC decisions not captured by this estimate"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_output_projection_weight_store_feasibility_v1",
+      "task_type": "l2_campaign",
+      "objective": "Estimate bank count, read width, and proxy storage-area feasibility for resident output-projection producer weights.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_output_projection_weight_store_feasibility",
+      "cost_class": "low",
+      "comparison_role": "producer_memory_hierarchy",
+      "paired_baseline_item_id": "l2_decoder_output_projection_producer_memory_hierarchy_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_output_projection_producer_memory_hierarchy_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If banked storage is plausible under the proxy envelope, queue a measured sharded weight-store interface wrapper; otherwise revisit model partitioning or memory assumptions."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_output_projection_producer_memory_hierarchy__l2_decoder_output_projection_producer_memory_hierarchy_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_output_projection_weight_store_feasibility.py",
+    "tests/test_llm_decoder_output_projection_weight_store_feasibility.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_output_projection_weight_store_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_output_projection_weight_store_feasibility.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Estimate resident output-projection weight-store banking feasibility."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: str | Path) -> JsonDict:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def _float_list(value: str) -> list[float]:
+    parsed = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not parsed or any(item <= 0 for item in parsed):
+        raise argparse.ArgumentTypeError("expected comma-separated positive floats")
+    return parsed
+
+
+def _int_list(value: str) -> list[int]:
+    parsed = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not parsed or any(item <= 0 for item in parsed):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return parsed
+
+
+def _ceil_div(a: float, b: float) -> int:
+    if b <= 0:
+        raise ValueError("divisor must be positive")
+    return int(math.ceil(a / b))
+
+
+def _shape_targets(memory_hierarchy: JsonDict) -> list[JsonDict]:
+    targets: list[JsonDict] = []
+    for summary in memory_hierarchy.get("shape_summaries", []):
+        if not isinstance(summary, dict):
+            continue
+        best = summary.get("best_parallel")
+        if not isinstance(best, dict):
+            continue
+        targets.append(
+            {
+                "label": summary.get("label"),
+                "sequence_length": summary.get("sequence_length"),
+                "hidden_size": summary.get("hidden_size"),
+                "vocab_size": summary.get("vocab_size"),
+                "baseline_producer_us": summary.get("baseline_producer_us"),
+                "best_parallel_us": best.get("producer_latency_us_parallel"),
+                "producer_lanes": best.get("producer_lanes"),
+                "macs_per_cycle": best.get("macs_per_cycle"),
+                "target_local_cache_bw_bytes_per_cycle": best.get("local_cache_bw_bytes_per_cycle"),
+                "target_cache_capacity_mb": best.get("cache_capacity_mb"),
+                "target_cache_hit_rate": best.get("effective_cache_hit_rate"),
+                "resident_weight_mb": best.get("resident_weight_mb"),
+                "cache_weight_mb": best.get("cache_weight_mb"),
+                "weight_bytes_per_tile": best.get("weight_bytes_per_tile"),
+                "local_weight_cycles_per_tile": best.get("local_weight_cycles_per_tile"),
+                "producer_ii_cycles_parallel": best.get("producer_ii_cycles_parallel"),
+            }
+        )
+    return targets
+
+
+def _candidate_row(
+    *,
+    target: JsonDict,
+    bank_capacity_mb: float,
+    bank_read_width_bits: int,
+    read_ports_per_bank: int,
+    area_budget_mm2: float,
+    bitcell_area_um2_per_bit: float,
+    peripheral_area_overhead: float,
+) -> JsonDict:
+    cache_weight_mb = float(target.get("cache_weight_mb") or target.get("resident_weight_mb") or 0.0)
+    target_bw = float(target.get("target_local_cache_bw_bytes_per_cycle") or 0.0)
+    weight_bytes_per_tile = float(target.get("weight_bytes_per_tile") or 0.0)
+    target_cycles = int(target.get("local_weight_cycles_per_tile") or 0)
+    read_width_bytes = bank_read_width_bits / 8.0
+    bank_bw = read_width_bytes * read_ports_per_bank
+    capacity_banks = _ceil_div(cache_weight_mb, bank_capacity_mb)
+    bandwidth_banks = _ceil_div(target_bw, bank_bw)
+    banks = max(capacity_banks, bandwidth_banks)
+    aggregate_bw = banks * bank_bw
+    aggregate_read_bits = int(banks * bank_read_width_bits * read_ports_per_bank)
+    delivered_cycles = _ceil_div(weight_bytes_per_tile, aggregate_bw)
+    provisioned_capacity_mb = banks * bank_capacity_mb
+    storage_bits = provisioned_capacity_mb * 1024.0 * 1024.0 * 8.0
+    proxy_area_mm2 = storage_bits * bitcell_area_um2_per_bit * (1.0 + peripheral_area_overhead) / 1_000_000.0
+    capacity_ok = provisioned_capacity_mb >= cache_weight_mb
+    bandwidth_ok = aggregate_bw >= target_bw and (target_cycles <= 0 or delivered_cycles <= target_cycles)
+    area_ok = proxy_area_mm2 <= area_budget_mm2
+    return {
+        "label": target.get("label"),
+        "sequence_length": target.get("sequence_length"),
+        "hidden_size": target.get("hidden_size"),
+        "vocab_size": target.get("vocab_size"),
+        "producer_lanes": target.get("producer_lanes"),
+        "target_local_cache_bw_bytes_per_cycle": target_bw,
+        "target_cache_hit_rate": target.get("target_cache_hit_rate"),
+        "cache_weight_mb": cache_weight_mb,
+        "resident_weight_mb": target.get("resident_weight_mb"),
+        "weight_bytes_per_tile": weight_bytes_per_tile,
+        "target_local_weight_cycles_per_tile": target_cycles,
+        "bank_capacity_mb": bank_capacity_mb,
+        "bank_read_width_bits": bank_read_width_bits,
+        "read_ports_per_bank": read_ports_per_bank,
+        "bank_bw_bytes_per_cycle": bank_bw,
+        "capacity_banks": capacity_banks,
+        "bandwidth_banks": bandwidth_banks,
+        "required_banks": banks,
+        "provisioned_capacity_mb": round(provisioned_capacity_mb, 6),
+        "aggregate_bw_bytes_per_cycle": round(aggregate_bw, 6),
+        "aggregate_read_bits_per_cycle": aggregate_read_bits,
+        "delivered_local_weight_cycles_per_tile": delivered_cycles,
+        "area_budget_mm2": area_budget_mm2,
+        "bitcell_area_um2_per_bit": bitcell_area_um2_per_bit,
+        "peripheral_area_overhead": peripheral_area_overhead,
+        "proxy_storage_area_mm2": round(proxy_area_mm2, 6),
+        "capacity_ok": capacity_ok,
+        "bandwidth_ok": bandwidth_ok,
+        "area_budget_ok": area_ok,
+        "feasible_under_budget": capacity_ok and bandwidth_ok and area_ok,
+        "dominant_requirement": "bandwidth" if bandwidth_banks >= capacity_banks else "capacity",
+    }
+
+
+def _best(rows: list[JsonDict], *, require_area: bool) -> JsonDict | None:
+    candidates = [
+        row
+        for row in rows
+        if row.get("capacity_ok") and row.get("bandwidth_ok") and (row.get("area_budget_ok") or not require_area)
+    ]
+    return min(
+        candidates,
+        key=lambda row: (
+            int(row["required_banks"]),
+            float(row["proxy_storage_area_mm2"]),
+            int(row["aggregate_read_bits_per_cycle"]),
+        ),
+        default=None,
+    )
+
+
+def build_report(
+    *,
+    memory_hierarchy: JsonDict,
+    bank_capacity_mb_list: list[float],
+    bank_read_width_bits_list: list[int],
+    read_ports_per_bank_list: list[int],
+    area_budget_mm2_list: list[float],
+    bitcell_area_um2_per_bit: float,
+    peripheral_area_overhead: float,
+) -> JsonDict:
+    targets = _shape_targets(memory_hierarchy)
+    rows: list[JsonDict] = []
+    for target in targets:
+        for bank_capacity in bank_capacity_mb_list:
+            for read_width in bank_read_width_bits_list:
+                for ports in read_ports_per_bank_list:
+                    for area_budget in area_budget_mm2_list:
+                        rows.append(
+                            _candidate_row(
+                                target=target,
+                                bank_capacity_mb=bank_capacity,
+                                bank_read_width_bits=read_width,
+                                read_ports_per_bank=ports,
+                                area_budget_mm2=area_budget,
+                                bitcell_area_um2_per_bit=bitcell_area_um2_per_bit,
+                                peripheral_area_overhead=peripheral_area_overhead,
+                            )
+                        )
+
+    shape_summaries: list[JsonDict] = []
+    for target in targets:
+        shape_rows = [row for row in rows if row.get("label") == target.get("label")]
+        shape_summaries.append(
+            {
+                **target,
+                "best_capacity_bandwidth": _best(shape_rows, require_area=False),
+                "best_area_budget_feasible": _best(shape_rows, require_area=True),
+                "area_budget_feasible_count": sum(1 for row in shape_rows if row.get("feasible_under_budget")),
+                "capacity_bandwidth_feasible_count": sum(
+                    1 for row in shape_rows if row.get("capacity_ok") and row.get("bandwidth_ok")
+                ),
+            }
+        )
+
+    global_best_area = _best(rows, require_area=True)
+    decision = (
+        "weight_store_area_budget_feasible"
+        if global_best_area
+        else "weight_store_capacity_bandwidth_feasible_area_unbounded"
+        if _best(rows, require_area=False)
+        else "weight_store_infeasible_in_sweep"
+    )
+    return {
+        "version": 0.1,
+        "model": "decoder_output_projection_weight_store_feasibility_v1",
+        "inputs": {
+            "memory_hierarchy_model": memory_hierarchy.get("model"),
+            "bank_capacity_mb_list": bank_capacity_mb_list,
+            "bank_read_width_bits_list": bank_read_width_bits_list,
+            "read_ports_per_bank_list": read_ports_per_bank_list,
+            "area_budget_mm2_list": area_budget_mm2_list,
+            "bitcell_area_um2_per_bit": bitcell_area_um2_per_bit,
+            "peripheral_area_overhead": peripheral_area_overhead,
+        },
+        "summary": {
+            "shape_count": len(targets),
+            "row_count": len(rows),
+            "area_budget_feasible_rows": sum(1 for row in rows if row.get("feasible_under_budget")),
+            "capacity_bandwidth_feasible_rows": sum(
+                1 for row in rows if row.get("capacity_ok") and row.get("bandwidth_ok")
+            ),
+            "global_best_capacity_bandwidth": _best(rows, require_area=False),
+            "global_best_area_budget_feasible": global_best_area,
+        },
+        "shape_summaries": shape_summaries,
+        "weight_store_sweep": rows,
+        "decision": {
+            "decision": decision,
+            "next_step": (
+                "If area-budget feasible rows exist, queue a bounded RTL wrapper for the selected sharded "
+                "weight-store interface; otherwise revisit external memory or model partitioning before RTL."
+            ),
+        },
+        "assumptions": [
+            "This is a banking and storage proxy, not a generated SRAM macro or routed memory subsystem.",
+            "The proxy area is bitcell_area_um2_per_bit times stored bits plus peripheral overhead.",
+            "Aggregate read bandwidth assumes banks can be read independently and combined by a distributed producer fabric.",
+            "The aggregate_read_bits_per_cycle field is an interface-width pressure indicator, not necessarily one physical bus.",
+            "Targets come from the best parallel producer memory-hierarchy rows after ranker calibration.",
+        ],
+    }
+
+
+def write_markdown(path: str | Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Output-Projection Weight-Store Feasibility",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']['decision']}`",
+        f"- row_count: `{payload['summary']['row_count']}`",
+        f"- area_budget_feasible_rows: `{payload['summary']['area_budget_feasible_rows']}`",
+        "",
+        "## Shape Summary",
+        "",
+        "| shape | cache_mb | target_bw_Bpc | best banks | read bits/cyc | proxy_area_mm2 | budget_ok | dominant |",
+        "|---|---:|---:|---:|---:|---:|---|---|",
+    ]
+    for row in payload["shape_summaries"]:
+        best = row.get("best_area_budget_feasible") or row.get("best_capacity_bandwidth") or {}
+        lines.append(
+            "| {label} | {cache} | {bw} | {banks} | {bits} | {area} | `{ok}` | {dom} |".format(
+                label=row.get("label"),
+                cache=row.get("cache_weight_mb"),
+                bw=row.get("target_local_cache_bw_bytes_per_cycle"),
+                banks=best.get("required_banks"),
+                bits=best.get("aggregate_read_bits_per_cycle"),
+                area=best.get("proxy_storage_area_mm2"),
+                ok=best.get("area_budget_ok"),
+                dom=best.get("dominant_requirement"),
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    for item in payload["assumptions"]:
+        lines.append(f"- {item}")
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--memory-hierarchy", required=True)
+    ap.add_argument("--bank-capacity-mb-list", type=_float_list, default=[0.5, 1.0, 2.0, 4.0, 8.0])
+    ap.add_argument("--bank-read-width-bits-list", type=_int_list, default=[256, 512, 1024, 2048])
+    ap.add_argument("--read-ports-per-bank-list", type=_int_list, default=[1, 2])
+    ap.add_argument("--area-budget-mm2-list", type=_float_list, default=[25.0, 100.0, 400.0])
+    ap.add_argument("--bitcell-area-um2-per-bit", type=float, default=0.2)
+    ap.add_argument("--peripheral-area-overhead", type=float, default=0.35)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+    payload = build_report(
+        memory_hierarchy=_load_json(args.memory_hierarchy),
+        bank_capacity_mb_list=args.bank_capacity_mb_list,
+        bank_read_width_bits_list=args.bank_read_width_bits_list,
+        read_ports_per_bank_list=args.read_ports_per_bank_list,
+        area_budget_mm2_list=args.area_budget_mm2_list,
+        bitcell_area_um2_per_bit=args.bitcell_area_um2_per_bit,
+        peripheral_area_overhead=args.peripheral_area_overhead,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "out": str(out), "out_md": args.out_md}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_output_projection_weight_store_feasibility.py
+++ b/tests/test_llm_decoder_output_projection_weight_store_feasibility.py
@@ -1,0 +1,67 @@
+from npu.eval.estimate_llm_decoder_output_projection_weight_store_feasibility import build_report
+
+
+def _memory_hierarchy() -> dict:
+    return {
+        "model": "memory_hierarchy",
+        "shape_summaries": [
+            {
+                "label": "toy",
+                "sequence_length": 128,
+                "hidden_size": 64,
+                "vocab_size": 256,
+                "baseline_producer_us": 0.2,
+                "best_parallel": {
+                    "producer_lanes": 64,
+                    "macs_per_cycle": 4096,
+                    "local_cache_bw_bytes_per_cycle": 1024.0,
+                    "cache_capacity_mb": 1.0,
+                    "effective_cache_hit_rate": 1.0,
+                    "resident_weight_mb": 1.0,
+                    "cache_weight_mb": 1.0,
+                    "weight_bytes_per_tile": 4096,
+                    "local_weight_cycles_per_tile": 4,
+                    "producer_ii_cycles_parallel": 4,
+                },
+            }
+        ],
+    }
+
+
+def test_weight_store_feasibility_satisfies_capacity_and_bandwidth() -> None:
+    report = build_report(
+        memory_hierarchy=_memory_hierarchy(),
+        bank_capacity_mb_list=[0.5],
+        bank_read_width_bits_list=[512],
+        read_ports_per_bank_list=[1],
+        area_budget_mm2_list=[100.0],
+        bitcell_area_um2_per_bit=0.01,
+        peripheral_area_overhead=0.0,
+    )
+
+    best = report["shape_summaries"][0]["best_area_budget_feasible"]
+    assert best["capacity_banks"] == 2
+    assert best["bandwidth_banks"] == 16
+    assert best["required_banks"] == 16
+    assert best["capacity_ok"] is True
+    assert best["bandwidth_ok"] is True
+    assert best["area_budget_ok"] is True
+    assert report["decision"]["decision"] == "weight_store_area_budget_feasible"
+
+
+def test_weight_store_feasibility_reports_area_unbounded_when_budget_fails() -> None:
+    report = build_report(
+        memory_hierarchy=_memory_hierarchy(),
+        bank_capacity_mb_list=[1.0],
+        bank_read_width_bits_list=[8192],
+        read_ports_per_bank_list=[1],
+        area_budget_mm2_list=[0.001],
+        bitcell_area_um2_per_bit=0.2,
+        peripheral_area_overhead=0.35,
+    )
+
+    summary = report["shape_summaries"][0]
+    assert summary["best_area_budget_feasible"] is None
+    assert summary["best_capacity_bandwidth"]["capacity_ok"] is True
+    assert summary["best_capacity_bandwidth"]["bandwidth_ok"] is True
+    assert report["decision"]["decision"] == "weight_store_capacity_bandwidth_feasible_area_unbounded"


### PR DESCRIPTION
## Summary
- add a resident output-projection weight-store feasibility estimator
- register `decoder_output_projection_weight_store_feasibility` as an L2 abstraction
- add proposal metadata and focused tests for the estimator and task-generator contract

## Why
The producer memory-hierarchy job showed a large potential speedup only if a resident/sharded weight store can provide very high local bandwidth. This job turns that requirement into concrete bank-count, read-width, and proxy storage-area envelopes before queueing a routed interface wrapper.

## Smoke Result
Using current merged artifacts:
- `gpt2_small`: best envelope uses 37 banks, 2 MB per bank, 2048-bit read width, 2 read ports/bank; proxy area `167.6 mm2`; aggregate read pressure `151552 bits/cycle`
- `gpt2_medium_proxy`: best envelope uses 50 banks with the same bank shape; proxy area `226.5 mm2`; aggregate read pressure `204800 bits/cycle`
- decision: `weight_store_area_budget_feasible` under the coarse 400 mm2 budget, but the interface width is high enough that a bounded routed wrapper remains necessary

## Validation
- `PYTHONPATH=/tmp/rtlgen-producer-ranker-calibration:/tmp/rtlgen-producer-ranker-calibration/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_output_projection_weight_store_feasibility.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_feasibility -q`
- `PYTHONPATH=/tmp/rtlgen-producer-ranker-calibration:/tmp/rtlgen-producer-ranker-calibration/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_llm_decoder_output_projection_weight_store_feasibility.py -q`
- smoke ran `estimate_llm_decoder_output_projection_weight_store_feasibility.py` against current producer memory-hierarchy artifact
