### PR TITLE
docs: add compute ceiling envelope proposal

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/README.md
@@ -1,0 +1,9 @@
+# Llama7B Attention/KV Compute Ceiling Envelope
+
+This proposal bounds the Llama7B 131k attention/KV frontier by physically
+plausible compute-density ceilings.
+
+The goal is to compare the current measured RTLGen compute density with
+optimistic external-reference envelopes before assuming that detailed SRAM/NoC
+or HBM-controller modeling is the dominant next problem.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/analysis_report.md
@@ -1,0 +1,13 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1`
+- `candidate_id`: `l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1`
+
+## Result
+- result: pending
+- summary: Awaiting evaluator result.
+
+## Recommendation
+- `pending`
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/design_brief.md
@@ -1,0 +1,31 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1`
+- `title`: `Llama7B attention/KV compute ceiling envelope`
+
+## Problem
+The previous compute-floor-gap result showed that the measured RTLGen compute
+density is far below the first HBM-bound Llama7B 131k attention/KV point.
+However, architecture decisions should also consider plausible external
+compute-density references before deciding whether the next work is compute,
+memory, or NoC dominated.
+
+## Hypothesis
+The measured RTLGen density remains compute-bound, while only aggressive
+custom-array density envelopes reach the HBM floor at large logic budgets.
+
+## Evaluation Scope
+- inputs: merged compute-sensitivity and measured-compute artifacts.
+- registry citations: internal measurements, external measurements, and the
+  compute-density comparison claim.
+- density envelopes: measured RTLGen best plus 150 and 300 MAC/cycle/mm2.
+- die sizes: 400, 800, and 1200 mm2.
+- logic fractions: 0.2, 0.4, and 0.6.
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-03T10:35:00Z
+- note: This is a low-cost analytic planning gate over merged artifacts.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-03T10:35:00Z
+- allowed_evaluations:
+  - Run `l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1` as a
+    low-cost analytic comparison over merged Llama7B attention/KV evidence.
+- note: This gate does not approve new RTL, synthesis, or PnR.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1",
+  "source_commit": "fc78d52c810b29f0bf120c54e553803821ce677f",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Bound the Llama7B attention/KV frontier under measured and optimistic compute-density ceilings with explicit design-registry citations.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_compute_ceiling_envelope",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_compute_floor_gap_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_compute_floor_gap_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "bound_compute_frontier",
+        "reason": "The job should identify whether measured, optimistic, or aggressive 45nm compute-density assumptions can reach the HBM-bound floor."
+      },
+      "status": "pending"
+    }
+  ]
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/implementation_summary.md
@@ -1,0 +1,17 @@
+# Implementation Summary
+
+## Scope
+- Added `npu/eval/estimate_llm_decoder_attention_kv_compute_ceiling_envelope.py`.
+- Wired the abstraction into Layer 2 task generation and artifact policy.
+- Required registry records for internal measurements and comparison claims.
+
+## Validation
+- `python3 npu/eval/estimate_llm_decoder_attention_kv_compute_ceiling_envelope.py ...`
+- targeted `pytest` for artifact policy and L2 task generation
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+
+## Evaluation Request
+- requested task: `l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1`
+- cost class: low
+- paired baseline: `l2_decoder_attention_kv_compute_floor_gap_llama7b_v1`
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/promotion_decision.json
@@ -1,0 +1,10 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1",
+  "decision": "pending",
+  "reason": "Awaiting evaluator result.",
+  "evidence_refs": [],
+  "next_action": "run l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1",
+  "requires_human_approval": false
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/promotion_gate.md
@@ -1,0 +1,5 @@
+# Promotion Gate
+
+- status: pending
+- note: Awaiting evaluator result.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/promotion_result.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1",
+  "created_utc": "2026-06-03T10:35:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B attention/KV compute ceiling envelope",
+  "hypothesis": "Under realistic 45nm compute-density ceilings, the current Llama7B 131k attention/KV frontier only reaches the HBM-bound floor for aggressive custom-array density assumptions and large logic budgets.",
+  "direct_comparison": {
+    "primary_question": "Which die size, logic fraction, and compute-density envelope can plausibly reach the 131072 MAC/cycle HBM-bound floor?",
+    "include": [
+      "Merged Llama7B physical-HBM compute-sensitivity artifact",
+      "Merged measured RTLGen compute artifact",
+      "Design evidence registry internal measurement records",
+      "Design evidence registry external calibration records",
+      "Density envelopes at 150 and 300 MAC/cycle/mm2 in addition to measured RTLGen density"
+    ],
+    "exclude": [
+      "New RTL or PnR",
+      "New quality-changing KV approximation",
+      "Detailed global NoC arbitration",
+      "HBM PHY/controller timing"
+    ],
+    "follow_on_broad_sweep": [
+      "If only aggressive density reaches the floor, define a dense compute-tile RTL experiment",
+      "If measured density reaches the floor, deepen SRAM/NoC scheduling and arbitration",
+      "If no plausible density reaches the floor, revise the 45nm Llama7B objective or context target"
+    ]
+  },
+  "expected_benefit": [
+    "Prevents over-interpreting abstract HBM-dominant points that require unrealistic compute area",
+    "Adds explicit registry citations to frontier reports",
+    "Connects RTLGen measured blocks with academic and commercial calibration references"
+  ],
+  "risks": [
+    "External references are calibration evidence, not direct ranking baselines",
+    "Ideal node scaling is optimistic and does not include routing, SRAM, timing, or voltage effects",
+    "The result is an analytic planning gate, not a routed full-chip implementation"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "Bound the Llama7B attention/KV frontier under measured and optimistic compute-density ceilings with explicit design-registry citations.",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_compute_floor_gap_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "bound_compute_frontier",
+        "reason": "The job should identify whether measured, optimistic, or aggressive 45nm compute-density assumptions can reach the HBM-bound floor."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/design_registry/internal_measurements.jsonl",
+    "runs/design_registry/external_measurements.jsonl",
+    "runs/design_registry/comparison_claims.jsonl",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_compute_sensitivity__l2_decoder_attention_kv_physical_hbm_compute_sensitivity_llama7b_v2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_compute__l2_decoder_attention_kv_measured_compute_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "pr:754",
+    "pr:756",
+    "discussion:2026-06-03 compare RTLGen compute density against embodied and third-party reference designs"
+  ]
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1/quality_gate.md
@@ -1,0 +1,17 @@
+# Quality Gate
+
+## Checks
+- metric: registry evidence
+  - threshold: report must cite required internal measurements and comparison
+    claims from `runs/design_registry`.
+- metric: density envelopes
+  - threshold: include measured RTLGen best density plus 150 and 300
+    MAC/cycle/mm2 envelopes.
+- metric: output fields
+  - threshold: report must include compute ceiling, HBM floor, selected latency,
+    and dominant resource by die, logic fraction, and density envelope.
+
+## Result
+- status: pending
+- note: Filled by evaluator result.
+


### PR DESCRIPTION
## Summary
- add the proposal scaffold for `l2_decoder_attention_kv_compute_ceiling_envelope_llama7b_v1`
- record registry evidence requirements and density-envelope evaluation scope
- prepare the work item for dispatch without placeholder proposal files

## Validation
- JSON parse check for proposal JSON files
- `python3 scripts/validate_runs.py --skip_eval_queue`
