### PR TITLE
docs: queue clustered attention schedule job

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
-  "source_commit": "a8aa60dbd7f0dd0eb477d8768b3b23a1f1e1786f",
+  "source_commit": "fb10bb5944bc7a07d081a9b0e7f3aa2ef59ae939",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
@@ -24,6 +24,25 @@
       "merge_commit": "c0ead960a1207d6946ce62b4b678b706f963f650",
       "merged_utc": "2026-05-27T15:10:52.821767Z",
       "notes": "Merged via PR #678 and merge c0ead960a1207d6946ce62b4b678b706f963f650 at 2026-05-27T15:10:52.821767Z."
+    },
+    {
+      "item_id": "l2_decoder_attention_kv_clustered_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the quality-backed native-GQA KV8 131k Llama7B measured-compute clustered schedule model with explicit cross-tile softmax/value reduction strategies.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_clustered_schedule",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_measured_compute_partition_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If explicit reduction keeps the same clustered frontier, move to measured command-routing hierarchy; if reduction changes the winner, refine the cluster/reducer architecture before RTL."
+      },
+      "status": "pending"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add the explicit clustered attention schedule L2 job to the measured-compute partition proposal
- keep it dependent on the merged partition result and point it at the merged estimator implementation

## Validation
- generated with control-plane generate-l2-campaign using --no-auto-dispatch