### PR TITLE
[codex] Add native GQA KV quality proxy

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -32,6 +32,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_physical_hbm_frontier__",
     "decoder_attention_kv_quality_gate__",
     "decoder_attention_kv_quality_proxy__",
+    "decoder_attention_kv_native_gqa_proxy__",
 }
 
 _ALLOWED_DATASET_SUFFIXES = {".json", ".md"}

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3404,6 +3404,43 @@ def _decoder_attention_kv_quality_proxy_evidence(*, item_id: str) -> dict[str, A
     }
 
 
+def _decoder_attention_kv_native_gqa_proxy_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_native_gqa_proxy__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_native_gqa_proxy__{item_id}.md"
+    quality_proxy = f"{base}/decoder_attention_kv_quality_proxy__l2_decoder_attention_kv_quality_proxy_llama7b_v1.json"
+    return {
+        "inputs": {
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_quality_proxy": quality_proxy,
+            "attention_kv_native_gqa_proxy_scope": (
+                "Native same-sharing attention/KV quality proxy for GQA8/MQA with KV8 and KV4. "
+                "Compare each candidate against a same-sharing KV16 reference, so GQA is not penalized "
+                "for differing from post-hoc MHA head sharing."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_native_gqa_proxy",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_native_gqa_proxy.py "
+                    f"--quality-proxy {quality_proxy} "
+                    "--attention-heads 32 "
+                    "--head-dim 32 "
+                    "--sequence-length-list 128,512 "
+                    "--regime-list native_correlated_queries,native_retrieval,native_low_margin "
+                    "--seed-count 2 "
+                    "--candidate-spec-list gqa8:kv8,gqa8:kv4,mqa:kv8,mqa:kv4 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_output_projection_weight_store_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_weight_store_feasibility__{item_id}.json"
@@ -4677,6 +4714,7 @@ def _build_payload(
         "decoder_attention_kv_physical_hbm_frontier",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
+        "decoder_attention_kv_native_gqa_proxy",
         "decoder_output_projection_producer_memory_hierarchy",
         "decoder_output_projection_weight_store_feasibility",
         "decoder_output_projection_weight_store_interface",
@@ -4729,6 +4767,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":
             decoder_evidence = _decoder_attention_kv_quality_proxy_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_native_gqa_proxy":
+            decoder_evidence = _decoder_attention_kv_native_gqa_proxy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_memory_hierarchy":
             decoder_evidence = _decoder_output_projection_producer_memory_hierarchy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_weight_store_feasibility":

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -51,3 +51,7 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_kv_quality_proxy__l2_decoder_attention_kv_quality_proxy_llama7b_v1.json"
     )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_native_gqa_proxy__l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1.md"
+    )

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3130,6 +3130,60 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_quality_proxy() -> 
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_native_gqa_proxy() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_native_gqa_proxy",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_attention_kv_native_gqa_proxy",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_attention_kv_native_gqa_proxy.py" in run
+            assert "--candidate-spec-list gqa8:kv8,gqa8:kv4,mqa:kv8,mqa:kv4" in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_native_gqa_proxy__"
+                "l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_kv_quality_proxy"].endswith(
+                "decoder_attention_kv_quality_proxy__l2_decoder_attention_kv_quality_proxy_llama7b_v1.json"
+            )
+            assert "same-sharing KV16 reference" in decoder_inputs["attention_kv_native_gqa_proxy_scope"]
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_native_gqa_proxy",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_feasibility() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1/proposal.json
@@ -1,0 +1,65 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1",
+  "created_utc": "2026-05-17T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_native_gqa_proxy",
+  "title": "Llama7B native GQA attention/KV quality proxy",
+  "hypothesis": "If GQA8 is trained or adapted natively, the post-hoc head-sharing penalty observed in the MHA-referenced proxy should disappear; KV4 should then be judged mainly by same-sharing quantization sensitivity before scheduling a trained-model or QAT run.",
+  "direct_comparison": {
+    "primary_question": "Do native GQA8/KV8 and native GQA8/KV4 preserve attention top-1, retrieval hits, distribution shape, and value outputs relative to a same-sharing KV16 reference?",
+    "include": [
+      "merged post-hoc attention/KV quality proxy evidence",
+      "GQA8/KV8 and GQA8/KV4 native-sharing candidates",
+      "MQA/KV8 and MQA/KV4 bound-only native-sharing candidates",
+      "native correlated-query, retrieval, and low-margin regimes",
+      "attention top-1 match, retrieval hit, KL divergence, output cosine, and output RMSE"
+    ],
+    "exclude": [
+      "claiming measured LLaMA perplexity or task accuracy",
+      "training native GQA or MQA weights",
+      "QAT or learned KV quantization scales",
+      "cycle-accurate attention hardware simulation"
+    ]
+  },
+  "expected_benefit": [
+    "separates native GQA feasibility from the pessimistic post-hoc MHA head-sharing proxy",
+    "tests whether GQA8/KV4 remains plausible enough for a model-native or QAT quality job",
+    "keeps MQA visible as a hardware lower bound while requiring explicit model evidence"
+  ],
+  "risks": [
+    "the proxy is synthetic and cannot replace trained-model perplexity or long-context retrieval tests",
+    "same-sharing references may be optimistic compared with an actual converted LLaMA checkpoint",
+    "KV quantization uses simple symmetric scales rather than learned or calibrated quantization"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a native same-sharing attention/KV quality proxy for GQA8 and KV4 candidates.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_native_gqa_proxy",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_quality_proxy_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_quality_proxy_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the native-sharing proxy to decide whether GQA8/KV4 should advance to a model-native or QAT quality run."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_quality_proxy__l2_decoder_attention_kv_quality_proxy_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_native_gqa_proxy.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_quality_proxy.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_native_gqa_proxy.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_native_gqa_proxy.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Proxy-test native GQA/MQA KV quantization against same-sharing KV16 references."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+from pathlib import Path
+from typing import Any
+
+try:
+    from npu.eval.estimate_llm_decoder_attention_kv_quality_proxy import (
+        JsonDict,
+        Matrix,
+        Vector,
+        _attention_eval,
+        _candidate_id,
+        _cosine,
+        _int_list,
+        _kl_divergence,
+        _quantize_vector,
+        _rmse,
+        _str_list,
+    )
+except ModuleNotFoundError:
+    from estimate_llm_decoder_attention_kv_quality_proxy import (  # type: ignore
+        JsonDict,
+        Matrix,
+        Vector,
+        _attention_eval,
+        _candidate_id,
+        _cosine,
+        _int_list,
+        _kl_divergence,
+        _quantize_vector,
+        _rmse,
+        _str_list,
+    )
+
+
+def _kv_group_count(*, attention_heads: int, kv_sharing: str) -> int:
+    if kv_sharing == "gqa4":
+        return max(1, math.ceil(attention_heads / 4))
+    if kv_sharing == "gqa8":
+        return max(1, math.ceil(attention_heads / 8))
+    if kv_sharing == "mqa":
+        return 1
+    raise ValueError(f"native GQA proxy supports gqa4, gqa8, and mqa; got {kv_sharing}")
+
+
+def _generate_native_shared_kv(
+    *,
+    rng: random.Random,
+    regime: str,
+    attention_heads: int,
+    sequence_length: int,
+    head_dim: int,
+    kv_sharing: str,
+) -> tuple[list[Matrix], list[Matrix], list[Vector], list[int]]:
+    kv_groups = _kv_group_count(attention_heads=attention_heads, kv_sharing=kv_sharing)
+    group_size = math.ceil(attention_heads / kv_groups)
+    group_keys = [
+        [[rng.gauss(0.0, 1.0) for _ in range(head_dim)] for _ in range(sequence_length)]
+        for _ in range(kv_groups)
+    ]
+    group_values = [
+        [[rng.gauss(0.0, 1.0) for _ in range(head_dim)] for _ in range(sequence_length)]
+        for _ in range(kv_groups)
+    ]
+    keys_by_head: list[Matrix] = []
+    values_by_head: list[Matrix] = []
+    queries: list[Vector] = []
+    targets: list[int] = []
+    for head in range(attention_heads):
+        group = min(kv_groups - 1, head // group_size)
+        keys = group_keys[group]
+        values = group_values[group]
+        if regime == "native_retrieval":
+            target = (31 * head + 7 * group + 5) % sequence_length
+            query = [2.3 * value + rng.gauss(0.0, 0.12) for value in keys[target]]
+            values[target] = [3.0 if index == (head % head_dim) else 0.0 for index in range(head_dim)]
+        elif regime == "native_low_margin":
+            target = (19 * head + 11 * group + 3) % sequence_length
+            distractor = (target + max(1, sequence_length // 7)) % sequence_length
+            query = [
+                0.58 * keys[target][index] + 0.52 * keys[distractor][index] + rng.gauss(0.0, 0.12)
+                for index in range(head_dim)
+            ]
+        elif regime == "native_correlated_queries":
+            target = (17 * head + 13 * group) % sequence_length
+            query = [value + rng.gauss(0.0, 0.08) for value in keys[target]]
+        else:
+            raise ValueError(f"unsupported native regime: {regime}")
+        keys_by_head.append(keys)
+        values_by_head.append(values)
+        queries.append(query)
+        targets.append(target)
+    return keys_by_head, values_by_head, queries, targets
+
+
+def _quantize_kv(keys: list[Matrix], values: list[Matrix], *, kv_bits: int) -> tuple[list[Matrix], list[Matrix]]:
+    return (
+        [[_quantize_vector(vector, kv_bits) for vector in head] for head in keys],
+        [[_quantize_vector(vector, kv_bits) for vector in head] for head in values],
+    )
+
+
+def _summarize(rows: list[JsonDict]) -> JsonDict:
+    out: JsonDict = {"sample_count": len(rows)}
+    for key in ("top1_match", "retrieval_hit", "kl_divergence", "output_cosine", "output_rmse"):
+        values = [float(row[key]) for row in rows]
+        out[f"mean_{key}"] = round(sum(values) / len(values), 6) if values else 0.0
+        out[f"min_{key}"] = round(min(values), 6) if values else 0.0
+        out[f"max_{key}"] = round(max(values), 6) if values else 0.0
+    return out
+
+
+def _decision(summary: JsonDict, *, kv_sharing: str, kv_bits: int) -> str:
+    if kv_sharing == "mqa":
+        return "native_mqa_still_requires_model_evidence"
+    if kv_bits >= 8 and summary["mean_top1_match"] >= 0.995 and summary["mean_output_cosine"] >= 0.999:
+        return "native_proxy_pass"
+    if kv_bits < 8 and summary["mean_top1_match"] >= 0.98 and summary["mean_output_cosine"] >= 0.995:
+        return "native_lowbit_promising"
+    return "native_proxy_risk"
+
+
+def _parse_candidate_specs(candidate_specs: list[str]) -> list[tuple[str, int, str]]:
+    out: list[tuple[str, int, str]] = []
+    for spec in candidate_specs:
+        try:
+            sharing, bits_text = spec.split(":kv", 1)
+            bits = int(bits_text)
+        except ValueError as exc:
+            raise ValueError(f"candidate spec must look like gqa8:kv4, got {spec}") from exc
+        out.append((sharing, bits, _candidate_id(kv_sharing=sharing, kv_bits=bits)))
+    return out
+
+
+def build_report(
+    *,
+    quality_proxy: JsonDict | None,
+    attention_heads: int,
+    head_dim: int,
+    sequence_length_list: list[int],
+    regime_list: list[str],
+    seed_count: int,
+    candidate_specs: list[str],
+) -> JsonDict:
+    candidates = _parse_candidate_specs(candidate_specs)
+    metric_rows: list[JsonDict] = []
+    for sequence_length in sequence_length_list:
+        for regime in regime_list:
+            for seed in range(seed_count):
+                for kv_sharing, kv_bits, candidate_id in candidates:
+                    rng = random.Random(
+                        0xB47A000
+                        + sequence_length * 131
+                        + seed * 17
+                        + len(regime) * 19
+                        + sum(ord(ch) for ch in kv_sharing)
+                    )
+                    keys, values, queries, targets = _generate_native_shared_kv(
+                        rng=rng,
+                        regime=regime,
+                        attention_heads=attention_heads,
+                        sequence_length=sequence_length,
+                        head_dim=head_dim,
+                        kv_sharing=kv_sharing,
+                    )
+                    reference = _attention_eval(
+                        keys_by_head=keys,
+                        values_by_head=values,
+                        queries=queries,
+                        targets=targets,
+                    )
+                    cand_keys, cand_values = _quantize_kv(keys, values, kv_bits=kv_bits)
+                    candidate = _attention_eval(
+                        keys_by_head=cand_keys,
+                        values_by_head=cand_values,
+                        queries=queries,
+                        targets=targets,
+                    )
+                    for ref_row, cand_row in zip(reference, candidate):
+                        metric_rows.append(
+                            {
+                                "candidate_id": candidate_id,
+                                "kv_sharing": kv_sharing,
+                                "kv_bits": kv_bits,
+                                "sequence_length": sequence_length,
+                                "regime": regime,
+                                "seed": seed,
+                                "head": ref_row["head"],
+                                "top1_match": 1.0 if ref_row["top1"] == cand_row["top1"] else 0.0,
+                                "retrieval_hit": 1.0 if cand_row["top1"] == ref_row["target"] else 0.0,
+                                "kl_divergence": _kl_divergence(ref_row["weights"], cand_row["weights"]),
+                                "output_cosine": _cosine(ref_row["output"], cand_row["output"]),
+                                "output_rmse": _rmse(ref_row["output"], cand_row["output"]),
+                            }
+                        )
+
+    candidate_summary: list[JsonDict] = []
+    for kv_sharing, kv_bits, candidate_id in candidates:
+        rows = [row for row in metric_rows if row["candidate_id"] == candidate_id]
+        summary = _summarize(rows)
+        summary.update(
+            {
+                "candidate_id": candidate_id,
+                "kv_sharing": kv_sharing,
+                "kv_bits": kv_bits,
+                "decision": _decision(summary, kv_sharing=kv_sharing, kv_bits=kv_bits),
+            }
+        )
+        candidate_summary.append(summary)
+
+    regime_summary: list[JsonDict] = []
+    for kv_sharing, kv_bits, candidate_id in candidates:
+        for regime in regime_list:
+            rows = [row for row in metric_rows if row["candidate_id"] == candidate_id and row["regime"] == regime]
+            summary = _summarize(rows)
+            summary.update(
+                {
+                    "candidate_id": candidate_id,
+                    "kv_sharing": kv_sharing,
+                    "kv_bits": kv_bits,
+                    "regime": regime,
+                    "decision": _decision(summary, kv_sharing=kv_sharing, kv_bits=kv_bits),
+                }
+            )
+            regime_summary.append(summary)
+
+    return {
+        "version": 0.1,
+        "model": "llm_decoder_attention_kv_native_gqa_proxy_v1",
+        "inputs": {
+            "quality_proxy_model": (quality_proxy or {}).get("model", ""),
+            "attention_heads": attention_heads,
+            "head_dim": head_dim,
+            "sequence_length_list": sequence_length_list,
+            "regime_list": regime_list,
+            "seed_count": seed_count,
+            "candidate_specs": candidate_specs,
+        },
+        "sweep_summary": {
+            "metric_row_count": len(metric_rows),
+            "candidate_count": len(candidates),
+        },
+        "candidate_summary": sorted(candidate_summary, key=lambda row: row["candidate_id"]),
+        "regime_summary": sorted(regime_summary, key=lambda row: (row["candidate_id"], row["regime"])),
+        "metric_rows_sample": metric_rows[:100],
+        "assumptions": [
+            "This is a native-sharing proxy, not measured LLaMA perplexity.",
+            "Each candidate is compared against a same-sharing KV16 reference, so GQA is not penalized for differing from MHA.",
+            "KV8 and KV4 use symmetric per-vector packed quantization without learned scales.",
+            "Passing this proxy only justifies a model-native GQA or QAT evaluation; it does not promote a final hardware format.",
+        ],
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Decoder Attention/KV Native GQA Proxy",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- metric_row_count: `{payload['sweep_summary']['metric_row_count']}`",
+        f"- candidates: `{payload['sweep_summary']['candidate_count']}`",
+        "",
+        "## Candidate Summary",
+        "",
+        "| candidate | top1 | retrieval | cosine | kl | decision |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["candidate_summary"]:
+        lines.append(
+            "| {candidate} | {top1} | {retrieval} | {cosine} | {kl} | {decision} |".format(
+                candidate=row["candidate_id"],
+                top1=row["mean_top1_match"],
+                retrieval=row["mean_retrieval_hit"],
+                cosine=row["mean_output_cosine"],
+                kl=row["mean_kl_divergence"],
+                decision=row["decision"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Regime Summary",
+            "",
+            "| candidate | regime | top1 | retrieval | cosine | kl | decision |",
+            "|---|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for row in payload["regime_summary"]:
+        lines.append(
+            "| {candidate} | {regime} | {top1} | {retrieval} | {cosine} | {kl} | {decision} |".format(
+                candidate=row["candidate_id"],
+                regime=row["regime"],
+                top1=row["mean_top1_match"],
+                retrieval=row["mean_retrieval_hit"],
+                cosine=row["mean_output_cosine"],
+                kl=row["mean_kl_divergence"],
+                decision=row["decision"],
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--quality-proxy")
+    ap.add_argument("--attention-heads", type=int, default=32)
+    ap.add_argument("--head-dim", type=int, default=32)
+    ap.add_argument("--sequence-length-list", type=_int_list, default=[128, 512])
+    ap.add_argument("--regime-list", type=_str_list, default=["native_correlated_queries", "native_retrieval", "native_low_margin"])
+    ap.add_argument("--seed-count", type=int, default=2)
+    ap.add_argument("--candidate-spec-list", type=_str_list, default=["gqa8:kv8", "gqa8:kv4", "mqa:kv8", "mqa:kv4"])
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    quality_proxy = json.loads(Path(args.quality_proxy).read_text(encoding="utf-8")) if args.quality_proxy else None
+    payload = build_report(
+        quality_proxy=quality_proxy,
+        attention_heads=args.attention_heads,
+        head_dim=args.head_dim,
+        sequence_length_list=args.sequence_length_list,
+        regime_list=args.regime_list,
+        seed_count=args.seed_count,
+        candidate_specs=args.candidate_spec_list,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(Path(args.out_md), payload)
+    print(json.dumps({"ok": True, "out": args.out, "out_md": args.out_md}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_attention_kv_native_gqa_proxy.py
+++ b/tests/test_llm_decoder_attention_kv_native_gqa_proxy.py
@@ -1,0 +1,38 @@
+from npu.eval.estimate_llm_decoder_attention_kv_native_gqa_proxy import build_report
+
+
+def _report():
+    return build_report(
+        quality_proxy={"model": "quality_proxy_fixture"},
+        attention_heads=8,
+        head_dim=8,
+        sequence_length_list=[32],
+        regime_list=["native_correlated_queries", "native_retrieval", "native_low_margin"],
+        seed_count=1,
+        candidate_specs=["gqa8:kv8", "gqa8:kv4", "mqa:kv4"],
+    )
+
+
+def test_native_gqa_proxy_compares_against_same_sharing_reference() -> None:
+    report = _report()
+    gqa8 = next(row for row in report["candidate_summary"] if row["candidate_id"] == "gqa8_kv8")
+
+    assert report["model"] == "llm_decoder_attention_kv_native_gqa_proxy_v1"
+    assert report["inputs"]["quality_proxy_model"] == "quality_proxy_fixture"
+    assert gqa8["mean_output_cosine"] > 0.999
+    assert gqa8["mean_top1_match"] > 0.99
+
+
+def test_native_gqa_proxy_keeps_kv4_as_promising_or_risky() -> None:
+    report = _report()
+    gqa4 = next(row for row in report["candidate_summary"] if row["candidate_id"] == "gqa8_kv4")
+
+    assert gqa4["mean_output_cosine"] > 0.99
+    assert gqa4["decision"] in {"native_lowbit_promising", "native_proxy_risk"}
+
+
+def test_native_gqa_proxy_keeps_mqa_bound_separate() -> None:
+    report = _report()
+    mqa4 = next(row for row in report["candidate_summary"] if row["candidate_id"] == "mqa_kv4")
+
+    assert mqa4["decision"] == "native_mqa_still_requires_model_evidence"


### PR DESCRIPTION
## Summary
- add a native same-sharing GQA/MQA KV quality proxy for the LLaMA7B attention frontier
- wire the new `decoder_attention_kv_native_gqa_proxy` abstraction into L2 task generation and artifact transport policy
- add the proposal and focused tests for the proxy and control-plane contract

## Why
The previous quality proxy correctly showed that post-hoc MHA-to-GQA head sharing is risky, but that also makes it pessimistic for a model trained or adapted natively with GQA. This proxy compares each GQA/MQA candidate against a same-sharing KV16 reference so the next evaluator job can isolate KV8/KV4 quantization sensitivity from head-sharing conversion risk.

## Validation
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_attention_kv_native_gqa_proxy.py tests/test_llm_decoder_attention_kv_quality_proxy.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py`
