### PR TITLE
Record L1 boundary failures as review artifacts

### DIFF
--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -341,6 +341,59 @@ def _best_metrics_row(
     return sorted(rows, key=_row_sort_key)[0]
 
 
+def _boundary_metrics_rows(
+    *,
+    repo_root: Path,
+    metrics_csvs: list[str],
+    tag_prefixes: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for metrics_csv in metrics_csvs:
+        path = _resolve_path(repo_root=repo_root, path_text=metrics_csv)
+        if not path.exists():
+            continue
+        for raw_row in _load_metrics_rows(path):
+            status = str(raw_row.get("status", "")).strip()
+            if status == "ok":
+                continue
+            if not _row_in_current_sweep_scope(raw_row, tag_prefixes=tag_prefixes):
+                continue
+            evidence: dict[str, Any] = {
+                "metrics_csv": metrics_csv,
+                "status": status,
+            }
+            for key in (
+                "design",
+                "platform",
+                "config_hash",
+                "param_hash",
+                "tag",
+                "critical_path_ns",
+                "die_area",
+                "total_power_mw",
+                "result_path",
+                "work_result_json",
+                "params_json",
+            ):
+                value = str(raw_row.get(key, "")).strip()
+                if value:
+                    evidence[key] = value
+            rows.append(evidence)
+    return rows
+
+
+def _boundary_evaluation_record(*, repo_root: Path, work_item: WorkItem, boundary_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    status_counts = Counter(str(row.get("status", "")).strip() or "unknown" for row in boundary_rows)
+    return {
+        "evaluation_mode": "measurement_only",
+        "abstraction_layer": _developer_loop_abstraction_layer(repo_root, work_item),
+        "result_kind": "boundary_evidence",
+        "physical_metrics_present": False,
+        "summary": "No status=ok Layer 1 rows were produced; non-ok metrics rows are recorded as explicit boundary evidence.",
+        "boundary_status_counts": dict(status_counts),
+    }
+
+
 def _proposal_entry(*, metrics_csv: str, best_row: dict[str, Any], evaluation_record: dict[str, Any]) -> dict[str, Any]:
     proposal: dict[str, Any] = {
         "metrics_ref": {
@@ -792,8 +845,21 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
                 )
             )
 
+    tag_prefixes = _current_sweep_tag_prefixes(repo_root, work_item)
+    boundary_rows = _boundary_metrics_rows(
+        repo_root=repo_root,
+        metrics_csvs=metrics_csvs,
+        tag_prefixes=tag_prefixes,
+    )
     if not proposals or evaluation_record is None:
-        raise Layer1ResultConsumerError(f"no status=ok metrics rows found for work item: {work_item.item_id}")
+        if not boundary_rows:
+            raise Layer1ResultConsumerError(f"no status=ok metrics rows found for work item: {work_item.item_id}")
+        proposals = []
+        evaluation_record = _boundary_evaluation_record(
+            repo_root=repo_root,
+            work_item=work_item,
+            boundary_rows=boundary_rows,
+        )
 
     trial_paths = _trial_artifact_paths(work_item.item_id)
     source_refs = {
@@ -810,6 +876,17 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
         source_refs=source_refs,
     )
     payload["trial_summary"] = summary_stats
+    if boundary_rows:
+        if not proposals:
+            payload["proposal_assessment"] = {
+                "outcome": "boundary_no_feasible_points",
+                "summary": "All current Layer 1 metrics rows are non-ok; this is accepted as frontier boundary evidence, not a promotable design point.",
+                "failure_row_count": len(boundary_rows),
+            }
+        payload["boundary_evidence"] = {
+            "row_count": len(boundary_rows),
+            "rows": boundary_rows,
+        }
     target_rel = request.target_path or _default_target_path(item_id=work_item.item_id)
     target_path = _resolve_path(repo_root=repo_root, path_text=target_rel)
     target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -184,6 +184,133 @@ def test_consume_l1_result_writes_promotion_proposal() -> None:
             assert artifact.path == f"control_plane/shadow_exports/l1_promotions/{item_id}.json"
 
 
+def test_consume_l1_result_records_failure_only_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        metrics_a = "runs/designs/activations/attention_kv_reducer_tree_p8_l16_v16_s16_a24_wrapper/metrics.csv"
+        metrics_b = "runs/designs/activations/attention_kv_reducer_tree_p16_l16_v16_s16_a24_wrapper/metrics.csv"
+        _write_metrics(
+            repo_root / metrics_a,
+            [
+                {
+                    "platform": "nangate45",
+                    "status": "failed",
+                    "param_hash": "d64a0205",
+                    "tag": "attention_kv_reducer_tree_nangate45_macro_frontier_175641b8",
+                    "result_path": "runs/designs/activations/attention_kv_reducer_tree_p8_l16_v16_s16_a24_wrapper/work/d64a0205/result.json",
+                },
+                {
+                    "platform": "nangate45",
+                    "status": "failed",
+                    "param_hash": "63079636",
+                    "tag": "attention_kv_reducer_tree_nangate45_macro_frontier_e0c384c0",
+                    "result_path": "runs/designs/activations/attention_kv_reducer_tree_p8_l16_v16_s16_a24_wrapper/work/63079636/result.json",
+                },
+            ],
+        )
+        _write_metrics(
+            repo_root / metrics_b,
+            [
+                {
+                    "platform": "nangate45",
+                    "status": "failed",
+                    "param_hash": "d64a0205",
+                    "tag": "attention_kv_reducer_tree_nangate45_macro_frontier_175641b8",
+                    "result_path": "runs/designs/activations/attention_kv_reducer_tree_p16_l16_v16_s16_a24_wrapper/work/d64a0205/result.json",
+                },
+                {
+                    "platform": "nangate45",
+                    "status": "failed",
+                    "param_hash": "63079636",
+                    "tag": "attention_kv_reducer_tree_nangate45_macro_frontier_e0c384c0",
+                    "result_path": "runs/designs/activations/attention_kv_reducer_tree_p16_l16_v16_s16_a24_wrapper/work/63079636/result.json",
+                },
+            ],
+        )
+
+        with Session(engine) as session:
+            task_request = TaskRequest(
+                request_key="l1_sweep:test_boundary_failure_only",
+                source="test",
+                requested_by="@tester",
+                title="Layer1 boundary failure-only test",
+                description="boundary failure-only test",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": "l1_test_boundary_failure_only",
+                    "layer": "layer1",
+                    "flow": "openroad",
+                    "abstraction_layer": "circuit_block",
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+
+            work_item = WorkItem(
+                work_item_key="l1_sweep:l1_test_boundary_failure_only",
+                task_request_id=task_request.id,
+                item_id="l1_test_boundary_failure_only",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l1_sweep",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="config",
+                input_manifest={"configs": [], "sweeps": []},
+                command_manifest=[],
+                expected_outputs=[metrics_a, metrics_b],
+                acceptance_rules=[
+                    "Each generated wrapper metrics.csv contains recorded rows with a status column; allow non-ok metrics such as flow_failed when the row is boundary evidence",
+                ],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+
+            run = Run(
+                run_key="l1_test_boundary_failure_only_run_1",
+                work_item_id=work_item.id,
+                attempt=1,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                result_summary="4/4 commands succeeded",
+                result_payload={"queue_result": {"metrics_rows": [metrics_a, metrics_b]}},
+            )
+            session.add(run)
+            session.commit()
+
+            result = consume_l1_result(
+                session,
+                Layer1ConsumeRequest(repo_root=str(repo_root), item_id=work_item.item_id),
+            )
+
+            assert result.proposal_count == 0
+            proposal_path = repo_root / "control_plane" / "shadow_exports" / "l1_promotions" / f"{work_item.item_id}.json"
+            payload = json.loads(proposal_path.read_text(encoding="utf-8"))
+            assert payload["proposal_count"] == 0
+            assert payload["proposals"] == []
+            assert payload["proposal_assessment"]["outcome"] == "boundary_no_feasible_points"
+            assert payload["evaluation_record"]["result_kind"] == "boundary_evidence"
+            assert payload["evaluation_record"]["boundary_status_counts"] == {"failed": 4}
+            assert payload["boundary_evidence"]["row_count"] == 4
+            assert {row["metrics_csv"] for row in payload["boundary_evidence"]["rows"]} == {metrics_a, metrics_b}
+            assert {row["param_hash"] for row in payload["boundary_evidence"]["rows"]} == {"d64a0205", "63079636"}
+
+            artifact = session.query(Artifact).filter_by(kind="promotion_proposal").one()
+            assert artifact.metadata_["proposal_count"] == 0
+
+
 def test_consume_l1_result_keeps_single_trial_metrics_without_trials_subdir() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- record non-ok Layer 1 metrics rows explicitly in promotion review payloads
- allow failure-only boundary sweeps to materialize a zero-proposal `promotion_proposal` artifact
- add regression coverage for the reducer-tree pattern: successful worker run, all metrics rows failed

## Verification
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_result_consumer.py -q`
- `python3 scripts/validate_runs.py --skip_eval_queue`

Note: broader operator-submission spot tests currently fail on unrelated harness assumptions (`missing developer_loop proposal linkage` / fake `gh api` behavior), so this PR keeps verification on the changed L1 consumer path.
