### PR TITLE
[codex] Use HF Python for native KV quality

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3501,8 +3501,8 @@ def _decoder_attention_kv_model_native_quality_evidence(*, item_id: str) -> dict
             {
                 "name": "evaluate_decoder_attention_kv_model_native_quality",
                 "run": (
-                    "python3 npu/eval/evaluate_llm_decoder_model_native_kv_quant.py "
-                    "--model-id ${RTLGEN_MODEL_NATIVE_GQA_MODEL_ID:-TinyLlama/TinyLlama-1.1B-Chat-v1.0} "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_kv_quant.py "
                     "--expected-gqa-group-size 8 "
                     "--kv-bits-list 8,4 "
                     "--max-prompts 8 "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3272,9 +3272,9 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
                 "evaluate_decoder_attention_kv_model_native_quality",
             ]
             run = work_item.command_manifest[0]["run"]
+            assert "run_hf_eval_python.sh" in run
             assert "evaluate_llm_decoder_model_native_kv_quant.py" in run
             assert "--kv-bits-list 8,4" in run
-            assert "TinyLlama/TinyLlama-1.1B-Chat-v1.0" in run
             assert decoder_inputs["attention_kv_memory_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_kv_model_native_quality__"

--- a/npu/eval/run_hf_eval_python.sh
+++ b/npu/eval/run_hf_eval_python.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if [[ "$#" -lt 1 ]]; then
+  printf 'usage: %s <script> [args...]\n' "$0" >&2
+  exit 2
+fi
+
+declare -a candidates=()
+if [[ -n "${RTLGEN_HF_MATERIALIZER_PYTHON:-}" ]]; then
+  candidates+=("${RTLGEN_HF_MATERIALIZER_PYTHON}")
+fi
+candidates+=("/orfs/tools/AutoTuner/autotuner_env/bin/python3" "python3")
+
+resolve_python() {
+  local candidate="$1"
+  if [[ "${candidate}" == */* ]]; then
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+    return 1
+  fi
+  command -v "${candidate}"
+}
+
+probe_python() {
+  local python_bin="$1"
+  "${python_bin}" - <<'PY'
+import importlib.util
+import sys
+
+required = ("torch", "transformers")
+missing = [name for name in required if importlib.util.find_spec(name) is None]
+if missing:
+    print(
+        "missing Hugging Face eval dependencies: " + ", ".join(missing),
+        file=sys.stderr,
+    )
+    sys.exit(42)
+PY
+}
+
+selected_python=""
+declare -a attempts=()
+for candidate in "${candidates[@]}"; do
+  if ! resolved="$(resolve_python "${candidate}")"; then
+    attempts+=("${candidate}: not found or not executable")
+    printf 'rtlgen hf eval: skipped %s: not found or not executable\n' "${candidate}" >&2
+    continue
+  fi
+
+  if probe_output="$(probe_python "${resolved}" 2>&1)"; then
+    selected_python="${resolved}"
+    break
+  fi
+
+  attempts+=("${resolved}: ${probe_output}")
+  printf 'rtlgen hf eval: skipped %s: %s\n' "${resolved}" "${probe_output}" >&2
+done
+
+if [[ -z "${selected_python}" ]]; then
+  printf 'rtlgen hf eval: no usable Python found.\n' >&2
+  printf 'rtlgen hf eval: set RTLGEN_HF_MATERIALIZER_PYTHON to an interpreter with torch and transformers.\n' >&2
+  for attempt in "${attempts[@]}"; do
+    printf '  - %s\n' "${attempt}" >&2
+  done
+  exit 42
+fi
+
+version="$("${selected_python}" -c 'import sys; print(sys.version.split()[0])')"
+printf 'rtlgen hf eval: using %s (Python %s)\n' "${selected_python}" "${version}" >&2
+
+script="$1"
+shift
+cd "${repo_root}"
+exec "${selected_python}" "${script}" "$@"


### PR DESCRIPTION
## Summary
- add a generic Hugging Face eval Python selector
- run the native GQA KV quality evaluator through that selector instead of plain python3
- keep model selection in the evaluator script via RTLGEN_MODEL_NATIVE_GQA_MODEL_ID/default

## Root cause
The first job run failed before model loading because the worker command used plain python3, which lacks torch/transformers in this environment. The stderr size matches the evaluator script dependency error.

## Validation
- bash -n npu/eval/run_hf_eval_python.sh
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_model_native_kv_quant.py tests/test_llm_decoder_attention_kv_trace_calibration.py tests/test_llm_decoder_attention_kv_native_gqa_proxy.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py