### PR TITLE
npu: cap memory noc sweep evidence

### DIFF
--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -566,3 +566,6 @@ python3 npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py \
 
 Treat high SRAM fractions and very large die points as planning bounds until
 they are backed by SRAM macro/floorplan data.
+For large sweeps, the JSON retains all global top rows and the 200 lowest
+latency grouped memory/NoC rows; the full generated row count is still recorded
+in `sweep_summary`.

--- a/npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
@@ -475,6 +475,22 @@ def build_report(
     for row in rows:
         key = str(row["dominant_tile_resource"])
         dominance[key] = dominance.get(key, 0) + 1
+    best_by_memory_noc = _best_by(
+        rows,
+        (
+            "sequence_length",
+            "die_area_mm2",
+            "sram_area_fraction",
+            "usable_sram_fraction",
+            "bitcell_area_um2_per_bit",
+            "local_sram_fraction",
+            "bank_count",
+            "bank_bandwidth_bytes_per_cycle",
+            "noc_bandwidth_bytes_per_cycle",
+            "noc_hops",
+        ),
+    )
+    retained_memory_noc = sorted(best_by_memory_noc, key=lambda row: row["latency_us"])[:200]
     return {
         "version": 0.1,
         "model": "llm_decoder_attention_kv_physical_hbm_frontier_llama7b_v1",
@@ -508,6 +524,8 @@ def build_report(
         "sweep_summary": {
             "generated_row_count": len(rows),
             "retained_top_row_count": min(50, len(rows_sorted)),
+            "best_by_memory_noc_row_count": len(best_by_memory_noc),
+            "retained_best_by_memory_noc_row_count": len(retained_memory_noc),
             "dominant_tile_resource_counts": dict(sorted(dominance.items())),
         },
         "best": rows_sorted[0],
@@ -525,21 +543,7 @@ def build_report(
                 "data_rate_mtps",
             ),
         ),
-        "best_by_memory_noc": _best_by(
-            rows,
-            (
-                "sequence_length",
-                "die_area_mm2",
-                "sram_area_fraction",
-                "usable_sram_fraction",
-                "bitcell_area_um2_per_bit",
-                "local_sram_fraction",
-                "bank_count",
-                "bank_bandwidth_bytes_per_cycle",
-                "noc_bandwidth_bytes_per_cycle",
-                "noc_hops",
-            ),
-        ),
+        "best_by_memory_noc": retained_memory_noc,
         "assumptions": [
             "This is a planning model for single-token decode attention/KV, not a JEDEC HBM timing model.",
             "HBM bandwidth is derived from stack count, pseudo-channel count, interface width, MT/s, and the core clock period.",


### PR DESCRIPTION
## Summary
- cap best_by_memory_noc evidence to the 200 lowest-latency grouped points
- keep total grouped row count in sweep_summary so large sweeps remain auditable
- document the retention behavior for physical-HBM memory/NoC sweeps

## Tests
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
- full proposed 92,160-row sweep: JSON reduced from ~5.2 MB to ~0.49 MB
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py