### PR TITLE
npu: add KV HBM compute sensitivity sweep

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -32,6 +32,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_physical_hbm_frontier__",
     "decoder_attention_kv_physical_hbm_quality_backed__",
     "decoder_attention_kv_physical_hbm_memory_noc__",
+    "decoder_attention_kv_physical_hbm_compute_sensitivity__",
     "decoder_attention_kv_quality_gate__",
     "decoder_attention_kv_quality_proxy__",
     "decoder_attention_kv_native_gqa_proxy__",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3479,6 +3479,75 @@ def _decoder_attention_kv_physical_hbm_memory_noc_evidence(*, item_id: str) -> d
     }
 
 
+def _decoder_attention_kv_physical_hbm_compute_sensitivity_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_physical_hbm_compute_sensitivity__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_physical_hbm_compute_sensitivity__{item_id}.md"
+    memory_noc = (
+        f"{base}/decoder_attention_kv_physical_hbm_memory_noc__"
+        "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2.json"
+    )
+    native_recovery = (
+        f"{base}/decoder_attention_kv_model_native_recovery__"
+        "l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_physical_hbm_memory_noc": memory_noc,
+            "attention_kv_model_native_recovery": native_recovery,
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_physical_hbm_compute_sensitivity_scope": (
+                "Quality-backed native-GQA KV8 compute-downsizing sensitivity at 131k context. "
+                "Hold the best practical HBM and high-SRAM memory/NoC region from the previous "
+                "frontier, then sweep MAC/cycle and vector-op/cycle throughput downward to find "
+                "the smallest compute array that remains memory-bound."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_physical_hbm_compute_sensitivity",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py "
+                    "--label llama7b_proxy "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 400,800,1200 "
+                    "--kv-sharing-list gqa8 "
+                    "--kv-bits-list 8 "
+                    "--stack-count-list 8 "
+                    "--pseudo-channels-per-stack-list 16 "
+                    "--pseudo-channel-width-bits-list 64 "
+                    "--data-rate-mtps-list 9000 "
+                    "--hbm-efficiency-list 0.75 "
+                    "--tile-tokens-list 512,1024 "
+                    "--prefetch-distance-tiles-list 4 "
+                    "--hbm-outstanding-list 16 "
+                    "--arbitration-efficiency-list 0.85 "
+                    "--virtual-channel-list 4 "
+                    "--prefetch-start-list during_qkv "
+                    "--sram-area-fraction 0.75 "
+                    "--usable-sram-fraction 0.7,0.85 "
+                    "--bitcell-area-um2-per-bit 0.02 "
+                    "--local-sram-fraction 0.1,0.25,0.5 "
+                    "--bank-count 16,64 "
+                    "--bank-bandwidth-bytes-per-cycle 2048 "
+                    "--bank-interleave-tokens 16 "
+                    "--bank-conflict-efficiency 0.75 "
+                    "--noc-bandwidth-bytes-per-cycle 32768 "
+                    "--noc-hops 1 "
+                    "--router-latency-cycles-per-hop 2 "
+                    "--macs-per-cycle 32768,65536,131072,262144,524288 "
+                    "--vector-ops-per-cycle 8192,16384,32768,65536 "
+                    "--clock-ns 1.0 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
@@ -4978,6 +5047,7 @@ def _build_payload(
         "decoder_attention_kv_physical_hbm_frontier",
         "decoder_attention_kv_physical_hbm_quality_backed",
         "decoder_attention_kv_physical_hbm_memory_noc",
+        "decoder_attention_kv_physical_hbm_compute_sensitivity",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
@@ -5036,6 +5106,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_physical_hbm_quality_backed_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_memory_noc":
             decoder_evidence = _decoder_attention_kv_physical_hbm_memory_noc_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_compute_sensitivity":
+            decoder_evidence = _decoder_attention_kv_physical_hbm_compute_sensitivity_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -55,6 +55,11 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
     )
     assert is_transportable_expected_output(
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_physical_hbm_compute_sensitivity__"
+        "l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v1.json"
+    )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_kv_quality_gate__l2_decoder_attention_kv_quality_gate_llama7b_v1.md"
     )
     assert is_transportable_expected_output(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3153,6 +3153,71 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_memory
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_compute_sensitivity() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_physical_hbm_compute_sensitivity",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_attention_kv_physical_hbm_compute_sensitivity",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_attention_kv_physical_hbm_frontier.py" in run
+            assert "--sequence-length-list 131072" in run
+            assert "--kv-sharing-list gqa8" in run
+            assert "--kv-bits-list 8" in run
+            assert "--die-area-mm2-list 400,800,1200" in run
+            assert "--usable-sram-fraction 0.7,0.85" in run
+            assert "--bank-count 16,64" in run
+            assert "--macs-per-cycle 32768,65536,131072,262144,524288" in run
+            assert "--vector-ops-per-cycle 8192,16384,32768,65536" in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_physical_hbm_compute_sensitivity__"
+                "l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_kv_physical_hbm_memory_noc"].endswith(
+                "decoder_attention_kv_physical_hbm_memory_noc__"
+                "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2.json"
+            )
+            assert (
+                "compute-downsizing sensitivity"
+                in decoder_inputs["attention_kv_physical_hbm_compute_sensitivity_scope"]
+            )
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_physical_hbm_compute_sensitivity",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_attention_kv_quality_gate() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v1",
+  "created_utc": "2026-05-18T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_physical_hbm_compute_sensitivity",
+  "title": "Llama7B quality-backed KV8 compute downsizing sensitivity at 131k context",
+  "hypothesis": "For quality-backed native-GQA KV8 at 131k context, the best practical memory/HBM region remains HBM-dominated even after the compute array is reduced substantially below the current fixed 524288 MAC/cycle planning point.",
+  "direct_comparison": {
+    "primary_question": "What is the smallest MAC/cycle and vector-op/cycle throughput point that keeps the selected llama7b_proxy 131k KV8 memory/HBM frontier memory-bound?",
+    "include": [
+      "llama7b_proxy at 131k tokens",
+      "native-GQA group-8 only",
+      "KV8 only, because KV4 has not passed the trained-checkpoint quality gate",
+      "die sizes 400, 800, and 1200 mm2 around the current long-context memory frontier",
+      "best practical HBM settings from the memory/NoC sweep: 8 stacks, 16 pseudo-channels per stack, 64-bit pseudo-channels, 9000 MT/s, 0.75 efficiency",
+      "high-SRAM region: 0.75 SRAM area fraction, 0.7 and 0.85 usable fractions, 0.02 um2/bit",
+      "local/shared SRAM split points 0.1, 0.25, and 0.5 local",
+      "bank-count points 16 and 64 with 2048 bytes/cycle per bank",
+      "MAC/cycle points 32768, 65536, 131072, 262144, and 524288",
+      "vector-op/cycle points 8192, 16384, 32768, and 65536"
+    ],
+    "exclude": [
+      "KV4, because native-checkpoint recovery failed the top-1/top-k quality gate",
+      "MQA or non-native KV sharing",
+      "full memory/NoC resweep",
+      "JEDEC-accurate HBM timing",
+      "physical proof that each compute-throughput point is placeable"
+    ]
+  },
+  "expected_benefit": [
+    "identifies whether the current nm1-style minimal-compute direction is consistent with the physical HBM planning model",
+    "finds how far compute parallelism can be reduced before the dominant resource changes from HBM/shared path to tile attention compute",
+    "prevents overbuilding compute arrays when long-context KV service is the limiting resource"
+  ],
+  "risks": [
+    "the compute-throughput values are planning proxies and need RTL/PPA follow-up for selected points",
+    "the fixed high-SRAM memory region could miss interactions where a lower-compute point benefits from a different local/shared split",
+    "the simple tile scheduler does not model detailed SRAM macro placement or NoC arbitration"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Sweep compute and vector throughput for quality-backed native-GQA KV8 131k physical-HBM points while holding the selected memory/NoC region fixed.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_physical_hbm_compute_sensitivity",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2",
+        "l2_decoder_attention_kv_model_native_recovery_tinyllama_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If lower compute points remain HBM-bound with similar latency, schedule RTL/PPA for smaller compute arrays; if tile attention becomes dominant, keep compute near the transition point and move back to memory/HBM improvements."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_memory_noc__l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py",
+    "docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_memory_noc__l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2.md"
+  ]
+}

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -549,9 +549,10 @@ count, pseudo-channel count, interface width, transfer rate, and core clock,
 then combines that with shared-SRAM residency, bank service, NoC service, tile
 size, and prefetch depth.
 
-The scalar memory and NoC options also accept comma-separated sweeps. This keeps
-quality-backed jobs from ranking unsafe KV4/MQA points while still testing how
-the optimum moves with die size and memory hierarchy assumptions:
+The scalar memory, NoC, MAC throughput, and vector throughput options also
+accept comma-separated sweeps. This keeps quality-backed jobs from ranking
+unsafe KV4/MQA points while still testing how the optimum moves with die size,
+memory hierarchy assumptions, and compute array sizing:
 
 ```sh
 python3 npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py \
@@ -561,6 +562,8 @@ python3 npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py \
   --sram-area-fraction 0.4,0.6,0.75 \
   --noc-bandwidth-bytes-per-cycle 8192,32768 \
   --noc-hops 1,4 \
+  --macs-per-cycle 32768,65536,131072,262144,524288 \
+  --vector-ops-per-cycle 8192,16384,32768,65536 \
   --out /tmp/kv.json --out-md /tmp/kv.md
 ```
 

--- a/npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
@@ -367,8 +367,8 @@ def build_report(
     noc_bandwidth_bytes_per_cycle_list: list[float],
     noc_hops_list: list[int],
     router_latency_cycles_per_hop_list: list[int],
-    macs_per_cycle: int,
-    vector_ops_per_cycle: int,
+    macs_per_cycle_list: list[int],
+    vector_ops_per_cycle_list: list[int],
     clock_ns: float,
 ) -> JsonDict:
     shapes = {
@@ -405,6 +405,8 @@ def build_report(
         noc_bandwidth_bytes_per_cycle_list,
         noc_hops_list,
         router_latency_cycles_per_hop_list,
+        macs_per_cycle_list,
+        vector_ops_per_cycle_list,
     )
     for (
         sequence_length,
@@ -433,6 +435,8 @@ def build_report(
         noc_bandwidth_bytes_per_cycle,
         noc_hops,
         router_latency_cycles_per_hop,
+        macs_per_cycle,
+        vector_ops_per_cycle,
     ) in itertools.product(*sweep_axes):
         rows.append(
             _shape_row(
@@ -490,6 +494,15 @@ def build_report(
             "noc_hops",
         ),
     )
+    best_by_compute = _best_by(
+        rows,
+        (
+            "sequence_length",
+            "die_area_mm2",
+            "macs_per_cycle",
+            "vector_ops_per_cycle",
+        ),
+    )
     retained_memory_noc = sorted(best_by_memory_noc, key=lambda row: row["latency_us"])[:200]
     return {
         "version": 0.1,
@@ -519,6 +532,8 @@ def build_report(
             "noc_bandwidth_bytes_per_cycle_list": noc_bandwidth_bytes_per_cycle_list,
             "noc_hops_list": noc_hops_list,
             "router_latency_cycles_per_hop_list": router_latency_cycles_per_hop_list,
+            "macs_per_cycle_list": macs_per_cycle_list,
+            "vector_ops_per_cycle_list": vector_ops_per_cycle_list,
             "clock_ns": clock_ns,
         },
         "sweep_summary": {
@@ -544,12 +559,14 @@ def build_report(
             ),
         ),
         "best_by_memory_noc": retained_memory_noc,
+        "best_by_compute": best_by_compute,
         "assumptions": [
             "This is a planning model for single-token decode attention/KV, not a JEDEC HBM timing model.",
             "HBM bandwidth is derived from stack count, pseudo-channel count, interface width, MT/s, and the core clock period.",
             "HBM efficiency represents controller scheduling, protocol overhead, row locality, and clock-crossing loss in aggregate.",
             "KV bits are treated as packed storage bits, so kv4 has half the byte traffic of kv8.",
             "Shared SRAM residency is capacity-based; the remaining KV-cache traffic spills to HBM.",
+            "MAC/cycle and vector-op/cycle values are throughput proxies for architecture sizing, not physical proofs of an implemented array.",
             "The tile scheduler is a compact service model intended to rank architecture directions before RTL.",
         ],
     }
@@ -566,13 +583,15 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         "",
         "## Best",
         "",
-        "| seq | die | kv | bits | stacks | pch/stack | width | MT/s | eff | hbm_B/cyc | hbm_share | latency_us | resource |",
-        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
-        "| {seq} | {die} | {kv} | {bits} | {stacks} | {pch} | {width} | {mtps} | {eff} | {bw} | {share} | {lat} | {res} |".format(
+        "| seq | die | kv | bits | MAC/cyc | vec/cyc | stacks | pch/stack | width | MT/s | eff | hbm_B/cyc | hbm_share | latency_us | resource |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        "| {seq} | {die} | {kv} | {bits} | {macs} | {vec} | {stacks} | {pch} | {width} | {mtps} | {eff} | {bw} | {share} | {lat} | {res} |".format(
             seq=best["sequence_length"],
             die=best["die_area_mm2"],
             kv=best["kv_sharing"],
             bits=best["kv_bits"],
+            macs=best["macs_per_cycle"],
+            vec=best["vector_ops_per_cycle"],
             stacks=best["stack_count"],
             pch=best["pseudo_channels_per_stack"],
             width=best["pseudo_channel_width_bits"],
@@ -586,16 +605,18 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         "",
         "## Best By Sequence And Die",
         "",
-        "| seq | die | kv | bits | stacks | MT/s | SRAM MiB | local_frac | NoC B/cyc | hops | hbm_share | latency_us | resource |",
-        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        "| seq | die | kv | bits | MAC/cyc | vec/cyc | stacks | MT/s | SRAM MiB | local_frac | NoC B/cyc | hops | hbm_share | latency_us | resource |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
     for row in payload["best_by_sequence_die"]:
         lines.append(
-            "| {seq} | {die} | {kv} | {bits} | {stacks} | {mtps} | {sram} | {local} | {noc} | {hops} | {share} | {lat} | {res} |".format(
+            "| {seq} | {die} | {kv} | {bits} | {macs} | {vec} | {stacks} | {mtps} | {sram} | {local} | {noc} | {hops} | {share} | {lat} | {res} |".format(
                 seq=row["sequence_length"],
                 die=row["die_area_mm2"],
                 kv=row["kv_sharing"],
                 bits=row["kv_bits"],
+                macs=row["macs_per_cycle"],
+                vec=row["vector_ops_per_cycle"],
                 stacks=row["stack_count"],
                 mtps=row["data_rate_mtps"],
                 sram=row["total_sram_mib"],
@@ -612,18 +633,20 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
             "",
             "## Top 10",
             "",
-            "| rank | seq | die | kv | bits | stacks | pch/stack | MT/s | hbm_B/cyc | hbm_share | latency_us | resource |",
-            "|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---|",
+            "| rank | seq | die | kv | bits | MAC/cyc | vec/cyc | stacks | pch/stack | MT/s | hbm_B/cyc | hbm_share | latency_us | resource |",
+            "|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
         ]
     )
     for index, row in enumerate(payload["top_rows"][:10], start=1):
         lines.append(
-            "| {rank} | {seq} | {die} | {kv} | {bits} | {stacks} | {pch} | {mtps} | {bw} | {share} | {lat} | {res} |".format(
+            "| {rank} | {seq} | {die} | {kv} | {bits} | {macs} | {vec} | {stacks} | {pch} | {mtps} | {bw} | {share} | {lat} | {res} |".format(
                 rank=index,
                 seq=row["sequence_length"],
                 die=row["die_area_mm2"],
                 kv=row["kv_sharing"],
                 bits=row["kv_bits"],
+                macs=row["macs_per_cycle"],
+                vec=row["vector_ops_per_cycle"],
                 stacks=row["stack_count"],
                 pch=row["pseudo_channels_per_stack"],
                 mtps=row["data_rate_mtps"],
@@ -668,8 +691,8 @@ def main() -> int:
     ap.add_argument("--noc-bandwidth-bytes-per-cycle", type=_float_list, default=[16384.0])
     ap.add_argument("--noc-hops", type=_int_list, default=[1])
     ap.add_argument("--router-latency-cycles-per-hop", type=_int_list, default=[2])
-    ap.add_argument("--macs-per-cycle", type=int, default=524288)
-    ap.add_argument("--vector-ops-per-cycle", type=int, default=65536)
+    ap.add_argument("--macs-per-cycle", type=_int_list, default=[524288])
+    ap.add_argument("--vector-ops-per-cycle", type=_int_list, default=[65536])
     ap.add_argument("--clock-ns", type=float, default=1.0)
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
@@ -703,8 +726,8 @@ def main() -> int:
         noc_bandwidth_bytes_per_cycle_list=args.noc_bandwidth_bytes_per_cycle,
         noc_hops_list=args.noc_hops,
         router_latency_cycles_per_hop_list=args.router_latency_cycles_per_hop,
-        macs_per_cycle=args.macs_per_cycle,
-        vector_ops_per_cycle=args.vector_ops_per_cycle,
+        macs_per_cycle_list=args.macs_per_cycle,
+        vector_ops_per_cycle_list=args.vector_ops_per_cycle,
         clock_ns=args.clock_ns,
     )
     out = Path(args.out)


### PR DESCRIPTION
## Summary
- promote MAC/cycle and vector-op/cycle to sweep axes in the physical HBM KV estimator
- add a quality-backed KV8 compute-downsizing L2 proposal and generator path
- allow the new compute-sensitivity dataset artifacts through transport policy and cover generator/finalizer contracts in tests

## Validation
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/artifact_policy.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py
- python3 scripts/validate_runs.py --skip_eval_queue
- dry-run estimator sweep for the proposed compute-sensitivity range