### PR TITLE
docs: propose on-chip service schedule job

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/README.md
@@ -1,0 +1,17 @@
+# Llama7B On-Chip SRAM/NoC Service Schedule
+
+This proposal queues the next non-HBM L2 scheduler run after the practical
+SRAM/NoC constrained frontier. The job consumes the retained frontier rows from
+`l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2` and
+refines only on-chip behavior:
+
+- SRAM bank arbitration policy
+- endpoint injection/ejection queue depth
+- bank queue depth
+- router/link hop latency
+- packet payload size
+- static wave, staggered wave, and prefetch-overlap scheduling
+
+HBM/DRAM service is intentionally inherited unchanged from the input row. This
+job is meant to identify which on-chip service policy should be embodied next
+with RTL or a more detailed simulator.

--- a/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by: developer_agent
+- approved_utc: 2026-06-09T00:52:00Z
+- allowed_evaluations:
+  - l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1
+- note: Focused non-HBM on-chip SRAM/NoC service policy refinement.

--- a/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1",
+  "source_commit": "2a03f9f8ad8bda90315946c41ac2b1e7d1d8bc33",
+  "source_commit_note": "Dispatch should use the proposal merge commit so the evaluator sees this proposal artifact; implementation requires at least 2a03f9f8ad8bda90315946c41ac2b1e7d1d8bc33.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Refine retained Llama7B SRAM/NoC-constrained dense-tile rows with explicit on-chip SRAM bank, endpoint queue, packet, router latency, and schedule policies while leaving HBM/DRAM assumptions unchanged.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_onchip_service_schedule",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "refine_dense_tile_scheduler_frontier_with_onchip_service_policies",
+        "reason": "The result should identify the best on-chip schedule/bank/queue/router policy and report slowdown versus the SRAM/NoC cap result without changing HBM/DRAM assumptions."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1",
+  "created_utc": "2026-06-09T00:52:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B on-chip SRAM/NoC service scheduler frontier",
+  "hypothesis": "When the retained Llama7B SRAM/NoC-constrained dense-tile rows are refined with explicit SRAM bank arbitration, endpoint queues, router hop latency, packet payload, and schedule policy, the shared-path frontier will show which on-chip service mechanism should be embodied next. HBM/DRAM service should remain unchanged in this job.",
+  "direct_comparison": {
+    "primary_question": "How does the Llama7B dense-tile frontier move when SRAM bank arbitration, endpoint queues, router latency, packet payload, and on-chip scheduling policy are modeled explicitly, excluding HBM/DRAM changes?",
+    "include": [
+      "merged SRAM/NoC constrained frontier l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2",
+      "SRAM bank arbitration policies: round_robin, locality_first, age_based",
+      "endpoint and bank queue depth sensitivity",
+      "router latency per hop sensitivity",
+      "packet payload sensitivity",
+      "static_wave, staggered_wave, and prefetch_overlap schedule policies",
+      "slowdown versus SRAM/NoC constrained cap result and topology-derived result"
+    ],
+    "exclude": [
+      "HBM/DRAM bandwidth, controller, refresh, or off-chip scheduling changes",
+      "new dense GEMM tile PPA",
+      "new SRAM compiler or placed SRAM macro floorplan",
+      "quality-affecting KV sharing or precision changes"
+    ],
+    "follow_on_broad_sweep": [
+      "embody the selected SRAM bank arbiter and endpoint queue as RTL",
+      "construct a routed NoC/link simulator or RTL fabric for the best topology family",
+      "add ready/valid backpressure equivalence between the scheduler model and RTL"
+    ]
+  },
+  "expected_benefit": [
+    "separate SRAM bank arbitration effects from endpoint queue and router latency effects",
+    "identify whether prefetch/staggering can recover shared-path latency without touching HBM",
+    "select the next concrete on-chip service block to embody"
+  ],
+  "risks": [
+    "the model is still a service simulator, not router or SRAM arbiter RTL",
+    "the run refines retained frontier rows instead of fully re-searching every topology-derived row",
+    "prefetch overlap is analytic until a producer/consumer command stream is generated"
+  ],
+  "needs_mapper_change": false,
+  "implementation_min_commit": "2a03f9f8ad8bda90315946c41ac2b1e7d1d8bc33",
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "onchip_service_dense_tile_schedule",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "refine_dense_tile_scheduler_frontier_with_onchip_service_policies",
+        "reason": "The result should report the Llama7B dense-tile frontier under explicit on-chip service policy parameters while leaving HBM/DRAM assumptions unchanged."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_sram_noc_constrained_schedule__l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1/analysis_report.md",
+    "npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/quality_gate.md
@@ -1,0 +1,31 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1`
+- `title`: `Llama7B on-chip SRAM/NoC service scheduler frontier`
+
+## Why This Gate Is Required
+- The SRAM/NoC constrained result still uses a simple min-cap service model.
+- We need to know whether arbitration, queue depth, router hop latency, packetization, or schedule policy dominates before choosing an RTL block to embody.
+- HBM/DRAM changes are explicitly out of scope for this job.
+
+## Reference
+- sram_noc_constrained_ref: `l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2`
+- implementation_min_commit: `2a03f9f8ad8bda90315946c41ac2b1e7d1d8bc33`
+
+## Checks
+- metric: generated rows
+  - threshold: nonzero successful output
+- metric: on-chip policy accounting
+  - threshold: report must include best rows by schedule/bank policy and queue/router setting
+- metric: HBM/DRAM isolation
+  - threshold: generated task command must not include HBM/DRAM data-rate or bandwidth knobs
+- metric: frontier comparison
+  - threshold: report must include slowdown versus the SRAM/NoC cap result
+
+## Local Commands
+- command: `python3 npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py --repo-root . --sram-noc-constrained-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_sram_noc_constrained_schedule__l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2.json --frontier-row-limit 128 --out /tmp/onchip_service.json --out-md /tmp/onchip_service.md`
+
+## Result
+- status: pending
+- note: Final quality decision waits for evaluator output.


### PR DESCRIPTION
## Summary
- add L2 proposal for refining retained Llama7B SRAM/NoC-constrained rows with on-chip service policy parameters
- explicitly excludes HBM/DRAM changes
- requests l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1

## Validation
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check
- python3 -m json.tool proposal/evaluation request files