### PR TITLE
[codex] read OpenROAD metadata metrics for block sweeps

### DIFF
--- a/npu/docs/workflow.md
+++ b/npu/docs/workflow.md
@@ -179,6 +179,9 @@ For the current practical baseline, use
   `stdcell_area_um2`, and `stdcell_count` when OpenROAD emits them. A timing or
   power point with blank cell/area columns is not enough to prove that requested
   parallel datapaths survived logic synthesis.
+  `run_block_sweep.py` runs ORFS `metadata-generate` after full-flow/finish runs
+  and reads `reports/<platform>/<design>/<variant>/metadata.json` for these
+  fields.
 - Keep run-level artifacts in `work/<hash>/result.json`.
 - Update `npu/docs/status.md` and affected plan docs after milestone runs.
 

--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -598,6 +598,13 @@ def parse_openroad_metrics_json(metrics_json_path: Path) -> Dict[str, object]:
     return raw
 
 
+def merge_openroad_metrics_json(paths: List[Path]) -> Dict[str, object]:
+    merged: Dict[str, object] = {}
+    for path in paths:
+        merged.update(parse_openroad_metrics_json(path))
+    return merged
+
+
 def first_openroad_metric(metrics_json: Dict[str, object], keys: List[str]) -> Optional[float]:
     for key in keys:
         value = safe_float(metrics_json.get(key))
@@ -617,6 +624,25 @@ def resolve_finish_metrics_path(platform: str, design_name: str, tag: str, flow_
     if base_path.exists():
         return base_path
     return tag_path
+
+
+def resolve_metadata_metrics_path(platform: str, design_name: str, tag: str, flow_variant: str) -> Path:
+    tag_path = REPORT_BASE / platform / design_name / str(tag) / "metadata.json"
+    if tag_path.exists():
+        return tag_path
+    variant_path = REPORT_BASE / platform / design_name / flow_variant / "metadata.json"
+    if variant_path.exists():
+        return variant_path
+    base_path = REPORT_BASE / platform / design_name / "base" / "metadata.json"
+    if base_path.exists():
+        return base_path
+    return tag_path
+
+
+def should_generate_openroad_metadata(make_target: Optional[str]) -> bool:
+    if make_target is None:
+        return True
+    return str(make_target).strip() in {"", "finish"}
 
 
 def add_utilization_metrics(
@@ -1571,6 +1597,13 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
         make_cmd.append(actual_make_target)
     print(f"[INFO] Running OpenROAD flow: {' '.join(make_cmd)}")
     subprocess.run(make_cmd, cwd="/orfs/flow", check=True, env=env)
+    if should_generate_openroad_metadata(actual_make_target):
+        metadata_cmd = list(make_cmd)
+        if actual_make_target:
+            metadata_cmd = metadata_cmd[:-1]
+        metadata_cmd.append("metadata-generate")
+        print(f"[INFO] Running OpenROAD metadata extraction: {' '.join(metadata_cmd)}")
+        subprocess.run(metadata_cmd, cwd="/orfs/flow", check=True, env=env)
 
     blackbox_counts: Dict[str, int] = {}
     missing_blackboxes: List[str] = []
@@ -1639,9 +1672,10 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
 
         metrics = parse_finish_report(report_path)
         finish_metrics_path = resolve_finish_metrics_path(platform, design_name, str(tag), flow_variant)
+        metadata_metrics_path = resolve_metadata_metrics_path(platform, design_name, str(tag), flow_variant)
         add_utilization_metrics(
             metrics,
-            metrics_json=parse_openroad_metrics_json(finish_metrics_path),
+            metrics_json=merge_openroad_metrics_json([finish_metrics_path, metadata_metrics_path]),
             sweep_params=sweep_params,
         )
         if platform.lower() == "asap7":

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -240,6 +240,31 @@ class SynthTargetMappingRegressionTest(unittest.TestCase):
         self.assertEqual("synth", self.run_block_sweep.resolve_make_target("1_2_yosys"))
         self.assertEqual("synth", self.run_block_sweep.resolve_make_target("1_synth.v"))
 
+    def test_should_generate_openroad_metadata_for_full_flow_and_finish(self):
+        self.assertTrue(self.run_block_sweep.should_generate_openroad_metadata(None))
+        self.assertTrue(self.run_block_sweep.should_generate_openroad_metadata(""))
+        self.assertTrue(self.run_block_sweep.should_generate_openroad_metadata("finish"))
+        self.assertFalse(self.run_block_sweep.should_generate_openroad_metadata("3_3_place_gp"))
+        self.assertFalse(self.run_block_sweep.should_generate_openroad_metadata("synth"))
+
+    def test_merge_openroad_metrics_json_prefers_later_paths(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            first = base / "6_finish.json"
+            second = base / "metadata.json"
+            first.write_text(
+                json.dumps({"finish__design__instance__area": 1.0, "shared": 1}),
+                encoding="utf-8",
+            )
+            second.write_text(
+                json.dumps({"synth__design__instance__count__stdcell": 2, "shared": 2}),
+                encoding="utf-8",
+            )
+            merged = self.run_block_sweep.merge_openroad_metrics_json([first, second])
+        self.assertEqual(1.0, merged["finish__design__instance__area"])
+        self.assertEqual(2, merged["synth__design__instance__count__stdcell"])
+        self.assertEqual(2, merged["shared"])
+
     def test_add_utilization_metrics_from_finish_json(self):
         metrics = {}
         self.run_block_sweep.add_utilization_metrics(


### PR DESCRIPTION
## Summary
- run ORFS `metadata-generate` after full-flow/finish block sweeps
- read `reports/<platform>/<design>/<variant>/metadata.json` alongside finish JSON for instance/stdcell area and stdcell count
- document the metadata source and add regression tests for metadata generation/merge behavior

## Why
PR #651 showed timing and power were captured, but `instance_area_um2`, `stdcell_area_um2`, and `stdcell_count` stayed blank. The runner was looking at finish logs, while ORFS aggregates these physical metrics into report metadata.

## Validation
- python3 tests/test_run_block_sweep_mode_compare.py
- python3 scripts/validate_runs.py --skip_eval_queue

## Follow-up
After this lands, update the evaluator and rerun `l1_npu_fp16_compute_parallelism_gate_count_audit_nm1_nm2_nm4_nm8_nm16_v1`; PR #651 should not be merged as gate-count evidence.