### PR TITLE
[codex] Refresh frontier synthesis inputs

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2971,8 +2971,8 @@ def _decoder_frontier_synthesis_policy_calibrated_evidence(*, item_id: str) -> d
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_frontier_synthesis__{item_id}.json"
     report = f"{base}/decoder_frontier_synthesis__{item_id}.md"
-    stage_out = f"{base}/decoder_stage_breakdown__l2_decoder_frontier_synthesis_integrated_v1.json"
-    attention_out = f"{base}/decoder_attention_kv_memory__l2_decoder_frontier_synthesis_integrated_v1.json"
+    stage_out = f"{base}/decoder_stage_breakdown__l2_decoder_stage_breakdown_large_array_v2.json"
+    attention_out = f"{base}/decoder_attention_kv_memory__l2_decoder_attention_kv_memory_broad_gqa8_v1.json"
     producer_out = f"{base}/decoder_producer_ranker_coupled_noc__l2_decoder_frontier_synthesis_integrated_v1.json"
     integration_out = (
         f"{base}/decoder_output_projection_producer_ranker_integration__"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2698,6 +2698,8 @@ def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_policy_calibr
             ]
             run = work_item.command_manifest[0]["run"]
             assert "--producer-ranker-policy-calibration" in run
+            assert "l2_decoder_stage_breakdown_large_array_v2.json" in run
+            assert "l2_decoder_attention_kv_memory_broad_gqa8_v1.json" in run
             assert "l2_decoder_producer_ranker_policy_calibration_v1.json" in run
             assert decoder_inputs["decoder_frontier_synthesis_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"


### PR DESCRIPTION
## Summary
- refresh policy-calibrated frontier synthesis inputs to use the large-array stage breakdown and broad GQA/MQA attention/KV artifact
- assert those source artifacts in the L2 generator test so future frontier refreshes do not silently fall back to stale inputs

## Why
The latest attention/KV exploration and large-array stage breakdown are now the relevant frontier inputs. The existing policy-calibrated synthesis path still referenced the older integrated artifacts, so official refresh jobs would miss the broader context that was just evaluated.

## Validation
- `PYTHONPATH=/tmp/rtlgen-producer-ranker-calibration/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q`
