### PR TITLE
l2: add dense tile reduction noc frontier job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4222,6 +4222,76 @@ def _decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule_evidence
     }
 
 
+def _decoder_attention_kv_dense_tile_reduction_noc_frontier_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_dense_tile_reduction_noc_frontier__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_dense_tile_reduction_noc_frontier__{item_id}.md"
+    dense_clustered = (
+        f"{base}/decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule__"
+        "l2_decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule_llama7b_v1.json"
+    )
+    all_measured_costs = "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_v1.json"
+    sram_profile = f"{base}/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    noc_profile = f"{base}/decoder_attention_noc_profile__l2_decoder_attention_noc_profile_v1.json"
+    return {
+        "inputs": {
+            "attention_kv_dense_tile_all_measured_l1_clustered_schedule": dense_clustered,
+            "attention_kv_all_measured_l1_costs": all_measured_costs,
+            "attention_sram_profile": sram_profile,
+            "attention_noc_profile": noc_profile,
+            "attention_kv_dense_tile_reduction_noc_frontier_out": out,
+            "attention_kv_dense_tile_reduction_noc_frontier_report": report,
+            "attention_kv_dense_tile_reduction_noc_frontier_scope": (
+                "Focused Llama7B 131k native-GQA KV8 frontier around the selected "
+                "dense_gemm_16x8_k1_p1 compute anchor. The sweep spends its row budget on "
+                "local/shared SRAM placement, NoC bandwidth and hop sensitivity, cluster "
+                "count, command overhead, and cross-tile reduction overhead to identify "
+                "whether the next detailed closure should prioritize global NoC, reduction "
+                "hierarchy, or SRAM placement."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_dense_tile_reduction_noc_frontier",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py "
+                    "--repo-root . "
+                    "--compute-source dense_gemm_tile "
+                    "--compute-arch-list dense_gemm_16x8_k1_p1 "
+                    "--tag-substring npu_dense_gemm_tile_v2_scale_hier "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 800,1200 "
+                    "--sram-area-fraction 0.35,0.4,0.5,0.6 "
+                    "--logic-area-fraction 0.3,0.4,0.5 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7 "
+                    "--local-sram-fraction 0.05,0.1,0.25,0.5 "
+                    "--tile-tokens-list 512,1024 "
+                    "--bank-count 16,64,128 "
+                    "--cluster-count 1,2,4,8,16,32 "
+                    "--noc-bandwidth-bytes-per-cycle 4096,8192,16384,32768,65536 "
+                    "--noc-hops 1,2,4,8 "
+                    "--reduction-strategy centralized_tile,owner_cluster,cluster_tree "
+                    "--vector-ops-per-mac 0.125 "
+                    "--reduction-scalar-bytes 2 "
+                    "--command-cycles-per-tile 0,4,16 "
+                    "--command-cycles-per-wave 0,16,64 "
+                    "--reducer-setup-cycles 0,64,256 "
+                    "--reduction-cycle-multiplier 1,2,4 "
+                    f"--measured-l1-costs {all_measured_costs} "
+                    "--measured-l1-profile hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_sram_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_sram_profile__{item_id}.json"
@@ -5805,6 +5875,7 @@ def _build_payload(
         "decoder_attention_kv_full_value_l1_clustered_schedule",
         "decoder_attention_kv_all_measured_l1_clustered_schedule",
         "decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule",
+        "decoder_attention_kv_dense_tile_reduction_noc_frontier",
         "decoder_attention_sram_profile",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
@@ -5894,6 +5965,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule_evidence(
                 item_id=item_id,
             )
+        elif abstraction_layer_name == "decoder_attention_kv_dense_tile_reduction_noc_frontier":
+            decoder_evidence = _decoder_attention_kv_dense_tile_reduction_noc_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_sram_profile":
             decoder_evidence = _decoder_attention_sram_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5243,3 +5243,52 @@ def test_generate_l2_campaign_task_adds_dense_tile_all_measured_l1_attention_evi
                 )
                 for output in expected_outputs
             )
+
+
+def test_generate_l2_campaign_task_adds_dense_tile_reduction_noc_frontier_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_dense_tile_reduction_noc_frontier",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+
+            assert "estimate_decoder_attention_kv_dense_tile_reduction_noc_frontier" in command_names
+            assert "attention_kv_dense_tile_all_measured_l1_clustered_schedule" in decoder_inputs
+            assert "attention_sram_profile" in decoder_inputs
+            assert "attention_noc_profile" in decoder_inputs
+            assert "--compute-source dense_gemm_tile" in commands[0]["run"]
+            assert "--compute-arch-list dense_gemm_16x8_k1_p1" in commands[0]["run"]
+            assert "--noc-bandwidth-bytes-per-cycle 4096,8192,16384,32768,65536" in commands[0]["run"]
+            assert "--reduction-strategy centralized_tile,owner_cluster,cluster_tree" in commands[0]["run"]
+            assert "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10" in commands[0]["run"]
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_dense_tile_reduction_noc_frontier__"
+                    "l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )

--- a/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py
@@ -35,6 +35,10 @@ def _profile_list(value: str) -> list[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
+def _optional_str_list(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
 def _metric(profile: JsonDict, component: str, key: str, default: float = 0.0) -> float:
     raw = profile.get(component, {})
     if not isinstance(raw, dict):
@@ -461,6 +465,7 @@ def build_report(
     repo_root: Path,
     tag_substring: str,
     compute_source: str,
+    compute_arch_list: list[str] | None,
     sequence_length_list: list[int],
     die_area_mm2_list: list[float],
     sram_area_fraction_list: list[float],
@@ -489,6 +494,11 @@ def build_report(
         tag_substring=tag_substring,
         compute_source=compute_source,
     )
+    if compute_arch_list:
+        allowed_arches = set(compute_arch_list)
+        candidates = [candidate for candidate in candidates if str(candidate["compute_arch"]) in allowed_arches]
+        if not candidates:
+            raise RuntimeError(f"no measured compute candidates matched compute_arch_list={sorted(allowed_arches)}")
     measured_l1_profiles = measured_l1_profiles or _load_measured_l1_profiles(
         repo_root=repo_root,
         costs_path=measured_l1_costs_path,
@@ -616,6 +626,7 @@ def build_report(
         "inputs": {
             "tag_substring": tag_substring,
             "compute_source": compute_source,
+            "compute_arch_list": compute_arch_list or [],
             "sequence_length_list": sequence_length_list,
             "die_area_mm2_list": die_area_mm2_list,
             "sram_area_fraction_list": sram_area_fraction_list,
@@ -809,6 +820,7 @@ def main() -> int:
         choices=["legacy_npu_block", "dense_gemm_tile", "all"],
         default="legacy_npu_block",
     )
+    ap.add_argument("--compute-arch-list", type=_optional_str_list, default=[])
     ap.add_argument("--sequence-length-list", type=_int_list, default=[131072])
     ap.add_argument("--die-area-mm2-list", type=_float_list, default=[100, 200, 400, 800, 1200])
     ap.add_argument("--sram-area-fraction", type=_float_list, default=[0.4, 0.6, 0.75])
@@ -838,6 +850,7 @@ def main() -> int:
         repo_root=Path(args.repo_root),
         tag_substring=args.tag_substring,
         compute_source=args.compute_source,
+        compute_arch_list=args.compute_arch_list,
         sequence_length_list=args.sequence_length_list,
         die_area_mm2_list=args.die_area_mm2_list,
         sram_area_fraction_list=args.sram_area_fraction,


### PR DESCRIPTION
## Summary
- add a compute-arch filter to the Llama7B clustered schedule estimator
- register a dense_gemm_16x8_k1_p1 reduction/NoC frontier L2 abstraction
- add generator coverage for the focused dense tile SRAM/NoC/reduction job

## Validation
- estimator smoke with --compute-source dense_gemm_tile --compute-arch-list dense_gemm_16x8_k1_p1
- PYTHONPATH=/tmp/rtlgen-reduction-noc/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check