### PR TITLE
Add attention KV quality gate

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -30,6 +30,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_spill_scheduler__",
     "decoder_attention_kv_hbm_controller__",
     "decoder_attention_kv_physical_hbm_frontier__",
+    "decoder_attention_kv_quality_gate__",
 }
 
 _ALLOWED_DATASET_SUFFIXES = {".json", ".md"}

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3331,6 +3331,42 @@ def _decoder_attention_kv_physical_hbm_frontier_evidence(*, item_id: str) -> dic
     }
 
 
+def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_quality_gate__{item_id}.md"
+    physical_frontier = (
+        f"{base}/decoder_attention_kv_physical_hbm_frontier__"
+        "l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_physical_hbm_frontier": physical_frontier,
+            "attention_kv_quality_gate_scope": (
+                "Quality-risk gate for structural KV reductions identified by the physical-HBM "
+                "frontier. Treat MQA and KV4 hardware wins as non-deployable until model-quality "
+                "or retraining evidence exists, and select practical GQA/KV candidates for follow-up."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_quality_gate",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_quality_gate.py "
+                    f"--physical-hbm-frontier {physical_frontier} "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 100,200,400 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_output_projection_weight_store_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_weight_store_feasibility__{item_id}.json"
@@ -4602,6 +4638,7 @@ def _build_payload(
         "decoder_attention_kv_spill_scheduler",
         "decoder_attention_kv_hbm_controller",
         "decoder_attention_kv_physical_hbm_frontier",
+        "decoder_attention_kv_quality_gate",
         "decoder_output_projection_producer_memory_hierarchy",
         "decoder_output_projection_weight_store_feasibility",
         "decoder_output_projection_weight_store_interface",
@@ -4650,6 +4687,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_hbm_controller_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_frontier":
             decoder_evidence = _decoder_attention_kv_physical_hbm_frontier_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
+            decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_memory_hierarchy":
             decoder_evidence = _decoder_output_projection_producer_memory_hierarchy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_weight_store_feasibility":

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -43,3 +43,7 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
         "decoder_attention_kv_physical_hbm_frontier__"
         "l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1.json"
     )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_quality_gate__l2_decoder_attention_kv_quality_gate_llama7b_v1.md"
+    )

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3027,6 +3027,58 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_fronti
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_quality_gate() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_quality_gate_llama7b_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_quality_gate_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_quality_gate_llama7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_quality_gate",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_attention_kv_quality_gate",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_attention_kv_quality_gate.py" in run
+            assert "l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1.json" in run
+            assert "--sequence-length-list 131072" in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_quality_gate__"
+                "l2_decoder_attention_kv_quality_gate_llama7b_v1.json"
+            )
+            assert "Quality-risk gate" in decoder_inputs["attention_kv_quality_gate_scope"]
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_quality_gate",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_feasibility() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_quality_gate_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_quality_gate_llama7b_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_quality_gate_llama7b_v1",
+  "created_utc": "2026-05-16T10:05:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_quality_gate",
+  "title": "Llama7B attention/KV structural-reduction quality gate",
+  "hypothesis": "The physical-HBM frontier's MQA/KV4 winner is a hardware lower bound rather than a deployable point; practical follow-up should prioritize GQA8/KV8 and test GQA8/KV4 quality before considering MQA.",
+  "direct_comparison": {
+    "primary_question": "Which KV structural-reduction points should remain practical architecture candidates once quality risk is considered alongside the physical-HBM benefit?",
+    "include": [
+      "merged physical-HBM frontier evidence for llama7b_proxy 131k",
+      "die areas 100, 200, and 400 mm2",
+      "KV sharing choices MHA, GQA4, GQA8, and MQA",
+      "KV storage precisions 16, 8, and 4 bits",
+      "quality-risk classification for head sharing and KV precision",
+      "hardware speedup and HBM byte share from the physical-HBM frontier"
+    ],
+    "exclude": [
+      "claiming measured LLaMA perplexity or task accuracy",
+      "training or QAT",
+      "cycle-accurate attention simulation",
+      "promoting MQA/KV4 as deployable without model evidence"
+    ]
+  },
+  "expected_benefit": [
+    "prevents hardware-only MQA/KV4 from being selected as the next architecture point",
+    "identifies GQA8/KV8 as the conservative structural candidate",
+    "identifies GQA8/KV4 as the targeted quality experiment for low-bit KV recovery"
+  ],
+  "risks": [
+    "quality-risk labels are conservative classifications, not measured LLaMA quality",
+    "GQA deployment still requires a model trained or adapted for grouped-query attention",
+    "KV4 still needs long-context quality and retrieval-stability evidence"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_quality_gate_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the attention/KV quality-risk gate over the merged physical-HBM frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_quality_gate",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the quality-risk gate to choose the next deployability experiment for GQA/KV quantization."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_frontier__l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_quality_gate.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_quality_gate.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_quality_gate.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Gate attention/KV structural reductions by quality risk and hardware benefit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return items
+
+
+def _float_list(value: str) -> list[float]:
+    items = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0.0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive floats")
+    return items
+
+
+def _kv_risk(*, kv_bits: int) -> tuple[str, str]:
+    if kv_bits >= 16:
+        return "low", "keeps baseline KV precision"
+    if kv_bits >= 8:
+        return "medium", "plausible cache quantization, but must be checked on long-context prompts"
+    return "high", "low-bit KV cache can perturb attention scores and retrieval behavior"
+
+
+def _sharing_risk(*, kv_sharing: str) -> tuple[str, str]:
+    if kv_sharing == "mha":
+        return "low", "preserves baseline per-head K/V structure"
+    if kv_sharing in {"gqa4", "gqa8"}:
+        return "medium", "plausible if the model is trained or adapted for grouped-query attention"
+    if kv_sharing == "mqa":
+        return "high", "collapses all K/V heads and should be treated as retraining-required"
+    return "unknown", "unrecognized KV sharing mode"
+
+
+def _risk_level(*, sharing_risk: str, kv_risk: str) -> str:
+    ordered = ["low", "medium", "high", "unknown"]
+    if "unknown" in {sharing_risk, kv_risk}:
+        return "unknown"
+    return max((sharing_risk, kv_risk), key=ordered.index)
+
+
+def _candidate_class(*, kv_sharing: str, kv_bits: int, combined_risk: str) -> str:
+    if kv_sharing == "mqa":
+        return "bound_only_retrain_required"
+    if kv_bits < 8:
+        return "quality_experiment_required"
+    if combined_risk == "low":
+        return "conservative_reference"
+    return "deployable_if_model_supports_structure"
+
+
+def _find_reference(rows: list[JsonDict]) -> JsonDict:
+    exact = [
+        row
+        for row in rows
+        if row["kv_sharing"] == "mha" and int(row["kv_bits"]) == 16
+    ]
+    if exact:
+        return exact[0]
+    return max(rows, key=lambda row: (int(row["kv_heads"]), int(row["kv_bits"])))
+
+
+def _focused_rows(
+    *,
+    physical_hbm_frontier: JsonDict,
+    sequence_length_list: list[int],
+    die_area_mm2_list: list[float],
+) -> list[JsonDict]:
+    wanted_seq = set(sequence_length_list)
+    wanted_die = {float(value) for value in die_area_mm2_list}
+    return [
+        row
+        for row in physical_hbm_frontier.get("best_by_kv_structure", [])
+        if int(row["sequence_length"]) in wanted_seq and float(row["die_area_mm2"]) in wanted_die
+    ]
+
+
+def build_report(
+    *,
+    physical_hbm_frontier: JsonDict,
+    sequence_length_list: list[int],
+    die_area_mm2_list: list[float],
+) -> JsonDict:
+    rows = _focused_rows(
+        physical_hbm_frontier=physical_hbm_frontier,
+        sequence_length_list=sequence_length_list,
+        die_area_mm2_list=die_area_mm2_list,
+    )
+    if not rows:
+        raise ValueError("no matching physical-HBM frontier rows for requested sequence/die focus")
+
+    grouped: dict[tuple[int, float], list[JsonDict]] = {}
+    for row in rows:
+        key = (int(row["sequence_length"]), float(row["die_area_mm2"]))
+        grouped.setdefault(key, []).append(row)
+
+    candidate_rows: list[JsonDict] = []
+    for key, group_rows in sorted(grouped.items()):
+        reference = _find_reference(group_rows)
+        reference_latency = float(reference["latency_us"])
+        for row in sorted(group_rows, key=lambda item: (float(item["latency_us"]), item["kv_sharing"], int(item["kv_bits"]))):
+            sharing_risk, sharing_reason = _sharing_risk(kv_sharing=str(row["kv_sharing"]))
+            kv_risk, kv_reason = _kv_risk(kv_bits=int(row["kv_bits"]))
+            combined = _risk_level(sharing_risk=sharing_risk, kv_risk=kv_risk)
+            candidate_class = _candidate_class(
+                kv_sharing=str(row["kv_sharing"]),
+                kv_bits=int(row["kv_bits"]),
+                combined_risk=combined,
+            )
+            speedup = reference_latency / float(row["latency_us"]) if float(row["latency_us"]) > 0 else 0.0
+            candidate_rows.append(
+                {
+                    "sequence_length": key[0],
+                    "die_area_mm2": key[1],
+                    "kv_sharing": row["kv_sharing"],
+                    "kv_heads": row["kv_heads"],
+                    "kv_bits": row["kv_bits"],
+                    "latency_us": row["latency_us"],
+                    "hbm_byte_share": row["hbm_byte_share"],
+                    "dominant_tile_resource": row["dominant_tile_resource"],
+                    "stack_count": row["stack_count"],
+                    "data_rate_mtps": row["data_rate_mtps"],
+                    "hardware_speedup_vs_mha16": round(speedup, 6),
+                    "sharing_quality_risk": sharing_risk,
+                    "kv_precision_quality_risk": kv_risk,
+                    "combined_quality_risk": combined,
+                    "candidate_class": candidate_class,
+                    "quality_rationale": [sharing_reason, kv_reason],
+                }
+            )
+
+    practical = [
+        row
+        for row in candidate_rows
+        if row["candidate_class"] in {"deployable_if_model_supports_structure", "conservative_reference"}
+        and row["combined_quality_risk"] in {"low", "medium"}
+    ]
+    experiments = [
+        row
+        for row in candidate_rows
+        if row["candidate_class"] == "quality_experiment_required"
+    ]
+    bounds = [
+        row
+        for row in candidate_rows
+        if row["candidate_class"] == "bound_only_retrain_required"
+    ]
+
+    practical_best = sorted(practical, key=lambda row: (row["latency_us"], row["hbm_byte_share"]))[:12]
+    experiment_best = sorted(experiments, key=lambda row: (row["latency_us"], row["hbm_byte_share"]))[:12]
+    bound_best = sorted(bounds, key=lambda row: (row["latency_us"], row["hbm_byte_share"]))[:12]
+    return {
+        "version": 0.1,
+        "model": "llm_decoder_attention_kv_quality_gate_v1",
+        "inputs": {
+            "physical_hbm_frontier_model": physical_hbm_frontier.get("model", ""),
+            "sequence_length_list": sequence_length_list,
+            "die_area_mm2_list": die_area_mm2_list,
+        },
+        "sweep_summary": {
+            "candidate_row_count": len(candidate_rows),
+            "practical_candidate_count": len(practical),
+            "quality_experiment_candidate_count": len(experiments),
+            "bound_only_candidate_count": len(bounds),
+        },
+        "recommendation": {
+            "primary_hardware_candidate": "gqa8_kv8",
+            "primary_quality_experiment": "gqa8_kv4",
+            "bound_only_candidate": "mqa_kv4",
+            "reason": (
+                "MQA/KV4 is the strongest hardware lower bound, but both dimensions carry high "
+                "quality risk. GQA8/KV8 is the conservative structural candidate; GQA8/KV4 is "
+                "the useful quality experiment for testing whether low-bit KV can recover enough "
+                "of the HBM benefit without changing to MQA."
+            ),
+        },
+        "practical_candidates": practical_best,
+        "quality_experiment_candidates": experiment_best,
+        "bound_only_candidates": bound_best,
+        "all_candidate_rows": candidate_rows,
+        "assumptions": [
+            "This gate does not claim measured LLaMA quality; it prevents hardware-only winners from being treated as deployable.",
+            "GQA candidates require a model trained or adapted for grouped-query attention before deployment.",
+            "MQA candidates are classified as bound-only unless a retrained/adapted model is supplied.",
+            "KV4 candidates require long-context quality and retrieval-stability experiments before they can be promoted.",
+            "The hardware benefit values come from the merged physical-HBM frontier artifact.",
+        ],
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    rec = payload["recommendation"]
+    lines = [
+        "# Decoder Attention/KV Quality Gate",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- candidate_row_count: `{payload['sweep_summary']['candidate_row_count']}`",
+        f"- primary_hardware_candidate: `{rec['primary_hardware_candidate']}`",
+        f"- primary_quality_experiment: `{rec['primary_quality_experiment']}`",
+        f"- bound_only_candidate: `{rec['bound_only_candidate']}`",
+        "",
+        "## Recommendation",
+        "",
+        rec["reason"],
+        "",
+        "## Practical Candidates",
+        "",
+        "| seq | die | kv | bits | latency_us | speedup | hbm_share | risk | class |",
+        "|---:|---:|---|---:|---:|---:|---:|---|---|",
+    ]
+    for row in payload["practical_candidates"][:10]:
+        lines.append(
+            "| {seq} | {die} | {kv} | {bits} | {lat} | {speed} | {share} | {risk} | {cls} |".format(
+                seq=row["sequence_length"],
+                die=row["die_area_mm2"],
+                kv=row["kv_sharing"],
+                bits=row["kv_bits"],
+                lat=row["latency_us"],
+                speed=row["hardware_speedup_vs_mha16"],
+                share=row["hbm_byte_share"],
+                risk=row["combined_quality_risk"],
+                cls=row["candidate_class"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Quality Experiments",
+            "",
+            "| seq | die | kv | bits | latency_us | speedup | hbm_share | risk |",
+            "|---:|---:|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for row in payload["quality_experiment_candidates"][:10]:
+        lines.append(
+            "| {seq} | {die} | {kv} | {bits} | {lat} | {speed} | {share} | {risk} |".format(
+                seq=row["sequence_length"],
+                die=row["die_area_mm2"],
+                kv=row["kv_sharing"],
+                bits=row["kv_bits"],
+                lat=row["latency_us"],
+                speed=row["hardware_speedup_vs_mha16"],
+                share=row["hbm_byte_share"],
+                risk=row["combined_quality_risk"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Bound Only",
+            "",
+            "| seq | die | kv | bits | latency_us | speedup | hbm_share | reason |",
+            "|---:|---:|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for row in payload["bound_only_candidates"][:10]:
+        lines.append(
+            "| {seq} | {die} | {kv} | {bits} | {lat} | {speed} | {share} | {reason} |".format(
+                seq=row["sequence_length"],
+                die=row["die_area_mm2"],
+                kv=row["kv_sharing"],
+                bits=row["kv_bits"],
+                lat=row["latency_us"],
+                speed=row["hardware_speedup_vs_mha16"],
+                share=row["hbm_byte_share"],
+                reason="; ".join(row["quality_rationale"]),
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--physical-hbm-frontier", required=True)
+    ap.add_argument("--sequence-length-list", type=_int_list, default=[131072])
+    ap.add_argument("--die-area-mm2-list", type=_float_list, default=[100, 200, 400])
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    physical = json.loads(Path(args.physical_hbm_frontier).read_text(encoding="utf-8"))
+    payload = build_report(
+        physical_hbm_frontier=physical,
+        sequence_length_list=args.sequence_length_list,
+        die_area_mm2_list=args.die_area_mm2_list,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(Path(args.out_md), payload)
+    print(json.dumps({"ok": True, "out": args.out, "out_md": args.out_md}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_attention_kv_quality_gate.py
+++ b/tests/test_llm_decoder_attention_kv_quality_gate.py
@@ -1,0 +1,83 @@
+from npu.eval.estimate_llm_decoder_attention_kv_physical_hbm_frontier import build_report as build_physical_report
+from npu.eval.estimate_llm_decoder_attention_kv_quality_gate import build_report
+
+
+def _physical_frontier():
+    return build_physical_report(
+        label="llama7b_proxy",
+        sequence_length_list=[131072],
+        die_area_mm2_list=[400],
+        kv_sharing_list=["mha", "gqa8", "mqa"],
+        kv_bits_list=[16, 8, 4],
+        stack_count_list=[1, 8],
+        pseudo_channels_per_stack_list=[16],
+        pseudo_channel_width_bits_list=[64],
+        data_rate_mtps_list=[6400],
+        hbm_efficiency_list=[0.55],
+        tile_tokens_list=[1024],
+        prefetch_distance_tiles_list=[4],
+        hbm_outstanding_list=[8],
+        arbitration_efficiency_list=[0.85],
+        virtual_channel_list=[4],
+        prefetch_start_list=["during_qkv"],
+        sram_area_fraction=0.6,
+        usable_sram_fraction=0.7,
+        bitcell_area_um2_per_bit=0.02,
+        local_sram_fraction=0.25,
+        bank_count=16,
+        bank_bandwidth_bytes_per_cycle=1024.0,
+        bank_interleave_tokens=16,
+        bank_conflict_efficiency=0.75,
+        noc_bandwidth_bytes_per_cycle=16384.0,
+        noc_hops=1,
+        router_latency_cycles_per_hop=2,
+        macs_per_cycle=524288,
+        vector_ops_per_cycle=65536,
+        clock_ns=1.0,
+    )
+
+
+def test_quality_gate_demotes_mqa_to_bound_only() -> None:
+    report = build_report(
+        physical_hbm_frontier=_physical_frontier(),
+        sequence_length_list=[131072],
+        die_area_mm2_list=[400],
+    )
+
+    assert report["recommendation"]["primary_hardware_candidate"] == "gqa8_kv8"
+    assert report["recommendation"]["primary_quality_experiment"] == "gqa8_kv4"
+    assert report["recommendation"]["bound_only_candidate"] == "mqa_kv4"
+    assert any(row["kv_sharing"] == "mqa" for row in report["bound_only_candidates"])
+    assert all(row["candidate_class"] == "bound_only_retrain_required" for row in report["bound_only_candidates"])
+
+
+def test_quality_gate_keeps_gqa8_kv8_as_practical_candidate() -> None:
+    report = build_report(
+        physical_hbm_frontier=_physical_frontier(),
+        sequence_length_list=[131072],
+        die_area_mm2_list=[400],
+    )
+
+    gqa8_kv8 = next(
+        row
+        for row in report["practical_candidates"]
+        if row["kv_sharing"] == "gqa8" and row["kv_bits"] == 8
+    )
+    assert gqa8_kv8["combined_quality_risk"] == "medium"
+    assert gqa8_kv8["candidate_class"] == "deployable_if_model_supports_structure"
+    assert gqa8_kv8["hardware_speedup_vs_mha16"] > 1.0
+
+
+def test_quality_gate_marks_kv4_as_quality_experiment() -> None:
+    report = build_report(
+        physical_hbm_frontier=_physical_frontier(),
+        sequence_length_list=[131072],
+        die_area_mm2_list=[400],
+    )
+
+    assert any(
+        row["kv_sharing"] == "gqa8"
+        and row["kv_bits"] == 4
+        and row["candidate_class"] == "quality_experiment_required"
+        for row in report["quality_experiment_candidates"]
+    )


### PR DESCRIPTION
## Summary
- add a quality-risk gate for attention/KV structural reductions identified by the physical-HBM frontier
- classify MQA as bound-only/retraining-required and KV4 as a quality experiment rather than a deployable default
- wire the new decoder_attention_kv_quality_gate abstraction into the L2 generator and artifact policy

## Validation
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_attention_kv_quality_gate.py tests/test_llm_decoder_attention_kv_physical_hbm_frontier.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 npu/eval/estimate_llm_decoder_attention_kv_quality_gate.py --physical-hbm-frontier runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_frontier__l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1.json --out /tmp/kv_quality_gate.json --out-md /tmp/kv_quality_gate.md