### PR TITLE
npu: add on-chip service endpoint RTL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,9 @@ set_tests_properties(test_attention_kv_tile PROPERTIES WORKING_DIRECTORY ${PROJE
 add_test(NAME test_attention_kv_reducer COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_attention_kv_reducer.sh)
 set_tests_properties(test_attention_kv_reducer PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
+add_test(NAME test_onchip_service_endpoint COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_onchip_service_endpoint.sh)
+set_tests_properties(test_onchip_service_endpoint PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
 if(RTLGEN_BUILD_FLOPOCO)
     set(FLOPOCO_STAGED_BIN ${PROJECT_SOURCE_DIR}/bin/flopoco)
     set(FLOPOCO_READY OFF)

--- a/npu/sim/rtl/onchip_service_endpoint.sv
+++ b/npu/sim/rtl/onchip_service_endpoint.sv
@@ -1,0 +1,178 @@
+`timescale 1ns/1ps
+
+// Ready/valid on-chip SRAM endpoint service model.
+//
+// The block models the part of the decoder-attention service path that was
+// still analytic in the cluster scheduler: finite endpoint buffering, finite
+// per-bank queues, and a locality-first bank drain policy.
+module onchip_service_endpoint #(
+  parameter integer DATA_W = 128,
+  parameter integer BANKS = 4,
+  parameter integer BANK_SEL_W = 2,
+  parameter integer BANK_QUEUE_DEPTH = 4,
+  parameter integer ENDPOINT_QUEUE_DEPTH = 8,
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire in_valid,
+  output wire in_ready,
+  input wire [BANK_SEL_W-1:0] in_bank,
+  input wire in_last,
+  input wire [DATA_W-1:0] in_data,
+
+  output wire out_valid,
+  input wire out_ready,
+  output wire [BANK_SEL_W-1:0] out_bank,
+  output wire out_last,
+  output wire [DATA_W-1:0] out_data,
+
+  output reg [COUNTER_W-1:0] accepted_beat_count,
+  output reg [COUNTER_W-1:0] emitted_beat_count,
+  output reg [COUNTER_W-1:0] producer_stall_cycles,
+  output reg [COUNTER_W-1:0] consumer_stall_cycles,
+  output reg [COUNTER_W-1:0] endpoint_max_occupancy,
+  output reg [COUNTER_W-1:0] bank_max_occupancy,
+  output reg [COUNTER_W-1:0] cycle_count,
+  output reg [COUNTER_W-1:0] final_completion_cycle
+);
+  localparam integer BANK_PTR_W = (BANK_QUEUE_DEPTH <= 1) ? 1 : $clog2(BANK_QUEUE_DEPTH);
+  localparam integer BANK_COUNT_W = (BANK_QUEUE_DEPTH <= 1) ? 1 : $clog2(BANK_QUEUE_DEPTH + 1);
+  localparam integer TOTAL_COUNT_W = (ENDPOINT_QUEUE_DEPTH <= 1) ? 1 : $clog2(ENDPOINT_QUEUE_DEPTH + 1);
+  localparam [BANK_COUNT_W-1:0] BANK_QUEUE_DEPTH_VALUE = BANK_QUEUE_DEPTH;
+  localparam [BANK_PTR_W-1:0] BANK_QUEUE_LAST = BANK_QUEUE_DEPTH - 1;
+  localparam [TOTAL_COUNT_W-1:0] ENDPOINT_QUEUE_DEPTH_VALUE = ENDPOINT_QUEUE_DEPTH;
+
+  reg [DATA_W-1:0] data_mem [0:BANKS-1][0:BANK_QUEUE_DEPTH-1];
+  reg last_mem [0:BANKS-1][0:BANK_QUEUE_DEPTH-1];
+  reg [BANK_PTR_W-1:0] rd_ptr [0:BANKS-1];
+  reg [BANK_PTR_W-1:0] wr_ptr [0:BANKS-1];
+  reg [BANK_COUNT_W-1:0] bank_count [0:BANKS-1];
+  reg [TOTAL_COUNT_W-1:0] total_count;
+  reg [BANK_SEL_W-1:0] preferred_bank;
+
+  reg any_bank_valid;
+  reg [BANK_SEL_W-1:0] grant_bank;
+
+  integer scan_i;
+  integer bank_i;
+  integer scan_bank_int;
+  reg [BANK_SEL_W-1:0] scan_bank;
+
+  always @(*) begin
+    any_bank_valid = 1'b0;
+    grant_bank = preferred_bank;
+    if (bank_count[preferred_bank] != {BANK_COUNT_W{1'b0}}) begin
+      any_bank_valid = 1'b1;
+      grant_bank = preferred_bank;
+    end else begin
+      for (scan_i = 1; scan_i <= BANKS; scan_i = scan_i + 1) begin
+        scan_bank_int = preferred_bank + scan_i;
+        if (scan_bank_int >= BANKS) begin
+          scan_bank_int = scan_bank_int - BANKS;
+        end
+        scan_bank = scan_bank_int[BANK_SEL_W-1:0];
+        if (!any_bank_valid && bank_count[scan_bank] != {BANK_COUNT_W{1'b0}}) begin
+          any_bank_valid = 1'b1;
+          grant_bank = scan_bank;
+        end
+      end
+    end
+  end
+
+  assign in_ready =
+    (bank_count[in_bank] < BANK_QUEUE_DEPTH_VALUE) &&
+    (total_count < ENDPOINT_QUEUE_DEPTH_VALUE);
+  assign out_valid = any_bank_valid;
+  assign out_bank = grant_bank;
+  assign out_last = any_bank_valid ? last_mem[grant_bank][rd_ptr[grant_bank]] : 1'b0;
+  assign out_data = any_bank_valid ? data_mem[grant_bank][rd_ptr[grant_bank]] : {DATA_W{1'b0}};
+
+  wire accept_fire = in_valid && in_ready;
+  wire emit_fire = out_valid && out_ready;
+
+  function [BANK_PTR_W-1:0] ptr_inc;
+    input [BANK_PTR_W-1:0] ptr;
+    begin
+      if (ptr == BANK_QUEUE_LAST) begin
+        ptr_inc = {BANK_PTR_W{1'b0}};
+      end else begin
+        ptr_inc = ptr + {{(BANK_PTR_W-1){1'b0}}, 1'b1};
+      end
+    end
+  endfunction
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      total_count <= {TOTAL_COUNT_W{1'b0}};
+      preferred_bank <= {BANK_SEL_W{1'b0}};
+      accepted_beat_count <= {COUNTER_W{1'b0}};
+      emitted_beat_count <= {COUNTER_W{1'b0}};
+      producer_stall_cycles <= {COUNTER_W{1'b0}};
+      consumer_stall_cycles <= {COUNTER_W{1'b0}};
+      endpoint_max_occupancy <= {COUNTER_W{1'b0}};
+      bank_max_occupancy <= {COUNTER_W{1'b0}};
+      cycle_count <= {COUNTER_W{1'b0}};
+      final_completion_cycle <= {COUNTER_W{1'b0}};
+      for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
+        rd_ptr[bank_i] <= {BANK_PTR_W{1'b0}};
+        wr_ptr[bank_i] <= {BANK_PTR_W{1'b0}};
+        bank_count[bank_i] <= {BANK_COUNT_W{1'b0}};
+      end
+    end else begin
+      cycle_count <= cycle_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
+
+      if (in_valid && !in_ready) begin
+        producer_stall_cycles <= producer_stall_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
+      end
+      if (out_valid && !out_ready) begin
+        consumer_stall_cycles <= consumer_stall_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
+      end
+
+      if (accept_fire) begin
+        data_mem[in_bank][wr_ptr[in_bank]] <= in_data;
+        last_mem[in_bank][wr_ptr[in_bank]] <= in_last;
+        wr_ptr[in_bank] <= ptr_inc(wr_ptr[in_bank]);
+        accepted_beat_count <= accepted_beat_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
+      end
+
+      if (emit_fire) begin
+        rd_ptr[grant_bank] <= ptr_inc(rd_ptr[grant_bank]);
+        preferred_bank <= grant_bank;
+        emitted_beat_count <= emitted_beat_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
+        if (out_last) begin
+          final_completion_cycle <= cycle_count;
+        end
+      end
+
+      if (accept_fire && emit_fire) begin
+        total_count <= total_count;
+        if (in_bank == grant_bank) begin
+          bank_count[in_bank] <= bank_count[in_bank];
+        end else begin
+          bank_count[in_bank] <= bank_count[in_bank] + {{(BANK_COUNT_W-1){1'b0}}, 1'b1};
+          bank_count[grant_bank] <= bank_count[grant_bank] - {{(BANK_COUNT_W-1){1'b0}}, 1'b1};
+          if ((bank_count[in_bank] + {{(BANK_COUNT_W-1){1'b0}}, 1'b1}) > bank_max_occupancy[BANK_COUNT_W-1:0]) begin
+            bank_max_occupancy <= {{(COUNTER_W-BANK_COUNT_W){1'b0}},
+                                   bank_count[in_bank] + {{(BANK_COUNT_W-1){1'b0}}, 1'b1}};
+          end
+        end
+      end else if (accept_fire) begin
+        total_count <= total_count + {{(TOTAL_COUNT_W-1){1'b0}}, 1'b1};
+        bank_count[in_bank] <= bank_count[in_bank] + {{(BANK_COUNT_W-1){1'b0}}, 1'b1};
+        if ((bank_count[in_bank] + {{(BANK_COUNT_W-1){1'b0}}, 1'b1}) > bank_max_occupancy[BANK_COUNT_W-1:0]) begin
+          bank_max_occupancy <= {{(COUNTER_W-BANK_COUNT_W){1'b0}},
+                                 bank_count[in_bank] + {{(BANK_COUNT_W-1){1'b0}}, 1'b1}};
+        end
+        if ((total_count + {{(TOTAL_COUNT_W-1){1'b0}}, 1'b1}) > endpoint_max_occupancy[TOTAL_COUNT_W-1:0]) begin
+          endpoint_max_occupancy <= {{(COUNTER_W-TOTAL_COUNT_W){1'b0}},
+                                     total_count + {{(TOTAL_COUNT_W-1){1'b0}}, 1'b1}};
+        end
+      end else if (emit_fire) begin
+        total_count <= total_count - {{(TOTAL_COUNT_W-1){1'b0}}, 1'b1};
+        bank_count[grant_bank] <= bank_count[grant_bank] - {{(BANK_COUNT_W-1){1'b0}}, 1'b1};
+      end
+    end
+  end
+endmodule

--- a/tests/onchip_service_endpoint_tb.v
+++ b/tests/onchip_service_endpoint_tb.v
@@ -1,0 +1,200 @@
+`timescale 1ns/1ps
+
+module onchip_service_endpoint_tb;
+  reg clk;
+  reg rst_n;
+  reg in_valid;
+  wire in_ready;
+  reg [1:0] in_bank;
+  reg in_last;
+  reg [15:0] in_data;
+  wire out_valid;
+  reg out_ready;
+  wire [1:0] out_bank;
+  wire out_last;
+  wire [15:0] out_data;
+  wire [15:0] accepted_beat_count;
+  wire [15:0] emitted_beat_count;
+  wire [15:0] producer_stall_cycles;
+  wire [15:0] consumer_stall_cycles;
+  wire [15:0] endpoint_max_occupancy;
+  wire [15:0] bank_max_occupancy;
+  wire [15:0] cycle_count;
+  wire [15:0] final_completion_cycle;
+
+  integer out_index;
+
+  onchip_service_endpoint #(
+    .DATA_W(16),
+    .BANKS(4),
+    .BANK_SEL_W(2),
+    .BANK_QUEUE_DEPTH(2),
+    .ENDPOINT_QUEUE_DEPTH(4),
+    .COUNTER_W(16)
+  ) dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .in_valid(in_valid),
+    .in_ready(in_ready),
+    .in_bank(in_bank),
+    .in_last(in_last),
+    .in_data(in_data),
+    .out_valid(out_valid),
+    .out_ready(out_ready),
+    .out_bank(out_bank),
+    .out_last(out_last),
+    .out_data(out_data),
+    .accepted_beat_count(accepted_beat_count),
+    .emitted_beat_count(emitted_beat_count),
+    .producer_stall_cycles(producer_stall_cycles),
+    .consumer_stall_cycles(consumer_stall_cycles),
+    .endpoint_max_occupancy(endpoint_max_occupancy),
+    .bank_max_occupancy(bank_max_occupancy),
+    .cycle_count(cycle_count),
+    .final_completion_cycle(final_completion_cycle)
+  );
+
+  always #5 clk = ~clk;
+
+  task send_beat;
+    input [1:0] bank;
+    input [15:0] data;
+    input last;
+    begin
+      @(negedge clk);
+      in_valid = 1'b1;
+      in_bank = bank;
+      in_data = data;
+      in_last = last;
+      @(posedge clk);
+      while (!in_ready) begin
+        @(posedge clk);
+      end
+      @(negedge clk);
+      in_valid = 1'b0;
+      in_bank = 2'd0;
+      in_data = 16'd0;
+      in_last = 1'b0;
+    end
+  endtask
+
+  initial begin
+    #2000;
+    $display("FAIL onchip_service_endpoint: simulation timeout");
+    $fatal;
+  end
+
+  always @(posedge clk) begin
+    if (rst_n && out_valid && out_ready) begin
+      $display(
+        "OUT index=%0d bank=%0d data=%0d last=%0d cycle=%0d",
+        out_index,
+        out_bank,
+        out_data,
+        out_last,
+        cycle_count
+      );
+      out_index = out_index + 1;
+    end
+  end
+
+`ifdef DEBUG_ONCHIP_SERVICE_ENDPOINT
+  always @(posedge clk) begin
+    if (rst_n) begin
+      $display(
+        "DBG cycle=%0d in_v=%0d in_r=%0d in_bank=%0d out_v=%0d out_r=%0d out_bank=%0d accepted=%0d emitted=%0d endpoint_max=%0d",
+        cycle_count,
+        in_valid,
+        in_ready,
+        in_bank,
+        out_valid,
+        out_ready,
+        out_bank,
+        accepted_beat_count,
+        emitted_beat_count,
+        endpoint_max_occupancy
+      );
+    end
+  end
+`endif
+
+  initial begin
+    clk = 1'b0;
+    rst_n = 1'b1;
+    in_valid = 1'b0;
+    in_bank = 2'd0;
+    in_last = 1'b0;
+    in_data = 16'd0;
+    out_ready = 1'b0;
+    out_index = 0;
+
+    #1 rst_n = 1'b0;
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+
+    send_beat(2'd0, 16'd10, 1'b0);
+    send_beat(2'd1, 16'd20, 1'b0);
+    send_beat(2'd0, 16'd11, 1'b0);
+    send_beat(2'd1, 16'd21, 1'b0);
+
+    @(negedge clk);
+    in_valid = 1'b1;
+    in_bank = 2'd2;
+    in_data = 16'd30;
+    in_last = 1'b1;
+    @(posedge clk);
+    if (in_ready !== 1'b0) begin
+      $display("FAIL onchip_service_endpoint: expected endpoint-full producer stall");
+      $fatal;
+    end
+    @(negedge clk);
+    out_ready = 1'b1;
+    while (!in_ready) begin
+      @(negedge clk);
+    end
+    @(posedge clk);
+    @(negedge clk);
+    in_valid = 1'b0;
+    in_bank = 2'd0;
+    in_data = 16'd0;
+    in_last = 1'b0;
+
+    while (emitted_beat_count !== 16'd5) begin
+      @(negedge clk);
+    end
+
+    out_ready = 1'b0;
+    repeat (2) @(negedge clk);
+
+    $display(
+      "SUMMARY accepted=%0d emitted=%0d producer_stalls=%0d consumer_stalls=%0d endpoint_max=%0d bank_max=%0d final_cycle=%0d",
+      accepted_beat_count,
+      emitted_beat_count,
+      producer_stall_cycles,
+      consumer_stall_cycles,
+      endpoint_max_occupancy,
+      bank_max_occupancy,
+      final_completion_cycle
+    );
+
+    if (accepted_beat_count !== 16'd5 || emitted_beat_count !== 16'd5) begin
+      $display("FAIL onchip_service_endpoint: wrong beat counts");
+      $fatal;
+    end
+    if (producer_stall_cycles === 16'd0 || consumer_stall_cycles === 16'd0) begin
+      $display("FAIL onchip_service_endpoint: expected backpressure counters to move");
+      $fatal;
+    end
+    if (endpoint_max_occupancy < 16'd4 || bank_max_occupancy < 16'd2) begin
+      $display("FAIL onchip_service_endpoint: expected finite queues to fill");
+      $fatal;
+    end
+    if (final_completion_cycle === 16'd0) begin
+      $display("FAIL onchip_service_endpoint: final completion cycle was not recorded");
+      $fatal;
+    end
+
+    $display("PASS onchip_service_endpoint");
+    $finish;
+  end
+endmodule

--- a/tests/test_onchip_service_endpoint.sh
+++ b/tests/test_onchip_service_endpoint.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+iverilog -g2012 -s onchip_service_endpoint_tb -o "$TMP/sim" \
+  "$ROOT/npu/sim/rtl/onchip_service_endpoint.sv" \
+  "$ROOT/tests/onchip_service_endpoint_tb.v"
+vvp "$TMP/sim" | tee "$TMP/out.log"
+
+python3 - "$TMP/out.log" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+
+def reference_locality_first(beats, banks):
+    queues = [[] for _ in range(banks)]
+    for beat in beats:
+        queues[beat["bank"]].append(beat)
+
+    preferred = 0
+    emitted = []
+    while any(queues):
+        if not queues[preferred]:
+            for offset in range(1, banks + 1):
+                candidate = (preferred + offset) % banks
+                if queues[candidate]:
+                    preferred = candidate
+                    break
+        emitted.append(queues[preferred].pop(0))
+    return emitted
+
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+out_re = re.compile(r"OUT index=(\d+) bank=(\d+) data=(\d+) last=(\d+) cycle=(\d+)")
+observed = []
+for match in out_re.finditer(text):
+    observed.append(
+        {
+            "index": int(match.group(1)),
+            "bank": int(match.group(2)),
+            "data": int(match.group(3)),
+            "last": int(match.group(4)),
+            "cycle": int(match.group(5)),
+        }
+    )
+
+input_beats = [
+    {"bank": 0, "data": 10, "last": 0},
+    {"bank": 1, "data": 20, "last": 0},
+    {"bank": 0, "data": 11, "last": 0},
+    {"bank": 1, "data": 21, "last": 0},
+    {"bank": 2, "data": 30, "last": 1},
+]
+expected = reference_locality_first(input_beats, banks=4)
+
+observed_order = [(beat["bank"], beat["data"], beat["last"]) for beat in observed]
+expected_order = [(beat["bank"], beat["data"], beat["last"]) for beat in expected]
+if observed_order != expected_order:
+    raise SystemExit(f"locality-first order mismatch: observed={observed_order} expected={expected_order}")
+if [beat["index"] for beat in observed] != list(range(len(expected))):
+    raise SystemExit(f"non-contiguous output indices: {observed}")
+if not all(a["cycle"] < b["cycle"] for a, b in zip(observed, observed[1:])):
+    raise SystemExit(f"output cycles are not monotonic: {observed}")
+
+summary = re.search(
+    r"SUMMARY accepted=(\d+) emitted=(\d+) producer_stalls=(\d+) "
+    r"consumer_stalls=(\d+) endpoint_max=(\d+) bank_max=(\d+) final_cycle=(\d+)",
+    text,
+)
+if not summary:
+    raise SystemExit("missing SUMMARY line")
+accepted, emitted, producer_stalls, consumer_stalls, endpoint_max, bank_max, final_cycle = (
+    int(value) for value in summary.groups()
+)
+if (accepted, emitted) != (5, 5):
+    raise SystemExit(f"unexpected beat counts: accepted={accepted} emitted={emitted}")
+if producer_stalls < 1 or consumer_stalls < 1:
+    raise SystemExit(
+        "expected both producer and consumer backpressure counters to move: "
+        f"producer={producer_stalls} consumer={consumer_stalls}"
+    )
+if endpoint_max != 4 or bank_max != 2:
+    raise SystemExit(f"unexpected occupancy maxima: endpoint={endpoint_max} bank={bank_max}")
+if final_cycle != observed[-1]["cycle"]:
+    raise SystemExit(f"final cycle {final_cycle} did not match final output {observed[-1]}")
+if "PASS onchip_service_endpoint" not in text:
+    raise SystemExit("testbench did not print PASS")
+PY
+
+YOSYS_BIN="${YOSYS_BIN:-}"
+if [[ -z "$YOSYS_BIN" ]]; then
+  if command -v yosys >/dev/null 2>&1; then
+    YOSYS_BIN="$(command -v yosys)"
+  elif [[ -x /oss-cad-suite/bin/yosys ]]; then
+    YOSYS_BIN=/oss-cad-suite/bin/yosys
+  fi
+fi
+if [[ -n "$YOSYS_BIN" ]]; then
+  "$YOSYS_BIN" -q -p "read_verilog -sv $ROOT/npu/sim/rtl/onchip_service_endpoint.sv; hierarchy -top onchip_service_endpoint; proc"
+fi


### PR DESCRIPTION
## Summary
- Add a parameterized on-chip service endpoint RTL model for finite endpoint buffering, finite per-bank queues, and locality-first bank draining.
- Add a deterministic ready/valid testbench that exercises producer stalls, consumer stalls, queue occupancy counters, and final completion-cycle observability.
- Register a CTest shell wrapper that compares RTL output order against a Python locality-first reference and runs a Yosys parse/proc smoke check when available.

## Verification
- bash tests/test_onchip_service_endpoint.sh
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check