### PR TITLE
npu: add quality-backed kv8 hbm frontier

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -30,6 +30,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_spill_scheduler__",
     "decoder_attention_kv_hbm_controller__",
     "decoder_attention_kv_physical_hbm_frontier__",
+    "decoder_attention_kv_physical_hbm_quality_backed__",
     "decoder_attention_kv_quality_gate__",
     "decoder_attention_kv_quality_proxy__",
     "decoder_attention_kv_native_gqa_proxy__",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3331,6 +3331,84 @@ def _decoder_attention_kv_physical_hbm_frontier_evidence(*, item_id: str) -> dic
     }
 
 
+def _decoder_attention_kv_physical_hbm_quality_backed_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_physical_hbm_quality_backed__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_physical_hbm_quality_backed__{item_id}.md"
+    native_quality = (
+        f"{base}/decoder_attention_kv_model_native_quality__"
+        "l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json"
+    )
+    native_recovery = (
+        f"{base}/decoder_attention_kv_model_native_recovery__"
+        "l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+    )
+    physical_frontier = (
+        f"{base}/decoder_attention_kv_physical_hbm_frontier__"
+        "l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_model_native_quality": native_quality,
+            "attention_kv_model_native_recovery": native_recovery,
+            "attention_kv_physical_hbm_frontier": physical_frontier,
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_physical_hbm_quality_backed_out": out,
+            "attention_kv_physical_hbm_quality_backed_report": report,
+            "attention_kv_physical_hbm_quality_backed_scope": (
+                "Quality-backed physical-HBM frontier for llama7b_proxy decode. "
+                "Constrain the physical sweep to native-GQA group-8 KV storage with "
+                "KV16 and KV8 only: native TinyLlama evidence accepts KV8, while "
+                "KV4 remains below top-1/top-k thresholds even with per-token-vector "
+                "scaling. MQA and other structural KV sharing are excluded until "
+                "trained-checkpoint quality evidence exists."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_physical_hbm_quality_backed",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py "
+                    "--label llama7b_proxy "
+                    "--sequence-length-list 32768,65536,131072 "
+                    "--die-area-mm2-list 100,200,400 "
+                    "--kv-sharing-list gqa8 "
+                    "--kv-bits-list 16,8 "
+                    "--stack-count-list 1,2,4,8 "
+                    "--pseudo-channels-per-stack-list 8,16 "
+                    "--pseudo-channel-width-bits-list 64 "
+                    "--data-rate-mtps-list 3200,6400,9000 "
+                    "--hbm-efficiency-list 0.35,0.55,0.75 "
+                    "--tile-tokens-list 512,1024 "
+                    "--prefetch-distance-tiles-list 4 "
+                    "--hbm-outstanding-list 8,16 "
+                    "--arbitration-efficiency-list 0.85 "
+                    "--virtual-channel-list 4 "
+                    "--prefetch-start-list during_qkv "
+                    "--sram-area-fraction 0.6 "
+                    "--usable-sram-fraction 0.7 "
+                    "--bitcell-area-um2-per-bit 0.02 "
+                    "--local-sram-fraction 0.25 "
+                    "--bank-count 16 "
+                    "--bank-bandwidth-bytes-per-cycle 1024 "
+                    "--bank-interleave-tokens 16 "
+                    "--bank-conflict-efficiency 0.75 "
+                    "--noc-bandwidth-bytes-per-cycle 16384 "
+                    "--noc-hops 1 "
+                    "--router-latency-cycles-per-hop 2 "
+                    "--macs-per-cycle 524288 "
+                    "--vector-ops-per-cycle 65536 "
+                    "--clock-ns 1.0 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
@@ -4828,6 +4906,7 @@ def _build_payload(
         "decoder_attention_kv_spill_scheduler",
         "decoder_attention_kv_hbm_controller",
         "decoder_attention_kv_physical_hbm_frontier",
+        "decoder_attention_kv_physical_hbm_quality_backed",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
@@ -4882,6 +4961,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_hbm_controller_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_frontier":
             decoder_evidence = _decoder_attention_kv_physical_hbm_frontier_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_quality_backed":
+            decoder_evidence = _decoder_attention_kv_physical_hbm_quality_backed_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -45,6 +45,11 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
     )
     assert is_transportable_expected_output(
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_physical_hbm_quality_backed__"
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1.json"
+    )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_kv_quality_gate__l2_decoder_attention_kv_quality_gate_llama7b_v1.md"
     )
     assert is_transportable_expected_output(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3027,6 +3027,70 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_fronti
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_quality_backed() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_physical_hbm_quality_backed",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_attention_kv_physical_hbm_quality_backed",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_attention_kv_physical_hbm_frontier.py" in run
+            assert "--kv-sharing-list gqa8" in run
+            assert "--kv-bits-list 16,8" in run
+            assert "--kv-bits-list 16,8,4" not in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_physical_hbm_quality_backed__"
+                "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_kv_model_native_quality"].endswith(
+                "decoder_attention_kv_model_native_quality__"
+                "l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json"
+            )
+            assert decoder_inputs["attention_kv_model_native_recovery"].endswith(
+                "decoder_attention_kv_model_native_recovery__"
+                "l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+            )
+            assert (
+                "Quality-backed physical-HBM"
+                in decoder_inputs["attention_kv_physical_hbm_quality_backed_scope"]
+            )
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_physical_hbm_quality_backed",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_attention_kv_quality_gate() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1",
+  "created_utc": "2026-05-17T10:25:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_physical_hbm_quality_backed",
+  "title": "Llama7B quality-backed native-GQA KV8 physical HBM frontier",
+  "hypothesis": "After trained-checkpoint evidence rejected post-training KV4, the immediate physical frontier should be rescored with only native-GQA group-8 KV16/KV8 points so architecture ranking is not dominated by unsafe KV4 or unproven MQA byte reductions.",
+  "direct_comparison": {
+    "primary_question": "Under the physical HBM model, how much of the long-context llama7b_proxy bottleneck remains when the ranked choices are restricted to quality-backed native-GQA KV16 and KV8?",
+    "include": [
+      "llama7b_proxy at 32k, 64k, and 131k tokens",
+      "die areas 100, 200, and 400 mm2",
+      "native-GQA group-8 KV sharing only",
+      "packed KV16 and KV8 storage only",
+      "HBM stack counts 1, 2, 4, and 8",
+      "pseudo-channels per stack 8 and 16",
+      "data rates 3200, 6400, and 9000 MT/s",
+      "aggregate HBM efficiency 0.35, 0.55, and 0.75"
+    ],
+    "exclude": [
+      "KV4 points rejected by native-checkpoint quality and granularity recovery evidence",
+      "MQA or other structural KV sharing without trained-checkpoint quality evidence",
+      "JEDEC-accurate HBM timing",
+      "cycle-accurate NoC arbitration",
+      "QAT or fine-tuning"
+    ]
+  },
+  "expected_benefit": [
+    "separates physically attractive but quality-unsafe KV4/MQA points from the current deployable frontier",
+    "shows whether KV8 still leaves HBM as the dominant limiter at 131k context",
+    "identifies the next practical target: HBM/SRAM scheduling if KV8 is still memory-bound, or true QAT if KV4 savings are required"
+  ],
+  "risks": [
+    "TinyLlama native-GQA evidence is a proxy for larger llama-family checkpoints and should be repeated on larger models when feasible",
+    "the HBM model remains a bandwidth/service model rather than a detailed DRAM timing trace",
+    "KV8 is quality-backed only for the sampled teacher-forced prompt set"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the quality-backed physical-HBM frontier restricted to native-GQA KV16/KV8.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_physical_hbm_quality_backed",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1",
+        "l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2",
+        "l2_decoder_attention_kv_model_native_recovery_tinyllama_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the quality-backed KV16/KV8 physical frontier to decide between continued HBM/SRAM scheduling work and a separate QAT/fine-tuning recovery track for KV4."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_frontier__l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_quality__l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py",
+    "npu/eval/evaluate_llm_decoder_model_native_kv_quant.py",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a quality-backed physical-HBM frontier abstraction restricted to native-GQA group-8 KV16/KV8
- link the new job to native TinyLlama KV quality and recovery evidence so unsafe KV4/MQA points do not dominate rankings
- add artifact-policy and generator coverage for the new dataset prefix

## Tests
- python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1/proposal.json >/dev/null
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py
- python3 npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py --label llama7b_proxy --sequence-length-list 32768 --die-area-mm2-list 100 --kv-sharing-list gqa8 --kv-bits-list 16,8 --stack-count-list 1 --pseudo-channels-per-stack-list 8 --pseudo-channel-width-bits-list 64 --data-rate-mtps-list 3200 --hbm-efficiency-list 0.35 --tile-tokens-list 512 --prefetch-distance-tiles-list 4 --hbm-outstanding-list 8 --arbitration-efficiency-list 0.85 --virtual-channel-list 4 --prefetch-start-list during_qkv --out /tmp/.../out.json --out-md /tmp/.../out.md