### PR TITLE
Allow partial L1 measurement boundary metrics

### DIFF
--- a/control_plane/control_plane/tests/test_worker_executor.py
+++ b/control_plane/control_plane/tests/test_worker_executor.py
@@ -392,6 +392,81 @@ def test_l1_worker_fails_when_expected_metrics_have_no_ok_rows() -> None:
             ]
 
 
+def test_l1_measurement_only_accepts_mixed_ok_and_failed_metrics_as_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        item_id = "item_l1_mixed_measurement_metrics"
+        ok_metrics_rel = f"runs/campaigns/{item_id}/ok_metrics.csv"
+        failed_metrics_rel = f"runs/campaigns/{item_id}/failed_metrics.csv"
+        with Session(engine) as session:
+            seed_ready_work_item(session, item_id=item_id, repo_root=repo_root, failing=False)
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            work_item.task_type = "l1_sweep"
+            work_item.layer = "layer1"
+            work_item.assigned_machine_key = "worker-1"
+            work_item.task_request.request_payload = {
+                "developer_loop": {"evaluation": {"mode": "measurement_only"}}
+            }
+            work_item.command_manifest = [
+                {
+                    "name": "write_mixed_metrics",
+                    "run": (
+                        "python3 -c \"from pathlib import Path; "
+                        f"ok=Path('{ok_metrics_rel}'); failed=Path('{failed_metrics_rel}'); "
+                        "ok.parent.mkdir(parents=True, exist_ok=True); "
+                        "ok.write_text('design,status,critical_path_ns\\nok_unit,ok,1.0\\n', encoding='utf-8'); "
+                        "failed.write_text('design,status,critical_path_ns\\nfailed_unit,failed,\\n', encoding='utf-8')\""
+                    ),
+                }
+            ]
+            work_item.expected_outputs = [ok_metrics_rel, failed_metrics_rel]
+            session.commit()
+
+        session_factory = build_session_factory(engine)
+        results = run_worker(
+            session_factory,
+            config=WorkerConfig(
+                repo_root=str(repo_root),
+                machine_key="worker-1",
+                capabilities={"platform": "nangate45", "flow": "openroad"},
+                capability_filter={"platform": "nangate45", "flow": "openroad"},
+                enforce_source_commit=False,
+                lease_seconds=60,
+                heartbeat_seconds=1,
+                max_retry_attempts=1,
+            ),
+            max_items=1,
+        )
+
+        assert len(results) == 1
+        assert results[0].status == "succeeded"
+
+        with Session(engine) as session:
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            run = session.query(Run).filter_by(run_key=results[0].run_key).one()
+            event = session.query(RunEvent).filter_by(run_id=run.id, event_type="acceptance_warnings").one()
+            warning = f"partial_success_boundary_evidence={failed_metrics_rel}: no status=ok rows (statuses=failed)"
+            assert work_item.state == WorkItemState.ARTIFACT_SYNC
+            assert run.status == RunStatus.SUCCEEDED
+            assert run.result_payload["queue_result"]["status"] == "ok"
+            assert run.result_payload["queue_result"]["metrics_rows"] == [
+                f"{ok_metrics_rel}:2",
+                f"{failed_metrics_rel}:2",
+            ]
+            assert run.result_payload["acceptance_warnings"] == [warning]
+            assert warning in run.result_payload["queue_result"]["notes"]
+            assert event.event_payload == {
+                "warnings": [warning],
+                "ok_file_count": 1,
+                "non_ok_file_count": 1,
+            }
+
+
 def test_l1_worker_allows_non_ok_metrics_for_boundary_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/workers/executor.py
+++ b/control_plane/control_plane/workers/executor.py
@@ -174,14 +174,50 @@ def _l1_acceptance_allows_non_ok_metrics(work_item: WorkItem) -> bool:
     )
 
 
+def _work_item_evaluation_mode(work_item: WorkItem) -> str:
+    payload = getattr(work_item.task_request, "request_payload", None)
+    if not isinstance(payload, dict):
+        return ""
+    evaluation = (payload.get("developer_loop") or {}).get("evaluation") or {}
+    if not isinstance(evaluation, dict):
+        return ""
+    return str(evaluation.get("mode", "")).strip()
+
+
+@dataclass(frozen=True)
+class L1MetricsAcceptance:
+    errors: list[str]
+    warnings: list[str]
+    ok_file_count: int
+    non_ok_file_count: int
+
+
 def _l1_metrics_acceptance_errors(
     *,
     repo_root: str,
     expected_outputs: list[str],
     require_ok_status: bool = True,
 ) -> list[str]:
+    return _l1_metrics_acceptance(
+        repo_root=repo_root,
+        expected_outputs=expected_outputs,
+        require_ok_status=require_ok_status,
+        allow_measurement_partial_success=False,
+    ).errors
+
+
+def _l1_metrics_acceptance(
+    *,
+    repo_root: str,
+    expected_outputs: list[str],
+    require_ok_status: bool = True,
+    allow_measurement_partial_success: bool = False,
+) -> L1MetricsAcceptance:
     repo_path = Path(repo_root).resolve()
     errors: list[str] = []
+    warnings: list[str] = []
+    ok_file_count = 0
+    non_ok_file_count = 0
     for output in expected_outputs:
         if not str(output).endswith("metrics.csv"):
             continue
@@ -198,10 +234,32 @@ def _l1_metrics_acceptance_errors(
             errors.append(f"{output}: metrics.csv lacks status column")
             continue
         ok_rows = [row for row in rows if str(row.get("status", "")).strip().lower() == "ok"]
+        if ok_rows:
+            ok_file_count += 1
+        else:
+            non_ok_file_count += 1
         if require_ok_status and not ok_rows:
             statuses = sorted({str(row.get("status", "")).strip() or "<blank>" for row in rows})
             errors.append(f"{output}: no status=ok rows (statuses={','.join(statuses)})")
-    return errors
+    if (
+        allow_measurement_partial_success
+        and ok_file_count > 0
+        and non_ok_file_count > 0
+        and errors
+        and all("no status=ok rows" in error for error in errors)
+    ):
+        warnings = [f"partial_success_boundary_evidence={error}" for error in errors]
+        errors = []
+    return L1MetricsAcceptance(
+        errors=errors,
+        warnings=warnings,
+        ok_file_count=ok_file_count,
+        non_ok_file_count=non_ok_file_count,
+    )
+
+
+def _l1_allows_measurement_partial_success(evaluation_mode: str) -> bool:
+    return evaluation_mode == "measurement_only"
 
 
 def _load_work_item(session: Session, work_item_id: str) -> WorkItem:
@@ -697,6 +755,7 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
         attempt = _next_attempt(session, work_item.id)
         trial_index = _next_trial_index(session, work_item)
         seed = _trial_policy(work_item)["seed_start"] + trial_index - 1
+        evaluation_mode = _work_item_evaluation_mode(work_item)
         run_key = f"{work_item.item_id}_{make_id('run')}"
 
     checkout_error: str | None = None
@@ -847,12 +906,16 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
     if not command_results and not work_item.command_manifest:
         success = True
     acceptance_errors: list[str] = []
+    acceptance_warnings: list[str] = []
     if success and str(work_item.task_type) == "l1_sweep":
-        acceptance_errors = _l1_metrics_acceptance_errors(
+        acceptance = _l1_metrics_acceptance(
             repo_root=checkout_info.work_dir,
             expected_outputs=active_expected_outputs,
             require_ok_status=not _l1_acceptance_allows_non_ok_metrics(work_item),
+            allow_measurement_partial_success=_l1_allows_measurement_partial_success(evaluation_mode),
         )
+        acceptance_errors = acceptance.errors
+        acceptance_warnings = acceptance.warnings
         if acceptance_errors:
             success = False
             with session_factory() as session:
@@ -861,6 +924,18 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
                     run_key=run_key,
                     event_type="acceptance_failed",
                     event_payload={"errors": acceptance_errors},
+                )
+        elif acceptance_warnings:
+            with session_factory() as session:
+                append_run_event(
+                    session,
+                    run_key=run_key,
+                    event_type="acceptance_warnings",
+                    event_payload={
+                        "warnings": acceptance_warnings,
+                        "ok_file_count": acceptance.ok_file_count,
+                        "non_ok_file_count": acceptance.non_ok_file_count,
+                    },
                 )
 
     artifacts = collect_expected_output_artifacts(
@@ -919,6 +994,8 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
         result_payload["worker_error"] = worker_error
     if acceptance_errors:
         result_payload["acceptance_errors"] = acceptance_errors
+    if acceptance_warnings:
+        result_payload["acceptance_warnings"] = acceptance_warnings
     failure = _classify_failure(
         command_results=command_results,
         worker_error=worker_error,
@@ -948,6 +1025,8 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
             notes.append(f"worker_error={worker_error}")
         for error in acceptance_errors:
             notes.append(f"acceptance_error={error}")
+        for warning in acceptance_warnings:
+            notes.append(warning)
         if failure["requeue"]:
             notes.append(
                 f"retry_scheduled=attempt_{failure['attempt'] + 1}_of_{failure['max_retry_attempts']}"
@@ -957,6 +1036,11 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
             "metrics_rows": queue_result.metrics_rows,
             "notes": notes,
         }
+    elif acceptance_warnings:
+        result_payload["queue_result"]["notes"] = [
+            *result_payload["queue_result"]["notes"],
+            *acceptance_warnings,
+        ]
 
     with session_factory() as session:
         if failure["requeue"]:


### PR DESCRIPTION
## Summary
- allow L1 `measurement_only` sweeps to succeed when at least one expected metrics CSV has `status=ok` rows and other expected metrics CSVs only contain explicit non-ok boundary rows
- record those converted acceptance failures as `acceptance_warnings` events and queue-result notes
- keep missing/empty/no-status metrics and all-failed measurement sweeps as acceptance failures; existing explicit boundary acceptance rules are unchanged

## Verification
- `PYTHONPATH=/tmp/rtlgen-dispatch-l2/control_plane:/tmp/rtlgen-dispatch-l2 /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_worker_executor.py::test_l1_worker_fails_when_expected_metrics_have_no_ok_rows control_plane/control_plane/tests/test_worker_executor.py::test_l1_measurement_only_accepts_mixed_ok_and_failed_metrics_as_boundary_evidence control_plane/control_plane/tests/test_worker_executor.py::test_l1_worker_allows_non_ok_metrics_for_boundary_evidence`
- `PYTHONPATH=/tmp/rtlgen-dispatch-l2/control_plane:/tmp/rtlgen-dispatch-l2 /workspaces/RTLGen/control_plane/.venv/bin/python -m compileall control_plane/control_plane/workers/executor.py`

## Context
This fixes the softmax L1 profile failure mode from #737: q12 PWL reciprocal q14/q16 produced explicit failed metrics rows while lower-width points produced valid PPA. The sweep should preserve both the successful measurements and failed boundary evidence instead of failing the whole work item.