### PR TITLE
Add dense FP16 GEMM tile PPA proposal

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -455,6 +455,57 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "dense_gemm_tile" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                f"dense GEMM tile config must live under repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=f"{design_dir}/metrics.csv",
+            commands=[
+                {
+                    "name": "build_generator",
+                    "run": _with_oss_cad_path("cmake -S . -B build && cmake --build build --target rtlgen"),
+                },
+                {
+                    "name": "generate_dense_gemm_tile_rtl",
+                    "run": _with_oss_cad_path(
+                        (
+                        "python3 npu/rtlgen/gen_dense_gemm_tile.py "
+                        f"--config {config_rel} "
+                        f"--out {design_dir}/verilog"
+                        )
+                    ),
+                },
+                {
+                    "name": "check_dense_gemm_tile_guard",
+                    "run": f"python3 npu/eval/check_dense_gemm_tile_guard.py --design-dir {design_dir}",
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        (
+                        "python3 npu/synth/run_block_sweep.py "
+                        f"--design_dir {design_dir} "
+                        "--platform {platform} "
+                        f"--top {top_name} "
+                        f"--sweep {{sweep_path}} "
+                        f"--out_root {out_root} "
+                        + (f"--make_target {make_target} " if make_target else "")
+                        + "--skip_existing"
+                        )
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "compute" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -363,6 +363,54 @@ def _write_example_block_repo(
     )
 
 
+def _write_example_dense_gemm_tile_repo(repo_root: Path) -> tuple[str, str]:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "npu_dense_gemm_tile_fp16_4x4_k1_p1"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "0.1",
+                "top_name": "dense_gemm_tile_fp16_4x4_k1_p1",
+                "dense_gemm_tile": {
+                    "module_name": "dense_gemm_tile_fp16_4x4_k1_p1",
+                    "precision": "fp16",
+                    "array_m": 4,
+                    "array_n": 4,
+                    "k_unroll": 1,
+                    "pipeline_stages": 1,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = repo_root / "runs" / "campaigns" / "npu" / "dense_gemm_tile_v1" / "sweeps" / "nangate45_dense_tile_hier.json"
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "flow_params": {
+                    "CLOCK_PERIOD": [10.0],
+                    "DIE_AREA": ["0 0 1200 1200"],
+                    "CORE_AREA": ["50 50 1150 1150"],
+                    "SYNTH_HIERARCHICAL": [1],
+                    "SYNTH_KEEP_MODULES": ["dense_gemm_tile_fp16_4x4_k1_p1 gemm_mac_fp16_ieee"],
+                },
+                "tag_prefix": "npu_dense_gemm_tile_v1",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return (
+        str(config_path.relative_to(repo_root)),
+        str(sweep_path.relative_to(repo_root)),
+    )
+
+
 
 def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
     with tempfile.TemporaryDirectory() as td:
@@ -981,6 +1029,59 @@ def test_generate_l1_sweep_task_supports_integrated_npu_block_configs() -> None:
                 "--skip_existing"
             )
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {"layer": "architecture_block"}
+
+
+def test_generate_l1_sweep_task_supports_dense_gemm_tile_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_dense_gemm_tile_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="architecture_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "build_generator",
+                "generate_dense_gemm_tile_rtl",
+                "check_dense_gemm_tile_guard",
+                "run_block_sweep",
+                "build_runs_index",
+                "validate",
+            ]
+            assert work_item.command_manifest[1]["run"] == (
+                "export PATH=/oss-cad-suite/bin:$PATH && "
+                "python3 npu/rtlgen/gen_dense_gemm_tile.py "
+                "--config runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1/config.json "
+                "--out runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1/verilog"
+            )
+            assert work_item.command_manifest[2]["run"] == (
+                "python3 npu/eval/check_dense_gemm_tile_guard.py "
+                "--design-dir runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1"
+            )
+            assert "--top dense_gemm_tile_fp16_4x4_k1_p1" in work_item.command_manifest[3]["run"]
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1/metrics.csv"
+            ]
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "architecture_block"
+            }
 
 
 def test_generate_l1_sweep_task_emits_commands_for_each_integrated_block_config() -> None:

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/README.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/README.md
@@ -1,0 +1,10 @@
+# Dense FP16 GEMM Tile V1
+
+This proposal introduces a dense FP16 GEMM-tile architecture point to test
+whether RTLGen can improve compute density beyond the corrected dynamic
+dispatcher baseline.
+
+The first evaluation measures `4x4` and `8x8` exact-FP16 MAC arrays with narrow
+self-stimulating wrapper IO and no replicated vector tail. The result is a
+planning gate for whether the Llama7B frontier should pursue dense compute
+tiles, precision changes, or return to memory/NoC modeling.

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/analysis_report.md
@@ -1,0 +1,12 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l1_npu_dense_gemm_tile_v1`
+- `candidate_id`: `l1_npu_dense_gemm_tile_v1`
+
+## Result
+- result: pending
+- summary: Awaiting evaluator result.
+
+## Recommendation
+- `pending`

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/design_brief.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/design_brief.md
@@ -1,0 +1,24 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l1_npu_dense_gemm_tile_v1`
+- `title`: `Dense FP16 GEMM tile V1`
+
+## Problem
+The Llama7B compute-ceiling envelope shows that measured `nm64_flat` density
+does not reach the HBM-bound floor. We need to determine whether a regular
+dense compute tile can improve density before exploring larger clustered
+memory/NoC schedules.
+
+## Architecture
+- exact RTLGen FP16 MAC primitive reused from corrected compute baseline.
+- `4x4` and `8x8` MAC arrays.
+- narrow self-stimulating wrapper: `clk`, `rst_n`, `start`, `seed`,
+  `done`, and `result_hash`.
+- all MAC outputs feed the visible result hash to prevent synthesis pruning.
+- no dynamic dispatcher, CQ, DMA, softmax, norm, reducer, or vector tail.
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-03T10:55:00Z

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-03T10:55:00Z
+- allowed_evaluations:
+  - Run `l1_npu_dense_gemm_tile_v1` as a hierarchy-preserving Layer 1 PPA sweep.
+- note: This gate does not approve 16x16+ arrays until the first dense-tile
+  boundary evidence is available.

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/evaluation_requests.json
@@ -1,0 +1,14 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_v1",
+  "source_commit": "",
+  "requested_items": [
+    {
+      "item_id": "l1_npu_dense_gemm_tile_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure dense FP16 GEMM tile PPA for 4x4 and 8x8 arrays, preserving hierarchy and recording MAC/cycle/mm2-ready metrics.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "architecture_block",
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/implementation_summary.md
@@ -1,0 +1,16 @@
+# Implementation Summary
+
+## Scope
+- Add `npu/rtlgen/gen_dense_gemm_tile.py`.
+- Add `4x4` and `8x8` dense-tile configs under `runs/designs/npu_blocks`.
+- Add a hierarchy-preserving Nangate45 sweep under
+  `runs/campaigns/npu/dense_gemm_tile_v1`.
+- Wire dense-tile configs into the Layer 1 task generator.
+
+## Validation
+- `cmake -S . -B build && cmake --build build --target rtlgen`
+- `python3 -m py_compile npu/rtlgen/gen_dense_gemm_tile.py npu/eval/check_dense_gemm_tile_guard.py`
+- Generated local RTL and passed `check_dense_gemm_tile_guard.py` for both
+  `4x4` and `8x8` configs.
+- Targeted Layer 1 task-generator tests passed.
+- `python3 scripts/validate_runs.py --skip_eval_queue`

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_v1",
+  "candidate_id": "l1_npu_dense_gemm_tile_v1",
+  "decision": "pending",
+  "reason": "Awaiting evaluator result.",
+  "evidence_refs": [],
+  "next_action": "run l1_npu_dense_gemm_tile_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/promotion_gate.md
@@ -1,0 +1,4 @@
+# Promotion Gate
+
+- status: pending
+- note: Awaiting evaluator result.

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/promotion_result.json
@@ -1,0 +1,8 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_v1",
+  "candidate_id": "l1_npu_dense_gemm_tile_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/proposal.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/proposal.json
@@ -1,0 +1,58 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_v1",
+  "created_utc": "2026-06-03T10:55:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "title": "Dense FP16 GEMM tile V1",
+  "abstraction_layer": "architecture_block",
+  "hypothesis": "A narrow-control dense FP16 GEMM tile that removes dynamic-dispatch and vector-tail overhead can exceed the corrected nm64_flat density of 70.94 MAC/cycle/mm2, and may indicate whether 150 MAC/cycle/mm2 is plausible on Nangate45.",
+  "direct_comparison": {
+    "primary_question": "Can a regular exact-FP16 MAC tile improve MAC/cycle/mm2 relative to the corrected nm64_flat compute block?",
+    "include": [
+      "4x4 k1 exact-FP16 dense tile",
+      "8x8 k1 exact-FP16 dense tile",
+      "Hierarchy-preserving Nangate45 PPA sweep",
+      "Structural guard that all MAC outputs fold into the visible result hash",
+      "Comparison against registry record rtlgen_npu_fp16_nm64_flat_cmp33_nangate45"
+    ],
+    "exclude": [
+      "Softmax, normalization, reducer, or vector-tail replication",
+      "Large 16x16+ arrays before first boundary evidence",
+      "Quality-changing precision approximation"
+    ]
+  },
+  "expected_benefit": [
+    "Separates MAC-array density from dynamic command distribution overhead",
+    "Provides a measured direction for the 150-300 MAC/cycle/mm2 compute-density envelope",
+    "Avoids wide external IO by using a narrow self-stimulating PPA harness"
+  ],
+  "risks": [
+    "The wrapper is a macro-style PPA harness, not a complete NPU block",
+    "The exact FP16 MAC primitive may itself dominate area and limit density",
+    "Pipeline stage 1 registers inputs but does not retime inside the generated MAC primitive"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l1_sweep",
+      "evaluation_mode": "measurement_only",
+      "objective": "Measure dense FP16 GEMM tile PPA for 4x4 and 8x8 arrays, preserving hierarchy and recording MAC/cycle/mm2-ready metrics.",
+      "cost_class": "medium",
+      "expected_result": {
+        "direction": "measure_dense_compute_density",
+        "reason": "The job should determine whether removing dynamic dispatcher/vector-tail overhead improves compute density toward the 150 MAC/cycle/mm2 planning threshold."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/design_registry/internal_measurements.jsonl",
+    "runs/design_registry/comparison_claims.jsonl",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm64_cmp/metrics.csv"
+  ],
+  "knowledge_refs": [
+    "pr:754",
+    "pr:758",
+    "discussion:2026-06-03 dense compute tile should be tested before deeper NoC/SRAM modeling"
+  ]
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_v1/quality_gate.md
@@ -1,0 +1,18 @@
+# Quality Gate
+
+## Checks
+- metric: structural MAC count
+  - threshold: generated manifest must report 16 MAC/cycle for `4x4` and
+    64 MAC/cycle for `8x8`.
+- metric: datapath connectivity
+  - threshold: every generated MAC instance output must fold into
+    `result_hash`.
+- metric: PPA output
+  - threshold: each design records `metrics.csv` rows, with failures preserved
+    as boundary evidence if timing or flow fails.
+- metric: comparison readiness
+  - threshold: result must be sufficient to compute MAC/cycle/mm2 and compare
+    against `rtlgen_npu_fp16_nm64_flat_cmp33_nangate45`.
+
+## Result
+- status: pending

--- a/npu/eval/check_dense_gemm_tile_guard.py
+++ b/npu/eval/check_dense_gemm_tile_guard.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Check dense GEMM tile generated RTL before PPA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", required=True)
+    args = parser.parse_args()
+
+    design_dir = Path(args.design_dir)
+    manifest_path = design_dir / "verilog" / "dense_gemm_tile_manifest.json"
+    top_path = design_dir / "verilog" / "top.v"
+    if not manifest_path.exists():
+        raise SystemExit(f"missing manifest: {manifest_path}")
+    if not top_path.exists():
+        raise SystemExit(f"missing generated RTL: {top_path}")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    top_text = top_path.read_text(encoding="utf-8")
+    expected_macs = int(manifest["macs_per_cycle"])
+    top_name = str(manifest["top_name"])
+    instance_count = len(re.findall(r"\bu_mac_\d{4}\s*\(", top_text))
+    if instance_count != expected_macs:
+        raise SystemExit(f"MAC instance count mismatch: expected {expected_macs}, found {instance_count}")
+    if f"module {top_name} " not in top_text:
+        raise SystemExit(f"missing top module {top_name}")
+    if "result_hash <=" not in top_text:
+        raise SystemExit("result_hash is not updated")
+    folded_match = re.search(r"\bassign\s+folded_result\s*=\s*(.*?);", top_text, flags=re.DOTALL)
+    if folded_match is None:
+        raise SystemExit("missing folded_result assignment")
+    folded_expr = folded_match.group(1)
+
+    missing_outputs: list[str] = []
+    pipeline_stages = int(manifest.get("pipeline_stages", 0))
+    for idx in range(expected_macs):
+        token = f"mac_r_{idx:04d}_q" if pipeline_stages >= 2 else f"mac_r_{idx:04d}"
+        if token not in folded_expr:
+            missing_outputs.append(token)
+    if missing_outputs:
+        raise SystemExit(f"MAC outputs are not visible in result fold: {missing_outputs[:8]}")
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "design_dir": str(design_dir),
+                "top_name": top_name,
+                "macs_per_cycle": expected_macs,
+                "instance_count": instance_count,
+                "pipeline_stages": pipeline_stages,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_dense_gemm_tile.py
+++ b/npu/rtlgen/gen_dense_gemm_tile.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Generate a dense FP16 GEMM-tile PPA harness.
+
+The generated top is intentionally narrow at the boundary. It self-stimulates a
+regular array of exact RTLGen FP16 MAC primitives from a small seed register and
+folds all MAC outputs into a visible result register. This measures the dense
+compute tile without replicating the current NPU dynamic dispatcher or vector
+tail, while keeping every MAC output connected to the datapath.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen import generate_cpp_fp16_mac_module
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_int(config: dict[str, Any], key: str, default: int) -> int:
+    return int(config.get(key, default))
+
+
+def _validate_tile(tile: dict[str, Any]) -> None:
+    array_m = _as_int(tile, "array_m", 4)
+    array_n = _as_int(tile, "array_n", 4)
+    k_unroll = _as_int(tile, "k_unroll", 1)
+    pipeline_stages = _as_int(tile, "pipeline_stages", 1)
+    if array_m < 1 or array_m > 16:
+        raise SystemExit("dense_gemm_tile.array_m must be in [1, 16]")
+    if array_n < 1 or array_n > 16:
+        raise SystemExit("dense_gemm_tile.array_n must be in [1, 16]")
+    if k_unroll < 1 or k_unroll > 4:
+        raise SystemExit("dense_gemm_tile.k_unroll must be in [1, 4]")
+    if pipeline_stages < 0 or pipeline_stages > 2:
+        raise SystemExit("dense_gemm_tile.pipeline_stages must be in [0, 2]")
+    if str(tile.get("precision", "fp16")).lower() != "fp16":
+        raise SystemExit("dense_gemm_tile.precision currently supports only fp16")
+
+
+def _signal_name(prefix: str, index: int) -> str:
+    return f"{prefix}_{index:04d}"
+
+
+def _write_top(*, cfg: dict[str, Any], out_path: Path, mac_module_name: str, mac_module_text: str) -> None:
+    tile = cfg["dense_gemm_tile"]
+    top_name = str(cfg.get("top_name", tile.get("module_name", "dense_gemm_tile_top"))).strip()
+    array_m = _as_int(tile, "array_m", 4)
+    array_n = _as_int(tile, "array_n", 4)
+    k_unroll = _as_int(tile, "k_unroll", 1)
+    pipeline_stages = _as_int(tile, "pipeline_stages", 1)
+    mac_count = array_m * array_n * k_unroll
+
+    wire_lines: list[str] = []
+    input_reg_lines: list[str] = []
+    input_reset_lines: list[str] = []
+    input_update_lines: list[str] = []
+    inst_lines: list[str] = []
+    result_terms: list[str] = ["32'h0000_0000"]
+    output_reg_lines: list[str] = []
+    output_reset_lines: list[str] = []
+    output_update_lines: list[str] = []
+    output_terms: list[str] = ["32'h0000_0000"]
+
+    for idx in range(mac_count):
+        row = idx // (array_n * k_unroll)
+        col = (idx // k_unroll) % array_n
+        ku = idx % k_unroll
+        const_a = (0x3C00 ^ ((row + 1) * 0x0131) ^ ((col + 1) * 0x0027) ^ (ku * 0x0041)) & 0xFFFF
+        const_b = (0x4000 ^ ((row + 1) * 0x001D) ^ ((col + 1) * 0x00A3) ^ (ku * 0x0055)) & 0xFFFF
+        const_c = (0x0000 ^ ((row + 1) * 0x0007) ^ ((col + 1) * 0x000B) ^ (ku * 0x0013)) & 0xFFFF
+        a_src = f"(seed_state[15:0] ^ 16'h{const_a:04x} ^ cycle_ctr[15:0])"
+        b_src = f"(seed_state[31:16] ^ 16'h{const_b:04x} ^ {{cycle_ctr[7:0], cycle_ctr[15:8]}})"
+        c_src = f"(result_hash[15:0] ^ 16'h{const_c:04x})"
+        a_name = _signal_name("mac_a", idx)
+        b_name = _signal_name("mac_b", idx)
+        c_name = _signal_name("mac_c", idx)
+        r_name = _signal_name("mac_r", idx)
+        if pipeline_stages >= 1:
+            input_reg_lines.extend(
+                [
+                    f"  reg [15:0] {a_name}_q;",
+                    f"  reg [15:0] {b_name}_q;",
+                    f"  reg [15:0] {c_name}_q;",
+                ]
+            )
+            input_reset_lines.extend(
+                [
+                    f"      {a_name}_q <= 16'h0000;",
+                    f"      {b_name}_q <= 16'h0000;",
+                    f"      {c_name}_q <= 16'h0000;",
+                ]
+            )
+            input_update_lines.extend(
+                [
+                    f"      {a_name}_q <= {a_src};",
+                    f"      {b_name}_q <= {b_src};",
+                    f"      {c_name}_q <= {c_src};",
+                ]
+            )
+            a_expr = f"{a_name}_q"
+            b_expr = f"{b_name}_q"
+            c_expr = f"{c_name}_q"
+        else:
+            wire_lines.extend(
+                [
+                    f"  wire [15:0] {a_name} = {a_src};",
+                    f"  wire [15:0] {b_name} = {b_src};",
+                    f"  wire [15:0] {c_name} = {c_src};",
+                ]
+            )
+            a_expr = a_name
+            b_expr = b_name
+            c_expr = c_name
+
+        wire_lines.append(f"  wire [15:0] {r_name};")
+        inst_lines.append(
+            f"""  {mac_module_name} u_mac_{idx:04d} (
+    .A({a_expr}),
+    .B({b_expr}),
+    .C({c_expr}),
+    .negateAB(1'b0),
+    .negateC(1'b0),
+    .RndMode(2'b00),
+    .R({r_name})
+  );"""
+        )
+        if pipeline_stages >= 2:
+            rq_name = f"{r_name}_q"
+            output_reg_lines.append(f"  reg [15:0] {rq_name};")
+            output_reset_lines.append(f"      {rq_name} <= 16'h0000;")
+            output_update_lines.append(f"      {rq_name} <= {r_name};")
+            output_terms.append(f"{{16'h0000, {rq_name}}}")
+        else:
+            result_terms.append(f"{{16'h0000, {r_name}}}")
+
+    if pipeline_stages >= 2:
+        folded_expr = "\n      ^ ".join(output_terms)
+    else:
+        folded_expr = "\n      ^ ".join(result_terms)
+
+    top_text = f"""// Auto-generated by npu/rtlgen/gen_dense_gemm_tile.py
+(* keep_hierarchy = 1 *)
+module {top_name} (
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire        start,
+    input  wire [31:0] seed,
+    output reg         done,
+    output reg  [31:0] result_hash
+);
+  localparam integer ARRAY_M = {array_m};
+  localparam integer ARRAY_N = {array_n};
+  localparam integer K_UNROLL = {k_unroll};
+  localparam integer MACS_PER_CYCLE = {mac_count};
+  localparam integer PIPELINE_STAGES = {pipeline_stages};
+
+  reg [31:0] seed_state;
+  reg [15:0] cycle_ctr;
+  wire [31:0] folded_result;
+
+{chr(10).join(wire_lines)}
+{chr(10).join(input_reg_lines)}
+{chr(10).join(output_reg_lines)}
+
+{chr(10).join(inst_lines)}
+
+  assign folded_result =
+      {folded_expr};
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      seed_state <= 32'h1;
+      cycle_ctr <= 16'h0;
+      result_hash <= 32'h0;
+      done <= 1'b0;
+{chr(10).join(input_reset_lines)}
+{chr(10).join(output_reset_lines)}
+    end else begin
+      seed_state <= {{seed_state[30:0], seed_state[31] ^ seed_state[21] ^ seed_state[1] ^ seed_state[0]}} ^ seed;
+      cycle_ctr <= cycle_ctr + 16'h1;
+      done <= start;
+{chr(10).join(input_update_lines)}
+{chr(10).join(output_update_lines)}
+      if (start) begin
+        result_hash <= result_hash ^ folded_result ^ seed_state ^ {{16'h0, cycle_ctr}};
+      end
+    end
+  end
+endmodule
+"""
+
+    out_path.mkdir(parents=True, exist_ok=True)
+    (out_path / "top.v").write_text(mac_module_text + "\n\n" + top_text, encoding="utf-8")
+    manifest = {
+        "version": 0.1,
+        "generator": "npu/rtlgen/gen_dense_gemm_tile.py",
+        "top_name": top_name,
+        "precision": "fp16",
+        "array_m": array_m,
+        "array_n": array_n,
+        "k_unroll": k_unroll,
+        "pipeline_stages": pipeline_stages,
+        "mac_primitive": mac_module_name,
+        "macs_per_cycle": mac_count,
+        "external_io_policy": "narrow_self_stimulating_hash",
+        "datapath_guard": "all MAC outputs fold into result_hash",
+    }
+    (out_path / "dense_gemm_tile_manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    (out_path / "config.json").write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    cfg = _load_json(Path(args.config))
+    tile = cfg.get("dense_gemm_tile")
+    if not isinstance(tile, dict):
+        raise SystemExit("config must contain dense_gemm_tile object")
+    _validate_tile(tile)
+
+    out_path = Path(args.out)
+    gemm_cfg = {
+        "rtlgen_cpp": tile.get(
+            "rtlgen_cpp",
+            {
+                "binary_path": "build/rtlgen",
+                "module_name": "gemm_mac_fp16_ieee",
+                "total_width": 16,
+                "mantissa_width": 10,
+            },
+        )
+    }
+    mac_module_name, mac_module_text = generate_cpp_fp16_mac_module(gemm_cfg, out_path)
+    _write_top(cfg=cfg, out_path=out_path, mac_module_name=mac_module_name, mac_module_text=mac_module_text)
+    print(f"dense-gemm-tile: wrote RTL to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/dense_gemm_tile_v1/sweeps/nangate45_dense_tile_hier.json
+++ b/runs/campaigns/npu/dense_gemm_tile_v1/sweeps/nangate45_dense_tile_hier.json
@@ -1,0 +1,30 @@
+{
+  "flow_params": {
+    "TAG": [
+      "npu_dense_gemm_tile_v1_hier"
+    ],
+    "FLOW_VARIANT": [
+      "dense_gemm_tile_v1_hier"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 1200 1200"
+    ],
+    "CORE_AREA": [
+      "50 50 1150 1150"
+    ],
+    "PLACE_DENSITY": [
+      0.35,
+      0.45
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "gemm_mac_fp16_ieee"
+    ]
+  },
+  "tag_prefix": "npu_dense_gemm_tile_v1"
+}

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1/README.md
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1/README.md
@@ -1,0 +1,6 @@
+# npu_dense_gemm_tile_fp16_4x4_k1_p1
+
+- source config: `runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1/config.json`
+- top module: `dense_gemm_tile_fp16_4x4_k1_p1`
+- MACs/cycle: `16`
+- purpose: first dense FP16 GEMM-tile PPA point without dynamic dispatcher or vector tail replication.

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1/config.json
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1/config.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1",
+  "top_name": "dense_gemm_tile_fp16_4x4_k1_p1",
+  "dense_gemm_tile": {
+    "module_name": "dense_gemm_tile_fp16_4x4_k1_p1",
+    "precision": "fp16",
+    "array_m": 4,
+    "array_n": 4,
+    "k_unroll": 1,
+    "pipeline_stages": 1,
+    "rtlgen_cpp": {
+      "binary_path": "build/rtlgen",
+      "module_name": "gemm_mac_fp16_ieee",
+      "total_width": 16,
+      "mantissa_width": 10
+    }
+  }
+}

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x8_k1_p1/README.md
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x8_k1_p1/README.md
@@ -1,0 +1,6 @@
+# npu_dense_gemm_tile_fp16_8x8_k1_p1
+
+- source config: `runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x8_k1_p1/config.json`
+- top module: `dense_gemm_tile_fp16_8x8_k1_p1`
+- MACs/cycle: `64`
+- purpose: dense FP16 GEMM-tile PPA point sized to compare directly against `nm64_flat`.

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x8_k1_p1/config.json
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x8_k1_p1/config.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1",
+  "top_name": "dense_gemm_tile_fp16_8x8_k1_p1",
+  "dense_gemm_tile": {
+    "module_name": "dense_gemm_tile_fp16_8x8_k1_p1",
+    "precision": "fp16",
+    "array_m": 8,
+    "array_n": 8,
+    "k_unroll": 1,
+    "pipeline_stages": 1,
+    "rtlgen_cpp": {
+      "binary_path": "build/rtlgen",
+      "module_name": "gemm_mac_fp16_ieee",
+      "total_width": 16,
+      "mantissa_width": 10
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dense FP16 GEMM tile RTL generator that reuses the exact RTLGen FP16 MAC primitive
- add 4x4 and 8x8 dense-tile configs plus a hierarchy-preserving Nangate45 sweep
- add a structural guard and Layer 1 task-generator support for dense-tile configs
- add proposal `prop_l1_npu_dense_gemm_tile_v1` to measure dense compute density against the corrected nm64 baseline

## Validation
- `cmake -S . -B build && cmake --build build --target rtlgen`
- `python3 -m py_compile npu/rtlgen/gen_dense_gemm_tile.py npu/eval/check_dense_gemm_tile_guard.py`
- generated local RTL and passed `check_dense_gemm_tile_guard.py` for both 4x4 and 8x8 configs
- `PYTHONPATH=/tmp/rtlgen-dense-gemm/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_supports_dense_gemm_tile_configs control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_supports_integrated_npu_block_configs control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_rejects_flattened_architecture_block_sweeps control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_accepts_hierarchical_architecture_block_sweeps`
- `python3 scripts/validate_runs.py --skip_eval_queue`