### PR TITLE
Fix NPU multi-trial sweep output paths

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -488,6 +488,7 @@ def _read_config_target(
                         "--platform {platform} "
                         f"--top {top_name} "
                         f"--sweep {{sweep_path}} "
+                        f"--out_root {out_root} "
                         + (f"--make_target {make_target} " if make_target else "")
                         + "--skip_existing"
                         )

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -940,6 +940,7 @@ def test_generate_l1_sweep_task_supports_integrated_npu_block_configs() -> None:
                 "--platform nangate45 "
                 "--top npu_top "
                 "--sweep runs/designs/npu_blocks/npu_fp16_cpp_nm1_sigmoidcmp/sweep_compare_33.json "
+                "--out_root runs/designs/npu_blocks "
                 "--skip_existing"
             )
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {"layer": "architecture_block"}
@@ -1009,6 +1010,7 @@ def test_generate_l1_sweep_task_emits_commands_for_each_integrated_block_config(
             assert "--config runs/designs/npu_blocks/npu_fp16_cpp_nm2_sigmoidcmp/config_nm2_sigmoid.json " in joined_commands
             assert "--design_dir runs/designs/npu_blocks/npu_fp16_cpp_nm1_sigmoidcmp " in joined_commands
             assert "--design_dir runs/designs/npu_blocks/npu_fp16_cpp_nm2_sigmoidcmp " in joined_commands
+            assert joined_commands.count("--out_root runs/designs/npu_blocks ") == 2
             assert work_item.expected_outputs == [
                 "runs/designs/npu_blocks/npu_fp16_cpp_nm1_sigmoidcmp/metrics.csv",
                 "runs/designs/npu_blocks/npu_fp16_cpp_nm2_sigmoidcmp/metrics.csv",

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -188,7 +188,7 @@ def test_active_command_manifest_injects_flow_random_seed_for_npu_block_sweep() 
     assert "--out_root runs/designs/npu_blocks/trials/trial_003" in commands[0]["run"]
 
 
-def test_active_expected_outputs_keeps_trial_scoped_outputs_for_multi_trial_sweep() -> None:
+def test_active_expected_outputs_filters_to_active_trial_for_multi_trial_sweep() -> None:
     work_item = WorkItem(
         item_id="seeded_item",
         task_type="l1_sweep",
@@ -197,14 +197,14 @@ def test_active_expected_outputs_keeps_trial_scoped_outputs_for_multi_trial_swee
             "runs/designs/activations/demo_wrapper/trials/trial_001/demo_wrapper/metrics.csv",
             "runs/designs/activations/demo_wrapper/trials/trial_002/demo_wrapper/metrics.csv",
             "runs/designs/activations/demo_wrapper/trials/trial_003/demo_wrapper/metrics.csv",
+            "runs/index.csv",
         ],
         trial_policy_json={"trial_count": 3, "seed_start": 100, "stop_after_failures": 3},
     )
 
     assert _active_expected_outputs(work_item, 2) == [
-        "runs/designs/activations/demo_wrapper/trials/trial_001/demo_wrapper/metrics.csv",
         "runs/designs/activations/demo_wrapper/trials/trial_002/demo_wrapper/metrics.csv",
-        "runs/designs/activations/demo_wrapper/trials/trial_003/demo_wrapper/metrics.csv",
+        "runs/index.csv",
     ]
 
 

--- a/control_plane/control_plane/workers/executor.py
+++ b/control_plane/control_plane/workers/executor.py
@@ -260,13 +260,16 @@ def _active_expected_outputs(work_item: WorkItem, trial_index: int) -> list[str]
         return expected_outputs
     prefix = f"{out_root}/"
     trial_prefix = f"{out_root}/trials/trial_"
+    current_trial_prefix = f"{trial_out_root}/"
     replacement = f"{trial_out_root}/"
     result: list[str] = []
     for rel_path in expected_outputs:
         if rel_path == "runs/index.csv":
             result.append(rel_path)
-        elif rel_path.startswith(trial_prefix):
+        elif rel_path.startswith(current_trial_prefix):
             result.append(rel_path)
+        elif rel_path.startswith(trial_prefix):
+            continue
         elif rel_path.startswith(prefix):
             result.append(rel_path.replace(prefix, replacement, 1))
         else:


### PR DESCRIPTION
## Summary

Fix the control-plane path mismatch that caused `l1_npu_fp16_compute_parallelism_stability_nm8_nm16_nm32_seed3_v1` to fail acceptance after successful OpenROAD execution.

Changes:
- add `--out_root {out_root}` to generated NPU `run_block_sweep.py` commands
- keep the existing worker rewrite to `.../trials/trial_00N` effective for NPU block sweeps
- filter trial-expanded expected outputs so a single trial attempt validates only its own `trial_00N` metrics, while retaining shared `runs/index.csv`
- update regression tests for NPU command generation and active expected-output filtering

## Root Cause

The stability job expected trial-scoped outputs, but generated NPU block commands did not pass `--out_root`. `run_block_sweep.py` therefore wrote to default non-trial design directories. The worker also checked all expanded trial outputs during each single trial attempt, so even a correctly scoped attempt would be asked to produce future trials.

## Validation

- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_worker_daemon.py control_plane/control_plane/tests/test_l1_task_generator.py -q`
- `python3 scripts/validate_runs.py --skip_eval_queue`

Related rescue issue: #641