### PR TITLE
control_plane: stage decoder attention dataset outputs

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -24,23 +24,9 @@ _ALLOWED_RUNS_SUFFIXES = {
 }
 
 _ALLOWED_DATASET_PREFIXES = {
-    "decoder_attention_kv_memory__",
-    "decoder_attention_kv_capacity_noc__",
-    "decoder_attention_kv_noc_scheduler__",
-    "decoder_attention_kv_spill_scheduler__",
-    "decoder_attention_kv_hbm_controller__",
-    "decoder_attention_kv_physical_hbm_frontier__",
-    "decoder_attention_kv_physical_hbm_quality_backed__",
-    "decoder_attention_kv_physical_hbm_memory_noc__",
-    "decoder_attention_kv_physical_hbm_compute_sensitivity__",
-    "decoder_attention_kv_compute_floor_gap__",
-    "decoder_attention_kv_compute_ceiling_envelope__",
-    "decoder_attention_kv_quality_gate__",
-    "decoder_attention_kv_quality_proxy__",
-    "decoder_attention_kv_native_gqa_proxy__",
-    "decoder_attention_kv_trace_calibration__",
-    "decoder_attention_kv_model_native_quality__",
-    "decoder_attention_kv_model_native_recovery__",
+    "decoder_attention_kv_",
+    "decoder_attention_noc_profile__",
+    "decoder_attention_sram_profile__",
 }
 
 _ALLOWED_DATASET_SUFFIXES = {".json", ".md"}

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -92,3 +92,16 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
     )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule__"
+        "l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_llama7b_v1.json"
+    )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_noc_profile__l2_decoder_attention_noc_profile_v1.md"
+    )

--- a/control_plane/control_plane/tests/test_artifact_stage.py
+++ b/control_plane/control_plane/tests/test_artifact_stage.py
@@ -102,3 +102,33 @@ def test_collect_expected_output_artifacts_includes_attention_kv_dataset(tmp_pat
     assert all(artifact.kind == "expected_output" for artifact in artifacts)
     assert all(artifact.metadata["transport_policy"] == "inline_text_evidence" for artifact in artifacts)
     assert all("inline_utf8" in artifact.metadata for artifact in artifacts)
+
+
+def test_collect_expected_output_artifacts_includes_large_attention_schedule_dataset(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    json_rel = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule__"
+        "l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_llama7b_v1.json"
+    )
+    report_rel = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule__"
+        "l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_llama7b_v1.md"
+    )
+    json_path = repo_root / json_rel
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text('{"rows":"' + ("x" * (1024 * 1024 + 1)) + '"}\n', encoding="utf-8")
+    (repo_root / report_rel).write_text("# endpoint schedule\n", encoding="utf-8")
+
+    artifacts = collect_expected_output_artifacts(
+        repo_root=str(repo_root),
+        expected_outputs=[json_rel, report_rel],
+    )
+
+    assert [artifact.path for artifact in artifacts] == [json_rel, report_rel]
+    assert artifacts[0].kind == "expected_output"
+    assert artifacts[0].metadata["transport_policy"] == "inline_text_evidence"
+    assert "inline_utf8" not in artifacts[0].metadata
+    assert artifacts[1].metadata["inline_utf8"] == "# endpoint schedule\n"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5289,6 +5289,7 @@ def test_generate_l2_campaign_task_adds_dense_tile_endpoint_measured_l1_attentio
                 )
                 for output in expected_outputs
             )
+            assert work_item.expected_outputs == expected_outputs
 
 
 def test_generate_l2_campaign_task_adds_dense_tile_reduction_noc_frontier_evidence() -> None:


### PR DESCRIPTION
## Summary
- allow the full decoder_attention_kv dataset evidence family through artifact transport
- allow decoder attention SRAM/NoC profile outputs through the same dataset policy
- add regressions for the endpoint measured schedule path, including a large JSON that is stored as a repo artifact without inline text
- assert L2 task generation keeps decoder evidence outputs in the work-item expected output list used by the worker

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_artifact_stage.py -q
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check