### PR TITLE
[codex] allow boundary l1 metrics evidence

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -597,6 +597,15 @@ def _build_payload(
     abstraction_layer: str | None,
     trial_policy: dict[str, int],
 ) -> dict[str, Any]:
+    lower_objective = objective.lower()
+    boundary_acceptance = "boundary" in lower_objective or "accept timing/flow failures" in lower_objective
+    metrics_acceptance = (
+        "Each generated wrapper metrics.csv contains recorded rows with a status column; "
+        "allow non-ok metrics such as flow_failed when the row is boundary evidence"
+        if boundary_acceptance
+        else "Each generated wrapper metrics.csv contains at least one status=ok row for the queued sweep"
+    )
+
     payload = {
         "version": 0.1,
         "item_id": item_id,
@@ -633,7 +642,7 @@ def _build_payload(
             ],
             "expected_outputs": expected_outputs,
             "acceptance": [
-                "Each generated wrapper metrics.csv contains at least one status=ok row for the queued sweep",
+                metrics_acceptance,
                 "Committed outputs stay lightweight (metrics.csv only; runs/index.csv is exported centrally after merge)",
                 "python3 scripts/build_runs_index.py and python3 scripts/validate_runs.py --skip_eval_queue pass",
             ],

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -422,12 +422,49 @@ def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
             assert payload["source_requirement"]["required_ref"] == "origin/master"
             assert payload["source_requirement"]["requires_daemon_restart"] is True
             assert payload["task"]["inputs"]["sweeps"] == [sweep_path]
+            assert payload["task"]["acceptance"][0] == (
+                "Each generated wrapper metrics.csv contains at least one status=ok row for the queued sweep"
+            )
             assert payload["task"]["inputs"]["required_submodules"] == [
                 "third_party/nlohmann_json",
                 "third_party/cacti",
             ]
             assert payload["developer_loop"]["abstraction"] == {"layer": "circuit_block"}
             assert payload["handoff"]["pr_body_fields"]["queue_item_id"] == result.item_id
+
+
+def test_generate_l1_sweep_task_uses_boundary_metrics_acceptance() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            with patch(
+                "control_plane.services.l1_task_generator._image_provided_l1_runtime_deps_available",
+                return_value=False,
+            ):
+                result = generate_l1_sweep_task(
+                    session,
+                    Layer1SweepGenerateRequest(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        objective="Measure physical boundary and accept timing/flow failures as boundary evidence",
+                    ),
+                )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert "allow non-ok metrics" in work_item.acceptance_rules[0]
+            assert "flow_failed" in work_item.acceptance_rules[0]
+            assert work_item.task_request.request_payload["task"]["acceptance"] == work_item.acceptance_rules
 
 
 def test_generate_l1_sweep_task_expands_expected_outputs_for_multi_trial_items() -> None:

--- a/control_plane/control_plane/tests/test_worker_executor.py
+++ b/control_plane/control_plane/tests/test_worker_executor.py
@@ -392,6 +392,69 @@ def test_l1_worker_fails_when_expected_metrics_have_no_ok_rows() -> None:
             ]
 
 
+def test_l1_worker_allows_non_ok_metrics_for_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        item_id = "item_l1_boundary_metrics"
+        metrics_rel = f"runs/campaigns/{item_id}/metrics.csv"
+        with Session(engine) as session:
+            seed_ready_work_item(session, item_id=item_id, repo_root=repo_root, failing=False)
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            work_item.task_type = "l1_sweep"
+            work_item.layer = "layer1"
+            work_item.assigned_machine_key = "worker-1"
+            work_item.command_manifest = [
+                {
+                    "name": "write_boundary_metrics",
+                    "run": (
+                        "python3 -c \"from pathlib import Path; "
+                        f"p=Path('{metrics_rel}'); "
+                        "p.parent.mkdir(parents=True, exist_ok=True); "
+                        "p.write_text('design,status,critical_path_ns\\nunit,flow_failed,\\n', encoding='utf-8')\""
+                    ),
+                }
+            ]
+            work_item.expected_outputs = [metrics_rel]
+            work_item.acceptance_rules = [
+                "Each generated wrapper metrics.csv contains recorded rows with a status column; "
+                "allow non-ok metrics such as flow_failed when the row is boundary evidence"
+            ]
+            session.commit()
+
+        session_factory = build_session_factory(engine)
+        results = run_worker(
+            session_factory,
+            config=WorkerConfig(
+                repo_root=str(repo_root),
+                machine_key="worker-1",
+                capabilities={"platform": "nangate45", "flow": "openroad"},
+                capability_filter={"platform": "nangate45", "flow": "openroad"},
+                enforce_source_commit=False,
+                lease_seconds=60,
+                heartbeat_seconds=1,
+                max_retry_attempts=1,
+            ),
+            max_items=1,
+        )
+
+        assert len(results) == 1
+        assert results[0].status == "succeeded"
+
+        with Session(engine) as session:
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            run = session.query(Run).filter_by(run_key=results[0].run_key).one()
+            assert work_item.state == WorkItemState.ARTIFACT_SYNC
+            assert run.status == RunStatus.SUCCEEDED
+            assert run.result_payload["queue_result"]["status"] == "ok"
+            assert run.result_payload["queue_result"]["metrics_rows"] == [f"{metrics_rel}:2"]
+            assert "acceptance_errors" not in run.result_payload
+
+
 def test_worker_skips_non_transportable_expected_outputs() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/workers/executor.py
+++ b/control_plane/control_plane/workers/executor.py
@@ -161,7 +161,25 @@ def _classify_failure(
     }
 
 
-def _l1_metrics_acceptance_errors(*, repo_root: str, expected_outputs: list[str]) -> list[str]:
+def _l1_acceptance_allows_non_ok_metrics(work_item: WorkItem) -> bool:
+    rules = [str(rule).lower() for rule in (work_item.acceptance_rules or [])]
+    return any(
+        (
+            "allow non-ok metrics" in rule
+            or "allow flow_failed metrics" in rule
+            or "accept timing/flow failures" in rule
+            or "flow failures are boundary evidence" in rule
+        )
+        for rule in rules
+    )
+
+
+def _l1_metrics_acceptance_errors(
+    *,
+    repo_root: str,
+    expected_outputs: list[str],
+    require_ok_status: bool = True,
+) -> list[str]:
     repo_path = Path(repo_root).resolve()
     errors: list[str] = []
     for output in expected_outputs:
@@ -180,7 +198,7 @@ def _l1_metrics_acceptance_errors(*, repo_root: str, expected_outputs: list[str]
             errors.append(f"{output}: metrics.csv lacks status column")
             continue
         ok_rows = [row for row in rows if str(row.get("status", "")).strip().lower() == "ok"]
-        if not ok_rows:
+        if require_ok_status and not ok_rows:
             statuses = sorted({str(row.get("status", "")).strip() or "<blank>" for row in rows})
             errors.append(f"{output}: no status=ok rows (statuses={','.join(statuses)})")
     return errors
@@ -820,6 +838,7 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
         acceptance_errors = _l1_metrics_acceptance_errors(
             repo_root=checkout_info.work_dir,
             expected_outputs=active_expected_outputs,
+            require_ok_status=not _l1_acceptance_allows_non_ok_metrics(work_item),
         )
         if acceptance_errors:
             success = False

--- a/docs/developer_agent_review.md
+++ b/docs/developer_agent_review.md
@@ -154,6 +154,24 @@ When mapper headroom is part of the conclusion, the review should say so
 explicitly and point to the follow-on mapper intake item or proposal when one
 exists.
 
+## Boundary Metric Rule
+
+Some physical exploration jobs are intended to find the point where a design
+stops being feasible. For those jobs, a `flow_failed` or timing-failed
+`metrics.csv` row can be valid evidence rather than a bad submission.
+
+When preparing or reviewing a boundary job:
+- the objective must say that timing/flow failures are accepted as boundary
+  evidence
+- the L1 acceptance rule must allow non-ok metrics rows with a valid `status`
+  column
+- the report must distinguish a useful boundary failure from an infrastructure,
+  checkout, or validation failure
+
+Do not use relaxed boundary acceptance for ordinary winner-selection sweeps.
+Those should continue to require at least one `status=ok` row for each expected
+metrics file.
+
 ## Merge Policy
 
 Evaluation PR merge rule:

--- a/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_npu_corrected_compute_frontier_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_npu_corrected_compute_frontier_v1",
-  "source_commit": "06c8844931c9ace09aaf06adbba3d20b14c545d7",
+  "source_commit": "f65101658410467b41d9a5b6f356d676fbf371ff",
   "requested_items": [
     {
       "item_id": "l2_npu_compute_full_path_equivalence_guard_v1",
@@ -44,7 +44,7 @@
     {
       "item_id": "l1_npu_corrected_compute_frontier_nm1_nm2_nm4_nm8_nm16_nm32_v1",
       "task_type": "l1_sweep",
-      "objective": "measure_corrected_parallelism_boundary",
+      "objective": "Measure corrected NPU compute parallelism boundary after full-path equivalence guard; accept timing/flow failures as boundary evidence and preserve lightweight metrics.",
       "evaluation_mode": "measurement_only",
       "abstraction_layer": "npu_corrected_compute_frontier",
       "comparison_role": "boundary",
@@ -53,7 +53,7 @@
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
-      "status": "ready_to_queue",
+      "status": "pending",
       "notes": "Prerequisites are merged; item is ready to queue."
     }
   ]


### PR DESCRIPTION
## Summary
- allow explicit L1 boundary jobs to accept non-ok metrics rows as evidence when the metrics file has recorded status rows
- keep ordinary L1 sweeps on the existing stricter status=ok acceptance
- document the boundary metric rule for developer-agent review

## Why
The corrected compute frontier boundary job is intended to find where physical feasibility breaks. A design point that records `flow_failed` can be useful boundary evidence, but the worker previously converted that into a validation failure because it always required a `status=ok` row.

## Validation
- `python -m pytest control_plane/tests/test_worker_executor.py::test_l1_worker_fails_when_expected_metrics_have_no_ok_rows control_plane/tests/test_worker_executor.py::test_l1_worker_allows_non_ok_metrics_for_boundary_evidence control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_creates_ready_work_item control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_uses_boundary_metrics_acceptance`
