### PR TITLE
[codex] add corrected npu compute frontier guard

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -504,6 +504,49 @@ PY2"""
     }
 
 
+def _npu_compute_full_path_equivalence_guard_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/campaigns/npu/frontier_guards"
+    guard_out = f"{base}/npu_compute_module_guard__{item_id}.json"
+    equivalence_log = f"{base}/npu_contract_equivalence__{item_id}.log"
+    configs = [
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp/config_nm1.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm2_cmp/config_nm2.json",
+        "runs/designs/npu_blocks/npu_fp16_cpp_nm4_cmp/config_nm4.json",
+    ]
+    config_args = " ".join(shlex.quote(path) for path in configs)
+    return {
+        "inputs": {
+            "npu_compute_guard_out": guard_out,
+            "npu_contract_equivalence_log": equivalence_log,
+            "rtlgen_configs": configs,
+            "guard_scope": (
+                "Pre-PPA guard for the corrected NPU compute frontier: prove RTL/perf "
+                "architectural writeback equivalence and confirm generated nm1/nm2/nm4 RTL "
+                "retains the requested FP16 GEMM module structure."
+            ),
+        },
+        "commands": [
+            {
+                "name": "build_generator",
+                "run": "export PATH=/oss-cad-suite/bin:$PATH && cmake -S . -B build && cmake --build build --target rtlgen",
+            },
+            {
+                "name": "check_npu_compute_module_guard",
+                "run": (
+                    "python3 npu/eval/check_npu_compute_module_guard.py "
+                    f"--configs {config_args} "
+                    f"--out {guard_out}"
+                ),
+            },
+            {
+                "name": "run_npu_contract_equivalence",
+                "run": f"mkdir -p {base} && python3 tests/test_npu_contract_equivalence.py > {equivalence_log} 2>&1",
+            },
+        ],
+        "expected_outputs": [guard_out, equivalence_log],
+    }
+
+
 def _decoder_probability_sweep_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_tiny_v1"
     path_evidence = _decoder_probability_path_evidence(item_id=item_id)
@@ -5071,8 +5114,11 @@ def _build_payload(
         "decoder_output_projection_producer_cq_ablation",
         "decoder_output_projection_producer_softmax_event_ablation",
         "decoder_quantization_outline",
+        "npu_compute_full_path_equivalence_guard",
     }:
-        if abstraction_layer_name == "decoder_quantization_outline":
+        if abstraction_layer_name == "npu_compute_full_path_equivalence_guard":
+            decoder_evidence = _npu_compute_full_path_equivalence_guard_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_quantization_outline":
             decoder_evidence = _decoder_quantization_outline_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_softmax_event_ablation":
             decoder_evidence = _decoder_output_projection_producer_softmax_event_ablation_evidence(item_id=item_id)

--- a/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/README.md
+++ b/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/README.md
@@ -1,0 +1,7 @@
+# Corrected NPU Compute Frontier
+
+Canonical proposal workspace for `prop_l1_npu_corrected_compute_frontier_v1`.
+
+The proposal rebuilds the FP16 NPU compute frontier after the GEMM/VEC
+writeback connection fix.  The first item is a correctness guard; PPA items are
+valid only after the guard passes.

--- a/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/design_brief.md
+++ b/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/design_brief.md
@@ -1,0 +1,10 @@
+# Design Brief
+
+- `proposal_id`: `prop_l1_npu_corrected_compute_frontier_v1`
+- scope: corrected FP16 NPU compute parallelism frontier
+- precondition: full-path RTL/perf architectural writeback equivalence and
+  generated RTL module-retention guard
+
+The previous pre-fix measurements can no longer drive architecture decisions.
+This proposal uses the corrected writeback-connected RTL and keeps the
+correctness guard as an explicit dependency of subsequent PPA sweeps.

--- a/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/evaluation_gate.md
@@ -1,0 +1,11 @@
+# Evaluation Gate
+
+The guard item must pass before interpreting new PPA rows:
+
+- `tests/test_npu_contract_equivalence.py` passes under plain `python3`
+- `npu/eval/check_npu_compute_module_guard.py` reports `status=ok`
+- nm1/nm2/nm4 generated RTL localparams and vector register counts match
+  `compute.gemm.num_modules`
+
+The stability and boundary sweeps should keep flat/hier results separated and
+record `flow_failed` or stalled points instead of repeated long retries.

--- a/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/evaluation_requests.json
@@ -1,0 +1,43 @@
+{
+  "proposal_id": "prop_l1_npu_corrected_compute_frontier_v1",
+  "source_commit": "7946362a3aac5dee1ef7563c37cddd61365c8149",
+  "requested_items": [
+    {
+      "item_id": "l2_npu_compute_full_path_equivalence_guard_v1",
+      "task_type": "l2_campaign",
+      "objective": "prove_corrected_compute_datapath_guard",
+      "evaluation_mode": "correctness_guard",
+      "abstraction_layer": "npu_compute_full_path_equivalence_guard",
+      "comparison_role": "precondition",
+      "status": "pending"
+    },
+    {
+      "item_id": "l1_npu_corrected_compute_frontier_nm1_nm2_nm4_seed3_v1",
+      "task_type": "l1_sweep",
+      "objective": "measure_corrected_seed_variance_low_nm",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "npu_corrected_compute_frontier",
+      "comparison_role": "stability",
+      "depends_on_item_ids": [
+        "l2_npu_compute_full_path_equivalence_guard_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "status": "pending"
+    },
+    {
+      "item_id": "l1_npu_corrected_compute_frontier_nm1_nm2_nm4_nm8_nm16_nm32_v1",
+      "task_type": "l1_sweep",
+      "objective": "measure_corrected_parallelism_boundary",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "npu_corrected_compute_frontier",
+      "comparison_role": "boundary",
+      "depends_on_item_ids": [
+        "l2_npu_compute_full_path_equivalence_guard_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/implementation_summary.md
@@ -1,0 +1,3 @@
+# Implementation Summary
+
+Pending evaluator execution.

--- a/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/proposal.json
@@ -1,0 +1,98 @@
+{
+  "proposal_id": "prop_l1_npu_corrected_compute_frontier_v1",
+  "created_utc": "2026-05-25T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "npu_corrected_compute_frontier",
+  "title": "Corrected NPU FP16 compute frontier",
+  "hypothesis": "After the GEMM/VEC writeback connection fix, the useful compute frontier should be rebuilt from guarded RTL/perf equivalence, seed-stability checks for nm1/nm2/nm4, and a bounded parallelism sweep through the largest practical current dynamic-dispatch point.",
+  "direct_comparison": {
+    "primary_question": "Which corrected FP16 NPU compute module count is the practical PPA anchor once disconnected-output measurements are excluded?",
+    "include": [
+      "full-path RTL/perf architectural writeback guard before new PPA decisions",
+      "nm1, nm2, and nm4 three-seed corrected PPA stability",
+      "nm1, nm2, nm4, nm8, nm16, and nm32 parallelism boundary measurement under the current dynamic dispatcher"
+    ],
+    "exclude": [
+      "quality-changing KV sharing or quantization decisions",
+      "new static scheduler or NoC implementation",
+      "promotion of pre-writeback-fix r2 metrics"
+    ]
+  },
+  "expected_benefit": [
+    "prevents another disconnected or optimized-away datapath result from entering the frontier",
+    "separates seed/floorplan noise from true nm1/nm2/nm4 PPA differences",
+    "identifies where the current dynamic dispatcher ceases to be a credible scaling path"
+  ],
+  "risks": [
+    "three seeds are still a first-order stability check, not a final statistical model",
+    "module-retention evidence is structural and must be interpreted with RTL/perf equivalence",
+    "nm32 may remain expensive; stalled or flow-failed points should be recorded rather than retried indefinitely"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_npu_compute_full_path_equivalence_guard_v1",
+      "task_type": "l2_campaign",
+      "objective": "prove_corrected_compute_datapath_guard",
+      "evaluation_mode": "correctness_guard",
+      "abstraction_layer": "npu_compute_full_path_equivalence_guard",
+      "cost_class": "low",
+      "comparison_role": "precondition",
+      "expected_result": {
+        "direction": "gate",
+        "reason": "Only run new corrected PPA sweeps if RTL/perf architectural writeback equivalence passes and nm1/nm2/nm4 generated RTL retains requested GEMM module structure."
+      }
+    },
+    {
+      "item_id": "l1_npu_corrected_compute_frontier_nm1_nm2_nm4_seed3_v1",
+      "task_type": "l1_sweep",
+      "objective": "measure_corrected_seed_variance_low_nm",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "npu_corrected_compute_frontier",
+      "cost_class": "medium",
+      "comparison_role": "stability",
+      "depends_on_item_ids": [
+        "l2_npu_compute_full_path_equivalence_guard_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Confirm whether nm2 remains the best low-power corrected PPA anchor across seed variation."
+      }
+    },
+    {
+      "item_id": "l1_npu_corrected_compute_frontier_nm1_nm2_nm4_nm8_nm16_nm32_v1",
+      "task_type": "l1_sweep",
+      "objective": "measure_corrected_parallelism_boundary",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "npu_corrected_compute_frontier",
+      "cost_class": "high",
+      "comparison_role": "boundary",
+      "depends_on_item_ids": [
+        "l2_npu_compute_full_path_equivalence_guard_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use corrected physical scaling through nm32 to decide whether to keep dynamic dispatch, reduce to low-nm anchors, or design a hierarchical/static scheduler."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l1_npu_fp16_compute_parallelism_gate_count_audit_v1/analysis_report.md",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp/metrics.csv",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm2_cmp/metrics.csv",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm4_cmp/metrics.csv"
+  ],
+  "knowledge_refs": [
+    "tests/test_npu_contract_equivalence.py",
+    "npu/eval/check_npu_compute_module_guard.py",
+    "npu/sim/perf/compare_tensor_traces.py",
+    "npu/synth/run_block_sweep.py",
+    "runs/campaigns/npu/compute_parallelism_stability/sweeps/nangate45_cmp33_mode_compare.json"
+  ]
+}

--- a/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/quality_gate.md
@@ -1,0 +1,8 @@
+# Quality Gate
+
+This proposal does not make model-quality claims.  It only rebuilds corrected
+physical compute evidence for later LLaMA-scale memory/NoC modeling.
+
+Any downstream LLaMA7B conclusion must continue to keep quality-changing
+choices such as MQA, GQA changes, and KV bit-width reductions separate from
+pure compute-array PPA choices.

--- a/npu/eval/check_npu_compute_module_guard.py
+++ b/npu/eval/check_npu_compute_module_guard.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _repo_rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _expected_num_modules(config: dict[str, Any]) -> int:
+    compute = config.get("compute")
+    if not isinstance(compute, dict):
+        raise ValueError("config missing compute block")
+    gemm = compute.get("gemm")
+    if not isinstance(gemm, dict):
+        raise ValueError("config missing compute.gemm block")
+    return int(gemm.get("num_modules", 1))
+
+
+def _extract_localparam(text: str, name: str) -> int | None:
+    pattern = re.compile(rf"\blocalparam\s+integer\s+{re.escape(name)}\s*=\s*(\d+)\s*;")
+    match = pattern.search(text)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _vector_register_count(text: str, prefix: str) -> int:
+    pattern = re.compile(rf"\breg\s+\[15:0\]\s+{re.escape(prefix)}(\d+)\s*;")
+    indexes = {int(match.group(1)) for match in pattern.finditer(text)}
+    if not indexes:
+        return 0
+    return max(indexes) + 1 if indexes == set(range(max(indexes) + 1)) else len(indexes)
+
+
+def _writeback_slot_count(text: str) -> int:
+    pattern = re.compile(r"\bdma_writeback_data\[15:0\]\s*<=\s*gemm_slot_accum(\d+)\s*;")
+    indexes = {int(match.group(1)) for match in pattern.finditer(text)}
+    if not indexes:
+        return 0
+    return max(indexes) + 1 if indexes == set(range(max(indexes) + 1)) else len(indexes)
+
+
+def _check_config(config_path: Path) -> dict[str, Any]:
+    config = _load_json(config_path)
+    expected = _expected_num_modules(config)
+    with tempfile.TemporaryDirectory() as td:
+        out_dir = Path(td) / "rtl"
+        subprocess.run(
+            [
+                sys.executable,
+                "npu/rtlgen/gen.py",
+                "--config",
+                str(config_path),
+                "--out",
+                str(out_dir),
+            ],
+            cwd=str(REPO_ROOT),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        top_v = out_dir / "top.v"
+        text = top_v.read_text(encoding="utf-8")
+
+    array_modules = _extract_localparam(text, "NUM_MODULES")
+    top_modules = _extract_localparam(text, "GEMM_NUM_MODULES")
+    a_regs = _vector_register_count(text, "gemm_mac_a_vec")
+    b_regs = _vector_register_count(text, "gemm_mac_b_vec")
+    writeback_slots = _writeback_slot_count(text)
+    has_slot_loop = "begin : g_slot" in text and "u_slot_mac" in text
+    ok = (
+        array_modules == expected
+        and top_modules == expected
+        and a_regs == expected
+        and b_regs == expected
+        and writeback_slots == expected
+        and has_slot_loop
+    )
+    return {
+        "config": _repo_rel(config_path),
+        "expected_num_modules": expected,
+        "rtl_num_modules_localparam": array_modules,
+        "top_gemm_num_modules_localparam": top_modules,
+        "gemm_mac_a_register_count": a_regs,
+        "gemm_mac_b_register_count": b_regs,
+        "has_gemm_slot_loop": has_slot_loop,
+        "gemm_writeback_slot_count": writeback_slots,
+        "status": "ok" if ok else "failed",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check generated NPU RTL keeps the requested FP16 GEMM module structure."
+    )
+    parser.add_argument("--configs", nargs="+", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    results = []
+    for config_text in args.configs:
+        config_path = Path(config_text)
+        if not config_path.is_absolute():
+            config_path = REPO_ROOT / config_path
+        results.append(_check_config(config_path.resolve()))
+
+    payload = {
+        "schema": "npu_compute_module_guard_v1",
+        "configs_checked": len(results),
+        "results": results,
+        "status": "ok" if all(row["status"] == "ok" for row in results) else "failed",
+    }
+    out_path = Path(args.out)
+    if not out_path.is_absolute():
+        out_path = REPO_ROOT / out_path
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {out_path}")
+    if payload["status"] != "ok":
+        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/frontier_guard/campaign_npu_compute_full_path_guard_v1.json
+++ b/runs/campaigns/npu/frontier_guard/campaign_npu_compute_full_path_guard_v1.json
@@ -1,0 +1,31 @@
+{
+  "version": 0.1,
+  "campaign_id": "npu_compute_full_path_guard_v1",
+  "model_set_id": "mlp_smoke_v0",
+  "model_manifest": "runs/models/mlp_smoke_v0/manifest.json",
+  "description": "Minimal campaign wrapper for corrected NPU compute full-path equivalence guard evidence.",
+  "platform": "nangate45",
+  "make_target": "3_3_place_gp",
+  "repeats": 1,
+  "models": [
+    {
+      "model_id": "mlp1",
+      "onnx_path": "runs/models/mlp_smoke_v0/mlp1.onnx",
+      "mapper_arch": "npu/arch/examples/minimal.yml",
+      "perf_config": "npu/sim/perf/example_config_fp16_cpp.json"
+    }
+  ],
+  "architecture_points": [
+    {
+      "arch_id": "fp16_nm1_guard",
+      "rtlgen_config": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp/config_nm1.json",
+      "synth_design_dir": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp",
+      "sweep_file": "runs/campaigns/npu/compute_parallelism_stability/sweeps/nangate45_cmp33_mode_compare.json"
+    }
+  ],
+  "outputs": {
+    "campaign_dir": "runs/campaigns/npu/frontier_guard/compute_full_path_guard_v1",
+    "results_csv": "runs/campaigns/npu/frontier_guard/compute_full_path_guard_v1/results.csv",
+    "report_md": "runs/campaigns/npu/frontier_guard/compute_full_path_guard_v1/report.md"
+  }
+}


### PR DESCRIPTION
## Summary
- add a corrected NPU compute frontier proposal with explicit guard, stability, and boundary jobs
- add `npu/eval/check_npu_compute_module_guard.py` to verify generated nm1/nm2/nm4 RTL retains the requested GEMM module structure and writeback slots
- add a Layer-2 guard abstraction that runs the structural guard plus the existing full-path RTL/perf architectural-writeback equivalence unittest

## Why
The previous compute-frontier data had to be revised because pre-fix RTL did not connect the GEMM/VEC output path to architectural writeback. The next PPA sweeps should be gated by evidence that the corrected datapath is visible to both RTL/perf equivalence and generated RTL structure checks.

## Validation
- `cmake -S . -B build && cmake --build build --target rtlgen -j2`
- `python3 npu/eval/check_npu_compute_module_guard.py --configs runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp/config_nm1.json runs/designs/npu_blocks/npu_fp16_cpp_nm2_cmp/config_nm2.json runs/designs/npu_blocks/npu_fp16_cpp_nm4_cmp/config_nm4.json --out /tmp/npu_compute_guard_check.json`
- `python3 tests/test_npu_contract_equivalence.py`
- `python3 -m py_compile npu/eval/check_npu_compute_module_guard.py control_plane/control_plane/services/l2_task_generator.py`
- `python3 npu/eval/validate.py --campaign runs/campaigns/npu/frontier_guard/campaign_npu_compute_full_path_guard_v1.json --check_paths`
- `python3 scripts/validate_runs.py --skip_eval_queue`
