### PR TITLE
[codex] scope l1 metrics rows to current sweep

### DIFF
--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -151,6 +151,30 @@ def _load_metrics_rows(path: Path) -> list[dict[str, str]]:
     return rows
 
 
+def _current_sweep_tag_prefixes(repo_root: Path, work_item: WorkItem) -> tuple[str, ...]:
+    prefixes: list[str] = []
+    input_manifest = dict(work_item.input_manifest or {})
+    for sweep_text in input_manifest.get("sweeps") or []:
+        sweep_path = _resolve_path(repo_root=repo_root, path_text=str(sweep_text))
+        if not sweep_path.exists():
+            continue
+        try:
+            sweep_doc = _load_json(sweep_path)
+        except Exception:
+            continue
+        tag_prefix = str(sweep_doc.get("tag_prefix", "")).strip()
+        if tag_prefix and tag_prefix not in prefixes:
+            prefixes.append(tag_prefix)
+    return tuple(prefixes)
+
+
+def _row_in_current_sweep_scope(row: dict[str, Any], *, tag_prefixes: tuple[str, ...]) -> bool:
+    if not tag_prefixes:
+        return True
+    tag = str(row.get("tag", "")).strip()
+    return any(tag.startswith(prefix) for prefix in tag_prefixes)
+
+
 def _work_item_make_target(work_item: WorkItem) -> str:
     for command in work_item.command_manifest or []:
         if str(command.get("name", "")).strip() != "run_block_sweep":
@@ -286,13 +310,20 @@ def _effective_evaluation_record(*, repo_root: Path, work_item: WorkItem, best_r
     }
 
 
-def _best_metrics_row(*, repo_root: Path, metrics_csv: str) -> dict[str, Any] | None:
+def _best_metrics_row(
+    *,
+    repo_root: Path,
+    metrics_csv: str,
+    tag_prefixes: tuple[str, ...] = (),
+) -> dict[str, Any] | None:
     path = _resolve_path(repo_root=repo_root, path_text=metrics_csv)
     if not path.exists():
         return None
     rows: list[dict[str, Any]] = []
     for row in _load_metrics_rows(path):
         if str(row.get("status", "")).strip() != "ok":
+            continue
+        if not _row_in_current_sweep_scope(row, tag_prefixes=tag_prefixes):
             continue
         rows.append(dict(row))
     if not rows:
@@ -386,8 +417,9 @@ def _filter_metrics_csvs_for_trial(run: Run, metrics_csvs: list[str]) -> list[st
 
 def _best_trial_row(repo_root: Path, run: Run) -> tuple[str, dict[str, Any]] | None:
     candidates: list[tuple[str, dict[str, Any]]] = []
+    tag_prefixes = _current_sweep_tag_prefixes(repo_root, run.work_item)
     for metrics_csv in _metrics_csvs_from_run(run, work_item=run.work_item):
-        best_row = _best_metrics_row(repo_root=repo_root, metrics_csv=metrics_csv)
+        best_row = _best_metrics_row(repo_root=repo_root, metrics_csv=metrics_csv, tag_prefixes=tag_prefixes)
         if best_row is None:
             continue
         candidates.append((metrics_csv, best_row))
@@ -399,12 +431,15 @@ def _best_trial_row(repo_root: Path, run: Run) -> tuple[str, dict[str, Any]] | N
 
 def _ok_trial_rows(repo_root: Path, run: Run) -> list[tuple[str, dict[str, Any]]]:
     candidates: list[tuple[str, dict[str, Any]]] = []
+    tag_prefixes = _current_sweep_tag_prefixes(repo_root, run.work_item)
     for metrics_csv in _metrics_csvs_from_run(run, work_item=run.work_item):
         metrics_path = _resolve_path(repo_root=repo_root, path_text=metrics_csv)
         if not metrics_path.exists():
             continue
         for row in _load_metrics_rows(metrics_path):
             if str(row.get("status", "")).strip() != "ok":
+                continue
+            if not _row_in_current_sweep_scope(row, tag_prefixes=tag_prefixes):
                 continue
             candidates.append((metrics_csv, dict(row)))
     return candidates
@@ -731,8 +766,9 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
             )
         )
     else:
+        tag_prefixes = _current_sweep_tag_prefixes(repo_root, work_item)
         for metrics_csv in metrics_csvs:
-            best_row = _best_metrics_row(repo_root=repo_root, metrics_csv=metrics_csv)
+            best_row = _best_metrics_row(repo_root=repo_root, metrics_csv=metrics_csv, tag_prefixes=tag_prefixes)
             if best_row is None:
                 continue
             row_evaluation = _effective_evaluation_record(repo_root=repo_root, work_item=work_item, best_row=best_row)

--- a/control_plane/control_plane/services/reconciliation_service.py
+++ b/control_plane/control_plane/services/reconciliation_service.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import copy
 import csv
+import json
 from pathlib import Path
 import re
 import socket
@@ -249,14 +250,47 @@ def _load_metrics_rows(path: Path) -> list[dict[str, str]]:
     return rows
 
 
-def _normalize_metrics_csv_refs(*, repo_root: Path, metrics_csv: str, allow_missing: bool = False) -> list[dict[str, Any]]:
+def _current_sweep_tag_prefixes(repo_root: Path, work_item: WorkItem) -> tuple[str, ...]:
+    prefixes: list[str] = []
+    input_manifest = dict(work_item.input_manifest or {})
+    for sweep_text in input_manifest.get("sweeps") or []:
+        sweep_path = (repo_root / str(sweep_text)).resolve()
+        if not sweep_path.exists():
+            continue
+        try:
+            sweep_doc = json.loads(sweep_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        tag_prefix = str(sweep_doc.get("tag_prefix", "")).strip()
+        if tag_prefix and tag_prefix not in prefixes:
+            prefixes.append(tag_prefix)
+    return tuple(prefixes)
+
+
+def _metrics_row_in_current_sweep_scope(row: dict[str, Any], *, tag_prefixes: tuple[str, ...]) -> bool:
+    if not tag_prefixes:
+        return True
+    tag = str(row.get("tag", "")).strip()
+    return any(tag.startswith(prefix) for prefix in tag_prefixes)
+
+
+def _normalize_metrics_csv_refs(
+    *,
+    repo_root: Path,
+    work_item: WorkItem,
+    metrics_csv: str,
+    allow_missing: bool = False,
+) -> list[dict[str, Any]]:
     path = (repo_root / metrics_csv).resolve()
     if not path.exists():
         if allow_missing:
             return []
         raise ArtifactSyncError(f"metrics csv not found: {metrics_csv}")
     rows: list[dict[str, Any]] = []
+    tag_prefixes = _current_sweep_tag_prefixes(repo_root, work_item)
     for row in _load_metrics_rows(path):
+        if not _metrics_row_in_current_sweep_scope(row, tag_prefixes=tag_prefixes):
+            continue
         status = str(row.get("status", "")).strip()
         platform = str(row.get("platform", "")).strip()
         param_hash = str(row.get("param_hash", "")).strip()
@@ -327,6 +361,7 @@ def _normalize_metrics_rows(
         normalized_rows.extend(
             _normalize_metrics_csv_refs(
                 repo_root=repo_root,
+                work_item=work_item,
                 metrics_csv=metrics_csv,
                 allow_missing=(status == "fail"),
             )

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -283,6 +283,108 @@ def test_consume_l1_result_keeps_single_trial_metrics_without_trials_subdir() ->
             assert payload["proposals"][0]["metrics_ref"]["metrics_csv"] == metrics_rel
 
 
+def test_consume_l1_result_filters_historical_rows_by_current_sweep_tag_prefix() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        metrics_rel = "runs/designs/npu_blocks/demo_block/metrics.csv"
+        sweep_rel = "runs/campaigns/npu/demo/sweeps/current.json"
+        sweep_path = repo_root / sweep_rel
+        sweep_path.parent.mkdir(parents=True, exist_ok=True)
+        sweep_path.write_text(json.dumps({"tag_prefix": "current_sweep"}) + "\n", encoding="utf-8")
+        _write_metrics(
+            repo_root / metrics_rel,
+            [
+                {
+                    "platform": "nangate45",
+                    "status": "ok",
+                    "param_hash": "oldfast",
+                    "tag": "old_sweep_flat",
+                    "critical_path_ns": "1.0",
+                    "die_area": "100",
+                    "total_power_mw": "0.1",
+                    "result_path": "runs/designs/npu_blocks/demo_block/work/oldfast/result.json",
+                },
+                {
+                    "platform": "nangate45",
+                    "status": "ok",
+                    "param_hash": "current",
+                    "tag": "current_sweep_flat",
+                    "critical_path_ns": "5.0",
+                    "die_area": "500",
+                    "total_power_mw": "0.5",
+                    "result_path": "runs/designs/npu_blocks/demo_block/work/current/result.json",
+                },
+            ],
+        )
+
+        with Session(engine) as session:
+            task_request = TaskRequest(
+                request_key="l1_sweep:test_current_scope",
+                source="test",
+                requested_by="@tester",
+                title="current scope",
+                description="current-sweep scope",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={"item_id": "l1_test_current_scope", "objective": "current-sweep scope"},
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key="l1_sweep:l1_test_current_scope",
+                task_request_id=task_request.id,
+                item_id="l1_test_current_scope",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l1_sweep",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="config",
+                input_manifest={"sweeps": [sweep_rel]},
+                command_manifest=[],
+                expected_outputs=[metrics_rel],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+            session.add(Run(
+                run_key="l1_test_current_scope_run_1",
+                work_item_id=work_item.id,
+                attempt=1,
+                trial_index=1,
+                seed=0,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                result_summary="ok",
+                result_payload={
+                    "trial": {"trial_index": 1, "seed": 0},
+                    "queue_result": {"status": "ok", "metrics_rows": [f"{metrics_rel}:2"]},
+                },
+            ))
+            session.flush()
+
+            consume_l1_result(session, Layer1ConsumeRequest(repo_root=str(repo_root), item_id=work_item.item_id))
+
+            payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l1_promotions" / f"{work_item.item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert payload["proposals"][0]["metrics_ref"]["param_hash"] == "current"
+            assert payload["trial_summary"]["metrics"]["critical_path_ns"]["best"] == 5.0
+
+
 def test_consume_l1_result_allows_explicit_target_path() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_reconciliation_service.py
+++ b/control_plane/control_plane/tests/test_reconciliation_service.py
@@ -477,6 +477,7 @@ def test_normalize_metrics_csv_refs_supports_modern_npu_metrics_shape() -> None:
 
         rows = _normalize_metrics_csv_refs(
             repo_root=repo_root,
+            work_item=WorkItem(input_manifest={}),
             metrics_csv="runs/designs/npu_blocks/demo_block/metrics.csv",
             allow_missing=False,
         )
@@ -485,6 +486,40 @@ def test_normalize_metrics_csv_refs_supports_modern_npu_metrics_shape() -> None:
         assert rows[0]["param_hash"] == "deadbeef"
         assert rows[0]["tag"] == "demo_tag"
         assert rows[0]["result_path"] == "runs/designs/npu_blocks/demo_block/work/deadbeef/result.json"
+
+
+def test_normalize_metrics_csv_refs_filters_current_sweep_tag_prefix() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        metrics_path = repo_root / "runs" / "designs" / "npu_blocks" / "demo_block" / "metrics.csv"
+        metrics_path.parent.mkdir(parents=True, exist_ok=True)
+        metrics_path.write_text(
+            (
+                "design,platform,config_hash,param_hash,tag,status,critical_path_ns,die_area,total_power_mw,"
+                "flow_elapsed_seconds,stage_elapsed_seconds,params_json,result_path,work_result_json,synth_script_path,synth_script_sha1\n"
+                "demo_block,nangate45,abc123,oldfast,old_sweep_flat,ok,1.0,100.0,0.1,10.0,4.0,{},"
+                "/orfs/flow/logs/demo/old.json,runs/designs/npu_blocks/demo_block/work/oldfast/result.json,,\n"
+                "demo_block,nangate45,abc123,current,current_sweep_flat,ok,5.0,500.0,0.5,10.0,4.0,{},"
+                "/orfs/flow/logs/demo/current.json,runs/designs/npu_blocks/demo_block/work/current/result.json,,\n"
+            ),
+            encoding="utf-8",
+        )
+        sweep_rel = "runs/campaigns/npu/demo/sweeps/current.json"
+        sweep_path = repo_root / sweep_rel
+        sweep_path.parent.mkdir(parents=True, exist_ok=True)
+        sweep_path.write_text(json.dumps({"tag_prefix": "current_sweep"}) + "\n", encoding="utf-8")
+
+        rows = _normalize_metrics_csv_refs(
+            repo_root=repo_root,
+            work_item=WorkItem(input_manifest={"sweeps": [sweep_rel]}),
+            metrics_csv="runs/designs/npu_blocks/demo_block/metrics.csv",
+            allow_missing=False,
+        )
+
+        assert len(rows) == 1
+        assert rows[0]["param_hash"] == "current"
+        assert rows[0]["tag"] == "current_sweep_flat"
 
 
 def test_sync_run_artifacts_defaults_to_shadow_export_path() -> None:


### PR DESCRIPTION
## Summary
- scope L1 result consumption to the tag prefix from the queued sweep file
- apply the same scope when normalizing artifact-sync metrics rows
- add regression tests that keep older rows in the same `metrics.csv` from winning current-sweep reviews

## Why
PR #669 exposed that accumulated `metrics.csv` files can contain old rows from earlier sweeps. The promotion consumer and artifact sync were selecting/normalizing all historical rows, so the boundary result mixed older `compute_ladder` evidence with the current corrected `compute_stability` run.

## Validation
- `python -m pytest control_plane/tests/test_l1_result_consumer.py::test_consume_l1_result_filters_historical_rows_by_current_sweep_tag_prefix control_plane/tests/test_reconciliation_service.py::test_normalize_metrics_csv_refs_supports_modern_npu_metrics_shape control_plane/tests/test_reconciliation_service.py::test_normalize_metrics_csv_refs_filters_current_sweep_tag_prefix`
