### PR TITLE
[codex] Add native KV4 granularity recovery screen

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -35,6 +35,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_native_gqa_proxy__",
     "decoder_attention_kv_trace_calibration__",
     "decoder_attention_kv_model_native_quality__",
+    "decoder_attention_kv_model_native_recovery__",
 }
 
 _ALLOWED_DATASET_SUFFIXES = {".json", ".md"}

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3517,6 +3517,46 @@ def _decoder_attention_kv_model_native_quality_evidence(*, item_id: str) -> dict
     }
 
 
+def _decoder_attention_kv_model_native_recovery_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_model_native_recovery__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_model_native_recovery__{item_id}.md"
+    native_quality = (
+        f"{base}/decoder_attention_kv_model_native_quality__"
+        "l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_model_native_quality": native_quality,
+            "attention_kv_model_native_recovery_scope": (
+                "Sweep KV4 quantization scale granularity on the same trained native-GQA checkpoint. "
+                "This is a recovery screen before full QAT: tensor-scale failure is already known; "
+                "per-KV-head or per-token-vector recovery would move the next question to hardware scale metadata cost."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_kv_model_native_recovery",
+                "run": (
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_kv_quant.py "
+                    "--expected-gqa-group-size 8 "
+                    "--kv-bits-list 4 "
+                    "--kv-granularity-list tensor,kv_head,token_vector "
+                    "--max-prompts 8 "
+                    "--generation-steps 8 "
+                    "--topk 5 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_output_projection_weight_store_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_output_projection_weight_store_feasibility__{item_id}.json"
@@ -4793,6 +4833,7 @@ def _build_payload(
         "decoder_attention_kv_native_gqa_proxy",
         "decoder_attention_kv_trace_calibration",
         "decoder_attention_kv_model_native_quality",
+        "decoder_attention_kv_model_native_recovery",
         "decoder_output_projection_producer_memory_hierarchy",
         "decoder_output_projection_weight_store_feasibility",
         "decoder_output_projection_weight_store_interface",
@@ -4851,6 +4892,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_trace_calibration_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_model_native_quality":
             decoder_evidence = _decoder_attention_kv_model_native_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_model_native_recovery":
+            decoder_evidence = _decoder_attention_kv_model_native_recovery_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_memory_hierarchy":
             decoder_evidence = _decoder_output_projection_producer_memory_hierarchy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_weight_store_feasibility":

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -63,3 +63,7 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_kv_model_native_quality__l2_decoder_attention_kv_model_native_quality_tinyllama_v1.md"
     )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+    )

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3290,6 +3290,63 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_recovery() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_model_native_recovery_tinyllama_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_model_native_recovery_tinyllama_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_model_native_recovery_tinyllama_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_model_native_recovery",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "evaluate_decoder_attention_kv_model_native_recovery",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "run_hf_eval_python.sh" in run
+            assert "evaluate_llm_decoder_model_native_kv_quant.py" in run
+            assert "--kv-bits-list 4" in run
+            assert "--kv-granularity-list tensor,kv_head,token_vector" in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_model_native_recovery__"
+                "l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+            )
+            assert decoder_inputs["attention_kv_model_native_quality"].endswith(
+                "decoder_attention_kv_model_native_quality__"
+                "l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json"
+            )
+            assert "per-token-vector recovery" in decoder_inputs["attention_kv_model_native_recovery_scope"]
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_model_native_recovery",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_feasibility() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_recovery_tinyllama_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_recovery_tinyllama_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_model_native_recovery_tinyllama_v1",
+  "created_utc": "2026-05-17T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_model_native_recovery",
+  "title": "Native GQA KV4 scale-granularity recovery screen",
+  "hypothesis": "TinyLlama native-GQA post-training tensor-scale KV4 failed next-token ranking, but a finer KV4 scaling granularity may recover enough quality to justify pricing scale metadata before moving to full QAT.",
+  "direct_comparison": {
+    "primary_question": "Can KV4 recover on a trained native-GQA checkpoint by changing quantization scale granularity from whole tensor to per-KV-head or per-token-vector scaling?",
+    "include": [
+      "same trained native-GQA checkpoint and prompt set as the merged native-quality run",
+      "KV4 tensor-scale baseline",
+      "KV4 per-KV-head scale candidate",
+      "KV4 per-token-vector scale candidate",
+      "top-1 match, top-k containment, logit cosine, probability KL, margin, and max logit-delta rollups",
+      "explicit best-KV4 candidate and promotion/hold decision"
+    ],
+    "exclude": [
+      "training or weight updates",
+      "claiming full QAT recovery",
+      "committing Hugging Face model weights",
+      "new physical synthesis or scale-metadata PPA"
+    ]
+  },
+  "expected_benefit": [
+    "separates quantization-granularity recoverability from true training recoverability",
+    "identifies whether the next useful work is scale metadata hardware pricing or actual QAT",
+    "keeps KV8 as the measured safe fallback while testing the closest low-bit recovery point"
+  ],
+  "risks": [
+    "per-token-vector scaling may recover quality but impose metadata and multiply costs that erase KV4 bandwidth benefit",
+    "TinyLlama remains smaller than the target LLaMA7B-class model",
+    "a failure does not prove QAT cannot recover KV4"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_model_native_recovery_tinyllama_v1",
+      "task_type": "l2_campaign",
+      "objective": "Sweep trained native-GQA KV4 quantization scale granularity after tensor-scale KV4 failed.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_model_native_recovery",
+      "cost_class": "medium",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_hf_model_access": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If fine-grain KV4 scaling recovers ranking, price the hardware scale metadata path; otherwise move to QAT/fine-tuning or keep KV8."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_quality__l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_kv_quant.py",
+    "npu/eval/run_hf_eval_python.sh"
+  ]
+}

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -93,6 +93,24 @@ the wrapper tries `/orfs/tools/AutoTuner/autotuner_env/bin/python3` and then
 `python3`. Later reference/candidate commands still use normal `python3` for
 ONNX Runtime inference.
 
+Native-checkpoint quality jobs that run Hugging Face models directly should use
+`run_hf_eval_python.sh` for the same interpreter selection without requiring the
+`onnx` export dependency. The native GQA KV feedback runner supports a recovery
+screen for KV4 scale granularity:
+
+```sh
+bash npu/eval/run_hf_eval_python.sh \
+  npu/eval/evaluate_llm_decoder_model_native_kv_quant.py \
+  --kv-bits-list 4 \
+  --kv-granularity-list tensor,kv_head,token_vector \
+  --out /tmp/native_kv_recovery.json \
+  --out-md /tmp/native_kv_recovery.md
+```
+
+Treat a recovered non-tensor granularity as a hardware metadata/scale-cost
+question, not as QAT evidence. If no granularity recovers top-1/top-k ranking,
+the next quality path is true QAT/fine-tuning or the KV8 fallback.
+
 ## Validation
 Validate campaign manifest:
 ```sh

--- a/npu/eval/evaluate_llm_decoder_model_native_kv_quant.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_kv_quant.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 JsonDict = dict[str, Any]
+CandidateKey = tuple[int, str]
 
 DEFAULT_PROMPTS = [
     "The capital of France is",
@@ -94,20 +95,25 @@ def _decision(candidate_summary: list[JsonDict], *, expected_gqa_group_size: int
         blockers.append(
             f"model_gqa_group_size {actual_gqa_group_size:g} does not match expected {expected_gqa_group_size}"
         )
-    by_bits = {int(row.get("kv_bits", 0)): row for row in candidate_summary}
-    kv4 = by_bits.get(4, {})
-    kv8 = by_bits.get(8, {})
+    kv4_candidates = [row for row in candidate_summary if int(row.get("kv_bits", 0)) == 4]
+    kv8_candidates = [row for row in candidate_summary if int(row.get("kv_bits", 0)) == 8]
+    kv4 = max(kv4_candidates, key=_candidate_rank_key) if kv4_candidates else {}
+    kv8 = max(kv8_candidates, key=_candidate_rank_key) if kv8_candidates else {}
+    kv4_granularity = str(kv4.get("kv_granularity", "tensor") or "tensor")
     if kv8 and _float(kv8.get("top1_match_rate")) < 0.995:
         cautions.append("KV8 changed at least one top-1 decision; check model/runtime determinism before trusting KV4")
     if not kv4:
         blockers.append("KV4 candidate was not evaluated")
     elif _float(kv4.get("top1_match_rate")) < 0.98 or _float(kv4.get("topk_contains_rate")) < 0.995:
-        blockers.append("KV4 changed too many native-checkpoint next-token rankings")
+        blockers.append("Best KV4 candidate changed too many native-checkpoint next-token rankings")
     elif _float(kv4.get("mean_logit_cosine")) < 0.999:
-        cautions.append("KV4 ranking mostly holds, but logit cosine is below the promotion caution line")
+        cautions.append("Best KV4 ranking mostly holds, but logit cosine is below the promotion caution line")
     if blockers:
         status = "hold_for_qat_or_safer_kv_format"
         next_step = "Run QAT/fine-tuning recovery or move the frontier back to KV8 for the native GQA checkpoint."
+    elif kv4_granularity != "tensor":
+        status = "kv4_granularity_recovery_promising"
+        next_step = "Price the recovered KV4 scale granularity in hardware metadata/bandwidth before larger-model confirmation."
     else:
         status = "native_checkpoint_kv4_promising"
         next_step = "Use this checkpoint evidence with the PPA model, then schedule a larger 7B-class or QAT confirmation."
@@ -116,6 +122,7 @@ def _decision(candidate_summary: list[JsonDict], *, expected_gqa_group_size: int
         "blockers": blockers,
         "cautions": cautions,
         "next_step": next_step,
+        "selected_kv4_granularity": kv4_granularity if kv4 else "",
         "thresholds": {
             "kv4_top1_match_min": 0.98,
             "kv4_topk_contains_min": 0.995,
@@ -151,6 +158,26 @@ def _parse_bits(value: str) -> list[int]:
     return bits
 
 
+def _parse_granularities(value: str) -> list[str]:
+    allowed = {"tensor", "kv_head", "token_vector"}
+    granularities = [item.strip() for item in value.split(",") if item.strip()]
+    if not granularities:
+        raise argparse.ArgumentTypeError("expected comma-separated KV quantization granularities")
+    invalid = sorted(set(granularities) - allowed)
+    if invalid:
+        raise argparse.ArgumentTypeError(f"unsupported KV quantization granularities: {', '.join(invalid)}")
+    return granularities
+
+
+def _candidate_rank_key(row: JsonDict) -> tuple[float, float, float, float]:
+    return (
+        _float(row.get("top1_match_rate")),
+        _float(row.get("topk_contains_rate")),
+        _float(row.get("mean_logit_cosine")),
+        -_float(row.get("mean_probability_kl")),
+    )
+
+
 def _write_report_md(payload: JsonDict) -> str:
     lines = [
         "# Native GQA KV Quantization Quality",
@@ -167,13 +194,14 @@ def _write_report_md(payload: JsonDict) -> str:
         "",
         "## Candidates",
         "",
-        "| kv_bits | comparisons | top1 | topk | cosine | kl | min_margin | max_delta |",
-        "|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| kv_bits | granularity | comparisons | top1 | topk | cosine | kl | min_margin | max_delta |",
+        "|---:|---|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for row in payload["candidate_summary"]:
         lines.append(
-            "| {kv_bits} | {comparison_count} | {top1:.6f} | {topk:.6f} | {cosine:.6f} | {kl:.6f} | {margin:.6f} | {delta:.6f} |".format(
+            "| {kv_bits} | {granularity} | {comparison_count} | {top1:.6f} | {topk:.6f} | {cosine:.6f} | {kl:.6f} | {margin:.6f} | {delta:.6f} |".format(
                 kv_bits=row["kv_bits"],
+                granularity=row.get("kv_granularity", "tensor"),
                 comparison_count=row["comparison_count"],
                 top1=row["top1_match_rate"],
                 topk=row["topk_contains_rate"],
@@ -223,7 +251,7 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
 
     levels_by_bits = {bits: (1 << (bits - 1)) - 1 for bits in args.kv_bits_list}
 
-    def quantize_tensor(tensor: Any, bits: int) -> Any:
+    def quantize_tensor_slice(tensor: Any, bits: int) -> Any:
         if not torch.is_tensor(tensor):
             return tensor
         levels = levels_by_bits[bits]
@@ -234,21 +262,45 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
         scale = max_abs / float(levels)
         return torch.clamp(torch.round(data / scale), -levels, levels).to(data.dtype) * scale
 
-    def quantize_past(past: Any, bits: int) -> Any:
+    def quantize_tensor(tensor: Any, bits: int, granularity: str) -> Any:
+        if not torch.is_tensor(tensor):
+            return tensor
+        data = tensor.detach()
+        if granularity == "tensor" or data.ndim < 4:
+            return quantize_tensor_slice(data, bits)
+        if granularity == "kv_head":
+            out = data.clone()
+            for batch in range(data.shape[0]):
+                for head in range(data.shape[1]):
+                    out[batch, head, :, :] = quantize_tensor_slice(data[batch, head, :, :], bits)
+            return out
+        if granularity == "token_vector":
+            out = data.clone()
+            for batch in range(data.shape[0]):
+                for head in range(data.shape[1]):
+                    for token in range(data.shape[2]):
+                        out[batch, head, token, :] = quantize_tensor_slice(data[batch, head, token, :], bits)
+            return out
+        raise SystemExit(f"unsupported KV quantization granularity: {granularity}")
+
+    def quantize_past(past: Any, bits: int, granularity: str) -> Any:
         if past is None:
             return None
         if torch.is_tensor(past):
-            return quantize_tensor(past, bits)
+            return quantize_tensor(past, bits, granularity)
         if isinstance(past, tuple):
-            return tuple(quantize_past(item, bits) for item in past)
+            return tuple(quantize_past(item, bits, granularity) for item in past)
         if isinstance(past, list):
-            return [quantize_past(item, bits) for item in past]
+            return [quantize_past(item, bits, granularity) for item in past]
         if hasattr(past, "to_legacy_cache"):
             legacy = past.to_legacy_cache()
-            return tuple(quantize_past(item, bits) for item in legacy)
+            return tuple(quantize_past(item, bits, granularity) for item in legacy)
         return past
 
-    rows_by_bits: dict[int, list[JsonDict]] = {bits: [] for bits in args.kv_bits_list}
+    candidate_keys: list[CandidateKey] = [
+        (bits, granularity) for bits in args.kv_bits_list for granularity in args.kv_granularity_list
+    ]
+    rows_by_candidate: dict[CandidateKey, list[JsonDict]] = {key: [] for key in candidate_keys}
     prompt_records: list[JsonDict] = []
     with torch.no_grad():
         for prompt_index, prompt in enumerate(prompts):
@@ -266,7 +318,10 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
                     "prefill_reference_margin": ref_logits[ref_top[0]] - ref_logits[ref_top[1]],
                 }
             )
-            candidate_past = {bits: quantize_past(fp_past, bits) for bits in args.kv_bits_list}
+            candidate_past = {
+                key: quantize_past(fp_past, key[0], key[1])
+                for key in candidate_keys
+            }
             next_input = torch.tensor([[ref_top[0]]], dtype=torch.long, device=device)
             for step in range(args.generation_steps):
                 ref_out = model(input_ids=next_input, past_key_values=fp_past, use_cache=True)
@@ -276,17 +331,19 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
                 ref_order = _topk(ref_logits, max(2, args.topk))
                 ref_next = ref_order[0]
                 ref_margin = ref_logits[ref_order[0]] - ref_logits[ref_order[1]]
-                for bits in args.kv_bits_list:
-                    cand_out = model(input_ids=next_input, past_key_values=candidate_past[bits], use_cache=True)
-                    candidate_past[bits] = quantize_past(cand_out.past_key_values, bits)
+                for bits, granularity in candidate_keys:
+                    key = (bits, granularity)
+                    cand_out = model(input_ids=next_input, past_key_values=candidate_past[key], use_cache=True)
+                    candidate_past[key] = quantize_past(cand_out.past_key_values, bits, granularity)
                     cand_logits = cand_out.logits[:, -1, :].float().cpu().reshape(-1).tolist()
                     cand_probs = _safe_exp_softmax(cand_logits)
                     cand_order = _topk(cand_logits, args.topk)
-                    rows_by_bits[bits].append(
+                    rows_by_candidate[key].append(
                         {
                             "prompt_index": prompt_index,
                             "step": step,
                             "kv_bits": bits,
+                            "kv_granularity": granularity,
                             "reference_top1": ref_next,
                             "candidate_top1": cand_order[0],
                             "top1_match": 1.0 if cand_order[0] == ref_next else 0.0,
@@ -300,12 +357,15 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
                 next_input = torch.tensor([[ref_next]], dtype=torch.long, device=device)
 
     candidate_summary: list[JsonDict] = []
-    for bits in args.kv_bits_list:
-        summary = _summarize_rows(rows_by_bits[bits])
+    for bits, granularity in candidate_keys:
+        summary = _summarize_rows(rows_by_candidate[(bits, granularity)])
         summary["kv_bits"] = bits
+        summary["kv_granularity"] = granularity
         candidate_summary.append(summary)
+    best_kv4_candidates = [row for row in candidate_summary if int(row.get("kv_bits", 0)) == 4]
+    best_kv4 = max(best_kv4_candidates, key=_candidate_rank_key) if best_kv4_candidates else None
     return {
-        "version": 0.1,
+        "version": 0.2,
         "model": {
             "model_id": model_id,
             "attention_heads": attention_heads,
@@ -317,8 +377,10 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
         "prompt_count": len(prompts),
         "generation_steps": args.generation_steps,
         "topk": args.topk,
+        "kv_granularity_list": args.kv_granularity_list,
         "prompt_records": prompt_records,
         "candidate_summary": candidate_summary,
+        "best_kv4_candidate": best_kv4,
         "decision": _decision(
             candidate_summary,
             expected_gqa_group_size=args.expected_gqa_group_size,
@@ -340,6 +402,7 @@ def main() -> int:
     parser.add_argument("--generation-steps", type=int, default=8)
     parser.add_argument("--topk", type=int, default=5)
     parser.add_argument("--kv-bits-list", type=_parse_bits, default=[8, 4])
+    parser.add_argument("--kv-granularity-list", type=_parse_granularities, default=["tensor"])
     parser.add_argument("--expected-gqa-group-size", type=int, default=8)
     parser.add_argument("--device", default="auto", choices=["auto", "cpu", "cuda"])
     parser.add_argument("--out", required=True)

--- a/tests/test_llm_decoder_model_native_kv_quant.py
+++ b/tests/test_llm_decoder_model_native_kv_quant.py
@@ -44,6 +44,35 @@ def test_decision_advances_when_native_checkpoint_kv4_rankings_hold() -> None:
     assert decision["blockers"] == []
 
 
+def test_decision_marks_non_tensor_kv4_granularity_as_recovery_candidate() -> None:
+    decision = _decision(
+        [
+            {
+                "kv_bits": 4,
+                "kv_granularity": "tensor",
+                "top1_match_rate": 0.75,
+                "topk_contains_rate": 0.9,
+                "mean_logit_cosine": 0.98,
+                "mean_probability_kl": 0.2,
+            },
+            {
+                "kv_bits": 4,
+                "kv_granularity": "token_vector",
+                "top1_match_rate": 1.0,
+                "topk_contains_rate": 1.0,
+                "mean_logit_cosine": 0.9999,
+                "mean_probability_kl": 0.0001,
+            },
+        ],
+        expected_gqa_group_size=8,
+        actual_gqa_group_size=8.0,
+    )
+
+    assert decision["status"] == "kv4_granularity_recovery_promising"
+    assert decision["selected_kv4_granularity"] == "token_vector"
+    assert decision["blockers"] == []
+
+
 def test_decision_blocks_wrong_gqa_group_or_kv4_rank_regression() -> None:
     decision = _decision(
         [
@@ -56,4 +85,4 @@ def test_decision_blocks_wrong_gqa_group_or_kv4_rank_regression() -> None:
 
     assert decision["status"] == "hold_for_qat_or_safer_kv_format"
     assert any("model_gqa_group_size" in blocker for blocker in decision["blockers"])
-    assert any("KV4 changed too many" in blocker for blocker in decision["blockers"])
+    assert any("KV4 candidate changed too many" in blocker for blocker in decision["blockers"])


### PR DESCRIPTION
## Summary
- extend the native GQA KV evaluator with KV scale granularity options: tensor, kv_head, token_vector
- add an L2 native KV4 recovery job/proposal after the TinyLlama tensor-scale KV4 failure
- allow the new compact recovery artifact in transport policy and document the HF eval/recovery workflow

## Validation
- python3 -m py_compile npu/eval/evaluate_llm_decoder_model_native_kv_quant.py
- python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_model_native_recovery_tinyllama_v1/proposal.json
- /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_model_native_kv_quant.py tests/test_llm_decoder_attention_kv_trace_calibration.py tests/test_llm_decoder_attention_kv_native_gqa_proxy.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py

## Intent
If fine-grain KV4 scaling recovers ranking, the next question is hardware metadata/scale cost. If it does not, the frontier should move to true QAT/fine-tuning or stay with KV8.