### PR TITLE
eval: add full value attention tile ppa target

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -425,6 +425,7 @@ def _read_config_target(
             "attention_kv_reducer_tree",
             "attention_kv_reducer_folded",
             "attention_kv_tile_reducer_folded",
+            "attention_kv_full_value_tile",
             "l1_memory_noc_primitive",
         }:
             raise Layer1TaskGenerationError(f"unsupported single-operation design type in {config_path}: {op_type}")

--- a/docs/proposals/prop_l1_decoder_attention_full_value_tile_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_full_value_tile_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_full_value_tile_v1",
+  "source_commit": "pending_source_pr_merge",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_full_value_tile_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 macro PPA for full local attention tile datapaths with explicit softmax-weighted value products and folded value reduction.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "cost_class": "medium",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l1_decoder_attention_tile_reducer_folded_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_tile_reducer_folded_v1",
+        "l2_decoder_attention_kv_measured_l1_clustered_schedule_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If full value-path PPA stays near the folded proxy, rerun L2 with the corrected profile; if it grows sharply, narrow the local tile architecture before NoC/SRAM hierarchy work."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_full_value_tile_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_full_value_tile_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_full_value_tile_v1",
+  "created_utc": "2026-05-31T11:20:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "ppa",
+  "abstraction_layer": "architecture_block",
+  "title": "Full value-path Llama attention tile PPA",
+  "hypothesis": "The measured folded tile/reducer proxy is missing the softmax-weighted value accumulation datapath; adding explicit score-weight by value products and wider value accumulation may materially change the local tile PPA used by the Llama7B clustered schedule model.",
+  "direct_comparison": {
+    "primary_question": "What is the Nangate45 macro PPA of a local attention tile that includes QK score generation, online partial-stat emission, softmax-weighted value products, and folded partial-value reduction?",
+    "include": [
+      "native KV8 operand width",
+      "hd64 area-conservative p8 ppc2 point",
+      "hd64 throughput-oriented p8 ppc4 point",
+      "hd128 wider sanity point with p16 ppc4",
+      "core utilization 50 and 60",
+      "macro-style wrapper without IO-pad assumptions"
+    ],
+    "exclude": [
+      "new L2 schedule sweep",
+      "cycle-accurate SRAM or NoC arbitration",
+      "model-quality changes such as MQA or KV4",
+      "large cluster-array integration"
+    ]
+  },
+  "expected_benefit": [
+    "closes the largest remaining local datapath abstraction in the measured-L1 Llama7B schedule model",
+    "tests whether weighted value accumulation is a small correction or a frontier-changing PPA term",
+    "provides updated local-cost anchors for the next L2 measured-cost schedule rerun"
+  ],
+  "risks": [
+    "the generated full-value tile still uses deterministic internal stimulus rather than a full memory-fed tile interface",
+    "softmax weight generation itself is approximated by score slices; the job measures value product/accumulation structure, not a complete softmax exponent pipeline",
+    "the wider point may hit routing or synthesis runtime limits"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_full_value_tile_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 macro PPA for full local attention tile datapaths with explicit softmax-weighted value products and folded value reduction.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "cost_class": "medium",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l1_decoder_attention_tile_reducer_folded_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_tile_reducer_folded_v1",
+        "l2_decoder_attention_kv_measured_l1_clustered_schedule_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "If full value-path PPA stays near the folded proxy, rerun L2 with the corrected profile; if it grows sharply, narrow the local tile architecture before NoC/SRAM hierarchy work."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_l1_clustered_schedule__l2_decoder_attention_kv_measured_l1_clustered_schedule_v1.json"
+  ],
+  "knowledge_refs": [
+    "scripts/generate_design.py",
+    "runs/designs/activations/attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc2_l16_v16_s16_a24_wrapper/metrics.csv",
+    "runs/designs/activations/attention_kv_tile_reducer_hd64_kv4_tl16_b128_p8_ppc4_l16_v16_s16_a24_wrapper/metrics.csv"
+  ]
+}

--- a/examples/config_attention_kv_full_value_tile.json
+++ b/examples/config_attention_kv_full_value_tile.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [{"name": "kv_fragment", "dimensions": 1, "bit_width": 4, "signed": true, "kind": "int"}],
+  "operations": [{
+    "type": "attention_kv_full_value_tile",
+    "module_name": "attention_kv_full_value_hd8_kv4_tl4_b16_p4_ppc2_w16_a24",
+    "operand": "kv_fragment",
+    "options": {
+      "head_dim": 8,
+      "kv_bits": 4,
+      "tile_lanes": 4,
+      "stream_bytes_per_cycle": 16,
+      "score_bits": 24,
+      "value_bits": 8,
+      "softmax_weight_bits": 8,
+      "weighted_value_bits": 16,
+      "reducer_lanes": 4,
+      "stat_bits": 12,
+      "partials": 4,
+      "partials_per_cycle": 2,
+      "reducer_accum_bits": 24,
+      "counter_bits": 16,
+      "signed_inputs": true,
+      "signed_values": true
+    }
+  }]
+}

--- a/runs/campaigns/activations/attention_kv_full_value_tile/sweeps/nangate45_macro_frontier.json
+++ b/runs/campaigns/activations/attention_kv_full_value_tile/sweeps/nangate45_macro_frontier.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "attention_kv_full_value_tile_nangate45_macro_frontier",
+  "flow_params": {
+    "CLOCK_PERIOD": [1.0],
+    "CORE_UTILIZATION": [50, 60],
+    "PLACE_DENSITY": [0.52]
+  }
+}

--- a/runs/designs/activations/attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40_wrapper/config_attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40.json
+++ b/runs/designs/activations/attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40_wrapper/config_attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [{"name": "kv_fragment", "dimensions": 1, "bit_width": 8, "signed": true, "kind": "int"}],
+  "operations": [{
+    "type": "attention_kv_full_value_tile",
+    "module_name": "attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40",
+    "operand": "kv_fragment",
+    "options": {
+      "head_dim": 128,
+      "kv_bits": 8,
+      "tile_lanes": 32,
+      "stream_bytes_per_cycle": 256,
+      "score_bits": 48,
+      "value_bits": 16,
+      "softmax_weight_bits": 16,
+      "weighted_value_bits": 24,
+      "reducer_lanes": 16,
+      "stat_bits": 16,
+      "partials": 16,
+      "partials_per_cycle": 4,
+      "reducer_accum_bits": 40,
+      "counter_bits": 32,
+      "signed_inputs": true,
+      "signed_values": true
+    }
+  }]
+}

--- a/runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/config_attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40.json
+++ b/runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/config_attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [{"name": "kv_fragment", "dimensions": 1, "bit_width": 8, "signed": true, "kind": "int"}],
+  "operations": [{
+    "type": "attention_kv_full_value_tile",
+    "module_name": "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40",
+    "operand": "kv_fragment",
+    "options": {
+      "head_dim": 64,
+      "kv_bits": 8,
+      "tile_lanes": 16,
+      "stream_bytes_per_cycle": 128,
+      "score_bits": 48,
+      "value_bits": 16,
+      "softmax_weight_bits": 16,
+      "weighted_value_bits": 24,
+      "reducer_lanes": 16,
+      "stat_bits": 16,
+      "partials": 8,
+      "partials_per_cycle": 2,
+      "reducer_accum_bits": 40,
+      "counter_bits": 32,
+      "signed_inputs": true,
+      "signed_values": true
+    }
+  }]
+}

--- a/runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40_wrapper/config_attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40.json
+++ b/runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40_wrapper/config_attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [{"name": "kv_fragment", "dimensions": 1, "bit_width": 8, "signed": true, "kind": "int"}],
+  "operations": [{
+    "type": "attention_kv_full_value_tile",
+    "module_name": "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40",
+    "operand": "kv_fragment",
+    "options": {
+      "head_dim": 64,
+      "kv_bits": 8,
+      "tile_lanes": 16,
+      "stream_bytes_per_cycle": 128,
+      "score_bits": 48,
+      "value_bits": 16,
+      "softmax_weight_bits": 16,
+      "weighted_value_bits": 24,
+      "reducer_lanes": 16,
+      "stat_bits": 16,
+      "partials": 8,
+      "partials_per_cycle": 4,
+      "reducer_accum_bits": 40,
+      "counter_bits": 32,
+      "signed_inputs": true,
+      "signed_values": true
+    }
+  }]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -351,14 +351,17 @@ def identify_design(config):
             "signed_values": bool(options.get("signed_values", True)),
             "include_mg_cpa": False,
         }
-    if op_type == "attention_kv_tile_reducer_folded":
+    if op_type in {"attention_kv_tile_reducer_folded", "attention_kv_full_value_tile"}:
         options = entry.get("options", {})
         kv_bits = int(options.get("kv_bits", bit_width) or bit_width)
         head_dim = int(options.get("head_dim", 64))
         tile_lanes = int(options.get("tile_lanes", options.get("lanes", 16)))
         stream_bytes_per_cycle = int(options.get("stream_bytes_per_cycle", 256))
         score_bits = int(options.get("score_bits", options.get("tile_accum_bits", 48)))
-        value_bits = int(options.get("value_bits", 16))
+        raw_value_bits = int(options.get("value_bits", 16))
+        softmax_weight_bits = int(options.get("softmax_weight_bits", min(score_bits, 16)))
+        weighted_value_bits = int(options.get("weighted_value_bits", raw_value_bits))
+        reducer_value_bits = weighted_value_bits if op_type == "attention_kv_full_value_tile" else raw_value_bits
         stat_bits = int(options.get("stat_bits", 16))
         reducer_lanes = int(options.get("reducer_lanes", 16))
         partials = int(options.get("partials", 8))
@@ -366,25 +369,31 @@ def identify_design(config):
         reducer_accum_bits = int(options.get("reducer_accum_bits", 24))
         counter_bits = int(options.get("counter_bits", 32))
         if head_dim <= 0:
-            raise ValueError("attention_kv_tile_reducer_folded head_dim must be positive")
+            raise ValueError(f"{op_type} head_dim must be positive")
         if kv_bits <= 0:
-            raise ValueError("attention_kv_tile_reducer_folded kv_bits must be positive")
+            raise ValueError(f"{op_type} kv_bits must be positive")
         if tile_lanes <= 0 or tile_lanes > head_dim:
-            raise ValueError("attention_kv_tile_reducer_folded tile_lanes must be in [1, head_dim]")
+            raise ValueError(f"{op_type} tile_lanes must be in [1, head_dim]")
         if stream_bytes_per_cycle * 8 < tile_lanes * kv_bits * 2:
-            raise ValueError("attention_kv_tile_reducer_folded stream_bytes_per_cycle cannot carry query+key lane payload")
+            raise ValueError(f"{op_type} stream_bytes_per_cycle cannot carry query+key lane payload")
         if score_bits <= 0:
-            raise ValueError("attention_kv_tile_reducer_folded score_bits must be positive")
-        if value_bits <= 0 or stat_bits <= 0 or reducer_lanes <= 0:
-            raise ValueError("attention_kv_tile_reducer_folded reducer widths/lanes must be positive")
+            raise ValueError(f"{op_type} score_bits must be positive")
+        if raw_value_bits <= 0 or weighted_value_bits <= 0 or softmax_weight_bits <= 0:
+            raise ValueError(f"{op_type} value/weight widths must be positive")
+        if softmax_weight_bits > score_bits:
+            raise ValueError(f"{op_type} softmax_weight_bits cannot exceed score_bits")
+        if weighted_value_bits > raw_value_bits + softmax_weight_bits:
+            raise ValueError(f"{op_type} weighted_value_bits cannot exceed value*weight product width")
+        if stat_bits <= 0 or reducer_lanes <= 0:
+            raise ValueError(f"{op_type} reducer widths/lanes must be positive")
         if partials <= 1:
-            raise ValueError("attention_kv_tile_reducer_folded partials must be greater than one")
+            raise ValueError(f"{op_type} partials must be greater than one")
         if partials_per_cycle <= 0 or partials_per_cycle > partials or partials % partials_per_cycle:
-            raise ValueError("attention_kv_tile_reducer_folded partials_per_cycle must divide partials")
+            raise ValueError(f"{op_type} partials_per_cycle must divide partials")
         if reducer_accum_bits <= 0 or counter_bits <= 0:
-            raise ValueError("attention_kv_tile_reducer_folded accum/counter bits must be positive")
+            raise ValueError(f"{op_type} accum/counter bits must be positive")
         return {
-            "kind": "attention_kv_tile_reducer_folded",
+            "kind": op_type,
             "module_name": module_name,
             "wrapper_name": f"{module_name}_wrapper",
             "kv_bits": kv_bits,
@@ -393,13 +402,16 @@ def identify_design(config):
             "stream_bytes_per_cycle": stream_bytes_per_cycle,
             "score_bits": score_bits,
             "tile_fragment_width": tile_lanes * kv_bits,
-            "value_bits": value_bits,
+            "raw_value_bits": raw_value_bits,
+            "softmax_weight_bits": softmax_weight_bits,
+            "weighted_value_bits": weighted_value_bits,
+            "value_bits": reducer_value_bits,
             "stat_bits": stat_bits,
             "reducer_lanes": reducer_lanes,
             "partials": partials,
             "partials_per_cycle": partials_per_cycle,
             "reducer_accum_bits": reducer_accum_bits,
-            "value_width": partials_per_cycle * reducer_lanes * value_bits,
+            "value_width": partials_per_cycle * reducer_lanes * reducer_value_bits,
             "stat_width": partials_per_cycle * 2 * stat_bits,
             "reduced_value_width": reducer_lanes * reducer_accum_bits,
             "reduced_stat_width": 2 * stat_bits,
@@ -493,7 +505,7 @@ def main():
         ld_paths = [ld_library_path, onnxruntime_lib, env.get("LD_LIBRARY_PATH", "")]
         env["LD_LIBRARY_PATH"] = ":".join([p for p in ld_paths if p])
 
-        if design["kind"] in ("attention_kv_tile_reducer_folded", "l1_memory_noc_primitive"):
+        if design["kind"] in ("attention_kv_tile_reducer_folded", "attention_kv_full_value_tile", "l1_memory_noc_primitive"):
             generate_direct_design(config, src_dir, design, env)
         else:
             subprocess.run([locate_rtlgen_binary(), args.config], env=env, check=True)
@@ -553,7 +565,7 @@ def _slice_counter(name, width, counter_bits):
 
 
 def generate_direct_design(config, src_dir, design, env):
-    if design["kind"] == "attention_kv_tile_reducer_folded":
+    if design["kind"] in ("attention_kv_tile_reducer_folded", "attention_kv_full_value_tile"):
         generate_attention_tile_reducer_design(config, src_dir, design, env)
     elif design["kind"] == "l1_memory_noc_primitive":
         generate_l1_memory_noc_design(src_dir, design)
@@ -568,6 +580,7 @@ def generate_attention_tile_reducer_design(config, src_dir, design, env):
     operand_name = config.get("operands", [{"name": "operand"}])[0].get("name", "operand")
     signed_inputs = bool(design.get("signed_inputs", True))
     signed_values = bool(design.get("signed_values", True))
+    full_value_path = design["kind"] == "attention_kv_full_value_tile"
 
     tile_cfg = {
         "version": config.get("version", "1.1"),
@@ -625,15 +638,28 @@ def generate_attention_tile_reducer_design(config, src_dir, design, env):
         tile_text = (Path(tmp) / f"{tile_name}.v").read_text(encoding="utf-8")
         reducer_text = (Path(tmp) / f"{reducer_name}.v").read_text(encoding="utf-8")
 
+    value_product_w = int(design["softmax_weight_bits"]) + int(design["raw_value_bits"])
+    product_wires = []
     value_assigns = []
     for partial in range(design["partials_per_cycle"]):
         for lane in range(design["reducer_lanes"]):
             base = (partial * design["reducer_lanes"] + lane) * design["value_bits"]
             salt = (partial + 1) * 19 + lane
-            value_assigns.append(
-                f"          reducer_value_fragments[{base} +: VALUE_W] <= "
-                f"score_latched[VALUE_W-1:0] + {_slice_counter('chunk_index', design['value_bits'], design['counter_bits'])} + {salt};"
-            )
+            if full_value_path:
+                wire_name = f"weighted_value_p{partial}_l{lane}"
+                product_wires.append(
+                    f"  wire signed [PRODUCT_W-1:0] {wire_name} = "
+                    f"$signed(score_latched[WEIGHT_W-1:0]) * "
+                    f"$signed({_slice_counter('value_source_count', design['raw_value_bits'], design['counter_bits'])} + {design['raw_value_bits']}'sd{salt});"
+                )
+                value_assigns.append(
+                    f"          reducer_value_fragments[{base} +: VALUE_W] <= {wire_name}[VALUE_W-1:0];"
+                )
+            else:
+                value_assigns.append(
+                    f"          reducer_value_fragments[{base} +: VALUE_W] <= "
+                    f"score_latched[VALUE_W-1:0] + {_slice_counter('chunk_index', design['value_bits'], design['counter_bits'])} + {salt};"
+                )
     stat_assigns = []
     for partial in range(design["partials_per_cycle"]):
         base0 = partial * 2 * design["stat_bits"]
@@ -676,6 +702,9 @@ module {module_name}(
   localparam integer TILE_FRAGMENT_W = {design['tile_fragment_width']};
   localparam integer SCORE_W = {design['score_bits']};
   localparam integer VALUE_W = {design['value_bits']};
+  localparam integer RAW_VALUE_W = {design['raw_value_bits']};
+  localparam integer WEIGHT_W = {design['softmax_weight_bits']};
+  localparam integer PRODUCT_W = {value_product_w};
   localparam integer STAT_W = {design['stat_bits']};
   localparam integer VALUE_WIDTH = {design['value_width']};
   localparam integer STAT_WIDTH = {design['stat_width']};
@@ -700,6 +729,7 @@ module {module_name}(
   reg signed [SCORE_W-1:0] score_latched;
   reg [COUNT_W-1:0] chunk_index;
   reg [COUNT_W-1:0] group_index;
+  reg [COUNT_W-1:0] value_source_count;
   reg reducer_valid;
   reg [VALUE_WIDTH-1:0] reducer_value_fragments;
   reg [STAT_WIDTH-1:0] reducer_stat_fragments;
@@ -707,6 +737,8 @@ module {module_name}(
   wire [COUNT_W-1:0] reducer_cycle_count;
   wire [COUNT_W-1:0] reducer_final_completion_cycle;
   wire [COUNT_W-1:0] reducer_final_completion_cycle_wire = reducer_final_completion_cycle;
+
+{chr(10).join(product_wires)}
 
   {tile_name} tile (
     .clk(clk),
@@ -760,6 +792,7 @@ module {module_name}(
       score_latched <= {{SCORE_W{{1'b0}}}};
       chunk_index <= {{COUNT_W{{1'b0}}}};
       group_index <= {{COUNT_W{{1'b0}}}};
+      value_source_count <= {{COUNT_W{{1'b0}}}};
       reducer_valid <= 1'b0;
       reducer_value_fragments <= {{VALUE_WIDTH{{1'b0}}}};
       reducer_stat_fragments <= {{STAT_WIDTH{{1'b0}}}};
@@ -791,6 +824,7 @@ module {module_name}(
         end else begin
           chunk_index <= chunk_index + {{{{(COUNT_W-1){{1'b0}}}}, 1'b1}};
         end
+        value_source_count <= value_source_count + {{{{(COUNT_W-1){{1'b0}}}}, 1'b1}};
       end else if (reducer_valid && reducer_ready) begin
         reducer_valid <= 1'b0;
       end
@@ -1526,7 +1560,7 @@ module {wrapper_name}(
 
 endmodule
 """
-    elif design["kind"] == "attention_kv_tile_reducer_folded":
+    elif design["kind"] in ("attention_kv_tile_reducer_folded", "attention_kv_full_value_tile"):
         reduced_value_width = int(design["reduced_value_width"])
         reduced_stat_width = int(design["reduced_stat_width"])
         counter_bits = int(design["counter_bits"])

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -140,6 +140,7 @@ def read_design_names(config_path: Path) -> Tuple[str, str]:
             "attention_kv_reducer_tree",
             "attention_kv_reducer_folded",
             "attention_kv_tile_reducer_folded",
+            "attention_kv_full_value_tile",
             "l1_memory_noc_primitive",
         ):
             raise ValueError(f"Unsupported single-operation design type in {config_path}: {entry['type']}")

--- a/tests/test_l1_attention_compose.sh
+++ b/tests/test_l1_attention_compose.sh
@@ -23,6 +23,23 @@ python3 "$ROOT/scripts/run_sweep.py" \
   --dry_run
 
 python3 "$ROOT/scripts/generate_design.py" \
+  "$ROOT/examples/config_attention_kv_full_value_tile.json" \
+  nangate45 \
+  --force_gen True
+
+iverilog -g2012 \
+  -s attention_kv_full_value_hd8_kv4_tl4_b16_p4_ppc2_w16_a24_wrapper \
+  -t null \
+  /orfs/flow/designs/src/attention_kv_full_value_hd8_kv4_tl4_b16_p4_ppc2_w16_a24_wrapper/*.v
+
+python3 "$ROOT/scripts/run_sweep.py" \
+  --configs "$ROOT/examples/config_attention_kv_full_value_tile.json" \
+  --platform nangate45 \
+  --sweep "$ROOT/runs/campaigns/activations/attention_kv_full_value_tile/sweeps/nangate45_macro_frontier.json" \
+  --out_root "$TMP/runs" \
+  --dry_run
+
+python3 "$ROOT/scripts/generate_design.py" \
   "$ROOT/examples/config_l1_memory_noc_primitive.json" \
   nangate45 \
   --force_gen True


### PR DESCRIPTION
## Summary
- add `attention_kv_full_value_tile`, a direct generated L1 attention tile that includes explicit softmax-weight-by-value products feeding the folded reducer
- add KV8 full-value hd64/hd128 configs plus a Nangate45 macro sweep
- add proposal `prop_l1_decoder_attention_full_value_tile_v1` for the next L1 PPA job

## Validation
- `python3 -m py_compile scripts/generate_design.py scripts/run_sweep.py control_plane/control_plane/services/l1_task_generator.py`
- `bash tests/test_l1_attention_compose.sh`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
- dry-run sweep over the three real full-value configs
- generated and compiled `attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper` with `iverilog -g2012 -t null`