### PR TITLE
docs: authorize SRAM/NoC constrained r2 job

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/evaluation_gate.md
@@ -5,4 +5,5 @@
 - approved_utc: 2026-06-08T22:00:46Z
 - allowed_evaluations:
   - l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1
+  - l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2
 - note: Focused L2 scheduler correction using practical SRAM-bank and endpoint NoC service caps.

--- a/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1",
-  "source_commit": "3a04282a22036915b9ad193ee2351dd2cf19dc64",
+  "source_commit": "ae6ec94916854459b672f613c64a17ee81500402",
   "source_commit_note": "Dispatch should use the proposal merge commit so the evaluator sees this proposal artifact; implementation requires at least 3a04282a22036915b9ad193ee2351dd2cf19dc64.",
   "requested_items": [
     {
@@ -20,7 +20,30 @@
       "expected_result": {
         "direction": "revise_dense_tile_scheduler_frontier_with_practical_sram_noc_caps",
         "reason": "The result should report slowdown versus topology-derived scheduling and identify whether topology, SRAM-bank service, or endpoint service caps the retained frontier."
-      }
+      },
+      "status": "superseded",
+      "superseded_by_item_id": "l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2",
+      "notes": "Superseded because v1 was dispatched with stale local control-plane generator code and ran the generic campaign path."
+    },
+    {
+      "item_id": "l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2",
+      "task_type": "l2_campaign",
+      "objective": "Apply practical SRAM-bank, local-buffer, and endpoint NoC service caps to the retained Llama7B topology-derived dense-tile scheduler frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_sram_noc_constrained_schedule",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
+        "l2_decoder_attention_sram_profile_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "revise_dense_tile_scheduler_frontier_with_practical_sram_noc_caps",
+        "reason": "The result should report slowdown versus topology-derived scheduling and identify whether topology, SRAM-bank service, or endpoint service caps the retained frontier."
+      },
+      "notes": "Retry using updated control-plane generator from the proposal merge commit."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- mark the stale v1 SRAM/NoC constrained job as superseded
- explicitly authorize l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2 in the proposal gate and evaluation request

## Validation
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check