### PR TITLE
upsert deterministic block sweep metrics rows

### DIFF
--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -1230,6 +1230,7 @@ def append_metrics(metrics_path: Path, row: Dict[str, object]):
     existing_rows: List[Dict[str, object]] = []
     header = list(default_header)
     needs_rewrite = False
+    replaced_existing = False
     if metrics_path.exists():
         with metrics_path.open("r", encoding="utf-8", newline="") as f:
             reader = csv.DictReader(f)
@@ -1244,7 +1245,22 @@ def append_metrics(metrics_path: Path, row: Dict[str, object]):
             else:
                 needs_rewrite = True
 
-    if needs_rewrite:
+    def identity_key(record: Dict[str, object]) -> tuple[str, str, str, str]:
+        return (
+            str(record.get("design", "")).strip(),
+            str(record.get("platform", "")).strip(),
+            str(record.get("param_hash", "")).strip(),
+            str(record.get("tag", "")).strip(),
+        )
+
+    row_key = identity_key(row)
+    if all(row_key):
+        kept_rows = [old_row for old_row in existing_rows if identity_key(old_row) != row_key]
+        replaced_existing = len(kept_rows) != len(existing_rows)
+        if replaced_existing:
+            existing_rows = kept_rows
+
+    if needs_rewrite or replaced_existing:
         with metrics_path.open("w", encoding="utf-8", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=header)
             writer.writeheader()

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Regression tests for run_block_sweep mode_compare behavior."""
 
+import csv
 import importlib.util
 import json
 import subprocess
@@ -285,6 +286,44 @@ class ModeCompareRegressionTest(unittest.TestCase):
             )
             self.assertIn("flow_failed", metrics_text)
             self.assertTrue((tmp / "out" / "demo_design" / "work").is_dir())
+
+    def test_append_metrics_replaces_same_run_identity(self):
+        with tempfile.TemporaryDirectory() as td:
+            metrics_path = Path(td) / "metrics.csv"
+            old_row = {
+                "design": "demo_design",
+                "platform": "nangate45",
+                "config_hash": "old_cfg",
+                "param_hash": "same_params",
+                "tag": "same_tag",
+                "status": "ok",
+                "critical_path_ns": 5.0,
+                "die_area": 1000.0,
+                "total_power_mw": 0.1,
+                "params_json": json.dumps({"TAG": "same_tag"}),
+                "result_path": "/orfs/flow/reports/old/6_finish.rpt",
+            }
+            new_row = dict(old_row)
+            new_row.update(
+                {
+                    "config_hash": "new_cfg",
+                    "status": "flow_failed",
+                    "critical_path_ns": None,
+                    "die_area": None,
+                    "total_power_mw": None,
+                    "result_path": "/orfs/flow/logs/new",
+                }
+            )
+
+            self.run_block_sweep.append_metrics(metrics_path, old_row)
+            self.run_block_sweep.append_metrics(metrics_path, new_row)
+
+            with metrics_path.open(newline="", encoding="utf-8") as f:
+                rows = list(csv.DictReader(f))
+            self.assertEqual(1, len(rows))
+            self.assertEqual("new_cfg", rows[0]["config_hash"])
+            self.assertEqual("flow_failed", rows[0]["status"])
+            self.assertEqual("/orfs/flow/logs/new", rows[0]["result_path"])
 
 class SynthTargetMappingRegressionTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Summary
- replace stale block-sweep metrics rows when a deterministic sweep point is rerun with the same design/platform/param_hash/tag
- keep the newest row, including intentional status=flow_failed rows, so fresh evaluator clones do not create duplicate run identities against tracked metrics.csv history
- add a regression test covering replacement of an old ok row by a newer flow_failed row

## Tests
- python3 -m unittest tests.test_run_block_sweep_mode_compare
- python3 scripts/validate_runs.py --skip_eval_queue

Fixes #658