### PR TITLE
control_plane: materialize inline artifacts before submission

### DIFF
--- a/control_plane/control_plane/services/docs_paths.py
+++ b/control_plane/control_plane/services/docs_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 
 
 def _resolve_path(repo_root: Path, path_text: str) -> Path:
@@ -90,6 +91,41 @@ def resolve_proposal_file(repo_root: Path, proposal_path: str | None = None, pro
     if proposal_dir is None:
         return None
     return proposal_dir / 'proposal.json'
+
+
+def proposal_placeholder_reason(proposal_json: Path) -> str | None:
+    try:
+        payload = json.loads(proposal_json.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    title = str(payload.get("title", "")).strip()
+    hypothesis = str(payload.get("hypothesis", "")).strip()
+    direct_comparison = payload.get("direct_comparison")
+    primary_question = ""
+    include_values: list[str] = []
+    exclude_values: list[str] = []
+    if isinstance(direct_comparison, dict):
+        primary_question = str(direct_comparison.get("primary_question", "")).strip()
+        include_values = [str(value).strip() for value in direct_comparison.get("include", []) if str(value).strip()]
+        exclude_values = [str(value).strip() for value in direct_comparison.get("exclude", []) if str(value).strip()]
+    expected_benefit = [str(value).strip() for value in payload.get("expected_benefit", []) if str(value).strip()]
+    risks = [str(value).strip() for value in payload.get("risks", []) if str(value).strip()]
+
+    placeholders = {
+        title == "Example proposal title",
+        hypothesis == "Replace this with a bounded engineering hypothesis.",
+        primary_question == "What focused comparison directly tests this proposal?",
+        any(value.startswith("describe ") for value in include_values),
+        any(value.startswith("describe ") for value in exclude_values),
+        any(value.startswith("describe ") for value in expected_benefit),
+        any(value.startswith("describe ") for value in risks),
+    }
+    if any(placeholders):
+        return "developer_loop proposal is still a template placeholder"
+    return None
 
 
 def canonicalize_proposal_path(repo_root: Path, proposal_path: str | None = None, proposal_id: str | None = None) -> str | None:

--- a/control_plane/control_plane/services/operator_submission.py
+++ b/control_plane/control_plane/services/operator_submission.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+import hashlib
 import json
 from pathlib import Path
 import re
 import subprocess
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 from sqlalchemy.orm import Session
 
@@ -35,7 +36,7 @@ from control_plane.services.review_publisher import (
 )
 from control_plane.services.submission_bridge import SubmissionPrepareError, SubmissionPrepareRequest, prepare_submission_branch
 from control_plane.services.submission_executor import SubmissionExecuteError, SubmissionExecuteRequest, execute_submission
-from control_plane.services.docs_paths import resolve_proposal_file
+from control_plane.services.docs_paths import proposal_placeholder_reason, resolve_proposal_file
 
 
 class OperatorSubmissionError(RuntimeError):
@@ -289,6 +290,68 @@ def _review_artifact_exists_on_disk(*, repo_root: Path, artifact: Artifact | Non
     return path.exists() and path.is_file()
 
 
+def _repo_artifact_path(repo_root: Path, path_text: str) -> Path | None:
+    path_text = str(path_text or "").strip()
+    if not path_text:
+        return None
+    candidate = Path(path_text)
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    try:
+        resolved = candidate.resolve()
+        resolved.relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
+def _materialize_inline_run_artifacts(
+    session: Session,
+    *,
+    repo_root: Path,
+    run: Run,
+    paths: Iterable[str] | None = None,
+) -> list[str]:
+    requested_paths = {str(path).strip() for path in paths or [] if str(path).strip()}
+    materialized: list[str] = []
+    artifacts = session.query(Artifact).filter(Artifact.run_id == run.id).all()
+    for artifact in artifacts:
+        rel_path = str(artifact.path or "").strip()
+        if requested_paths and rel_path not in requested_paths:
+            continue
+        metadata = artifact.metadata_ if isinstance(artifact.metadata_, dict) else {}
+        inline_text = metadata.get("inline_utf8")
+        if not isinstance(inline_text, str):
+            continue
+        target = _repo_artifact_path(repo_root, rel_path)
+        if target is None or target.exists():
+            continue
+        if artifact.sha256:
+            digest = hashlib.sha256(inline_text.encode("utf-8")).hexdigest()
+            if digest != artifact.sha256:
+                continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(inline_text, encoding="utf-8")
+        try:
+            materialized.append(str(target.relative_to(repo_root)))
+        except ValueError:
+            materialized.append(str(target))
+    if materialized:
+        session.add(
+            RunEvent(
+                run_id=run.id,
+                event_time=utcnow(),
+                event_type="inline_artifacts_materialized",
+                event_payload={
+                    "count": len(materialized),
+                    "paths": materialized,
+                },
+            )
+        )
+        session.commit()
+    return materialized
+
+
 def _latest_submission_failure_reason(session: Session, *, run_id: str) -> str | None:
     event = (
         session.query(RunEvent)
@@ -318,6 +381,9 @@ def _proposal_linkage_reason(*, repo_root: Path, work_item: WorkItem) -> str | N
     proposal_json = resolve_proposal_file(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
     if proposal_json is None or not proposal_json.exists():
         return "developer_loop proposal linkage does not resolve to a proposal"
+    placeholder_reason = proposal_placeholder_reason(proposal_json)
+    if placeholder_reason is not None:
+        return placeholder_reason
     return None
 
 
@@ -444,6 +510,7 @@ def _ensure_review_artifact_materialized(
     run: Run,
     force: bool = False,
 ) -> None:
+    _materialize_inline_run_artifacts(session, repo_root=repo_root, run=run)
     required_kind = _required_review_artifact_kind(work_item.task_type)
     artifact = _review_artifact(session, run_id=run.id, kind=required_kind)
     if not force and artifact is not None and _review_artifact_exists_on_disk(repo_root=repo_root, artifact=artifact):

--- a/control_plane/control_plane/services/submission_bridge.py
+++ b/control_plane/control_plane/services/submission_bridge.py
@@ -18,7 +18,7 @@ from control_plane.models.enums import ArtifactStorageMode
 from control_plane.models.run_events import RunEvent
 from control_plane.models.runs import Run
 from control_plane.models.work_items import WorkItem
-from control_plane.services.docs_paths import resolve_proposal_file
+from control_plane.services.docs_paths import proposal_placeholder_reason, resolve_proposal_file
 from control_plane.services.review_publisher import ReviewPublishRequest, publish_review_package
 from control_plane.workers.artifact_stage import collect_linked_results_artifacts
 
@@ -128,6 +128,9 @@ def _collect_proposal_files(*, repo_root: Path, package_payload: dict[str, Any],
         if proposal_id or proposal_path:
             raise SubmissionPrepareError("developer_loop proposal linkage does not resolve to a proposal")
         return
+    placeholder_reason = proposal_placeholder_reason(proposal_file)
+    if placeholder_reason is not None:
+        raise SubmissionPrepareError(placeholder_reason)
     proposal_dir = proposal_file.parent
     for candidate in sorted(path for path in proposal_dir.rglob("*") if path.is_file()):
         try:

--- a/control_plane/control_plane/tests/test_operator_submission.py
+++ b/control_plane/control_plane/tests/test_operator_submission.py
@@ -15,8 +15,17 @@ from sqlalchemy.orm import Session
 from control_plane.clock import utcnow
 from control_plane.db import create_all
 from control_plane.models.artifacts import Artifact
-from control_plane.models.enums import ExecutorType, FlowName, GitHubLinkState, LayerName, RunStatus, WorkItemState
+from control_plane.models.enums import (
+    ArtifactStorageMode,
+    ExecutorType,
+    FlowName,
+    GitHubLinkState,
+    LayerName,
+    RunStatus,
+    WorkItemState,
+)
 from control_plane.models.github_links import GitHubLink
+from control_plane.models.run_events import RunEvent
 from control_plane.models.runs import Run
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
@@ -338,6 +347,10 @@ def _make_fake_bin(fake_bin: Path, log_path: Path) -> None:
         "    branch=argv[4]\n"
         "    print(json.dumps({'number':321,'url':'https://github.com/yhmtmt/RTLGen/pull/321','headRefName':branch,'baseRefName':'master'}))\n"
         "    sys.exit(0)\n"
+        "if len(argv) >= 4 and argv[0] == 'api' and argv[1].startswith('repos/yhmtmt/RTLGen/pulls/') and argv[2:4] == ['-X','PATCH']:\n"
+        "    number=int(argv[1].rsplit('/', 1)[1])\n"
+        "    print(json.dumps({'number':number,'html_url':f'https://github.com/yhmtmt/RTLGen/pull/{number}'}))\n"
+        "    sys.exit(0)\n"
         "sys.exit(1)\n",
     )
     os.chmod(fake_bin / "git", 0o755)
@@ -448,6 +461,31 @@ def test_assess_submission_eligibility_rejects_orphan_l1_review_item() -> None:
             assert eligibility.reason == "missing developer_loop proposal linkage"
 
 
+def test_assess_submission_eligibility_rejects_template_proposal_linkage() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, run_key = _seed_l1_reviewable(session, repo_root)
+            proposal_json = repo_root / "docs" / "proposals" / "prop_l1_operate_demo" / "proposal.json"
+            payload = json.loads(proposal_json.read_text(encoding="utf-8"))
+            payload["title"] = "Example proposal title"
+            payload["hypothesis"] = "Replace this with a bounded engineering hypothesis."
+            proposal_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            eligibility = assess_submission_eligibility(
+                session,
+                work_item=work_item,
+                run=session.query(Run).filter_by(run_key=run_key).one(),
+                repo_root=repo_root,
+            )
+            assert eligibility.eligible is False
+            assert eligibility.reason == "developer_loop proposal is still a template placeholder"
 
 
 def test_operate_submission_rebuilds_when_saved_manifest_files_are_missing() -> None:
@@ -934,6 +972,68 @@ def test_operate_submission_rebuilds_missing_l1_review_file_before_submission() 
             assert artifact_path.exists()
             payload = json.loads(artifact_path.read_text(encoding="utf-8"))
             assert payload["item_id"] == item_id
+
+
+def test_operate_submission_materializes_inline_artifacts_before_rebuilding_review_file() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, run_key = _seed_l1_reviewable(session, repo_root)
+            run = session.query(Run).filter_by(run_key=run_key).one()
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            metrics_rel = next(path for path in work_item.expected_outputs if str(path).endswith("metrics.csv"))
+            metrics_path = repo_root / metrics_rel
+            metrics_text = metrics_path.read_text(encoding="utf-8")
+            metrics_path.unlink()
+            session.add(
+                Artifact(
+                    run_id=run.id,
+                    kind="expected_output",
+                    storage_mode=ArtifactStorageMode.REPO,
+                    path=metrics_rel,
+                    sha256=None,
+                    metadata_={"inline_utf8": metrics_text},
+                )
+            )
+
+            review_artifact = session.query(Artifact).filter_by(run_id=run.id, kind="promotion_proposal").one()
+            review_path = repo_root / review_artifact.path
+            review_path.unlink()
+            session.commit()
+            assert not metrics_path.exists()
+            assert not review_path.exists()
+
+            fake_bin = repo_root / "fake_bin"
+            log_path = repo_root / "fake_cmds.log"
+            _make_fake_bin(fake_bin, log_path)
+            old_path = os.environ.get("PATH", "")
+            os.environ["PATH"] = f"{fake_bin}:{old_path}"
+            try:
+                result = operate_submission(
+                    session,
+                    OperatorSubmissionRequest(
+                        repo_root=str(repo_root),
+                        repo="yhmtmt/RTLGen",
+                        item_id=item_id,
+                        evaluator_id="cpbot",
+                        session_id="s20260310t090200z",
+                        host="cp-host",
+                        worktree_root=str(repo_root / "tmp_submit"),
+                    ),
+                )
+            finally:
+                os.environ["PATH"] = old_path
+
+            assert result.pr_number == 321
+            assert metrics_path.read_text(encoding="utf-8") == metrics_text
+            assert review_path.exists()
+            event = session.query(RunEvent).filter_by(run_id=run.id, event_type="inline_artifacts_materialized").one()
+            assert event.event_payload["paths"] == [metrics_rel]
 
 
 def test_operate_submission_force_rematerializes_existing_l1_review_artifact() -> None:


### PR DESCRIPTION
## Summary
- materialize missing inline UTF-8 run artifacts before rebuilding review artifacts during operator submission
- reject active developer-loop proposal links that still point at unfilled proposal templates
- apply the same proposal-template guard in submission branch preparation, including forced submissions

## Tests
- PYTHONPATH=/tmp/rtlgen-submission-hardening/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_operator_submission.py::test_assess_submission_eligibility_rejects_template_proposal_linkage control_plane/control_plane/tests/test_operator_submission.py::test_operate_submission_materializes_inline_artifacts_before_rebuilding_review_file control_plane/control_plane/tests/test_submission_bridge.py
- python3 scripts/validate_runs.py --skip_eval_queue