### PR TITLE
control-plane: sync absolute completion target artifacts

### DIFF
--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -30,6 +30,7 @@ from control_plane.workers.executor import (
     _active_command_manifest,
     _active_expected_outputs,
     _next_trial_index,
+    _sync_completion_artifacts_to_repo,
 )
 
 
@@ -504,6 +505,35 @@ def test_worker_daemon_syncs_expected_outputs_before_immediate_completion() -> N
         assert process_completed.call_count == 1
         assert (repo_root / "control_plane" / "shadow_exports" / "review" / "daemon_item_sync_before_completion" / "evaluated.json").exists()
         assert (repo_root / "control_plane" / "shadow_exports" / "frozen_review" / "daemon_item_sync_before_completion" / "run_001" / "evidence.json").exists()
+
+
+def test_sync_completion_artifacts_accepts_absolute_checkout_target_path() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        checkout_root = Path(td) / "checkout"
+        repo_root = Path(td) / "repo"
+        checkout_root.mkdir()
+        repo_root.mkdir()
+
+        item_id = "daemon_item_absolute_promotion"
+        promotion_path = (
+            checkout_root
+            / "control_plane"
+            / "shadow_exports"
+            / "l1_promotions"
+            / f"{item_id}.json"
+        )
+        promotion_path.parent.mkdir(parents=True, exist_ok=True)
+        promotion_path.write_text('{"proposal": true}\n', encoding="utf-8")
+
+        _sync_completion_artifacts_to_repo(
+            checkout_root=str(checkout_root),
+            repo_root=str(repo_root),
+            item_id=item_id,
+            target_path=str(promotion_path),
+        )
+
+        copied = repo_root / "control_plane" / "shadow_exports" / "l1_promotions" / f"{item_id}.json"
+        assert copied.read_text(encoding="utf-8") == '{"proposal": true}\n'
 
 
 def test_worker_daemon_immediately_processes_completion_for_supported_items() -> None:

--- a/control_plane/control_plane/workers/executor.py
+++ b/control_plane/control_plane/workers/executor.py
@@ -440,6 +440,17 @@ def _sync_completion_artifacts_to_repo(
     if source_root == target_root:
         return
 
+    def _source_relative(path_text: str) -> str | None:
+        path = Path(str(path_text).strip())
+        if not str(path):
+            return None
+        if not path.is_absolute():
+            return str(path)
+        try:
+            return str(path.resolve().relative_to(source_root))
+        except ValueError:
+            return None
+
     def _copy_file(rel_path: str) -> None:
         source_path = (source_root / rel_path).resolve()
         if not source_path.exists() or not source_path.is_file():
@@ -461,7 +472,9 @@ def _sync_completion_artifacts_to_repo(
             _copy_file(rel_path)
 
     if target_path:
-        _copy_file(str(target_path))
+        rel_target_path = _source_relative(str(target_path))
+        if rel_target_path:
+            _copy_file(rel_target_path)
     _copy_tree(f'control_plane/shadow_exports/review/{item_id}')
     _copy_tree(f'control_plane/shadow_exports/frozen_review/{item_id}')
     _copy_tree(f'control_plane/shadow_exports/l1_trials/{item_id}')


### PR DESCRIPTION
## Summary
- normalize absolute completion target paths back to checkout-relative paths before copying artifacts into the service repo
- add regression coverage for the L1 promotion JSON path produced from a temporary checkout

## Why
The full-value tile run completed, but immediate completion wrote `target_path` as an absolute path under a temporary checkout. `_sync_completion_artifacts_to_repo` treated that as repo-relative, so the L1 promotion JSON was not copied back to the daemon repo. The resolver then reported `missing promotion_proposal review file`.

## Validation
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_worker_daemon.py -k 'absolute_checkout_target_path or syncs_expected_outputs_before_immediate_completion or immediately_processes_completion'`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m py_compile control_plane/control_plane/workers/executor.py control_plane/control_plane/tests/test_worker_daemon.py`
- `git diff --check`