### PR TITLE
Relax dense tile job DB dependency

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/README.md
@@ -10,5 +10,9 @@ and which die/logic budget reaches the practical HBM floor.
 The job consumes existing merged evidence only:
 
 - `l1_npu_dense_gemm_tile_scaling_v2`
-- `l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2`
 - `l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2`
+
+It also reads the materialized physical-HBM memory/NoC JSON already present in
+`runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/`; that artifact is not
+listed as a DB dependency because clean control-plane DBs may not retain the
+older work item row.

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/design_brief.md
@@ -24,8 +24,10 @@ Direct comparison set: consume the merged dense tile metrics from
 Evaluation mode: `frontier_detail`. The result is expected to select a measured
 dense tile compute anchor, not prove final full-system closure.
 
-Dependency order: this item requires merged dense tile metrics, the physical
-HBM memory/NoC baseline, and the dense compute ceiling envelope.
+Dependency order: this item requires merged dense tile metrics and the dense
+compute ceiling envelope as DB-tracked dependencies. The physical HBM
+memory/NoC baseline is consumed as a materialized repo JSON input because clean
+control-plane DBs may not retain the older work item row.
 
 Excluded first-stage comparisons: no new dense RTL/PPA points, no KV4/MQA
 quality-risky modes, and no detailed NoC/SRAM arbitration simulation.

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1",
-  "source_commit": "5ad164d6d8b6be4fb8eafb838a0849fe261e4ef3",
+  "source_commit": "31c9f2111ce18cebf1afddf7004e418aada7a8fb",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1",
@@ -12,7 +12,6 @@
       "paired_baseline_item_id": "l2_decoder_attention_kv_measured_compute_llama7b_v1",
       "depends_on_item_ids": [
         "l1_npu_dense_gemm_tile_scaling_v2",
-        "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2",
         "l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2"
       ],
       "requires_merged_inputs": true,

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1/proposal.json
@@ -40,7 +40,6 @@
       "cost_class": "medium",
       "depends_on_item_ids": [
         "l1_npu_dense_gemm_tile_scaling_v2",
-        "l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2",
         "l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2"
       ],
       "requires_merged_inputs": true,
@@ -53,7 +52,8 @@
   ],
   "baseline_refs": [
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_compute__l2_decoder_attention_kv_measured_compute_llama7b_v1.json",
-    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_compute_ceiling_envelope__l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2.json"
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_compute_ceiling_envelope__l2_decoder_attention_kv_dense_compute_ceiling_envelope_llama7b_v2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_memory_noc__l2_decoder_attention_kv_physical_hbm_memory_noc_llama7b_v1_r2.json"
   ],
   "knowledge_refs": [
     "docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v2/analysis_report.md",


### PR DESCRIPTION
## Summary
- remove the older physical-HBM memory/NoC item id from the DB dependency gate for the dense-tile measured compute job
- keep the materialized physical-HBM memory/NoC JSON documented as a repo input
- refresh the proposal source commit recorded in evaluation_requests.json

## Why
Clean control-plane DBs may not retain the older physical-HBM memory/NoC work item row, while the required JSON input is already materialized in the repo.

## Validation
- python3 -m json.tool proposal/evaluation JSON
- python3 scripts/validate_runs.py --skip_eval_queue