### PR TITLE
docs: register nm1/nm2/nm4 stability evaluation

### DIFF
--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_stability_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_stability_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_npu_fp16_compute_parallelism_stability_v1",
-  "source_commit": "8676df60746526fc9b52620f4eaf0e6e85d0845e",
+  "source_commit": "7f343c3aa1b1f1bcaf7ecdb78f89795467958573",
   "requested_items": [
     {
       "item_id": "l1_npu_fp16_compute_parallelism_stability_nm8_nm16_nm32_seed3_v1_r2",
@@ -16,6 +16,14 @@
       "merged_pr_number": 643,
       "merge_commit": "2fc56472d35f180e699506368666c6351210f52c",
       "merged_utc": "2026-05-20T21:09:59.271940Z"
+    },
+    {
+      "item_id": "l1_npu_fp16_compute_parallelism_stability_nm1_nm2_nm4_seed3_v1",
+      "task_type": "l1_sweep",
+      "objective": "measure_seed_variance",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "npu_compute_parallelism_stability",
+      "status": "pending"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- register `l1_npu_fp16_compute_parallelism_stability_nm1_nm2_nm4_seed3_v1` as an active requested evaluation under the compute-parallelism stability proposal
- update the request file source commit to the current master that produced the completed run

## Reason
The completed nm1/nm2/nm4 seed-stability run reached artifact_sync, but submission eligibility was blocked because the parent proposal had already been finalized by PR #643 and this follow-up item was not listed as an active requested evaluation.

## Validation
- documentation-only change