### PR TITLE
docs: propose topology-derived dense tile scheduler job

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/README.md
@@ -1,0 +1,17 @@
+# Llama7B Dense Tile Topology-Derived Schedule
+
+This proposal queues the follow-on L2 scheduler run after the topology/scheduler
+validity filter. The job consumes the compact valid topology-pair artifact and
+reruns the dense-tile Llama7B clustered schedule using topology-derived NoC
+service rows.
+
+The key correction is that `cluster_count`, `bank_count`,
+`local_sram_fraction`, `reduction_strategy`, link width, virtual channels, and
+worst-hop latency are coupled. The job no longer sweeps abstract
+`noc_bandwidth_bytes_per_cycle` and `noc_hops` independently.
+
+Expected output:
+
+- revised Llama7B dense-tile latency frontier under valid topology service rows
+- best rows by topology, scheduler, die size, and reduction policy
+- explicit comparison to the previous abstract 65kB/cycle one-hop NoC target

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by: developer_agent
+- approved_utc: 2026-06-08T13:57:33Z
+- allowed_evaluations:
+  - l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1
+- note: Focused L2 scheduler rerun using topology-derived NoC service rows.

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
+  "source_commit": "",
+  "source_commit_note": "Dispatch should use the proposal merge commit so the evaluator sees this proposal artifact; implementation requires at least 650081546b870d025144cc530425e9847d4d30f0.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the dense-tile Llama7B scheduler using topology-derived NoC service rows from valid topology/scheduler pairs.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_dense_tile_topology_derived_schedule",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "revise_dense_tile_scheduler_frontier_with_topology_service",
+        "reason": "The result should provide the Llama7B dense-tile scheduler frontier under valid topology-derived NoC service rows."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
+  "created_utc": "2026-06-08T13:57:33Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B dense tile topology-derived scheduler frontier",
+  "hypothesis": "When the dense-tile Llama7B scheduler consumes only logically valid topology-derived NoC service rows, the earlier abstract 65kB/cycle one-hop frontier will move to a slower but physically more meaningful latency region. The result should identify which topology/scheduler family is worth modeling in more detail next.",
+  "direct_comparison": {
+    "primary_question": "What is the revised dense-tile Llama7B 131k latency frontier when NoC service is derived from valid topology/scheduler pairs instead of independent bandwidth/hop knobs?",
+    "include": [
+      "dense_gemm_16x8_k1_p1 compute anchor",
+      "valid topology service rows from l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1_r2",
+      "die areas 800 and 1200 mm2",
+      "SRAM area fractions 0.35, 0.4, 0.5, and 0.6",
+      "logic fractions 0.3, 0.4, and 0.5",
+      "tile sizes 512 and 1024",
+      "command and reducer overhead sensitivities"
+    ],
+    "exclude": [
+      "independent abstract NoC bandwidth/hop sweeps",
+      "cycle-accurate routed NoC RTL",
+      "new dense GEMM tile PPA",
+      "quality-affecting KV sharing or precision changes"
+    ],
+    "follow_on_broad_sweep": [
+      "build a detailed SRAM/NoC simulator or RTL fabric around the best topology family",
+      "extend the model from single-stage topology service to SRAM banking and routing schedules"
+    ]
+  },
+  "expected_benefit": [
+    "replace the optimistic abstract NoC frontier with a topology-coupled frontier",
+    "identify whether mesh/tree/ring/crossbar scheduler families remain viable under Llama7B 131k traffic",
+    "select the next concrete NoC/SRAM modeling target"
+  ],
+  "risks": [
+    "topology service rows are still analytic, not routed NoC RTL",
+    "SRAM bank arbitration remains simplified",
+    "best rows may be sensitive to the chosen top-k topology service row limit"
+  ],
+  "needs_mapper_change": false,
+  "implementation_min_commit": "650081546b870d025144cc530425e9847d4d30f0",
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "dense_tile_topology_derived_schedule",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "revise_dense_tile_scheduler_frontier_with_topology_service",
+        "reason": "The result should provide the Llama7B dense-tile scheduler frontier under valid topology-derived NoC service rows."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_reduction_noc_frontier__l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_topology_scheduler_pairs__l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/analysis_report.md",
+    "npu/eval/estimate_llm_decoder_attention_kv_topology_derived_schedule.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/quality_gate.md
@@ -1,0 +1,30 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1`
+- `title`: `Llama7B dense tile topology-derived scheduler frontier`
+
+## Why This Gate Is Required
+- The previous topology-pair result showed the abstract 65kB/cycle one-hop NoC target is not a proven topology.
+- The scheduler frontier must be recomputed using coupled topology service rows before it guides NoC/SRAM design.
+
+## Reference
+- topology_pairs_ref: `l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1_r2`
+- implementation_min_commit: `650081546b870d025144cc530425e9847d4d30f0`
+
+## Checks
+- metric: generated rows
+  - threshold: nonzero successful output
+- metric: topology service rows
+  - threshold: output must cite the number of topology service rows used
+- metric: abstract NoC knobs
+  - threshold: generated task command must not include independent `--noc-bandwidth-bytes-per-cycle` or `--noc-hops`
+- metric: frontier comparison
+  - threshold: report must include best topology/scheduler and gap to the previous abstract NoC service target
+
+## Local Commands
+- command: `python3 npu/eval/estimate_llm_decoder_attention_kv_topology_derived_schedule.py --repo-root . --topology-pairs-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_topology_scheduler_pairs__l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1_r2.json --out /tmp/topology_derived.json --out-md /tmp/topology_derived.md`
+
+## Result
+- status: pending
+- note: Final quality decision waits for evaluator output.


### PR DESCRIPTION
## Summary
- propose `l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1`
- rerun the dense-tile Llama7B scheduler from valid topology-derived NoC service rows
- document that dispatch should use the proposal merge commit while requiring implementation commit `65008154` or newer

## Checks
- `python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/proposal.json`
- `python3 -m json.tool docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/evaluation_requests.json`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`