### PR TITLE
eval: add clustered attention schedule estimator

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3692,6 +3692,58 @@ def _decoder_attention_kv_measured_compute_partition_evidence(*, item_id: str) -
     }
 
 
+def _decoder_attention_kv_clustered_schedule_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_clustered_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_clustered_schedule__{item_id}.md"
+    measured_partition = (
+        f"{base}/decoder_attention_kv_measured_compute_partition__"
+        "l2_decoder_attention_kv_measured_compute_partition_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_measured_compute_partition": measured_partition,
+            "attention_kv_clustered_schedule_out": out,
+            "attention_kv_clustered_schedule_report": report,
+            "attention_kv_clustered_schedule_scope": (
+                "Quality-backed native-GQA KV8 Llama7B 131k estimate that keeps measured "
+                "compute PPA and clustered sequence tiling, but makes cross-tile softmax/value "
+                "reduction explicit. The sweep compares centralized per-tile reduction, "
+                "owner-cluster local reduction, and tree reduction so the prior wave-only "
+                "partition model can be checked for hidden reduction optimism."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_clustered_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py "
+                    "--repo-root . "
+                    "--tag-substring compute_stability_cmp33 "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 100,200,400,800,1200 "
+                    "--sram-area-fraction 0.4,0.6,0.75 "
+                    "--logic-area-fraction 0.05,0.1,0.2 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7,0.85 "
+                    "--local-sram-fraction 0.1,0.25,0.5 "
+                    "--tile-tokens-list 256,512,1024 "
+                    "--bank-count 16,64 "
+                    "--cluster-count 1,2,4,8,16 "
+                    "--noc-bandwidth-bytes-per-cycle 8192,32768,131072 "
+                    "--noc-hops 1,2,4 "
+                    "--reduction-strategy owner_cluster,cluster_tree,centralized_tile "
+                    "--vector-ops-per-mac 0.125 "
+                    "--reduction-scalar-bytes 2 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
@@ -5194,6 +5246,7 @@ def _build_payload(
         "decoder_attention_kv_physical_hbm_compute_sensitivity",
         "decoder_attention_kv_measured_compute",
         "decoder_attention_kv_measured_compute_partition",
+        "decoder_attention_kv_clustered_schedule",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
@@ -5261,6 +5314,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_measured_compute_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_measured_compute_partition":
             decoder_evidence = _decoder_attention_kv_measured_compute_partition_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_clustered_schedule":
+            decoder_evidence = _decoder_attention_kv_clustered_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":

--- a/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Estimate clustered Llama7B attention scheduling with explicit reductions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval.estimate_llm_decoder_attention_kv_measured_compute import (  # noqa: E402
+    _best_by,
+    _float_list,
+    _int_list,
+    _load_compute_candidates,
+)
+from npu.eval.estimate_llm_decoder_attention_kv_physical_hbm_frontier import (  # noqa: E402
+    _active_banks,
+    _ceil_div,
+    _kv_heads,
+    _physical_hbm_bytes_per_cycle,
+    _sram_capacity_bytes,
+)
+
+JsonDict = dict[str, Any]
+
+
+def _reduction_factor(strategy: str, active_clusters: int) -> tuple[int, int]:
+    if strategy == "centralized_tile":
+        return 0, active_clusters
+    if strategy == "owner_cluster":
+        return max(0, active_clusters - 1), max(1, active_clusters)
+    if strategy == "cluster_tree":
+        return max(0, _ceil_div(math.log2(max(1, active_clusters)), 1)), max(1, active_clusters)
+    raise ValueError(f"unsupported reduction strategy: {strategy}")
+
+
+def _shape_row(
+    *,
+    candidate: JsonDict,
+    die_area_mm2: float,
+    sram_area_fraction: float,
+    logic_area_fraction: float,
+    reserved_area_fraction: float,
+    sequence_length: int,
+    usable_sram_fraction: float,
+    local_sram_fraction: float,
+    tile_tokens: int,
+    bank_count: int,
+    cluster_count: int,
+    noc_bandwidth_bytes_per_cycle: float,
+    noc_hops: int,
+    reduction_strategy: str,
+    vector_ops_per_mac: float,
+    reduction_scalar_bytes: int,
+) -> JsonDict | None:
+    if sram_area_fraction + logic_area_fraction + reserved_area_fraction > 1.0:
+        return None
+    compute_budget_um2 = die_area_mm2 * 1_000_000.0 * logic_area_fraction
+    replica_count = int(compute_budget_um2 // float(candidate["block_area_um2"]))
+    if replica_count < 1 or cluster_count > replica_count:
+        return None
+
+    layers = 32
+    hidden_size = 4096
+    attention_heads = 32
+    kv_bits = 8
+    kv_heads = _kv_heads(attention_heads=attention_heads, kv_sharing="gqa8")
+    head_dim = hidden_size // attention_heads
+    kv_width = kv_heads * head_dim
+    kv_bytes_per_scalar = kv_bits / 8.0
+    kv_cache_bytes = 2 * sequence_length * kv_width * kv_bytes_per_scalar * layers
+
+    total_sram_bytes = _sram_capacity_bytes(
+        die_area_mm2=die_area_mm2,
+        sram_area_fraction=sram_area_fraction,
+        usable_sram_fraction=usable_sram_fraction,
+        bitcell_area_um2_per_bit=0.02,
+    )
+    local_capacity_bytes = int(total_sram_bytes * local_sram_fraction)
+    shared_capacity_bytes = max(0, total_sram_bytes - local_capacity_bytes)
+    local_resident_bytes = min(kv_cache_bytes, local_capacity_bytes)
+    shared_resident_bytes = min(max(0, kv_cache_bytes - local_resident_bytes), shared_capacity_bytes)
+    local_read_share = local_resident_bytes / kv_cache_bytes if kv_cache_bytes else 0.0
+    shared_read_share = shared_resident_bytes / kv_cache_bytes if kv_cache_bytes else 0.0
+    hbm_read_share = max(0.0, 1.0 - local_read_share - shared_read_share)
+
+    block_macs_per_cycle = int(candidate["block_macs_per_cycle"])
+    total_macs_per_cycle = replica_count * block_macs_per_cycle
+    total_vector_ops_per_cycle = max(1, int(math.ceil(total_macs_per_cycle * vector_ops_per_mac)))
+    active_clusters = min(cluster_count, _ceil_div(sequence_length, tile_tokens))
+    replicas_per_cluster_floor = replica_count // cluster_count
+    replicas_per_cluster_ceil = math.ceil(replica_count / cluster_count)
+    per_cluster_macs = max(1, replicas_per_cluster_floor * block_macs_per_cycle)
+    per_cluster_vector_ops = max(1, int(math.ceil(per_cluster_macs * vector_ops_per_mac)))
+
+    clock_ns = float(candidate["block_clock_ns"])
+    raw_hbm_bw = _physical_hbm_bytes_per_cycle(
+        stack_count=8,
+        pseudo_channels_per_stack=16,
+        pseudo_channel_width_bits=64,
+        data_rate_mtps=9000,
+        core_clock_ns=clock_ns,
+    )
+    effective_hbm_bw = raw_hbm_bw * 0.75
+    active_banks = _active_banks(tile_tokens=tile_tokens, bank_interleave_tokens=16, bank_count=bank_count)
+    aggregate_bank_bw = active_banks * 2048.0 * 0.75
+    vc_gain = min(1.0, 0.85 + 0.05 * (4 - 1))
+    aggregate_noc_bw = (noc_bandwidth_bytes_per_cycle / max(1, noc_hops)) * 0.85 * vc_gain
+
+    concurrent_clusters = max(1, active_clusters)
+    hbm_bw_per_cluster = max(1.0, effective_hbm_bw / concurrent_clusters)
+    shared_bank_bw_per_cluster = max(1.0, aggregate_bank_bw / concurrent_clusters)
+    noc_bw_per_cluster = max(1.0, aggregate_noc_bw / concurrent_clusters)
+    local_bank_bw_per_cluster = max(
+        1.0,
+        aggregate_bank_bw * max(local_sram_fraction, 1.0 / concurrent_clusters) / concurrent_clusters,
+    )
+
+    qkv_macs = hidden_size * hidden_size + 2 * hidden_size * kv_width
+    qkv_cycles = _ceil_div(qkv_macs, total_macs_per_cycle)
+    tile_count = _ceil_div(sequence_length, tile_tokens)
+    tile_waves = _ceil_div(tile_count, active_clusters)
+    tiles_per_cluster_floor = tile_count // active_clusters
+    tiles_per_cluster_ceil = math.ceil(tile_count / active_clusters)
+
+    tile_qk_cycles = _ceil_div(tile_tokens * hidden_size, per_cluster_macs)
+    tile_value_cycles = _ceil_div(tile_tokens * hidden_size, per_cluster_macs)
+    tile_stats_cycles = _ceil_div(3 * attention_heads * tile_tokens, per_cluster_vector_ops)
+    tile_attention_cycles = tile_qk_cycles + tile_stats_cycles + tile_value_cycles
+
+    full_tile_bytes = 2 * tile_tokens * kv_width * kv_bytes_per_scalar
+    tile_local_cycles = _ceil_div(full_tile_bytes * local_read_share, local_bank_bw_per_cluster)
+    tile_shared_bank_cycles = _ceil_div(full_tile_bytes * shared_read_share, shared_bank_bw_per_cluster)
+    tile_noc_cycles = _ceil_div(full_tile_bytes * shared_read_share, noc_bw_per_cluster) + noc_hops * 2
+    tile_shared_path_cycles = max(tile_shared_bank_cycles, tile_noc_cycles)
+    tile_hbm_cycles = _ceil_div(full_tile_bytes * hbm_read_share, hbm_bw_per_cluster)
+    tile_memory_cycles = max(tile_local_cycles, tile_shared_path_cycles, tile_hbm_cycles)
+    tile_service_cycles = max(tile_attention_cycles, tile_memory_cycles)
+
+    stat_payload_bytes = attention_heads * 2 * reduction_scalar_bytes
+    value_payload_bytes = hidden_size * reduction_scalar_bytes
+    partial_payload_bytes = stat_payload_bytes + value_payload_bytes
+    if reduction_strategy == "centralized_tile":
+        reduction_payload_bytes = tile_count * partial_payload_bytes
+        local_reduce_cycles = 0
+    else:
+        reduction_payload_bytes = active_clusters * partial_payload_bytes
+        local_reduce_cycles = _ceil_div(
+            tiles_per_cluster_ceil * (hidden_size + 2 * attention_heads),
+            per_cluster_vector_ops,
+        )
+    reduction_stages, _ = _reduction_factor(reduction_strategy, active_clusters)
+    reduction_noc_cycles = _ceil_div(reduction_payload_bytes, max(1.0, aggregate_noc_bw)) + reduction_stages * noc_hops * 2
+    reduction_vector_cycles = _ceil_div(
+        max(1, active_clusters) * (hidden_size + 2 * attention_heads),
+        total_vector_ops_per_cycle,
+    )
+    cross_tile_reduction_cycles = local_reduce_cycles + max(reduction_noc_cycles, reduction_vector_cycles)
+
+    kv_write_bytes = 2 * kv_width * kv_bytes_per_scalar
+    kv_write_cycles = _ceil_div(kv_write_bytes, max(1.0, min(aggregate_bank_bw, aggregate_noc_bw)))
+    layer_cycles = qkv_cycles + tile_waves * tile_service_cycles + cross_tile_reduction_cycles + kv_write_cycles
+    total_cycles = layer_cycles * layers
+    dominant = max(
+        {
+            "tile_attention": tile_attention_cycles,
+            "local_sram": tile_local_cycles,
+            "shared_path": tile_shared_path_cycles,
+            "hbm": tile_hbm_cycles,
+            "cross_tile_reduction": cross_tile_reduction_cycles,
+        }.items(),
+        key=lambda item: item[1],
+    )[0]
+
+    return {
+        "label": "llama7b_proxy",
+        "layers": layers,
+        "hidden_size": hidden_size,
+        "attention_heads": attention_heads,
+        "sequence_length": sequence_length,
+        "die_area_mm2": die_area_mm2,
+        "kv_sharing": "gqa8",
+        "kv_heads": kv_heads,
+        "kv_bits": kv_bits,
+        "kv_cache_mib": round(kv_cache_bytes / (1024 * 1024), 6),
+        "sram_area_fraction": sram_area_fraction,
+        "usable_sram_fraction": usable_sram_fraction,
+        "local_sram_fraction": local_sram_fraction,
+        "total_sram_mib": round(total_sram_bytes / (1024 * 1024), 6),
+        "local_capacity_mib": round(local_capacity_bytes / (1024 * 1024), 6),
+        "shared_capacity_mib": round(shared_capacity_bytes / (1024 * 1024), 6),
+        "local_byte_share": round(local_read_share, 6),
+        "shared_byte_share": round(shared_read_share, 6),
+        "hbm_byte_share": round(hbm_read_share, 6),
+        "bank_count": bank_count,
+        "active_banks": active_banks,
+        "noc_bandwidth_bytes_per_cycle": noc_bandwidth_bytes_per_cycle,
+        "noc_hops": noc_hops,
+        "aggregate_noc_effective_bytes_per_cycle": round(aggregate_noc_bw, 6),
+        "per_cluster_noc_effective_bytes_per_cycle": round(noc_bw_per_cluster, 6),
+        "raw_hbm_bytes_per_cycle": round(raw_hbm_bw, 6),
+        "effective_hbm_bytes_per_cycle": round(effective_hbm_bw, 6),
+        "per_cluster_hbm_bytes_per_cycle": round(hbm_bw_per_cluster, 6),
+        "tile_tokens": tile_tokens,
+        "tile_count": tile_count,
+        "tile_waves": tile_waves,
+        "tiles_per_cluster_floor": tiles_per_cluster_floor,
+        "tiles_per_cluster_ceil": tiles_per_cluster_ceil,
+        "cluster_count": cluster_count,
+        "active_clusters": active_clusters,
+        "replicas_per_cluster_floor": replicas_per_cluster_floor,
+        "replicas_per_cluster_ceil": replicas_per_cluster_ceil,
+        "compute_arch": candidate["compute_arch"],
+        "compute_replica_count": replica_count,
+        "compute_logic_area_fraction": logic_area_fraction,
+        "reserved_area_fraction": reserved_area_fraction,
+        "compute_budget_um2": round(compute_budget_um2, 6),
+        "compute_area_um2": round(replica_count * float(candidate["block_area_um2"]), 6),
+        "compute_power_mw": round(replica_count * float(candidate["block_power_mw"]), 6),
+        "macs_per_cycle": total_macs_per_cycle,
+        "vector_ops_per_cycle": total_vector_ops_per_cycle,
+        "per_cluster_macs_per_cycle": per_cluster_macs,
+        "per_cluster_vector_ops_per_cycle": per_cluster_vector_ops,
+        "clock_ns": clock_ns,
+        "qkv_cycles": qkv_cycles,
+        "tile_qk_cycles": tile_qk_cycles,
+        "tile_stats_cycles": tile_stats_cycles,
+        "tile_value_cycles": tile_value_cycles,
+        "tile_attention_cycles": tile_attention_cycles,
+        "tile_local_sram_cycles": tile_local_cycles,
+        "tile_shared_path_cycles": tile_shared_path_cycles,
+        "tile_hbm_cycles": tile_hbm_cycles,
+        "tile_memory_cycles": tile_memory_cycles,
+        "tile_service_cycles": tile_service_cycles,
+        "reduction_strategy": reduction_strategy,
+        "reduction_scalar_bytes": reduction_scalar_bytes,
+        "partial_reduction_payload_bytes": partial_payload_bytes,
+        "cross_tile_reduction_payload_bytes": reduction_payload_bytes,
+        "local_reduction_cycles": local_reduce_cycles,
+        "cross_tile_reduction_noc_cycles": reduction_noc_cycles,
+        "cross_tile_reduction_vector_cycles": reduction_vector_cycles,
+        "cross_tile_reduction_cycles": cross_tile_reduction_cycles,
+        "kv_write_cycles": kv_write_cycles,
+        "layer_cycles": layer_cycles,
+        "total_cycles": total_cycles,
+        "latency_us": round(total_cycles * clock_ns / 1000.0, 6),
+        "dominant_tile_resource": dominant,
+        "measured_block_macs_per_cycle": candidate["block_macs_per_cycle"],
+        "measured_block_clock_ns": candidate["block_clock_ns"],
+        "measured_block_area_um2": candidate["block_area_um2"],
+        "measured_block_power_mw": candidate["block_power_mw"],
+        "metrics_csv": candidate["metrics_csv"],
+        "metrics_tag": candidate["metrics_tag"],
+        "metrics_param_hash": candidate["metrics_param_hash"],
+        "vector_ops_per_mac_assumption": vector_ops_per_mac,
+    }
+
+
+def build_report(
+    *,
+    repo_root: Path,
+    tag_substring: str,
+    sequence_length_list: list[int],
+    die_area_mm2_list: list[float],
+    sram_area_fraction_list: list[float],
+    logic_area_fraction_list: list[float],
+    reserved_area_fraction: float,
+    usable_sram_fraction_list: list[float],
+    local_sram_fraction_list: list[float],
+    tile_tokens_list: list[int],
+    bank_count_list: list[int],
+    cluster_count_list: list[int],
+    noc_bandwidth_bytes_per_cycle_list: list[float],
+    noc_hops_list: list[int],
+    reduction_strategy_list: list[str],
+    vector_ops_per_mac: float,
+    reduction_scalar_bytes: int,
+) -> JsonDict:
+    candidates = _load_compute_candidates(repo_root=repo_root, tag_substring=tag_substring)
+    rows: list[JsonDict] = []
+    skipped_area_budget = 0
+    for sequence_length in sequence_length_list:
+        for die_area_mm2 in die_area_mm2_list:
+            for sram_area_fraction in sram_area_fraction_list:
+                for logic_area_fraction in logic_area_fraction_list:
+                    for usable_sram_fraction in usable_sram_fraction_list:
+                        for local_sram_fraction in local_sram_fraction_list:
+                            for tile_tokens in tile_tokens_list:
+                                for bank_count in bank_count_list:
+                                    for cluster_count in cluster_count_list:
+                                        for noc_bw in noc_bandwidth_bytes_per_cycle_list:
+                                            for noc_hops in noc_hops_list:
+                                                for reduction_strategy in reduction_strategy_list:
+                                                    for candidate in candidates:
+                                                        row = _shape_row(
+                                                            candidate=candidate,
+                                                            die_area_mm2=die_area_mm2,
+                                                            sram_area_fraction=sram_area_fraction,
+                                                            logic_area_fraction=logic_area_fraction,
+                                                            reserved_area_fraction=reserved_area_fraction,
+                                                            sequence_length=sequence_length,
+                                                            usable_sram_fraction=usable_sram_fraction,
+                                                            local_sram_fraction=local_sram_fraction,
+                                                            tile_tokens=tile_tokens,
+                                                            bank_count=bank_count,
+                                                            cluster_count=cluster_count,
+                                                            noc_bandwidth_bytes_per_cycle=noc_bw,
+                                                            noc_hops=noc_hops,
+                                                            reduction_strategy=reduction_strategy,
+                                                            vector_ops_per_mac=vector_ops_per_mac,
+                                                            reduction_scalar_bytes=reduction_scalar_bytes,
+                                                        )
+                                                        if row is None:
+                                                            skipped_area_budget += 1
+                                                        else:
+                                                            rows.append(row)
+    if not rows:
+        raise RuntimeError("no rows generated; area budget or cluster count may be infeasible")
+    rows_sorted = sorted(rows, key=lambda row: row["latency_us"])
+    dominance: dict[str, int] = {}
+    for row in rows:
+        key = str(row["dominant_tile_resource"])
+        dominance[key] = dominance.get(key, 0) + 1
+    return {
+        "version": 0.1,
+        "model": "llm_decoder_attention_kv_clustered_schedule_llama7b_v1",
+        "inputs": {
+            "tag_substring": tag_substring,
+            "sequence_length_list": sequence_length_list,
+            "die_area_mm2_list": die_area_mm2_list,
+            "sram_area_fraction_list": sram_area_fraction_list,
+            "logic_area_fraction_list": logic_area_fraction_list,
+            "reserved_area_fraction": reserved_area_fraction,
+            "usable_sram_fraction_list": usable_sram_fraction_list,
+            "local_sram_fraction_list": local_sram_fraction_list,
+            "tile_tokens_list": tile_tokens_list,
+            "bank_count_list": bank_count_list,
+            "cluster_count_list": cluster_count_list,
+            "noc_bandwidth_bytes_per_cycle_list": noc_bandwidth_bytes_per_cycle_list,
+            "noc_hops_list": noc_hops_list,
+            "reduction_strategy_list": reduction_strategy_list,
+            "vector_ops_per_mac": vector_ops_per_mac,
+            "reduction_scalar_bytes": reduction_scalar_bytes,
+        },
+        "compute_candidates": candidates,
+        "sweep_summary": {
+            "generated_row_count": len(rows),
+            "skipped_area_budget_count": skipped_area_budget,
+            "dominant_tile_resource_counts": dict(sorted(dominance.items())),
+        },
+        "best": rows_sorted[0],
+        "top_rows": rows_sorted[:50],
+        "best_by_die": _best_by(rows, ("sequence_length", "die_area_mm2")),
+        "best_by_die_cluster": _best_by(rows, ("sequence_length", "die_area_mm2", "cluster_count")),
+        "best_by_reduction_strategy": _best_by(rows, ("sequence_length", "die_area_mm2", "reduction_strategy")),
+        "best_by_memory_noc": sorted(
+            _best_by(
+                rows,
+                (
+                    "sequence_length",
+                    "die_area_mm2",
+                    "sram_area_fraction",
+                    "local_sram_fraction",
+                    "bank_count",
+                    "noc_bandwidth_bytes_per_cycle",
+                    "noc_hops",
+                    "reduction_strategy",
+                ),
+            ),
+            key=lambda row: row["latency_us"],
+        )[:200],
+        "assumptions": [
+            "One decode-token attention pass is split into sequence KV tiles.",
+            "Tiles are statically assigned to active clusters by wave; each active cluster handles at most one tile per wave.",
+            "Each tile produces softmax statistics and a partial value vector for the current token.",
+            "Reduction strategies model cross-tile combination after tile service: centralized_tile sends every tile partial, owner_cluster and cluster_tree first reduce tiles locally per cluster.",
+            "This is an analytic schedule model; it still does not model RTL command queues or cycle-accurate SRAM/NoC arbitration.",
+        ],
+    }
+
+
+def _write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best"]
+    lines = [
+        "# Decoder Attention/KV Clustered Schedule",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- generated_row_count: `{payload['sweep_summary']['generated_row_count']}`",
+        f"- skipped_area_budget_count: `{payload['sweep_summary']['skipped_area_budget_count']}`",
+        "",
+        "## Best",
+        "",
+        "| seq | die | SRAM | logic | arch | replicas | clusters | reduction | tile | clock ns | latency us | resource |",
+        "|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---:|---|",
+        "| {seq} | {die} | {sram} | {logic} | {arch} | {rep} | {cluster} | {red} | {tile} | {clk} | {lat} | {res} |".format(
+            seq=best["sequence_length"],
+            die=best["die_area_mm2"],
+            sram=best["sram_area_fraction"],
+            logic=best["compute_logic_area_fraction"],
+            arch=best["compute_arch"],
+            rep=best["compute_replica_count"],
+            cluster=best["cluster_count"],
+            red=best["reduction_strategy"],
+            tile=best["tile_tokens"],
+            clk=best["clock_ns"],
+            lat=best["latency_us"],
+            res=best["dominant_tile_resource"],
+        ),
+        "",
+        "## Best By Die And Cluster",
+        "",
+        "| die | clusters | arch | replicas | reduction | tile waves | tile service | reduction cycles | latency us | resource |",
+        "|---:|---:|---|---:|---|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["best_by_die_cluster"]:
+        lines.append(
+            "| {die} | {cluster} | {arch} | {rep} | {red} | {waves} | {service} | {reduce} | {lat} | {res} |".format(
+                die=row["die_area_mm2"],
+                cluster=row["cluster_count"],
+                arch=row["compute_arch"],
+                rep=row["compute_replica_count"],
+                red=row["reduction_strategy"],
+                waves=row["tile_waves"],
+                service=row["tile_service_cycles"],
+                reduce=row["cross_tile_reduction_cycles"],
+                lat=row["latency_us"],
+                res=row["dominant_tile_resource"],
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _str_list(value: str) -> list[str]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    allowed = {"centralized_tile", "owner_cluster", "cluster_tree"}
+    if not items or any(item not in allowed for item in items):
+        raise argparse.ArgumentTypeError(f"expected comma-separated values from {sorted(allowed)}")
+    return items
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-root", default=".")
+    ap.add_argument("--tag-substring", default="compute_stability_cmp33")
+    ap.add_argument("--sequence-length-list", type=_int_list, default=[131072])
+    ap.add_argument("--die-area-mm2-list", type=_float_list, default=[100, 200, 400, 800, 1200])
+    ap.add_argument("--sram-area-fraction", type=_float_list, default=[0.4, 0.6, 0.75])
+    ap.add_argument("--logic-area-fraction", type=_float_list, default=[0.05, 0.1, 0.2])
+    ap.add_argument("--reserved-area-fraction", type=float, default=0.1)
+    ap.add_argument("--usable-sram-fraction", type=_float_list, default=[0.7, 0.85])
+    ap.add_argument("--local-sram-fraction", type=_float_list, default=[0.1, 0.25, 0.5])
+    ap.add_argument("--tile-tokens-list", type=_int_list, default=[256, 512, 1024])
+    ap.add_argument("--bank-count", type=_int_list, default=[16, 64])
+    ap.add_argument("--cluster-count", type=_int_list, default=[1, 2, 4, 8, 16])
+    ap.add_argument("--noc-bandwidth-bytes-per-cycle", type=_float_list, default=[8192, 32768, 131072])
+    ap.add_argument("--noc-hops", type=_int_list, default=[1, 2, 4])
+    ap.add_argument("--reduction-strategy", type=_str_list, default=["owner_cluster", "cluster_tree", "centralized_tile"])
+    ap.add_argument("--vector-ops-per-mac", type=float, default=0.125)
+    ap.add_argument("--reduction-scalar-bytes", type=int, default=2)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    payload = build_report(
+        repo_root=Path(args.repo_root),
+        tag_substring=args.tag_substring,
+        sequence_length_list=args.sequence_length_list,
+        die_area_mm2_list=args.die_area_mm2_list,
+        sram_area_fraction_list=args.sram_area_fraction,
+        logic_area_fraction_list=args.logic_area_fraction,
+        reserved_area_fraction=args.reserved_area_fraction,
+        usable_sram_fraction_list=args.usable_sram_fraction,
+        local_sram_fraction_list=args.local_sram_fraction,
+        tile_tokens_list=args.tile_tokens_list,
+        bank_count_list=args.bank_count,
+        cluster_count_list=args.cluster_count,
+        noc_bandwidth_bytes_per_cycle_list=args.noc_bandwidth_bytes_per_cycle,
+        noc_hops_list=args.noc_hops,
+        reduction_strategy_list=args.reduction_strategy,
+        vector_ops_per_mac=args.vector_ops_per_mac,
+        reduction_scalar_bytes=args.reduction_scalar_bytes,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(Path(args.out_md), payload)
+    print(json.dumps({"ok": True, "out": args.out, "out_md": args.out_md}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_attention_kv_clustered_schedule.py
+++ b/tests/test_llm_decoder_attention_kv_clustered_schedule.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from npu.eval import estimate_llm_decoder_attention_kv_clustered_schedule as sched
+
+
+def _candidate():
+    return {
+        "compute_arch": "nm64_flat",
+        "block_macs_per_cycle": 64,
+        "block_clock_ns": 2.0,
+        "block_area_um2": 1000.0,
+        "block_power_mw": 1.0,
+        "metrics_csv": "runs/designs/npu_blocks/npu_fp16_cpp_nm64_cmp/metrics.csv",
+        "metrics_tag": "unit",
+        "metrics_param_hash": "unit",
+    }
+
+
+def _report(monkeypatch, *, strategies):
+    monkeypatch.setattr(sched, "_load_compute_candidates", lambda repo_root, tag_substring: [_candidate()])
+    return sched.build_report(
+        repo_root=Path("."),
+        tag_substring="unit",
+        sequence_length_list=[2048],
+        die_area_mm2_list=[1.0],
+        sram_area_fraction_list=[0.4],
+        logic_area_fraction_list=[0.2],
+        reserved_area_fraction=0.1,
+        usable_sram_fraction_list=[0.7],
+        local_sram_fraction_list=[0.25],
+        tile_tokens_list=[512],
+        bank_count_list=[16],
+        cluster_count_list=[1, 2, 4],
+        noc_bandwidth_bytes_per_cycle_list=[8192.0],
+        noc_hops_list=[1],
+        reduction_strategy_list=strategies,
+        vector_ops_per_mac=0.125,
+        reduction_scalar_bytes=2,
+    )
+
+
+def test_clustered_schedule_exposes_tile_waves_and_reduction(monkeypatch) -> None:
+    report = _report(monkeypatch, strategies=["owner_cluster"])
+    by_cluster = {row["cluster_count"]: row for row in report["best_by_die_cluster"]}
+
+    assert report["model"] == "llm_decoder_attention_kv_clustered_schedule_llama7b_v1"
+    assert by_cluster[1]["tile_count"] == 4
+    assert by_cluster[1]["tile_waves"] == 4
+    assert by_cluster[2]["tile_waves"] == 2
+    assert by_cluster[4]["tile_waves"] == 1
+    assert by_cluster[2]["cross_tile_reduction_cycles"] > 0
+    assert by_cluster[2]["layer_cycles"] == (
+        by_cluster[2]["qkv_cycles"]
+        + by_cluster[2]["tile_waves"] * by_cluster[2]["tile_service_cycles"]
+        + by_cluster[2]["cross_tile_reduction_cycles"]
+        + by_cluster[2]["kv_write_cycles"]
+    )
+
+
+def test_clustered_schedule_exposes_centralized_tile_payload(monkeypatch) -> None:
+    report = _report(monkeypatch, strategies=["owner_cluster", "centralized_tile"])
+    rows = {
+        row["reduction_strategy"]: row
+        for row in report["best_by_reduction_strategy"]
+        if row["die_area_mm2"] == 1.0
+    }
+
+    assert rows["centralized_tile"]["cross_tile_reduction_payload_bytes"] > rows["owner_cluster"]["cross_tile_reduction_payload_bytes"]
+    assert rows["centralized_tile"]["local_reduction_cycles"] == 0
+    assert rows["owner_cluster"]["local_reduction_cycles"] > 0


### PR DESCRIPTION
## Summary
- add an explicit clustered Llama7B attention schedule estimator with cross-tile reduction costs
- wire the new decoder_attention_kv_clustered_schedule abstraction into L2 task generation
- add focused tests for tile waves and reduction payload accounting

## Validation
- PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_attention_kv_clustered_schedule.py
- PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py control_plane/control_plane/services/l2_task_generator.py
- PYTHONPATH=. python3 scripts/validate_runs.py --skip_eval_queue