### PR TITLE
fix: allow trial-scoped metrics duplicate flow paths

### DIFF
--- a/scripts/validate_runs.py
+++ b/scripts/validate_runs.py
@@ -136,6 +136,16 @@ def read_metrics_csv(path: Path):
     return legacy_header, legacy_rows
 
 
+def _trial_duplicate_scope(metrics_path: Path) -> str:
+    parts = metrics_path.parts
+    for index, part in enumerate(parts[:-1]):
+        if part == "trials" and index + 1 < len(parts):
+            trial_part = parts[index + 1]
+            if trial_part.startswith("trial_"):
+                return f"trials/{trial_part}"
+    return ""
+
+
 def validate_metrics():
     errors = []
     seen = set()
@@ -150,6 +160,7 @@ def validate_metrics():
                 row.get("platform"),
                 row.get("param_hash"),
                 row.get("result_path"),
+                _trial_duplicate_scope(metrics_path),
             )
             if key in seen:
                 errors.append(f"duplicate run: {key} in {metrics_path}")

--- a/tests/test_runs_parsers.py
+++ b/tests/test_runs_parsers.py
@@ -204,6 +204,36 @@ class RunsParserRegressionTest(unittest.TestCase):
             ordered[0]["metrics_path"],
         )
 
+    def test_validate_runs_allows_seed_trial_metrics_with_shared_result_path(self):
+        row = (
+            "npu_fp16_cpp_nm8_cmp,nangate45,cfg123,param123,trial_tag,ok,"
+            '5.3,2250000.0,0.234,"{""CLOCK_PERIOD"": 10.0}",'
+            "/orfs/flow/reports/nangate45/npu_fp16_cpp_nm8_cmp/shared/6_finish.rpt"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            for trial in ("trial_001", "trial_002"):
+                metrics_path = (
+                    root
+                    / "runs"
+                    / "designs"
+                    / "npu_blocks"
+                    / "trials"
+                    / trial
+                    / "npu_fp16_cpp_nm8_cmp"
+                    / "metrics.csv"
+                )
+                metrics_path.parent.mkdir(parents=True, exist_ok=True)
+                metrics_path.write_text("\n".join([HEADER, row]) + "\n", encoding="utf-8")
+
+            old = self._set_validate_runs_paths(root)
+            try:
+                errors = self.validate_runs.validate_metrics()
+            finally:
+                self._restore_validate_runs_paths(old)
+
+        self.assertEqual([], errors)
+
     def test_run_sweep_normalizes_repo_relative_paths(self):
         repo_root = self.run_sweep.REPO_ROOT
         abs_result = str(repo_root / "runs" / "designs" / "activations" / "demo" / "work" / "abcd1234" / "result.json")


### PR DESCRIPTION
## Summary
- include `trials/trial_###` in `validate_runs.py` duplicate detection keys for trial-scoped metrics
- keep non-trial duplicate detection unchanged
- add a regression test for seed trials that share the same ORFS result path

## Validation
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_runs_parsers.py -q`