### PR TITLE
Add Llama7B attention NoC profile closure job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3962,6 +3962,39 @@ def _decoder_attention_sram_profile_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
+    report = f"{base}/decoder_attention_noc_profile__{item_id}.md"
+    primitive_profile = "control_plane/shadow_exports/l1_promotions/l1_decoder_memory_noc_primitives_v1.json"
+    return {
+        "inputs": {
+            "attention_noc_profile_out": out,
+            "attention_noc_profile_report": report,
+            "attention_noc_primitive_profile": primitive_profile,
+            "attention_noc_profile_scope": (
+                "Quantify selected Llama7B attention NoC traffic for shared tile reads, "
+                "cross-tile reduction, and KV writeback using measured FIFO/router PPA "
+                "anchors plus explicit flit width, hop, virtual-channel, and arbitration "
+                "efficiency bounds. This closes the hidden bandwidth/hop proxy terms for "
+                "the final schedule, while leaving full routed NoC RTL as a named residual."
+            ),
+        },
+        "commands": [
+            {
+                "name": "measure_decoder_attention_noc_profile",
+                "run": (
+                    "python3 npu/eval/measure_llm_decoder_attention_noc_profile.py "
+                    "--repo-root . "
+                    f"--out {out} "
+                    f"--report {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_quality_gate_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_quality_gate__{item_id}.json"
@@ -5469,6 +5502,7 @@ def _build_payload(
         "decoder_attention_kv_measured_l1_clustered_schedule",
         "decoder_attention_kv_full_value_l1_clustered_schedule",
         "decoder_attention_sram_profile",
+        "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
         "decoder_attention_kv_native_gqa_proxy",
@@ -5546,6 +5580,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_full_value_l1_clustered_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_sram_profile":
             decoder_evidence = _decoder_attention_sram_profile_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_noc_profile":
+            decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":
             decoder_evidence = _decoder_attention_kv_quality_gate_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_proxy":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -4992,3 +4992,41 @@ def test_generate_l2_campaign_task_adds_attention_sram_profile_evidence() -> Non
                 for output in expected_outputs
             )
             assert "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json" in expected_outputs
+
+
+def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_noc_profile_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_noc_profile",
+                    evaluation_mode="profile_measurement",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+
+            assert "measure_decoder_attention_noc_profile" in command_names
+            assert "attention_noc_primitive_profile" in decoder_inputs
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith("decoder_attention_noc_profile__l2_decoder_attention_noc_profile_v1.json")
+                for output in expected_outputs
+            )

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -36,10 +36,13 @@ than free or heuristic assumptions.
 3. NoC arbitration and contention
    - Scope: per-cluster local router/fifo cost is already measured, but current
      schedule still uses bandwidth divided by hop count for contention.
-   - First measurement: routed multi-source arbitration microbenchmarks for the
-     selected 128-bit and 256-bit local paths.
-   - First L2 consumer: replace the bandwidth/hop proxy with measured effective
-     payload/cycle and arbitration latency under producer/reducer traffic mixes.
+   - First measurement: `l2_decoder_attention_noc_profile_v1`, which records
+     selected shared-tile, cross-tile reduction, and KV-write traffic bytes,
+     flits, and service-cycle bounds for the measured 128-bit and 256-bit
+     FIFO/router primitive anchors.
+   - First L2 consumer: replace hidden bandwidth/hop proxy terms with explicit
+     payload/cycle and arbitration-latency bounds under the selected
+     producer/reducer traffic mix.
 
 4. Integrated schedule closure
    - Scope: rerun the Llama7B attention schedule with measured compute,

--- a/docs/proposals/prop_l2_decoder_attention_noc_profile_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_noc_profile_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_noc_profile_v1",
+  "created_utc": "2026-06-02T05:50:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_noc_profile",
+  "title": "Llama7B attention NoC traffic profile",
+  "hypothesis": "The selected Llama7B 131k clustered-attention schedule should expose shared-tile, cross-tile reduction, and KV-write NoC service quantities rather than hiding them behind a bandwidth divided by hop-count proxy.",
+  "direct_comparison": {
+    "primary_question": "For the selected 512-token, 8-cluster Llama7B attention frontier, what NoC payload bytes, flits, and service-cycle bounds apply under 128/256-bit paths, hop counts, virtual channels, and arbitration efficiencies?",
+    "include": [
+      "selected Llama7B proxy hidden size 4096, 32 attention heads, 4 KV heads, and 512-token tiles",
+      "shared tile payload derived from the current best shared-byte fraction",
+      "cross-tile reduction payload for cluster-tree/owner-cluster style partial reductions",
+      "KV writeback payload",
+      "128-bit and 256-bit measured FIFO/router primitive references",
+      "hop, virtual-channel, and arbitration-efficiency service bounds"
+    ],
+    "exclude": [
+      "cycle-accurate routed NoC RTL simulation",
+      "adaptive routing and topology floorplan",
+      "wire delay extraction",
+      "SRAM capacity placement decisions"
+    ]
+  },
+  "expected_benefit": [
+    "turns NoC traffic and service assumptions into explicit rows consumed by the final schedule closure",
+    "keeps measured router/FIFO PPA references attached to the service profile",
+    "bounds the sensitivity of the selected frontier to NoC arbitration efficiency and hop count"
+  ],
+  "risks": [
+    "effective payload/cycle remains a bounded service model, not full NoC RTL",
+    "the shared-byte fraction comes from the current selected frontier and must be regenerated if the memory frontier moves",
+    "wire delay and physical topology can still change final NoC timing"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_noc_profile_v1",
+      "task_type": "l2_campaign",
+      "objective": "Quantify selected Llama7B attention NoC traffic payloads, flits, and service-cycle bounds using measured FIFO/router primitive references.",
+      "evaluation_mode": "profile_measurement",
+      "abstraction_layer": "decoder_attention_noc_profile",
+      "cost_class": "low",
+      "comparison_role": "abstraction_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_full_value_l1_clustered_schedule_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_full_value_l1_clustered_schedule_v1",
+        "l1_decoder_memory_noc_primitives_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_abstraction",
+        "reason": "Use the measured NoC traffic profile to replace hidden bandwidth/hop proxy terms in the final Llama7B attention schedule closure."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_full_value_l1_clustered_schedule__l2_decoder_attention_kv_full_value_l1_clustered_schedule_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_memory_noc_primitives_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "npu/eval/measure_llm_decoder_attention_noc_profile.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py"
+  ]
+}

--- a/npu/eval/measure_llm_decoder_attention_noc_profile.py
+++ b/npu/eval/measure_llm_decoder_attention_noc_profile.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Build a bounded NoC service profile for Llama7B decoder attention."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+
+def _ceil_div(numerator: float, denominator: float) -> int:
+    return int(math.ceil(float(numerator) / float(denominator)))
+
+
+def _float_list(value: str) -> list[float]:
+    return [float(item.strip()) for item in value.split(",") if item.strip()]
+
+
+def _int_list(value: str) -> list[int]:
+    return [int(item.strip()) for item in value.split(",") if item.strip()]
+
+
+def _load_best_metrics(metrics_csv: Path) -> JsonDict | None:
+    if not metrics_csv.exists():
+        return None
+    with metrics_csv.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    ok_rows = [row for row in rows if row.get("status") == "ok"]
+    if not ok_rows:
+        return None
+    best = min(
+        ok_rows,
+        key=lambda row: (
+            float(row["critical_path_ns"]),
+            float(row["die_area"]),
+            float(row["total_power_mw"]),
+        ),
+    )
+    return {
+        "metrics_csv": str(metrics_csv),
+        "critical_path_ns": float(best["critical_path_ns"]),
+        "area_um2": float(best["die_area"]),
+        "power_mw": float(best["total_power_mw"]),
+        "tag": best.get("tag", ""),
+        "param_hash": best.get("param_hash", ""),
+        "result_path": best.get("result_path", ""),
+    }
+
+
+def _primitive_metrics(repo_root: Path, flit_bits: int) -> JsonDict:
+    fifo = _load_best_metrics(repo_root / f"runs/designs/noc/l1_noc_fifo_w{flit_bits}_d16_wrapper/metrics.csv")
+    router = _load_best_metrics(repo_root / f"runs/designs/noc/l1_noc_router_p4_w{flit_bits}_wrapper/metrics.csv")
+    return {
+        "fifo": fifo,
+        "router": router,
+    }
+
+
+def build_profile(args: argparse.Namespace) -> JsonDict:
+    head_dim = args.hidden_size // args.attention_heads
+    kv_width = args.kv_heads * head_dim
+    full_tile_bytes = int(2 * args.tile_tokens * kv_width * args.kv_bits / 8)
+    shared_tile_bytes = int(math.ceil(full_tile_bytes * args.shared_byte_share))
+    stat_payload_bytes = args.attention_heads * 2 * args.reduction_scalar_bytes
+    value_payload_bytes = args.hidden_size * args.reduction_scalar_bytes
+    partial_payload_bytes = stat_payload_bytes + value_payload_bytes
+    cross_tile_reduction_payload_bytes = args.active_clusters * partial_payload_bytes
+    kv_write_bytes = int(2 * kv_width * args.kv_bits / 8)
+
+    rows: list[JsonDict] = []
+    repo_root = args.repo_root.resolve()
+    primitive_by_width = {flit_bits: _primitive_metrics(repo_root, flit_bits) for flit_bits in args.flit_bits}
+    for flit_bits in args.flit_bits:
+        flit_bytes = flit_bits // 8
+        for raw_bandwidth in args.raw_bandwidth_bytes_per_cycle:
+            for hops in args.hops:
+                for virtual_channels in args.virtual_channels:
+                    vc_gain = min(1.0, args.vc_base_efficiency + args.vc_increment * (virtual_channels - 1))
+                    for arbitration_efficiency in args.arbitration_efficiency:
+                        aggregate_payload_bpc = raw_bandwidth / max(1, hops) * arbitration_efficiency * vc_gain
+                        per_cluster_payload_bpc = aggregate_payload_bpc / max(1, args.active_clusters)
+                        router_latency_cycles = hops * args.router_latency_cycles_per_hop
+                        shared_tile_cycles = _ceil_div(shared_tile_bytes, per_cluster_payload_bpc) + router_latency_cycles
+                        reduction_cycles = _ceil_div(cross_tile_reduction_payload_bytes, aggregate_payload_bpc) + router_latency_cycles
+                        kv_write_cycles = _ceil_div(kv_write_bytes, aggregate_payload_bpc) + router_latency_cycles
+                        rows.append(
+                            {
+                                "flit_bits": flit_bits,
+                                "flit_bytes": flit_bytes,
+                                "raw_bandwidth_bytes_per_cycle": raw_bandwidth,
+                                "hops": hops,
+                                "virtual_channels": virtual_channels,
+                                "arbitration_efficiency": arbitration_efficiency,
+                                "vc_gain": round(vc_gain, 6),
+                                "aggregate_effective_payload_bytes_per_cycle": round(aggregate_payload_bpc, 6),
+                                "per_cluster_effective_payload_bytes_per_cycle": round(per_cluster_payload_bpc, 6),
+                                "shared_tile_payload_bytes": shared_tile_bytes,
+                                "shared_tile_flits": _ceil_div(shared_tile_bytes, flit_bytes),
+                                "shared_tile_noc_cycles": shared_tile_cycles,
+                                "cross_tile_reduction_payload_bytes": cross_tile_reduction_payload_bytes,
+                                "cross_tile_reduction_flits": _ceil_div(cross_tile_reduction_payload_bytes, flit_bytes),
+                                "cross_tile_reduction_noc_cycles": reduction_cycles,
+                                "kv_write_payload_bytes": kv_write_bytes,
+                                "kv_write_flits": _ceil_div(kv_write_bytes, flit_bytes),
+                                "kv_write_noc_cycles": kv_write_cycles,
+                                "dominant_noc_service": max(
+                                    {
+                                        "shared_tile": shared_tile_cycles,
+                                        "cross_tile_reduction": reduction_cycles,
+                                        "kv_write": kv_write_cycles,
+                                    }.items(),
+                                    key=lambda item: item[1],
+                                )[0],
+                            }
+                        )
+
+    best_rows = sorted(rows, key=lambda row: row["shared_tile_noc_cycles"])[: min(12, len(rows))]
+    worst_rows = sorted(rows, key=lambda row: row["shared_tile_noc_cycles"], reverse=True)[: min(12, len(rows))]
+    return {
+        "version": 1,
+        "model": "llama7b_proxy",
+        "profile": "decoder_attention_noc_profile",
+        "parameters": {
+            "sequence_length": args.sequence_length,
+            "tile_tokens": args.tile_tokens,
+            "tile_count": _ceil_div(args.sequence_length, args.tile_tokens),
+            "hidden_size": args.hidden_size,
+            "attention_heads": args.attention_heads,
+            "kv_heads": args.kv_heads,
+            "head_dim": head_dim,
+            "kv_bits": args.kv_bits,
+            "active_clusters": args.active_clusters,
+            "shared_byte_share": args.shared_byte_share,
+            "reduction_scalar_bytes": args.reduction_scalar_bytes,
+            "router_latency_cycles_per_hop": args.router_latency_cycles_per_hop,
+        },
+        "traffic_quantities": {
+            "full_tile_kv_bytes": full_tile_bytes,
+            "shared_tile_payload_bytes": shared_tile_bytes,
+            "partial_reduction_payload_bytes": partial_payload_bytes,
+            "cross_tile_reduction_payload_bytes": cross_tile_reduction_payload_bytes,
+            "kv_write_payload_bytes": kv_write_bytes,
+        },
+        "measured_primitives": primitive_by_width,
+        "rows": rows,
+        "best_shared_tile_rows": best_rows,
+        "worst_shared_tile_rows": worst_rows,
+        "remaining_abstractions": [
+            "Effective payload/cycle is a bounded service model using measured FIFO/router PPA plus explicit arbitration efficiency; it is not a cycle-accurate routed NoC RTL simulation.",
+            "Wire delay, topology floorplan, and adaptive routing are not modeled.",
+            "The full scheduler must still choose how much traffic is local SRAM, shared SRAM, or HBM before applying this profile.",
+        ],
+    }
+
+
+def write_report(payload: JsonDict, report: Path) -> None:
+    lines = [
+        "# Llama7B Attention NoC Profile",
+        "",
+        "## Traffic Quantities",
+        "",
+        "| quantity | bytes |",
+        "|---|---:|",
+    ]
+    for key, value in payload["traffic_quantities"].items():
+        lines.append(f"| {key} | {value} |")
+    lines.extend(
+        [
+            "",
+            "## Best Shared-Tile Service Rows",
+            "",
+            "| flit | raw B/cyc | hops | vc | arb | eff agg B/cyc | eff cluster B/cyc | tile cycles | reduction cycles |",
+            "|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in payload["best_shared_tile_rows"]:
+        lines.append(
+            "| {flit_bits} | {raw_bandwidth_bytes_per_cycle} | {hops} | {virtual_channels} | "
+            "{arbitration_efficiency} | {aggregate_effective_payload_bytes_per_cycle} | "
+            "{per_cluster_effective_payload_bytes_per_cycle} | {shared_tile_noc_cycles} | "
+            "{cross_tile_reduction_noc_cycles} |".format(**row)
+        )
+    lines.extend(
+        [
+            "",
+            "## Measured Primitive Inputs",
+            "",
+        ]
+    )
+    for flit_bits, metrics in payload["measured_primitives"].items():
+        lines.append(f"### {flit_bits}-bit flits")
+        for primitive, values in metrics.items():
+            if values is None:
+                lines.append(f"- {primitive}: missing metrics")
+            else:
+                lines.append(
+                    f"- {primitive}: area `{values['area_um2']}` um2, "
+                    f"clock `{values['critical_path_ns']}` ns, power `{values['power_mw']}` mW"
+                )
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "- Rows are service bounds for selected traffic; they close the hidden NoC-efficiency knobs but do not replace a full routed NoC implementation.",
+        ]
+    )
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--sequence-length", type=int, default=131072)
+    parser.add_argument("--tile-tokens", type=int, default=512)
+    parser.add_argument("--hidden-size", type=int, default=4096)
+    parser.add_argument("--attention-heads", type=int, default=32)
+    parser.add_argument("--kv-heads", type=int, default=4)
+    parser.add_argument("--kv-bits", type=int, default=8)
+    parser.add_argument("--active-clusters", type=int, default=8)
+    parser.add_argument("--shared-byte-share", type=float, default=0.44005)
+    parser.add_argument("--reduction-scalar-bytes", type=int, default=2)
+    parser.add_argument("--flit-bits", type=_int_list, default=[128, 256])
+    parser.add_argument("--raw-bandwidth-bytes-per-cycle", type=_float_list, default=[8192.0, 32768.0])
+    parser.add_argument("--hops", type=_int_list, default=[1, 2, 4])
+    parser.add_argument("--virtual-channels", type=_int_list, default=[1, 2, 4])
+    parser.add_argument("--arbitration-efficiency", type=_float_list, default=[0.55, 0.70, 0.85])
+    parser.add_argument("--vc-base-efficiency", type=float, default=0.85)
+    parser.add_argument("--vc-increment", type=float, default=0.05)
+    parser.add_argument("--router-latency-cycles-per-hop", type=int, default=2)
+    args = parser.parse_args()
+
+    if args.hidden_size % args.attention_heads != 0:
+        raise SystemExit("--hidden-size must be divisible by --attention-heads")
+    if any(flit_bits % 8 != 0 or flit_bits <= 0 for flit_bits in args.flit_bits):
+        raise SystemExit("--flit-bits values must be positive multiples of 8")
+
+    payload = build_profile(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_attention_noc_profile.py
+++ b/tests/test_llm_decoder_attention_noc_profile.py
@@ -1,0 +1,49 @@
+import argparse
+from pathlib import Path
+
+from npu.eval.measure_llm_decoder_attention_noc_profile import build_profile
+
+
+def _args(tmp_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo_root=tmp_path,
+        sequence_length=131072,
+        tile_tokens=512,
+        hidden_size=4096,
+        attention_heads=32,
+        kv_heads=4,
+        kv_bits=8,
+        active_clusters=8,
+        shared_byte_share=0.44005,
+        reduction_scalar_bytes=2,
+        flit_bits=[128],
+        raw_bandwidth_bytes_per_cycle=[8192.0],
+        hops=[1],
+        virtual_channels=[4],
+        arbitration_efficiency=[0.85],
+        vc_base_efficiency=0.85,
+        vc_increment=0.05,
+        router_latency_cycles_per_hop=2,
+    )
+
+
+def test_attention_noc_profile_default_traffic_quantities(tmp_path: Path) -> None:
+    profile = build_profile(_args(tmp_path))
+    traffic = profile["traffic_quantities"]
+
+    assert traffic["full_tile_kv_bytes"] == 2 * 512 * 4 * 128
+    assert traffic["shared_tile_payload_bytes"] == 230713
+    assert traffic["partial_reduction_payload_bytes"] == 4096 * 2 + 32 * 2 * 2
+    assert traffic["cross_tile_reduction_payload_bytes"] == 8 * (4096 * 2 + 32 * 2 * 2)
+    assert traffic["kv_write_payload_bytes"] == 2 * 4 * 128
+
+
+def test_attention_noc_profile_matches_selected_best_bandwidth(tmp_path: Path) -> None:
+    profile = build_profile(_args(tmp_path))
+    row = profile["rows"][0]
+
+    assert row["aggregate_effective_payload_bytes_per_cycle"] == 6963.2
+    assert row["per_cluster_effective_payload_bytes_per_cycle"] == 870.4
+    assert row["shared_tile_flits"] == 14420
+    assert row["shared_tile_noc_cycles"] == 268
+    assert row["cross_tile_reduction_noc_cycles"] == 12


### PR DESCRIPTION
Adds the NoC service-profile source job for the Llama7B attention abstraction-closure ladder.

What it adds:
- deterministic NoC profile script for selected 512-token, 8-cluster Llama7B attention traffic
- explicit traffic quantities: 524,288 B full K/V tile, 230,713 B shared tile payload, 66,560 B cross-tile reduction, 1,024 B KV writeback
- service rows across 128/256-bit flits, raw bandwidth, hops, virtual channels, and arbitration efficiency
- measured FIFO/router primitive references from existing L1 NoC metrics
- proposal `prop_l2_decoder_attention_noc_profile_v1` and closure-plan wording
- focused tests for traffic math and control-plane task payload wiring

Verification:
- `PYTHONPATH=/tmp/rtlgen-dispatch-l2/control_plane:/tmp/rtlgen-dispatch-l2 /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_attention_noc_profile.py tests/test_llm_decoder_attention_sram_profile.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_noc_profile_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_sram_profile_evidence`
- `PYTHONPATH=/tmp/rtlgen-dispatch-l2/control_plane:/tmp/rtlgen-dispatch-l2 /workspaces/RTLGen/control_plane/.venv/bin/python -m compileall npu/eval/measure_llm_decoder_attention_noc_profile.py control_plane/control_plane/services/l2_task_generator.py`
