### PR TITLE
npu: add endpoint topology scheduler jobs

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4413,6 +4413,55 @@ def _decoder_attention_kv_dense_tile_topology_scheduler_pairs_evidence(
     }
 
 
+def _decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs__{item_id}.md"
+    endpoint_frontier = (
+        f"{base}/decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule__"
+        "l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule": endpoint_frontier,
+            "attention_kv_dense_tile_endpoint_topology_scheduler_pairs_out": out,
+            "attention_kv_dense_tile_endpoint_topology_scheduler_pairs_report": report,
+            "attention_kv_dense_tile_endpoint_topology_scheduler_pairs_scope": (
+                "Validate logically compatible NoC topology, scheduler, reducer, bank-placement, "
+                "link-width, and virtual-channel pairs against the endpoint-measured dense-tile "
+                "Llama7B attention schedule. This uses the endpoint-inclusive frontier as the "
+                "traffic/service target before the next topology-derived scheduler run."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_topology_scheduler_pairs.py "
+                    "--repo-root . "
+                    f"--frontier-json {endpoint_frontier} "
+                    "--cluster-count-list 1,2,4,8,16 "
+                    "--topology-list local_only,cluster_tree,mesh2d,ring,crossbar "
+                    "--scheduler-policy-list static_wave,locality_aware,bank_aware_prefetch,"
+                    "tree_reduction_aware,double_buffered_overlap "
+                    "--reduction-strategy-list centralized_tile,owner_cluster,cluster_tree "
+                    "--bank-placement-list per_cluster_local,grouped_shared,distributed_shared "
+                    "--bank-count-list 16,64,128 "
+                    "--link-width-bits-list 256,512,1024,2048 "
+                    "--virtual-channel-list 1,2,4 "
+                    "--local-sram-fraction-list 0.05,0.1,0.25 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_dense_tile_topology_derived_schedule_evidence(
     *,
     item_id: str,
@@ -4463,6 +4512,68 @@ def _decoder_attention_kv_dense_tile_topology_derived_schedule_evidence(
                     "--reducer-setup-cycles 0,64,256 "
                     "--reduction-cycle-multiplier 1,2,4 "
                     f"--measured-l1-costs {all_measured_costs} "
+                    "--measured-l1-profile hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
+def _decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule__{item_id}.md"
+    endpoint_topology_pairs = (
+        f"{base}/decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs__"
+        "l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1.json"
+    )
+    endpoint_measured_costs = (
+        "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_dense_tile_endpoint_topology_scheduler_pairs": endpoint_topology_pairs,
+            "attention_kv_endpoint_measured_l1_costs": endpoint_measured_costs,
+            "attention_kv_dense_tile_endpoint_topology_derived_schedule_out": out,
+            "attention_kv_dense_tile_endpoint_topology_derived_schedule_report": report,
+            "attention_kv_dense_tile_endpoint_topology_derived_schedule_scope": (
+                "Rerun the endpoint-measured Llama7B dense-tile clustered schedule using only "
+                "topology-derived NoC service rows from the endpoint topology/scheduler matrix. "
+                "This keeps endpoint, FIFO/router, softmax, and local attention datapath PPA "
+                "measured while replacing independent abstract NoC bandwidth/hops."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_topology_derived_schedule.py "
+                    "--repo-root . "
+                    f"--topology-pairs-json {endpoint_topology_pairs} "
+                    "--compute-source dense_gemm_tile "
+                    "--compute-arch-list dense_gemm_16x8_k1_p1 "
+                    "--tag-substring npu_dense_gemm_tile_v2_scale_hier "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 800,1200 "
+                    "--sram-area-fraction 0.35,0.4,0.5,0.6 "
+                    "--logic-area-fraction 0.3,0.4,0.5 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7 "
+                    "--tile-tokens-list 512,1024 "
+                    "--topology-row-limit 128 "
+                    "--vector-ops-per-mac 0.125 "
+                    "--reduction-scalar-bytes 2 "
+                    "--command-cycles-per-tile 0,4,16 "
+                    "--command-cycles-per-wave 0,16,64 "
+                    "--reducer-setup-cycles 0,64,256 "
+                    "--reduction-cycle-multiplier 1,2,4 "
+                    f"--measured-l1-costs {endpoint_measured_costs} "
                     "--measured-l1-profile hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10 "
                     f"--out {out} "
                     f"--out-md {report}"
@@ -6156,7 +6267,9 @@ def _build_payload(
         "decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule",
         "decoder_attention_kv_dense_tile_reduction_noc_frontier",
         "decoder_attention_kv_dense_tile_topology_scheduler_pairs",
+        "decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs",
         "decoder_attention_kv_dense_tile_topology_derived_schedule",
+        "decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule",
         "decoder_attention_kv_sram_noc_constrained_schedule",
         "decoder_attention_kv_onchip_service_schedule",
         "decoder_attention_sram_profile",
@@ -6256,8 +6369,16 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_dense_tile_reduction_noc_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dense_tile_topology_scheduler_pairs":
             decoder_evidence = _decoder_attention_kv_dense_tile_topology_scheduler_pairs_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs":
+            decoder_evidence = _decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_evidence(
+                item_id=item_id,
+            )
         elif abstraction_layer_name == "decoder_attention_kv_dense_tile_topology_derived_schedule":
             decoder_evidence = _decoder_attention_kv_dense_tile_topology_derived_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule":
+            decoder_evidence = _decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_evidence(
+                item_id=item_id,
+            )
         elif abstraction_layer_name == "decoder_attention_kv_sram_noc_constrained_schedule":
             decoder_evidence = _decoder_attention_kv_sram_noc_constrained_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_onchip_service_schedule":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5389,6 +5389,53 @@ def test_generate_l2_campaign_task_adds_dense_tile_topology_scheduler_pairs_evid
             )
 
 
+def test_generate_l2_campaign_task_adds_dense_tile_endpoint_topology_scheduler_pairs_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+
+            assert "estimate_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs" in command_names
+            assert "attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule" in decoder_inputs
+            assert "attention_kv_dense_tile_endpoint_topology_scheduler_pairs_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_topology_scheduler_pairs.py" in commands[0]["run"]
+            assert "decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule__" in commands[0]["run"]
+            assert "--topology-list local_only,cluster_tree,mesh2d,ring,crossbar" in commands[0]["run"]
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.expected_outputs == expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs__"
+                    "l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_dense_tile_topology_derived_schedule_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -5432,6 +5479,55 @@ def test_generate_l2_campaign_task_adds_dense_tile_topology_derived_schedule_evi
                 output.endswith(
                     "decoder_attention_kv_dense_tile_topology_derived_schedule__"
                     "l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
+def test_generate_l2_campaign_task_adds_dense_tile_endpoint_topology_derived_schedule_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+
+            assert "estimate_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule" in command_names
+            assert "attention_kv_dense_tile_endpoint_topology_scheduler_pairs" in decoder_inputs
+            assert "attention_kv_endpoint_measured_l1_costs" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_topology_derived_schedule.py" in commands[0]["run"]
+            assert "l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1.json" in commands[0]["run"]
+            assert "llama7b_attention_local_costs_all_measured_endpoint_v1.json" in commands[0]["run"]
+            assert "--noc-bandwidth-bytes-per-cycle" not in commands[0]["run"]
+            assert "--noc-hops" not in commands[0]["run"]
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.expected_outputs == expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule__"
+                    "l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_llama7b_v1.json"
                 )
                 for output in expected_outputs
             )

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/README.md
@@ -1,0 +1,18 @@
+# Proposal Template
+
+Canonical template location for new proposal workspaces.
+
+The template file set mirrors the proposal artifact contract used by the
+current developer loop:
+
+- `proposal.json`
+- `design_brief.md`
+- `implementation_summary.md`
+- `evaluation_gate.md`
+- `evaluation_requests.json`
+- `quality_gate.md`
+- `analysis_report.md`
+- `promotion_decision.json`
+- `promotion_result.json`
+
+This is the only supported proposal template for new work. The legacy template path exists only as a compatibility symlink.

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/analysis_report.md
@@ -1,0 +1,31 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_example_v1`
+- `candidate_id`: `cand_example_v1_r1`
+
+## Evaluations Consumed
+- work item ids
+- run keys
+- source commit
+
+## Baseline Comparison
+- baseline used
+- key deltas
+
+## Result
+- win / loss / mixed
+- confidence level
+- estimated mapper optimization room
+- whether the architecture conclusion is robust to plausible schedule changes
+
+## Failures and Caveats
+- flow failures
+- validation anomalies
+- mapper limitations
+
+## Recommendation
+- reject / iterate / promote
+- short reason
+- follow-on mapper item or proposal when mapper limitations are the main reason
+  to iterate

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/design_brief.md
@@ -1,0 +1,46 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_example_v1`
+- `title`: `Example proposal title`
+
+## Problem
+- what bottleneck or limitation is being targeted
+
+## Hypothesis
+- short explanation of why this change may help
+
+## Evaluation Scope
+- direct comparison set:
+  - the smallest set of variants or architecture points needed to test the
+    hypothesis
+- evaluation modes:
+  - note whether each requested item is `measurement_only`,
+    `baseline_refresh`, `paired_comparison`, or `broad_ranking`
+  - record any expected non-win/lose result, such as a refreshed baseline that
+    is expected to look worse than a historical run
+- dependency order:
+  - list any item ids that must merge before a dependent item can be exported
+    or reviewed
+  - note whether the dependent item requires merged inputs, materialized repo
+    refs, or both
+- excluded first-stage comparisons:
+  - broader points intentionally left out of the first evaluation
+- follow-on broad sweep:
+  - optional wider comparison to run only if the focused result is positive,
+    ambiguous, or interaction-sensitive
+
+## Knowledge Inputs
+- papers
+- notes
+- prior runs
+- discussion references
+
+## Candidate Direction
+- what will change at a high level
+
+## Direction Gate
+- status: pending
+- approved_by:
+- approved_utc:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - task summary
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1",
+  "source_commit": "b11120e2809c12e9cce67a23fc23130a68fd085d",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the endpoint-measured dense-tile Llama7B schedule with topology-derived NoC service envelopes.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "topology_constraints_should_reduce_optimistic_cross_tile_service",
+        "reason": "The result should quantify the cost of replacing abstract NoC bandwidth/hops with valid topology-derived service rows."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/implementation_summary.md
@@ -1,0 +1,24 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_example_v1`
+- short title
+
+## Scope
+- what changed
+- what did not change
+
+## Files Changed
+- repo paths
+
+## Local Validation
+- commands run
+- pass/fail summary
+
+## Evaluation Request
+- requested remote tasks
+- cost class
+- baseline to compare against
+
+## Risks
+- remaining technical risks

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/promotion_decision.json
@@ -1,0 +1,12 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Replace with the actual decision rationale.",
+  "evidence_refs": [
+    "item:example",
+    "run:example"
+  ],
+  "next_action": "Describe the next action.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/proposal.json
@@ -1,0 +1,56 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1",
+  "created_utc": "2026-06-09T03:20:42.205371Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Endpoint-measured topology-derived attention schedule",
+  "hypothesis": "Rerunning the endpoint-measured Llama7B dense-tile schedule using topology-derived NoC service rows will expose whether cross-tile reduction remains dominant under valid on-chip topology and scheduler assumptions.",
+  "direct_comparison": {
+    "primary_question": "How does the endpoint-measured Llama7B dense-tile schedule move when NoC service is restricted to valid endpoint topology/scheduler pairs?",
+    "include": [
+      "Use the endpoint-measured dense-tile Llama7B attention schedule merged in PR #799.",
+      "Keep HBM/DRAM service out of scope; this item is limited to on-chip topology, reduction, SRAM placement, and scheduler assumptions.",
+      "Retain measured endpoint, FIFO/router, softmax, and local attention datapath PPA anchors."
+    ],
+    "exclude": [
+      "Do not change HBM/DRAM bandwidth or service modeling.",
+      "Do not introduce new quality-impacting attention approximations.",
+      "Do not run additional physical closure in this L2 item."
+    ],
+    "follow_on_broad_sweep": [
+      "Use the resulting endpoint topology-derived schedule as the input to practical SRAM/endpoint service caps."
+    ]
+  },
+  "expected_benefit": [
+    "Close the independent abstract NoC bandwidth/hop assumption for the endpoint-measured Llama7B attention path.",
+    "Show whether cross-tile reduction remains the dominant on-chip bottleneck under valid topology/scheduler constraints."
+  ],
+  "risks": [
+    "The topology model is still an analytic service envelope, not routed global NoC RTL/PPA.",
+    "The result can shift again when practical SRAM bank arbitration and endpoint queue capacity are applied."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "Rerun the endpoint-measured dense-tile Llama7B schedule with topology-derived NoC service envelopes.",
+      "cost_class": "low",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "topology_constraints_should_reduce_optimistic_cross_tile_service",
+        "reason": "The result should quantify the cost of replacing abstract NoC bandwidth/hops with valid topology-derived service rows."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule__l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "PR #799 endpoint-measured Llama7B dense-tile schedule",
+    "PR #800 decoder attention artifact transport fix"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_v1/quality_gate.md
@@ -1,0 +1,25 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`:
+- `title`:
+
+## Why This Gate Is Required
+- describe the output or numerical behavior that may change
+
+## Reference
+- baseline_ref:
+- reference_ref:
+
+## Checks
+- metric:
+  - threshold:
+- metric:
+  - threshold:
+
+## Local Commands
+- command:
+
+## Result
+- status: pending
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/README.md
@@ -1,0 +1,18 @@
+# Proposal Template
+
+Canonical template location for new proposal workspaces.
+
+The template file set mirrors the proposal artifact contract used by the
+current developer loop:
+
+- `proposal.json`
+- `design_brief.md`
+- `implementation_summary.md`
+- `evaluation_gate.md`
+- `evaluation_requests.json`
+- `quality_gate.md`
+- `analysis_report.md`
+- `promotion_decision.json`
+- `promotion_result.json`
+
+This is the only supported proposal template for new work. The legacy template path exists only as a compatibility symlink.

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/analysis_report.md
@@ -1,0 +1,31 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_example_v1`
+- `candidate_id`: `cand_example_v1_r1`
+
+## Evaluations Consumed
+- work item ids
+- run keys
+- source commit
+
+## Baseline Comparison
+- baseline used
+- key deltas
+
+## Result
+- win / loss / mixed
+- confidence level
+- estimated mapper optimization room
+- whether the architecture conclusion is robust to plausible schedule changes
+
+## Failures and Caveats
+- flow failures
+- validation anomalies
+- mapper limitations
+
+## Recommendation
+- reject / iterate / promote
+- short reason
+- follow-on mapper item or proposal when mapper limitations are the main reason
+  to iterate

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/design_brief.md
@@ -1,0 +1,46 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_example_v1`
+- `title`: `Example proposal title`
+
+## Problem
+- what bottleneck or limitation is being targeted
+
+## Hypothesis
+- short explanation of why this change may help
+
+## Evaluation Scope
+- direct comparison set:
+  - the smallest set of variants or architecture points needed to test the
+    hypothesis
+- evaluation modes:
+  - note whether each requested item is `measurement_only`,
+    `baseline_refresh`, `paired_comparison`, or `broad_ranking`
+  - record any expected non-win/lose result, such as a refreshed baseline that
+    is expected to look worse than a historical run
+- dependency order:
+  - list any item ids that must merge before a dependent item can be exported
+    or reviewed
+  - note whether the dependent item requires merged inputs, materialized repo
+    refs, or both
+- excluded first-stage comparisons:
+  - broader points intentionally left out of the first evaluation
+- follow-on broad sweep:
+  - optional wider comparison to run only if the focused result is positive,
+    ambiguous, or interaction-sensitive
+
+## Knowledge Inputs
+- papers
+- notes
+- prior runs
+- discussion references
+
+## Candidate Direction
+- what will change at a high level
+
+## Direction Gate
+- status: pending
+- approved_by:
+- approved_utc:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - task summary
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1",
+  "source_commit": "b11120e2809c12e9cce67a23fc23130a68fd085d",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Enumerate endpoint-measured topology/scheduler service envelopes for the Llama7B dense-tile attention frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "valid_pairs_should_bound_independent_noc_sweep",
+        "reason": "The job should replace independent NoC bandwidth/hop assumptions with explicit valid topology/scheduler/service rows."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/implementation_summary.md
@@ -1,0 +1,24 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_example_v1`
+- short title
+
+## Scope
+- what changed
+- what did not change
+
+## Files Changed
+- repo paths
+
+## Local Validation
+- commands run
+- pass/fail summary
+
+## Evaluation Request
+- requested remote tasks
+- cost class
+- baseline to compare against
+
+## Risks
+- remaining technical risks

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/promotion_decision.json
@@ -1,0 +1,12 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Replace with the actual decision rationale.",
+  "evidence_refs": [
+    "item:example",
+    "run:example"
+  ],
+  "next_action": "Describe the next action.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/proposal.json
@@ -1,0 +1,56 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1",
+  "created_utc": "2026-06-09T03:20:42.196188Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Endpoint-measured attention topology scheduler pairs",
+  "hypothesis": "Using the endpoint-measured dense-tile Llama7B attention schedule as the traffic target will identify logically valid topology, scheduler, bank-placement, and reduction pairs before replacing abstract NoC bandwidth and hop sweeps.",
+  "direct_comparison": {
+    "primary_question": "Which topology/scheduler pairs are logically valid for the endpoint-measured Llama7B dense-tile attention frontier?",
+    "include": [
+      "Use the endpoint-measured dense-tile Llama7B attention schedule merged in PR #799.",
+      "Keep HBM/DRAM service out of scope; this item is limited to on-chip topology, reduction, SRAM placement, and scheduler assumptions.",
+      "Retain measured endpoint, FIFO/router, softmax, and local attention datapath PPA anchors."
+    ],
+    "exclude": [
+      "Do not change HBM/DRAM bandwidth or service modeling.",
+      "Do not introduce new quality-impacting attention approximations.",
+      "Do not run additional physical closure in this L2 item."
+    ],
+    "follow_on_broad_sweep": [
+      "Use the resulting endpoint topology-derived schedule as the input to practical SRAM/endpoint service caps."
+    ]
+  },
+  "expected_benefit": [
+    "Close the independent abstract NoC bandwidth/hop assumption for the endpoint-measured Llama7B attention path.",
+    "Show whether cross-tile reduction remains the dominant on-chip bottleneck under valid topology/scheduler constraints."
+  ],
+  "risks": [
+    "The topology model is still an analytic service envelope, not routed global NoC RTL/PPA.",
+    "The result can shift again when practical SRAM bank arbitration and endpoint queue capacity are applied."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "Enumerate endpoint-measured topology/scheduler service envelopes for the Llama7B dense-tile attention frontier.",
+      "cost_class": "low",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "valid_pairs_should_bound_independent_noc_sweep",
+        "reason": "The job should replace independent NoC bandwidth/hop assumptions with explicit valid topology/scheduler/service rows."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule__l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "PR #799 endpoint-measured Llama7B dense-tile schedule",
+    "PR #800 decoder attention artifact transport fix"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_v1/quality_gate.md
@@ -1,0 +1,25 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`:
+- `title`:
+
+## Why This Gate Is Required
+- describe the output or numerical behavior that may change
+
+## Reference
+- baseline_ref:
+- reference_ref:
+
+## Checks
+- metric:
+  - threshold:
+- metric:
+  - threshold:
+
+## Local Commands
+- command:
+
+## Result
+- status: pending
+- note:


### PR DESCRIPTION
## Summary
- add endpoint-measured dense-tile topology/scheduler pair generation
- add endpoint-measured topology-derived schedule generation using endpoint-inclusive L1 costs
- add proposal scaffolds for both new L2 jobs
- add generator tests for the new endpoint topology paths

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check
- smoke: estimate_llm_decoder_attention_kv_topology_scheduler_pairs.py with endpoint frontier
- smoke: estimate_llm_decoder_attention_kv_topology_derived_schedule.py with endpoint topology pairs