### PR TITLE
docs: propose dense tile topology scheduler pairs job

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/README.md
@@ -1,0 +1,19 @@
+# Llama7B Dense Tile Topology/Scheduler Pairs
+
+This proposal queues a focused L2 job to validate logically compatible NoC
+topology, scheduler, reducer, bank-placement, link-width, and virtual-channel
+pairs for the Llama7B dense-tile attention frontier.
+
+The previous reduction/NoC frontier used independent service knobs such as
+`noc_bandwidth_bytes_per_cycle=65536`, `noc_hops=1`, and
+`reduction_strategy=cluster_tree`. That was useful for locating pressure, but
+it can combine assumptions that do not correspond to a realizable topology.
+This job derives service envelopes from explicit topology/link choices and
+records invalid-pair reasons before the next scheduler/performance sweep.
+
+Expected output:
+
+- a valid-pair matrix across `cluster_tree`, `mesh2d`, `ring`, and `crossbar`
+- explicit invalid reasons for topology/scheduler/reducer/bank combinations
+- derived aggregate/per-cluster payload service and hop counts
+- a shortlist to feed into the next clustered scheduler run

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by: developer_agent
+- approved_utc: 2026-06-08T13:17:31Z
+- allowed_evaluations:
+  - l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1
+- note: Focused L2 topology/scheduler validity filter before the next Llama7B NoC scheduler run.

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1",
+  "source_commit": "",
+  "source_commit_note": "Dispatch should use the proposal merge commit so the evaluator sees this proposal artifact; implementation requires at least c93db2ccf9c8e92a2d1fe6a1ac5a85dc5e61181c.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Validate logically compatible NoC topology/scheduler/reducer/bank-placement pairs for the Llama7B dense-tile attention frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_dense_tile_topology_scheduler_pairs",
+      "comparison_role": "frontier_filter",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "filter_topology_scheduler_pairs",
+        "reason": "The result should produce a valid-pair matrix and derived topology service envelopes so the next Llama7B scheduler run does not rank logically impossible NoC assumptions."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1",
+  "created_utc": "2026-06-08T13:17:31Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B dense tile topology/scheduler pairs",
+  "hypothesis": "The Llama7B dense-tile attention frontier should be filtered through logically valid NoC topology, scheduler, reducer, bank-placement, link-width, and virtual-channel pairs before latency is ranked. The previous abstract 65kB/cycle one-hop NoC service is expected to be far above simple mesh/tree/ring service envelopes and should not be swept independently.",
+  "direct_comparison": {
+    "primary_question": "Which NoC topology/scheduler/reducer/bank-placement pairs are logically valid for the dense_gemm_16x8_k1_p1 Llama7B attention frontier, and how far are their derived service envelopes from the previous abstract NoC service point?",
+    "include": [
+      "cluster counts 4, 8, and 16",
+      "topologies cluster_tree, mesh2d, ring, and crossbar",
+      "scheduler policies static_wave, locality_aware, bank_aware_prefetch, tree_reduction_aware, and double_buffered_overlap",
+      "reduction strategies centralized_tile, owner_cluster, and cluster_tree",
+      "bank placements per_cluster_local, grouped_shared, and distributed_shared",
+      "bank counts 16, 64, and 128",
+      "link widths 256, 512, 1024, and 2048 bits",
+      "virtual channels 1, 2, and 4"
+    ],
+    "exclude": [
+      "cycle-accurate routed NoC RTL",
+      "new SRAM macro PPA",
+      "new dense GEMM tile PPA",
+      "quality-affecting KV-sharing or precision changes"
+    ],
+    "follow_on_broad_sweep": [
+      "rerun the clustered Llama7B scheduler using only valid topology-derived service rows",
+      "embody the winning topology family in a more detailed NoC/SRAM model"
+    ]
+  },
+  "expected_benefit": [
+    "prevent impossible topology/scheduler/reducer combinations from entering the frontier ranking",
+    "quantify how optimistic the prior independent NoC bandwidth/hop sweep was",
+    "select the next physically meaningful scheduler/performance points"
+  ],
+  "risks": [
+    "service envelopes are analytic and still not routed NoC RTL",
+    "area cost is a proxy rather than measured fabric PPA",
+    "validity rules may need revision after a concrete NoC implementation is introduced"
+  ],
+  "needs_mapper_change": false,
+  "implementation_min_commit": "c93db2ccf9c8e92a2d1fe6a1ac5a85dc5e61181c",
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "dense_tile_topology_scheduler_pairs",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "filter_topology_scheduler_pairs",
+        "reason": "The result should produce a valid-pair matrix and derived topology service envelopes so the next Llama7B scheduler run does not rank logically impossible NoC assumptions."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_reduction_noc_frontier__l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1/analysis_report.md",
+    "npu/eval/estimate_llm_decoder_attention_kv_topology_scheduler_pairs.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/quality_gate.md
@@ -1,0 +1,31 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1`
+- `title`: `Llama7B dense tile topology/scheduler pairs`
+
+## Why This Gate Is Required
+- The previous frontier used independent NoC bandwidth, hop, cluster-count, and reduction knobs.
+- The next architecture ranking should only consume topology/scheduler pairs that can coexist logically.
+- The report must make invalid combinations explicit so future scheduler jobs can filter them.
+
+## Reference
+- reduction_noc_frontier: `l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1`
+- implementation_min_commit: `c93db2ccf9c8e92a2d1fe6a1ac5a85dc5e61181c`
+
+## Checks
+- metric: valid pair count
+  - threshold: nonzero successful output
+- metric: invalid pair count
+  - threshold: nonzero rejected output with explicit invalid reasons
+- metric: previous bandwidth gap
+  - threshold: report must compare valid topology service to the previous 65kB/cycle one-hop service target
+- metric: next-sweep readiness
+  - threshold: output must include `best_valid_pairs`
+
+## Local Commands
+- command: `python3 npu/eval/estimate_llm_decoder_attention_kv_topology_scheduler_pairs.py --repo-root . --frontier-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_reduction_noc_frontier__l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1.json --out /tmp/topology_pairs.json --out-md /tmp/topology_pairs.md`
+
+## Result
+- status: pending
+- note: Final quality decision waits for evaluator output.


### PR DESCRIPTION
## Summary
- propose `l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1`
- gate the next Llama7B dense-tile NoC scheduler work on logically valid topology/scheduler/reducer/bank-placement pairs
- document that dispatch should use the proposal merge commit while requiring implementation commit `c93db2cc` or newer

## Checks
- `python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/proposal.json`
- `python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/evaluation_requests.json`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`