### PR TITLE
Add Llama7B attention SRAM profile closure job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3923,6 +3923,45 @@ def _decoder_attention_kv_full_value_l1_clustered_schedule_evidence(*, item_id: 
     }
 
 
+def _decoder_attention_sram_profile_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_sram_profile__{item_id}.json"
+    report = f"{base}/decoder_attention_sram_profile__{item_id}.md"
+    arch = f"runs/designs/sram/llama7b_attention_tile_buffers_v1/arch.yml"
+    sram_metrics = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json"
+    sram_summary = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics_summary.json"
+    return {
+        "inputs": {
+            "attention_sram_profile_out": out,
+            "attention_sram_profile_report": report,
+            "attention_sram_profile_arch": arch,
+            "attention_sram_metrics_json": sram_metrics,
+            "attention_sram_metrics_summary_json": sram_summary,
+            "attention_sram_profile_scope": (
+                "Measure the selected Llama7B 131k tile-local attention SRAM quantities for "
+                "score buffering, softmax weights, staged K/V reads, partial-value buffering, "
+                "and result writeback. This closes tile-local SRAM access/energy inputs for "
+                "the clustered schedule; full KV-cache capacity placement and NoC contention "
+                "remain separate closure items."
+            ),
+        },
+        "commands": [
+            {
+                "name": "measure_decoder_attention_sram_profile",
+                "run": (
+                    "python3 npu/eval/measure_llm_decoder_attention_sram_profile.py "
+                    f"--out {out} "
+                    f"--report {report} "
+                    f"--arch-out {arch} "
+                    "--sram-id llama7b_attention_tile_buffers_v1 "
+                    "--run-cacti"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report, arch, sram_metrics, sram_summary],
+    }
+
+
 def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
@@ -5429,6 +5468,7 @@ def _build_payload(
         "decoder_attention_kv_clustered_schedule_overhead",
         "decoder_attention_kv_measured_l1_clustered_schedule",
         "decoder_attention_kv_full_value_l1_clustered_schedule",
+        "decoder_attention_sram_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
@@ -5504,6 +5544,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_measured_l1_clustered_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_full_value_l1_clustered_schedule":
             decoder_evidence = _decoder_attention_kv_full_value_l1_clustered_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_sram_profile":
+            decoder_evidence = _decoder_attention_sram_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -4953,3 +4953,42 @@ def test_generate_l2_campaign_task_rejects_source_commit_not_pushed_to_origin() 
                 assert "not reachable from origin" in str(exc)
             else:
                 raise AssertionError("expected Layer2TaskGenerationError")
+
+
+def test_generate_l2_campaign_task_adds_attention_sram_profile_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_sram_profile_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_sram_profile",
+                    evaluation_mode="profile_measurement",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+
+            assert "measure_decoder_attention_sram_profile" in command_names
+            assert "attention_sram_metrics_json" in decoder_inputs
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith("decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json")
+                for output in expected_outputs
+            )
+            assert "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json" in expected_outputs

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -27,8 +27,9 @@ than free or heuristic assumptions.
 2. SRAM timing and energy
    - Scope: tile-local score/value buffering, KV tile reads, partial-value
      buffering, and result writeback.
-   - First measurement: SRAM primitive/profile sweep at the tile-buffer widths
-     used by the selected frontier.
+   - First measurement: `l2_decoder_attention_sram_profile_v1`, which records
+     the selected 512-token tile-local buffer bytes and CACTI-backed SRAM
+     access time, area, read energy, and write energy.
    - First L2 consumer: replace ideal local/shared SRAM access latency and
      energy with measured bandwidth, access-time, and capacity profiles.
 

--- a/docs/proposals/prop_l2_decoder_attention_sram_profile_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_sram_profile_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_sram_profile_v1",
+  "created_utc": "2026-06-02T05:35:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_sram_profile",
+  "title": "Llama7B attention tile-local SRAM profile",
+  "hypothesis": "The selected Llama7B 131k clustered-attention frontier should charge tile-local SRAM access time, energy, and area using measured SRAM macro estimates rather than ideal local/shared buffer assumptions.",
+  "direct_comparison": {
+    "primary_question": "What are the concrete tile-local SRAM quantities and CACTI-backed access metrics for score buffering, softmax weights, staged K/V reads, partial values, and result writeback at the selected 512-token Llama7B attention tile?",
+    "include": [
+      "Llama7B proxy hidden size 4096, 32 attention heads, 4 KV heads, and 512-token tiles",
+      "score and softmax-weight buffers at 16 bits per head per tile token",
+      "K/V tile read staging at KV8 for the selected KV sharing",
+      "partial-value and result writeback buffers for the full 4096-wide token output",
+      "CACTI-backed SRAM access time, area, read energy, and write energy where CACTI is available"
+    ],
+    "exclude": [
+      "full 131k-token KV-cache residency allocation",
+      "HBM controller service",
+      "cycle-accurate NoC arbitration",
+      "placed SRAM compiler macro floorplanning"
+    ]
+  },
+  "expected_benefit": [
+    "turns the tile-local SRAM abstraction into explicit bytes and measured access metrics",
+    "provides a measured-cost input for the integrated full-value plus softmax clustered schedule",
+    "keeps the remaining KV-capacity and NoC-contention abstractions separate and auditable"
+  ],
+  "risks": [
+    "CACTI estimates are not a replacement for foundry SRAM compiler macros",
+    "tile-local SRAM is only one part of the memory hierarchy; whole-KV cache placement remains an L2 architecture decision",
+    "the chosen 256-bit SRAM bank width is a profile target, not proof of final physical banking"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_sram_profile_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure the Llama7B attention tile-local SRAM profile and publish logical buffer quantities plus CACTI SRAM metrics.",
+      "evaluation_mode": "profile_measurement",
+      "abstraction_layer": "decoder_attention_sram_profile",
+      "cost_class": "low",
+      "comparison_role": "abstraction_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_full_value_l1_clustered_schedule_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_full_value_l1_clustered_schedule_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_abstraction",
+        "reason": "Use the measured SRAM profile to replace ideal tile-local SRAM access/energy inputs in the final Llama7B attention schedule closure."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_full_value_l1_clustered_schedule__l2_decoder_attention_kv_full_value_l1_clustered_schedule_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "npu/eval/measure_llm_decoder_attention_sram_profile.py",
+    "npu/synth/sram_ppa.py",
+    "npu/synth/aggregate_sram_metrics.py"
+  ]
+}

--- a/npu/eval/measure_llm_decoder_attention_sram_profile.py
+++ b/npu/eval/measure_llm_decoder_attention_sram_profile.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Build a measured SRAM profile target for Llama7B decoder attention."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.synth.aggregate_sram_metrics import summarize_metrics  # noqa: E402
+
+
+JsonDict = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BufferSpec:
+    name: str
+    scope: str
+    logical_bytes: int
+    word_bits: int
+    banks: int
+    depth: int
+    width_bits: int
+    access_role: str
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    return (numerator + denominator - 1) // denominator
+
+
+def _next_power_of_two(value: int) -> int:
+    if value <= 1:
+        return 1
+    return 1 << (value - 1).bit_length()
+
+
+def _round_sram_shape(*, logical_bytes: int, preferred_word_bits: int, max_bank_width_bits: int) -> tuple[int, int, int]:
+    word_bits = min(preferred_word_bits, max_bank_width_bits)
+    word_bytes = max(1, word_bits // 8)
+    words = _ceil_div(logical_bytes, word_bytes)
+    depth = _next_power_of_two(words)
+    return 1, depth, word_bits
+
+
+def build_buffer_specs(
+    *,
+    tile_tokens: int,
+    hidden_size: int,
+    attention_heads: int,
+    kv_heads: int,
+    score_bits: int,
+    softmax_weight_bits: int,
+    kv_bits: int,
+    accumulator_bits: int,
+    output_bits: int,
+    max_bank_width_bits: int,
+) -> list[BufferSpec]:
+    head_dim = hidden_size // attention_heads
+    per_token_kv_bits = kv_heads * head_dim * kv_bits
+    logical_specs = [
+        (
+            "score_tile_buffer",
+            "tile-local score buffering before softmax",
+            tile_tokens * attention_heads * score_bits // 8,
+            attention_heads * score_bits,
+            "read_write",
+        ),
+        (
+            "softmax_weight_buffer",
+            "normalized softmax weights consumed by value accumulation",
+            tile_tokens * attention_heads * softmax_weight_bits // 8,
+            attention_heads * softmax_weight_bits,
+            "read_write",
+        ),
+        (
+            "kv_tile_read_buffer",
+            "tile-local K and V read staging for the selected KV sharing",
+            2 * tile_tokens * per_token_kv_bits // 8,
+            min(max_bank_width_bits, per_token_kv_bits),
+            "read",
+        ),
+        (
+            "partial_value_buffer",
+            "per-head partial value vector before cross-tile reduction",
+            hidden_size * accumulator_bits // 8,
+            max_bank_width_bits,
+            "read_write",
+        ),
+        (
+            "result_writeback_buffer",
+            "final attention output writeback staging",
+            hidden_size * output_bits // 8,
+            max_bank_width_bits,
+            "write",
+        ),
+        (
+            "softmax_stats_buffer",
+            "per-head max and sum statistics for stable normalization",
+            attention_heads * 2 * accumulator_bits // 8,
+            max_bank_width_bits,
+            "read_write",
+        ),
+    ]
+
+    buffers: list[BufferSpec] = []
+    for name, scope, logical_bytes, preferred_word_bits, access_role in logical_specs:
+        banks, depth, width_bits = _round_sram_shape(
+            logical_bytes=max(1, int(logical_bytes)),
+            preferred_word_bits=max(8, int(preferred_word_bits)),
+            max_bank_width_bits=max_bank_width_bits,
+        )
+        buffers.append(
+            BufferSpec(
+                name=name,
+                scope=scope,
+                logical_bytes=int(logical_bytes),
+                word_bits=int(preferred_word_bits),
+                banks=banks,
+                depth=depth,
+                width_bits=width_bits,
+                access_role=access_role,
+            )
+        )
+    return buffers
+
+
+def arch_payload(*, buffers: list[BufferSpec], pdk: str, tech_node_nm: int) -> JsonDict:
+    return {
+        "schema_version": "0.2-draft",
+        "platform": {
+            "target_pdk": pdk,
+            "tech_node_nm": tech_node_nm,
+        },
+        "memory": {
+            "instances": [
+                {
+                    "name": buffer.name,
+                    "depth": buffer.depth,
+                    "width": buffer.width_bits,
+                    "banks": buffer.banks,
+                    "port": "1r1w",
+                }
+                for buffer in buffers
+            ]
+        },
+    }
+
+
+def _write_report(payload: JsonDict, report_path: Path) -> None:
+    lines = [
+        "# Llama7B Attention SRAM Profile",
+        "",
+        "## Logical Buffers",
+        "",
+        "| buffer | scope | logical bytes | SRAM shape | role |",
+        "|---|---|---:|---|---|",
+    ]
+    for buffer in payload["buffers"]:
+        shape = f"{buffer['banks']} x depth {buffer['depth']} x width {buffer['width_bits']}"
+        lines.append(
+            f"| {buffer['name']} | {buffer['scope']} | {buffer['logical_bytes']} | {shape} | {buffer['access_role']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Totals",
+            "",
+            f"- logical_buffer_bytes: `{payload['totals']['logical_buffer_bytes']}`",
+            f"- allocated_sram_bytes: `{payload['totals']['allocated_sram_bytes']}`",
+            f"- capacity_overhead: `{payload['totals']['capacity_overhead']}`",
+        ]
+    )
+    metrics = payload.get("sram_metrics_summary")
+    if metrics:
+        lines.extend(
+            [
+                "",
+                "## CACTI Summary",
+                "",
+                f"- total_area_um2: `{metrics.get('total_area_um2')}`",
+                f"- max_access_time_ns: `{metrics.get('max_access_time_ns')}`",
+                f"- total_read_energy_pj: `{metrics.get('total_read_energy_pj')}`",
+                f"- total_write_energy_pj: `{metrics.get('total_write_energy_pj')}`",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "- This profile measures tile-local buffering only; the full 131k-token KV cache residency remains a higher-level memory-capacity decision.",
+            "- SRAM shapes are banked logical targets for CACTI and are not a placed SRAM macro floorplan.",
+        ]
+    )
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_profile_payload(
+    *,
+    buffers: list[BufferSpec],
+    args: argparse.Namespace,
+    sram_metrics_summary: JsonDict | None,
+    sram_metrics_json: str | None,
+) -> JsonDict:
+    allocated_bytes = sum(buffer.banks * buffer.depth * buffer.width_bits // 8 for buffer in buffers)
+    logical_bytes = sum(buffer.logical_bytes for buffer in buffers)
+    return {
+        "version": 1,
+        "model": "llama7b_proxy",
+        "profile": "decoder_attention_sram_profile",
+        "parameters": {
+            "sequence_length": args.sequence_length,
+            "tile_tokens": args.tile_tokens,
+            "hidden_size": args.hidden_size,
+            "attention_heads": args.attention_heads,
+            "kv_heads": args.kv_heads,
+            "head_dim": args.hidden_size // args.attention_heads,
+            "score_bits": args.score_bits,
+            "softmax_weight_bits": args.softmax_weight_bits,
+            "kv_bits": args.kv_bits,
+            "accumulator_bits": args.accumulator_bits,
+            "output_bits": args.output_bits,
+            "max_bank_width_bits": args.max_bank_width_bits,
+        },
+        "buffers": [asdict(buffer) for buffer in buffers],
+        "totals": {
+            "logical_buffer_bytes": logical_bytes,
+            "allocated_sram_bytes": allocated_bytes,
+            "capacity_overhead": round(allocated_bytes / logical_bytes, 6) if logical_bytes else None,
+        },
+        "sram_metrics_json": sram_metrics_json,
+        "sram_metrics_summary": sram_metrics_summary,
+        "remaining_abstractions": [
+            "CACTI SRAM estimates are macro-level access/energy estimates, not placed SRAM compiler macros.",
+            "The full KV cache capacity and HBM service are not included in this tile-local profile.",
+            "NoC arbitration and contention are measured by a separate closure item.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--arch-out", required=True, type=Path)
+    parser.add_argument("--sram-id", default="llama7b_attention_tile_buffers_v1")
+    parser.add_argument("--sequence-length", type=int, default=131072)
+    parser.add_argument("--tile-tokens", type=int, default=512)
+    parser.add_argument("--hidden-size", type=int, default=4096)
+    parser.add_argument("--attention-heads", type=int, default=32)
+    parser.add_argument("--kv-heads", type=int, default=4)
+    parser.add_argument("--score-bits", type=int, default=16)
+    parser.add_argument("--softmax-weight-bits", type=int, default=16)
+    parser.add_argument("--kv-bits", type=int, default=8)
+    parser.add_argument("--accumulator-bits", type=int, default=32)
+    parser.add_argument("--output-bits", type=int, default=16)
+    parser.add_argument("--max-bank-width-bits", type=int, default=256)
+    parser.add_argument("--pdk", default="nangate45")
+    parser.add_argument("--tech-node-nm", type=int, default=45)
+    parser.add_argument("--run-cacti", action="store_true")
+    args = parser.parse_args()
+
+    if args.hidden_size % args.attention_heads != 0:
+        raise SystemExit("--hidden-size must be divisible by --attention-heads")
+    if args.max_bank_width_bits % 8 != 0:
+        raise SystemExit("--max-bank-width-bits must be a multiple of 8")
+
+    buffers = build_buffer_specs(
+        tile_tokens=args.tile_tokens,
+        hidden_size=args.hidden_size,
+        attention_heads=args.attention_heads,
+        kv_heads=args.kv_heads,
+        score_bits=args.score_bits,
+        softmax_weight_bits=args.softmax_weight_bits,
+        kv_bits=args.kv_bits,
+        accumulator_bits=args.accumulator_bits,
+        output_bits=args.output_bits,
+        max_bank_width_bits=args.max_bank_width_bits,
+    )
+
+    args.arch_out.parent.mkdir(parents=True, exist_ok=True)
+    args.arch_out.write_text(yaml.safe_dump(arch_payload(buffers=buffers, pdk=args.pdk, tech_node_nm=args.tech_node_nm), sort_keys=False), encoding="utf-8")
+
+    sram_metrics_summary = None
+    sram_metrics_json = None
+    if args.run_cacti:
+        subprocess.run(
+            [
+                sys.executable,
+                "npu/synth/sram_ppa.py",
+                str(args.arch_out),
+                "--id",
+                args.sram_id,
+            ],
+            cwd=_REPO_ROOT,
+            check=True,
+        )
+        metrics_path = Path("runs/designs/sram") / args.sram_id / "sram_metrics.json"
+        sram_metrics_json = str(metrics_path)
+        sram_metrics_summary = summarize_metrics(_REPO_ROOT / metrics_path)
+        summary_path = _REPO_ROOT / "runs/designs/sram" / args.sram_id / "sram_metrics_summary.json"
+        summary_path.write_text(json.dumps(sram_metrics_summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    payload = build_profile_payload(
+        buffers=buffers,
+        args=args,
+        sram_metrics_summary=sram_metrics_summary,
+        sram_metrics_json=sram_metrics_json,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_attention_sram_profile.py
+++ b/tests/test_llm_decoder_attention_sram_profile.py
@@ -1,0 +1,51 @@
+from npu.eval.measure_llm_decoder_attention_sram_profile import build_buffer_specs
+
+
+def test_attention_sram_profile_default_logical_quantities() -> None:
+    buffers = build_buffer_specs(
+        tile_tokens=512,
+        hidden_size=4096,
+        attention_heads=32,
+        kv_heads=4,
+        score_bits=16,
+        softmax_weight_bits=16,
+        kv_bits=8,
+        accumulator_bits=32,
+        output_bits=16,
+        max_bank_width_bits=256,
+    )
+
+    by_name = {buffer.name: buffer for buffer in buffers}
+
+    assert by_name["score_tile_buffer"].logical_bytes == 512 * 32 * 2
+    assert by_name["softmax_weight_buffer"].logical_bytes == 512 * 32 * 2
+    assert by_name["kv_tile_read_buffer"].logical_bytes == 2 * 512 * 4 * 128
+    assert by_name["partial_value_buffer"].logical_bytes == 4096 * 4
+    assert by_name["result_writeback_buffer"].logical_bytes == 4096 * 2
+    assert by_name["softmax_stats_buffer"].logical_bytes == 32 * 2 * 4
+
+
+def test_attention_sram_profile_shapes_are_cacti_friendly() -> None:
+    buffers = build_buffer_specs(
+        tile_tokens=512,
+        hidden_size=4096,
+        attention_heads=32,
+        kv_heads=4,
+        score_bits=16,
+        softmax_weight_bits=16,
+        kv_bits=8,
+        accumulator_bits=32,
+        output_bits=16,
+        max_bank_width_bits=256,
+    )
+
+    for buffer in buffers:
+        assert buffer.width_bits % 8 == 0
+        assert buffer.depth > 0
+        assert buffer.depth & (buffer.depth - 1) == 0
+        assert buffer.banks >= 1
+
+    total_logical = sum(buffer.logical_bytes for buffer in buffers)
+    total_allocated = sum(buffer.banks * buffer.depth * buffer.width_bits // 8 for buffer in buffers)
+    assert total_allocated >= total_logical
+    assert total_allocated / total_logical < 1.1


### PR DESCRIPTION
Adds the next abstraction-closure source job after softmax: a Llama7B attention tile-local SRAM profile.

What it adds:
- deterministic SRAM profile script for selected 512-token Llama7B attention tile buffers
- exact logical quantities: 32 KiB score buffer, 32 KiB softmax weights, 512 KiB staged K/V, 16 KiB partial value, 8 KiB result writeback, 256 B softmax stats
- CACTI-backed evidence command through the L2 task generator
- proposal `prop_l2_decoder_attention_sram_profile_v1` and closure-plan wording
- focused tests for SRAM quantities and control-plane task payload wiring

Verification:
- `PYTHONPATH=/tmp/rtlgen-dispatch-l2/control_plane:/tmp/rtlgen-dispatch-l2 /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_attention_sram_profile.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_sram_profile_evidence`
- `PYTHONPATH=/tmp/rtlgen-dispatch-l2/control_plane:/tmp/rtlgen-dispatch-l2 /workspaces/RTLGen/control_plane/.venv/bin/python -m compileall npu/eval/measure_llm_decoder_attention_sram_profile.py control_plane/control_plane/services/l2_task_generator.py`
