### PR TITLE
l2: support dense tile clustered schedule jobs

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4150,6 +4150,78 @@ def _decoder_attention_kv_all_measured_l1_clustered_schedule_evidence(*, item_id
     }
 
 
+def _decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule__{item_id}.md"
+    dense_compute = (
+        f"{base}/decoder_attention_kv_dense_tile_measured_compute__"
+        "l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1.json"
+    )
+    full_value_costs = "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_full_value_v1.json"
+    all_measured_costs = "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_v1.json"
+    softmax_promotion = "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_softmax_weight_generator_v1_r2.json"
+    sram_profile = f"{base}/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    noc_profile = f"{base}/decoder_attention_noc_profile__l2_decoder_attention_noc_profile_v1.json"
+    return {
+        "inputs": {
+            "attention_kv_dense_tile_measured_compute": dense_compute,
+            "attention_kv_full_value_l1_costs": full_value_costs,
+            "attention_kv_all_measured_l1_costs": all_measured_costs,
+            "attention_softmax_weight_generator_promotion": softmax_promotion,
+            "attention_sram_profile": sram_profile,
+            "attention_noc_profile": noc_profile,
+            "attention_kv_dense_tile_all_measured_l1_clustered_schedule_out": out,
+            "attention_kv_dense_tile_all_measured_l1_clustered_schedule_report": report,
+            "attention_kv_dense_tile_all_measured_l1_clustered_schedule_scope": (
+                "Llama7B 131k native-GQA KV8 schedule ranking using measured dense GEMM tile "
+                "compute PPA, full-value attention tile datapaths, exact-int softmax-weight "
+                "generator PPA, and measured FIFO/router local NoC anchors. SRAM capacity/"
+                "service and global NoC arbitration remain analytic L2 service terms, with "
+                "the merged SRAM/NoC profile outputs recorded as calibration references."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py "
+                    "--repo-root . "
+                    "--compute-source dense_gemm_tile "
+                    "--tag-substring npu_dense_gemm_tile_v2_scale_hier "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 200,400,800,1200 "
+                    "--sram-area-fraction 0.4,0.6 "
+                    "--logic-area-fraction 0.1,0.2,0.4 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7 "
+                    "--local-sram-fraction 0.1,0.25 "
+                    "--tile-tokens-list 512 "
+                    "--bank-count 16,64 "
+                    "--cluster-count 1,2,4,8,16 "
+                    "--noc-bandwidth-bytes-per-cycle 8192,32768 "
+                    "--noc-hops 1,2,4 "
+                    "--reduction-strategy owner_cluster,cluster_tree "
+                    "--vector-ops-per-mac 0.125 "
+                    "--reduction-scalar-bytes 2 "
+                    "--command-cycles-per-tile 0,4 "
+                    "--command-cycles-per-wave 0,16 "
+                    "--reducer-setup-cycles 0,64 "
+                    "--reduction-cycle-multiplier 1,2 "
+                    f"--measured-l1-costs {all_measured_costs} "
+                    "--measured-l1-profile all "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_sram_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_sram_profile__{item_id}.json"
@@ -5732,6 +5804,7 @@ def _build_payload(
         "decoder_attention_kv_measured_l1_clustered_schedule",
         "decoder_attention_kv_full_value_l1_clustered_schedule",
         "decoder_attention_kv_all_measured_l1_clustered_schedule",
+        "decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule",
         "decoder_attention_sram_profile",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
@@ -5817,6 +5890,10 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_full_value_l1_clustered_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_all_measured_l1_clustered_schedule":
             decoder_evidence = _decoder_attention_kv_all_measured_l1_clustered_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule":
+            decoder_evidence = _decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule_evidence(
+                item_id=item_id,
+            )
         elif abstraction_layer_name == "decoder_attention_sram_profile":
             decoder_evidence = _decoder_attention_sram_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5196,3 +5196,50 @@ def test_generate_l2_campaign_task_adds_all_measured_l1_attention_evidence() -> 
                 )
                 for output in expected_outputs
             )
+
+
+def test_generate_l2_campaign_task_adds_dense_tile_all_measured_l1_attention_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule",
+                    evaluation_mode="broad_ranking",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+
+            assert "estimate_decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule" in command_names
+            assert "attention_kv_dense_tile_measured_compute" in decoder_inputs
+            assert "attention_kv_all_measured_l1_costs" in decoder_inputs
+            assert "attention_sram_profile" in decoder_inputs
+            assert "attention_noc_profile" in decoder_inputs
+            assert "--compute-source dense_gemm_tile" in commands[0]["run"]
+            assert "--tag-substring npu_dense_gemm_tile_v2_scale_hier" in commands[0]["run"]
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule__"
+                    "l2_decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule_v1.json"
+                )
+                for output in expected_outputs
+            )

--- a/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
@@ -370,6 +370,7 @@ def _shape_row(
         "replicas_per_cluster_floor": replicas_per_cluster_floor,
         "replicas_per_cluster_ceil": replicas_per_cluster_ceil,
         "compute_arch": candidate["compute_arch"],
+        "compute_source": candidate.get("compute_source", "legacy_npu_block"),
         "compute_replica_count": replica_count,
         "compute_logic_area_fraction": logic_area_fraction,
         "reserved_area_fraction": reserved_area_fraction,
@@ -447,6 +448,10 @@ def _shape_row(
         "metrics_csv": candidate["metrics_csv"],
         "metrics_tag": candidate["metrics_tag"],
         "metrics_param_hash": candidate["metrics_param_hash"],
+        "dense_array_m": candidate.get("dense_array_m"),
+        "dense_array_n": candidate.get("dense_array_n"),
+        "dense_k_unroll": candidate.get("dense_k_unroll"),
+        "dense_pipeline_stages": candidate.get("dense_pipeline_stages"),
         "vector_ops_per_mac_assumption": vector_ops_per_mac,
     }
 
@@ -455,6 +460,7 @@ def build_report(
     *,
     repo_root: Path,
     tag_substring: str,
+    compute_source: str,
     sequence_length_list: list[int],
     die_area_mm2_list: list[float],
     sram_area_fraction_list: list[float],
@@ -478,7 +484,11 @@ def build_report(
     measured_l1_profile_list: list[str] | None = None,
     measured_l1_profiles: list[JsonDict | None] | None = None,
 ) -> JsonDict:
-    candidates = _load_compute_candidates(repo_root=repo_root, tag_substring=tag_substring)
+    candidates = _load_compute_candidates(
+        repo_root=repo_root,
+        tag_substring=tag_substring,
+        compute_source=compute_source,
+    )
     measured_l1_profiles = measured_l1_profiles or _load_measured_l1_profiles(
         repo_root=repo_root,
         costs_path=measured_l1_costs_path,
@@ -605,6 +615,7 @@ def build_report(
         "model": "llm_decoder_attention_kv_clustered_schedule_llama7b_v1",
         "inputs": {
             "tag_substring": tag_substring,
+            "compute_source": compute_source,
             "sequence_length_list": sequence_length_list,
             "die_area_mm2_list": die_area_mm2_list,
             "sram_area_fraction_list": sram_area_fraction_list,
@@ -793,6 +804,11 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--repo-root", default=".")
     ap.add_argument("--tag-substring", default="compute_stability_cmp33")
+    ap.add_argument(
+        "--compute-source",
+        choices=["legacy_npu_block", "dense_gemm_tile", "all"],
+        default="legacy_npu_block",
+    )
     ap.add_argument("--sequence-length-list", type=_int_list, default=[131072])
     ap.add_argument("--die-area-mm2-list", type=_float_list, default=[100, 200, 400, 800, 1200])
     ap.add_argument("--sram-area-fraction", type=_float_list, default=[0.4, 0.6, 0.75])
@@ -821,6 +837,7 @@ def main() -> int:
     payload = build_report(
         repo_root=Path(args.repo_root),
         tag_substring=args.tag_substring,
+        compute_source=args.compute_source,
         sequence_length_list=args.sequence_length_list,
         die_area_mm2_list=args.die_area_mm2_list,
         sram_area_fraction_list=args.sram_area_fraction,


### PR DESCRIPTION
## Summary
- add compute-source selection to the Llama7B clustered schedule estimator, preserving legacy compute blocks as the default
- register a dense-tile all-measured L1 clustered schedule L2 abstraction
- add generator coverage for the dense-tile clustered job

## Validation
- python3 npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py --repo-root . --compute-source dense_gemm_tile --tag-substring npu_dense_gemm_tile_v2_scale_hier ...
- PYTHONPATH=/tmp/rtlgen-dense-noc/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check