### PR TITLE
Add NPU compute parallelism ladder inputs

### DIFF
--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_ladder_v1/proposal.json
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_ladder_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l1_npu_fp16_compute_parallelism_ladder_v1",
+  "created_utc": "2026-05-18T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "npu_compute_parallelism_ladder",
+  "title": "NPU FP16 compute parallelism ladder",
+  "hypothesis": "The current decoder frontier uses analytical MAC/cycle knobs that are much larger than the measured nm1/nm2 NPU physical anchors. Measuring wider full-NPU FP16 compute arrays will show the physically achievable parallelism trend before the decoder attention/KV frontier is re-ranked.",
+  "direct_comparison": {
+    "primary_question": "How do full-NPU Nangate45 PPA, timing, and implementation runtime scale when FP16 GEMM module count increases beyond the measured nm1/nm2 anchors?",
+    "include": [
+      "full npu_top wrapper with the same SRAM, DMA, CQ, AXI, and vector settings as nm1/nm2 cmp anchors",
+      "FP16 GEMM num_modules ladder beginning with nm4 and nm8",
+      "flat_nomacro and hier_macro mode comparison using the existing cmp33 floorplan",
+      "metrics.csv rows suitable for fitting MAC parallelism against area, power, timing, and implementation feasibility"
+    ],
+    "exclude": [
+      "decoder-quality or QAT experiments",
+      "memory hierarchy or NoC contention modeling",
+      "new floorplan tuning for nm16+",
+      "claiming the analytical decoder MAC/cycle points are physically feasible before measured or fitted support exists"
+    ]
+  },
+  "expected_benefit": [
+    "anchors decoder attention/KV compute sensitivity to generated physical designs instead of free analytical MAC/cycle values",
+    "identifies whether the first practical bottleneck is compute-array area, timing, or implementation runtime",
+    "selects the next wider ladder point, such as nm16 or nm32, with a measured runtime boundary"
+  ],
+  "risks": [
+    "the inherited cmp33 floorplan may become limiting before the compute array itself does",
+    "flat_nomacro may become slow or infeasible at higher module counts",
+    "nm4/nm8 still remain far below Llama7B-scale throughput, so the result must feed a scaling model rather than be treated as a final architecture"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_npu_fp16_compute_parallelism_ladder_nm4_nm8_v1",
+      "task_type": "l1_sweep",
+      "objective": "Run full Nangate45 OpenROAD PPA measurement for full-NPU FP16 nm4 and nm8 compute parallelism using the cmp33 mode-compare sweep.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "npu_compute_parallelism_ladder",
+      "cost_class": "bounded-high",
+      "comparison_role": "physical_compute_anchor",
+      "paired_baseline_item_id": "npu_fp16_cpp_nm2_cmp",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use nm4/nm8 measured PPA and runtime to decide whether to launch nm16/nm32 full physical measurement or a synth-prefilter boundary job first."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp/metrics.csv",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm2_cmp/metrics.csv",
+    "runs/index.csv"
+  ],
+  "knowledge_refs": [
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp/config_nm1.json",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm2_cmp/config_nm2.json",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp/sweep_compare_33.json",
+    "npu/rtlgen/gen.py",
+    "npu/synth/run_block_sweep.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py"
+  ]
+}

--- a/runs/campaigns/npu/compute_parallelism_ladder/sweeps/nangate45_cmp33_mode_compare.json
+++ b/runs/campaigns/npu/compute_parallelism_ladder/sweeps/nangate45_cmp33_mode_compare.json
@@ -1,0 +1,27 @@
+{
+  "flow_params": {
+    "TAG": [
+      "npu_fp16_compute_ladder_cmp33"
+    ],
+    "FLOW_VARIANT": [
+      "compute_ladder_cmp33"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 1500 1500"
+    ],
+    "CORE_AREA": [
+      "50 50 1450 1450"
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "gemm_compute_array"
+    ]
+  },
+  "tag_prefix": "npu_fp16_compute_ladder",
+  "mode_compare": true
+}

--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm4_cmp/config_nm4.json
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm4_cmp/config_nm4.json
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "top_name": "npu_top",
+  "mmio_addr_width": 12,
+  "data_width": 32,
+  "dma_addr_width": 64,
+  "dma_data_width": 256,
+  "axi_addr_width": 64,
+  "axi_data_width": 256,
+  "axi_id_width": 4,
+  "sram_instances": [
+    {
+      "name": "activation_sram",
+      "depth": 16384,
+      "width": 256,
+      "banks": 8,
+      "read_latency": 1,
+      "byte_en": true,
+      "port": "1r1w",
+      "pdk": "sky130",
+      "tech_node_nm": 130,
+      "base_addr": "0x80000000",
+      "alignment_bytes": 64
+    }
+  ],
+  "queue_depth": 16,
+  "enable_irq": true,
+  "enable_dma_ports": true,
+  "enable_cq_mem_ports": true,
+  "enable_axi_ports": true,
+  "enable_axi_lite_wrapper": true,
+  "compute": {
+    "enabled": true,
+    "gemm": {
+      "mac_type": "fp16",
+      "lanes": 1,
+      "accum_width": 16,
+      "pipeline": 1,
+      "fp16": {
+        "semantics": "ieee_half",
+        "accumulation": "fp16",
+        "rounding": "rne",
+        "subnormals": "preserve"
+      },
+      "rtlgen_cpp": {
+        "binary_path": "build/rtlgen",
+        "module_name": "gemm_mac_fp16_ieee",
+        "total_width": 16,
+        "mantissa_width": 10
+      },
+      "num_modules": 4,
+      "lanes_per_module": 1
+    },
+    "vec": {
+      "lanes": 1,
+      "ops": [
+        "add",
+        "mul",
+        "relu"
+      ]
+    }
+  }
+}

--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm8_cmp/config_nm8.json
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm8_cmp/config_nm8.json
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "top_name": "npu_top",
+  "mmio_addr_width": 12,
+  "data_width": 32,
+  "dma_addr_width": 64,
+  "dma_data_width": 256,
+  "axi_addr_width": 64,
+  "axi_data_width": 256,
+  "axi_id_width": 4,
+  "sram_instances": [
+    {
+      "name": "activation_sram",
+      "depth": 16384,
+      "width": 256,
+      "banks": 8,
+      "read_latency": 1,
+      "byte_en": true,
+      "port": "1r1w",
+      "pdk": "sky130",
+      "tech_node_nm": 130,
+      "base_addr": "0x80000000",
+      "alignment_bytes": 64
+    }
+  ],
+  "queue_depth": 16,
+  "enable_irq": true,
+  "enable_dma_ports": true,
+  "enable_cq_mem_ports": true,
+  "enable_axi_ports": true,
+  "enable_axi_lite_wrapper": true,
+  "compute": {
+    "enabled": true,
+    "gemm": {
+      "mac_type": "fp16",
+      "lanes": 1,
+      "accum_width": 16,
+      "pipeline": 1,
+      "fp16": {
+        "semantics": "ieee_half",
+        "accumulation": "fp16",
+        "rounding": "rne",
+        "subnormals": "preserve"
+      },
+      "rtlgen_cpp": {
+        "binary_path": "build/rtlgen",
+        "module_name": "gemm_mac_fp16_ieee",
+        "total_width": 16,
+        "mantissa_width": 10
+      },
+      "num_modules": 8,
+      "lanes_per_module": 1
+    },
+    "vec": {
+      "lanes": 1,
+      "ops": [
+        "add",
+        "mul",
+        "relu"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first physically anchored NPU FP16 compute-parallelism ladder inputs:

- new full `npu_top` cmp configs for `num_modules=4` and `num_modules=8`
- a Nangate45 cmp33 mode-compare sweep matching the nm1/nm2 anchor style
- a Layer 1 proposal for measuring the nm4/nm8 PPA/runtime boundary before extrapolating decoder-attention MAC/cycle assumptions

## Validation

- `python3 -m json.tool` on the new proposal, sweep, and config files
- `cmake -S . -B build && cmake --build build --target rtlgen`
- `python3 npu/rtlgen/gen.py --config runs/designs/npu_blocks/npu_fp16_cpp_nm4_cmp/config_nm4.json --out /tmp/rtlgen_nm4_smoke`
- `python3 npu/rtlgen/gen.py --config runs/designs/npu_blocks/npu_fp16_cpp_nm8_cmp/config_nm8.json --out /tmp/rtlgen_nm8_smoke`
