### PR TITLE
[codex] Fix trace calibration dependency gate

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_trace_calibration_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_trace_calibration_v1/proposal.json
@@ -15,7 +15,8 @@
       "merged distilgpt2 prompt-stress decoder quality compare with present.* KV trace summaries",
       "next-token and top-k exactness controls",
       "KV4 trace mean, max, scale, and outlier rollups",
-      "explicit low-margin caution from the native GQA proxy"
+      "explicit low-margin caution from the native GQA proxy",
+      "GPT-2 and distilgpt2 quality compare JSONs as materialized repo references rather than DB-gated work-item dependencies"
     ],
     "exclude": [
       "claiming native GQA model quality",
@@ -46,9 +47,7 @@
       "comparison_role": "frontier_synthesis",
       "paired_baseline_item_id": "l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1",
       "depends_on_item_ids": [
-        "l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1",
-        "l2_decoder_gpt2_prompt_stress_v1",
-        "l2_decoder_distilgpt2_prompt_stress_v1"
+        "l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,


### PR DESCRIPTION
## Summary
- fix the trace-calibration proposal dependency gate
- keep GPT-2/distilgpt2 quality compare files as materialized repo references instead of DB-gated work-item dependencies

## Why
The rebuilt control-plane DB may not contain historical GPT-2/distilgpt2 work items even though their compact artifacts are already merged in the repo. Gating on those item IDs blocks dispatch unnecessarily; the only live DB dependency needed here is the native GQA proxy item.

## Validation
- `python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_trace_calibration_v1/proposal.json`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_trace_calibration`
