### PR TITLE
[codex] Expand weight-store interface probe to full banks

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3128,10 +3128,10 @@ def _decoder_output_projection_weight_store_interface_evidence(*, item_id: str) 
                 "run": (
                     "python3 npu/eval/probe_llm_decoder_output_projection_weight_store_interface.py "
                     f"--weight-store-feasibility {feasibility} "
-                    "--max-representative-banks 8 "
-                    "--read-latency-cycles-list 1,2 "
-                    "--request-count 12 "
-                    "--address-stride 3 "
+                    "--max-representative-banks 64 "
+                    "--read-latency-cycles-list 1,2,4,8 "
+                    "--request-count 16 "
+                    "--address-stride 5 "
                     f"--out {out} "
                     f"--out-md {report}"
                 ),

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2853,7 +2853,8 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_i
             ]
             run = work_item.command_manifest[0]["run"]
             assert "probe_llm_decoder_output_projection_weight_store_interface.py" in run
-            assert "--max-representative-banks 8" in run
+            assert "--max-representative-banks 64" in run
+            assert "--read-latency-cycles-list 1,2,4,8" in run
             assert "l2_decoder_output_projection_weight_store_feasibility_v1.json" in run
             assert decoder_inputs["weight_store_interface_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"


### PR DESCRIPTION
## Summary
- expand the weight-store interface L2 probe to cover full selected bank counts from the feasibility result
- sweep read latency 1/2/4/8 cycles and 16 requests per scenario
- update generator coverage for the wider command

## Why
The first official interface artifact used 8 representative banks. Local RTL simulation showed the interface-only probe remains fast at the actual selected bank counts: 37 banks for GPT-2 small and 50 banks for the medium proxy. This updates future reruns to record that stronger evidence.

## Validation
- `PYTHONPATH=/tmp/rtlgen-producer-ranker-calibration:/tmp/rtlgen-producer-ranker-calibration/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_interface tests/test_llm_decoder_output_projection_weight_store_interface.py -q`
- local full-bank smoke: `weight_store_interface_contract_passed`, 8/8 scenarios passed for 37/50 banks and latency 1/2/4/8.
