### PR TITLE
[codex] filter normalized l1 metrics rows

### DIFF
--- a/control_plane/control_plane/services/reconciliation_service.py
+++ b/control_plane/control_plane/services/reconciliation_service.py
@@ -328,7 +328,10 @@ def _normalize_metrics_rows(
     metrics_rows = queue_result.get("metrics_rows")
     if isinstance(metrics_rows, list) and metrics_rows and all(isinstance(row, dict) for row in metrics_rows):
         normalized: list[dict[str, Any]] = []
+        tag_prefixes = _current_sweep_tag_prefixes(repo_root, work_item)
         for row in metrics_rows:
+            if not _metrics_row_in_current_sweep_scope(row, tag_prefixes=tag_prefixes):
+                continue
             new_row = dict(row)
             result_path = _portable_metrics_result_path(new_row, repo_root)
             if not result_path:

--- a/control_plane/control_plane/tests/test_reconciliation_service.py
+++ b/control_plane/control_plane/tests/test_reconciliation_service.py
@@ -20,6 +20,7 @@ from control_plane.services.reconciliation_service import (
     ArtifactSyncRequest,
     _ensure_queue_snapshot_artifact,
     _normalize_metrics_csv_refs,
+    _normalize_metrics_rows,
     sync_run_artifacts,
 )
 from control_plane.services.worker_service import run_worker
@@ -520,6 +521,44 @@ def test_normalize_metrics_csv_refs_filters_current_sweep_tag_prefix() -> None:
         assert len(rows) == 1
         assert rows[0]["param_hash"] == "current"
         assert rows[0]["tag"] == "current_sweep_flat"
+
+
+def test_normalize_metrics_rows_filters_already_normalized_current_sweep_rows() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        sweep_rel = "runs/campaigns/npu/demo/sweeps/current.json"
+        sweep_path = repo_root / sweep_rel
+        sweep_path.parent.mkdir(parents=True, exist_ok=True)
+        sweep_path.write_text(json.dumps({"tag_prefix": "current_sweep"}) + "\n", encoding="utf-8")
+        work_item = WorkItem(input_manifest={"sweeps": [sweep_rel]})
+
+        rows = _normalize_metrics_rows(
+            repo_root=repo_root,
+            work_item=work_item,
+            queue_result={
+                "status": "ok",
+                "metrics_rows": [
+                    {
+                        "metrics_csv": "runs/designs/npu_blocks/demo_block/metrics.csv",
+                        "platform": "nangate45",
+                        "status": "ok",
+                        "param_hash": "oldfast",
+                        "tag": "old_sweep_flat",
+                    },
+                    {
+                        "metrics_csv": "runs/designs/npu_blocks/demo_block/metrics.csv",
+                        "platform": "nangate45",
+                        "status": "ok",
+                        "param_hash": "current",
+                        "tag": "current_sweep_flat",
+                    },
+                ],
+            },
+        )
+
+        assert len(rows) == 1
+        assert rows[0]["param_hash"] == "current"
 
 
 def test_sync_run_artifacts_defaults_to_shadow_export_path() -> None:


### PR DESCRIPTION
## Summary
- apply current-sweep tag-prefix filtering to already-normalized metrics row dicts during artifact sync
- add a regression test for this path

## Why
PR #669 showed that a queue snapshot can already contain expanded metrics row dictionaries from a previous sync. The first scoping fix filtered CSV expansion, but this dict-row path also needs filtering when a review package is regenerated.

## Validation
- `python -m pytest control_plane/tests/test_reconciliation_service.py::test_normalize_metrics_rows_filters_already_normalized_current_sweep_rows control_plane/tests/test_reconciliation_service.py::test_normalize_metrics_csv_refs_filters_current_sweep_tag_prefix`
