### PR TITLE
npu: add on-chip service schedule estimator

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4452,6 +4452,53 @@ def _decoder_attention_kv_sram_noc_constrained_schedule_evidence(
     }
 
 
+def _decoder_attention_kv_onchip_service_schedule_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_onchip_service_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_onchip_service_schedule__{item_id}.md"
+    sram_noc_constrained = (
+        f"{base}/decoder_attention_kv_sram_noc_constrained_schedule__"
+        "l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_sram_noc_constrained_schedule": sram_noc_constrained,
+            "attention_kv_onchip_service_schedule_out": out,
+            "attention_kv_onchip_service_schedule_report": report,
+            "attention_kv_onchip_service_schedule_scope": (
+                "Refine retained Llama7B SRAM/NoC-constrained dense-tile rows with explicit "
+                "on-chip service policy parameters: SRAM bank arbitration, endpoint queue depth, "
+                "bank queue depth, packet payload, router hop latency, schedule staggering, and "
+                "prefetch overlap. HBM/DRAM service is intentionally inherited unchanged."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_onchip_service_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py "
+                    "--repo-root . "
+                    f"--sram-noc-constrained-json {sram_noc_constrained} "
+                    "--frontier-row-limit 128 "
+                    "--schedule-policy static_wave,staggered_wave,prefetch_overlap "
+                    "--bank-arbiter-policy round_robin,locality_first,age_based "
+                    "--endpoint-queue-depth-bytes 2048,8192,32768 "
+                    "--bank-queue-depth-bytes 2048,8192,32768 "
+                    "--router-latency-cycles-per-hop 1,2 "
+                    "--packet-payload-bytes 32,64,128 "
+                    "--prefetch-overlap-fraction 0,0.25,0.5 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_sram_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_sram_profile__{item_id}.json"
@@ -6039,6 +6086,7 @@ def _build_payload(
         "decoder_attention_kv_dense_tile_topology_scheduler_pairs",
         "decoder_attention_kv_dense_tile_topology_derived_schedule",
         "decoder_attention_kv_sram_noc_constrained_schedule",
+        "decoder_attention_kv_onchip_service_schedule",
         "decoder_attention_sram_profile",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
@@ -6136,6 +6184,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_dense_tile_topology_derived_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_sram_noc_constrained_schedule":
             decoder_evidence = _decoder_attention_kv_sram_noc_constrained_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_onchip_service_schedule":
+            decoder_evidence = _decoder_attention_kv_onchip_service_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_sram_profile":
             decoder_evidence = _decoder_attention_sram_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5438,3 +5438,53 @@ def test_generate_l2_campaign_task_adds_sram_noc_constrained_schedule_evidence()
                 )
                 for output in expected_outputs
             )
+
+
+def test_generate_l2_campaign_task_adds_onchip_service_schedule_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_onchip_service_schedule",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+
+            assert "estimate_decoder_attention_kv_onchip_service_schedule" in command_names
+            assert "attention_kv_sram_noc_constrained_schedule" in decoder_inputs
+            assert "attention_kv_onchip_service_schedule_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_onchip_service_schedule.py" in commands[0]["run"]
+            assert "l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2.json" in commands[0]["run"]
+            assert "--schedule-policy static_wave,staggered_wave,prefetch_overlap" in commands[0]["run"]
+            assert "--endpoint-queue-depth-bytes 2048,8192,32768" in commands[0]["run"]
+            assert "--router-latency-cycles-per-hop 1,2" in commands[0]["run"]
+            assert "--noc-bandwidth-bytes-per-cycle" not in commands[0]["run"]
+            assert "--data-rate-mtps" not in commands[0]["run"]
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_onchip_service_schedule__"
+                    "l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )

--- a/npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Estimate Llama7B schedules with explicit on-chip SRAM/NoC service policies."""
+
+from __future__ import annotations
+
+import argparse
+import heapq
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval import estimate_llm_decoder_attention_kv_clustered_schedule as clustered  # noqa: E402
+from npu.eval import estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule as constrained  # noqa: E402
+
+
+JsonDict = dict[str, Any]
+
+
+def _float_list(value: str) -> list[float]:
+    items = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item < 0.0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated nonnegative floats")
+    return items
+
+
+def _positive_float_list(value: str) -> list[float]:
+    items = _float_list(value)
+    if any(item <= 0.0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive floats")
+    return items
+
+
+def _int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return items
+
+
+def _str_list(value: str) -> list[str]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated names")
+    return items
+
+
+def _ceil_div(numerator: int | float, denominator: int | float) -> int:
+    if numerator <= 0:
+        return 0
+    return int(math.ceil(float(numerator) / max(1.0, float(denominator))))
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _source_rows(payload: JsonDict, *, limit: int) -> list[JsonDict]:
+    rows = constrained._dedupe_rows(payload, limit=limit)
+    return [row for row in rows if int(row.get("cluster_count", 0)) > 0]
+
+
+def _full_tile_bytes(row: JsonDict) -> float:
+    head_dim = int(row["hidden_size"]) // int(row["attention_heads"])
+    kv_width = int(row["kv_heads"]) * head_dim
+    return 2.0 * int(row["tile_tokens"]) * kv_width * int(row["kv_bits"]) / 8.0
+
+
+def _bank_policy_efficiency(policy: str) -> float:
+    if policy == "round_robin":
+        return 0.90
+    if policy == "locality_first":
+        return 1.00
+    if policy == "age_based":
+        return 0.95
+    raise ValueError(f"unknown bank policy: {policy}")
+
+
+def _schedule_policy_efficiency(policy: str) -> tuple[float, float]:
+    """Return (fabric contention efficiency, explicit start-spread cycles per cluster)."""
+    if policy == "static_wave":
+        return 1.0, 0.0
+    if policy == "staggered_wave":
+        return 1.12, 2.0
+    if policy == "prefetch_overlap":
+        return 1.05, 1.0
+    raise ValueError(f"unknown schedule policy: {policy}")
+
+
+def _queue_penalty(
+    *,
+    payload_bytes_per_cluster: float,
+    service_bytes_per_cycle: float,
+    queue_depth_bytes: int,
+    latency_cycles: int,
+) -> int:
+    if payload_bytes_per_cluster <= 0.0:
+        return 0
+    inflight_bytes = service_bytes_per_cycle * max(1, latency_cycles)
+    if queue_depth_bytes >= inflight_bytes:
+        return 0
+    shortfall = min(payload_bytes_per_cluster, inflight_bytes - queue_depth_bytes)
+    return _ceil_div(shortfall, service_bytes_per_cycle)
+
+
+def _annotate_service(
+    row: JsonDict,
+    *,
+    schedule_policy: str,
+    bank_arbiter_policy: str,
+    endpoint_queue_depth_bytes: int,
+    bank_queue_depth_bytes: int,
+    router_latency_cycles_per_hop: int,
+    packet_payload_bytes: int,
+    prefetch_overlap_fraction: float,
+) -> JsonDict:
+    active_clusters = max(1, int(row["active_clusters"]))
+    cluster_count = max(1, int(row["cluster_count"]))
+    full_tile_bytes = _full_tile_bytes(row)
+    shared_bytes_per_cluster = full_tile_bytes * float(row["shared_byte_share"])
+    local_bytes_per_cluster = full_tile_bytes * float(row["local_byte_share"])
+    hbm_cycles = int(row["tile_hbm_cycles"])
+
+    topology_agg_bpc = float(
+        row.get(
+            "topology_aggregate_payload_bytes_per_cycle",
+            row.get("practical_aggregate_noc_effective_bytes_per_cycle", 1.0),
+        )
+    )
+    endpoint_bpc_per_cluster = float(row["endpoint_bytes_per_cycle_per_cluster"])
+    endpoint_agg_bpc = endpoint_bpc_per_cluster * active_clusters
+    shared_bank_bpc_per_cluster = float(row["practical_shared_bank_bytes_per_cycle_per_cluster"])
+    local_bank_bpc_per_cluster = float(row["practical_local_bank_bytes_per_cycle_per_cluster"])
+    bank_eff = _bank_policy_efficiency(bank_arbiter_policy)
+    fabric_eff, stagger_cycles_per_cluster = _schedule_policy_efficiency(schedule_policy)
+    hop_latency = max(0, int(row["noc_hops"]) * router_latency_cycles_per_hop)
+    packet_count_per_cluster = _ceil_div(shared_bytes_per_cluster, packet_payload_bytes)
+
+    local_bank_cycles = _ceil_div(local_bytes_per_cluster, local_bank_bpc_per_cluster * bank_eff)
+    shared_bank_cycles = _ceil_div(shared_bytes_per_cluster, shared_bank_bpc_per_cluster * bank_eff)
+    endpoint_cycles = _ceil_div(shared_bytes_per_cluster, endpoint_bpc_per_cluster)
+    fabric_service_bpc = min(topology_agg_bpc * fabric_eff, endpoint_agg_bpc)
+    fabric_cycles = _ceil_div(shared_bytes_per_cluster * active_clusters, fabric_service_bpc)
+    endpoint_queue_penalty = _queue_penalty(
+        payload_bytes_per_cluster=shared_bytes_per_cluster,
+        service_bytes_per_cycle=endpoint_bpc_per_cluster,
+        queue_depth_bytes=endpoint_queue_depth_bytes,
+        latency_cycles=hop_latency + 1,
+    )
+    bank_queue_penalty = _queue_penalty(
+        payload_bytes_per_cluster=shared_bytes_per_cluster,
+        service_bytes_per_cycle=shared_bank_bpc_per_cluster * bank_eff,
+        queue_depth_bytes=bank_queue_depth_bytes,
+        latency_cycles=max(1, packet_count_per_cluster // 4),
+    )
+    wave_stagger_cycles = int(math.ceil(max(0, active_clusters - 1) * stagger_cycles_per_cluster))
+    shared_service_cycles = (
+        max(shared_bank_cycles, endpoint_cycles, fabric_cycles)
+        + hop_latency
+        + endpoint_queue_penalty
+        + bank_queue_penalty
+        + wave_stagger_cycles
+    )
+
+    overlap_fraction = prefetch_overlap_fraction if schedule_policy == "prefetch_overlap" else 0.0
+    hidden_shared_cycles = min(shared_service_cycles, int(row["tile_attention_cycles"]) * overlap_fraction)
+    exposed_shared_cycles = max(0, int(math.ceil(shared_service_cycles - hidden_shared_cycles)))
+    tile_shared_path_cycles = max(shared_bank_cycles, exposed_shared_cycles)
+    tile_memory_cycles = max(local_bank_cycles, tile_shared_path_cycles, hbm_cycles)
+    tile_service_cycles = max(int(row["tile_attention_cycles"]), tile_memory_cycles)
+
+    stages, _ = clustered._reduction_factor(str(row["reduction_strategy"]), active_clusters)
+    reduction_service_bpc = min(topology_agg_bpc * fabric_eff, endpoint_agg_bpc)
+    reduction_noc_cycles = (
+        _ceil_div(int(row["cross_tile_reduction_payload_bytes"]), reduction_service_bpc)
+        + stages * hop_latency
+        + _queue_penalty(
+            payload_bytes_per_cluster=float(row["partial_reduction_payload_bytes"]),
+            service_bytes_per_cycle=endpoint_bpc_per_cluster,
+            queue_depth_bytes=endpoint_queue_depth_bytes,
+            latency_cycles=hop_latency + 1,
+        )
+    )
+    base_reduction_cycles = int(row["local_reduction_cycles"]) + max(
+        reduction_noc_cycles,
+        int(row["cross_tile_reduction_vector_cycles"]),
+    )
+    cross_tile_reduction_cycles = (
+        _ceil_div(base_reduction_cycles * float(row["reduction_cycle_multiplier"]), 1)
+        + int(row["reducer_setup_cycles"])
+    )
+
+    kv_write_bytes = 2 * (int(row["kv_heads"]) * (int(row["hidden_size"]) // int(row["attention_heads"]))) * int(row["kv_bits"]) / 8.0
+    kv_write_cycles = _ceil_div(kv_write_bytes, min(endpoint_bpc_per_cluster, shared_bank_bpc_per_cluster * bank_eff))
+    command_backpressure_cycles = _ceil_div(endpoint_queue_penalty * int(row["tile_waves"]), active_clusters)
+    command_dispatch_cycles = int(row["command_dispatch_cycles"]) + command_backpressure_cycles
+    layer_cycles = (
+        int(row["qkv_cycles"])
+        + int(row["tile_waves"]) * tile_service_cycles
+        + command_dispatch_cycles
+        + cross_tile_reduction_cycles
+        + kv_write_cycles
+    )
+    total_cycles = layer_cycles * int(row["layers"])
+    clock_ns = float(row["clock_ns"])
+    dominant = max(
+        {
+            "tile_attention": int(row["tile_attention_cycles"]),
+            "local_sram": local_bank_cycles,
+            "shared_path": tile_shared_path_cycles,
+            "hbm": hbm_cycles,
+            "cross_tile_reduction": cross_tile_reduction_cycles,
+            "command_dispatch": command_dispatch_cycles,
+        }.items(),
+        key=lambda item: item[1],
+    )[0]
+
+    out = dict(row)
+    out.update(
+        {
+            "onchip_service_model": "cycle_stepped_sram_bank_endpoint_router_v1",
+            "schedule_policy": schedule_policy,
+            "bank_arbiter_policy": bank_arbiter_policy,
+            "endpoint_queue_depth_bytes": endpoint_queue_depth_bytes,
+            "bank_queue_depth_bytes": bank_queue_depth_bytes,
+            "router_latency_cycles_per_hop": router_latency_cycles_per_hop,
+            "packet_payload_bytes": packet_payload_bytes,
+            "prefetch_overlap_fraction": overlap_fraction,
+            "onchip_full_tile_bytes": int(full_tile_bytes),
+            "onchip_shared_bytes_per_cluster": int(math.ceil(shared_bytes_per_cluster)),
+            "onchip_local_bytes_per_cluster": int(math.ceil(local_bytes_per_cluster)),
+            "onchip_hbm_cycles_inherited": hbm_cycles,
+            "onchip_topology_aggregate_bytes_per_cycle": round(topology_agg_bpc, 6),
+            "onchip_fabric_service_bytes_per_cycle": round(fabric_service_bpc, 6),
+            "onchip_endpoint_bytes_per_cycle_per_cluster": round(endpoint_bpc_per_cluster, 6),
+            "onchip_shared_bank_bytes_per_cycle_per_cluster": round(shared_bank_bpc_per_cluster * bank_eff, 6),
+            "onchip_local_bank_bytes_per_cycle_per_cluster": round(local_bank_bpc_per_cluster * bank_eff, 6),
+            "onchip_packet_count_per_cluster": packet_count_per_cluster,
+            "onchip_hop_latency_cycles": hop_latency,
+            "onchip_endpoint_queue_penalty_cycles": endpoint_queue_penalty,
+            "onchip_bank_queue_penalty_cycles": bank_queue_penalty,
+            "onchip_wave_stagger_cycles": wave_stagger_cycles,
+            "onchip_shared_service_cycles": shared_service_cycles,
+            "onchip_hidden_shared_cycles": int(math.floor(hidden_shared_cycles)),
+            "onchip_exposed_shared_cycles": exposed_shared_cycles,
+            "tile_local_sram_cycles": local_bank_cycles,
+            "tile_shared_path_cycles": tile_shared_path_cycles,
+            "tile_memory_cycles": tile_memory_cycles,
+            "tile_service_cycles": tile_service_cycles,
+            "cross_tile_reduction_noc_cycles": reduction_noc_cycles,
+            "base_cross_tile_reduction_cycles": base_reduction_cycles,
+            "cross_tile_reduction_cycles": cross_tile_reduction_cycles,
+            "command_dispatch_cycles": command_dispatch_cycles,
+            "kv_write_cycles": kv_write_cycles,
+            "layer_cycles": layer_cycles,
+            "total_cycles": total_cycles,
+            "latency_us": round(total_cycles * clock_ns / 1000.0, 6),
+            "dominant_tile_resource": dominant,
+            "latency_slowdown_vs_sram_noc_cap": round(
+                (total_cycles * clock_ns / 1000.0) / max(1e-9, float(row["latency_us"])),
+                6,
+            ),
+            "latency_slowdown_vs_topology_derived": round(
+                (total_cycles * clock_ns / 1000.0) / max(1e-9, float(row.get("unconstrained_latency_us", row["latency_us"]))),
+                6,
+            ),
+        }
+    )
+    return out
+
+
+def _update_best(target: dict[tuple[Any, ...], JsonDict], keys: tuple[str, ...], row: JsonDict) -> None:
+    key = tuple(row.get(item) for item in keys)
+    current = target.get(key)
+    if current is None or float(row["latency_us"]) < float(current["latency_us"]):
+        target[key] = row
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    repo_root = args.repo_root
+    source_payload = _load_json(repo_root / args.sram_noc_constrained_json)
+    source_rows = _source_rows(source_payload, limit=args.frontier_row_limit)
+
+    best: JsonDict | None = None
+    generated = 0
+    dominance = Counter()
+    schedule_counts = Counter()
+    top_heap: list[tuple[float, int, JsonDict]] = []
+    heap_counter = 0
+    best_by_policy: dict[tuple[Any, ...], JsonDict] = {}
+    best_by_topology: dict[tuple[Any, ...], JsonDict] = {}
+    best_by_queue: dict[tuple[Any, ...], JsonDict] = {}
+
+    for row in source_rows:
+        for schedule_policy in args.schedule_policy:
+            for bank_policy in args.bank_arbiter_policy:
+                for endpoint_queue_depth_bytes in args.endpoint_queue_depth_bytes:
+                    for bank_queue_depth_bytes in args.bank_queue_depth_bytes:
+                        for router_latency_cycles_per_hop in args.router_latency_cycles_per_hop:
+                            for packet_payload_bytes in args.packet_payload_bytes:
+                                for prefetch_overlap_fraction in args.prefetch_overlap_fraction:
+                                    if schedule_policy != "prefetch_overlap" and prefetch_overlap_fraction != 0.0:
+                                        continue
+                                    if schedule_policy == "prefetch_overlap" and prefetch_overlap_fraction <= 0.0:
+                                        continue
+                                    out = _annotate_service(
+                                        row,
+                                        schedule_policy=schedule_policy,
+                                        bank_arbiter_policy=bank_policy,
+                                        endpoint_queue_depth_bytes=endpoint_queue_depth_bytes,
+                                        bank_queue_depth_bytes=bank_queue_depth_bytes,
+                                        router_latency_cycles_per_hop=router_latency_cycles_per_hop,
+                                        packet_payload_bytes=packet_payload_bytes,
+                                        prefetch_overlap_fraction=prefetch_overlap_fraction,
+                                    )
+                                    generated += 1
+                                    dominance[str(out["dominant_tile_resource"])] += 1
+                                    schedule_counts[str(out["schedule_policy"])] += 1
+                                    if best is None or float(out["latency_us"]) < float(best["latency_us"]):
+                                        best = out
+                                    entry = (-float(out["latency_us"]), heap_counter, out)
+                                    heap_counter += 1
+                                    if len(top_heap) < args.top_k:
+                                        heapq.heappush(top_heap, entry)
+                                    elif entry[0] > top_heap[0][0]:
+                                        heapq.heapreplace(top_heap, entry)
+                                    _update_best(best_by_policy, ("schedule_policy", "bank_arbiter_policy"), out)
+                                    _update_best(best_by_topology, ("topology", "scheduler_policy", "reduction_strategy"), out)
+                                    _update_best(
+                                        best_by_queue,
+                                        ("endpoint_queue_depth_bytes", "bank_queue_depth_bytes", "router_latency_cycles_per_hop"),
+                                        out,
+                                    )
+    if best is None:
+        raise RuntimeError("no on-chip service rows generated")
+    top_rows = [entry[2] for entry in sorted(top_heap, key=lambda entry: (entry[2]["latency_us"], entry[1]))]
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_kv_onchip_service_schedule_llama7b_v1",
+        "sram_noc_constrained_json": str(args.sram_noc_constrained_json),
+        "source_model": source_payload.get("model"),
+        "inputs": {
+            "frontier_row_limit": args.frontier_row_limit,
+            "schedule_policy": args.schedule_policy,
+            "bank_arbiter_policy": args.bank_arbiter_policy,
+            "endpoint_queue_depth_bytes": args.endpoint_queue_depth_bytes,
+            "bank_queue_depth_bytes": args.bank_queue_depth_bytes,
+            "router_latency_cycles_per_hop": args.router_latency_cycles_per_hop,
+            "packet_payload_bytes": args.packet_payload_bytes,
+            "prefetch_overlap_fraction": args.prefetch_overlap_fraction,
+        },
+        "sweep_summary": {
+            "source_rows_used": len(source_rows),
+            "generated_row_count": generated,
+            "dominant_tile_resource_counts": dict(sorted(dominance.items())),
+            "schedule_policy_counts": dict(sorted(schedule_counts.items())),
+        },
+        "best": best,
+        "top_rows": top_rows,
+        "best_by_policy": sorted(best_by_policy.values(), key=lambda row: row["latency_us"])[:100],
+        "best_by_topology": sorted(best_by_topology.values(), key=lambda row: row["latency_us"])[:100],
+        "best_by_queue": sorted(best_by_queue.values(), key=lambda row: row["latency_us"])[:100],
+        "assumptions": [
+            "This pass refines on-chip SRAM/NoC service only; HBM/DRAM cycles and bandwidth fields are inherited from the input row.",
+            "SRAM bank arbitration is modeled as per-cycle service under a named policy, not as placed SRAM macro RTL.",
+            "Endpoint queues, packet payload, router hop latency, and schedule staggering are explicit parameters.",
+            "The model is still an analytic service simulator; it does not yet generate RTL routers or prove ready/valid equivalence.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best"]
+    lines = [
+        "# Llama7B On-Chip SRAM/NoC Service Schedule",
+        "",
+        f"- source rows used: `{payload['sweep_summary']['source_rows_used']}`",
+        f"- generated rows: `{payload['sweep_summary']['generated_row_count']}`",
+        f"- dominant resources: `{payload['sweep_summary']['dominant_tile_resource_counts']}`",
+        "",
+        "## Best",
+        "",
+        "| topology | schedule | bank policy | clusters | link bits | endpoint q | bank q | router hop | packet | latency us | vs cap | vs topo | resource |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        "| {topology} | {schedule_policy} | {bank_arbiter_policy} | {cluster_count} | {link_width_bits} | "
+        "{endpoint_queue_depth_bytes} | {bank_queue_depth_bytes} | {router_latency_cycles_per_hop} | "
+        "{packet_payload_bytes} | {latency_us} | {latency_slowdown_vs_sram_noc_cap} | "
+        "{latency_slowdown_vs_topology_derived} | {dominant_tile_resource} |".format(**best),
+        "",
+        "## Best By Policy",
+        "",
+        "| schedule | bank policy | latency us | vs cap | shared service cycles | exposed shared | resource |",
+        "|---|---|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["best_by_policy"][:30]:
+        lines.append(
+            "| {schedule_policy} | {bank_arbiter_policy} | {latency_us} | {latency_slowdown_vs_sram_noc_cap} | "
+            "{onchip_shared_service_cycles} | {onchip_exposed_shared_cycles} | {dominant_tile_resource} |".format(**row)
+        )
+    lines.extend(
+        [
+            "",
+            "## Best By Queue/Router Setting",
+            "",
+            "| endpoint q | bank q | router hop | latency us | queue penalties | resource |",
+            "|---:|---:|---:|---:|---|---|",
+        ]
+    )
+    for row in payload["best_by_queue"][:30]:
+        penalties = f"endpoint={row['onchip_endpoint_queue_penalty_cycles']},bank={row['onchip_bank_queue_penalty_cycles']}"
+        lines.append(
+            "| {endpoint_queue_depth_bytes} | {bank_queue_depth_bytes} | {router_latency_cycles_per_hop} | "
+            "{latency_us} | {penalties} | {dominant_tile_resource} |".format(**row, penalties=penalties)
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-root", type=Path, default=Path("."))
+    ap.add_argument("--sram-noc-constrained-json", required=True, type=Path)
+    ap.add_argument("--frontier-row-limit", type=int, default=128)
+    ap.add_argument("--schedule-policy", type=_str_list, default=["static_wave", "staggered_wave", "prefetch_overlap"])
+    ap.add_argument("--bank-arbiter-policy", type=_str_list, default=["round_robin", "locality_first", "age_based"])
+    ap.add_argument("--endpoint-queue-depth-bytes", type=_int_list, default=[2048, 8192, 32768])
+    ap.add_argument("--bank-queue-depth-bytes", type=_int_list, default=[2048, 8192, 32768])
+    ap.add_argument("--router-latency-cycles-per-hop", type=_int_list, default=[1, 2])
+    ap.add_argument("--packet-payload-bytes", type=_int_list, default=[32, 64, 128])
+    ap.add_argument("--prefetch-overlap-fraction", type=_float_list, default=[0.0, 0.25, 0.5])
+    ap.add_argument("--top-k", type=int, default=50)
+    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--out-md", required=True, type=Path)
+    args = ap.parse_args()
+
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an L2 estimator that refines retained Llama7B SRAM/NoC-constrained rows with on-chip service policy parameters
- model SRAM bank arbitration policy, endpoint/bank queue depth, packet payload, router hop latency, schedule staggering, and prefetch overlap
- register decoder_attention_kv_onchip_service_schedule in the control-plane generator

## Validation
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py
- python3 npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py --repo-root . --sram-noc-constrained-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_sram_noc_constrained_schedule__l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2.json --frontier-row-limit 128 --out /tmp/onchip_service.json --out-md /tmp/onchip_service.md
- PYTHONPATH=/tmp/rtlgen-onchip-service/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check