### PR TITLE
Propose dense tile measured compute L2 job

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/README.md
@@ -1,0 +1,14 @@
+# Llama7B Dense Tile Measured Compute Substitution
+
+This proposal queues an L2 frontier-detail job that substitutes merged dense
+FP16 GEMM tile PPA into the Llama7B 131k physical-HBM memory/NoC model.
+
+The focused question is whether the dense tile scaling result from PR #764
+selects a better measured compute anchor than the older nm-count compute blocks,
+and which die/logic budget reaches the practical HBM floor.
+
+The job consumes existing merged evidence only:
+
+- `l1_npu_dense_gemm_tile_scaling_v2`
+- `l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2`
+- `l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2`

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/analysis_report.md
@@ -1,0 +1,22 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1`
+- `candidate_id`: `l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1`
+
+## Evaluations Consumed
+- pending evaluator run
+
+## Baseline Comparison
+- baseline: `l2_decoder_attention_kv_measured_compute_llama7b_v1`
+- comparison: dense tile measured compute source versus older nm-count measured compute source
+
+## Result
+- pending evaluator result
+
+## Failures and Caveats
+- Dense tile replica scaling does not yet model global command routing, placement, or inter-tile composition overhead.
+- SRAM and NoC service remain L2 model assumptions.
+
+## Recommendation
+- pending evaluator result

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/design_brief.md
@@ -1,0 +1,48 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1`
+- `title`: `Llama7B dense tile measured compute substitution`
+
+## Problem
+The previous Llama7B compute envelope used either older nm-count compute blocks
+or analytic dense-density envelopes. PR #764 measured dense FP16 GEMM tiles, but
+those PPA rows have not yet been substituted into the die-budgeted Llama7B
+physical-HBM memory/NoC model.
+
+## Hypothesis
+The 128-MAC dense tiles, especially `16x8_k1_p1` or `8x16_k1_p1`, should provide
+a better measured compute anchor than the older nm-count blocks. The 256-MAC
+`16x16_k1_p2` tile is expected to be less attractive because its measured
+MAC/cycle/mm2 density dropped relative to the 128-MAC points.
+
+## Evaluation Scope
+Direct comparison set: consume the merged dense tile metrics from
+`l1_npu_dense_gemm_tile_scaling_v2` and sweep die areas 100, 200, 400, 800, and
+1200 mm2 with logic fractions 0.05, 0.1, 0.2, 0.4, and 0.6.
+
+Evaluation mode: `frontier_detail`. The result is expected to select a measured
+dense tile compute anchor, not prove final full-system closure.
+
+Dependency order: this item requires merged dense tile metrics, the physical
+HBM memory/NoC baseline, and the dense compute ceiling envelope.
+
+Excluded first-stage comparisons: no new dense RTL/PPA points, no KV4/MQA
+quality-risky modes, and no detailed NoC/SRAM arbitration simulation.
+
+Follow-on broad sweep: use the selected dense anchor in clustered schedule and
+memory/NoC closure.
+
+## Knowledge Inputs
+- `docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/analysis_report.md`
+- `docs/proposals/prop_l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2/analysis_report.md`
+
+## Candidate Direction
+Extend the measured-compute estimator to load dense GEMM tile metrics and scale
+replica count by the available logic area budget.
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-05T12:46:48Z
+- note: Proceed with a focused L2 substitution job.

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by: developer_agent
+- approved_utc: 2026-06-05T12:46:48Z
+- allowed_evaluations:
+  - l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1
+- note: Focused L2 substitution of already merged dense tile PPA.

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1",
+  "source_commit": "5ad164d6d8b6be4fb8eafb838a0849fe261e4ef3",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the quality-backed native-GQA KV8 Llama7B 131k physical-HBM memory/NoC model using merged dense GEMM tile PPA from PR #764 as die-budgeted compute blocks.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_dense_tile_measured_compute",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_measured_compute_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_npu_dense_gemm_tile_scaling_v2",
+        "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2",
+        "l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "select_dense_tile_compute_anchor",
+        "reason": "The job should identify the dense tile shape and die/logic budget frontier after substituting PR #764 measured dense tile PPA into the Llama7B 131k physical-HBM model."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/implementation_summary.md
@@ -1,0 +1,38 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1`
+- title: Llama7B dense tile measured compute substitution
+
+## Scope
+- Added a dense-tile compute source to the measured-compute estimator.
+- Added a control-plane L2 abstraction that dispatches the dense-tile
+  substitution job.
+- Did not add new physical synthesis points.
+- Did not change SRAM/NoC service assumptions.
+
+## Files Changed
+- `npu/eval/estimate_llm_decoder_attention_kv_measured_compute.py`
+- `control_plane/control_plane/services/l2_task_generator.py`
+- proposal metadata under this directory
+
+## Local Validation
+- Dense-tile estimator smoke passed and selected `dense_gemm_16x8_k1_p1` at
+  1200 mm2 / 40% SRAM / 40% logic in the local run.
+- Legacy measured-compute estimator smoke passed.
+- `PYTHONPATH=/tmp/rtlgen-dense-scale-consumer/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q`
+  passed with 93 tests.
+- `python3 scripts/validate_runs.py --skip_eval_queue` passed.
+
+## Evaluation Request
+- item_id: `l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1`
+- task_type: `l2_campaign`
+- evaluation_mode: `frontier_detail`
+- baseline: `l2_decoder_attention_kv_measured_compute_llama7b_v1`
+- cost class: medium
+
+## Risks
+- Dense tile replica scaling does not include global command distribution or
+  placement overhead for many replicas.
+- Vector throughput is still tied to MAC throughput by assumption.
+- SRAM service and NoC arbitration remain model terms.

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1",
+  "decision": "iterate",
+  "reason": "Pending evaluator result.",
+  "evidence_refs": [
+    "item:l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1"
+  ],
+  "next_action": "Run the requested L2 frontier-detail job and compare the selected dense tile anchor against the older measured-compute baseline.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1",
+  "created_utc": "2026-06-05T12:46:48.454785Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B dense tile measured compute substitution",
+  "hypothesis": "Merged dense FP16 GEMM tile PPA should improve the die-budgeted Llama7B 131k compute frontier relative to the older nm-count compute blocks, with 128-MAC dense tiles expected to dominate the 256-MAC p2 tile by density and timing.",
+  "direct_comparison": {
+    "primary_question": "When dense tile PPA from l1_npu_dense_gemm_tile_scaling_v2 is substituted into the quality-backed native-GQA KV8 Llama7B 131k physical-HBM memory/NoC model, which die and logic budgets become feasible and which dense tile shape is selected?",
+    "include": [
+      "dense_gemm_8x16_k1_p1, dense_gemm_16x8_k1_p1, and dense_gemm_16x16_k1_p2 metrics from PR #764",
+      "die areas 100, 200, 400, 800, and 1200 mm2",
+      "logic fractions 0.05, 0.1, 0.2, 0.4, and 0.6 under the existing SRAM/HBM/NoC assumptions"
+    ],
+    "exclude": [
+      "new dense tile RTL/PPA points",
+      "cycle-accurate SRAM arbitration or routed NoC simulation",
+      "KV4, MQA, or other quality-unbacked KV reductions"
+    ],
+    "follow_on_broad_sweep": [
+      "rerun clustered schedule or memory/NoC closure using the selected dense compute anchor"
+    ]
+  },
+  "expected_benefit": [
+    "replace the abstract dense compute envelope with die-budgeted measured dense tile PPA",
+    "identify whether the 128-MAC dense tile family can reach the HBM floor at practical die and logic fractions"
+  ],
+  "risks": [
+    "replica scaling assumes dense tile blocks can be composed without additional command-distribution or placement overhead",
+    "vector throughput remains tied to MAC throughput by vector_ops_per_mac rather than separately measured",
+    "SRAM service and NoC arbitration remain L2 model terms"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "dense_tile_measured_compute_substitution",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l1_npu_dense_gemm_tile_scaling_v2",
+        "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2",
+        "l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "select_dense_tile_compute_anchor",
+        "reason": "The result should show the best dense tile shape and die/logic frontier for the Llama7B 131k physical-HBM model."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_compute__l2_decoder_attention_kv_measured_compute_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_compute_ceiling_envelope__l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/analysis_report.md",
+    "docs/proposals/prop_l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2/analysis_report.md"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/quality_gate.md
@@ -1,0 +1,25 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1`
+- `title`: `Llama7B dense tile measured compute substitution`
+
+## Why This Gate Is Required
+- The Llama7B 131k frontier may move when measured dense tile PPA replaces the older compute block source.
+
+## Reference
+- baseline_ref: `l2_decoder_attention_kv_measured_compute_llama7b_v1`
+- reference_ref: `l1_npu_dense_gemm_tile_scaling_v2`
+
+## Checks
+- metric: generated rows
+  - threshold: nonzero successful output
+- metric: selected compute source
+  - threshold: all selected rows must cite dense GEMM tile metrics
+
+## Local Commands
+- command: `python3 npu/eval/estimate_llm_decoder_attention_kv_measured_compute.py --compute-source dense_gemm_tile ...`
+
+## Result
+- status: pending
+- note: Final quality decision waits for evaluator output.


### PR DESCRIPTION
## Summary
- add proposal metadata for the L2 dense-tile measured compute substitution job
- records dependencies on dense tile scaling, physical HBM memory/NoC, and dense compute envelope evidence
- keeps the job focused on measured dense tile PPA substitution before clustered schedule closure

## Validation
- python3 -m json.tool proposal/evaluation JSON
- python3 scripts/validate_runs.py --skip_eval_queue