### PR TITLE
docs: propose SRAM/NoC constrained scheduler job

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/README.md
@@ -1,0 +1,22 @@
+# Llama7B SRAM/NoC Constrained Schedule
+
+This proposal queues the follow-on L2 scheduler run after the topology-derived
+dense-tile frontier. The job consumes the merged topology-derived schedule and
+the measured SRAM tile-buffer profile, then applies practical caps for:
+
+- local tile-buffer capacity per cluster
+- 256-bit SRAM-bank read service
+- endpoint injection/ejection service per cluster
+- topology-derived aggregate NoC payload service
+
+The purpose is to correct the optimistic abstract SRAM-bank bandwidth in the
+previous scheduler while keeping the NoC topology/scheduler coupling from the
+valid topology-pair result.
+
+Expected output:
+
+- revised Llama7B dense-tile frontier under practical SRAM/NoC endpoint caps
+- slowdown versus the topology-derived schedule
+- cap-source counts showing whether topology, endpoint, or SRAM-bank service is
+  limiting the retained frontier
+- best rows by topology and endpoint/SRAM setting

--- a/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by: developer_agent
+- approved_utc: 2026-06-08T22:00:46Z
+- allowed_evaluations:
+  - l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1
+- note: Focused L2 scheduler correction using practical SRAM-bank and endpoint NoC service caps.

--- a/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1",
+  "source_commit": "3a04282a22036915b9ad193ee2351dd2cf19dc64",
+  "source_commit_note": "Dispatch should use the proposal merge commit so the evaluator sees this proposal artifact; implementation requires at least 3a04282a22036915b9ad193ee2351dd2cf19dc64.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Apply practical SRAM-bank, local-buffer, and endpoint NoC service caps to the retained Llama7B topology-derived dense-tile scheduler frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_sram_noc_constrained_schedule",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
+        "l2_decoder_attention_sram_profile_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "revise_dense_tile_scheduler_frontier_with_practical_sram_noc_caps",
+        "reason": "The result should report slowdown versus topology-derived scheduling and identify whether topology, SRAM-bank service, or endpoint service caps the retained frontier."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1",
+  "created_utc": "2026-06-08T22:00:46Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B SRAM/NoC constrained dense tile scheduler frontier",
+  "hypothesis": "When retained topology-derived Llama7B dense-tile schedule rows are capped by practical 256-bit SRAM-bank service, local tile-buffer capacity, and endpoint injection/ejection service, the previous topology-derived frontier will slow down and reveal whether SRAM banks or NoC endpoints dominate before a detailed NoC/SRAM simulator is built.",
+  "direct_comparison": {
+    "primary_question": "What is the revised Llama7B 131k dense-tile latency frontier after applying practical SRAM-bank and endpoint NoC service caps to the topology-derived schedule?",
+    "include": [
+      "merged topology-derived schedule l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
+      "measured SRAM tile-buffer profile l2_decoder_attention_sram_profile_v1",
+      "256-bit SRAM-bank read service default",
+      "endpoint port width and endpoint port count sensitivity",
+      "local tile-buffer capacity multiplier sensitivity",
+      "slowdown versus topology-derived schedule"
+    ],
+    "exclude": [
+      "independent abstract NoC bandwidth/hop sweeps",
+      "cycle-accurate routed NoC RTL",
+      "new dense GEMM tile PPA",
+      "new SRAM compiler or placed SRAM macro floorplan",
+      "quality-affecting KV sharing or precision changes"
+    ],
+    "follow_on_broad_sweep": [
+      "expand from retained frontier rows to a full scheduler re-search if cap sensitivity changes ranking materially",
+      "construct a detailed SRAM/NoC simulator for the best topology family",
+      "embody per-cluster SRAM ports, routers, injection queues, and static/dynamic scheduler interfaces"
+    ]
+  },
+  "expected_benefit": [
+    "replace the optimistic active_banks * 2048 B/cycle SRAM service abstraction with a measured-width bank-port cap",
+    "identify whether SRAM-bank service or endpoint NoC service is the immediate limiter",
+    "select the next concrete NoC/SRAM modeling target for the Llama7B architecture goal"
+  ],
+  "risks": [
+    "the first pass uses retained frontier rows rather than the full 746k generated topology-derived schedule space",
+    "SRAM arbitration remains an analytic cap, not a cycle-accurate bank scheduler",
+    "endpoint caps are parametric until router/injection queue RTL is embodied"
+  ],
+  "needs_mapper_change": false,
+  "implementation_min_commit": "3a04282a22036915b9ad193ee2351dd2cf19dc64",
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "sram_noc_constrained_dense_tile_schedule",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
+        "l2_decoder_attention_sram_profile_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "revise_dense_tile_scheduler_frontier_with_practical_sram_noc_caps",
+        "reason": "The result should show the Llama7B dense-tile frontier after practical SRAM-bank and endpoint NoC service caps are applied."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_topology_derived_schedule__l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1/analysis_report.md",
+    "npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/quality_gate.md
@@ -1,0 +1,33 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1`
+- `title`: `Llama7B SRAM/NoC constrained dense tile scheduler frontier`
+
+## Why This Gate Is Required
+- The topology-derived schedule still inherited an optimistic SRAM-bank service abstraction.
+- The next Llama7B frontier should be interpreted under practical SRAM-bank and endpoint service caps before selecting a detailed NoC/SRAM implementation target.
+
+## Reference
+- topology_derived_ref: `l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1`
+- sram_profile_ref: `l2_decoder_attention_sram_profile_v1`
+- implementation_min_commit: `3a04282a22036915b9ad193ee2351dd2cf19dc64`
+
+## Checks
+- metric: generated rows
+  - threshold: nonzero successful output
+- metric: cap-source accounting
+  - threshold: report must include practical NoC cap-source counts
+- metric: practical SRAM bank service
+  - threshold: output must cite SRAM bank port bytes per cycle and local tile-buffer bytes
+- metric: abstract NoC knobs
+  - threshold: generated task command must not include independent `--noc-bandwidth-bytes-per-cycle` or `--noc-hops`
+- metric: frontier comparison
+  - threshold: report must include slowdown versus the topology-derived schedule
+
+## Local Commands
+- command: `python3 npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py --repo-root . --topology-derived-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_topology_derived_schedule__l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1.json --sram-profile-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json --frontier-row-limit 256 --out /tmp/sram_noc_constrained.json --out-md /tmp/sram_noc_constrained.md`
+
+## Result
+- status: pending
+- note: Final quality decision waits for evaluator output.


### PR DESCRIPTION
## Summary
- add the L2 proposal for applying practical SRAM-bank, local-buffer, and endpoint NoC caps to the retained Llama7B topology-derived dense-tile scheduler frontier
- request item l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1
- depend on the merged topology-derived schedule and measured SRAM profile artifacts

## Validation
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check
- python3 -m json.tool proposal/evaluation request files