### PR TITLE
npu: add quality-backed kv memory noc sweep

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -31,6 +31,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_hbm_controller__",
     "decoder_attention_kv_physical_hbm_frontier__",
     "decoder_attention_kv_physical_hbm_quality_backed__",
+    "decoder_attention_kv_physical_hbm_memory_noc__",
     "decoder_attention_kv_quality_gate__",
     "decoder_attention_kv_quality_proxy__",
     "decoder_attention_kv_native_gqa_proxy__",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3409,6 +3409,76 @@ def _decoder_attention_kv_physical_hbm_quality_backed_evidence(*, item_id: str) 
     }
 
 
+def _decoder_attention_kv_physical_hbm_memory_noc_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_physical_hbm_memory_noc__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_physical_hbm_memory_noc__{item_id}.md"
+    quality_backed = (
+        f"{base}/decoder_attention_kv_physical_hbm_quality_backed__"
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1.json"
+    )
+    native_recovery = (
+        f"{base}/decoder_attention_kv_model_native_recovery__"
+        "l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_physical_hbm_quality_backed": quality_backed,
+            "attention_kv_model_native_recovery": native_recovery,
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_physical_hbm_memory_noc_scope": (
+                "Quality-backed native-GQA KV8 memory/NoC sensitivity at 131k context. "
+                "Keep KV4 and MQA out of the ranking, then vary die size, SRAM area/use "
+                "fraction, local/shared split, bank service, NoC bandwidth/hops, tile size, "
+                "and HBM service to see whether the optimum moves from HBM-bound to SRAM/NoC "
+                "or compute-bound under practical physical constraints."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_physical_hbm_memory_noc",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py "
+                    "--label llama7b_proxy "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 100,200,400,800,1200 "
+                    "--kv-sharing-list gqa8 "
+                    "--kv-bits-list 8,16 "
+                    "--stack-count-list 8 "
+                    "--pseudo-channels-per-stack-list 16 "
+                    "--pseudo-channel-width-bits-list 64 "
+                    "--data-rate-mtps-list 6400,9000 "
+                    "--hbm-efficiency-list 0.55,0.75 "
+                    "--tile-tokens-list 512,1024 "
+                    "--prefetch-distance-tiles-list 4 "
+                    "--hbm-outstanding-list 8,16 "
+                    "--arbitration-efficiency-list 0.85 "
+                    "--virtual-channel-list 4 "
+                    "--prefetch-start-list during_qkv "
+                    "--sram-area-fraction 0.4,0.6,0.75 "
+                    "--usable-sram-fraction 0.7,0.85 "
+                    "--bitcell-area-um2-per-bit 0.02,0.05 "
+                    "--local-sram-fraction 0.1,0.25,0.5 "
+                    "--bank-count 16,64 "
+                    "--bank-bandwidth-bytes-per-cycle 512,2048 "
+                    "--bank-interleave-tokens 16 "
+                    "--bank-conflict-efficiency 0.75 "
+                    "--noc-bandwidth-bytes-per-cycle 8192,32768 "
+                    "--noc-hops 1,4 "
+                    "--router-latency-cycles-per-hop 2 "
+                    "--macs-per-cycle 524288 "
+                    "--vector-ops-per-cycle 65536 "
+                    "--clock-ns 1.0 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
@@ -4907,6 +4977,7 @@ def _build_payload(
         "decoder_attention_kv_hbm_controller",
         "decoder_attention_kv_physical_hbm_frontier",
         "decoder_attention_kv_physical_hbm_quality_backed",
+        "decoder_attention_kv_physical_hbm_memory_noc",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
@@ -4963,6 +5034,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_physical_hbm_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_quality_backed":
             decoder_evidence = _decoder_attention_kv_physical_hbm_quality_backed_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_memory_noc":
+            decoder_evidence = _decoder_attention_kv_physical_hbm_memory_noc_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -50,6 +50,11 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
     )
     assert is_transportable_expected_output(
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_physical_hbm_memory_noc__"
+        "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1.json"
+    )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_kv_quality_gate__l2_decoder_attention_kv_quality_gate_llama7b_v1.md"
     )
     assert is_transportable_expected_output(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3091,6 +3091,68 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_qualit
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_memory_noc() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_physical_hbm_memory_noc",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_attention_kv_physical_hbm_memory_noc",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_attention_kv_physical_hbm_frontier.py" in run
+            assert "--sequence-length-list 131072" in run
+            assert "--kv-sharing-list gqa8" in run
+            assert "--kv-bits-list 8,16" in run
+            assert "--sram-area-fraction 0.4,0.6,0.75" in run
+            assert "--noc-hops 1,4" in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_physical_hbm_memory_noc__"
+                "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_kv_physical_hbm_quality_backed"].endswith(
+                "decoder_attention_kv_physical_hbm_quality_backed__"
+                "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1.json"
+            )
+            assert (
+                "memory/NoC sensitivity"
+                in decoder_inputs["attention_kv_physical_hbm_memory_noc_scope"]
+            )
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_physical_hbm_memory_noc",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_attention_kv_quality_gate() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1",
+  "created_utc": "2026-05-17T10:35:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_physical_hbm_memory_noc",
+  "title": "Llama7B quality-backed KV8 memory/NoC sensitivity at 131k context",
+  "hypothesis": "For quality-backed native-GQA KV8 at 131k context, the optimum remains HBM-dominated across practical monolithic die sizes unless SRAM allocation and NoC service are large enough to keep a much larger KV fraction resident.",
+  "direct_comparison": {
+    "primary_question": "How does the best memory and NoC architecture move with die size when llama7b_proxy is restricted to quality-backed native-GQA KV8/KV16 at 131k context?",
+    "include": [
+      "llama7b_proxy at 131k tokens",
+      "native-GQA group-8 only",
+      "KV8 and KV16 only",
+      "die sizes 100, 200, 400, 800, and 1200 mm2",
+      "SRAM area fractions 0.4, 0.6, and 0.75",
+      "usable SRAM fractions 0.7 and 0.85",
+      "bitcell area points 0.02 and 0.05 um2/bit",
+      "local/shared SRAM split points 0.1, 0.25, and 0.5 local",
+      "NoC bandwidth and hop-count sensitivity",
+      "bank count and bank bandwidth sensitivity"
+    ],
+    "exclude": [
+      "KV4, because native-checkpoint recovery failed the top-1/top-k quality gate",
+      "MQA or non-native KV sharing, because trained-checkpoint quality evidence is not available",
+      "JEDEC-accurate HBM timing",
+      "cycle-accurate NoC arbitration",
+      "SRAM macro floorplanning"
+    ]
+  },
+  "expected_benefit": [
+    "shows whether the practical frontier is still HBM service, SRAM capacity, shared-bank service, or NoC topology",
+    "turns the previous fixed-SRAM physical-HBM result into a die-size and memory-hierarchy sensitivity",
+    "identifies whether the next architectural work should target SRAM residency, HBM controller service, NoC scheduling, or KV4 QAT recovery"
+  ],
+  "risks": [
+    "large SRAM fractions and 800-1200 mm2 points are planning bounds, not proof of manufacturable single-die implementation",
+    "bitcell-area points are coarse and do not include periphery, ECC, repair, or macro floorplan loss",
+    "the model remains a bandwidth/service approximation, so detailed NoC and SRAM macro evaluation is still required for selected points"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Sweep quality-backed native-GQA KV8/KV16 131k physical-HBM points across die size, SRAM allocation, bank service, and NoC service.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_physical_hbm_memory_noc",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1",
+        "l2_decoder_attention_kv_model_native_recovery_tinyllama_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If the best 131k points remain HBM-bound, prioritize HBM service and KV compression/QAT; if SRAM/NoC dominates at large die sizes, select those points for detailed memory hierarchy modeling."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed__l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py",
+    "docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed__l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1.md"
+  ]
+}

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -541,3 +541,28 @@ Outputs:
 - `objective_sweep.csv`
 - `objective_sweep.md`
 - per-profile reports under `objective_profiles/<profile>/`
+
+## Decoder Attention/KV Physical HBM Model
+`estimate_llm_decoder_attention_kv_physical_hbm_frontier.py` is the planning
+model for long-context KV-cache service. It derives HBM bytes/cycle from stack
+count, pseudo-channel count, interface width, transfer rate, and core clock,
+then combines that with shared-SRAM residency, bank service, NoC service, tile
+size, and prefetch depth.
+
+The scalar memory and NoC options also accept comma-separated sweeps. This keeps
+quality-backed jobs from ranking unsafe KV4/MQA points while still testing how
+the optimum moves with die size and memory hierarchy assumptions:
+
+```sh
+python3 npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py \
+  --sequence-length-list 131072 \
+  --kv-sharing-list gqa8 \
+  --kv-bits-list 8,16 \
+  --sram-area-fraction 0.4,0.6,0.75 \
+  --noc-bandwidth-bytes-per-cycle 8192,32768 \
+  --noc-hops 1,4 \
+  --out /tmp/kv.json --out-md /tmp/kv.md
+```
+
+Treat high SRAM fractions and very large die points as planning bounds until
+they are backed by SRAM macro/floorplan data.

--- a/npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import itertools
 import heapq
 import json
 import math
@@ -291,9 +292,20 @@ def _shape_row(
         "kv_heads": kv_heads,
         "kv_bits": kv_bits,
         "kv_cache_mib": round(kv_cache_bytes / (1024 * 1024), 6),
+        "sram_area_fraction": sram_area_fraction,
+        "usable_sram_fraction": usable_sram_fraction,
+        "bitcell_area_um2_per_bit": bitcell_area_um2_per_bit,
+        "local_sram_fraction": local_sram_fraction,
         "total_sram_mib": round(total_sram_bytes / (1024 * 1024), 6),
         "shared_capacity_mib": round(shared_capacity_bytes / (1024 * 1024), 6),
         "hbm_byte_share": round(hbm_read_share, 6),
+        "bank_count": bank_count,
+        "bank_bandwidth_bytes_per_cycle": bank_bandwidth_bytes_per_cycle,
+        "bank_interleave_tokens": bank_interleave_tokens,
+        "bank_conflict_efficiency": bank_conflict_efficiency,
+        "noc_bandwidth_bytes_per_cycle": noc_bandwidth_bytes_per_cycle,
+        "noc_hops": noc_hops,
+        "router_latency_cycles_per_hop": router_latency_cycles_per_hop,
         "stack_count": stack_count,
         "pseudo_channels_per_stack": pseudo_channels_per_stack,
         "pseudo_channel_width_bits": pseudo_channel_width_bits,
@@ -344,17 +356,17 @@ def build_report(
     arbitration_efficiency_list: list[float],
     virtual_channel_list: list[int],
     prefetch_start_list: list[str],
-    sram_area_fraction: float,
-    usable_sram_fraction: float,
-    bitcell_area_um2_per_bit: float,
-    local_sram_fraction: float,
-    bank_count: int,
-    bank_bandwidth_bytes_per_cycle: float,
-    bank_interleave_tokens: int,
-    bank_conflict_efficiency: float,
-    noc_bandwidth_bytes_per_cycle: float,
-    noc_hops: int,
-    router_latency_cycles_per_hop: int,
+    sram_area_fraction_list: list[float],
+    usable_sram_fraction_list: list[float],
+    bitcell_area_um2_per_bit_list: list[float],
+    local_sram_fraction_list: list[float],
+    bank_count_list: list[int],
+    bank_bandwidth_bytes_per_cycle_list: list[float],
+    bank_interleave_tokens_list: list[int],
+    bank_conflict_efficiency_list: list[float],
+    noc_bandwidth_bytes_per_cycle_list: list[float],
+    noc_hops_list: list[int],
+    router_latency_cycles_per_hop_list: list[int],
     macs_per_cycle: int,
     vector_ops_per_cycle: int,
     clock_ns: float,
@@ -366,56 +378,97 @@ def build_report(
         raise ValueError(f"unsupported label: {label}")
     shape = shapes[label]
     rows: list[JsonDict] = []
-    for sequence_length in sequence_length_list:
-        for die_area_mm2 in die_area_mm2_list:
-            for kv_sharing in kv_sharing_list:
-                for kv_bits in kv_bits_list:
-                    for stack_count in stack_count_list:
-                        for pseudo_channels_per_stack in pseudo_channels_per_stack_list:
-                            for pseudo_channel_width_bits in pseudo_channel_width_bits_list:
-                                for data_rate_mtps in data_rate_mtps_list:
-                                    for hbm_efficiency in hbm_efficiency_list:
-                                        for tile_tokens in tile_tokens_list:
-                                            for prefetch_distance_tiles in prefetch_distance_tiles_list:
-                                                for hbm_outstanding in hbm_outstanding_list:
-                                                    for arbitration_efficiency in arbitration_efficiency_list:
-                                                        for virtual_channels in virtual_channel_list:
-                                                            for prefetch_start in prefetch_start_list:
-                                                                rows.append(
-                                                                    _shape_row(
-                                                                        label=label,
-                                                                        sequence_length=sequence_length,
-                                                                        die_area_mm2=die_area_mm2,
-                                                                        kv_sharing=kv_sharing,
-                                                                        kv_bits=kv_bits,
-                                                                        stack_count=stack_count,
-                                                                        pseudo_channels_per_stack=pseudo_channels_per_stack,
-                                                                        pseudo_channel_width_bits=pseudo_channel_width_bits,
-                                                                        data_rate_mtps=data_rate_mtps,
-                                                                        hbm_efficiency=hbm_efficiency,
-                                                                        tile_tokens=tile_tokens,
-                                                                        prefetch_distance_tiles=prefetch_distance_tiles,
-                                                                        hbm_outstanding=hbm_outstanding,
-                                                                        arbitration_efficiency=arbitration_efficiency,
-                                                                        virtual_channels=virtual_channels,
-                                                                        prefetch_start=prefetch_start,
-                                                                        sram_area_fraction=sram_area_fraction,
-                                                                        usable_sram_fraction=usable_sram_fraction,
-                                                                        bitcell_area_um2_per_bit=bitcell_area_um2_per_bit,
-                                                                        local_sram_fraction=local_sram_fraction,
-                                                                        bank_count=bank_count,
-                                                                        bank_bandwidth_bytes_per_cycle=bank_bandwidth_bytes_per_cycle,
-                                                                        bank_interleave_tokens=bank_interleave_tokens,
-                                                                        bank_conflict_efficiency=bank_conflict_efficiency,
-                                                                        noc_bandwidth_bytes_per_cycle=noc_bandwidth_bytes_per_cycle,
-                                                                        noc_hops=noc_hops,
-                                                                        router_latency_cycles_per_hop=router_latency_cycles_per_hop,
-                                                                        macs_per_cycle=macs_per_cycle,
-                                                                        vector_ops_per_cycle=vector_ops_per_cycle,
-                                                                        clock_ns=clock_ns,
-                                                                        **shape,
-                                                                    )
-                                                                )
+    sweep_axes = (
+        sequence_length_list,
+        die_area_mm2_list,
+        kv_sharing_list,
+        kv_bits_list,
+        stack_count_list,
+        pseudo_channels_per_stack_list,
+        pseudo_channel_width_bits_list,
+        data_rate_mtps_list,
+        hbm_efficiency_list,
+        tile_tokens_list,
+        prefetch_distance_tiles_list,
+        hbm_outstanding_list,
+        arbitration_efficiency_list,
+        virtual_channel_list,
+        prefetch_start_list,
+        sram_area_fraction_list,
+        usable_sram_fraction_list,
+        bitcell_area_um2_per_bit_list,
+        local_sram_fraction_list,
+        bank_count_list,
+        bank_bandwidth_bytes_per_cycle_list,
+        bank_interleave_tokens_list,
+        bank_conflict_efficiency_list,
+        noc_bandwidth_bytes_per_cycle_list,
+        noc_hops_list,
+        router_latency_cycles_per_hop_list,
+    )
+    for (
+        sequence_length,
+        die_area_mm2,
+        kv_sharing,
+        kv_bits,
+        stack_count,
+        pseudo_channels_per_stack,
+        pseudo_channel_width_bits,
+        data_rate_mtps,
+        hbm_efficiency,
+        tile_tokens,
+        prefetch_distance_tiles,
+        hbm_outstanding,
+        arbitration_efficiency,
+        virtual_channels,
+        prefetch_start,
+        sram_area_fraction,
+        usable_sram_fraction,
+        bitcell_area_um2_per_bit,
+        local_sram_fraction,
+        bank_count,
+        bank_bandwidth_bytes_per_cycle,
+        bank_interleave_tokens,
+        bank_conflict_efficiency,
+        noc_bandwidth_bytes_per_cycle,
+        noc_hops,
+        router_latency_cycles_per_hop,
+    ) in itertools.product(*sweep_axes):
+        rows.append(
+            _shape_row(
+                label=label,
+                sequence_length=sequence_length,
+                die_area_mm2=die_area_mm2,
+                kv_sharing=kv_sharing,
+                kv_bits=kv_bits,
+                stack_count=stack_count,
+                pseudo_channels_per_stack=pseudo_channels_per_stack,
+                pseudo_channel_width_bits=pseudo_channel_width_bits,
+                data_rate_mtps=data_rate_mtps,
+                hbm_efficiency=hbm_efficiency,
+                tile_tokens=tile_tokens,
+                prefetch_distance_tiles=prefetch_distance_tiles,
+                hbm_outstanding=hbm_outstanding,
+                arbitration_efficiency=arbitration_efficiency,
+                virtual_channels=virtual_channels,
+                prefetch_start=prefetch_start,
+                sram_area_fraction=sram_area_fraction,
+                usable_sram_fraction=usable_sram_fraction,
+                bitcell_area_um2_per_bit=bitcell_area_um2_per_bit,
+                local_sram_fraction=local_sram_fraction,
+                bank_count=bank_count,
+                bank_bandwidth_bytes_per_cycle=bank_bandwidth_bytes_per_cycle,
+                bank_interleave_tokens=bank_interleave_tokens,
+                bank_conflict_efficiency=bank_conflict_efficiency,
+                noc_bandwidth_bytes_per_cycle=noc_bandwidth_bytes_per_cycle,
+                noc_hops=noc_hops,
+                router_latency_cycles_per_hop=router_latency_cycles_per_hop,
+                macs_per_cycle=macs_per_cycle,
+                vector_ops_per_cycle=vector_ops_per_cycle,
+                clock_ns=clock_ns,
+                **shape,
+            )
+        )
 
     rows_sorted = sorted(rows, key=lambda row: row["latency_us"])
     dominance: dict[str, int] = {}
@@ -439,6 +492,17 @@ def build_report(
             "tile_tokens_list": tile_tokens_list,
             "prefetch_distance_tiles_list": prefetch_distance_tiles_list,
             "hbm_outstanding_list": hbm_outstanding_list,
+            "sram_area_fraction_list": sram_area_fraction_list,
+            "usable_sram_fraction_list": usable_sram_fraction_list,
+            "bitcell_area_um2_per_bit_list": bitcell_area_um2_per_bit_list,
+            "local_sram_fraction_list": local_sram_fraction_list,
+            "bank_count_list": bank_count_list,
+            "bank_bandwidth_bytes_per_cycle_list": bank_bandwidth_bytes_per_cycle_list,
+            "bank_interleave_tokens_list": bank_interleave_tokens_list,
+            "bank_conflict_efficiency_list": bank_conflict_efficiency_list,
+            "noc_bandwidth_bytes_per_cycle_list": noc_bandwidth_bytes_per_cycle_list,
+            "noc_hops_list": noc_hops_list,
+            "router_latency_cycles_per_hop_list": router_latency_cycles_per_hop_list,
             "clock_ns": clock_ns,
         },
         "sweep_summary": {
@@ -459,6 +523,21 @@ def build_report(
                 "pseudo_channels_per_stack",
                 "pseudo_channel_width_bits",
                 "data_rate_mtps",
+            ),
+        ),
+        "best_by_memory_noc": _best_by(
+            rows,
+            (
+                "sequence_length",
+                "die_area_mm2",
+                "sram_area_fraction",
+                "usable_sram_fraction",
+                "bitcell_area_um2_per_bit",
+                "local_sram_fraction",
+                "bank_count",
+                "bank_bandwidth_bytes_per_cycle",
+                "noc_bandwidth_bytes_per_cycle",
+                "noc_hops",
             ),
         ),
         "assumptions": [
@@ -503,18 +582,22 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         "",
         "## Best By Sequence And Die",
         "",
-        "| seq | die | kv | bits | stacks | MT/s | hbm_share | latency_us | resource |",
-        "|---:|---:|---|---:|---:|---:|---:|---:|---|",
+        "| seq | die | kv | bits | stacks | MT/s | SRAM MiB | local_frac | NoC B/cyc | hops | hbm_share | latency_us | resource |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
     for row in payload["best_by_sequence_die"]:
         lines.append(
-            "| {seq} | {die} | {kv} | {bits} | {stacks} | {mtps} | {share} | {lat} | {res} |".format(
+            "| {seq} | {die} | {kv} | {bits} | {stacks} | {mtps} | {sram} | {local} | {noc} | {hops} | {share} | {lat} | {res} |".format(
                 seq=row["sequence_length"],
                 die=row["die_area_mm2"],
                 kv=row["kv_sharing"],
                 bits=row["kv_bits"],
                 stacks=row["stack_count"],
                 mtps=row["data_rate_mtps"],
+                sram=row["total_sram_mib"],
+                local=row["local_sram_fraction"],
+                noc=row["noc_bandwidth_bytes_per_cycle"],
+                hops=row["noc_hops"],
                 share=row["hbm_byte_share"],
                 lat=row["latency_us"],
                 res=row["dominant_tile_resource"],
@@ -570,17 +653,17 @@ def main() -> int:
     ap.add_argument("--arbitration-efficiency-list", type=_float_list, default=[0.85])
     ap.add_argument("--virtual-channel-list", type=_int_list, default=[4])
     ap.add_argument("--prefetch-start-list", type=_str_list, default=["during_qkv"])
-    ap.add_argument("--sram-area-fraction", type=float, default=0.6)
-    ap.add_argument("--usable-sram-fraction", type=float, default=0.7)
-    ap.add_argument("--bitcell-area-um2-per-bit", type=float, default=0.02)
-    ap.add_argument("--local-sram-fraction", type=float, default=0.25)
-    ap.add_argument("--bank-count", type=int, default=16)
-    ap.add_argument("--bank-bandwidth-bytes-per-cycle", type=float, default=1024.0)
-    ap.add_argument("--bank-interleave-tokens", type=int, default=16)
-    ap.add_argument("--bank-conflict-efficiency", type=float, default=0.75)
-    ap.add_argument("--noc-bandwidth-bytes-per-cycle", type=float, default=16384.0)
-    ap.add_argument("--noc-hops", type=int, default=1)
-    ap.add_argument("--router-latency-cycles-per-hop", type=int, default=2)
+    ap.add_argument("--sram-area-fraction", type=_float_list, default=[0.6])
+    ap.add_argument("--usable-sram-fraction", type=_float_list, default=[0.7])
+    ap.add_argument("--bitcell-area-um2-per-bit", type=_float_list, default=[0.02])
+    ap.add_argument("--local-sram-fraction", type=_float_list, default=[0.25])
+    ap.add_argument("--bank-count", type=_int_list, default=[16])
+    ap.add_argument("--bank-bandwidth-bytes-per-cycle", type=_float_list, default=[1024.0])
+    ap.add_argument("--bank-interleave-tokens", type=_int_list, default=[16])
+    ap.add_argument("--bank-conflict-efficiency", type=_float_list, default=[0.75])
+    ap.add_argument("--noc-bandwidth-bytes-per-cycle", type=_float_list, default=[16384.0])
+    ap.add_argument("--noc-hops", type=_int_list, default=[1])
+    ap.add_argument("--router-latency-cycles-per-hop", type=_int_list, default=[2])
     ap.add_argument("--macs-per-cycle", type=int, default=524288)
     ap.add_argument("--vector-ops-per-cycle", type=int, default=65536)
     ap.add_argument("--clock-ns", type=float, default=1.0)
@@ -605,17 +688,17 @@ def main() -> int:
         arbitration_efficiency_list=args.arbitration_efficiency_list,
         virtual_channel_list=args.virtual_channel_list,
         prefetch_start_list=args.prefetch_start_list,
-        sram_area_fraction=args.sram_area_fraction,
-        usable_sram_fraction=args.usable_sram_fraction,
-        bitcell_area_um2_per_bit=args.bitcell_area_um2_per_bit,
-        local_sram_fraction=args.local_sram_fraction,
-        bank_count=args.bank_count,
-        bank_bandwidth_bytes_per_cycle=args.bank_bandwidth_bytes_per_cycle,
-        bank_interleave_tokens=args.bank_interleave_tokens,
-        bank_conflict_efficiency=args.bank_conflict_efficiency,
-        noc_bandwidth_bytes_per_cycle=args.noc_bandwidth_bytes_per_cycle,
-        noc_hops=args.noc_hops,
-        router_latency_cycles_per_hop=args.router_latency_cycles_per_hop,
+        sram_area_fraction_list=args.sram_area_fraction,
+        usable_sram_fraction_list=args.usable_sram_fraction,
+        bitcell_area_um2_per_bit_list=args.bitcell_area_um2_per_bit,
+        local_sram_fraction_list=args.local_sram_fraction,
+        bank_count_list=args.bank_count,
+        bank_bandwidth_bytes_per_cycle_list=args.bank_bandwidth_bytes_per_cycle,
+        bank_interleave_tokens_list=args.bank_interleave_tokens,
+        bank_conflict_efficiency_list=args.bank_conflict_efficiency,
+        noc_bandwidth_bytes_per_cycle_list=args.noc_bandwidth_bytes_per_cycle,
+        noc_hops_list=args.noc_hops,
+        router_latency_cycles_per_hop_list=args.router_latency_cycles_per_hop,
         macs_per_cycle=args.macs_per_cycle,
         vector_ops_per_cycle=args.vector_ops_per_cycle,
         clock_ns=args.clock_ns,


### PR DESCRIPTION
## Summary
- extend the physical-HBM estimator so SRAM and NoC scalar knobs can also be swept with comma-separated values
- add a quality-backed 131k native-GQA KV8/KV16 memory/NoC sensitivity proposal and generator path
- allow the new compact dataset prefix through artifact policy and document the physical-HBM sweep knobs

## Tests
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
- python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1/proposal.json >/dev/null
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py
- full proposed estimator sweep: 92,160 rows, ~15.3s locally, ~5.2MB JSON