### PR TITLE
eval: charge measured l1 costs in clustered attention schedule

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3800,6 +3800,67 @@ def _decoder_attention_kv_clustered_schedule_overhead_evidence(*, item_id: str) 
     }
 
 
+def _decoder_attention_kv_measured_l1_clustered_schedule_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_measured_l1_clustered_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_measured_l1_clustered_schedule__{item_id}.md"
+    clustered_schedule = (
+        f"{base}/decoder_attention_kv_clustered_schedule_overhead__"
+        "l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1.json"
+    )
+    measured_l1_costs = "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_v1.json"
+    return {
+        "inputs": {
+            "attention_kv_clustered_schedule_overhead": clustered_schedule,
+            "attention_kv_measured_l1_clustered_schedule_out": out,
+            "attention_kv_measured_l1_clustered_schedule_report": report,
+            "attention_kv_measured_l1_costs": measured_l1_costs,
+            "attention_kv_measured_l1_clustered_schedule_scope": (
+                "Quality-backed native-GQA KV8 Llama7B 131k estimate that keeps measured "
+                "compute-array PPA, explicit clustered reduction, and overhead sensitivity, "
+                "then replaces the free local cluster datapath assumption with measured folded "
+                "attention tile/reducer plus FIFO/router PPA anchors. This is still an L2 "
+                "schedule model; it charges area, power, and clock for the measured L1 proxies "
+                "without claiming full value-datapath RTL closure."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_measured_l1_clustered_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py "
+                    "--repo-root . "
+                    "--tag-substring compute_stability_cmp33 "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 200,400,800,1200 "
+                    "--sram-area-fraction 0.4,0.6 "
+                    "--logic-area-fraction 0.1,0.2 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7 "
+                    "--local-sram-fraction 0.1,0.25 "
+                    "--tile-tokens-list 512 "
+                    "--bank-count 16,64 "
+                    "--cluster-count 1,2,4,8,16 "
+                    "--noc-bandwidth-bytes-per-cycle 8192,32768 "
+                    "--noc-hops 1,2,4 "
+                    "--reduction-strategy owner_cluster,cluster_tree "
+                    "--vector-ops-per-mac 0.125 "
+                    "--reduction-scalar-bytes 2 "
+                    "--command-cycles-per-tile 0,4 "
+                    "--command-cycles-per-wave 0,16 "
+                    "--reducer-setup-cycles 0,64 "
+                    "--reduction-cycle-multiplier 1,2 "
+                    f"--measured-l1-costs {measured_l1_costs} "
+                    "--measured-l1-profile all "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
@@ -5304,6 +5365,7 @@ def _build_payload(
         "decoder_attention_kv_measured_compute_partition",
         "decoder_attention_kv_clustered_schedule",
         "decoder_attention_kv_clustered_schedule_overhead",
+        "decoder_attention_kv_measured_l1_clustered_schedule",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
@@ -5375,6 +5437,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_clustered_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_clustered_schedule_overhead":
             decoder_evidence = _decoder_attention_kv_clustered_schedule_overhead_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_measured_l1_clustered_schedule":
+            decoder_evidence = _decoder_attention_kv_measured_l1_clustered_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_l1_clustered_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_l1_clustered_schedule_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_l1_clustered_schedule_v1",
+  "source_commit": "93a3e3b58a9950470927bfca947a85fee48ffefe",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_measured_l1_clustered_schedule_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the Llama7B 131k clustered attention schedule sweep with measured L1 folded tile/reducer and FIFO/router costs charged against each cluster.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_measured_l1_clustered_schedule",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1",
+        "l1_decoder_attention_tile_reducer_folded_v1",
+        "l1_decoder_memory_noc_primitives_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If the same clustered frontier survives measured L1 local costs, proceed toward full L1 value-datapath closure; if the winner shifts, refine local cluster sizing or NoC hierarchy before deeper RTL."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_l1_clustered_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_l1_clustered_schedule_v1/proposal.json
@@ -1,0 +1,83 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_l1_clustered_schedule_v1",
+  "created_utc": "2026-05-31T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_measured_l1_clustered_schedule",
+  "title": "Llama7B clustered attention schedule with measured L1 local costs",
+  "hypothesis": "The Llama7B 131k-context clustered attention frontier can move when each cluster is charged for measured folded attention tile/reducer datapath, FIFO, and router PPA instead of treating local datapath and interconnect logic as free.",
+  "direct_comparison": {
+    "primary_question": "For quality-backed native-GQA KV8 at 131k context, which die size, SRAM split, compute replica count, cluster count, NoC bandwidth, and reduction strategy remains best after measured per-cluster L1 local costs are subtracted from the logic budget?",
+    "include": [
+      "llama7b_proxy at 131k tokens",
+      "native-GQA group-8 only",
+      "KV8 only",
+      "merged corrected compute PPA rows selected by compute_stability_cmp33",
+      "merged folded attention tile/reducer L1 PPA from PR 719",
+      "merged L1 FIFO/router PPA from PR 720",
+      "die sizes 200, 400, 800, and 1200 mm2",
+      "SRAM area fractions 0.4 and 0.6",
+      "logic area fractions 0.1 and 0.2",
+      "cluster counts 1, 2, 4, 8, and 16",
+      "NoC bandwidth values 8192 and 32768 bytes/cycle",
+      "owner-cluster and cluster-tree reductions"
+    ],
+    "exclude": [
+      "new RTL/PPA runs",
+      "cycle-accurate NoC arbitration",
+      "SRAM macro floorplanning",
+      "full softmax-weighted value datapath closure",
+      "quality-degraded KV4 or MQA ranking"
+    ]
+  },
+  "expected_benefit": [
+    "tests whether the current clustered Llama7B frontier survives measured local datapath and NoC primitive costs",
+    "turns the L1 tile/reducer and memory/NoC primitive results into an immediate L2 architecture-ranking signal",
+    "identifies the next concrete L1 closure target: full value datapath, router hierarchy, or larger compute-cluster fabric"
+  ],
+  "risks": [
+    "the measured L1 tile/reducer profiles are local proxies rather than the complete attention datapath",
+    "FIFO/router costs are charged per cluster with simple counts and do not model routed multi-hop topology in detail",
+    "NoC contention is still represented by bandwidth and hop parameters, not cycle-accurate arbitration"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_measured_l1_clustered_schedule_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the Llama7B 131k clustered attention schedule sweep with measured L1 folded tile/reducer and FIFO/router costs charged against each cluster.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_measured_l1_clustered_schedule",
+      "cost_class": "low",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1",
+        "l1_decoder_attention_tile_reducer_folded_v1",
+        "l1_decoder_memory_noc_primitives_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If the same clustered frontier survives measured L1 local costs, proceed toward full L1 value-datapath closure; if the winner shifts, refine local cluster sizing or NoC hierarchy before deeper RTL."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_clustered_schedule_overhead__l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1.json",
+    "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py",
+    "runs/designs/activations/attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc2_l16_v16_s16_a24_wrapper/metrics.csv",
+    "runs/designs/activations/attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc4_l16_v16_s16_a24_wrapper/metrics.csv",
+    "runs/designs/activations/attention_kv_tile_reducer_hd128_kv4_tl32_b256_p8_ppc4_l16_v16_s16_a24_wrapper/metrics.csv",
+    "runs/designs/activations/attention_kv_tile_reducer_hd128_kv8_tl64_b512_p16_ppc4_l16_v16_s16_a24_wrapper/metrics.csv",
+    "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv",
+    "runs/designs/noc/l1_noc_fifo_w256_d16_wrapper/metrics.csv",
+    "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv",
+    "runs/designs/noc/l1_noc_router_p4_w256_wrapper/metrics.csv"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
@@ -31,6 +31,114 @@ from npu.eval.estimate_llm_decoder_attention_kv_physical_hbm_frontier import (  
 JsonDict = dict[str, Any]
 
 
+def _profile_list(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _metric(profile: JsonDict, component: str, key: str, default: float = 0.0) -> float:
+    raw = profile.get(component, {})
+    if not isinstance(raw, dict):
+        return default
+    value = raw.get(key, default)
+    return float(value)
+
+
+def _path_metric(profile: JsonDict, component: str) -> str:
+    raw = profile.get(component, {})
+    if not isinstance(raw, dict):
+        return ""
+    return str(raw.get("metrics_csv", ""))
+
+
+def _measured_l1_overhead(profile: JsonDict | None, cluster_count: int) -> JsonDict:
+    if profile is None:
+        return {
+            "profile": "analytic_unmeasured",
+            "area_um2": 0.0,
+            "power_mw": 0.0,
+            "clock_ns": 0.0,
+            "local_datapath_area_um2": 0.0,
+            "local_datapath_power_mw": 0.0,
+            "local_datapath_clock_ns": 0.0,
+            "noc_fifo_area_um2": 0.0,
+            "noc_fifo_power_mw": 0.0,
+            "noc_fifo_clock_ns": 0.0,
+            "noc_router_area_um2": 0.0,
+            "noc_router_power_mw": 0.0,
+            "noc_router_clock_ns": 0.0,
+            "fifo_per_cluster": 0,
+            "router_per_cluster": 0,
+            "local_datapath_metrics_csv": "",
+            "noc_fifo_metrics_csv": "",
+            "noc_router_metrics_csv": "",
+        }
+    fifo_per_cluster = int(profile.get("fifo_per_cluster", 1))
+    router_per_cluster = int(profile.get("router_per_cluster", 1))
+    local_area = _metric(profile, "local_datapath", "area_um2")
+    local_power = _metric(profile, "local_datapath", "power_mw")
+    local_clock = _metric(profile, "local_datapath", "clock_ns")
+    fifo_area = _metric(profile, "noc_fifo", "area_um2")
+    fifo_power = _metric(profile, "noc_fifo", "power_mw")
+    fifo_clock = _metric(profile, "noc_fifo", "clock_ns")
+    router_area = _metric(profile, "noc_router", "area_um2")
+    router_power = _metric(profile, "noc_router", "power_mw")
+    router_clock = _metric(profile, "noc_router", "clock_ns")
+    per_cluster_area = local_area + fifo_per_cluster * fifo_area + router_per_cluster * router_area
+    per_cluster_power = local_power + fifo_per_cluster * fifo_power + router_per_cluster * router_power
+    return {
+        "profile": str(profile["name"]),
+        "area_um2": cluster_count * per_cluster_area,
+        "power_mw": cluster_count * per_cluster_power,
+        "clock_ns": max(local_clock, fifo_clock, router_clock),
+        "local_datapath_area_um2": local_area,
+        "local_datapath_power_mw": local_power,
+        "local_datapath_clock_ns": local_clock,
+        "noc_fifo_area_um2": fifo_area,
+        "noc_fifo_power_mw": fifo_power,
+        "noc_fifo_clock_ns": fifo_clock,
+        "noc_router_area_um2": router_area,
+        "noc_router_power_mw": router_power,
+        "noc_router_clock_ns": router_clock,
+        "fifo_per_cluster": fifo_per_cluster,
+        "router_per_cluster": router_per_cluster,
+        "local_datapath_metrics_csv": _path_metric(profile, "local_datapath"),
+        "noc_fifo_metrics_csv": _path_metric(profile, "noc_fifo"),
+        "noc_router_metrics_csv": _path_metric(profile, "noc_router"),
+    }
+
+
+def _load_measured_l1_profiles(
+    *,
+    repo_root: Path,
+    costs_path: Path | None,
+    profile_names: list[str] | None,
+) -> list[JsonDict | None]:
+    if costs_path is None:
+        return [None]
+    resolved = costs_path if costs_path.is_absolute() else repo_root / costs_path
+    payload = json.loads(resolved.read_text(encoding="utf-8"))
+    raw_profiles = payload.get("profiles", [])
+    if isinstance(raw_profiles, dict):
+        profiles = list(raw_profiles.values())
+    elif isinstance(raw_profiles, list):
+        profiles = raw_profiles
+    else:
+        raise ValueError(f"measured L1 cost profile file has invalid profiles field: {resolved}")
+    names = set(profile_names or [])
+    if "all" in names:
+        names = set()
+    selected: list[JsonDict | None] = []
+    for profile in profiles:
+        if not isinstance(profile, dict) or not profile.get("name"):
+            raise ValueError(f"measured L1 cost profile lacks a name: {resolved}")
+        if names and str(profile["name"]) not in names:
+            continue
+        selected.append(profile)
+    if not selected:
+        raise ValueError(f"no measured L1 cost profiles selected from {resolved}")
+    return selected
+
+
 def _reduction_factor(strategy: str, active_clusters: int) -> tuple[int, int]:
     if strategy == "centralized_tile":
         return 0, active_clusters
@@ -63,11 +171,14 @@ def _shape_row(
     command_cycles_per_wave: int,
     reducer_setup_cycles: int,
     reduction_cycle_multiplier: float,
+    measured_l1_profile: JsonDict | None,
 ) -> JsonDict | None:
     if sram_area_fraction + logic_area_fraction + reserved_area_fraction > 1.0:
         return None
     compute_budget_um2 = die_area_mm2 * 1_000_000.0 * logic_area_fraction
-    replica_count = int(compute_budget_um2 // float(candidate["block_area_um2"]))
+    measured_l1 = _measured_l1_overhead(measured_l1_profile, cluster_count)
+    available_compute_budget_um2 = compute_budget_um2 - float(measured_l1["area_um2"])
+    replica_count = int(available_compute_budget_um2 // float(candidate["block_area_um2"]))
     if replica_count < 1 or cluster_count > replica_count:
         return None
 
@@ -104,7 +215,7 @@ def _shape_row(
     per_cluster_macs = max(1, replicas_per_cluster_floor * block_macs_per_cycle)
     per_cluster_vector_ops = max(1, int(math.ceil(per_cluster_macs * vector_ops_per_mac)))
 
-    clock_ns = float(candidate["block_clock_ns"])
+    clock_ns = max(float(candidate["block_clock_ns"]), float(measured_l1["clock_ns"]))
     raw_hbm_bw = _physical_hbm_bytes_per_cycle(
         stack_count=8,
         pseudo_channels_per_stack=16,
@@ -228,8 +339,33 @@ def _shape_row(
         "compute_logic_area_fraction": logic_area_fraction,
         "reserved_area_fraction": reserved_area_fraction,
         "compute_budget_um2": round(compute_budget_um2, 6),
+        "compute_array_budget_after_measured_l1_um2": round(available_compute_budget_um2, 6),
         "compute_area_um2": round(replica_count * float(candidate["block_area_um2"]), 6),
         "compute_power_mw": round(replica_count * float(candidate["block_power_mw"]), 6),
+        "measured_l1_profile": measured_l1["profile"],
+        "measured_l1_overhead_area_um2": round(float(measured_l1["area_um2"]), 6),
+        "measured_l1_overhead_power_mw": round(float(measured_l1["power_mw"]), 6),
+        "measured_l1_overhead_clock_ns": round(float(measured_l1["clock_ns"]), 6),
+        "logic_area_used_um2": round(replica_count * float(candidate["block_area_um2"]) + float(measured_l1["area_um2"]), 6),
+        "logic_area_slack_um2": round(
+            compute_budget_um2 - replica_count * float(candidate["block_area_um2"]) - float(measured_l1["area_um2"]),
+            6,
+        ),
+        "logic_power_mw": round(replica_count * float(candidate["block_power_mw"]) + float(measured_l1["power_mw"]), 6),
+        "local_datapath_area_um2": round(float(measured_l1["local_datapath_area_um2"]), 6),
+        "local_datapath_power_mw": round(float(measured_l1["local_datapath_power_mw"]), 6),
+        "local_datapath_clock_ns": round(float(measured_l1["local_datapath_clock_ns"]), 6),
+        "local_datapath_metrics_csv": measured_l1["local_datapath_metrics_csv"],
+        "noc_fifo_area_um2": round(float(measured_l1["noc_fifo_area_um2"]), 6),
+        "noc_fifo_power_mw": round(float(measured_l1["noc_fifo_power_mw"]), 6),
+        "noc_fifo_clock_ns": round(float(measured_l1["noc_fifo_clock_ns"]), 6),
+        "noc_fifo_per_cluster": measured_l1["fifo_per_cluster"],
+        "noc_fifo_metrics_csv": measured_l1["noc_fifo_metrics_csv"],
+        "noc_router_area_um2": round(float(measured_l1["noc_router_area_um2"]), 6),
+        "noc_router_power_mw": round(float(measured_l1["noc_router_power_mw"]), 6),
+        "noc_router_clock_ns": round(float(measured_l1["noc_router_clock_ns"]), 6),
+        "noc_router_per_cluster": measured_l1["router_per_cluster"],
+        "noc_router_metrics_csv": measured_l1["noc_router_metrics_csv"],
         "macs_per_cycle": total_macs_per_cycle,
         "vector_ops_per_cycle": total_vector_ops_per_cycle,
         "per_cluster_macs_per_cycle": per_cluster_macs,
@@ -298,8 +434,16 @@ def build_report(
     command_cycles_per_wave_list: list[int] | None = None,
     reducer_setup_cycles_list: list[int] | None = None,
     reduction_cycle_multiplier_list: list[float] | None = None,
+    measured_l1_costs_path: Path | None = None,
+    measured_l1_profile_list: list[str] | None = None,
+    measured_l1_profiles: list[JsonDict | None] | None = None,
 ) -> JsonDict:
     candidates = _load_compute_candidates(repo_root=repo_root, tag_substring=tag_substring)
+    measured_l1_profiles = measured_l1_profiles or _load_measured_l1_profiles(
+        repo_root=repo_root,
+        costs_path=measured_l1_costs_path,
+        profile_names=measured_l1_profile_list,
+    )
     command_cycles_per_tile_list = command_cycles_per_tile_list or [0]
     command_cycles_per_wave_list = command_cycles_per_wave_list or [0]
     reducer_setup_cycles_list = reducer_setup_cycles_list or [0]
@@ -322,33 +466,35 @@ def build_report(
                                                         for command_cycles_per_wave in command_cycles_per_wave_list:
                                                             for reducer_setup_cycles in reducer_setup_cycles_list:
                                                                 for reduction_cycle_multiplier in reduction_cycle_multiplier_list:
-                                                                    for candidate in candidates:
-                                                                        row = _shape_row(
-                                                                            candidate=candidate,
-                                                                            die_area_mm2=die_area_mm2,
-                                                                            sram_area_fraction=sram_area_fraction,
-                                                                            logic_area_fraction=logic_area_fraction,
-                                                                            reserved_area_fraction=reserved_area_fraction,
-                                                                            sequence_length=sequence_length,
-                                                                            usable_sram_fraction=usable_sram_fraction,
-                                                                            local_sram_fraction=local_sram_fraction,
-                                                                            tile_tokens=tile_tokens,
-                                                                            bank_count=bank_count,
-                                                                            cluster_count=cluster_count,
-                                                                            noc_bandwidth_bytes_per_cycle=noc_bw,
-                                                                            noc_hops=noc_hops,
-                                                                            reduction_strategy=reduction_strategy,
-                                                                            vector_ops_per_mac=vector_ops_per_mac,
-                                                                            reduction_scalar_bytes=reduction_scalar_bytes,
-                                                                            command_cycles_per_tile=command_cycles_per_tile,
-                                                                            command_cycles_per_wave=command_cycles_per_wave,
-                                                                            reducer_setup_cycles=reducer_setup_cycles,
-                                                                            reduction_cycle_multiplier=reduction_cycle_multiplier,
-                                                                        )
-                                                                        if row is None:
-                                                                            skipped_area_budget += 1
-                                                                        else:
-                                                                            rows.append(row)
+                                                                    for measured_l1_profile in measured_l1_profiles:
+                                                                        for candidate in candidates:
+                                                                            row = _shape_row(
+                                                                                candidate=candidate,
+                                                                                die_area_mm2=die_area_mm2,
+                                                                                sram_area_fraction=sram_area_fraction,
+                                                                                logic_area_fraction=logic_area_fraction,
+                                                                                reserved_area_fraction=reserved_area_fraction,
+                                                                                sequence_length=sequence_length,
+                                                                                usable_sram_fraction=usable_sram_fraction,
+                                                                                local_sram_fraction=local_sram_fraction,
+                                                                                tile_tokens=tile_tokens,
+                                                                                bank_count=bank_count,
+                                                                                cluster_count=cluster_count,
+                                                                                noc_bandwidth_bytes_per_cycle=noc_bw,
+                                                                                noc_hops=noc_hops,
+                                                                                reduction_strategy=reduction_strategy,
+                                                                                vector_ops_per_mac=vector_ops_per_mac,
+                                                                                reduction_scalar_bytes=reduction_scalar_bytes,
+                                                                                command_cycles_per_tile=command_cycles_per_tile,
+                                                                                command_cycles_per_wave=command_cycles_per_wave,
+                                                                                reducer_setup_cycles=reducer_setup_cycles,
+                                                                                reduction_cycle_multiplier=reduction_cycle_multiplier,
+                                                                                measured_l1_profile=measured_l1_profile,
+                                                                            )
+                                                                            if row is None:
+                                                                                skipped_area_budget += 1
+                                                                            else:
+                                                                                rows.append(row)
     if not rows:
         raise RuntimeError("no rows generated; area budget or cluster count may be infeasible")
     rows_sorted = sorted(rows, key=lambda row: row["latency_us"])
@@ -380,7 +526,10 @@ def build_report(
             "command_cycles_per_wave_list": command_cycles_per_wave_list,
             "reducer_setup_cycles_list": reducer_setup_cycles_list,
             "reduction_cycle_multiplier_list": reduction_cycle_multiplier_list,
+            "measured_l1_costs_path": str(measured_l1_costs_path or ""),
+            "measured_l1_profile_list": measured_l1_profile_list or [],
         },
+        "measured_l1_profiles": [profile for profile in measured_l1_profiles if profile is not None],
         "compute_candidates": candidates,
         "sweep_summary": {
             "generated_row_count": len(rows),
@@ -403,6 +552,7 @@ def build_report(
                 "reduction_cycle_multiplier",
             ),
         ),
+        "best_by_measured_l1_profile": _best_by(rows, ("sequence_length", "die_area_mm2", "measured_l1_profile")),
         "best_by_memory_noc": sorted(
             _best_by(
                 rows,
@@ -426,6 +576,9 @@ def build_report(
             "Reduction strategies model cross-tile combination after tile service: centralized_tile sends every tile partial, owner_cluster and cluster_tree first reduce tiles locally per cluster.",
             "This is an analytic schedule model; it still does not model RTL command queues or cycle-accurate SRAM/NoC arbitration.",
             "Optional command and reducer overhead parameters are sensitivity knobs, not measured RTL/PPA.",
+            "When measured L1 cost profiles are provided, their per-cluster tile/reducer, FIFO, and router area is subtracted from the logic budget before compute replicas are allocated.",
+            "Measured L1 profile clock is combined by max() with measured compute-array clock; this is a conservative local macro proxy, not a full routed SoC timing closure.",
+            "Measured L1 tile/reducer profiles cover QK/stat/local partial reduction structure and memory/NoC primitives; the full softmax-weighted value datapath still needs a later L1 closure run.",
         ],
     }
 
@@ -441,13 +594,14 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         "",
         "## Best",
         "",
-        "| seq | die | SRAM | logic | arch | replicas | clusters | reduction | tile | clock ns | latency us | resource |",
-        "|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---:|---|",
-        "| {seq} | {die} | {sram} | {logic} | {arch} | {rep} | {cluster} | {red} | {tile} | {clk} | {lat} | {res} |".format(
+        "| seq | die | SRAM | logic | L1 profile | arch | replicas | clusters | reduction | tile | clock ns | latency us | resource |",
+        "|---:|---:|---:|---:|---|---|---:|---:|---|---:|---:|---:|---|",
+        "| {seq} | {die} | {sram} | {logic} | {l1} | {arch} | {rep} | {cluster} | {red} | {tile} | {clk} | {lat} | {res} |".format(
             seq=best["sequence_length"],
             die=best["die_area_mm2"],
             sram=best["sram_area_fraction"],
             logic=best["compute_logic_area_fraction"],
+            l1=best["measured_l1_profile"],
             arch=best["compute_arch"],
             rep=best["compute_replica_count"],
             cluster=best["cluster_count"],
@@ -471,6 +625,26 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
                 cw=row["command_cycles_per_wave"],
                 setup=row["reducer_setup_cycles"],
                 mult=row["reduction_cycle_multiplier"],
+                cluster=row["cluster_count"],
+                red=row["reduction_strategy"],
+                lat=row["latency_us"],
+                res=row["dominant_tile_resource"],
+            )
+        )
+    lines.extend([
+        "",
+        "## Best By Measured L1 Profile",
+        "",
+        "| die | L1 profile | logic used um2 | replicas | clusters | reduction | latency us | resource |",
+        "|---:|---|---:|---:|---:|---|---:|---|",
+    ])
+    for row in payload["best_by_measured_l1_profile"]:
+        lines.append(
+            "| {die} | {l1} | {used} | {rep} | {cluster} | {red} | {lat} | {res} |".format(
+                die=row["die_area_mm2"],
+                l1=row["measured_l1_profile"],
+                used=row["logic_area_used_um2"],
+                rep=row["compute_replica_count"],
                 cluster=row["cluster_count"],
                 red=row["reduction_strategy"],
                 lat=row["latency_us"],
@@ -536,6 +710,8 @@ def main() -> int:
     ap.add_argument("--command-cycles-per-wave", type=_int_list, default=[0])
     ap.add_argument("--reducer-setup-cycles", type=_int_list, default=[0])
     ap.add_argument("--reduction-cycle-multiplier", type=_float_list, default=[1.0])
+    ap.add_argument("--measured-l1-costs", default="")
+    ap.add_argument("--measured-l1-profile", type=_profile_list, default=["all"])
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
     args = ap.parse_args()
@@ -562,6 +738,8 @@ def main() -> int:
         command_cycles_per_wave_list=args.command_cycles_per_wave,
         reducer_setup_cycles_list=args.reducer_setup_cycles,
         reduction_cycle_multiplier_list=args.reduction_cycle_multiplier,
+        measured_l1_costs_path=Path(args.measured_l1_costs) if args.measured_l1_costs else None,
+        measured_l1_profile_list=args.measured_l1_profile,
     )
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign__l2_decoder_attention_kv_measured_l1_clustered_schedule_v1.json
+++ b/runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse/campaign__l2_decoder_attention_kv_measured_l1_clustered_schedule_v1.json
@@ -1,0 +1,68 @@
+{
+  "version": 0.1,
+  "campaign_id": "npu_e2e_eval_mlp_smoke_v1_reuse",
+  "model_set_id": "mlp_smoke_v1",
+  "model_manifest": "runs/models/mlp_smoke_v1/manifest.json",
+  "physical_source_campaign": "runs/campaigns/npu/e2e_eval_v0/campaign.json",
+  "description": "Model-set revision campaign shell for the L2 Llama7B measured-L1 clustered attention schedule analysis.",
+  "platform": "nangate45",
+  "make_target": "3_3_place_gp",
+  "repeats": 5,
+  "models": [
+    {
+      "model_id": "mlp1",
+      "onnx_path": "runs/models/mlp_smoke_v1/mlp1.onnx",
+      "mapper_arch": "npu/arch/examples/minimal.yml",
+      "perf_config": "npu/sim/perf/example_config_fp16_cpp.json"
+    },
+    {
+      "model_id": "mlp2",
+      "onnx_path": "runs/models/mlp_smoke_v1/mlp2.onnx",
+      "mapper_arch": "npu/arch/examples/minimal.yml",
+      "perf_config": "npu/sim/perf/example_config_fp16_cpp.json"
+    }
+  ],
+  "architecture_points": [
+    {
+      "arch_id": "fp16_nm1",
+      "rtlgen_config": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp/config_nm1.json",
+      "synth_design_dir": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp",
+      "sweep_file": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_cmp/sweep_compare_33.json",
+      "macro_manifest": "runs/designs/npu_macros/gemm_compute_array_fp16_nm1_c250/macro_manifest.json",
+      "layer1_modules": {
+        "manifest": "runs/candidates/nangate45/module_candidates.json",
+        "variant_ids": [
+          "mult16u_normal_koggestone_nangate45_base",
+          "adder_koggestone_64u_nangate45_base"
+        ]
+      },
+      "physical_select": {
+        "compare_group": "baed737c",
+        "tag_prefix": "npu_fp16_nm1_cmp33"
+      }
+    },
+    {
+      "arch_id": "fp16_nm2",
+      "rtlgen_config": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_cmp/config_nm2.json",
+      "synth_design_dir": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_cmp",
+      "sweep_file": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_cmp/sweep_compare_33.json",
+      "macro_manifest": "runs/designs/npu_macros/gemm_compute_array_fp16_2slot_c300/macro_manifest.json",
+      "layer1_modules": {
+        "manifest": "runs/candidates/nangate45/module_candidates.json",
+        "variant_ids": [
+          "mult16u_normal_koggestone_nangate45_base",
+          "adder_koggestone_64u_nangate45_base"
+        ]
+      },
+      "physical_select": {
+        "compare_group": "37c65ce6",
+        "tag_prefix": "npu_fp16_nm2_cmp33"
+      }
+    }
+  ],
+  "outputs": {
+    "report_md": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__l2_decoder_attention_kv_measured_l1_clustered_schedule_v1/report.md",
+    "results_csv": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__l2_decoder_attention_kv_measured_l1_clustered_schedule_v1/results.csv",
+    "campaign_dir": "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__l2_decoder_attention_kv_measured_l1_clustered_schedule_v1"
+  }
+}

--- a/runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_v1.json
+++ b/runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_v1.json
@@ -1,0 +1,134 @@
+{
+  "version": 0.1,
+  "name": "llama7b_attention_local_costs_v1",
+  "platform": "nangate45",
+  "core_utilization": 60,
+  "source_prs": [719, 720],
+  "scope": "Per-cluster L1 proxy costs for Llama7B attention schedule modeling. Profiles include measured folded attention tile/reducer datapaths plus one FIFO and one 4-port router per cluster. They are local-area and local-clock anchors, not full softmax-weighted value datapath closure.",
+  "profiles": [
+    {
+      "name": "hd64_kv4_p8_ppc2_noc128",
+      "description": "Small hd64/kv4 folded tile reducer with 128-bit local NoC primitives.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc2_l16_v16_s16_a24_wrapper",
+        "clock_ns": 0.7757,
+        "area_um2": 40306.585225,
+        "power_mw": 0.0218,
+        "metrics_csv": "runs/designs/activations/attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc2_l16_v16_s16_a24_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w128_d16_wrapper",
+        "width_bits": 128,
+        "depth": 16,
+        "clock_ns": 0.2965,
+        "area_um2": 11606.830225,
+        "power_mw": 0.00862,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w128_wrapper",
+        "ports": 4,
+        "width_bits": 128,
+        "clock_ns": 0.2424,
+        "area_um2": 3123.133225,
+        "power_mw": 0.00176,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd64_kv4_p8_ppc4_noc128",
+      "description": "Higher parallelism hd64/kv4 folded tile reducer with 128-bit local NoC primitives.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc4_l16_v16_s16_a24_wrapper",
+        "clock_ns": 0.7833,
+        "area_um2": 52918.4016,
+        "power_mw": 0.0269,
+        "metrics_csv": "runs/designs/activations/attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc4_l16_v16_s16_a24_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w128_d16_wrapper",
+        "width_bits": 128,
+        "depth": 16,
+        "clock_ns": 0.2965,
+        "area_um2": 11606.830225,
+        "power_mw": 0.00862,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w128_wrapper",
+        "ports": 4,
+        "width_bits": 128,
+        "clock_ns": 0.2424,
+        "area_um2": 3123.133225,
+        "power_mw": 0.00176,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd128_kv4_p8_ppc4_noc256",
+      "description": "hd128/kv4 folded tile reducer with 256-bit local NoC primitives.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_tile_reducer_hd128_kv4_tl32_b256_p8_ppc4_l16_v16_s16_a24_wrapper",
+        "clock_ns": 0.8686,
+        "area_um2": 56846.480625,
+        "power_mw": 0.0267,
+        "metrics_csv": "runs/designs/activations/attention_kv_tile_reducer_hd128_kv4_tl32_b256_p8_ppc4_l16_v16_s16_a24_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w256_d16_wrapper",
+        "width_bits": 256,
+        "depth": 16,
+        "clock_ns": 0.29,
+        "area_um2": 11779.846225,
+        "power_mw": 0.00869,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w256_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w256_wrapper",
+        "ports": 4,
+        "width_bits": 256,
+        "clock_ns": 0.2401,
+        "area_um2": 3299.3536,
+        "power_mw": 0.00171,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w256_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd128_kv8_p16_ppc4_noc256",
+      "description": "Larger hd128/kv8 folded tile reducer with 256-bit local NoC primitives.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_tile_reducer_hd128_kv8_tl64_b512_p16_ppc4_l16_v16_s16_a24_wrapper",
+        "clock_ns": 0.8687,
+        "area_um2": 102240.0625,
+        "power_mw": 0.0305,
+        "metrics_csv": "runs/designs/activations/attention_kv_tile_reducer_hd128_kv8_tl64_b512_p16_ppc4_l16_v16_s16_a24_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w256_d16_wrapper",
+        "width_bits": 256,
+        "depth": 16,
+        "clock_ns": 0.29,
+        "area_um2": 11779.846225,
+        "power_mw": 0.00869,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w256_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w256_wrapper",
+        "ports": 4,
+        "width_bits": 256,
+        "clock_ns": 0.2401,
+        "area_um2": 3299.3536,
+        "power_mw": 0.00171,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w256_wrapper/metrics.csv"
+      }
+    }
+  ]
+}

--- a/tests/test_llm_decoder_attention_kv_clustered_schedule.py
+++ b/tests/test_llm_decoder_attention_kv_clustered_schedule.py
@@ -113,3 +113,61 @@ def test_clustered_schedule_charges_command_and_reducer_overhead(monkeypatch) ->
     )
     assert report["inputs"]["command_cycles_per_tile_list"] == [3]
     assert report["inputs"]["reduction_cycle_multiplier_list"] == [2.0]
+
+
+def test_clustered_schedule_charges_measured_l1_profile(monkeypatch) -> None:
+    monkeypatch.setattr(sched, "_load_compute_candidates", lambda repo_root, tag_substring: [_candidate()])
+    report = sched.build_report(
+        repo_root=Path("."),
+        tag_substring="unit",
+        sequence_length_list=[2048],
+        die_area_mm2_list=[1.0],
+        sram_area_fraction_list=[0.4],
+        logic_area_fraction_list=[0.2],
+        reserved_area_fraction=0.1,
+        usable_sram_fraction_list=[0.7],
+        local_sram_fraction_list=[0.25],
+        tile_tokens_list=[512],
+        bank_count_list=[16],
+        cluster_count_list=[2],
+        noc_bandwidth_bytes_per_cycle_list=[8192.0],
+        noc_hops_list=[1],
+        reduction_strategy_list=["owner_cluster"],
+        vector_ops_per_mac=0.125,
+        reduction_scalar_bytes=2,
+        measured_l1_profiles=[
+            {
+                "name": "unit_l1",
+                "fifo_per_cluster": 1,
+                "router_per_cluster": 2,
+                "local_datapath": {
+                    "clock_ns": 3.0,
+                    "area_um2": 10000.0,
+                    "power_mw": 0.5,
+                    "metrics_csv": "local.csv",
+                },
+                "noc_fifo": {
+                    "clock_ns": 1.0,
+                    "area_um2": 1000.0,
+                    "power_mw": 0.1,
+                    "metrics_csv": "fifo.csv",
+                },
+                "noc_router": {
+                    "clock_ns": 0.5,
+                    "area_um2": 500.0,
+                    "power_mw": 0.05,
+                    "metrics_csv": "router.csv",
+                },
+            }
+        ],
+    )
+    row = report["best"]
+
+    assert row["measured_l1_profile"] == "unit_l1"
+    assert row["measured_l1_overhead_area_um2"] == 24000.0
+    assert row["measured_l1_overhead_power_mw"] == 1.4
+    assert row["clock_ns"] == 3.0
+    assert row["compute_replica_count"] == 176
+    assert row["logic_area_used_um2"] == 200000.0
+    assert row["local_datapath_metrics_csv"] == "local.csv"
+    assert report["best_by_measured_l1_profile"][0]["measured_l1_profile"] == "unit_l1"


### PR DESCRIPTION
## Summary
- add measured L1 local-cost profiles from the folded attention tile/reducer and FIFO/router PPA runs
- extend the Llama7B clustered attention schedule estimator to charge per-cluster measured local area, power, and clock
- add a measured-L1 L2 task-generator abstraction, proposal, campaign shell, and regression coverage

## Verification
- `/workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_attention_kv_clustered_schedule.py`
- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py control_plane/control_plane/services/l2_task_generator.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- direct measured-L1 estimator smoke run to `/tmp/measured_l1_schedule_smoke.{json,md}`