### PR TITLE
Allow L1 composed attention and NoC sweep tasks

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -424,6 +424,8 @@ def _read_config_target(
             "attention_kv_reducer",
             "attention_kv_reducer_tree",
             "attention_kv_reducer_folded",
+            "attention_kv_tile_reducer_folded",
+            "l1_memory_noc_primitive",
         }:
             raise Layer1TaskGenerationError(f"unsupported single-operation design type in {config_path}: {op_type}")
         module_name = entry["module_name"]


### PR DESCRIPTION
## Summary
- allow `attention_kv_tile_reducer_folded` and `l1_memory_noc_primitive` configs through the Layer-1 task generator

## Validation
- `python3 -m py_compile control_plane/control_plane/services/l1_task_generator.py`
- `git diff --check`