### PR TITLE
Relax full-value L2 dependency materialization gate

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_full_value_l1_clustered_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_full_value_l1_clustered_schedule_v1/proposal.json
@@ -51,7 +51,7 @@
         "l2_decoder_attention_kv_measured_l1_clustered_schedule_v1"
       ],
       "requires_merged_inputs": true,
-      "requires_materialized_refs": true,
+      "requires_materialized_refs": false,
       "expected_result": {
         "direction": "iterate",
         "reason": "Use the full-value measured-L1 schedule frontier to choose the next concrete attention memory/NoC integration point."


### PR DESCRIPTION
## Summary
- keep the full-value L2 schedule dependent on the merged folded baseline and full-value L1 run
- remove the materialized-ref requirement because the folded baseline's legacy DB artifact row points at a non-committed decision proposal file that the new estimator does not consume

## Validation
- python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_full_value_l1_clustered_schedule_v1/proposal.json
- python3 scripts/validate_runs.py --skip_eval_queue