### PR TITLE
docs: add endpoint schedule proposal

### DIFF
--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/README.md
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/README.md
@@ -1,0 +1,18 @@
+# Proposal Template
+
+Canonical template location for new proposal workspaces.
+
+The template file set mirrors the proposal artifact contract used by the
+current developer loop:
+
+- `proposal.json`
+- `design_brief.md`
+- `implementation_summary.md`
+- `evaluation_gate.md`
+- `evaluation_requests.json`
+- `quality_gate.md`
+- `analysis_report.md`
+- `promotion_decision.json`
+- `promotion_result.json`
+
+This is the only supported proposal template for new work. The legacy template path exists only as a compatibility symlink.

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/analysis_report.md
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/analysis_report.md
@@ -1,0 +1,31 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_example_v1`
+- `candidate_id`: `cand_example_v1_r1`
+
+## Evaluations Consumed
+- work item ids
+- run keys
+- source commit
+
+## Baseline Comparison
+- baseline used
+- key deltas
+
+## Result
+- win / loss / mixed
+- confidence level
+- estimated mapper optimization room
+- whether the architecture conclusion is robust to plausible schedule changes
+
+## Failures and Caveats
+- flow failures
+- validation anomalies
+- mapper limitations
+
+## Recommendation
+- reject / iterate / promote
+- short reason
+- follow-on mapper item or proposal when mapper limitations are the main reason
+  to iterate

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/design_brief.md
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/design_brief.md
@@ -1,0 +1,46 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_example_v1`
+- `title`: `Example proposal title`
+
+## Problem
+- what bottleneck or limitation is being targeted
+
+## Hypothesis
+- short explanation of why this change may help
+
+## Evaluation Scope
+- direct comparison set:
+  - the smallest set of variants or architecture points needed to test the
+    hypothesis
+- evaluation modes:
+  - note whether each requested item is `measurement_only`,
+    `baseline_refresh`, `paired_comparison`, or `broad_ranking`
+  - record any expected non-win/lose result, such as a refreshed baseline that
+    is expected to look worse than a historical run
+- dependency order:
+  - list any item ids that must merge before a dependent item can be exported
+    or reviewed
+  - note whether the dependent item requires merged inputs, materialized repo
+    refs, or both
+- excluded first-stage comparisons:
+  - broader points intentionally left out of the first evaluation
+- follow-on broad sweep:
+  - optional wider comparison to run only if the focused result is positive,
+    ambiguous, or interaction-sensitive
+
+## Knowledge Inputs
+- papers
+- notes
+- prior runs
+- discussion references
+
+## Candidate Direction
+- what will change at a high level
+
+## Direction Gate
+- status: pending
+- approved_by:
+- approved_utc:
+- note:

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/evaluation_gate.md
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - task summary
+- note:

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/evaluation_requests.json
@@ -1,0 +1,19 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1",
+  "source_commit": "f70c220539bf8ade4457882bf477edfad4a37b6d",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Model-set revision campaign that reuses existing physical baselines and reruns mapper+perf reporting.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule",
+      "comparison_role": "",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/implementation_summary.md
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/implementation_summary.md
@@ -1,0 +1,24 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_example_v1`
+- short title
+
+## Scope
+- what changed
+- what did not change
+
+## Files Changed
+- repo paths
+
+## Local Validation
+- commands run
+- pass/fail summary
+
+## Evaluation Request
+- requested remote tasks
+- cost class
+- baseline to compare against
+
+## Risks
+- remaining technical risks

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/promotion_decision.json
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/promotion_decision.json
@@ -1,0 +1,12 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Replace with the actual decision rationale.",
+  "evidence_refs": [
+    "item:example",
+    "run:example"
+  ],
+  "next_action": "Describe the next action.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/promotion_gate.md
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/promotion_result.json
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/proposal.json
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/proposal.json
@@ -1,0 +1,59 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1",
+  "created_utc": "2026-06-09T02:16:36.358061Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Endpoint-measured dense-tile Llama7B schedule",
+  "hypothesis": "Charging the measured on-chip endpoint service primitive alongside dense GEMM tile compute, full-value attention datapaths, softmax weight generation, and local FIFO/router PPA should slightly reduce available compute area without changing the dominant Llama7B 131k attention frontier ranking. The result bounds the remaining abstraction to SRAM capacity/service, HBM/DRAM service, and global NoC arbitration.",
+  "direct_comparison": {
+    "primary_question": "Does adding one measured on-chip endpoint service block per cluster materially change the dense-tile all-measured Llama7B 131k schedule frontier?",
+    "include": [
+      "Compare against the merged dense-tile all-measured L1 schedule that charged dense GEMM tile compute, full-value attention datapaths, softmax weight generation, FIFO, and router PPA.",
+      "Use the measured endpoint primitive from PR #795 at the best timing row: 0.7162 ns, 15293.032225 um2, 0.00983 mW.",
+      "Keep HBM/DRAM service, global NoC arbitration, and SRAM service analytic so the only added measured component is the endpoint service primitive."
+    ],
+    "exclude": [
+      "Do not change HBM/DRAM modeling in this item.",
+      "Do not run additional physical closure; this is an L2 schedule revision using merged L1/PPA anchors.",
+      "Do not introduce new quality-impacting attention approximations."
+    ],
+    "follow_on_broad_sweep": [
+      "After endpoint charging is merged, refine SRAM bank/service and global NoC arbitration with physically plausible bandwidth and scheduler assumptions."
+    ]
+  },
+  "expected_benefit": [
+    "Close one remaining local L1 abstraction in the Llama7B attention schedule cost model.",
+    "Produce a directly comparable endpoint-inclusive frontier against the existing dense-tile all-measured L1 schedule.",
+    "Expose endpoint area, power, and clock fields in the schedule output for later cost breakdowns."
+  ],
+  "risks": [
+    "The endpoint primitive is still a local service block; it does not by itself validate global NoC arbitration or SRAM bank scheduling.",
+    "If endpoint area changes frontier selection only marginally, the next bottleneck remains memory/NoC modeling rather than local endpoint PPA."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "Run the dense-tile endpoint-measured L1 clustered Llama7B schedule and submit the generated artifacts.",
+      "cost_class": "low",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "endpoint_charge_should_not_invert_frontier_unless_compute_area_is_tight",
+        "reason": "The measured endpoint is much smaller than the measured attention datapath and softmax generator, so it should mostly reduce compute slack while preserving the main frontier ordering."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule__l2_decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule_llama7b_v1.json",
+    "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_v1.json",
+    "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+  ],
+  "knowledge_refs": [
+    "PR #795 endpoint PPA result",
+    "PR #796 endpoint-inclusive L1 cost bundle and L2 abstraction"
+  ]
+}

--- a/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/quality_gate.md
+++ b/docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/quality_gate.md
@@ -1,0 +1,25 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`:
+- `title`:
+
+## Why This Gate Is Required
+- describe the output or numerical behavior that may change
+
+## Reference
+- baseline_ref:
+- reference_ref:
+
+## Checks
+- metric:
+  - threshold:
+- metric:
+  - threshold:
+
+## Local Commands
+- command:
+
+## Result
+- status: pending
+- note:


### PR DESCRIPTION
## Summary
- add the missing developer-loop proposal scaffold for the endpoint-measured dense-tile Llama7B schedule item
- fill proposal fields with the endpoint measurement objective and expected comparison

## Validation
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check

This unblocks the already completed evaluator run whose submission is waiting on proposal resolution.