### PR TITLE
[codex] Add llama HBM controller realism estimator

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -28,6 +28,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_capacity_noc__",
     "decoder_attention_kv_noc_scheduler__",
     "decoder_attention_kv_spill_scheduler__",
+    "decoder_attention_kv_hbm_controller__",
 }
 
 _ALLOWED_DATASET_SUFFIXES = {".json", ".md"}

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3211,6 +3211,67 @@ def _decoder_attention_kv_spill_scheduler_evidence(*, item_id: str) -> dict[str,
     }
 
 
+def _decoder_attention_kv_hbm_controller_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_hbm_controller__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_hbm_controller__{item_id}.md"
+    capacity_noc = (
+        f"{base}/decoder_attention_kv_capacity_noc__"
+        "l2_decoder_attention_kv_capacity_noc_baseline_v1.json"
+    )
+    spill = (
+        f"{base}/decoder_attention_kv_spill_scheduler__"
+        "l2_decoder_attention_kv_spill_scheduler_llama7b_v1_r2.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_capacity_noc_baseline": capacity_noc,
+            "attention_kv_spill_scheduler": spill,
+            "attention_kv_hbm_controller_scope": (
+                "HBM-controller realism refinement for the llama7b_proxy 131k 400 mm2 "
+                "spill point. Derive HBM service from channel count, per-channel bandwidth, "
+                "burst size, outstanding requests, command overhead, row-hit rate, row-miss "
+                "penalty, and scheduler efficiency before rerunning the tile-level spill model."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_hbm_controller",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_hbm_controller.py "
+                    f"--capacity-noc-baseline {capacity_noc} "
+                    "--label llama7b_proxy "
+                    "--sequence-length 131072 "
+                    "--die-area-mm2 400 "
+                    "--tile-tokens-list 1024,2048,4096 "
+                    "--prefetch-distance-tiles-list 2,4,8,16 "
+                    "--channel-count-list 4,8,16 "
+                    "--channel-bandwidth-bytes-per-cycle-list 128,256,512 "
+                    "--burst-bytes-list 256,512,1024 "
+                    "--hbm-outstanding-list 2,4,8,16 "
+                    "--request-overhead-cycles-list 4,8,16 "
+                    "--row-hit-rate-list 0.5,0.75,0.9 "
+                    "--row-miss-penalty-cycles-list 16,32,64 "
+                    "--scheduler-efficiency-list 0.6,0.75,0.9 "
+                    "--arbitration-efficiency-list 0.7,0.85 "
+                    "--virtual-channel-list 2,4 "
+                    "--prefetch-start-list during_qkv "
+                    "--bank-interleave-tokens 16 "
+                    "--bank-conflict-efficiency 0.75 "
+                    "--router-latency-cycles-per-hop 2 "
+                    "--macs-per-cycle 524288 "
+                    "--vector-ops-per-cycle 65536 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_output_projection_weight_store_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_weight_store_feasibility__{item_id}.json"
@@ -4480,6 +4541,7 @@ def _build_payload(
         "decoder_attention_kv_capacity_noc",
         "decoder_attention_kv_noc_scheduler",
         "decoder_attention_kv_spill_scheduler",
+        "decoder_attention_kv_hbm_controller",
         "decoder_output_projection_producer_memory_hierarchy",
         "decoder_output_projection_weight_store_feasibility",
         "decoder_output_projection_weight_store_interface",
@@ -4524,6 +4586,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_noc_scheduler_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_spill_scheduler":
             decoder_evidence = _decoder_attention_kv_spill_scheduler_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_hbm_controller":
+            decoder_evidence = _decoder_attention_kv_hbm_controller_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_memory_hierarchy":
             decoder_evidence = _decoder_output_projection_producer_memory_hierarchy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_weight_store_feasibility":

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -34,3 +34,7 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_kv_spill_scheduler__l2_decoder_attention_kv_spill_scheduler_llama7b_v1.json"
     )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_hbm_controller__l2_decoder_attention_kv_hbm_controller_llama7b_v1.md"
+    )

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -2920,6 +2920,58 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_spill_scheduler() -
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_hbm_controller() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_hbm_controller_llama7b_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_hbm_controller_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_hbm_controller_llama7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_hbm_controller",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_attention_kv_hbm_controller",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_attention_kv_hbm_controller.py" in run
+            assert "--channel-count-list 4,8,16" in run
+            assert "--row-hit-rate-list 0.5,0.75,0.9" in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_hbm_controller__"
+                "l2_decoder_attention_kv_hbm_controller_llama7b_v1.json"
+            )
+            assert "HBM-controller realism" in decoder_inputs["attention_kv_hbm_controller_scope"]
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_hbm_controller",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_feasibility() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_hbm_controller_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_hbm_controller_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_hbm_controller_llama7b_v1",
+  "source_commit": "53d999d3597790d2794bef1542bc1f5d2930706a",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_hbm_controller_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run an HBM-controller realism sweep for the llama7b_proxy 131k 400 mm2 attention/KV spill point.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_hbm_controller",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_spill_scheduler_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_capacity_noc_baseline_v1",
+        "l2_decoder_attention_kv_spill_scheduler_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use HBM-controller feasibility to choose the next concrete memory/NoC RTL or HBM prefetch interface measurement."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_hbm_controller_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_hbm_controller_llama7b_v1/proposal.json
@@ -1,0 +1,73 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_hbm_controller_llama7b_v1",
+  "created_utc": "2026-05-16T08:40:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_hbm_controller",
+  "title": "Llama7B attention/KV HBM controller realism",
+  "hypothesis": "The llama7b_proxy 131k-token spill point remains HBM dominated unless a concrete controller configuration can sustain the effective service assumed by the compact spill scheduler.",
+  "direct_comparison": {
+    "primary_question": "Which HBM channel, burst, outstanding-request, command-overhead, and row-locality assumptions are needed to make the llama7B spill schedule plausible?",
+    "include": [
+      "llama7b_proxy at 131k tokens and 400 mm2",
+      "capacity/NoC baseline residency split for shared SRAM plus HBM spill",
+      "tile sizes 1024, 2048, and 4096",
+      "HBM channel counts 4, 8, and 16",
+      "per-channel bandwidth 128, 256, and 512 bytes/cycle",
+      "burst sizes 256, 512, and 1024 bytes",
+      "outstanding HBM requests 2, 4, 8, and 16",
+      "request overhead 4, 8, and 16 cycles",
+      "row-hit rates 0.50, 0.75, and 0.90",
+      "row-miss penalties 16, 32, and 64 cycles",
+      "scheduler efficiency 0.60, 0.75, and 0.90"
+    ],
+    "exclude": [
+      "JEDEC-accurate HBM timing",
+      "physical HBM PHY/interface layout",
+      "cycle-accurate NoC arbitration",
+      "SRAM macro timing closure"
+    ]
+  },
+  "expected_benefit": [
+    "replaces the scalar HBM-efficiency assumption with a controller-facing service model",
+    "identifies whether the current 77.92 us spill result needs unrealistic HBM locality or request concurrency",
+    "selects the next RTL-facing HBM prefetch queue or controller interface target"
+  ],
+  "risks": [
+    "row-hit rate and scheduler efficiency are still modeled parameters",
+    "channels are modeled as aggregate bandwidth rather than routed physical channels",
+    "the result should be treated as a feasibility bound, not a DRAM controller implementation"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_hbm_controller_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run an HBM-controller realism sweep for the llama7b_proxy 131k 400 mm2 attention/KV spill point.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_hbm_controller",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_spill_scheduler_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_capacity_noc_baseline_v1",
+        "l2_decoder_attention_kv_spill_scheduler_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use HBM-controller feasibility to choose the next concrete memory/NoC RTL or HBM prefetch interface measurement."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_capacity_noc__l2_decoder_attention_kv_capacity_noc_baseline_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_spill_scheduler__l2_decoder_attention_kv_spill_scheduler_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_hbm_controller.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_spill_scheduler.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_hbm_controller.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_hbm_controller.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Estimate HBM-controller realism for the llama7B attention/KV spill point."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from npu.eval.estimate_llm_decoder_attention_kv_spill_scheduler import _find_baseline_row, _simulate_layer
+
+JsonDict = dict[str, Any]
+
+
+def _int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return items
+
+
+def _float_list(value: str) -> list[float]:
+    items = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0.0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive floats")
+    return items
+
+
+def _str_list(value: str) -> list[str]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated strings")
+    return items
+
+
+def _byte_width(bits: int) -> int:
+    return max(1, math.ceil(bits / 8))
+
+
+def _ceil_div(a: int | float, b: int | float) -> int:
+    return int(math.ceil(a / b)) if a else 0
+
+
+def _tile_hbm_bytes(*, baseline_row: JsonDict, tile_tokens: int) -> float:
+    hidden_size = int(baseline_row["hidden_size"])
+    attention_heads = int(baseline_row["attention_heads"])
+    kv_heads = int(baseline_row["kv_heads"])
+    kv_bits = int(baseline_row["kv_bits"])
+    head_dim = hidden_size // attention_heads
+    kv_width = kv_heads * head_dim
+    kv_cache_bytes = int(baseline_row["kv_cache_bytes"])
+    hbm_read_share = float(baseline_row.get("hbm_bytes", 0)) / kv_cache_bytes if kv_cache_bytes else 0.0
+    return 2 * tile_tokens * kv_width * _byte_width(kv_bits) * hbm_read_share
+
+
+def _controller_effective_bw(
+    *,
+    tile_hbm_bytes: float,
+    channel_count: int,
+    channel_bandwidth_bytes_per_cycle: float,
+    burst_bytes: int,
+    request_overhead_cycles: int,
+    row_hit_rate: float,
+    row_miss_penalty_cycles: int,
+    scheduler_efficiency: float,
+) -> JsonDict:
+    payload_bw = channel_count * channel_bandwidth_bytes_per_cycle * scheduler_efficiency
+    payload_cycles = _ceil_div(tile_hbm_bytes, payload_bw)
+    burst_count = _ceil_div(tile_hbm_bytes, burst_bytes)
+    overhead_cycles = burst_count * request_overhead_cycles
+    row_miss_cycles = math.ceil(burst_count * (1.0 - row_hit_rate) * row_miss_penalty_cycles)
+    service_cycles = max(1, payload_cycles + overhead_cycles + row_miss_cycles)
+    effective_bw = tile_hbm_bytes / service_cycles if service_cycles else 0.0
+    return {
+        "tile_hbm_bytes": int(tile_hbm_bytes),
+        "payload_cycles": payload_cycles,
+        "burst_count": burst_count,
+        "overhead_cycles": overhead_cycles,
+        "row_miss_cycles": row_miss_cycles,
+        "service_cycles": service_cycles,
+        "effective_hbm_bytes_per_cycle": round(effective_bw, 6),
+    }
+
+
+def build_report(
+    *,
+    capacity_noc_baseline: JsonDict,
+    label: str,
+    sequence_length: int,
+    die_area_mm2: float,
+    tile_tokens_list: list[int],
+    prefetch_distance_tiles_list: list[int],
+    channel_count_list: list[int],
+    channel_bandwidth_bytes_per_cycle_list: list[float],
+    burst_bytes_list: list[int],
+    hbm_outstanding_list: list[int],
+    request_overhead_cycles_list: list[int],
+    row_hit_rate_list: list[float],
+    row_miss_penalty_cycles_list: list[int],
+    scheduler_efficiency_list: list[float],
+    arbitration_efficiency_list: list[float],
+    virtual_channel_list: list[int],
+    prefetch_start_list: list[str],
+    bank_interleave_tokens: int,
+    bank_conflict_efficiency: float,
+    router_latency_cycles_per_hop: int,
+    macs_per_cycle: int,
+    vector_ops_per_cycle: int,
+    clock_ns: float,
+) -> JsonDict:
+    baseline_row = _find_baseline_row(
+        capacity_noc_baseline=capacity_noc_baseline,
+        label=label,
+        sequence_length=sequence_length,
+        die_area_mm2=die_area_mm2,
+    )
+    baseline_hbm_bw = float(baseline_row["hbm_bandwidth_bytes_per_cycle"])
+    layers = int(baseline_row["layers"])
+    rows: list[JsonDict] = []
+    for tile_tokens in tile_tokens_list:
+        tile_hbm_bytes = _tile_hbm_bytes(baseline_row=baseline_row, tile_tokens=tile_tokens)
+        for channel_count in channel_count_list:
+            for channel_bw in channel_bandwidth_bytes_per_cycle_list:
+                for burst_bytes in burst_bytes_list:
+                    for request_overhead in request_overhead_cycles_list:
+                        for row_hit_rate in row_hit_rate_list:
+                            for row_miss_penalty in row_miss_penalty_cycles_list:
+                                for scheduler_efficiency in scheduler_efficiency_list:
+                                    hbm_service = _controller_effective_bw(
+                                        tile_hbm_bytes=tile_hbm_bytes,
+                                        channel_count=channel_count,
+                                        channel_bandwidth_bytes_per_cycle=channel_bw,
+                                        burst_bytes=burst_bytes,
+                                        request_overhead_cycles=request_overhead,
+                                        row_hit_rate=row_hit_rate,
+                                        row_miss_penalty_cycles=row_miss_penalty,
+                                        scheduler_efficiency=scheduler_efficiency,
+                                    )
+                                    hbm_efficiency = min(
+                                        1.0,
+                                        max(0.01, hbm_service["effective_hbm_bytes_per_cycle"] / baseline_hbm_bw),
+                                    )
+                                    for hbm_outstanding in hbm_outstanding_list:
+                                        for prefetch_distance in prefetch_distance_tiles_list:
+                                            for arbitration_efficiency in arbitration_efficiency_list:
+                                                for virtual_channels in virtual_channel_list:
+                                                    for prefetch_start in prefetch_start_list:
+                                                        layer = _simulate_layer(
+                                                            baseline_row=baseline_row,
+                                                            tile_tokens=tile_tokens,
+                                                            prefetch_distance_tiles=prefetch_distance,
+                                                            hbm_outstanding=hbm_outstanding,
+                                                            hbm_efficiency=hbm_efficiency,
+                                                            arbitration_efficiency=arbitration_efficiency,
+                                                            virtual_channels=virtual_channels,
+                                                            bank_interleave_tokens=bank_interleave_tokens,
+                                                            bank_conflict_efficiency=bank_conflict_efficiency,
+                                                            router_latency_cycles_per_hop=router_latency_cycles_per_hop,
+                                                            prefetch_start=prefetch_start,
+                                                            macs_per_cycle=macs_per_cycle,
+                                                            vector_ops_per_cycle=vector_ops_per_cycle,
+                                                        )
+                                                        total_cycles = layer["layer_cycles"] * layers
+                                                        rows.append(
+                                                            {
+                                                                "label": label,
+                                                                "sequence_length": sequence_length,
+                                                                "die_area_mm2": die_area_mm2,
+                                                                "placement": baseline_row["placement"],
+                                                                "kv_sharing": baseline_row["kv_sharing"],
+                                                                "kv_bits": baseline_row["kv_bits"],
+                                                                "kv_cache_mib": baseline_row["kv_cache_mib"],
+                                                                "hbm_byte_share": baseline_row["hbm_byte_share"],
+                                                                "tile_tokens": tile_tokens,
+                                                                "prefetch_distance_tiles": prefetch_distance,
+                                                                "hbm_outstanding": hbm_outstanding,
+                                                                "channel_count": channel_count,
+                                                                "channel_bandwidth_bytes_per_cycle": channel_bw,
+                                                                "burst_bytes": burst_bytes,
+                                                                "request_overhead_cycles": request_overhead,
+                                                                "row_hit_rate": row_hit_rate,
+                                                                "row_miss_penalty_cycles": row_miss_penalty,
+                                                                "scheduler_efficiency": scheduler_efficiency,
+                                                                "derived_hbm_efficiency": round(hbm_efficiency, 6),
+                                                                "arbitration_efficiency": arbitration_efficiency,
+                                                                "virtual_channels": virtual_channels,
+                                                                "prefetch_start": prefetch_start,
+                                                                "total_cycles": total_cycles,
+                                                                "latency_us": round(total_cycles * clock_ns / 1000.0, 6),
+                                                                **hbm_service,
+                                                                **layer,
+                                                            }
+                                                        )
+
+    rows_sorted = sorted(rows, key=lambda row: row["latency_us"])
+    best = rows_sorted[0]
+    dominance: dict[str, int] = {}
+    for row in rows:
+        key = str(row["dominant_tile_resource"])
+        dominance[key] = dominance.get(key, 0) + 1
+    return {
+        "version": 0.1,
+        "model": "llm_decoder_attention_kv_hbm_controller_llama7b_131k_v1",
+        "inputs": {
+            "capacity_noc_model": capacity_noc_baseline.get("model"),
+            "selected_point": {
+                "label": label,
+                "sequence_length": sequence_length,
+                "die_area_mm2": die_area_mm2,
+            },
+            "tile_tokens_list": tile_tokens_list,
+            "prefetch_distance_tiles_list": prefetch_distance_tiles_list,
+            "channel_count_list": channel_count_list,
+            "channel_bandwidth_bytes_per_cycle_list": channel_bandwidth_bytes_per_cycle_list,
+            "burst_bytes_list": burst_bytes_list,
+            "hbm_outstanding_list": hbm_outstanding_list,
+            "request_overhead_cycles_list": request_overhead_cycles_list,
+            "row_hit_rate_list": row_hit_rate_list,
+            "row_miss_penalty_cycles_list": row_miss_penalty_cycles_list,
+            "scheduler_efficiency_list": scheduler_efficiency_list,
+            "arbitration_efficiency_list": arbitration_efficiency_list,
+            "virtual_channel_list": virtual_channel_list,
+            "prefetch_start_list": prefetch_start_list,
+            "bank_interleave_tokens": bank_interleave_tokens,
+            "bank_conflict_efficiency": bank_conflict_efficiency,
+            "router_latency_cycles_per_hop": router_latency_cycles_per_hop,
+            "macs_per_cycle": macs_per_cycle,
+            "vector_ops_per_cycle": vector_ops_per_cycle,
+            "clock_ns": clock_ns,
+        },
+        "sweep_summary": {
+            "generated_row_count": len(rows),
+            "retained_top_row_count": min(50, len(rows_sorted)),
+            "dominant_tile_resource_counts": dominance,
+        },
+        "best": best,
+        "top_rows": rows_sorted[:50],
+        "assumptions": [
+            "This is an HBM-controller service model layered onto the llama7B 131k spill scheduler.",
+            "Effective HBM service is derived from channels, per-channel bandwidth, burst size, command overhead, row-hit rate, row-miss penalty, and scheduler efficiency.",
+            "The derived HBM bandwidth replaces the previous scalar HBM efficiency before running the tile-level spill scheduler.",
+            "NoC/shared-SRAM service still uses the compact bank and arbitration model from the spill scheduler.",
+            "This is not a DRAM timing model; it is intended to bound whether the assumed HBM efficiency is physically plausible.",
+        ],
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best"]
+    lines = [
+        "# Decoder Attention/KV HBM Controller Realism",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- generated_row_count: `{payload['sweep_summary']['generated_row_count']}`",
+        f"- selected_point: `{best['label']} seq={best['sequence_length']} die={best['die_area_mm2']}mm2`",
+        "",
+        "## Best",
+        "",
+        "| tile | channels | ch_B/cyc | burst | out | row_hit | sched_eff | hbm_eff | latency_us | resource | hbm_service_cyc |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|",
+        "| {tile} | {channels} | {ch_bw} | {burst} | {out} | {row_hit} | {sched} | {hbm_eff} | {lat} | {res} | {service} |".format(
+            tile=best["tile_tokens"],
+            channels=best["channel_count"],
+            ch_bw=best["channel_bandwidth_bytes_per_cycle"],
+            burst=best["burst_bytes"],
+            out=best["hbm_outstanding"],
+            row_hit=best["row_hit_rate"],
+            sched=best["scheduler_efficiency"],
+            hbm_eff=best["derived_hbm_efficiency"],
+            lat=best["latency_us"],
+            res=best["dominant_tile_resource"],
+            service=best["service_cycles"],
+        ),
+        "",
+        "## Top 10",
+        "",
+        "| rank | tile | channels | burst | out | row_hit | sched_eff | hbm_eff | latency_us | resource |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for index, row in enumerate(payload["top_rows"][:10], start=1):
+        lines.append(
+            "| {rank} | {tile} | {channels} | {burst} | {out} | {row_hit} | {sched} | {hbm_eff} | {lat} | {res} |".format(
+                rank=index,
+                tile=row["tile_tokens"],
+                channels=row["channel_count"],
+                burst=row["burst_bytes"],
+                out=row["hbm_outstanding"],
+                row_hit=row["row_hit_rate"],
+                sched=row["scheduler_efficiency"],
+                hbm_eff=row["derived_hbm_efficiency"],
+                lat=row["latency_us"],
+                res=row["dominant_tile_resource"],
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--capacity-noc-baseline", required=True)
+    ap.add_argument("--label", default="llama7b_proxy")
+    ap.add_argument("--sequence-length", type=int, default=131072)
+    ap.add_argument("--die-area-mm2", type=float, default=400.0)
+    ap.add_argument("--tile-tokens-list", type=_int_list, default=[1024, 2048, 4096])
+    ap.add_argument("--prefetch-distance-tiles-list", type=_int_list, default=[2, 4, 8, 16])
+    ap.add_argument("--channel-count-list", type=_int_list, default=[4, 8, 16])
+    ap.add_argument("--channel-bandwidth-bytes-per-cycle-list", type=_float_list, default=[128, 256, 512])
+    ap.add_argument("--burst-bytes-list", type=_int_list, default=[256, 512, 1024])
+    ap.add_argument("--hbm-outstanding-list", type=_int_list, default=[2, 4, 8, 16])
+    ap.add_argument("--request-overhead-cycles-list", type=_int_list, default=[4, 8, 16])
+    ap.add_argument("--row-hit-rate-list", type=_float_list, default=[0.5, 0.75, 0.9])
+    ap.add_argument("--row-miss-penalty-cycles-list", type=_int_list, default=[16, 32, 64])
+    ap.add_argument("--scheduler-efficiency-list", type=_float_list, default=[0.6, 0.75, 0.9])
+    ap.add_argument("--arbitration-efficiency-list", type=_float_list, default=[0.7, 0.85])
+    ap.add_argument("--virtual-channel-list", type=_int_list, default=[2, 4])
+    ap.add_argument("--prefetch-start-list", type=_str_list, default=["during_qkv"])
+    ap.add_argument("--bank-interleave-tokens", type=int, default=16)
+    ap.add_argument("--bank-conflict-efficiency", type=float, default=0.75)
+    ap.add_argument("--router-latency-cycles-per-hop", type=int, default=2)
+    ap.add_argument("--macs-per-cycle", type=int, default=524288)
+    ap.add_argument("--vector-ops-per-cycle", type=int, default=65536)
+    ap.add_argument("--clock-ns", type=float, default=1.0)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    baseline = json.loads(Path(args.capacity_noc_baseline).read_text(encoding="utf-8"))
+    payload = build_report(
+        capacity_noc_baseline=baseline,
+        label=args.label,
+        sequence_length=args.sequence_length,
+        die_area_mm2=args.die_area_mm2,
+        tile_tokens_list=args.tile_tokens_list,
+        prefetch_distance_tiles_list=args.prefetch_distance_tiles_list,
+        channel_count_list=args.channel_count_list,
+        channel_bandwidth_bytes_per_cycle_list=args.channel_bandwidth_bytes_per_cycle_list,
+        burst_bytes_list=args.burst_bytes_list,
+        hbm_outstanding_list=args.hbm_outstanding_list,
+        request_overhead_cycles_list=args.request_overhead_cycles_list,
+        row_hit_rate_list=args.row_hit_rate_list,
+        row_miss_penalty_cycles_list=args.row_miss_penalty_cycles_list,
+        scheduler_efficiency_list=args.scheduler_efficiency_list,
+        arbitration_efficiency_list=args.arbitration_efficiency_list,
+        virtual_channel_list=args.virtual_channel_list,
+        prefetch_start_list=args.prefetch_start_list,
+        bank_interleave_tokens=args.bank_interleave_tokens,
+        bank_conflict_efficiency=args.bank_conflict_efficiency,
+        router_latency_cycles_per_hop=args.router_latency_cycles_per_hop,
+        macs_per_cycle=args.macs_per_cycle,
+        vector_ops_per_cycle=args.vector_ops_per_cycle,
+        clock_ns=args.clock_ns,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(Path(args.out_md), payload)
+    print(json.dumps({"ok": True, "out": args.out, "out_md": args.out_md}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_attention_kv_hbm_controller.py
+++ b/tests/test_llm_decoder_attention_kv_hbm_controller.py
@@ -1,0 +1,89 @@
+from npu.eval.estimate_llm_decoder_attention_kv_capacity_noc import build_report as build_capacity_report
+from npu.eval.estimate_llm_decoder_attention_kv_hbm_controller import build_report as build_hbm_report
+
+
+def _capacity_baseline() -> dict:
+    return build_capacity_report(
+        sequence_length_list=[131072],
+        kv_sharing_list=["mqa"],
+        kv_bits_list=[8],
+        die_area_mm2_list=[400],
+        sram_area_fraction_list=[0.6],
+        usable_sram_fraction_list=[0.7],
+        bitcell_area_um2_per_bit_list=[0.05],
+        local_sram_fraction_list=[0.25],
+        bank_count_list=[16],
+        bank_bandwidth_bytes_per_cycle_list=[1024],
+        noc_bandwidth_bytes_per_cycle_list=[16384],
+        noc_hops_list=[1],
+        hbm_bandwidth_bytes_per_cycle_list=[4096],
+        macs_per_cycle=524288,
+        vector_ops_per_cycle=65536,
+        clock_ns=1.0,
+    )
+
+
+def test_hbm_controller_targets_llama_spill_point() -> None:
+    report = build_hbm_report(
+        capacity_noc_baseline=_capacity_baseline(),
+        label="llama7b_proxy",
+        sequence_length=131072,
+        die_area_mm2=400.0,
+        tile_tokens_list=[1024],
+        prefetch_distance_tiles_list=[2],
+        channel_count_list=[4],
+        channel_bandwidth_bytes_per_cycle_list=[256],
+        burst_bytes_list=[512],
+        hbm_outstanding_list=[2],
+        request_overhead_cycles_list=[8],
+        row_hit_rate_list=[0.75],
+        row_miss_penalty_cycles_list=[32],
+        scheduler_efficiency_list=[0.75],
+        arbitration_efficiency_list=[0.85],
+        virtual_channel_list=[4],
+        prefetch_start_list=["during_qkv"],
+        bank_interleave_tokens=16,
+        bank_conflict_efficiency=0.75,
+        router_latency_cycles_per_hop=2,
+        macs_per_cycle=524288,
+        vector_ops_per_cycle=65536,
+        clock_ns=1.0,
+    )
+
+    best = report["best"]
+    assert best["placement"] == "shared_sram_hbm_spill"
+    assert best["label"] == "llama7b_proxy"
+    assert best["derived_hbm_efficiency"] > 0.0
+    assert best["service_cycles"] >= best["payload_cycles"]
+
+
+def test_hbm_controller_improves_with_more_channels() -> None:
+    report = build_hbm_report(
+        capacity_noc_baseline=_capacity_baseline(),
+        label="llama7b_proxy",
+        sequence_length=131072,
+        die_area_mm2=400.0,
+        tile_tokens_list=[2048],
+        prefetch_distance_tiles_list=[2],
+        channel_count_list=[4, 16],
+        channel_bandwidth_bytes_per_cycle_list=[256],
+        burst_bytes_list=[1024],
+        hbm_outstanding_list=[4],
+        request_overhead_cycles_list=[4],
+        row_hit_rate_list=[0.9],
+        row_miss_penalty_cycles_list=[16],
+        scheduler_efficiency_list=[0.9],
+        arbitration_efficiency_list=[0.85],
+        virtual_channel_list=[4],
+        prefetch_start_list=["during_qkv"],
+        bank_interleave_tokens=16,
+        bank_conflict_efficiency=0.75,
+        router_latency_cycles_per_hop=2,
+        macs_per_cycle=524288,
+        vector_ops_per_cycle=65536,
+        clock_ns=1.0,
+    )
+
+    by_channels = {row["channel_count"]: row for row in report["top_rows"]}
+    assert by_channels[16]["derived_hbm_efficiency"] >= by_channels[4]["derived_hbm_efficiency"]
+    assert by_channels[16]["latency_us"] <= by_channels[4]["latency_us"]


### PR DESCRIPTION
## Summary
- add `estimate_llm_decoder_attention_kv_hbm_controller.py` for the llama7B 131k 400 mm2 spill point
- derive HBM service from channel count, per-channel bandwidth, burst size, outstanding requests, command overhead, row-hit rate, row-miss penalty, and scheduler efficiency
- wire the new `decoder_attention_kv_hbm_controller` abstraction into L2 generation and artifact transport
- add proposal `prop_l2_decoder_attention_kv_hbm_controller_llama7b_v1`

## Validation
- `PYTHONPATH=/tmp/rtlgen-finalize-clean /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_attention_kv_hbm_controller.py tests/test_llm_decoder_attention_kv_spill_scheduler.py -q`
- `PYTHONPATH=/tmp/rtlgen-finalize-clean/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_hbm_controller control_plane/control_plane/tests/test_artifact_policy.py -q`
- `PYTHONPATH=/tmp/rtlgen-finalize-clean python3 npu/eval/estimate_llm_decoder_attention_kv_hbm_controller.py --capacity-noc-baseline runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_capacity_noc__l2_decoder_attention_kv_capacity_noc_baseline_v1.json --out /tmp/attention_kv_hbm_controller_full.json --out-md /tmp/attention_kv_hbm_controller_full.md`
