### PR TITLE
[codex] retain gate-count metrics for block sweeps

### DIFF
--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/README.md
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/README.md
@@ -1,0 +1,18 @@
+# Proposal Workspace
+
+Canonical proposal workspace for `prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1`.
+
+This proposal audits whether the FP16 compute parallelism ladder physically
+retains the requested GEMM module count after synthesis and place/route.
+
+Artifacts in this workspace follow the standard proposal contract:
+
+- `proposal.json`
+- `design_brief.md`
+- `implementation_summary.md`
+- `evaluation_gate.md`
+- `evaluation_requests.json`
+- `quality_gate.md`
+- `analysis_report.md`
+- `promotion_decision.json`
+- `promotion_result.json`

--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/analysis_report.md
@@ -1,0 +1,12 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1`
+- `candidate_id`: pending
+
+## Evaluations Consumed
+- pending
+
+## Result
+- result: pending
+- summary: Awaiting gate-count audit results.

--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/design_brief.md
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/design_brief.md
@@ -1,0 +1,30 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1`
+- `title`: `NPU FP16 compute parallelism gate-count audit`
+
+## Problem
+- The current FP16 compute parallelism data shows `nm4` as unusually attractive
+  in timing and power.
+- Before using that result, we need to rule out a synthesis artifact where some
+  requested GEMM modules are disconnected and optimized away.
+- The retained physical metrics currently leave `stdcell_count`,
+  `stdcell_area_um2`, and `instance_area_um2` blank for recent rows.
+
+## Evaluation Scope
+- Re-run the current cmp33 mode-compare sweep for:
+  - `nm1`
+  - `nm2`
+  - `nm4`
+  - `nm8`
+  - `nm16`
+- Preserve timing, power, placed area, stdcell area, and stdcell count in each
+  metrics row.
+- Compare cell/area scaling against requested `compute.gemm.num_modules`.
+
+## Direction Gate
+- status: approved
+- approved_by: `user`
+- approved_utc: `2026-05-21T00:00:00Z`
+- note: User identified gate-count scaling as the first suspicion to resolve.

--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: `user`
+- approved_utc: `2026-05-21T00:00:00Z`
+- allowed_evaluations:
+  - `l1_sweep`: `runs/campaigns/npu/compute_parallelism_stability/sweeps/nangate45_cmp33_mode_compare.json`
+- note: The first audit must preserve physical cell/area columns before timing
+  or power rankings are used for architecture decisions.

--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/evaluation_requests.json
@@ -1,0 +1,14 @@
+{
+  "proposal_id": "prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1",
+  "source_commit": "",
+  "requested_items": [
+    {
+      "item_id": "l1_npu_fp16_compute_parallelism_gate_count_audit_nm1_nm2_nm4_nm8_nm16_v1",
+      "task_type": "l1_sweep",
+      "objective": "audit_gate_count_scaling",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "npu_compute_parallelism_gate_count",
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/implementation_summary.md
@@ -1,0 +1,19 @@
+# Implementation Summary
+
+## Current State
+- `run_block_sweep.py` now accepts finish/final/place/route/synth variants of
+  OpenROAD instance area, stdcell area, and stdcell count metric keys.
+- The local RTL/Yosys sanity check confirmed generated MAC instance counts of
+  1, 2, 4, 8, and 16 before flattening for nm1 through nm16.
+
+## First Evaluation Plan
+- Dispatch one Layer 1 sweep item for nm1, nm2, nm4, nm8, and nm16.
+- Use the existing cmp33 `mode_compare` sweep so the audit remains comparable
+  with the current stability results.
+- Accept the result only if metrics rows contain populated physical cell/area
+  columns.
+
+## Expected Deliverable
+- A lightweight metrics-only PR with one row per wrapper/mode.
+- A conclusion stating whether `nm4` can be interpreted as a retained-logic
+  physical result or should be discarded as suspect.

--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1",
+  "candidate_id": "",
+  "decision": "pending",
+  "reason": "Awaiting gate-count audit result.",
+  "evidence_refs": [],
+  "next_action": "dispatch l1_npu_fp16_compute_parallelism_gate_count_audit_nm1_nm2_nm4_nm8_nm16_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1",
+  "decision": "pending"
+}

--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/proposal.json
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1",
+  "created_utc": "2026-05-21T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "npu_compute_parallelism_gate_count",
+  "title": "NPU FP16 compute parallelism gate-count audit",
+  "hypothesis": "The nm4 timing and power result is only meaningful if synthesis and place/route physically retain the requested GEMM modules. Capturing mapped cell count and stdcell area across nm1, nm2, nm4, nm8, and nm16 will reveal whether any parallel units were optimized away or whether the nm4 result is a real physical-quality point.",
+  "direct_comparison": {
+    "primary_question": "Do mapped stdcell count and area scale consistently with requested FP16 GEMM module count after OpenROAD synthesis and place/route?",
+    "include": [
+      "npu_top wrappers with num_modules nm1, nm2, nm4, nm8, and nm16",
+      "flat_nomacro and hier_macro mode comparison using the cmp33 floorplan",
+      "stdcell_count, stdcell_area_um2, instance_area_um2, timing, and power in metrics.csv"
+    ],
+    "exclude": [
+      "new dispatcher architecture changes",
+      "new memory hierarchy or NoC modeling",
+      "quality conclusions from timing/power until physical retention is confirmed"
+    ]
+  },
+  "expected_benefit": [
+    "separates real physical scaling from accidental dead-logic elimination",
+    "adds retained cell/area evidence to the current compute-parallelism frontier",
+    "provides a gate-count sanity check before using nm4 as a preferred point"
+  ],
+  "risks": [
+    "OpenROAD metrics key names can vary by stage or flow version",
+    "cell count alone does not prove full functional utilization of every data path",
+    "fixed floorplan quality can still dominate timing even when cell count scales correctly"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_npu_fp16_compute_parallelism_gate_count_audit_nm1_nm2_nm4_nm8_nm16_v1",
+      "task_type": "l1_sweep",
+      "objective": "audit_gate_count_scaling",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "npu_compute_parallelism_gate_count",
+      "cost_class": "medium",
+      "comparison_role": "sanity_check",
+      "depends_on_item_ids": [
+        "l1_npu_fp16_compute_parallelism_stability_nm1_nm2_nm4_seed3_v1",
+        "l1_npu_fp16_compute_parallelism_stability_nm8_nm16_nm32_seed3_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "expected_result": {
+        "direction": "validate_or_invalidate",
+        "reason": "Confirm whether timing and power comparisons can be interpreted as physical architecture evidence."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/designs/npu_blocks/trials/trial_003/npu_fp16_cpp_nm1_cmp/metrics.csv",
+    "runs/designs/npu_blocks/trials/trial_003/npu_fp16_cpp_nm2_cmp/metrics.csv",
+    "runs/designs/npu_blocks/trials/trial_003/npu_fp16_cpp_nm4_cmp/metrics.csv",
+    "runs/designs/npu_blocks/trials/trial_003/npu_fp16_cpp_nm8_cmp/metrics.csv",
+    "runs/designs/npu_blocks/trials/trial_003/npu_fp16_cpp_nm16_cmp/metrics.csv"
+  ],
+  "knowledge_refs": [
+    "npu/rtlgen/gen.py",
+    "npu/synth/run_block_sweep.py",
+    "runs/campaigns/npu/compute_parallelism_stability/sweeps/nangate45_cmp33_mode_compare.json",
+    "docs/proposals/prop_l1_npu_fp16_compute_parallelism_stability_v1/analysis_report.md"
+  ]
+}

--- a/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/quality_gate.md
@@ -1,0 +1,21 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1`
+- `title`: `NPU FP16 compute parallelism gate-count audit`
+
+## Checks
+- metric:
+  - threshold: each metrics row has non-empty `stdcell_count`
+- metric:
+  - threshold: each metrics row has non-empty `stdcell_area_um2`
+- metric:
+  - threshold: `stdcell_count` and/or `stdcell_area_um2` increase from nm1 to
+    larger module counts unless a documented synthesis explanation is present
+- metric:
+  - threshold: `config_nmN.json` and retained metrics agree on the requested
+    `compute.gemm.num_modules`
+
+## Result
+- status: pending
+- note: Evaluate after the gate-count audit result is available.

--- a/npu/docs/workflow.md
+++ b/npu/docs/workflow.md
@@ -175,6 +175,10 @@ For the current practical baseline, use
 
 ## 8) Aggregate results and iterate
 - Track result rows in per-design `metrics.csv`.
+- For physical architecture comparisons, retain `instance_area_um2`,
+  `stdcell_area_um2`, and `stdcell_count` when OpenROAD emits them. A timing or
+  power point with blank cell/area columns is not enough to prove that requested
+  parallel datapaths survived logic synthesis.
 - Keep run-level artifacts in `work/<hash>/result.json`.
 - Update `npu/docs/status.md` and affected plan docs after milestone runs.
 

--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -598,6 +598,14 @@ def parse_openroad_metrics_json(metrics_json_path: Path) -> Dict[str, object]:
     return raw
 
 
+def first_openroad_metric(metrics_json: Dict[str, object], keys: List[str]) -> Optional[float]:
+    for key in keys:
+        value = safe_float(metrics_json.get(key))
+        if value is not None:
+            return value
+    return None
+
+
 def resolve_finish_metrics_path(platform: str, design_name: str, tag: str, flow_variant: str) -> Path:
     tag_path = LOG_BASE / platform / design_name / str(tag) / "6_finish.json"
     if tag_path.exists():
@@ -617,17 +625,54 @@ def add_utilization_metrics(
     metrics_json: Dict[str, object],
     sweep_params: Dict[str, object],
 ) -> None:
-    instance_area = safe_float(metrics_json.get("finish__design__instance__area"))
-    if instance_area is None:
-        instance_area = safe_float(metrics_json.get("placeopt__design__instance__area"))
+    instance_area = first_openroad_metric(
+        metrics_json,
+        [
+            "finish__design__instance__area",
+            "final__design__instance__area",
+            "detailedroute__design__instance__area",
+            "globalroute__design__instance__area",
+            "cts__design__instance__area",
+            "detailedplace__design__instance__area",
+            "placeopt__design__instance__area",
+            "globalplace__design__instance__area",
+            "synth__design__instance__area",
+        ],
+    )
     if instance_area is not None:
         metrics["instance_area_um2"] = instance_area
 
-    stdcell_area = safe_float(metrics_json.get("synth__design__instance__area__stdcell"))
+    stdcell_area = first_openroad_metric(
+        metrics_json,
+        [
+            "finish__design__instance__area__stdcell",
+            "final__design__instance__area__stdcell",
+            "detailedroute__design__instance__area__stdcell",
+            "globalroute__design__instance__area__stdcell",
+            "cts__design__instance__area__stdcell",
+            "detailedplace__design__instance__area__stdcell",
+            "placeopt__design__instance__area__stdcell",
+            "globalplace__design__instance__area__stdcell",
+            "synth__design__instance__area__stdcell",
+        ],
+    )
     if stdcell_area is not None:
         metrics["stdcell_area_um2"] = stdcell_area
 
-    stdcell_count = safe_float(metrics_json.get("placeopt__design__instance__count__stdcell"))
+    stdcell_count = first_openroad_metric(
+        metrics_json,
+        [
+            "finish__design__instance__count__stdcell",
+            "final__design__instance__count__stdcell",
+            "detailedroute__design__instance__count__stdcell",
+            "globalroute__design__instance__count__stdcell",
+            "cts__design__instance__count__stdcell",
+            "detailedplace__design__instance__count__stdcell",
+            "placeopt__design__instance__count__stdcell",
+            "globalplace__design__instance__count__stdcell",
+            "synth__design__instance__count__stdcell",
+        ],
+    )
     if stdcell_count is not None:
         metrics["stdcell_count"] = stdcell_count
 

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -220,11 +220,6 @@ class ModeCompareRegressionTest(unittest.TestCase):
             self.assertIn("'SYNTH_HIERARCHICAL': 0", out)
             self.assertIn("'SYNTH_HIERARCHICAL': 1", out)
 
-
-if __name__ == "__main__":
-    unittest.main()
-
-
 class SynthTargetMappingRegressionTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -261,3 +256,39 @@ class SynthTargetMappingRegressionTest(unittest.TestCase):
         self.assertEqual(12345.0, metrics["stdcell_count"])
         self.assertEqual(1960000.0, metrics["core_area_um2"])
         self.assertAlmostEqual(25.0, metrics["utilization_pct"])
+
+    def test_add_utilization_metrics_accepts_final_stage_cell_metrics(self):
+        metrics = {}
+        self.run_block_sweep.add_utilization_metrics(
+            metrics,
+            metrics_json={
+                "final__design__instance__area": 510000.0,
+                "final__design__instance__area__stdcell": 501000.0,
+                "final__design__instance__count__stdcell": 23456,
+            },
+            sweep_params={"CORE_AREA": "50 50 1450 1450"},
+        )
+        self.assertEqual(510000.0, metrics["instance_area_um2"])
+        self.assertEqual(501000.0, metrics["stdcell_area_um2"])
+        self.assertEqual(23456.0, metrics["stdcell_count"])
+        self.assertAlmostEqual(510000.0 * 100.0 / 1960000.0, metrics["utilization_pct"])
+
+    def test_add_utilization_metrics_accepts_synth_only_cell_metrics(self):
+        metrics = {}
+        self.run_block_sweep.add_utilization_metrics(
+            metrics,
+            metrics_json={
+                "synth__design__instance__area": 410000.0,
+                "synth__design__instance__area__stdcell": 409000.0,
+                "synth__design__instance__count__stdcell": 19876,
+            },
+            sweep_params={"CORE_AREA": "0 0 1000 1000"},
+        )
+        self.assertEqual(410000.0, metrics["instance_area_um2"])
+        self.assertEqual(409000.0, metrics["stdcell_area_um2"])
+        self.assertEqual(19876.0, metrics["stdcell_count"])
+        self.assertAlmostEqual(41.0, metrics["utilization_pct"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make block sweep metric extraction tolerate finish/final/place/route/synth OpenROAD metric key variants
- add regression coverage for final-stage and synth-only stdcell count/area extraction
- add the FP16 compute parallelism gate-count audit proposal and document the physical-evidence requirement

## Validation
- python3 tests/test_run_block_sweep_mode_compare.py
- python3 scripts/validate_runs.py --skip_eval_queue

## Next
After this lands, dispatch `l1_npu_fp16_compute_parallelism_gate_count_audit_nm1_nm2_nm4_nm8_nm16_v1` so the nm sweep reruns with populated cell/area metrics.