### PR TITLE
docs: queue clustered schedule overhead sensitivity

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
-  "source_commit": "badb82b832ece370d9a2b287b4d01a8a134ad997",
+  "source_commit": "82b98cb1a7c967067a2bb4fb0b00423935c549bb",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_kv_measured_compute_partition_llama7b_v1",
@@ -50,6 +50,25 @@
       "merge_commit": "5a182a5c3b6ede968341918449598b24e8d6414e",
       "merged_utc": "2026-05-28T04:31:51.076496Z",
       "notes": "Merged via PR #684 and merge 5a182a5c3b6ede968341918449598b24e8d6414e at 2026-05-28T04:31:51.076496Z."
+    },
+    {
+      "item_id": "l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the quality-backed native-GQA KV8 131k Llama7B clustered schedule model with command-dispatch and reducer overhead sensitivity knobs around the current frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_clustered_schedule_overhead",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_clustered_schedule_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_clustered_schedule_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If the frontier survives plausible command/reducer overheads, move to routed command/reducer RTL calibration; if it flips, narrow cluster/reducer architecture first."
+      },
+      "status": "pending"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- queue `l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1`
- source requirement points at merged estimator/generator commit `82b98cb1a7c967067a2bb4fb0b00423935c549bb`
- depends on merged clustered schedule r2 result

## Expected result
If the frontier survives plausible command/reducer overheads, move to routed command/reducer RTL calibration; if it flips, narrow cluster/reducer architecture first.