### PR TITLE
Add dense GEMM tile scaling proposal

### DIFF
--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/README.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/README.md
@@ -1,0 +1,8 @@
+# Dense FP16 GEMM Tile Scaling V2
+
+This proposal measures whether the dense FP16 GEMM tile density observed at
+8x8 holds at larger 128- and 256-MAC/cycle tile sizes.
+
+The result is the physical anchor for deciding whether the Llama7B
+attention/KV frontier can use dense compute macros, or whether the 8x8 density
+was only a small-tile artifact.

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/analysis_report.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/analysis_report.md
@@ -1,0 +1,12 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l1_npu_dense_gemm_tile_scaling_v2`
+- `candidate_id`: `l1_npu_dense_gemm_tile_scaling_v2`
+
+## Result
+- result: pending
+- summary: Awaiting evaluator result.
+
+## Recommendation
+- `pending`

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/design_brief.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/design_brief.md
@@ -1,0 +1,24 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l1_npu_dense_gemm_tile_scaling_v2`
+- `title`: `Dense FP16 GEMM tile scaling V2`
+
+## Problem
+The 8x8 dense GEMM tile reached about `270 MAC/cycle/mm2`, enough to make the
+Llama7B HBM floor plausible at the large 1200 mm2 / 60% logic point. We need to
+know whether that density survives at 128 and 256 MAC/cycle tile sizes before
+building a clustered dense compute hierarchy.
+
+## Architecture
+- exact RTLGen FP16 MAC primitive reused from the dense V1 tile.
+- `8x16` and `16x8` p1 arrays for 128 MAC/cycle aspect-ratio comparison.
+- `16x16` p2 array for first 256 MAC/cycle boundary point.
+- narrow self-stimulating wrapper with all MAC outputs folded into
+  `result_hash`.
+- no memory, NoC, producer, vector tail, softmax, norm, or reducer.
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-04T01:45:00Z

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/evaluation_gate.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-04T01:45:00Z
+- allowed_evaluations:
+  - Run `l1_npu_dense_gemm_tile_scaling_v2` as a hierarchy-preserving Layer 1
+    PPA sweep.
+- note: This gate does not approve producer, memory, NoC, or full-NPU PnR.

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/evaluation_requests.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/evaluation_requests.json
@@ -1,0 +1,14 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_scaling_v2",
+  "source_commit": "",
+  "requested_items": [
+    {
+      "item_id": "l1_npu_dense_gemm_tile_scaling_v2",
+      "task_type": "l1_sweep",
+      "objective": "Measure dense FP16 GEMM tile scaling PPA for 8x16, 16x8, and 16x16 p2 arrays with hierarchy preserved.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "architecture_block",
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/implementation_summary.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/implementation_summary.md
@@ -1,0 +1,18 @@
+# Implementation Summary
+
+## Scope
+- Add `8x16`, `16x8`, and `16x16 p2` dense GEMM tile configs.
+- Add a hierarchy-preserving Nangate45 scaling sweep.
+- Reuse the dense GEMM tile generator and structural guard from V1.
+
+## Validation
+- `cmake -S . -B build && cmake --build build --target rtlgen`
+- Generated local RTL and passed `check_dense_gemm_tile_guard.py` for
+  `8x16`, `16x8`, and `16x16 p2`.
+- Targeted dense-tile Layer 1 task-generator test passed.
+- `python3 scripts/validate_runs.py --skip_eval_queue`
+- `python3 scripts/build_runs_index.py` confirmed `runs/index.csv` unchanged.
+
+## Evaluation Request
+- requested task: `l1_npu_dense_gemm_tile_scaling_v2`
+- cost class: medium

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/promotion_decision.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_scaling_v2",
+  "candidate_id": "l1_npu_dense_gemm_tile_scaling_v2",
+  "decision": "pending",
+  "reason": "Awaiting evaluator result.",
+  "evidence_refs": [],
+  "next_action": "run l1_npu_dense_gemm_tile_scaling_v2",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/promotion_gate.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/promotion_gate.md
@@ -1,0 +1,4 @@
+# Promotion Gate
+
+- status: pending
+- note: Awaiting evaluator result.

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/promotion_result.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/promotion_result.json
@@ -1,0 +1,8 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_scaling_v2",
+  "candidate_id": "l1_npu_dense_gemm_tile_scaling_v2",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/proposal.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/proposal.json
@@ -1,0 +1,59 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_scaling_v2",
+  "created_utc": "2026-06-04T01:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "title": "Dense FP16 GEMM tile scaling V2",
+  "abstraction_layer": "architecture_block",
+  "hypothesis": "The measured dense FP16 8x8 tile density of about 270 MAC/cycle/mm2 can hold within useful bounds at 128 MAC/cycle, while the 256-MAC 16x16 p2 point exposes the first scaling or PnR boundary.",
+  "direct_comparison": {
+    "primary_question": "Does dense FP16 GEMM tile compute density remain near the 8x8 result when scaled to 128 and 256 MAC/cycle?",
+    "include": [
+      "8x16 k1 p1 exact-FP16 dense tile",
+      "16x8 k1 p1 exact-FP16 dense tile",
+      "16x16 k1 p2 exact-FP16 dense tile",
+      "Hierarchy-preserving Nangate45 PPA sweep",
+      "Structural guard that all MAC outputs fold into the visible result hash",
+      "Comparison against registered 8x8 dense tile density"
+    ],
+    "exclude": [
+      "Softmax, normalization, reducer, CQ, DMA, or vector-tail replication",
+      "Producer, SRAM, or NoC integration",
+      "Quality-changing precision approximation"
+    ]
+  },
+  "expected_benefit": [
+    "Tests whether the 8x8 dense compute-density result is scalable",
+    "Provides a physical bound for the number and area of dense compute macros needed by Llama7B",
+    "Separates aspect-ratio effects from total MAC-count scaling"
+  ],
+  "risks": [
+    "16x16 may expose synthesis or PnR runtime boundaries",
+    "The wrapper remains a macro-style PPA harness rather than a complete NPU block",
+    "Pipeline stage 2 registers MAC outputs but does not retime inside the exact FP16 MAC primitive"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l1_sweep",
+      "evaluation_mode": "measurement_only",
+      "objective": "Measure dense FP16 GEMM tile scaling PPA for 8x16, 16x8, and 16x16 p2 arrays with hierarchy preserved.",
+      "cost_class": "medium",
+      "expected_result": {
+        "direction": "measure_dense_tile_scaling",
+        "reason": "The job should determine whether the 8x8 density can be used for larger dense compute macro planning."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/design_registry/internal_measurements.jsonl",
+    "runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x8_k1_p1/metrics.csv"
+  ],
+  "knowledge_refs": [
+    "pr:760",
+    "pr:761",
+    "pr:762",
+    "claim:rtlgen_dense_gemm_tile_improves_compute_density_v1"
+  ]
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/quality_gate.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/quality_gate.md
@@ -1,0 +1,18 @@
+# Quality Gate
+
+## Checks
+- metric: structural MAC count
+  - threshold: generated manifest must report 128 MAC/cycle for `8x16` and
+    `16x8`, and 256 MAC/cycle for `16x16`.
+- metric: datapath connectivity
+  - threshold: every generated MAC instance output must fold into
+    `result_hash`.
+- metric: PPA output
+  - threshold: each design records `metrics.csv` rows, with failures preserved
+    as boundary evidence if timing or flow fails.
+- metric: comparison readiness
+  - threshold: result must be sufficient to compute MAC/cycle/mm2 and compare
+    against `rtlgen_npu_dense_gemm_tile_fp16_8x8_k1_p1_nangate45`.
+
+## Result
+- status: pending

--- a/runs/campaigns/npu/dense_gemm_tile_v2/sweeps/nangate45_dense_tile_scale_hier.json
+++ b/runs/campaigns/npu/dense_gemm_tile_v2/sweeps/nangate45_dense_tile_scale_hier.json
@@ -1,0 +1,30 @@
+{
+  "flow_params": {
+    "TAG": [
+      "npu_dense_gemm_tile_v2_scale_hier"
+    ],
+    "FLOW_VARIANT": [
+      "dense_gemm_tile_v2_scale_hier"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 1600 1600"
+    ],
+    "CORE_AREA": [
+      "50 50 1550 1550"
+    ],
+    "PLACE_DENSITY": [
+      0.35,
+      0.45
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "gemm_mac_fp16_ieee"
+    ]
+  },
+  "tag_prefix": "npu_dense_gemm_tile_v2_scale"
+}

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p2/README.md
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p2/README.md
@@ -1,0 +1,6 @@
+# npu_dense_gemm_tile_fp16_16x16_k1_p2
+
+- source config: `runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p2/config.json`
+- top module: `dense_gemm_tile_fp16_16x16_k1_p2`
+- MACs/cycle: `256`
+- purpose: first 256-MAC/cycle dense FP16 GEMM-tile boundary point with registered MAC outputs.

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p2/config.json
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p2/config.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1",
+  "top_name": "dense_gemm_tile_fp16_16x16_k1_p2",
+  "dense_gemm_tile": {
+    "module_name": "dense_gemm_tile_fp16_16x16_k1_p2",
+    "precision": "fp16",
+    "array_m": 16,
+    "array_n": 16,
+    "k_unroll": 1,
+    "pipeline_stages": 2,
+    "rtlgen_cpp": {
+      "binary_path": "build/rtlgen",
+      "module_name": "gemm_mac_fp16_ieee",
+      "total_width": 16,
+      "mantissa_width": 10
+    }
+  }
+}

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x8_k1_p1/README.md
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x8_k1_p1/README.md
@@ -1,0 +1,6 @@
+# npu_dense_gemm_tile_fp16_16x8_k1_p1
+
+- source config: `runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x8_k1_p1/config.json`
+- top module: `dense_gemm_tile_fp16_16x8_k1_p1`
+- MACs/cycle: `128`
+- purpose: aspect-ratio companion to `8x16` for dense FP16 GEMM-tile scaling.

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x8_k1_p1/config.json
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x8_k1_p1/config.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1",
+  "top_name": "dense_gemm_tile_fp16_16x8_k1_p1",
+  "dense_gemm_tile": {
+    "module_name": "dense_gemm_tile_fp16_16x8_k1_p1",
+    "precision": "fp16",
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "pipeline_stages": 1,
+    "rtlgen_cpp": {
+      "binary_path": "build/rtlgen",
+      "module_name": "gemm_mac_fp16_ieee",
+      "total_width": 16,
+      "mantissa_width": 10
+    }
+  }
+}

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x16_k1_p1/README.md
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x16_k1_p1/README.md
@@ -1,0 +1,6 @@
+# npu_dense_gemm_tile_fp16_8x16_k1_p1
+
+- source config: `runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x16_k1_p1/config.json`
+- top module: `dense_gemm_tile_fp16_8x16_k1_p1`
+- MACs/cycle: `128`
+- purpose: dense FP16 GEMM-tile scaling point to test whether 8x8 density holds at 128 MAC/cycle.

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x16_k1_p1/config.json
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_8x16_k1_p1/config.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1",
+  "top_name": "dense_gemm_tile_fp16_8x16_k1_p1",
+  "dense_gemm_tile": {
+    "module_name": "dense_gemm_tile_fp16_8x16_k1_p1",
+    "precision": "fp16",
+    "array_m": 8,
+    "array_n": 16,
+    "k_unroll": 1,
+    "pipeline_stages": 1,
+    "rtlgen_cpp": {
+      "binary_path": "build/rtlgen",
+      "module_name": "gemm_mac_fp16_ieee",
+      "total_width": 16,
+      "mantissa_width": 10
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add dense FP16 GEMM tile scaling configs for 8x16, 16x8, and 16x16 p2
- add a hierarchy-preserving Nangate45 scaling sweep with a larger 1600um die/core window
- add proposal `prop_l1_npu_dense_gemm_tile_scaling_v2` and evaluation request `l1_npu_dense_gemm_tile_scaling_v2`

## Validation
- `cmake -S . -B build && cmake --build build --target rtlgen`
- generated local RTL and passed `check_dense_gemm_tile_guard.py` for 8x16, 16x8, and 16x16 p2
- `PYTHONPATH=/tmp/rtlgen-dense-scale-noc/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_supports_dense_gemm_tile_configs`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `python3 scripts/build_runs_index.py` confirmed `runs/index.csv` unchanged