### PR TITLE
Add NPU architectural writeback pre-PPA gates

### DIFF
--- a/npu/eval/tensor_trace_summary.py
+++ b/npu/eval/tensor_trace_summary.py
@@ -174,13 +174,16 @@ def _parse_tensor_trace_line(line: str) -> JsonDict | None:
         if len(text) % 2 != 0:
             raise ValueError('TENSOR_TRACE bytes_hex must contain an even number of nybbles')
         data_bytes = [int(text[idx:idx + 2], 16) for idx in range(0, len(text), 2)]
-        return byte_vector_tensor_summary(
+        summary = byte_vector_tensor_summary(
             name=fields.get('name', 'tensor'),
             step=int(fields.get('step', 0)),
             data_bytes=data_bytes,
             dtype=fields.get('dtype', 'u8'),
             shape=_parse_shape(fields['shape']) if 'shape' in fields else None,
         )
+        if 'addr' in fields:
+            summary['addr'] = fields['addr']
+        return summary
 
     required = ('name', 'step', 'shape', 'dtype', 'min', 'max', 'mean', 'std')
     missing = [key for key in required if key not in fields]
@@ -203,6 +206,8 @@ def _parse_tensor_trace_line(line: str) -> JsonDict | None:
             summary['quantization'] = quantization
     if 'raw_hex' in fields:
         summary['raw_hex'] = fields['raw_hex']
+    if 'addr' in fields:
+        summary['addr'] = fields['addr']
     return summary
 
 

--- a/npu/rtlgen/gen.py
+++ b/npu/rtlgen/gen.py
@@ -98,6 +98,11 @@ module {top_name} (
   reg [8:0]  dma_beats_left;
   reg [7:0]  dma_arlen;
   reg [{axi_data_width_minus1}:0] dma_buf_mem [0:255];
+  reg        dma_writeback;
+  reg [{axi_data_width_minus1}:0] dma_writeback_data;
+  reg [{axi_strb_width_minus1}:0] dma_writeback_wstrb;
+  reg        dma_vec_read;
+  reg        dma_vec_write;
   reg [7:0]  dma_rd_idx;
   reg [7:0]  dma_wr_idx;
   reg [{data_width_minus1}:0] error_code;
@@ -227,6 +232,11 @@ module {top_name} (
       dma_beats <= 0;
       dma_beats_left <= 0;
       dma_arlen <= 0;
+      dma_writeback <= 0;
+      dma_writeback_data <= 0;
+      dma_writeback_wstrb <= 0;
+      dma_vec_read <= 0;
+      dma_vec_write <= 0;
       dma_rd_idx <= 0;
       dma_wr_idx <= 0;
 {dma_reset}
@@ -1454,6 +1464,8 @@ def write_outputs(cfg: dict, out_dir: str) -> None:
     gemm_mac_vec_width = gemm_mac_lanes * gemm_elem_bits
     gemm_mac_vec_width_minus1 = gemm_mac_vec_width - 1
     gemm_accum_width_minus1 = gemm_accum_width - 1
+    gemm_accum_byte_width = max(1, min(axi_strb_width, (gemm_accum_width + 7) // 8))
+    gemm_writeback_wstrb = (1 << gemm_accum_byte_width) - 1
     gemm_a_hi = 64 + gemm_mac_vec_width - 1
     gemm_b_hi = 128 + gemm_mac_vec_width - 1
     gemm_slot_count_minus1 = gemm_num_modules - 1
@@ -1512,6 +1524,8 @@ def write_outputs(cfg: dict, out_dir: str) -> None:
     gemm_slots_busy_expr = f"(gemm_slot_valid != {gemm_slot_valid_zero})"
     vec_data_width = vec_lanes * 8
     vec_data_width_minus1 = vec_data_width - 1
+    vec_writeback_byte_width = max(1, min(axi_strb_width, vec_data_width // 8))
+    vec_writeback_wstrb = (1 << vec_writeback_byte_width) - 1
     vec_a_hi = 64 + vec_data_width - 1
     vec_b_hi = 128 + vec_data_width - 1
     vec_fp16_elem_lanes = max(1, vec_lanes // 2)
@@ -1613,6 +1627,11 @@ def write_outputs(cfg: dict, out_dir: str) -> None:
             f"  reg [{vec_data_width_minus1}:0] vec_in0;",
             f"  reg [{vec_data_width_minus1}:0] vec_in1;",
             f"  reg [{vec_data_width_minus1}:0] vec_last_result;",
+            f"  reg [{dma_addr_width_minus1}:0] vec_mem_dst;",
+            "  reg [31:0] vec_mem_bytes;",
+            "  reg [3:0] vec_mem_op_sel;",
+            "  reg [3:0] vec_mem_dtype_sel;",
+            "  reg vec_mem_writeback;",
             "  reg [3:0] vec_op_sel;",
             "  reg [3:0] vec_dtype_sel;",
             "  reg vec_pending;",
@@ -2172,12 +2191,26 @@ endmodule
 """
     compute_instances = gemm_compute_instances + vec_compute_instances + softmax_compute_instances
 
-    vec_update = """      vec_done_pulse <= 1'b0;
+    vec_update = f"""      vec_done_pulse <= 1'b0;
       if (vec_pending) begin
         vec_last_result <= vec_result_next;
         vec_pending <= 1'b0;
-        vec_done_pulse <= 1'b1;
-        irq_status[IRQ_EVENT] <= 1'b1;
+        if (vec_mem_writeback) begin
+          dma_dst <= vec_mem_dst;
+          dma_size <= vec_mem_bytes;
+          dma_beats <= 1;
+          dma_arlen <= 0;
+          dma_writeback <= 1'b1;
+          dma_writeback_data <= 0;
+          dma_writeback_data[{vec_data_width_minus1}:0] <= vec_result_next;
+          dma_writeback_wstrb <= {axi_strb_width}'h{vec_writeback_wstrb:x};
+          dma_vec_write <= 1'b1;
+          dma_pending <= 1'b1;
+          vec_mem_writeback <= 1'b0;
+        end else begin
+          vec_done_pulse <= 1'b1;
+          irq_status[IRQ_EVENT] <= 1'b1;
+        end
       end
 """
     softmax_update = """      softmax_done_pulse <= 1'b0;
@@ -2213,6 +2246,11 @@ endmodule
             "      vec_in0 <= 0;",
             "      vec_in1 <= 0;",
             "      vec_last_result <= 0;",
+            "      vec_mem_dst <= 0;",
+            "      vec_mem_bytes <= 0;",
+            "      vec_mem_op_sel <= 0;",
+            "      vec_mem_dtype_sel <= 0;",
+            "      vec_mem_writeback <= 0;",
             "      vec_op_sel <= 0;",
             "      vec_dtype_sel <= 0;",
             "      vec_pending <= 0;",
@@ -2398,9 +2436,13 @@ endmodule
                 f"        {branch_kw} (gemm_slot_done[{slot_idx}]) begin",
                 f"          dma_src <= gemm_slot_src{slot_idx};",
                 f"          dma_dst <= gemm_slot_dst{slot_idx};",
-                f"          dma_size <= gemm_slot_size{slot_idx};",
-                f"          dma_beats <= gemm_slot_beats{slot_idx};",
-                f"          dma_arlen <= gemm_slot_arlen{slot_idx};",
+                f"          dma_size <= {gemm_accum_byte_width};",
+                "          dma_beats <= 1;",
+                "          dma_arlen <= 0;",
+                "          dma_writeback <= 1'b1;",
+                "          dma_writeback_data <= 0;",
+                f"          dma_writeback_data[{gemm_accum_width_minus1}:0] <= gemm_slot_accum{slot_idx};",
+                f"          dma_writeback_wstrb <= {axi_strb_width}'h{gemm_writeback_wstrb:x};",
                 "          dma_pending <= 1'b1;",
                 f"          gemm_slot_valid[{slot_idx}] <= 1'b0;",
                 f"          gemm_slot_done[{slot_idx}] <= 1'b0;",
@@ -2410,7 +2452,7 @@ endmodule
         )
     gemm_dispatch_block = "\n".join(gemm_dispatch_lines)
 
-    gemm_update = f"""      // {gemm_num_modules}-slot GEMM stub with OOO-capable completion scheduling.
+    gemm_update = f"""      // {gemm_num_modules}-slot GEMM compute path with scalar accumulator writeback.
       gemm_done_pulse <= 1'b0;
 {vec_update}\
 {softmax_update}\
@@ -2503,15 +2545,38 @@ endmodule
               dma_size <= cq_mem_rdata[223:192];
               dma_beats <= {dma_beats_expr};
               dma_arlen <= {dma_arlen_expr};
+              dma_writeback <= 1'b0;
+              dma_writeback_data <= 0;
+              dma_writeback_wstrb <= 0;
               dma_pending <= 1'b1;
             end else if (cq_mem_rdata[7:0] == 8'h10) begin
-              // GEMM stub: v0.1 sizes packed in TAG.
+              // GEMM v0.1: sizes packed in TAG.
 {gemm_issue_chain_v1}
             end else if (cq_mem_rdata[7:0] == 8'h11) begin
               // VEC_OP (v0.1): input vectors are carried in descriptor payload bytes.
               if (vec_pending) begin
                 error_code <= 32'h3; // VEC in-flight queue full
               end else begin
+                if (cq_mem_rdata[63]) begin
+                  if (dma_pending) begin
+                    error_code <= 32'h9; // VEC memory read while DMA engine busy
+                  end else begin
+                    vec_mem_dst <= cq_mem_rdata[191:128];
+                    vec_mem_bytes <= cq_mem_rdata[223:192];
+                    vec_mem_op_sel <= cq_mem_rdata[11:8];
+                    vec_mem_dtype_sel <= cq_mem_rdata[15:12];
+                    dma_src <= cq_mem_rdata[127:64];
+                    dma_dst <= cq_mem_rdata[191:128];
+                    dma_size <= cq_mem_rdata[223:192];
+                    dma_beats <= 1;
+                    dma_arlen <= 0;
+                    dma_writeback <= 1'b0;
+                    dma_writeback_data <= 0;
+                    dma_writeback_wstrb <= 0;
+                    dma_vec_read <= 1'b1;
+                    dma_pending <= 1'b1;
+                  end
+                end else begin
                 vec_in0 <= cq_mem_rdata[{vec_a_hi}:64];
                 vec_in1 <= cq_mem_rdata[{vec_b_hi}:128];
                 vec_op_sel <= cq_mem_rdata[11:8];
@@ -2564,6 +2629,7 @@ endmodule
                   error_code <= 32'h6; // unsupported configured VEC op
                 end else begin
                   vec_pending <= 1'b1;
+                end
                 end
               end
             end else if (cq_mem_rdata[7:0] == 8'h12) begin
@@ -2619,13 +2685,33 @@ endmodule
             last_size <= cq_mem_rdata[31:0];
             last_op_uid <= cq_mem_rdata[255:192];
             if (cq_word0[7:0] == 8'h10) begin
-              // GEMM stub: v0.2 sizes in extension.
+              // GEMM v0.2: sizes in extension.
 {gemm_issue_chain_v2}
             end else if (cq_word0[7:0] == 8'h11) begin
               // VEC_OP (v0.2 base word): vectors are sourced from header payload.
               if (vec_pending) begin
                 error_code <= 32'h3; // VEC in-flight queue full
               end else begin
+                if (cq_word0[63]) begin
+                  if (dma_pending) begin
+                    error_code <= 32'h9; // VEC memory read while DMA engine busy
+                  end else begin
+                    vec_mem_dst <= cq_word0[191:128];
+                    vec_mem_bytes <= cq_word0[223:192];
+                    vec_mem_op_sel <= cq_word0[11:8];
+                    vec_mem_dtype_sel <= cq_word0[15:12];
+                    dma_src <= cq_word0[127:64];
+                    dma_dst <= cq_word0[191:128];
+                    dma_size <= cq_word0[223:192];
+                    dma_beats <= 1;
+                    dma_arlen <= 0;
+                    dma_writeback <= 1'b0;
+                    dma_writeback_data <= 0;
+                    dma_writeback_wstrb <= 0;
+                    dma_vec_read <= 1'b1;
+                    dma_pending <= 1'b1;
+                  end
+                end else begin
                 vec_in0 <= cq_word0[{vec_a_hi}:64];
                 vec_in1 <= cq_word0[{vec_b_hi}:128];
                 vec_op_sel <= cq_word0[11:8];
@@ -2684,6 +2770,7 @@ endmodule
                   error_code <= 32'h6;
                 end else begin
                   vec_pending <= 1'b1;
+                end
                 end
               end
             end else begin
@@ -2773,6 +2860,9 @@ endmodule
             dma_size <= cq_mem_rdata[223:192];
             dma_beats <= {dma_beats_expr};
             dma_arlen <= {dma_arlen_expr};
+            dma_writeback <= 1'b0;
+            dma_writeback_data <= 0;
+            dma_writeback_wstrb <= 0;
             dma_pending <= 1'b1;
           end
           cq_head <= cq_head + 32;
@@ -3294,27 +3384,45 @@ endmodule
       case (dma_state)
         0: begin
           if (dma_pending) begin
-            if (dma_beats_left == 0) begin
-              dma_beats_left <= dma_beats;
-              dma_rd_idx <= 0;
+            if (dma_writeback) begin
+              dma_beats_left <= 1;
               dma_wr_idx <= 0;
-            end
-            m_axi_arvalid <= 1'b1;
-            m_axi_araddr <= dma_src;
-            m_axi_arlen <= dma_arlen;
-            m_axi_arsize <= 3'd{axi_size}; // beat bytes = 2**{axi_size}
-            if (m_axi_arready) begin
-              dma_state <= 1;
+              dma_state <= 2;
+            end else begin
+              if (dma_beats_left == 0) begin
+                dma_beats_left <= dma_beats;
+                dma_rd_idx <= 0;
+                dma_wr_idx <= 0;
+              end
+              m_axi_arvalid <= 1'b1;
+              m_axi_araddr <= dma_src;
+              m_axi_arlen <= dma_arlen;
+              m_axi_arsize <= 3'd{axi_size}; // beat bytes = 2**{axi_size}
+              if (m_axi_arready) begin
+                dma_state <= 1;
+              end
             end
           end
         end
         1: begin
           m_axi_rready <= 1'b1;
           if (m_axi_rvalid) begin
-            dma_buf_mem[dma_rd_idx] <= m_axi_rdata;
-            dma_rd_idx <= dma_rd_idx + 1;
-            if (m_axi_rlast) begin
-              dma_state <= 2;
+            if (dma_vec_read) begin
+              vec_in0 <= m_axi_rdata[{vec_data_width_minus1}:0];
+              vec_in1 <= 0;
+              vec_op_sel <= vec_mem_op_sel;
+              vec_dtype_sel <= vec_mem_dtype_sel;
+              vec_pending <= 1'b1;
+              vec_mem_writeback <= 1'b1;
+              dma_vec_read <= 1'b0;
+              dma_pending <= 1'b0;
+              dma_state <= 0;
+            end else begin
+              dma_buf_mem[dma_rd_idx] <= m_axi_rdata;
+              dma_rd_idx <= dma_rd_idx + 1;
+              if (m_axi_rlast) begin
+                dma_state <= 2;
+              end
             end
           end
         end
@@ -3329,8 +3437,8 @@ endmodule
         end
         3: begin
           m_axi_wvalid <= 1'b1;
-          m_axi_wdata <= dma_buf_mem[dma_wr_idx];
-          m_axi_wstrb <= {{{axi_strb_width}{{1'b1}}}};
+          m_axi_wdata <= dma_writeback ? dma_writeback_data : dma_buf_mem[dma_wr_idx];
+          m_axi_wstrb <= dma_writeback ? dma_writeback_wstrb : {{{axi_strb_width}{{1'b1}}}};
           m_axi_wlast <= (dma_beats_left == 1);
           if (m_axi_wready) begin
             if (dma_beats_left == 1) begin
@@ -3347,6 +3455,11 @@ endmodule
             dma_beats_left <= 0;
             dma_state <= 0;
             dma_pending <= 1'b0;
+            dma_writeback <= 1'b0;
+            if (dma_vec_write) begin
+              vec_done_pulse <= 1'b1;
+              dma_vec_write <= 1'b0;
+            end
             irq_status[IRQ_EVENT] <= 1'b1;
           end
         end

--- a/npu/sim/perf/README.md
+++ b/npu/sim/perf/README.md
@@ -78,6 +78,7 @@ make -f npu/sim/perf/Makefile test
   - `compare_compute_results.py` reduces both sides to the canonical `npu_compute_equivalence_trace_v1` summary, prints the RTL/perf SHA-256 values, and fails strict equivalence on summary hash mismatch.
   - `run_golden.sh` writes durable `*_compute_summary.json` artifacts next to each RTL log and perf trace for post-run inspection.
   - `compare_tensor_traces.py` compares RTL `TENSOR_TRACE` lines for GEMM accumulations, generic VEC results, semantic softmax/normalization-family VEC results, and dedicated `SOFTMAX` expected output bytes when a perf memory image is supplied. It writes durable `*_tensor_trace_summary.json` artifacts.
+  - `compare_tensor_traces.py --require-architectural-writeback` switches from internal summaries to memory-visible writeback tensors. The RTL log must emit `gemm.c` for GEMM C destinations and `vec.dst` for memory-backed VEC destinations; perf compares those bytes against its memory model. `--require-architectural-gemm-writeback` remains as a compatibility alias.
 - Runs timing cross-check:
   - `compare_gemm_timing.py` compares RTL GEMM cycles vs perf GEMM latency model.
   - `golden_gemm_v2_ooo` additionally checks out-of-order completion behavior (`--require-order-change`).
@@ -115,6 +116,11 @@ make -f npu/sim/perf/Makefile test
   `python3 npu/synth/pre_synth_memory.py <arch.yml> --id <id>`.
 - VEC op decode uses descriptor `flags` low nibble (`[3:0]`) for op code and
   high nibble (`[7:4]`) for dtype.
+- VEC descriptors with `tag[31]` set are memory-backed: descriptor bytes
+  `[15:8]` are interpreted as `src`, `[23:16]` as `dst`, and `[27:24]` as
+  byte count. Perf reads the source bytes from its memory image and writes the
+  computed result bytes back to `dst`, matching the stricter RTL architectural
+  writeback gate.
 
 ### Bandwidth units
 All `*_bw_gbps` knobs are interpreted as effective **GB/s** (gigabytes per

--- a/npu/sim/perf/compare_tensor_traces.py
+++ b/npu/sim/perf/compare_tensor_traces.py
@@ -33,6 +33,7 @@ def _build_perf_tensor_trace(path: str | Path) -> list[dict[str, Any]]:
 
     tensors = []
     gemm_step = 0
+    vec_step = 0
     softmax_step = 0
     vec_step = 0
     for event in trace.get('trace', []):
@@ -92,6 +93,54 @@ def _build_perf_tensor_trace(path: str | Path) -> list[dict[str, Any]]:
     return sorted(tensors, key=lambda entry: (int(entry.get('step', 0)), str(entry.get('name', ''))))
 
 
+def _int32_le_bytes(value: int | str) -> list[int]:
+    raw = int(str(value), 0) if isinstance(value, str) else int(value)
+    raw &= 0xFFFF_FFFF
+    return [(raw >> (8 * idx)) & 0xFF for idx in range(4)]
+
+
+def _build_perf_arch_tensor_trace(path: str | Path) -> list[dict[str, Any]]:
+    with Path(path).open('r', encoding='utf-8') as f:
+        trace = json.load(f)
+
+    tensors = []
+    gemm_step = 0
+    vec_step = 0
+    for event in trace.get('trace', []):
+        if event.get('name') == 'GEMM':
+            if 'expected_accum' not in event:
+                raise ValueError('perf GEMM event missing expected_accum')
+            if 'c' not in event:
+                raise ValueError('perf GEMM event missing architectural destination c')
+            gemm_step += 1
+            tensor = byte_vector_tensor_summary(
+                name='gemm.c',
+                step=gemm_step,
+                data_bytes=_int32_le_bytes(event['expected_accum']),
+                dtype='int32_le',
+                shape=[1, 4],
+            )
+            tensor['addr'] = str(event['c'])
+            tensors.append(tensor)
+        elif event.get('name') == 'VEC_OP' and event.get('memory_backed'):
+            if 'expected_result_bytes' not in event:
+                raise ValueError('perf memory-backed VEC_OP event missing expected_result_bytes')
+            if 'dst' not in event:
+                raise ValueError('perf memory-backed VEC_OP event missing dst')
+            vec_step += 1
+            data_bytes = [int(value) & 0xFF for value in event['expected_result_bytes']]
+            tensor = byte_vector_tensor_summary(
+                name='vec.dst',
+                step=vec_step,
+                data_bytes=data_bytes,
+                dtype='packed_u8',
+                shape=[1, len(data_bytes)],
+            )
+            tensor['addr'] = str(event['dst'])
+            tensors.append(tensor)
+    return sorted(tensors, key=lambda entry: (int(entry.get('step', 0)), str(entry.get('name', ''))))
+
+
 def _write_json(path: str | None, payload: Any) -> None:
     if not path:
         return
@@ -104,11 +153,25 @@ def main() -> int:
     ap.add_argument('--perf-trace', required=True, help='Perf trace JSON file')
     ap.add_argument('--rtl-summary-out', help='Optional path to write canonical RTL tensor trace JSON')
     ap.add_argument('--perf-summary-out', help='Optional path to write canonical perf tensor trace JSON')
+    ap.add_argument(
+        '--require-architectural-gemm-writeback',
+        action='store_true',
+        help='Compare memory-visible GEMM C writeback tensors instead of internal GEMM accumulator traces',
+    )
+    ap.add_argument(
+        '--require-architectural-writeback',
+        action='store_true',
+        help='Compare memory-visible architectural writeback tensors such as GEMM C and memory-backed VEC dst',
+    )
     args = ap.parse_args()
 
     try:
         rtl_tensors = parse_rtl_tensor_trace_log(args.rtl_log)
-        perf_tensors = _build_perf_tensor_trace(args.perf_trace)
+        if args.require_architectural_gemm_writeback or args.require_architectural_writeback:
+            rtl_tensors = [entry for entry in rtl_tensors if entry.get('name') in ('gemm.c', 'vec.dst')]
+            perf_tensors = _build_perf_arch_tensor_trace(args.perf_trace)
+        else:
+            perf_tensors = _build_perf_tensor_trace(args.perf_trace)
     except ValueError as exc:
         print(f'compare-tensor-trace: {exc}', file=sys.stderr)
         return 2

--- a/npu/sim/perf/run.py
+++ b/npu/sim/perf/run.py
@@ -540,6 +540,11 @@ def _bytes_to_hex_le(data):
     return "0x" + payload[::-1].hex()
 
 
+def _int32_le_bytes(value):
+    raw = int(value) & 0xFFFFFFFF
+    return [(raw >> (8 * idx)) & 0xFF for idx in range(4)]
+
+
 def _load_memory_image(path):
     doc = json.loads(Path(path).read_text(encoding="utf-8"))
     segments = doc.get("segments", [])
@@ -795,7 +800,25 @@ def desc_to_event(desc, cfg, memory=None):
         op_code = desc["flags"] & 0xF
         op_name = VEC_OP_NAMES.get(op_code, "unknown")
         dtype_code, dtype_name, dtype_bytes = _decode_dtype(desc["flags"], cfg, "vec")
-        vec_expected = _vec_expected_result(raw, desc["flags"], cfg, dtype_code=dtype_code)
+        memory_backed = bool(int(desc["tag"]) & 0x80000000)
+        expected_raw = raw
+        if memory_backed:
+            if memory is None:
+                event["warning"] = "vec expected-result unavailable: missing memory image"
+            else:
+                src_bytes = _mem_read_bytes(memory, src, min(int(size), 32))
+                if src_bytes is None:
+                    event["warning"] = (
+                        f"vec expected-result unavailable: missing memory image for "
+                        f"src=0x{src:016x} bytes={size}"
+                    )
+                else:
+                    expected_raw = bytearray(raw)
+                    for idx, byte in enumerate(src_bytes[:8]):
+                        expected_raw[8 + idx] = int(byte) & 0xFF
+                    for idx in range(8):
+                        expected_raw[16 + idx] = 0
+        vec_expected = _vec_expected_result(expected_raw, desc["flags"], cfg, dtype_code=dtype_code)
         event.update({
             "name": "VEC_OP",
             "op": op_name,
@@ -805,6 +828,7 @@ def desc_to_event(desc, cfg, memory=None):
             "src": f"0x{src:016x}",
             "dst": f"0x{dst:016x}",
             "bytes": size,
+            "memory_backed": memory_backed,
             "duration_ns": model.vec_time_ns(size, op_name, cfg, dtype_bytes=dtype_bytes),
         })
         event.update(
@@ -1035,10 +1059,14 @@ def build_trace(descs, cfg, overlap, memory=None):
         elif name == "GEMM":
             stats["gemm_ops"] += 1
             stats["gemm_time_ns"] += dur
+            if memory is not None and "expected_accum" in event:
+                _mem_write_bytes(memory, int(event["c"], 0), _int32_le_bytes(event["expected_accum"]))
         elif name == "VEC_OP":
             stats["vec_ops"] += 1
             stats["total_bytes"] += int(event.get("bytes", 0))
             stats["vec_time_ns"] += dur
+            if memory is not None and "expected_result_bytes" in event:
+                _mem_write_bytes(memory, int(event["dst"], 0), event["expected_result_bytes"])
         elif name == "SOFTMAX":
             stats["softmax_ops"] += 1
             stats["softmax_issue_count"] += 1

--- a/npu/sim/perf/tests/test_compare_compute_results.py
+++ b/npu/sim/perf/tests/test_compare_compute_results.py
@@ -380,3 +380,104 @@ def test_compare_tensor_traces_includes_dedicated_softmax_result_bytes():
     assert rtl_doc == perf_doc
     assert perf_doc[0]["name"] == "softmax.result"
     assert perf_doc[0]["raw_hex"] == "0x017f0040"
+
+
+def test_compare_tensor_traces_can_require_architectural_gemm_writeback():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        rtl_log = tmp / "rtl.log"
+        perf_trace = tmp / "perf.json"
+        rtl_summary = tmp / "rtl_tensor.json"
+        perf_summary = tmp / "perf_tensor.json"
+        rtl_log.write_text(
+            "TENSOR_TRACE name=gemm.c step=1 addr=0x0000000000003000 shape=1,4 dtype=int32_le bytes_hex=0x7b000000\n",
+            encoding="utf-8",
+        )
+        perf_trace.write_text(
+            json.dumps(
+                {
+                    "trace": [
+                        {
+                            "name": "GEMM",
+                            "c": "0x0000000000003000",
+                            "expected_accum": 123,
+                        }
+                    ]
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        proc = subprocess.run(
+            [
+                "python3",
+                "npu/sim/perf/compare_tensor_traces.py",
+                "--rtl-log",
+                str(rtl_log),
+                "--perf-trace",
+                str(perf_trace),
+                "--rtl-summary-out",
+                str(rtl_summary),
+                "--perf-summary-out",
+                str(perf_summary),
+                "--require-architectural-gemm-writeback",
+            ],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        rtl_doc = json.loads(rtl_summary.read_text(encoding="utf-8"))
+        perf_doc = json.loads(perf_summary.read_text(encoding="utf-8"))
+
+    assert proc.returncode == 0, proc.stderr
+    assert "compare-tensor-trace: OK" in proc.stdout
+    assert rtl_doc == perf_doc
+    assert perf_doc[0]["name"] == "gemm.c"
+    assert perf_doc[0]["addr"] == "0x0000000000003000"
+
+
+def test_compare_tensor_traces_architectural_gemm_writeback_mismatch_fails():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        rtl_log = tmp / "rtl.log"
+        perf_trace = tmp / "perf.json"
+        rtl_log.write_text(
+            "TENSOR_TRACE name=gemm.c step=1 addr=0x0000000000003000 shape=1,4 dtype=int32_le bytes_hex=0x00010203\n",
+            encoding="utf-8",
+        )
+        perf_trace.write_text(
+            json.dumps(
+                {
+                    "trace": [
+                        {
+                            "name": "GEMM",
+                            "c": "0x0000000000003000",
+                            "expected_accum": 123,
+                        }
+                    ]
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        proc = subprocess.run(
+            [
+                "python3",
+                "npu/sim/perf/compare_tensor_traces.py",
+                "--rtl-log",
+                str(rtl_log),
+                "--perf-trace",
+                str(perf_trace),
+                "--require-architectural-gemm-writeback",
+            ],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    assert proc.returncode == 1
+    assert "FAIL canonical tensor trace hash mismatch" in proc.stderr

--- a/npu/sim/rtl/README.md
+++ b/npu/sim/rtl/README.md
@@ -75,6 +75,7 @@ The tests validate descriptor execution behavior, MMIO/IRQ flow, and AXI memory 
   - Canonical GEMM/VEC tensor trace summaries (`*_tensor_trace_summary.json`) with strict SHA-256 equality checks.
 - Future activation trace emitters should use the shared `TENSOR_TRACE` summary line contract documented by `npu/eval/tensor_trace_summary.py`, so RTL traces can be hashed against software/perf summaries without a schema translation layer.
 - Dedicated SOFTMAX byte-vector traces use `TENSOR_TRACE name=softmax.result step=<n> shape=<rows,row_bytes> dtype=<encoding> bytes_hex=0x...`; the RTL testbench emits the aggregated row-engine output stream, and perf emits the matching summary when `--mem-json` provides descriptor source bytes.
+- When `+contract_trace=1` is enabled, the testbench also emits memory-visible writeback snapshots: `TENSOR_TRACE name=gemm.c step=<n> addr=<c_addr> shape=1,4 dtype=int32_le bytes_hex=0x...` for GEMM C destinations, and `TENSOR_TRACE name=vec.dst ... dtype=packed_u8 ...` for memory-backed VEC destinations. These traces feed the stricter architectural writeback gate and should be preferred over internal-only `gemm.accum` as the correctness proof.
 
 ## Current coverage boundaries
 

--- a/npu/sim/rtl/tb_npu_shell.sv
+++ b/npu/sim/rtl/tb_npu_shell.sv
@@ -150,6 +150,7 @@ module tb_npu_shell;
   integer gemm_desc_offsets [0:127];
   reg [31:0] gemm_desc_tags [0:127];
   reg [63:0] gemm_desc_uids [0:127];
+  reg [63:0] gemm_desc_c_addrs [0:127];
   integer gemm_desc_expected_accum [0:127];
   integer softmax_count;
   integer softmax_desc_count;
@@ -163,6 +164,8 @@ module tb_npu_shell;
   integer vec_count;
   integer vec_desc_count;
   integer vec_desc_offsets [0:127];
+  reg vec_desc_memory_backed [0:127];
+  reg [63:0] vec_desc_dst_addrs [0:127];
   reg [63:0] vec_desc_expected [0:127];
   reg [3:0] vec_desc_op [0:127];
   reg [3:0] vec_desc_dtype [0:127];
@@ -599,6 +602,10 @@ module tb_npu_shell;
         scan_tag = {bin_data[scan_off + 7], bin_data[scan_off + 6], bin_data[scan_off + 5], bin_data[scan_off + 4]};
         gemm_desc_tags[gemm_desc_count] = scan_tag;
         gemm_desc_offsets[gemm_desc_count] = scan_off;
+        gemm_desc_c_addrs[gemm_desc_count] = {
+          bin_data[scan_off + 31], bin_data[scan_off + 30], bin_data[scan_off + 29], bin_data[scan_off + 28],
+          bin_data[scan_off + 27], bin_data[scan_off + 26], bin_data[scan_off + 25], bin_data[scan_off + 24]
+        };
         if (scan_size >= 2) begin
           gemm_desc_uids[gemm_desc_count] = {
             bin_data[scan_off + 63], bin_data[scan_off + 62], bin_data[scan_off + 61], bin_data[scan_off + 60],
@@ -649,8 +656,13 @@ module tb_npu_shell;
       end else if ((scan_opcode == 8'h11) && (vec_desc_count < 128)) begin
         vec_op_sel = bin_data[scan_off + 1] & 8'hf;
         vec_desc_dtype[vec_desc_count] = (bin_data[scan_off + 1] >> 4) & 4'hf;
+        vec_desc_memory_backed[vec_desc_count] = bin_data[scan_off + 7][7];
+        vec_desc_dst_addrs[vec_desc_count] = {
+          bin_data[scan_off + 23], bin_data[scan_off + 22], bin_data[scan_off + 21], bin_data[scan_off + 20],
+          bin_data[scan_off + 19], bin_data[scan_off + 18], bin_data[scan_off + 17], bin_data[scan_off + 16]
+        };
         vec_expected_vec = 64'h0;
-        if (vec_desc_dtype[vec_desc_count] == 4'h0) begin
+        if ((vec_desc_dtype[vec_desc_count] == 4'h0) && !vec_desc_memory_backed[vec_desc_count]) begin
           for (gemm_lane = 0; gemm_lane < vec_lanes; gemm_lane = gemm_lane + 1) begin
             if (vec_op_sel == 1) begin
               vec_tmp = sx8(bin_data[scan_off + 8 + gemm_lane]) + sx8(bin_data[scan_off + 16 + gemm_lane]);
@@ -854,43 +866,93 @@ module tb_npu_shell;
           $finish(1);
         end
       end
-      gemm_test_bytes = 0;
-      if ($value$plusargs("gemm_mem_test=%d", gemm_test_bytes)) begin
-        // GEMM stub path: C should match A for test_bytes
-        for (j = 0; j < gemm_test_bytes; j = j + 1) begin
-          if (axi_mem.mem[21'h3000 + j] !== axi_mem.mem[21'h1000 + j]) begin
-            $display("ERROR: GEMM mem copy mismatch at byte %0d", j);
-            $finish(1);
-          end
-        end
-      end
     end
 
     // With multi-inflight GEMM, IRQ/CQ may complete before GEMM compute finishes.
     // Wait for all GEMM descriptors to emit completion timing lines.
     if (gemm_desc_count > 0) begin : wait_gemm_done
       integer w;
-      for (w = 0; w < 2000; w = w + 1) begin
-        @(negedge clk);
-        if (gemm_count >= gemm_desc_count)
-          disable wait_gemm_done;
+      integer gw;
+      integer all_writebacks_ok;
+      begin : wait_gemm_done_loop
+        for (w = 0; w < 2000; w = w + 1) begin
+          @(negedge clk);
+          if (gemm_count >= gemm_desc_count)
+            disable wait_gemm_done_loop;
+        end
       end
       if (gemm_count < gemm_desc_count) begin
         $display("ERROR: GEMM completion timeout count=%0d expected=%0d", gemm_count, gemm_desc_count);
         $finish(1);
       end
+      gemm_test_bytes = 0;
+      if ($value$plusargs("gemm_mem_test=%d", gemm_test_bytes)) begin
+        begin : wait_gemm_writeback_loop
+          for (gw = 0; gw < 2000; gw = gw + 1) begin
+            all_writebacks_ok = 1;
+            for (gemm_lookup_i = 0; gemm_lookup_i < gemm_desc_count; gemm_lookup_i = gemm_lookup_i + 1) begin
+              for (j = 0; j < 4; j = j + 1) begin
+                if (axi_mem.mem[gemm_desc_c_addrs[gemm_lookup_i][20:0] + j] !==
+                    ((gemm_desc_expected_accum[gemm_lookup_i] >> (8 * j)) & 8'hff)) begin
+                  all_writebacks_ok = 0;
+                end
+              end
+            end
+            if (all_writebacks_ok)
+              disable wait_gemm_writeback_loop;
+            @(negedge clk);
+          end
+        end
+        // GEMM architectural writeback path: C[0:3] should contain the int32 accumulator.
+        for (gemm_lookup_i = 0; gemm_lookup_i < gemm_desc_count; gemm_lookup_i = gemm_lookup_i + 1) begin
+          for (j = 0; j < 4; j = j + 1) begin
+            if (axi_mem.mem[gemm_desc_c_addrs[gemm_lookup_i][20:0] + j] !==
+                ((gemm_desc_expected_accum[gemm_lookup_i] >> (8 * j)) & 8'hff)) begin
+              $display("ERROR: GEMM writeback mismatch index=%0d byte=%0d got=0x%02h exp=0x%02h",
+                       gemm_lookup_i, j,
+                       axi_mem.mem[gemm_desc_c_addrs[gemm_lookup_i][20:0] + j],
+                       ((gemm_desc_expected_accum[gemm_lookup_i] >> (8 * j)) & 8'hff));
+              $finish(1);
+            end
+          end
+        end
+      end
+      if (contract_trace) begin
+        for (w = 0; w < gemm_desc_count; w = w + 1) begin
+          $write("TENSOR_TRACE name=gemm.c step=%0d addr=0x%016h shape=1,4 dtype=int32_le bytes_hex=0x",
+                 w + 1, gemm_desc_c_addrs[w]);
+          for (j = 0; j < 4; j = j + 1) begin
+            $write("%02x", axi_mem.mem[gemm_desc_c_addrs[w][20:0] + j]);
+          end
+          $display("");
+        end
+      end
     end
 
     if (vec_desc_count > 0) begin : wait_vec_done
       integer vw;
-      for (vw = 0; vw < 2000; vw = vw + 1) begin
-        @(negedge clk);
-        if (vec_count >= vec_desc_count)
-          disable wait_vec_done;
+      begin : wait_vec_done_loop
+        for (vw = 0; vw < 2000; vw = vw + 1) begin
+          @(negedge clk);
+          if (vec_count >= vec_desc_count)
+            disable wait_vec_done_loop;
+        end
       end
       if (vec_count < vec_desc_count) begin
         $display("ERROR: VEC completion timeout count=%0d expected=%0d", vec_count, vec_desc_count);
         $finish(1);
+      end
+      if (contract_trace) begin
+        for (vw = 0; vw < vec_desc_count; vw = vw + 1) begin
+          if (vec_desc_memory_backed[vw]) begin
+            $write("TENSOR_TRACE name=vec.dst step=%0d addr=0x%016h shape=1,%0d dtype=packed_u8 bytes_hex=0x",
+                   vw + 1, vec_desc_dst_addrs[vw], vec_lanes);
+            for (j = 0; j < vec_lanes; j = j + 1) begin
+              $write("%02x", axi_mem.mem[vec_desc_dst_addrs[vw][20:0] + j]);
+            end
+            $display("");
+          end
+        end
       end
     end
 
@@ -1133,7 +1195,7 @@ module tb_npu_shell;
           $display("ERROR: unexpected VEC completion vec_count=%0d vec_desc_count=%0d", vec_count, vec_desc_count);
           $finish(1);
         end
-        if (vec_desc_dtype[vec_count] == 4'h0) begin
+        if ((vec_desc_dtype[vec_count] == 4'h0) && !vec_desc_memory_backed[vec_count]) begin
           for (gemm_lane = 0; gemm_lane < vec_lanes; gemm_lane = gemm_lane + 1) begin
             if (dut.vec_last_result[(gemm_lane*8) +: 8] !== vec_desc_expected[vec_count][(gemm_lane*8) +: 8]) begin
               $display("ERROR: VEC mismatch index=%0d lane=%0d got=0x%02h exp=0x%02h",

--- a/tests/test_npu_contract_equivalence.py
+++ b/tests/test_npu_contract_equivalence.py
@@ -59,9 +59,35 @@ def _write_gemm_event_dma_stream(path: Path) -> None:
     path.write_bytes(bytes(raw))
 
 
-def _run_perf(bin_path: Path, out_path: Path, cfg_path: Path) -> list[dict[str, object]]:
-    subprocess.run(
-        [
+def _write_gemm_vec_dependent_stream(path: Path) -> None:
+    raw = bytearray()
+
+    gemm = _pack_desc(0x10, tag=_encode_gemm_tag(1, 1, 1))
+    for idx, value in enumerate([2, 3, 4, 5, 6, 7, 8, 9]):
+        gemm[8 + idx] = value
+    for idx in range(8):
+        gemm[16 + idx] = 1
+    struct.pack_into("<Q", gemm, 24, 0x3000)
+    raw.extend(gemm)
+
+    raw.extend(_pack_desc(0x20, tag=1))
+    raw.extend(_pack_desc(0x21, tag=1))
+
+    vec = _pack_desc(0x11, flags=0x00, tag=0x80000000)
+    struct.pack_into("<QQI", vec, 8, 0x3000, 0x6000, 8)
+    raw.extend(vec)
+
+    path.write_bytes(bytes(raw))
+
+
+def _run_perf(
+    bin_path: Path,
+    out_path: Path,
+    cfg_path: Path,
+    *,
+    mem_path: Path | None = None,
+) -> list[dict[str, object]]:
+    cmd = [
             sys.executable,
             str(REPO_ROOT / "npu/sim/perf/run.py"),
             "--bin",
@@ -71,7 +97,11 @@ def _run_perf(bin_path: Path, out_path: Path, cfg_path: Path) -> list[dict[str, 
             "--config",
             str(cfg_path),
             "--overlap",
-        ],
+        ]
+    if mem_path is not None:
+        cmd.extend(["--mem-json", str(mem_path)])
+    subprocess.run(
+        cmd,
         cwd=str(REPO_ROOT),
         check=True,
     )
@@ -106,7 +136,7 @@ def _normalize_perf_trace(trace: list[dict[str, object]], scenario: str) -> list
     return normalized
 
 
-def _run_rtl(bin_path: Path, plusargs: list[str]) -> list[dict[str, object]]:
+def _run_rtl_stdout(bin_path: Path, plusargs: list[str]) -> str:
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
         rtl_out = tmp / "rtl_out"
@@ -156,12 +186,17 @@ def _run_rtl(bin_path: Path, plusargs: list[str]) -> list[dict[str, object]]:
             text=True,
         )
 
+    return completed.stdout
+
+
+def _run_rtl(bin_path: Path, plusargs: list[str]) -> list[dict[str, object]]:
+    stdout = _run_rtl_stdout(bin_path, plusargs)
     pattern = re.compile(
         r"^CONTRACT_TRACE kind=(?P<kind>[a-z_]+) opcode=0x(?P<opcode>[0-9a-fA-F]+) "
         r"offset=(?P<offset>-?\d+) cycle=(?P<cycle>\d+)$"
     )
     normalized: list[dict[str, object]] = []
-    for line in completed.stdout.splitlines():
+    for line in stdout.splitlines():
         match = pattern.match(line.strip())
         if not match:
             continue
@@ -207,6 +242,119 @@ class NpuContractEquivalenceTest(unittest.TestCase):
         ]
         self.assertEqual(perf_trace, expected)
         self.assertEqual(rtl_trace, expected)
+
+    def test_gemm_architectural_writeback_matches_between_perf_and_rtl(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            bin_path = tmp / "gemm_event_dma.bin"
+            perf_path = tmp / "trace.json"
+            cfg_path = tmp / "cfg.json"
+            rtl_log = tmp / "rtl.log"
+            rtl_summary = tmp / "rtl_arch_summary.json"
+            perf_summary = tmp / "perf_arch_summary.json"
+            _write_gemm_event_dma_stream(bin_path)
+            cfg_path.write_text(
+                json.dumps(
+                    {
+                        "gemm_tops": 1.0,
+                        "dma_bw_gbps": 16.0,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            _run_perf(bin_path, perf_path, cfg_path)
+            rtl_log.write_text(
+                _run_rtl_stdout(
+                    bin_path,
+                    ["+bytes=128", "+contract_trace=1", "+gemm_mac_test=1", "+contract_gemm_event_dma_test=1"],
+                ),
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "npu/sim/perf/compare_tensor_traces.py"),
+                    "--rtl-log",
+                    str(rtl_log),
+                    "--perf-trace",
+                    str(perf_path),
+                    "--rtl-summary-out",
+                    str(rtl_summary),
+                    "--perf-summary-out",
+                    str(perf_summary),
+                    "--require-architectural-gemm-writeback",
+                ],
+                cwd=str(REPO_ROOT),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr + completed.stdout)
+        self.assertIn("compare-tensor-trace: OK", completed.stdout)
+
+    def test_gemm_to_memory_backed_vec_matches_between_perf_and_rtl(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            bin_path = tmp / "gemm_vec.bin"
+            perf_path = tmp / "trace.json"
+            cfg_path = tmp / "cfg.json"
+            mem_path = tmp / "mem.json"
+            rtl_log = tmp / "rtl.log"
+            _write_gemm_vec_dependent_stream(bin_path)
+            cfg_path.write_text(
+                json.dumps(
+                    {
+                        "gemm_tops": 1.0,
+                        "dma_bw_gbps": 16.0,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            mem_path.write_text(
+                json.dumps(
+                    {
+                        "segments": [
+                            {
+                                "addr": "0x3000",
+                                "data_bytes": [0, 1, 2, 3, 4, 5, 6, 7],
+                            }
+                        ]
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            _run_perf(bin_path, perf_path, cfg_path, mem_path=mem_path)
+            rtl_log.write_text(
+                _run_rtl_stdout(
+                    bin_path,
+                    ["+bytes=128", "+vec_test=1", "+contract_trace=1", "+gemm_mac_test=1"],
+                ),
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "npu/sim/perf/compare_tensor_traces.py"),
+                    "--rtl-log",
+                    str(rtl_log),
+                    "--perf-trace",
+                    str(perf_path),
+                    "--require-architectural-writeback",
+                ],
+                cwd=str(REPO_ROOT),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr + completed.stdout)
+        self.assertIn("compare-tensor-trace: OK", completed.stdout)
 
     def test_gemm_event_dma_contract_matches_between_perf_and_rtl(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_npu_pre_ppa_observability.py
+++ b/tests/test_npu_pre_ppa_observability.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Pre-PPA observability checks for generated NPU compute datapaths."""
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASE_CONFIG = REPO_ROOT / "npu/rtlgen/examples/minimal_gemm_4modules.json"
+
+
+def _write_config(path: Path, *, num_modules: int) -> None:
+    cfg = json.loads(BASE_CONFIG.read_text(encoding="utf-8"))
+    cfg["compute"]["gemm"]["num_modules"] = int(num_modules)
+    path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+
+def _generate_rtl(config: Path, out_dir: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "npu/rtlgen/gen.py"),
+            "--config",
+            str(config),
+            "--out",
+            str(out_dir),
+        ],
+        cwd=str(REPO_ROOT),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _yosys_stat(top_v: Path) -> str:
+    completed = subprocess.run(
+        [
+            "yosys",
+            "-p",
+            f"read_verilog -sv {top_v}; hierarchy -check -top npu_top; proc; opt; stat",
+        ],
+        cwd=str(REPO_ROOT),
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    return completed.stdout + completed.stderr
+
+
+def _max_gemm_mac_count(stat_log: str) -> int:
+    counts = [
+        int(match.group(1))
+        for match in re.finditer(r"gemm_mac_int8[ \t]+(\d+)", stat_log)
+    ]
+    if not counts:
+        return 0
+    return max(counts)
+
+
+@unittest.skipIf(shutil.which("yosys") is None, "yosys is required for pre-PPA observability checks")
+class NpuPrePpaObservabilityTest(unittest.TestCase):
+    def test_gemm_mac_instances_survive_yosys_opt_for_num_modules(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            counts: dict[int, int] = {}
+            for num_modules in (1, 4):
+                config = tmp / f"nm{num_modules}.json"
+                out_dir = tmp / f"nm{num_modules}"
+                _write_config(config, num_modules=num_modules)
+                _generate_rtl(config, out_dir)
+                stat_log = _yosys_stat(out_dir / "top.v")
+                counts[num_modules] = _max_gemm_mac_count(stat_log)
+                self.assertIn("gemm_compute_array", stat_log)
+
+        self.assertEqual(counts[1], 1)
+        self.assertEqual(counts[4], 4)
+        self.assertGreater(counts[4], counts[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the pre-PPA functional and synthesis guards needed before rerunning NPU PPA exploration:

- wires GEMM completion to an architectural scalar C writeback instead of relying only on internal accumulator traces
- adds memory-backed VEC descriptors so a dependent `GEMM -> VEC` program reads GEMM output from memory and writes a visible VEC destination
- extends perf memory modeling and tensor-trace comparison for architectural writeback tensors (`gemm.c`, `vec.dst`)
- adds a Yosys pre-PPA observability regression proving GEMM MAC instances survive optimization and scale from nm1 to nm4

## Validation

```text
python3 -m unittest tests.test_npu_contract_equivalence tests.test_npu_pre_ppa_observability -v
Ran 5 tests in 19.187s
OK
```

```text
python3 -m py_compile npu/rtlgen/gen.py npu/sim/perf/run.py npu/eval/tensor_trace_summary.py npu/sim/perf/compare_tensor_traces.py npu/sim/perf/tests/test_compare_compute_results.py tests/test_npu_contract_equivalence.py tests/test_npu_pre_ppa_observability.py
git diff --check
```
