### PR TITLE
control_plane: tolerate inline artifact hash drift

### DIFF
--- a/control_plane/control_plane/services/operator_submission.py
+++ b/control_plane/control_plane/services/operator_submission.py
@@ -314,6 +314,7 @@ def _materialize_inline_run_artifacts(
 ) -> list[str]:
     requested_paths = {str(path).strip() for path in paths or [] if str(path).strip()}
     materialized: list[str] = []
+    sha_mismatch_paths: list[str] = []
     artifacts = session.query(Artifact).filter(Artifact.run_id == run.id).all()
     for artifact in artifacts:
         rel_path = str(artifact.path or "").strip()
@@ -329,7 +330,7 @@ def _materialize_inline_run_artifacts(
         if artifact.sha256:
             digest = hashlib.sha256(inline_text.encode("utf-8")).hexdigest()
             if digest != artifact.sha256:
-                continue
+                sha_mismatch_paths.append(rel_path)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(inline_text, encoding="utf-8")
         try:
@@ -345,6 +346,7 @@ def _materialize_inline_run_artifacts(
                 event_payload={
                     "count": len(materialized),
                     "paths": materialized,
+                    "sha_mismatch_paths": sha_mismatch_paths,
                 },
             )
         )

--- a/control_plane/control_plane/tests/test_operator_submission.py
+++ b/control_plane/control_plane/tests/test_operator_submission.py
@@ -996,7 +996,7 @@ def test_operate_submission_materializes_inline_artifacts_before_rebuilding_revi
                     kind="expected_output",
                     storage_mode=ArtifactStorageMode.REPO,
                     path=metrics_rel,
-                    sha256=None,
+                    sha256="0" * 64,
                     metadata_={"inline_utf8": metrics_text},
                 )
             )
@@ -1034,6 +1034,7 @@ def test_operate_submission_materializes_inline_artifacts_before_rebuilding_revi
             assert review_path.exists()
             event = session.query(RunEvent).filter_by(run_id=run.id, event_type="inline_artifacts_materialized").one()
             assert event.event_payload["paths"] == [metrics_rel]
+            assert event.event_payload["sha_mismatch_paths"] == [metrics_rel]
 
 
 def test_operate_submission_force_rematerializes_existing_l1_review_artifact() -> None:


### PR DESCRIPTION
## Summary
- materialize inline UTF-8 artifacts even when the stored file sha differs from the inline text hash
- record mismatched paths in the inline_artifacts_materialized run event for audit
- cover the recovery path with a regression test

## Tests
- PYTHONPATH=/tmp/rtlgen-next-dispatch/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_operator_submission.py::test_operate_submission_materializes_inline_artifacts_before_rebuilding_review_file control_plane/control_plane/tests/test_submission_bridge.py
- python3 scripts/validate_runs.py --skip_eval_queue