### PR TITLE
Add all-measured Llama7B attention L2 schedule

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3923,6 +3923,74 @@ def _decoder_attention_kv_full_value_l1_clustered_schedule_evidence(*, item_id: 
     }
 
 
+def _decoder_attention_kv_all_measured_l1_clustered_schedule_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_all_measured_l1_clustered_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_all_measured_l1_clustered_schedule__{item_id}.md"
+    clustered_schedule = (
+        f"{base}/decoder_attention_kv_clustered_schedule_overhead__"
+        "l2_decoder_attention_kv_clustered_schedule_overhead_llama7b_v1.json"
+    )
+    full_value_costs = "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_full_value_v1.json"
+    all_measured_costs = "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_v1.json"
+    softmax_promotion = "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_softmax_weight_generator_v1_r2.json"
+    sram_profile = f"{base}/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    noc_profile = f"{base}/decoder_attention_noc_profile__l2_decoder_attention_noc_profile_v1.json"
+    return {
+        "inputs": {
+            "attention_kv_clustered_schedule_overhead": clustered_schedule,
+            "attention_kv_full_value_l1_costs": full_value_costs,
+            "attention_kv_all_measured_l1_costs": all_measured_costs,
+            "attention_softmax_weight_generator_promotion": softmax_promotion,
+            "attention_sram_profile": sram_profile,
+            "attention_noc_profile": noc_profile,
+            "attention_kv_all_measured_l1_clustered_schedule_out": out,
+            "attention_kv_all_measured_l1_clustered_schedule_report": report,
+            "attention_kv_all_measured_l1_clustered_schedule_scope": (
+                "Llama7B 131k native-GQA KV8 schedule ranking using measured compute-array PPA, "
+                "full-value attention tile datapaths, exact-int softmax-weight generator PPA, "
+                "and measured FIFO/router local NoC anchors. SRAM capacity/service and global "
+                "NoC arbitration remain analytic L2 service terms, with the merged SRAM/NoC "
+                "profile outputs recorded as calibration references."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_all_measured_l1_clustered_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py "
+                    "--repo-root . "
+                    "--tag-substring compute_stability_cmp33 "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 200,400,800,1200 "
+                    "--sram-area-fraction 0.4,0.6 "
+                    "--logic-area-fraction 0.1,0.2 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7 "
+                    "--local-sram-fraction 0.1,0.25 "
+                    "--tile-tokens-list 512 "
+                    "--bank-count 16,64 "
+                    "--cluster-count 1,2,4,8,16 "
+                    "--noc-bandwidth-bytes-per-cycle 8192,32768 "
+                    "--noc-hops 1,2,4 "
+                    "--reduction-strategy owner_cluster,cluster_tree "
+                    "--vector-ops-per-mac 0.125 "
+                    "--reduction-scalar-bytes 2 "
+                    "--command-cycles-per-tile 0,4 "
+                    "--command-cycles-per-wave 0,16 "
+                    "--reducer-setup-cycles 0,64 "
+                    "--reduction-cycle-multiplier 1,2 "
+                    f"--measured-l1-costs {all_measured_costs} "
+                    "--measured-l1-profile all "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_sram_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_sram_profile__{item_id}.json"
@@ -5501,6 +5569,7 @@ def _build_payload(
         "decoder_attention_kv_clustered_schedule_overhead",
         "decoder_attention_kv_measured_l1_clustered_schedule",
         "decoder_attention_kv_full_value_l1_clustered_schedule",
+        "decoder_attention_kv_all_measured_l1_clustered_schedule",
         "decoder_attention_sram_profile",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
@@ -5578,6 +5647,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_measured_l1_clustered_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_full_value_l1_clustered_schedule":
             decoder_evidence = _decoder_attention_kv_full_value_l1_clustered_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_all_measured_l1_clustered_schedule":
+            decoder_evidence = _decoder_attention_kv_all_measured_l1_clustered_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_sram_profile":
             decoder_evidence = _decoder_attention_sram_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5030,3 +5030,49 @@ def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None
                 output.endswith("decoder_attention_noc_profile__l2_decoder_attention_noc_profile_v1.json")
                 for output in expected_outputs
             )
+
+
+def test_generate_l2_campaign_task_adds_all_measured_l1_attention_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_all_measured_l1_clustered_schedule_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_all_measured_l1_clustered_schedule",
+                    evaluation_mode="broad_ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+
+            assert "estimate_decoder_attention_kv_all_measured_l1_clustered_schedule" in command_names
+            assert "attention_kv_all_measured_l1_costs" in decoder_inputs
+            assert "attention_softmax_weight_generator_promotion" in decoder_inputs
+            assert "attention_sram_profile" in decoder_inputs
+            assert "attention_noc_profile" in decoder_inputs
+            assert "--measured-l1-costs runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_v1.json" in commands[0]["run"]
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_all_measured_l1_clustered_schedule__"
+                    "l2_decoder_attention_kv_all_measured_l1_clustered_schedule_v1.json"
+                )
+                for output in expected_outputs
+            )

--- a/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
@@ -66,14 +66,20 @@ def _measured_l1_overhead(profile: JsonDict | None, cluster_count: int) -> JsonD
             "noc_router_area_um2": 0.0,
             "noc_router_power_mw": 0.0,
             "noc_router_clock_ns": 0.0,
+            "softmax_weight_generator_area_um2": 0.0,
+            "softmax_weight_generator_power_mw": 0.0,
+            "softmax_weight_generator_clock_ns": 0.0,
             "fifo_per_cluster": 0,
             "router_per_cluster": 0,
+            "softmax_weight_generator_per_cluster": 0,
             "local_datapath_metrics_csv": "",
             "noc_fifo_metrics_csv": "",
             "noc_router_metrics_csv": "",
+            "softmax_weight_generator_metrics_csv": "",
         }
     fifo_per_cluster = int(profile.get("fifo_per_cluster", 1))
     router_per_cluster = int(profile.get("router_per_cluster", 1))
+    softmax_per_cluster = int(profile.get("softmax_weight_generator_per_cluster", 0))
     local_area = _metric(profile, "local_datapath", "area_um2")
     local_power = _metric(profile, "local_datapath", "power_mw")
     local_clock = _metric(profile, "local_datapath", "clock_ns")
@@ -83,13 +89,26 @@ def _measured_l1_overhead(profile: JsonDict | None, cluster_count: int) -> JsonD
     router_area = _metric(profile, "noc_router", "area_um2")
     router_power = _metric(profile, "noc_router", "power_mw")
     router_clock = _metric(profile, "noc_router", "clock_ns")
-    per_cluster_area = local_area + fifo_per_cluster * fifo_area + router_per_cluster * router_area
-    per_cluster_power = local_power + fifo_per_cluster * fifo_power + router_per_cluster * router_power
+    softmax_area = _metric(profile, "softmax_weight_generator", "area_um2")
+    softmax_power = _metric(profile, "softmax_weight_generator", "power_mw")
+    softmax_clock = _metric(profile, "softmax_weight_generator", "clock_ns")
+    per_cluster_area = (
+        local_area
+        + fifo_per_cluster * fifo_area
+        + router_per_cluster * router_area
+        + softmax_per_cluster * softmax_area
+    )
+    per_cluster_power = (
+        local_power
+        + fifo_per_cluster * fifo_power
+        + router_per_cluster * router_power
+        + softmax_per_cluster * softmax_power
+    )
     return {
         "profile": str(profile["name"]),
         "area_um2": cluster_count * per_cluster_area,
         "power_mw": cluster_count * per_cluster_power,
-        "clock_ns": max(local_clock, fifo_clock, router_clock),
+        "clock_ns": max(local_clock, fifo_clock, router_clock, softmax_clock),
         "local_datapath_area_um2": local_area,
         "local_datapath_power_mw": local_power,
         "local_datapath_clock_ns": local_clock,
@@ -99,11 +118,16 @@ def _measured_l1_overhead(profile: JsonDict | None, cluster_count: int) -> JsonD
         "noc_router_area_um2": router_area,
         "noc_router_power_mw": router_power,
         "noc_router_clock_ns": router_clock,
+        "softmax_weight_generator_area_um2": softmax_area,
+        "softmax_weight_generator_power_mw": softmax_power,
+        "softmax_weight_generator_clock_ns": softmax_clock,
         "fifo_per_cluster": fifo_per_cluster,
         "router_per_cluster": router_per_cluster,
+        "softmax_weight_generator_per_cluster": softmax_per_cluster,
         "local_datapath_metrics_csv": _path_metric(profile, "local_datapath"),
         "noc_fifo_metrics_csv": _path_metric(profile, "noc_fifo"),
         "noc_router_metrics_csv": _path_metric(profile, "noc_router"),
+        "softmax_weight_generator_metrics_csv": _path_metric(profile, "softmax_weight_generator"),
     }
 
 
@@ -366,6 +390,11 @@ def _shape_row(
         "noc_router_clock_ns": round(float(measured_l1["noc_router_clock_ns"]), 6),
         "noc_router_per_cluster": measured_l1["router_per_cluster"],
         "noc_router_metrics_csv": measured_l1["noc_router_metrics_csv"],
+        "softmax_weight_generator_area_um2": round(float(measured_l1["softmax_weight_generator_area_um2"]), 6),
+        "softmax_weight_generator_power_mw": round(float(measured_l1["softmax_weight_generator_power_mw"]), 6),
+        "softmax_weight_generator_clock_ns": round(float(measured_l1["softmax_weight_generator_clock_ns"]), 6),
+        "softmax_weight_generator_per_cluster": measured_l1["softmax_weight_generator_per_cluster"],
+        "softmax_weight_generator_metrics_csv": measured_l1["softmax_weight_generator_metrics_csv"],
         "macs_per_cycle": total_macs_per_cycle,
         "vector_ops_per_cycle": total_vector_ops_per_cycle,
         "per_cluster_macs_per_cycle": per_cluster_macs,
@@ -578,7 +607,7 @@ def build_report(
             "Optional command and reducer overhead parameters are sensitivity knobs, not measured RTL/PPA.",
             "When measured L1 cost profiles are provided, their per-cluster tile/reducer, FIFO, and router area is subtracted from the logic budget before compute replicas are allocated.",
             "Measured L1 profile clock is combined by max() with measured compute-array clock; this is a conservative local macro proxy, not a full routed SoC timing closure.",
-            "Measured L1 profiles charge the local tile/value datapath and memory/NoC primitives listed in the selected cost file; softmax-weight generation, SRAM timing, and cycle-accurate NoC arbitration are only charged after separate measured profiles are provided.",
+            "Measured L1 profiles charge the local tile/value datapath, optional softmax-weight generator, and memory/NoC primitives listed in the selected cost file; cycle-accurate SRAM/NoC arbitration remains an analytic service model.",
         ],
     }
 

--- a/runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_v1.json
+++ b/runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_v1.json
@@ -1,0 +1,361 @@
+{
+  "version": 0.1,
+  "name": "llama7b_attention_local_costs_all_measured_v1",
+  "platform": "nangate45",
+  "core_utilization": 60,
+  "source_prs": [720, 728, 739],
+  "scope": "Per-cluster L1 costs for Llama7B attention schedule modeling with measured full-value attention tile datapaths, one FIFO, one 4-port router, and one exact-int softmax weight generator per cluster. These are local-area, local-power, and local-clock anchors for L2 scheduling; SRAM capacity/service and global NoC arbitration remain analytic L2 terms.",
+  "profiles": [
+    {
+      "name": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10",
+      "description": "Area-conservative hd64/kv8 full-value attention tile with 128-bit local NoC primitives and exact-int q10 reciprocal softmax weights.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "softmax_weight_generator_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper",
+        "clock_ns": 0.8235,
+        "area_um2": 139416.358225,
+        "power_mw": 0.0341,
+        "metrics_csv": "runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/metrics.csv"
+      },
+      "softmax_weight_generator": {
+        "design": "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper",
+        "clock_ns": 5.5948,
+        "area_um2": 39776.3136,
+        "power_mw": 0.00479,
+        "metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w128_d16_wrapper",
+        "width_bits": 128,
+        "depth": 16,
+        "clock_ns": 0.2965,
+        "area_um2": 11606.830225,
+        "power_mw": 0.00862,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w128_wrapper",
+        "ports": 4,
+        "width_bits": 128,
+        "clock_ns": 0.2424,
+        "area_um2": 3123.133225,
+        "power_mw": 0.00176,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q12",
+      "description": "Area-conservative hd64/kv8 full-value attention tile with 128-bit local NoC primitives and exact-int q12 reciprocal softmax weights.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "softmax_weight_generator_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper",
+        "clock_ns": 0.8235,
+        "area_um2": 139416.358225,
+        "power_mw": 0.0341,
+        "metrics_csv": "runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/metrics.csv"
+      },
+      "softmax_weight_generator": {
+        "design": "attention_softmax_weight_int8_r8_acc24_recip_q12_wrapper",
+        "clock_ns": 5.746,
+        "area_um2": 43505.6164,
+        "power_mw": 0.0139,
+        "metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q12_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w128_d16_wrapper",
+        "width_bits": 128,
+        "depth": 16,
+        "clock_ns": 0.2965,
+        "area_um2": 11606.830225,
+        "power_mw": 0.00862,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w128_wrapper",
+        "ports": 4,
+        "width_bits": 128,
+        "clock_ns": 0.2424,
+        "area_um2": 3123.133225,
+        "power_mw": 0.00176,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q16",
+      "description": "Area-conservative hd64/kv8 full-value attention tile with 128-bit local NoC primitives and exact-int q16 reciprocal softmax weights.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "softmax_weight_generator_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper",
+        "clock_ns": 0.8235,
+        "area_um2": 139416.358225,
+        "power_mw": 0.0341,
+        "metrics_csv": "runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/metrics.csv"
+      },
+      "softmax_weight_generator": {
+        "design": "attention_softmax_weight_int8_r8_acc24_recip_q16_wrapper",
+        "clock_ns": 5.7951,
+        "area_um2": 45315.765625,
+        "power_mw": 0.0319,
+        "metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q16_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w128_d16_wrapper",
+        "width_bits": 128,
+        "depth": 16,
+        "clock_ns": 0.2965,
+        "area_um2": 11606.830225,
+        "power_mw": 0.00862,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w128_wrapper",
+        "ports": 4,
+        "width_bits": 128,
+        "clock_ns": 0.2424,
+        "area_um2": 3123.133225,
+        "power_mw": 0.00176,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd64_kv8_full_value_p8_ppc4_noc128_softmax_int8_q10",
+      "description": "Higher-throughput hd64/kv8 full-value attention tile with 128-bit local NoC primitives and exact-int q10 reciprocal softmax weights.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "softmax_weight_generator_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40_wrapper",
+        "clock_ns": 0.8662,
+        "area_um2": 222812.3209,
+        "power_mw": 0.0446,
+        "metrics_csv": "runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40_wrapper/metrics.csv"
+      },
+      "softmax_weight_generator": {
+        "design": "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper",
+        "clock_ns": 5.5948,
+        "area_um2": 39776.3136,
+        "power_mw": 0.00479,
+        "metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w128_d16_wrapper",
+        "width_bits": 128,
+        "depth": 16,
+        "clock_ns": 0.2965,
+        "area_um2": 11606.830225,
+        "power_mw": 0.00862,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w128_wrapper",
+        "ports": 4,
+        "width_bits": 128,
+        "clock_ns": 0.2424,
+        "area_um2": 3123.133225,
+        "power_mw": 0.00176,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd64_kv8_full_value_p8_ppc4_noc128_softmax_int8_q12",
+      "description": "Higher-throughput hd64/kv8 full-value attention tile with 128-bit local NoC primitives and exact-int q12 reciprocal softmax weights.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "softmax_weight_generator_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40_wrapper",
+        "clock_ns": 0.8662,
+        "area_um2": 222812.3209,
+        "power_mw": 0.0446,
+        "metrics_csv": "runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40_wrapper/metrics.csv"
+      },
+      "softmax_weight_generator": {
+        "design": "attention_softmax_weight_int8_r8_acc24_recip_q12_wrapper",
+        "clock_ns": 5.746,
+        "area_um2": 43505.6164,
+        "power_mw": 0.0139,
+        "metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q12_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w128_d16_wrapper",
+        "width_bits": 128,
+        "depth": 16,
+        "clock_ns": 0.2965,
+        "area_um2": 11606.830225,
+        "power_mw": 0.00862,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w128_wrapper",
+        "ports": 4,
+        "width_bits": 128,
+        "clock_ns": 0.2424,
+        "area_um2": 3123.133225,
+        "power_mw": 0.00176,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd64_kv8_full_value_p8_ppc4_noc128_softmax_int8_q16",
+      "description": "Higher-throughput hd64/kv8 full-value attention tile with 128-bit local NoC primitives and exact-int q16 reciprocal softmax weights.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "softmax_weight_generator_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40_wrapper",
+        "clock_ns": 0.8662,
+        "area_um2": 222812.3209,
+        "power_mw": 0.0446,
+        "metrics_csv": "runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc4_w24_a40_wrapper/metrics.csv"
+      },
+      "softmax_weight_generator": {
+        "design": "attention_softmax_weight_int8_r8_acc24_recip_q16_wrapper",
+        "clock_ns": 5.7951,
+        "area_um2": 45315.765625,
+        "power_mw": 0.0319,
+        "metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q16_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w128_d16_wrapper",
+        "width_bits": 128,
+        "depth": 16,
+        "clock_ns": 0.2965,
+        "area_um2": 11606.830225,
+        "power_mw": 0.00862,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w128_wrapper",
+        "ports": 4,
+        "width_bits": 128,
+        "clock_ns": 0.2424,
+        "area_um2": 3123.133225,
+        "power_mw": 0.00176,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd128_kv8_full_value_p16_ppc4_noc256_softmax_int8_q10",
+      "description": "Larger hd128/kv8 full-value attention tile with 256-bit local NoC primitives and exact-int q10 reciprocal softmax weights.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "softmax_weight_generator_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40_wrapper",
+        "clock_ns": 0.864,
+        "area_um2": 238241.61,
+        "power_mw": 0.0454,
+        "metrics_csv": "runs/designs/activations/attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40_wrapper/metrics.csv"
+      },
+      "softmax_weight_generator": {
+        "design": "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper",
+        "clock_ns": 5.5948,
+        "area_um2": 39776.3136,
+        "power_mw": 0.00479,
+        "metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w256_d16_wrapper",
+        "width_bits": 256,
+        "depth": 16,
+        "clock_ns": 0.29,
+        "area_um2": 11779.846225,
+        "power_mw": 0.00869,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w256_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w256_wrapper",
+        "ports": 4,
+        "width_bits": 256,
+        "clock_ns": 0.2401,
+        "area_um2": 3299.3536,
+        "power_mw": 0.00171,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w256_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd128_kv8_full_value_p16_ppc4_noc256_softmax_int8_q12",
+      "description": "Larger hd128/kv8 full-value attention tile with 256-bit local NoC primitives and exact-int q12 reciprocal softmax weights.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "softmax_weight_generator_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40_wrapper",
+        "clock_ns": 0.864,
+        "area_um2": 238241.61,
+        "power_mw": 0.0454,
+        "metrics_csv": "runs/designs/activations/attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40_wrapper/metrics.csv"
+      },
+      "softmax_weight_generator": {
+        "design": "attention_softmax_weight_int8_r8_acc24_recip_q12_wrapper",
+        "clock_ns": 5.746,
+        "area_um2": 43505.6164,
+        "power_mw": 0.0139,
+        "metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q12_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w256_d16_wrapper",
+        "width_bits": 256,
+        "depth": 16,
+        "clock_ns": 0.29,
+        "area_um2": 11779.846225,
+        "power_mw": 0.00869,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w256_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w256_wrapper",
+        "ports": 4,
+        "width_bits": 256,
+        "clock_ns": 0.2401,
+        "area_um2": 3299.3536,
+        "power_mw": 0.00171,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w256_wrapper/metrics.csv"
+      }
+    },
+    {
+      "name": "hd128_kv8_full_value_p16_ppc4_noc256_softmax_int8_q16",
+      "description": "Larger hd128/kv8 full-value attention tile with 256-bit local NoC primitives and exact-int q16 reciprocal softmax weights.",
+      "fifo_per_cluster": 1,
+      "router_per_cluster": 1,
+      "softmax_weight_generator_per_cluster": 1,
+      "local_datapath": {
+        "design": "attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40_wrapper",
+        "clock_ns": 0.864,
+        "area_um2": 238241.61,
+        "power_mw": 0.0454,
+        "metrics_csv": "runs/designs/activations/attention_kv_full_value_hd128_kv8_tl32_b256_p16_ppc4_w24_a40_wrapper/metrics.csv"
+      },
+      "softmax_weight_generator": {
+        "design": "attention_softmax_weight_int8_r8_acc24_recip_q16_wrapper",
+        "clock_ns": 5.7951,
+        "area_um2": 45315.765625,
+        "power_mw": 0.0319,
+        "metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q16_wrapper/metrics.csv"
+      },
+      "noc_fifo": {
+        "design": "l1_noc_fifo_w256_d16_wrapper",
+        "width_bits": 256,
+        "depth": 16,
+        "clock_ns": 0.29,
+        "area_um2": 11779.846225,
+        "power_mw": 0.00869,
+        "metrics_csv": "runs/designs/noc/l1_noc_fifo_w256_d16_wrapper/metrics.csv"
+      },
+      "noc_router": {
+        "design": "l1_noc_router_p4_w256_wrapper",
+        "ports": 4,
+        "width_bits": 256,
+        "clock_ns": 0.2401,
+        "area_um2": 3299.3536,
+        "power_mw": 0.00171,
+        "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w256_wrapper/metrics.csv"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the next L2 Llama7B attention scheduling point that charges all currently merged measured local anchors.\n\nChanges:\n- adds an all-measured L1 cost profile combining full-value attention tile, FIFO/router, and exact-int softmax weight-generator PPA\n- extends the clustered schedule estimator to charge an optional softmax-weight generator component per cluster\n- wires a new control-plane abstraction layer, decoder_attention_kv_all_measured_l1_clustered_schedule, for the follow-on job\n- adds focused generator coverage\n\nValidation:\n- python3 -m json.tool runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_v1.json >/dev/null\n- python3 npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py ... --measured-l1-costs runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_v1.json ...\n- PYTHONPATH=/tmp/rtlgen-dispatch-l2/control_plane:/tmp/rtlgen-dispatch-l2 /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q\n- python3 -m compileall -q npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py