### PR TITLE
[codex] Broaden attention KV memory frontier grid

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2815,11 +2815,11 @@ def _decoder_attention_kv_memory_evidence(*, item_id: str) -> dict[str, Any]:
             ),
             "attention_kv_memory_grid": {
                 "sequence_length_list": [128, 512, 2048, 8192, 32768],
-                "macs_per_cycle_list": [8192, 32768, 131072],
+                "macs_per_cycle_list": [8192, 32768, 131072, 524288],
                 "kv_memory_tier_list": ["local_sram", "shared_sram", "hbm", "remote_hbm"],
-                "kv_sharing_list": ["mha", "gqa4", "mqa"],
+                "kv_sharing_list": ["mha", "gqa4", "gqa8", "mqa"],
                 "kv_bits_list": [8, 16],
-                "noc_hops_list": [0, 1, 2, 4],
+                "noc_hops_list": [0, 1, 2, 4, 8],
             },
             "measured_tile_metrics": [
                 "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/metrics.csv",
@@ -2836,12 +2836,12 @@ def _decoder_attention_kv_memory_evidence(*, item_id: str) -> dict[str, Any]:
                 "run": (
                     "python3 npu/eval/estimate_llm_decoder_attention_kv_memory.py "
                     "--sequence-length-list 128,512,2048,8192,32768 "
-                    "--macs-per-cycle-list 8192,32768,131072 "
+                    "--macs-per-cycle-list 8192,32768,131072,524288 "
                     "--kv-memory-tier-list local_sram,shared_sram,hbm,remote_hbm "
-                    "--kv-sharing-list mha,gqa4,mqa "
+                    "--kv-sharing-list mha,gqa4,gqa8,mqa "
                     "--kv-bits-list 8,16 "
-                    "--noc-hops-list 1,2,4 "
-                    "--noc-bandwidth-bytes-per-cycle 256 "
+                    "--noc-hops-list 1,2,4,8 "
+                    "--noc-bandwidth-bytes-per-cycle 4096 "
                     "--measured-tile-metrics "
                     "runs/designs/activations/attention_kv_tile_hd64_kv4_l16_b128_wrapper/metrics.csv,"
                     "runs/designs/activations/attention_kv_tile_hd64_kv4_l32_b256_wrapper/metrics.csv,"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2535,7 +2535,10 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence() -
             run = work_item.command_manifest[0]["run"]
             assert "--sequence-length-list 128,512,2048,8192,32768" in run
             assert "--kv-memory-tier-list local_sram,shared_sram,hbm,remote_hbm" in run
-            assert "--kv-sharing-list mha,gqa4,mqa" in run
+            assert "--macs-per-cycle-list 8192,32768,131072,524288" in run
+            assert "--kv-sharing-list mha,gqa4,gqa8,mqa" in run
+            assert "--noc-hops-list 1,2,4,8" in run
+            assert "--noc-bandwidth-bytes-per-cycle 4096" in run
             assert "--measured-tile-metrics " in run
             assert "attention_kv_tile_hd128_kv16_l64_b512_wrapper/metrics.csv" in run
             assert decoder_inputs["attention_kv_memory_out"] == (


### PR DESCRIPTION
## Summary
- broaden the attention/KV memory frontier grid with `gqa8`
- add the `524288` MAC/cycle compute point
- include 8-hop NoC rows and use the broader 4096 B/cycle NoC bandwidth assumption

## Why
The current exploration needs a broader rough outline before narrowing into exact physical points. This expands the attention/KV sweep so it can compare MHA/GQA4/GQA8/MQA and larger compute arrays for long-context proxy models.

## Validation
- `PYTHONPATH=/tmp/rtlgen-producer-ranker-calibration:/tmp/rtlgen-producer-ranker-calibration/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence -q`
- local broad sweep completed earlier with the same gqa8/524288-style grid.
