### PR TITLE
eval: add llama7b measured compute partition sweep

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3642,6 +3642,56 @@ def _decoder_attention_kv_measured_compute_evidence(*, item_id: str) -> dict[str
     }
 
 
+def _decoder_attention_kv_measured_compute_partition_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_measured_compute_partition__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_measured_compute_partition__{item_id}.md"
+    measured_compute = (
+        f"{base}/decoder_attention_kv_measured_compute__"
+        "l2_decoder_attention_kv_measured_compute_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_measured_compute": measured_compute,
+            "attention_kv_partition_out": out,
+            "attention_kv_partition_report": report,
+            "attention_kv_measured_compute_partition_scope": (
+                "Quality-backed native-GQA KV8 Llama7B 131k estimate that keeps merged measured "
+                "NPU compute PPA but compares clustered sequence-sharded compute fabrics. The "
+                "sweep varies cluster count, local/shared SRAM split, NoC bandwidth, and NoC hop "
+                "penalty so the measured-compute frontier is not ranked only as one monolithic "
+                "compute fabric."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_measured_compute_partition",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_measured_compute_partition.py "
+                    "--repo-root . "
+                    "--tag-substring compute_stability_cmp33 "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 100,200,400,800,1200 "
+                    "--sram-area-fraction 0.4,0.6,0.75 "
+                    "--logic-area-fraction 0.05,0.1,0.2 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7,0.85 "
+                    "--local-sram-fraction 0.1,0.25,0.5 "
+                    "--tile-tokens-list 512,1024 "
+                    "--bank-count 16,64 "
+                    "--cluster-count 1,2,4,8,16,32,64 "
+                    "--noc-bandwidth-bytes-per-cycle 8192,32768,131072 "
+                    "--noc-hops 1,2,4 "
+                    "--vector-ops-per-mac 0.125 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
@@ -5143,6 +5193,7 @@ def _build_payload(
         "decoder_attention_kv_physical_hbm_memory_noc",
         "decoder_attention_kv_physical_hbm_compute_sensitivity",
         "decoder_attention_kv_measured_compute",
+        "decoder_attention_kv_measured_compute_partition",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
@@ -5208,6 +5259,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_physical_hbm_compute_sensitivity_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_measured_compute":
             decoder_evidence = _decoder_attention_kv_measured_compute_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_measured_compute_partition":
+            decoder_evidence = _decoder_attention_kv_measured_compute_partition_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/README.md
@@ -1,0 +1,4 @@
+# Llama7B Measured Compute Partition Frontier
+
+This proposal follows the measured-compute substitution result by checking whether the ranking is stable when the compute fabric is partitioned into clustered, sequence-sharded tiles instead of treated as one monolithic pool of replicas.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/analysis_report.md
@@ -1,0 +1,26 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1`
+- `candidate_id`: `l2_decoder_attention_kv_measured_compute_partition_llama7b_v1`
+
+## Evaluations Consumed
+- pending: `l2_decoder_attention_kv_measured_compute_partition_llama7b_v1`
+- baseline: `l2_decoder_attention_kv_measured_compute_llama7b_v1`
+- source commit: `7c44fa3d51c80e20a8b1b9c7fe7792fc0bc6c2b3`
+
+## Baseline Comparison
+- baseline uses measured compute PPA as one monolithic compute fabric.
+- candidate adds clustered sequence-tile scheduling, local/shared SRAM shares, and NoC bandwidth/hop contention.
+
+## Result
+- pending evaluator result.
+
+## Failures and Caveats
+- This is a service/scheduling model, not detailed NoC or SRAM macro RTL/PPA.
+- QKV projection uses aggregate compute while attention tiles are statically sequence-sharded.
+
+## Recommendation
+- iterate after evaluator evidence is merged.
+- If cluster count does not materially change the frontier, queue command-routing hierarchy RTL/PPA.
+- If NoC or local/shared SRAM split changes the frontier, refine memory/NOC hierarchy first.

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/design_brief.md
@@ -1,0 +1,14 @@
+# Design Brief
+
+The previous measured-compute substitution selected replicated `nm64_flat` blocks because the estimator allowed all replicas to behave as a single compute fabric. That is useful as a first bound, but it hides the architectural choice between a large dynamic dispatcher and a more regular cluster hierarchy.
+
+This job keeps the same corrected compute PPA inputs and adds a planning model with:
+
+- static sequence-tile sharding across compute clusters,
+- floor/ceil assignment of measured compute replicas to clusters,
+- local SRAM treated as sharded resident KV storage,
+- shared SRAM and HBM bandwidth contended by active clusters,
+- explicit NoC bandwidth and hop penalties.
+
+The result should identify whether the practical next point is a small number of large clusters, many smaller clusters, or continued memory/NOC refinement before RTL.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+Required inputs:
+
+- merged Llama7B measured-compute substitution evidence,
+- merged corrected compute PPA rows for nm1..nm64,
+- quality-backed native-GQA KV8 restriction.
+
+The evaluation is a Layer 2 planning estimate only. It must not be used as a final PPA result for a hierarchical NPU top, NoC, or SRAM macro floorplan.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+  "source_commit": "7c44fa3d51c80e20a8b1b9c7fe7792fc0bc6c2b3",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the quality-backed native-GQA KV8 131k Llama7B measured-compute model with clustered sequence-sharded compute, local/shared SRAM, and NoC contention sweeps.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_measured_compute_partition",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_measured_compute_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_measured_compute_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If clustered partitioning keeps nm64-flat dominant, move to RTL/PPA command-routing hierarchy; if smaller clusters win or NoC dominates, refine memory/NOC hierarchy before deeper RTL."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
-  "source_commit": "7c44fa3d51c80e20a8b1b9c7fe7792fc0bc6c2b3",
+  "source_commit": "a8aa60dbd7f0dd0eb477d8768b3b23a1f1e1786f",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/implementation_summary.md
@@ -1,0 +1,30 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1`
+- Llama7B measured-compute clustered partition frontier.
+
+## Scope
+- Added a Layer 2 estimator that reuses merged corrected NPU compute PPA rows.
+- Added clustered sequence-tile scheduling, local/shared SRAM residency shares, and NoC bandwidth/hop contention.
+- Added a control-plane evidence hook for `decoder_attention_kv_measured_compute_partition`.
+- Did not add new RTL/PPA, cycle-accurate NoC arbitration, or SRAM macro floorplanning.
+
+## Files Changed
+- `npu/eval/estimate_llm_decoder_attention_kv_measured_compute_partition.py`
+- `control_plane/control_plane/services/l2_task_generator.py`
+- `docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/*`
+
+## Local Validation
+- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_measured_compute_partition.py control_plane/control_plane/services/l2_task_generator.py`
+- Reduced smoke estimator run passed.
+- Full local estimator run generated 672408 rows with 212112 skipped infeasible area/cluster rows.
+
+## Evaluation Request
+- `item_id`: `l2_decoder_attention_kv_measured_compute_partition_llama7b_v1`
+- cost class: low Layer 2 campaign
+- paired baseline: `l2_decoder_attention_kv_measured_compute_llama7b_v1`
+
+## Risks
+- NoC contention and SRAM residency remain planning assumptions.
+- The best cluster count should be used to choose the next deeper RTL/PPA target, not as a final implementation claim.

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/promotion_decision.json
@@ -1,0 +1,12 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+  "decision": "iterate",
+  "reason": "Pending evaluator evidence. The proposal is intentionally queued as a follow-on frontier-planning job after measured-compute substitution.",
+  "evidence_refs": [
+    "item:l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+    "baseline:l2_decoder_attention_kv_measured_compute_llama7b_v1"
+  ],
+  "next_action": "Run the clustered measured-compute partition sweep and use the result to pick either command-routing hierarchy RTL/PPA or memory/NOC refinement.",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/promotion_gate.md
@@ -1,0 +1,4 @@
+# Promotion Gate
+
+Promote only as frontier-planning evidence. A promoted result may choose the next RTL/PPA target for clustered compute, command routing, SRAM banking, or NoC service, but it does not replace detailed implementation evidence.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/proposal.json
@@ -1,0 +1,72 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+  "created_utc": "2026-05-27T12:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_measured_compute_partition",
+  "title": "Llama7B measured-compute clustered partition frontier",
+  "hypothesis": "The measured-compute Llama7B frontier is sensitive to whether replicated compute blocks are modeled as one monolithic fabric or as clustered sequence-sharded tiles with local/shared SRAM and contended NoC service.",
+  "direct_comparison": {
+    "primary_question": "For quality-backed native-GQA KV8 at 131k context, which compute cluster count and memory/NOC split gives the best latency under measured corrected compute PPA and practical die budgets?",
+    "include": [
+      "llama7b_proxy at 131k tokens",
+      "native-GQA group-8 only",
+      "KV8 only",
+      "merged corrected compute PPA rows for nm1, nm2, nm4, nm8, nm16, nm32, and nm64",
+      "flat and hierarchical rows where status=ok",
+      "die sizes 100, 200, 400, 800, and 1200 mm2",
+      "SRAM area fractions 0.4, 0.6, and 0.75",
+      "logic area fractions 0.05, 0.1, and 0.2",
+      "cluster counts 1, 2, 4, 8, 16, 32, and 64",
+      "NoC bandwidth values 8192, 32768, and 131072 bytes/cycle",
+      "NoC hop counts 1, 2, and 4"
+    ],
+    "exclude": [
+      "new RTL/PPA runs",
+      "cycle-accurate NoC arbitration",
+      "SRAM macro floorplanning",
+      "quality-degraded KV4 or MQA ranking"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the current nm64-flat best point is an artifact of monolithic compute pooling",
+    "estimates the cost of cluster count, local SRAM share, shared SRAM contention, and NoC hop count before implementing hierarchy RTL",
+    "selects the next concrete RTL/PPA target for clustered command routing or memory hierarchy"
+  ],
+  "risks": [
+    "local/shared SRAM behavior is still a service model",
+    "NoC contention is represented by bandwidth division over active clusters, not cycle-accurate arbitration",
+    "qkv projection is assumed to use aggregate compute while attention tiles are sequence-sharded"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the quality-backed native-GQA KV8 131k Llama7B measured-compute model with clustered sequence-sharded compute, local/shared SRAM, and NoC contention sweeps.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_measured_compute_partition",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_measured_compute_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_measured_compute_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If clustered partitioning keeps nm64-flat dominant, move to RTL/PPA command-routing hierarchy; if smaller clusters win or NoC dominates, refine memory/NOC hierarchy before deeper RTL."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_compute__l2_decoder_attention_kv_measured_compute_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_measured_compute.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_measured_compute_partition.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/quality_gate.md
@@ -1,0 +1,4 @@
+# Quality Gate
+
+Keep the deployable ranking restricted to native-GQA KV8. Do not promote KV4 or MQA from this job.
+

--- a/npu/eval/estimate_llm_decoder_attention_kv_measured_compute_partition.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_measured_compute_partition.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Estimate Llama7B attention/KV with measured compute blocks under clustered partitioning."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval.estimate_llm_decoder_attention_kv_measured_compute import (  # noqa: E402
+    _best_by,
+    _float_list,
+    _int_list,
+    _load_compute_candidates,
+)
+from npu.eval.estimate_llm_decoder_attention_kv_physical_hbm_frontier import (  # noqa: E402
+    _active_banks,
+    _ceil_div,
+    _kv_heads,
+    _physical_hbm_bytes_per_cycle,
+    _sram_capacity_bytes,
+)
+
+JsonDict = dict[str, Any]
+
+
+def _partitioned_shape_row(
+    *,
+    candidate: JsonDict,
+    die_area_mm2: float,
+    sram_area_fraction: float,
+    logic_area_fraction: float,
+    reserved_area_fraction: float,
+    sequence_length: int,
+    usable_sram_fraction: float,
+    local_sram_fraction: float,
+    tile_tokens: int,
+    bank_count: int,
+    cluster_count: int,
+    noc_bandwidth_bytes_per_cycle: float,
+    noc_hops: int,
+    vector_ops_per_mac: float,
+) -> JsonDict | None:
+    if sram_area_fraction + logic_area_fraction + reserved_area_fraction > 1.0:
+        return None
+    compute_budget_um2 = die_area_mm2 * 1_000_000.0 * logic_area_fraction
+    replica_count = int(compute_budget_um2 // float(candidate["block_area_um2"]))
+    if replica_count < 1 or cluster_count > replica_count:
+        return None
+
+    layers = 32
+    hidden_size = 4096
+    attention_heads = 32
+    kv_bits = 8
+    kv_heads = _kv_heads(attention_heads=attention_heads, kv_sharing="gqa8")
+    head_dim = hidden_size // attention_heads
+    kv_width = kv_heads * head_dim
+    kv_bytes_per_scalar = kv_bits / 8.0
+    kv_cache_bytes = 2 * sequence_length * kv_width * kv_bytes_per_scalar * layers
+
+    total_sram_bytes = _sram_capacity_bytes(
+        die_area_mm2=die_area_mm2,
+        sram_area_fraction=sram_area_fraction,
+        usable_sram_fraction=usable_sram_fraction,
+        bitcell_area_um2_per_bit=0.02,
+    )
+    local_capacity_bytes = int(total_sram_bytes * local_sram_fraction)
+    shared_capacity_bytes = max(0, total_sram_bytes - local_capacity_bytes)
+    local_resident_bytes = min(kv_cache_bytes, local_capacity_bytes)
+    shared_resident_bytes = min(max(0, kv_cache_bytes - local_resident_bytes), shared_capacity_bytes)
+    local_read_share = local_resident_bytes / kv_cache_bytes if kv_cache_bytes else 0.0
+    shared_read_share = shared_resident_bytes / kv_cache_bytes if kv_cache_bytes else 0.0
+    hbm_read_share = max(0.0, 1.0 - local_read_share - shared_read_share)
+
+    block_macs_per_cycle = int(candidate["block_macs_per_cycle"])
+    total_macs_per_cycle = replica_count * block_macs_per_cycle
+    total_vector_ops_per_cycle = max(1, int(math.ceil(total_macs_per_cycle * vector_ops_per_mac)))
+    active_clusters = min(cluster_count, _ceil_div(sequence_length, tile_tokens))
+    replicas_per_cluster_floor = replica_count // cluster_count
+    replicas_per_cluster_ceil = math.ceil(replica_count / cluster_count)
+    per_cluster_macs = max(1, replicas_per_cluster_floor * block_macs_per_cycle)
+    per_cluster_vector_ops = max(1, int(math.ceil(per_cluster_macs * vector_ops_per_mac)))
+
+    clock_ns = float(candidate["block_clock_ns"])
+    raw_hbm_bw = _physical_hbm_bytes_per_cycle(
+        stack_count=8,
+        pseudo_channels_per_stack=16,
+        pseudo_channel_width_bits=64,
+        data_rate_mtps=9000,
+        core_clock_ns=clock_ns,
+    )
+    effective_hbm_bw = raw_hbm_bw * 0.75
+    active_banks = _active_banks(tile_tokens=tile_tokens, bank_interleave_tokens=16, bank_count=bank_count)
+    aggregate_bank_bw = active_banks * 2048.0 * 0.75
+    vc_gain = min(1.0, 0.85 + 0.05 * (4 - 1))
+    aggregate_noc_bw = (noc_bandwidth_bytes_per_cycle / max(1, noc_hops)) * 0.85 * vc_gain
+
+    concurrent_clusters = max(1, active_clusters)
+    hbm_bw_per_cluster = max(1.0, effective_hbm_bw / concurrent_clusters)
+    shared_bank_bw_per_cluster = max(1.0, aggregate_bank_bw / concurrent_clusters)
+    noc_bw_per_cluster = max(1.0, aggregate_noc_bw / concurrent_clusters)
+    local_bank_bw_per_cluster = max(1.0, aggregate_bank_bw * max(local_sram_fraction, 1.0 / concurrent_clusters) / concurrent_clusters)
+
+    qkv_macs = hidden_size * hidden_size + 2 * hidden_size * kv_width
+    qkv_cycles = _ceil_div(qkv_macs, total_macs_per_cycle)
+    tile_count = _ceil_div(sequence_length, tile_tokens)
+    tile_waves = _ceil_div(tile_count, active_clusters)
+
+    tile_compute_cycles = _ceil_div(2 * tile_tokens * hidden_size, per_cluster_macs)
+    tile_softmax_cycles = _ceil_div(5 * attention_heads * tile_tokens, per_cluster_vector_ops)
+    tile_attention_cycles = tile_compute_cycles + tile_softmax_cycles
+
+    full_tile_bytes = 2 * tile_tokens * kv_width * kv_bytes_per_scalar
+    tile_local_cycles = _ceil_div(full_tile_bytes * local_read_share, local_bank_bw_per_cluster)
+    tile_shared_bank_cycles = _ceil_div(full_tile_bytes * shared_read_share, shared_bank_bw_per_cluster)
+    tile_noc_cycles = _ceil_div(full_tile_bytes * shared_read_share, noc_bw_per_cluster) + noc_hops * 2
+    tile_shared_path_cycles = max(tile_shared_bank_cycles, tile_noc_cycles)
+    tile_hbm_cycles = _ceil_div(full_tile_bytes * hbm_read_share, hbm_bw_per_cluster)
+    tile_memory_cycles = max(tile_local_cycles, tile_shared_path_cycles, tile_hbm_cycles)
+    tile_service_cycles = max(tile_attention_cycles, tile_memory_cycles)
+
+    kv_write_bytes = 2 * kv_width * kv_bytes_per_scalar
+    kv_write_cycles = _ceil_div(kv_write_bytes, max(1.0, min(aggregate_bank_bw, aggregate_noc_bw)))
+    layer_cycles = qkv_cycles + tile_waves * tile_service_cycles + kv_write_cycles
+    total_cycles = layer_cycles * layers
+    dominant = max(
+        {
+            "tile_attention": tile_attention_cycles,
+            "local_sram": tile_local_cycles,
+            "shared_path": tile_shared_path_cycles,
+            "hbm": tile_hbm_cycles,
+        }.items(),
+        key=lambda item: item[1],
+    )[0]
+    ideal_cluster_cycles = tile_count * tile_attention_cycles / concurrent_clusters if concurrent_clusters else 0.0
+    realized_tile_cycles = tile_waves * tile_service_cycles
+
+    return {
+        "label": "llama7b_proxy",
+        "layers": layers,
+        "hidden_size": hidden_size,
+        "attention_heads": attention_heads,
+        "sequence_length": sequence_length,
+        "die_area_mm2": die_area_mm2,
+        "kv_sharing": "gqa8",
+        "kv_heads": kv_heads,
+        "kv_bits": kv_bits,
+        "kv_cache_mib": round(kv_cache_bytes / (1024 * 1024), 6),
+        "sram_area_fraction": sram_area_fraction,
+        "usable_sram_fraction": usable_sram_fraction,
+        "local_sram_fraction": local_sram_fraction,
+        "total_sram_mib": round(total_sram_bytes / (1024 * 1024), 6),
+        "local_capacity_mib": round(local_capacity_bytes / (1024 * 1024), 6),
+        "shared_capacity_mib": round(shared_capacity_bytes / (1024 * 1024), 6),
+        "local_byte_share": round(local_read_share, 6),
+        "shared_byte_share": round(shared_read_share, 6),
+        "hbm_byte_share": round(hbm_read_share, 6),
+        "bank_count": bank_count,
+        "active_banks": active_banks,
+        "noc_bandwidth_bytes_per_cycle": noc_bandwidth_bytes_per_cycle,
+        "noc_hops": noc_hops,
+        "aggregate_noc_effective_bytes_per_cycle": round(aggregate_noc_bw, 6),
+        "per_cluster_noc_effective_bytes_per_cycle": round(noc_bw_per_cluster, 6),
+        "raw_hbm_bytes_per_cycle": round(raw_hbm_bw, 6),
+        "effective_hbm_bytes_per_cycle": round(effective_hbm_bw, 6),
+        "per_cluster_hbm_bytes_per_cycle": round(hbm_bw_per_cluster, 6),
+        "tile_tokens": tile_tokens,
+        "tile_count": tile_count,
+        "tile_waves": tile_waves,
+        "cluster_count": cluster_count,
+        "active_clusters": active_clusters,
+        "replicas_per_cluster_floor": replicas_per_cluster_floor,
+        "replicas_per_cluster_ceil": replicas_per_cluster_ceil,
+        "compute_arch": candidate["compute_arch"],
+        "compute_replica_count": replica_count,
+        "compute_logic_area_fraction": logic_area_fraction,
+        "reserved_area_fraction": reserved_area_fraction,
+        "compute_budget_um2": round(compute_budget_um2, 6),
+        "compute_area_um2": round(replica_count * float(candidate["block_area_um2"]), 6),
+        "compute_power_mw": round(replica_count * float(candidate["block_power_mw"]), 6),
+        "macs_per_cycle": total_macs_per_cycle,
+        "vector_ops_per_cycle": total_vector_ops_per_cycle,
+        "per_cluster_macs_per_cycle": per_cluster_macs,
+        "per_cluster_vector_ops_per_cycle": per_cluster_vector_ops,
+        "clock_ns": clock_ns,
+        "qkv_cycles": qkv_cycles,
+        "tile_attention_cycles": tile_attention_cycles,
+        "tile_local_sram_cycles": tile_local_cycles,
+        "tile_shared_path_cycles": tile_shared_path_cycles,
+        "tile_hbm_cycles": tile_hbm_cycles,
+        "tile_memory_cycles": tile_memory_cycles,
+        "tile_service_cycles": tile_service_cycles,
+        "kv_write_cycles": kv_write_cycles,
+        "layer_cycles": layer_cycles,
+        "total_cycles": total_cycles,
+        "latency_us": round(total_cycles * clock_ns / 1000.0, 6),
+        "dominant_tile_resource": dominant,
+        "cluster_tile_efficiency": round(ideal_cluster_cycles / realized_tile_cycles, 6) if realized_tile_cycles else 0.0,
+        "measured_block_macs_per_cycle": candidate["block_macs_per_cycle"],
+        "measured_block_clock_ns": candidate["block_clock_ns"],
+        "measured_block_area_um2": candidate["block_area_um2"],
+        "measured_block_power_mw": candidate["block_power_mw"],
+        "metrics_csv": candidate["metrics_csv"],
+        "metrics_tag": candidate["metrics_tag"],
+        "metrics_param_hash": candidate["metrics_param_hash"],
+        "vector_ops_per_mac_assumption": vector_ops_per_mac,
+    }
+
+
+def build_report(
+    *,
+    repo_root: Path,
+    tag_substring: str,
+    sequence_length_list: list[int],
+    die_area_mm2_list: list[float],
+    sram_area_fraction_list: list[float],
+    logic_area_fraction_list: list[float],
+    reserved_area_fraction: float,
+    usable_sram_fraction_list: list[float],
+    local_sram_fraction_list: list[float],
+    tile_tokens_list: list[int],
+    bank_count_list: list[int],
+    cluster_count_list: list[int],
+    noc_bandwidth_bytes_per_cycle_list: list[float],
+    noc_hops_list: list[int],
+    vector_ops_per_mac: float,
+) -> JsonDict:
+    candidates = _load_compute_candidates(repo_root=repo_root, tag_substring=tag_substring)
+    rows: list[JsonDict] = []
+    skipped_area_budget = 0
+    for sequence_length in sequence_length_list:
+        for die_area_mm2 in die_area_mm2_list:
+            for sram_area_fraction in sram_area_fraction_list:
+                for logic_area_fraction in logic_area_fraction_list:
+                    for usable_sram_fraction in usable_sram_fraction_list:
+                        for local_sram_fraction in local_sram_fraction_list:
+                            for tile_tokens in tile_tokens_list:
+                                for bank_count in bank_count_list:
+                                    for cluster_count in cluster_count_list:
+                                        for noc_bw in noc_bandwidth_bytes_per_cycle_list:
+                                            for noc_hops in noc_hops_list:
+                                                for candidate in candidates:
+                                                    row = _partitioned_shape_row(
+                                                        candidate=candidate,
+                                                        die_area_mm2=die_area_mm2,
+                                                        sram_area_fraction=sram_area_fraction,
+                                                        logic_area_fraction=logic_area_fraction,
+                                                        reserved_area_fraction=reserved_area_fraction,
+                                                        sequence_length=sequence_length,
+                                                        usable_sram_fraction=usable_sram_fraction,
+                                                        local_sram_fraction=local_sram_fraction,
+                                                        tile_tokens=tile_tokens,
+                                                        bank_count=bank_count,
+                                                        cluster_count=cluster_count,
+                                                        noc_bandwidth_bytes_per_cycle=noc_bw,
+                                                        noc_hops=noc_hops,
+                                                        vector_ops_per_mac=vector_ops_per_mac,
+                                                    )
+                                                    if row is None:
+                                                        skipped_area_budget += 1
+                                                    else:
+                                                        rows.append(row)
+    if not rows:
+        raise RuntimeError("no rows generated; area budget or cluster count may be infeasible")
+    rows_sorted = sorted(rows, key=lambda row: row["latency_us"])
+    dominance: dict[str, int] = {}
+    for row in rows:
+        key = str(row["dominant_tile_resource"])
+        dominance[key] = dominance.get(key, 0) + 1
+    best_by_memory_noc = _best_by(
+        rows,
+        (
+            "sequence_length",
+            "die_area_mm2",
+            "sram_area_fraction",
+            "local_sram_fraction",
+            "bank_count",
+            "noc_bandwidth_bytes_per_cycle",
+            "noc_hops",
+        ),
+    )
+    return {
+        "version": 0.1,
+        "model": "llm_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+        "inputs": {
+            "tag_substring": tag_substring,
+            "sequence_length_list": sequence_length_list,
+            "die_area_mm2_list": die_area_mm2_list,
+            "sram_area_fraction_list": sram_area_fraction_list,
+            "logic_area_fraction_list": logic_area_fraction_list,
+            "reserved_area_fraction": reserved_area_fraction,
+            "usable_sram_fraction_list": usable_sram_fraction_list,
+            "local_sram_fraction_list": local_sram_fraction_list,
+            "tile_tokens_list": tile_tokens_list,
+            "bank_count_list": bank_count_list,
+            "cluster_count_list": cluster_count_list,
+            "noc_bandwidth_bytes_per_cycle_list": noc_bandwidth_bytes_per_cycle_list,
+            "noc_hops_list": noc_hops_list,
+            "vector_ops_per_mac": vector_ops_per_mac,
+        },
+        "compute_candidates": candidates,
+        "sweep_summary": {
+            "generated_row_count": len(rows),
+            "skipped_area_budget_count": skipped_area_budget,
+            "dominant_tile_resource_counts": dict(sorted(dominance.items())),
+        },
+        "best": rows_sorted[0],
+        "top_rows": rows_sorted[:50],
+        "best_by_die": _best_by(rows, ("sequence_length", "die_area_mm2")),
+        "best_by_die_cluster": _best_by(rows, ("sequence_length", "die_area_mm2", "cluster_count")),
+        "best_by_die_sram_logic": _best_by(
+            rows,
+            ("sequence_length", "die_area_mm2", "sram_area_fraction", "compute_logic_area_fraction"),
+        ),
+        "best_by_compute_arch": _best_by(rows, ("sequence_length", "die_area_mm2", "compute_arch")),
+        "best_by_memory_noc": sorted(best_by_memory_noc, key=lambda row: row["latency_us"])[:200],
+        "assumptions": [
+            "Compute blocks use merged corrected NPU PPA rows and are replicated within the logic area budget.",
+            "cluster_count is a planning partition count; replicas are statically assigned to clusters by floor/ceil division.",
+            "Attention tiles are sequence-sharded across active clusters; qkv projection uses aggregate compute throughput.",
+            "Local SRAM is modeled as sequence-sharded resident KV storage; shared SRAM and HBM bandwidth are contended across active clusters.",
+            "NoC bandwidth is divided across active clusters and penalized by hop count plus router latency.",
+            "This is a scheduling/service model, not cycle-accurate NoC arbitration or SRAM macro floorplanning.",
+        ],
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best"]
+    lines = [
+        "# Decoder Attention/KV Measured Compute Partition",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- generated_row_count: `{payload['sweep_summary']['generated_row_count']}`",
+        f"- skipped_area_budget_count: `{payload['sweep_summary']['skipped_area_budget_count']}`",
+        "",
+        "## Best",
+        "",
+        "| seq | die | SRAM | logic | arch | replicas | clusters | MAC/cyc | clock ns | latency us | resource |",
+        "|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|---|",
+        "| {seq} | {die} | {sram} | {logic} | {arch} | {rep} | {cluster} | {macs} | {clk} | {lat} | {res} |".format(
+            seq=best["sequence_length"],
+            die=best["die_area_mm2"],
+            sram=best["sram_area_fraction"],
+            logic=best["compute_logic_area_fraction"],
+            arch=best["compute_arch"],
+            rep=best["compute_replica_count"],
+            cluster=best["cluster_count"],
+            macs=best["macs_per_cycle"],
+            clk=best["clock_ns"],
+            lat=best["latency_us"],
+            res=best["dominant_tile_resource"],
+        ),
+        "",
+        "## Best By Die",
+        "",
+        "| seq | die | SRAM | logic | arch | replicas | clusters | local share | shared share | hbm share | latency us | resource |",
+        "|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["best_by_die"]:
+        lines.append(
+            "| {seq} | {die} | {sram} | {logic} | {arch} | {rep} | {cluster} | {local} | {shared} | {hbm} | {lat} | {res} |".format(
+                seq=row["sequence_length"],
+                die=row["die_area_mm2"],
+                sram=row["sram_area_fraction"],
+                logic=row["compute_logic_area_fraction"],
+                arch=row["compute_arch"],
+                rep=row["compute_replica_count"],
+                cluster=row["cluster_count"],
+                local=row["local_byte_share"],
+                shared=row["shared_byte_share"],
+                hbm=row["hbm_byte_share"],
+                lat=row["latency_us"],
+                res=row["dominant_tile_resource"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Best By Die And Cluster",
+            "",
+            "| die | clusters | arch | replicas | per-cluster MAC/cyc | latency us | efficiency | resource |",
+            "|---:|---:|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for row in payload["best_by_die_cluster"]:
+        lines.append(
+            "| {die} | {cluster} | {arch} | {rep} | {pcmac} | {lat} | {eff} | {res} |".format(
+                die=row["die_area_mm2"],
+                cluster=row["cluster_count"],
+                arch=row["compute_arch"],
+                rep=row["compute_replica_count"],
+                pcmac=row["per_cluster_macs_per_cycle"],
+                lat=row["latency_us"],
+                eff=row["cluster_tile_efficiency"],
+                res=row["dominant_tile_resource"],
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-root", default=".")
+    ap.add_argument("--tag-substring", default="compute_stability_cmp33")
+    ap.add_argument("--sequence-length-list", type=_int_list, default=[131072])
+    ap.add_argument("--die-area-mm2-list", type=_float_list, default=[100, 200, 400, 800, 1200])
+    ap.add_argument("--sram-area-fraction", type=_float_list, default=[0.4, 0.6, 0.75])
+    ap.add_argument("--logic-area-fraction", type=_float_list, default=[0.05, 0.1, 0.2])
+    ap.add_argument("--reserved-area-fraction", type=float, default=0.1)
+    ap.add_argument("--usable-sram-fraction", type=_float_list, default=[0.7, 0.85])
+    ap.add_argument("--local-sram-fraction", type=_float_list, default=[0.1, 0.25, 0.5])
+    ap.add_argument("--tile-tokens-list", type=_int_list, default=[512, 1024])
+    ap.add_argument("--bank-count", type=_int_list, default=[16, 64])
+    ap.add_argument("--cluster-count", type=_int_list, default=[1, 2, 4, 8, 16, 32, 64])
+    ap.add_argument("--noc-bandwidth-bytes-per-cycle", type=_float_list, default=[8192, 32768, 131072])
+    ap.add_argument("--noc-hops", type=_int_list, default=[1, 2, 4])
+    ap.add_argument("--vector-ops-per-mac", type=float, default=0.125)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    payload = build_report(
+        repo_root=Path(args.repo_root),
+        tag_substring=args.tag_substring,
+        sequence_length_list=args.sequence_length_list,
+        die_area_mm2_list=args.die_area_mm2_list,
+        sram_area_fraction_list=args.sram_area_fraction,
+        logic_area_fraction_list=args.logic_area_fraction,
+        reserved_area_fraction=args.reserved_area_fraction,
+        usable_sram_fraction_list=args.usable_sram_fraction,
+        local_sram_fraction_list=args.local_sram_fraction,
+        tile_tokens_list=args.tile_tokens_list,
+        bank_count_list=args.bank_count,
+        cluster_count_list=args.cluster_count,
+        noc_bandwidth_bytes_per_cycle_list=args.noc_bandwidth_bytes_per_cycle,
+        noc_hops_list=args.noc_hops,
+        vector_ops_per_mac=args.vector_ops_per_mac,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(Path(args.out_md), payload)
+    print(json.dumps({"ok": True, "out": args.out, "out_md": args.out_md}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Layer 2 estimator for clustered measured-compute partitioning of Llama7B attention/KV
- wire the control-plane evidence hook for decoder_attention_kv_measured_compute_partition
- add proposal docs and queue metadata for l2_decoder_attention_kv_measured_compute_partition_llama7b_v1

## Validation
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_measured_compute_partition.py control_plane/control_plane/services/l2_task_generator.py
- local reduced estimator smoke run
- local full estimator run generated 672408 rows