### PR TITLE
eval: add clustered schedule overhead sensitivity

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3744,6 +3744,62 @@ def _decoder_attention_kv_clustered_schedule_evidence(*, item_id: str) -> dict[s
     }
 
 
+def _decoder_attention_kv_clustered_schedule_overhead_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_clustered_schedule_overhead__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_clustered_schedule_overhead__{item_id}.md"
+    clustered_schedule = (
+        f"{base}/decoder_attention_kv_clustered_schedule__"
+        "l2_decoder_attention_kv_clustered_schedule_llama7b_v1_r2.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_clustered_schedule": clustered_schedule,
+            "attention_kv_clustered_schedule_overhead_out": out,
+            "attention_kv_clustered_schedule_overhead_report": report,
+            "attention_kv_clustered_schedule_overhead_scope": (
+                "Sensitivity pass for the quality-backed native-GQA KV8 Llama7B 131k clustered "
+                "attention schedule. Keep the measured-compute sweep space but add explicit "
+                "command-dispatch and reducer overhead knobs to test whether the current "
+                "nm64-flat/owner-cluster frontier is fragile before investing in routed command "
+                "hierarchy RTL."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_clustered_schedule_overhead",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py "
+                    "--repo-root . "
+                    "--tag-substring compute_stability_cmp33 "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 400,800,1200 "
+                    "--sram-area-fraction 0.4 "
+                    "--logic-area-fraction 0.2 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7 "
+                    "--local-sram-fraction 0.1,0.25 "
+                    "--tile-tokens-list 1024 "
+                    "--bank-count 16 "
+                    "--cluster-count 1,2,4,8,16 "
+                    "--noc-bandwidth-bytes-per-cycle 32768 "
+                    "--noc-hops 1,2 "
+                    "--reduction-strategy owner_cluster,cluster_tree,centralized_tile "
+                    "--vector-ops-per-mac 0.125 "
+                    "--reduction-scalar-bytes 2 "
+                    "--command-cycles-per-tile 0,1,4,16 "
+                    "--command-cycles-per-wave 0,8,32 "
+                    "--reducer-setup-cycles 0,32,128 "
+                    "--reduction-cycle-multiplier 1,2,4 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
@@ -5247,6 +5303,7 @@ def _build_payload(
         "decoder_attention_kv_measured_compute",
         "decoder_attention_kv_measured_compute_partition",
         "decoder_attention_kv_clustered_schedule",
+        "decoder_attention_kv_clustered_schedule_overhead",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
@@ -5316,6 +5373,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_measured_compute_partition_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_clustered_schedule":
             decoder_evidence = _decoder_attention_kv_clustered_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_clustered_schedule_overhead":
+            decoder_evidence = _decoder_attention_kv_clustered_schedule_overhead_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3270,6 +3270,59 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_quality_gate() -> N
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_clustered_schedule_overhead() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_clustered_schedule_overhead",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_attention_kv_clustered_schedule_overhead",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_attention_kv_clustered_schedule.py" in run
+            assert "--command-cycles-per-tile 0,1,4,16" in run
+            assert "--reducer-setup-cycles 0,32,128" in run
+            assert "--reduction-cycle-multiplier 1,2,4" in run
+            assert decoder_inputs["attention_kv_clustered_schedule_overhead_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_clustered_schedule_overhead__"
+                "l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1.json"
+            )
+            assert "Sensitivity pass" in decoder_inputs["attention_kv_clustered_schedule_overhead_scope"]
+            assert decoder_inputs["attention_kv_clustered_schedule_overhead_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_clustered_schedule_overhead",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_attention_kv_quality_proxy() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
@@ -59,6 +59,10 @@ def _shape_row(
     reduction_strategy: str,
     vector_ops_per_mac: float,
     reduction_scalar_bytes: int,
+    command_cycles_per_tile: int,
+    command_cycles_per_wave: int,
+    reducer_setup_cycles: int,
+    reduction_cycle_multiplier: float,
 ) -> JsonDict | None:
     if sram_area_fraction + logic_area_fraction + reserved_area_fraction > 1.0:
         return None
@@ -161,11 +165,13 @@ def _shape_row(
         )
     reduction_stages, _ = _reduction_factor(reduction_strategy, active_clusters)
     reduction_noc_cycles = _ceil_div(reduction_payload_bytes, max(1.0, aggregate_noc_bw)) + reduction_stages * noc_hops * 2
-    cross_tile_reduction_cycles = local_reduce_cycles + max(reduction_noc_cycles, reduction_vector_cycles)
+    base_cross_tile_reduction_cycles = local_reduce_cycles + max(reduction_noc_cycles, reduction_vector_cycles)
+    cross_tile_reduction_cycles = _ceil_div(base_cross_tile_reduction_cycles * reduction_cycle_multiplier, 1) + reducer_setup_cycles
+    command_dispatch_cycles = tile_count * command_cycles_per_tile + tile_waves * command_cycles_per_wave
 
     kv_write_bytes = 2 * kv_width * kv_bytes_per_scalar
     kv_write_cycles = _ceil_div(kv_write_bytes, max(1.0, min(aggregate_bank_bw, aggregate_noc_bw)))
-    layer_cycles = qkv_cycles + tile_waves * tile_service_cycles + cross_tile_reduction_cycles + kv_write_cycles
+    layer_cycles = qkv_cycles + tile_waves * tile_service_cycles + command_dispatch_cycles + cross_tile_reduction_cycles + kv_write_cycles
     total_cycles = layer_cycles * layers
     dominant = max(
         {
@@ -174,6 +180,7 @@ def _shape_row(
             "shared_path": tile_shared_path_cycles,
             "hbm": tile_hbm_cycles,
             "cross_tile_reduction": cross_tile_reduction_cycles,
+            "command_dispatch": command_dispatch_cycles,
         }.items(),
         key=lambda item: item[1],
     )[0]
@@ -245,7 +252,13 @@ def _shape_row(
         "local_reduction_cycles": local_reduce_cycles,
         "cross_tile_reduction_noc_cycles": reduction_noc_cycles,
         "cross_tile_reduction_vector_cycles": reduction_vector_cycles,
+        "base_cross_tile_reduction_cycles": base_cross_tile_reduction_cycles,
+        "reduction_cycle_multiplier": reduction_cycle_multiplier,
+        "reducer_setup_cycles": reducer_setup_cycles,
         "cross_tile_reduction_cycles": cross_tile_reduction_cycles,
+        "command_cycles_per_tile": command_cycles_per_tile,
+        "command_cycles_per_wave": command_cycles_per_wave,
+        "command_dispatch_cycles": command_dispatch_cycles,
         "kv_write_cycles": kv_write_cycles,
         "layer_cycles": layer_cycles,
         "total_cycles": total_cycles,
@@ -281,8 +294,16 @@ def build_report(
     reduction_strategy_list: list[str],
     vector_ops_per_mac: float,
     reduction_scalar_bytes: int,
+    command_cycles_per_tile_list: list[int] | None = None,
+    command_cycles_per_wave_list: list[int] | None = None,
+    reducer_setup_cycles_list: list[int] | None = None,
+    reduction_cycle_multiplier_list: list[float] | None = None,
 ) -> JsonDict:
     candidates = _load_compute_candidates(repo_root=repo_root, tag_substring=tag_substring)
+    command_cycles_per_tile_list = command_cycles_per_tile_list or [0]
+    command_cycles_per_wave_list = command_cycles_per_wave_list or [0]
+    reducer_setup_cycles_list = reducer_setup_cycles_list or [0]
+    reduction_cycle_multiplier_list = reduction_cycle_multiplier_list or [1.0]
     rows: list[JsonDict] = []
     skipped_area_budget = 0
     for sequence_length in sequence_length_list:
@@ -297,29 +318,37 @@ def build_report(
                                         for noc_bw in noc_bandwidth_bytes_per_cycle_list:
                                             for noc_hops in noc_hops_list:
                                                 for reduction_strategy in reduction_strategy_list:
-                                                    for candidate in candidates:
-                                                        row = _shape_row(
-                                                            candidate=candidate,
-                                                            die_area_mm2=die_area_mm2,
-                                                            sram_area_fraction=sram_area_fraction,
-                                                            logic_area_fraction=logic_area_fraction,
-                                                            reserved_area_fraction=reserved_area_fraction,
-                                                            sequence_length=sequence_length,
-                                                            usable_sram_fraction=usable_sram_fraction,
-                                                            local_sram_fraction=local_sram_fraction,
-                                                            tile_tokens=tile_tokens,
-                                                            bank_count=bank_count,
-                                                            cluster_count=cluster_count,
-                                                            noc_bandwidth_bytes_per_cycle=noc_bw,
-                                                            noc_hops=noc_hops,
-                                                            reduction_strategy=reduction_strategy,
-                                                            vector_ops_per_mac=vector_ops_per_mac,
-                                                            reduction_scalar_bytes=reduction_scalar_bytes,
-                                                        )
-                                                        if row is None:
-                                                            skipped_area_budget += 1
-                                                        else:
-                                                            rows.append(row)
+                                                    for command_cycles_per_tile in command_cycles_per_tile_list:
+                                                        for command_cycles_per_wave in command_cycles_per_wave_list:
+                                                            for reducer_setup_cycles in reducer_setup_cycles_list:
+                                                                for reduction_cycle_multiplier in reduction_cycle_multiplier_list:
+                                                                    for candidate in candidates:
+                                                                        row = _shape_row(
+                                                                            candidate=candidate,
+                                                                            die_area_mm2=die_area_mm2,
+                                                                            sram_area_fraction=sram_area_fraction,
+                                                                            logic_area_fraction=logic_area_fraction,
+                                                                            reserved_area_fraction=reserved_area_fraction,
+                                                                            sequence_length=sequence_length,
+                                                                            usable_sram_fraction=usable_sram_fraction,
+                                                                            local_sram_fraction=local_sram_fraction,
+                                                                            tile_tokens=tile_tokens,
+                                                                            bank_count=bank_count,
+                                                                            cluster_count=cluster_count,
+                                                                            noc_bandwidth_bytes_per_cycle=noc_bw,
+                                                                            noc_hops=noc_hops,
+                                                                            reduction_strategy=reduction_strategy,
+                                                                            vector_ops_per_mac=vector_ops_per_mac,
+                                                                            reduction_scalar_bytes=reduction_scalar_bytes,
+                                                                            command_cycles_per_tile=command_cycles_per_tile,
+                                                                            command_cycles_per_wave=command_cycles_per_wave,
+                                                                            reducer_setup_cycles=reducer_setup_cycles,
+                                                                            reduction_cycle_multiplier=reduction_cycle_multiplier,
+                                                                        )
+                                                                        if row is None:
+                                                                            skipped_area_budget += 1
+                                                                        else:
+                                                                            rows.append(row)
     if not rows:
         raise RuntimeError("no rows generated; area budget or cluster count may be infeasible")
     rows_sorted = sorted(rows, key=lambda row: row["latency_us"])
@@ -347,6 +376,10 @@ def build_report(
             "reduction_strategy_list": reduction_strategy_list,
             "vector_ops_per_mac": vector_ops_per_mac,
             "reduction_scalar_bytes": reduction_scalar_bytes,
+            "command_cycles_per_tile_list": command_cycles_per_tile_list,
+            "command_cycles_per_wave_list": command_cycles_per_wave_list,
+            "reducer_setup_cycles_list": reducer_setup_cycles_list,
+            "reduction_cycle_multiplier_list": reduction_cycle_multiplier_list,
         },
         "compute_candidates": candidates,
         "sweep_summary": {
@@ -359,6 +392,17 @@ def build_report(
         "best_by_die": _best_by(rows, ("sequence_length", "die_area_mm2")),
         "best_by_die_cluster": _best_by(rows, ("sequence_length", "die_area_mm2", "cluster_count")),
         "best_by_reduction_strategy": _best_by(rows, ("sequence_length", "die_area_mm2", "reduction_strategy")),
+        "best_by_overhead": _best_by(
+            rows,
+            (
+                "sequence_length",
+                "die_area_mm2",
+                "command_cycles_per_tile",
+                "command_cycles_per_wave",
+                "reducer_setup_cycles",
+                "reduction_cycle_multiplier",
+            ),
+        ),
         "best_by_memory_noc": sorted(
             _best_by(
                 rows,
@@ -381,6 +425,7 @@ def build_report(
             "Each tile produces softmax statistics and a partial value vector for the current token.",
             "Reduction strategies model cross-tile combination after tile service: centralized_tile sends every tile partial, owner_cluster and cluster_tree first reduce tiles locally per cluster.",
             "This is an analytic schedule model; it still does not model RTL command queues or cycle-accurate SRAM/NoC arbitration.",
+            "Optional command and reducer overhead parameters are sensitivity knobs, not measured RTL/PPA.",
         ],
     }
 
@@ -413,11 +458,32 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
             res=best["dominant_tile_resource"],
         ),
         "",
+        "## Best By Overhead",
+        "",
+        "| die | cmd/tile | cmd/wave | reducer setup | reduction x | clusters | reduction | latency us | resource |",
+        "|---:|---:|---:|---:|---:|---:|---|---:|---|",
+    ]
+    for row in payload["best_by_overhead"]:
+        lines.append(
+            "| {die} | {ct} | {cw} | {setup} | {mult} | {cluster} | {red} | {lat} | {res} |".format(
+                die=row["die_area_mm2"],
+                ct=row["command_cycles_per_tile"],
+                cw=row["command_cycles_per_wave"],
+                setup=row["reducer_setup_cycles"],
+                mult=row["reduction_cycle_multiplier"],
+                cluster=row["cluster_count"],
+                red=row["reduction_strategy"],
+                lat=row["latency_us"],
+                res=row["dominant_tile_resource"],
+            )
+        )
+    lines.extend([
+        "",
         "## Best By Die And Cluster",
         "",
         "| die | clusters | arch | replicas | reduction | tile waves | tile service | reduction cycles | latency us | resource |",
         "|---:|---:|---|---:|---|---:|---:|---:|---:|---|",
-    ]
+    ])
     for row in payload["best_by_die_cluster"]:
         lines.append(
             "| {die} | {cluster} | {arch} | {rep} | {red} | {waves} | {service} | {reduce} | {lat} | {res} |".format(
@@ -466,6 +532,10 @@ def main() -> int:
     ap.add_argument("--reduction-strategy", type=_str_list, default=["owner_cluster", "cluster_tree", "centralized_tile"])
     ap.add_argument("--vector-ops-per-mac", type=float, default=0.125)
     ap.add_argument("--reduction-scalar-bytes", type=int, default=2)
+    ap.add_argument("--command-cycles-per-tile", type=_int_list, default=[0])
+    ap.add_argument("--command-cycles-per-wave", type=_int_list, default=[0])
+    ap.add_argument("--reducer-setup-cycles", type=_int_list, default=[0])
+    ap.add_argument("--reduction-cycle-multiplier", type=_float_list, default=[1.0])
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
     args = ap.parse_args()
@@ -488,6 +558,10 @@ def main() -> int:
         reduction_strategy_list=args.reduction_strategy,
         vector_ops_per_mac=args.vector_ops_per_mac,
         reduction_scalar_bytes=args.reduction_scalar_bytes,
+        command_cycles_per_tile_list=args.command_cycles_per_tile,
+        command_cycles_per_wave_list=args.command_cycles_per_wave,
+        reducer_setup_cycles_list=args.reducer_setup_cycles,
+        reduction_cycle_multiplier_list=args.reduction_cycle_multiplier,
     )
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_llm_decoder_attention_kv_clustered_schedule.py
+++ b/tests/test_llm_decoder_attention_kv_clustered_schedule.py
@@ -39,6 +39,33 @@ def _report(monkeypatch, *, strategies):
     )
 
 
+def _report_with_overhead(monkeypatch):
+    monkeypatch.setattr(sched, "_load_compute_candidates", lambda repo_root, tag_substring: [_candidate()])
+    return sched.build_report(
+        repo_root=Path("."),
+        tag_substring="unit",
+        sequence_length_list=[2048],
+        die_area_mm2_list=[1.0],
+        sram_area_fraction_list=[0.4],
+        logic_area_fraction_list=[0.2],
+        reserved_area_fraction=0.1,
+        usable_sram_fraction_list=[0.7],
+        local_sram_fraction_list=[0.25],
+        tile_tokens_list=[512],
+        bank_count_list=[16],
+        cluster_count_list=[2],
+        noc_bandwidth_bytes_per_cycle_list=[8192.0],
+        noc_hops_list=[1],
+        reduction_strategy_list=["owner_cluster"],
+        vector_ops_per_mac=0.125,
+        reduction_scalar_bytes=2,
+        command_cycles_per_tile_list=[3],
+        command_cycles_per_wave_list=[5],
+        reducer_setup_cycles_list=[7],
+        reduction_cycle_multiplier_list=[2.0],
+    )
+
+
 def test_clustered_schedule_exposes_tile_waves_and_reduction(monkeypatch) -> None:
     report = _report(monkeypatch, strategies=["owner_cluster"])
     by_cluster = {row["cluster_count"]: row for row in report["best_by_die_cluster"]}
@@ -69,3 +96,20 @@ def test_clustered_schedule_exposes_centralized_tile_payload(monkeypatch) -> Non
     assert rows["centralized_tile"]["local_reduction_cycles"] == 0
     assert rows["owner_cluster"]["local_reduction_cycles"] > 0
     assert rows["centralized_tile"]["cross_tile_reduction_vector_cycles"] >= rows["owner_cluster"]["cross_tile_reduction_vector_cycles"]
+
+
+def test_clustered_schedule_charges_command_and_reducer_overhead(monkeypatch) -> None:
+    report = _report_with_overhead(monkeypatch)
+    row = report["best"]
+
+    assert row["command_dispatch_cycles"] == row["tile_count"] * 3 + row["tile_waves"] * 5
+    assert row["cross_tile_reduction_cycles"] == row["base_cross_tile_reduction_cycles"] * 2 + 7
+    assert row["layer_cycles"] == (
+        row["qkv_cycles"]
+        + row["tile_waves"] * row["tile_service_cycles"]
+        + row["command_dispatch_cycles"]
+        + row["cross_tile_reduction_cycles"]
+        + row["kv_write_cycles"]
+    )
+    assert report["inputs"]["command_cycles_per_tile_list"] == [3]
+    assert report["inputs"]["reduction_cycle_multiplier_list"] == [2.0]


### PR DESCRIPTION
## Summary
- add command-dispatch and reducer overhead sensitivity knobs to the clustered attention/KV schedule estimator
- add a focused L2 abstraction for the frontier-neighborhood overhead sweep
- cover overhead accounting and task generation in tests

## Tests
- PYTHONPATH=/tmp/rtlgen-active/control_plane:/tmp/rtlgen-active /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_attention_kv_clustered_schedule.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_clustered_schedule_overhead
- local focused overhead smoke: 252720 generated rows in 5.5s