### PR TITLE
[codex] Fix HBM controller script import

### DIFF
--- a/npu/eval/estimate_llm_decoder_attention_kv_hbm_controller.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_hbm_controller.py
@@ -9,7 +9,10 @@ import math
 from pathlib import Path
 from typing import Any
 
-from npu.eval.estimate_llm_decoder_attention_kv_spill_scheduler import _find_baseline_row, _simulate_layer
+try:
+    from npu.eval.estimate_llm_decoder_attention_kv_spill_scheduler import _find_baseline_row, _simulate_layer
+except ModuleNotFoundError:
+    from estimate_llm_decoder_attention_kv_spill_scheduler import _find_baseline_row, _simulate_layer
 
 JsonDict = dict[str, Any]
 


### PR DESCRIPTION
## Summary
- allow `estimate_llm_decoder_attention_kv_hbm_controller.py` to run both as a package import and as a direct worker script
- fixes worker failure: `ModuleNotFoundError: No module named 'npu'`

## Validation
- `python3 npu/eval/estimate_llm_decoder_attention_kv_hbm_controller.py --capacity-noc-baseline runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_capacity_noc__l2_decoder_attention_kv_capacity_noc_baseline_v1.json --channel-count-list 4 --channel-bandwidth-bytes-per-cycle-list 256 --burst-bytes-list 512 --hbm-outstanding-list 2 --request-overhead-cycles-list 8 --row-hit-rate-list 0.75 --row-miss-penalty-cycles-list 32 --scheduler-efficiency-list 0.75 --tile-tokens-list 1024 --prefetch-distance-tiles-list 2 --out /tmp/hbm_import_fix.json --out-md /tmp/hbm_import_fix.md`
- `PYTHONPATH=/tmp/rtlgen-finalize-clean /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_attention_kv_hbm_controller.py -q`
