### PR TITLE
[codex] Extend attention KV context sweep

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -2814,7 +2814,7 @@ def _decoder_attention_kv_memory_evidence(*, item_id: str) -> dict[str, Any]:
                 "NoC hops, KV precision, and MHA/GQA/MQA sharing."
             ),
             "attention_kv_memory_grid": {
-                "sequence_length_list": [128, 512, 2048, 8192, 32768],
+                "sequence_length_list": [128, 512, 2048, 8192, 32768, 131072],
                 "macs_per_cycle_list": [8192, 32768, 131072, 524288],
                 "kv_memory_tier_list": ["local_sram", "shared_sram", "hbm", "remote_hbm"],
                 "kv_sharing_list": ["mha", "gqa4", "gqa8", "mqa"],
@@ -2835,7 +2835,7 @@ def _decoder_attention_kv_memory_evidence(*, item_id: str) -> dict[str, Any]:
                 "name": "estimate_decoder_attention_kv_memory",
                 "run": (
                     "python3 npu/eval/estimate_llm_decoder_attention_kv_memory.py "
-                    "--sequence-length-list 128,512,2048,8192,32768 "
+                    "--sequence-length-list 128,512,2048,8192,32768,131072 "
                     "--macs-per-cycle-list 8192,32768,131072,524288 "
                     "--kv-memory-tier-list local_sram,shared_sram,hbm,remote_hbm "
                     "--kv-sharing-list mha,gqa4,gqa8,mqa "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2533,7 +2533,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence() -
             decoder_inputs = work_item.input_manifest["decoder_contract"]
             assert work_item.command_manifest[0]["name"] == "estimate_decoder_attention_kv_memory"
             run = work_item.command_manifest[0]["run"]
-            assert "--sequence-length-list 128,512,2048,8192,32768" in run
+            assert "--sequence-length-list 128,512,2048,8192,32768,131072" in run
             assert "--kv-memory-tier-list local_sram,shared_sram,hbm,remote_hbm" in run
             assert "--macs-per-cycle-list 8192,32768,131072,524288" in run
             assert "--kv-sharing-list mha,gqa4,gqa8,mqa" in run


### PR DESCRIPTION
## Summary
- extend the decoder attention/KV L2 sweep to include 131072-token context
- update the L2 generator test to lock the longer-context source command

## Why
The broad attention/KV result currently tops out at 32768 tokens, while the stage breakdown already covers 131072. The frontier synthesis therefore cannot directly test where attention/KV overtakes output projection at larger context lengths.

## Validation
- `PYTHONPATH=/tmp/rtlgen-source-contract-clean/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q`
