### PR TITLE
Add nm16 NPU compute ladder point

### DIFF
--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_ladder_v1/proposal.json
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_ladder_v1/proposal.json
@@ -50,6 +50,25 @@
         "direction": "iterate",
         "reason": "Use nm4/nm8 measured PPA and runtime to decide whether to launch nm16/nm32 full physical measurement or a synth-prefilter boundary job first."
       }
+    },
+    {
+      "item_id": "l1_npu_fp16_compute_parallelism_ladder_nm16_v1",
+      "task_type": "l1_sweep",
+      "objective": "Run full Nangate45 OpenROAD PPA measurement for full-NPU FP16 nm16 compute parallelism using the same cmp33 mode-compare sweep after nm4/nm8 completed.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "npu_compute_parallelism_ladder",
+      "cost_class": "bounded-high",
+      "comparison_role": "physical_compute_anchor",
+      "paired_baseline_item_id": "l1_npu_fp16_compute_parallelism_ladder_nm4_nm8_v1",
+      "depends_on_item_ids": [
+        "l1_npu_fp16_compute_parallelism_ladder_nm4_nm8_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use nm16 PPA and runtime to determine whether nm32 should run as full PnR, synth-prefilter, or require floorplan/hierarchy changes first."
+      }
     }
   ],
   "baseline_refs": [

--- a/runs/designs/npu_blocks/npu_fp16_cpp_nm16_cmp/config_nm16.json
+++ b/runs/designs/npu_blocks/npu_fp16_cpp_nm16_cmp/config_nm16.json
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "top_name": "npu_top",
+  "mmio_addr_width": 12,
+  "data_width": 32,
+  "dma_addr_width": 64,
+  "dma_data_width": 256,
+  "axi_addr_width": 64,
+  "axi_data_width": 256,
+  "axi_id_width": 4,
+  "sram_instances": [
+    {
+      "name": "activation_sram",
+      "depth": 16384,
+      "width": 256,
+      "banks": 8,
+      "read_latency": 1,
+      "byte_en": true,
+      "port": "1r1w",
+      "pdk": "sky130",
+      "tech_node_nm": 130,
+      "base_addr": "0x80000000",
+      "alignment_bytes": 64
+    }
+  ],
+  "queue_depth": 16,
+  "enable_irq": true,
+  "enable_dma_ports": true,
+  "enable_cq_mem_ports": true,
+  "enable_axi_ports": true,
+  "enable_axi_lite_wrapper": true,
+  "compute": {
+    "enabled": true,
+    "gemm": {
+      "mac_type": "fp16",
+      "lanes": 1,
+      "accum_width": 16,
+      "pipeline": 1,
+      "fp16": {
+        "semantics": "ieee_half",
+        "accumulation": "fp16",
+        "rounding": "rne",
+        "subnormals": "preserve"
+      },
+      "rtlgen_cpp": {
+        "binary_path": "build/rtlgen",
+        "module_name": "gemm_mac_fp16_ieee",
+        "total_width": 16,
+        "mantissa_width": 10
+      },
+      "num_modules": 16,
+      "lanes_per_module": 1
+    },
+    "vec": {
+      "lanes": 1,
+      "ops": [
+        "add",
+        "mul",
+        "relu"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the next physical compute-parallelism ladder point:

- full `npu_top` cmp config for `num_modules=16`
- proposal entry for `l1_npu_fp16_compute_parallelism_ladder_nm16_v1`, dependent on the merged nm4/nm8 measurement

This keeps nm16 as a separate bounded job before deciding whether nm32 should be full PnR or synth-prefilter.

## Validation

- `python3 -m json.tool` on the updated proposal and nm16 config
- `python3 npu/rtlgen/gen.py --config runs/designs/npu_blocks/npu_fp16_cpp_nm16_cmp/config_nm16.json --out /tmp/rtlgen_nm16_smoke`
