### PR TITLE
[codex] Add native GQA KV quality job

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -34,6 +34,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_quality_proxy__",
     "decoder_attention_kv_native_gqa_proxy__",
     "decoder_attention_kv_trace_calibration__",
+    "decoder_attention_kv_model_native_quality__",
 }
 
 _ALLOWED_DATASET_SUFFIXES = {".json", ".md"}

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3481,6 +3481,42 @@ def _decoder_attention_kv_trace_calibration_evidence(*, item_id: str) -> dict[st
     }
 
 
+def _decoder_attention_kv_model_native_quality_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_model_native_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_model_native_quality__{item_id}.md"
+    trace_calibration = f"{base}/decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json"
+    return {
+        "inputs": {
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_trace_calibration": trace_calibration,
+            "attention_kv_model_native_quality_scope": (
+                "Run a trained native-GQA checkpoint through teacher-forced decode while feeding back "
+                "KV8/KV4-quantized past_key_values. This is the first real-checkpoint quality gate after "
+                "the synthetic native-GQA proxy and GPT-2-family trace calibration; it is not QAT."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_kv_model_native_quality",
+                "run": (
+                    "python3 npu/eval/evaluate_llm_decoder_model_native_kv_quant.py "
+                    "--model-id ${RTLGEN_MODEL_NATIVE_GQA_MODEL_ID:-TinyLlama/TinyLlama-1.1B-Chat-v1.0} "
+                    "--expected-gqa-group-size 8 "
+                    "--kv-bits-list 8,4 "
+                    "--max-prompts 8 "
+                    "--generation-steps 8 "
+                    "--topk 5 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_output_projection_weight_store_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_weight_store_feasibility__{item_id}.json"
@@ -4756,6 +4792,7 @@ def _build_payload(
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
         "decoder_attention_kv_trace_calibration",
+        "decoder_attention_kv_model_native_quality",
         "decoder_output_projection_producer_memory_hierarchy",
         "decoder_output_projection_weight_store_feasibility",
         "decoder_output_projection_weight_store_interface",
@@ -4812,6 +4849,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_native_gqa_proxy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_trace_calibration":
             decoder_evidence = _decoder_attention_kv_trace_calibration_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_model_native_quality":
+            decoder_evidence = _decoder_attention_kv_model_native_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_memory_hierarchy":
             decoder_evidence = _decoder_output_projection_producer_memory_hierarchy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_weight_store_feasibility":

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -59,3 +59,7 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json"
     )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_model_native_quality__l2_decoder_attention_kv_model_native_quality_tinyllama_v1.md"
+    )

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3235,6 +3235,61 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_trace_calibration()
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_quality() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_model_native_quality_tinyllama_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_model_native_quality_tinyllama_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_model_native_quality_tinyllama_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_model_native_quality",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "evaluate_decoder_attention_kv_model_native_quality",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "evaluate_llm_decoder_model_native_kv_quant.py" in run
+            assert "--kv-bits-list 8,4" in run
+            assert "TinyLlama/TinyLlama-1.1B-Chat-v1.0" in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_model_native_quality__"
+                "l2_decoder_attention_kv_model_native_quality_tinyllama_v1.json"
+            )
+            assert decoder_inputs["attention_kv_trace_calibration"].endswith(
+                "decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json"
+            )
+            assert "teacher-forced decode" in decoder_inputs["attention_kv_model_native_quality_scope"]
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_model_native_quality",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_feasibility() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_tinyllama_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_tinyllama_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_model_native_quality_tinyllama_v1",
+  "created_utc": "2026-05-17T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_model_native_quality",
+  "title": "Native trained-GQA checkpoint KV4 quality gate",
+  "hypothesis": "After the synthetic native-GQA proxy and GPT-2-family trace calibration, the next useful frontier check is a trained native-GQA checkpoint where KV8/KV4 cache values are fed back through decoding rather than only summarized as traces.",
+  "direct_comparison": {
+    "primary_question": "Does post-training KV4 cache quantization preserve next-token ranking on a trained native-GQA checkpoint closely enough to keep GQA8/KV4 on the LLaMA-class frontier before QAT?",
+    "include": [
+      "trained native-GQA Hugging Face causal LM checkpoint",
+      "teacher-forced greedy decode over prompt-stress-style prompts",
+      "KV8 and KV4 quantized past_key_values feedback",
+      "top-1 match, top-k containment, logit cosine, probability KL, margin, and max logit-delta rollups",
+      "explicit GQA group-size check against the intended GQA8 architecture",
+      "model id override through RTLGEN_MODEL_NATIVE_GQA_MODEL_ID for evaluator-local checkpoint selection"
+    ],
+    "exclude": [
+      "QAT or fine-tuning",
+      "claiming final LLaMA7B quality",
+      "committing Hugging Face model weights",
+      "new physical synthesis"
+    ]
+  },
+  "expected_benefit": [
+    "tests the actual feedback path missing from the KV trace calibration",
+    "separates native GQA checkpoint evidence from synthetic attention-only proxies",
+    "provides an explicit go/no-go gate for scheduling larger 7B-class or QAT confirmation"
+  ],
+  "risks": [
+    "TinyLlama is a smaller checkpoint than the target LLaMA7B-class architecture, so a pass is not final deployability evidence",
+    "post-training KV4 may fail even if QAT could recover it",
+    "Hugging Face model access and evaluator memory determine whether the run is feasible"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_model_native_quality_tinyllama_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure trained native-GQA checkpoint sensitivity to KV8/KV4 cache quantization feedback.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_model_native_quality",
+      "cost_class": "medium",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_trace_calibration_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_trace_calibration_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_hf_model_access": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use native trained-checkpoint KV feedback quality to decide whether the frontier should proceed to larger 7B-class/QAT confirmation or retreat to KV8/safer formats."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_native_gqa_proxy__l2_decoder_attention_kv_native_gqa_proxy_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_kv_quant.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_trace_calibration.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_native_gqa_proxy.py"
+  ]
+}

--- a/npu/eval/evaluate_llm_decoder_model_native_kv_quant.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_kv_quant.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Evaluate native-GQA checkpoint sensitivity to quantized KV cache feedback."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+DEFAULT_PROMPTS = [
+    "The capital of France is",
+    "Two plus two equals",
+    "In a transformer decoder, the key value cache stores",
+    "The next word in the sequence Monday Tuesday Wednesday is",
+    "If a system has a narrow top-token margin, quantization can",
+    "A hardware accelerator with limited SRAM should",
+    "The color of the clear daytime sky is",
+    "When comparing approximate inference results, the safest metric is",
+]
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _safe_exp_softmax(logits: list[float]) -> list[float]:
+    if not logits:
+        return []
+    top = max(logits)
+    exps = [math.exp(min(80.0, value - top)) for value in logits]
+    denom = sum(exps)
+    return [value / denom for value in exps]
+
+
+def _topk(values: list[float], k: int) -> list[int]:
+    return sorted(range(len(values)), key=lambda idx: values[idx], reverse=True)[: max(1, min(k, len(values)))]
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    aa = math.sqrt(sum(value * value for value in a))
+    bb = math.sqrt(sum(value * value for value in b))
+    if aa == 0.0 or bb == 0.0:
+        return 1.0 if aa == bb else 0.0
+    return sum(x * y for x, y in zip(a, b)) / (aa * bb)
+
+
+def _kl_divergence(reference: list[float], candidate: list[float]) -> float:
+    eps = 1e-12
+    return sum(p * math.log(max(eps, p) / max(eps, q)) for p, q in zip(reference, candidate))
+
+
+def _summarize_rows(rows: list[JsonDict]) -> JsonDict:
+    if not rows:
+        return {
+            "comparison_count": 0,
+            "top1_match_rate": 0.0,
+            "topk_contains_rate": 0.0,
+            "mean_logit_cosine": 0.0,
+            "mean_probability_kl": 0.0,
+            "mean_reference_margin": 0.0,
+            "min_reference_margin": 0.0,
+            "max_abs_logit_delta_mean": 0.0,
+            "max_abs_logit_delta_max": 0.0,
+        }
+    return {
+        "comparison_count": len(rows),
+        "top1_match_rate": _mean([_float(row.get("top1_match")) for row in rows]),
+        "topk_contains_rate": _mean([_float(row.get("topk_contains")) for row in rows]),
+        "mean_logit_cosine": _mean([_float(row.get("logit_cosine")) for row in rows]),
+        "mean_probability_kl": _mean([_float(row.get("probability_kl")) for row in rows]),
+        "mean_reference_margin": _mean([_float(row.get("reference_margin")) for row in rows]),
+        "min_reference_margin": min(_float(row.get("reference_margin")) for row in rows),
+        "max_abs_logit_delta_mean": _mean([_float(row.get("max_abs_logit_delta")) for row in rows]),
+        "max_abs_logit_delta_max": max(_float(row.get("max_abs_logit_delta")) for row in rows),
+    }
+
+
+def _decision(candidate_summary: list[JsonDict], *, expected_gqa_group_size: int, actual_gqa_group_size: float) -> JsonDict:
+    blockers: list[str] = []
+    cautions: list[str] = []
+    if expected_gqa_group_size > 0 and abs(actual_gqa_group_size - expected_gqa_group_size) > 1e-6:
+        blockers.append(
+            f"model_gqa_group_size {actual_gqa_group_size:g} does not match expected {expected_gqa_group_size}"
+        )
+    by_bits = {int(row.get("kv_bits", 0)): row for row in candidate_summary}
+    kv4 = by_bits.get(4, {})
+    kv8 = by_bits.get(8, {})
+    if kv8 and _float(kv8.get("top1_match_rate")) < 0.995:
+        cautions.append("KV8 changed at least one top-1 decision; check model/runtime determinism before trusting KV4")
+    if not kv4:
+        blockers.append("KV4 candidate was not evaluated")
+    elif _float(kv4.get("top1_match_rate")) < 0.98 or _float(kv4.get("topk_contains_rate")) < 0.995:
+        blockers.append("KV4 changed too many native-checkpoint next-token rankings")
+    elif _float(kv4.get("mean_logit_cosine")) < 0.999:
+        cautions.append("KV4 ranking mostly holds, but logit cosine is below the promotion caution line")
+    if blockers:
+        status = "hold_for_qat_or_safer_kv_format"
+        next_step = "Run QAT/fine-tuning recovery or move the frontier back to KV8 for the native GQA checkpoint."
+    else:
+        status = "native_checkpoint_kv4_promising"
+        next_step = "Use this checkpoint evidence with the PPA model, then schedule a larger 7B-class or QAT confirmation."
+    return {
+        "status": status,
+        "blockers": blockers,
+        "cautions": cautions,
+        "next_step": next_step,
+        "thresholds": {
+            "kv4_top1_match_min": 0.98,
+            "kv4_topk_contains_min": 0.995,
+            "kv4_mean_logit_cosine_caution_below": 0.999,
+            "kv8_top1_match_caution_below": 0.995,
+        },
+    }
+
+
+def _load_prompts(path: str) -> list[str]:
+    if not path:
+        return list(DEFAULT_PROMPTS)
+    prompts: list[str] = []
+    with Path(path).open("r", encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            if text.startswith("{"):
+                doc = json.loads(text)
+                text = str(doc.get("prompt") or doc.get("text") or "").strip()
+            if text:
+                prompts.append(text)
+    if not prompts:
+        raise SystemExit(f"no prompts loaded from {path}")
+    return prompts
+
+
+def _parse_bits(value: str) -> list[int]:
+    bits = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not bits or any(bit < 2 for bit in bits):
+        raise argparse.ArgumentTypeError("expected comma-separated KV bit widths >= 2")
+    return bits
+
+
+def _write_report_md(payload: JsonDict) -> str:
+    lines = [
+        "# Native GQA KV Quantization Quality",
+        "",
+        f"- model_id: `{payload['model']['model_id']}`",
+        f"- decision: `{payload['decision']['status']}`",
+        f"- next_step: {payload['decision']['next_step']}",
+        "",
+        "## Model",
+        "",
+        f"- attention_heads: `{payload['model']['attention_heads']}`",
+        f"- kv_heads: `{payload['model']['kv_heads']}`",
+        f"- gqa_group_size: `{payload['model']['gqa_group_size']}`",
+        "",
+        "## Candidates",
+        "",
+        "| kv_bits | comparisons | top1 | topk | cosine | kl | min_margin | max_delta |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["candidate_summary"]:
+        lines.append(
+            "| {kv_bits} | {comparison_count} | {top1:.6f} | {topk:.6f} | {cosine:.6f} | {kl:.6f} | {margin:.6f} | {delta:.6f} |".format(
+                kv_bits=row["kv_bits"],
+                comparison_count=row["comparison_count"],
+                top1=row["top1_match_rate"],
+                topk=row["topk_contains_rate"],
+                cosine=row["mean_logit_cosine"],
+                kl=row["mean_probability_kl"],
+                margin=row["min_reference_margin"],
+                delta=row["max_abs_logit_delta_max"],
+            )
+        )
+    if payload["decision"].get("blockers"):
+        lines.extend(["", "## Blockers", ""])
+        lines.extend(f"- {item}" for item in payload["decision"]["blockers"])
+    if payload["decision"].get("cautions"):
+        lines.extend(["", "## Cautions", ""])
+        lines.extend(f"- {item}" for item in payload["decision"]["cautions"])
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    return "\n".join(lines) + "\n"
+
+
+def _run_model_eval(args: argparse.Namespace) -> JsonDict:
+    try:
+        import torch  # type: ignore
+        from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            "missing runtime dependency for model-native KV quality: install torch and transformers"
+        ) from exc
+
+    model_id = args.model_id or os.environ.get("RTLGEN_MODEL_NATIVE_GQA_MODEL_ID") or "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+    device = args.device
+    if device == "auto":
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.float16 if device.startswith("cuda") else torch.float32
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=dtype)
+    model.to(device)
+    model.eval()
+
+    config = model.config
+    attention_heads = int(getattr(config, "num_attention_heads", 0) or getattr(config, "n_head", 0) or 0)
+    kv_heads = int(getattr(config, "num_key_value_heads", 0) or attention_heads)
+    if attention_heads <= 0 or kv_heads <= 0:
+        raise SystemExit("model config does not expose attention and KV head counts")
+    gqa_group_size = attention_heads / kv_heads
+    prompts = _load_prompts(args.prompt_file)[: args.max_prompts]
+
+    levels_by_bits = {bits: (1 << (bits - 1)) - 1 for bits in args.kv_bits_list}
+
+    def quantize_tensor(tensor: Any, bits: int) -> Any:
+        if not torch.is_tensor(tensor):
+            return tensor
+        levels = levels_by_bits[bits]
+        data = tensor.detach()
+        max_abs = torch.amax(torch.abs(data)).item() if data.numel() else 0.0
+        if max_abs == 0.0:
+            return data.clone()
+        scale = max_abs / float(levels)
+        return torch.clamp(torch.round(data / scale), -levels, levels).to(data.dtype) * scale
+
+    def quantize_past(past: Any, bits: int) -> Any:
+        if past is None:
+            return None
+        if torch.is_tensor(past):
+            return quantize_tensor(past, bits)
+        if isinstance(past, tuple):
+            return tuple(quantize_past(item, bits) for item in past)
+        if isinstance(past, list):
+            return [quantize_past(item, bits) for item in past]
+        if hasattr(past, "to_legacy_cache"):
+            legacy = past.to_legacy_cache()
+            return tuple(quantize_past(item, bits) for item in legacy)
+        return past
+
+    rows_by_bits: dict[int, list[JsonDict]] = {bits: [] for bits in args.kv_bits_list}
+    prompt_records: list[JsonDict] = []
+    with torch.no_grad():
+        for prompt_index, prompt in enumerate(prompts):
+            encoded = tokenizer(prompt, return_tensors="pt")
+            input_ids = encoded["input_ids"].to(device)
+            prefill = model(input_ids=input_ids, use_cache=True)
+            fp_past = prefill.past_key_values
+            ref_logits = prefill.logits[:, -1, :].float().cpu().reshape(-1).tolist()
+            ref_top = _topk(ref_logits, max(2, args.topk))
+            prompt_records.append(
+                {
+                    "prompt_index": prompt_index,
+                    "prompt": prompt,
+                    "prefill_reference_top1": ref_top[0],
+                    "prefill_reference_margin": ref_logits[ref_top[0]] - ref_logits[ref_top[1]],
+                }
+            )
+            candidate_past = {bits: quantize_past(fp_past, bits) for bits in args.kv_bits_list}
+            next_input = torch.tensor([[ref_top[0]]], dtype=torch.long, device=device)
+            for step in range(args.generation_steps):
+                ref_out = model(input_ids=next_input, past_key_values=fp_past, use_cache=True)
+                fp_past = ref_out.past_key_values
+                ref_logits = ref_out.logits[:, -1, :].float().cpu().reshape(-1).tolist()
+                ref_probs = _safe_exp_softmax(ref_logits)
+                ref_order = _topk(ref_logits, max(2, args.topk))
+                ref_next = ref_order[0]
+                ref_margin = ref_logits[ref_order[0]] - ref_logits[ref_order[1]]
+                for bits in args.kv_bits_list:
+                    cand_out = model(input_ids=next_input, past_key_values=candidate_past[bits], use_cache=True)
+                    candidate_past[bits] = quantize_past(cand_out.past_key_values, bits)
+                    cand_logits = cand_out.logits[:, -1, :].float().cpu().reshape(-1).tolist()
+                    cand_probs = _safe_exp_softmax(cand_logits)
+                    cand_order = _topk(cand_logits, args.topk)
+                    rows_by_bits[bits].append(
+                        {
+                            "prompt_index": prompt_index,
+                            "step": step,
+                            "kv_bits": bits,
+                            "reference_top1": ref_next,
+                            "candidate_top1": cand_order[0],
+                            "top1_match": 1.0 if cand_order[0] == ref_next else 0.0,
+                            "topk_contains": 1.0 if ref_next in cand_order else 0.0,
+                            "reference_margin": ref_margin,
+                            "logit_cosine": _cosine(ref_logits, cand_logits),
+                            "probability_kl": _kl_divergence(ref_probs, cand_probs),
+                            "max_abs_logit_delta": max(abs(a - b) for a, b in zip(ref_logits, cand_logits)),
+                        }
+                    )
+                next_input = torch.tensor([[ref_next]], dtype=torch.long, device=device)
+
+    candidate_summary: list[JsonDict] = []
+    for bits in args.kv_bits_list:
+        summary = _summarize_rows(rows_by_bits[bits])
+        summary["kv_bits"] = bits
+        candidate_summary.append(summary)
+    return {
+        "version": 0.1,
+        "model": {
+            "model_id": model_id,
+            "attention_heads": attention_heads,
+            "kv_heads": kv_heads,
+            "gqa_group_size": gqa_group_size,
+            "device": device,
+            "dtype": str(dtype),
+        },
+        "prompt_count": len(prompts),
+        "generation_steps": args.generation_steps,
+        "topk": args.topk,
+        "prompt_records": prompt_records,
+        "candidate_summary": candidate_summary,
+        "decision": _decision(
+            candidate_summary,
+            expected_gqa_group_size=args.expected_gqa_group_size,
+            actual_gqa_group_size=gqa_group_size,
+        ),
+        "assumptions": [
+            "This is post-training native-checkpoint KV cache quantization, not QAT.",
+            "Teacher-forced reference tokens isolate KV-cache perturbation from divergent generated text.",
+            "The evaluator must have Hugging Face model access; generated model weights are not committed.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", default="")
+    parser.add_argument("--prompt-file", default="")
+    parser.add_argument("--max-prompts", type=int, default=8)
+    parser.add_argument("--generation-steps", type=int, default=8)
+    parser.add_argument("--topk", type=int, default=5)
+    parser.add_argument("--kv-bits-list", type=_parse_bits, default=[8, 4])
+    parser.add_argument("--expected-gqa-group-size", type=int, default=8)
+    parser.add_argument("--device", default="auto", choices=["auto", "cpu", "cuda"])
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--out-md", required=True)
+    args = parser.parse_args()
+    if args.max_prompts <= 0 or args.generation_steps <= 0 or args.topk <= 0:
+        raise SystemExit("max-prompts, generation-steps, and topk must be positive")
+    payload = _run_model_eval(args)
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    report = Path(args.out_md)
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text(_write_report_md(payload), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_model_native_kv_quant.py
+++ b/tests/test_llm_decoder_model_native_kv_quant.py
@@ -1,0 +1,59 @@
+from npu.eval.evaluate_llm_decoder_model_native_kv_quant import _decision, _summarize_rows
+
+
+def test_summarize_rows_records_rank_and_logit_metrics() -> None:
+    rows = [
+        {
+            "top1_match": 1.0,
+            "topk_contains": 1.0,
+            "logit_cosine": 0.9999,
+            "probability_kl": 0.0001,
+            "reference_margin": 0.1,
+            "max_abs_logit_delta": 0.02,
+        },
+        {
+            "top1_match": 0.0,
+            "topk_contains": 1.0,
+            "logit_cosine": 0.998,
+            "probability_kl": 0.001,
+            "reference_margin": 0.01,
+            "max_abs_logit_delta": 0.05,
+        },
+    ]
+
+    summary = _summarize_rows(rows)
+
+    assert summary["comparison_count"] == 2
+    assert summary["top1_match_rate"] == 0.5
+    assert summary["topk_contains_rate"] == 1.0
+    assert summary["min_reference_margin"] == 0.01
+    assert summary["max_abs_logit_delta_max"] == 0.05
+
+
+def test_decision_advances_when_native_checkpoint_kv4_rankings_hold() -> None:
+    decision = _decision(
+        [
+            {"kv_bits": 8, "top1_match_rate": 1.0, "topk_contains_rate": 1.0, "mean_logit_cosine": 0.99999},
+            {"kv_bits": 4, "top1_match_rate": 0.99, "topk_contains_rate": 1.0, "mean_logit_cosine": 0.9995},
+        ],
+        expected_gqa_group_size=8,
+        actual_gqa_group_size=8.0,
+    )
+
+    assert decision["status"] == "native_checkpoint_kv4_promising"
+    assert decision["blockers"] == []
+
+
+def test_decision_blocks_wrong_gqa_group_or_kv4_rank_regression() -> None:
+    decision = _decision(
+        [
+            {"kv_bits": 8, "top1_match_rate": 1.0, "topk_contains_rate": 1.0, "mean_logit_cosine": 0.99999},
+            {"kv_bits": 4, "top1_match_rate": 0.9, "topk_contains_rate": 0.95, "mean_logit_cosine": 0.9995},
+        ],
+        expected_gqa_group_size=8,
+        actual_gqa_group_size=4.0,
+    )
+
+    assert decision["status"] == "hold_for_qat_or_safer_kv_format"
+    assert any("model_gqa_group_size" in blocker for blocker in decision["blockers"])
+    assert any("KV4 changed too many" in blocker for blocker in decision["blockers"])


### PR DESCRIPTION
## Summary
- add a Hugging Face native-GQA checkpoint KV feedback quality evaluator
- wire the decoder_attention_kv_model_native_quality abstraction into L2 task generation and artifact policy
- add the TinyLlama GQA8/KV4 follow-up proposal after trace calibration

## Validation
- python3 -m py_compile npu/eval/evaluate_llm_decoder_model_native_kv_quant.py
- python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_tinyllama_v1/proposal.json
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_model_native_kv_quant.py tests/test_llm_decoder_attention_kv_trace_calibration.py tests/test_llm_decoder_attention_kv_native_gqa_proxy.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py

Note: the real HF checkpoint run is intentionally left to the evaluator because it downloads/loads the model.