### PR TITLE
Add L1 composition proposal linkages

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_tile_reducer_folded_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_tile_reducer_folded_v1/evaluation_requests.json
@@ -1,0 +1,14 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_tile_reducer_folded_v1",
+  "source_commit": "3092a61412e191e4471b35d38f57c19ffd4e5842",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_tile_reducer_folded_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure concrete attention tile to folded reducer local datapath candidates for Llama7B frontier modeling.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "status": "completed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_tile_reducer_folded_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_tile_reducer_folded_v1/proposal.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_tile_reducer_folded_v1",
+  "title": "Measure attention tile to folded reducer local datapath",
+  "status": "proposed",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "motivation": "The Llama7B decoder frontier now needs measured local attention datapath composition instead of standalone tile and reducer estimates. The immediate missing point is the timing, area, and power cost of placing the measured attention/KV tile and folded reducer behind a registered local handoff.",
+  "hypothesis": "A composed attention tile plus folded reducer macro will remain physically feasible at the current local-cluster scale, and its PPA will bound the overhead of replacing separate standalone estimates in the Llama7B architecture model.",
+  "expected_behavior": {
+    "functional": "The tile computes the measured query/key dot-product stream and the folded reducer consumes deterministic score-derived value/stat fragments through registered local nets.",
+    "timing_model": "The measured macro closes the tile score output, handoff registers, reducer input, and reducer ready/valid control in one physical block.",
+    "physical_model": "The top-level macro exposes only reduced outputs and observability counters; high-width producer-side fragment buses remain internal."
+  },
+  "comparison_points": [
+    "attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc2_l16_v16_s16_a24_wrapper",
+    "attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc4_l16_v16_s16_a24_wrapper",
+    "attention_kv_tile_reducer_hd128_kv4_tl32_b256_p8_ppc4_l16_v16_s16_a24_wrapper",
+    "attention_kv_tile_reducer_hd128_kv8_tl64_b512_p16_ppc4_l16_v16_s16_a24_wrapper"
+  ],
+  "risks": [
+    "The current handoff is still a score-derived proxy, not the final softmax-weighted value datapath.",
+    "This measurement does not yet include the clustered scheduler, SRAM hierarchy, or multihop NoC.",
+    "Any promoted result must be labeled as local L1 datapath evidence, not a complete Llama7B attention block."
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_memory_noc_primitives_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_memory_noc_primitives_v1/evaluation_requests.json
@@ -1,0 +1,14 @@
+{
+  "proposal_id": "prop_l1_decoder_memory_noc_primitives_v1",
+  "source_commit": "3092a61412e191e4471b35d38f57c19ffd4e5842",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_memory_noc_primitives_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure concrete FIFO and router primitives for Llama7B local memory/NoC modeling.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "status": "completed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_memory_noc_primitives_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_memory_noc_primitives_v1/proposal.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l1_decoder_memory_noc_primitives_v1",
+  "title": "Measure L1 memory and NoC primitive PPA anchors",
+  "status": "proposed",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "motivation": "The Llama7B architecture model needs concrete local buffering and routing costs before larger clustered schedules can be compared. FIFO and router primitives provide the first measured anchors for local memory and NoC overhead.",
+  "hypothesis": "Small registered FIFO and fixed-port router primitives will be physically feasible and cheap enough to include explicitly in near-frontier local cluster estimates, while also exposing whether flit width starts to dominate local interconnect cost.",
+  "expected_behavior": {
+    "functional": "The primitives use deterministic internal traffic and expose counters and observed flits for synthesis-visible activity.",
+    "timing_model": "The FIFO captures local buffering cost; the router captures fixed-port flit selection and arbitration-state cost.",
+    "physical_model": "The primitives are macro-style blocks with registered internal traffic, not chip-pad IO stress tests."
+  },
+  "comparison_points": [
+    "l1_noc_fifo_w128_d16_wrapper",
+    "l1_noc_fifo_w256_d16_wrapper",
+    "l1_noc_router_p4_w128_wrapper",
+    "l1_noc_router_p4_w256_wrapper"
+  ],
+  "risks": [
+    "These primitives are not a full network scheduler.",
+    "The SRAM hierarchy is still modeled separately and must be connected before claiming complete Llama7B memory behavior.",
+    "The router traffic pattern is deterministic and only provides a PPA anchor, not workload-optimal NoC scheduling evidence."
+  ]
+}


### PR DESCRIPTION
## Summary
- add canonical proposal documents for the L1 attention tile/reducer composition job
- add canonical proposal documents for the L1 memory/NoC primitive job
- these documents unblock artifact_sync submission eligibility for the already completed evaluation runs

## Validation
- `python3 -m json.tool` on all added JSON files
- `git diff --check`