### PR TITLE
Add cap-aware endpoint SRAM/NoC full search

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4632,6 +4632,79 @@ def _decoder_attention_kv_endpoint_sram_noc_constrained_schedule_evidence(
     )
 
 
+def _decoder_attention_kv_endpoint_sram_noc_full_search_schedule_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__{item_id}.md"
+    endpoint_topology_pairs = (
+        f"{base}/decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs__"
+        "l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1.json"
+    )
+    endpoint_measured_costs = (
+        "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+    )
+    sram_profile = f"{base}/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    return {
+        "inputs": {
+            "attention_kv_dense_tile_endpoint_topology_scheduler_pairs": endpoint_topology_pairs,
+            "attention_kv_endpoint_measured_l1_costs": endpoint_measured_costs,
+            "attention_sram_profile": sram_profile,
+            "attention_kv_endpoint_sram_noc_full_search_schedule_out": out,
+            "attention_kv_endpoint_sram_noc_full_search_schedule_report": report,
+            "attention_kv_endpoint_sram_noc_full_search_schedule_scope": (
+                "Regenerate the endpoint-measured Llama7B dense-tile topology-derived schedule "
+                "from the full topology/scheduler pair matrix, then apply practical SRAM-bank, "
+                "local-buffer, and endpoint injection/ejection caps before ranking. This checks "
+                "whether practical on-chip service caps change the best topology/scheduler point."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_endpoint_sram_noc_full_search_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py "
+                    "--repo-root . "
+                    f"--topology-pairs-json {endpoint_topology_pairs} "
+                    f"--sram-profile-json {sram_profile} "
+                    "--compute-source dense_gemm_tile "
+                    "--compute-arch-list dense_gemm_16x8_k1_p1 "
+                    "--tag-substring npu_dense_gemm_tile_v2_scale_hier "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 800,1200 "
+                    "--sram-area-fraction 0.35,0.4,0.5,0.6 "
+                    "--logic-area-fraction 0.3,0.4,0.5 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7 "
+                    "--tile-tokens-list 512,1024 "
+                    "--topology-row-limit 128 "
+                    "--vector-ops-per-mac 0.125 "
+                    "--reduction-scalar-bytes 2 "
+                    "--command-cycles-per-tile 0,4,16 "
+                    "--command-cycles-per-wave 0,16,64 "
+                    "--reducer-setup-cycles 0,64,256 "
+                    "--reduction-cycle-multiplier 1,2,4 "
+                    f"--measured-l1-costs {endpoint_measured_costs} "
+                    "--measured-l1-profile hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10 "
+                    "--sram-bank-port-bytes-per-cycle 32 "
+                    "--sram-read-ports-per-bank 1 "
+                    "--sram-bank-efficiency 0.70,0.85 "
+                    "--endpoint-port-bytes-per-cycle 32,64,128 "
+                    "--endpoint-ports-per-cluster 1,2 "
+                    "--endpoint-efficiency 0.70,0.85 "
+                    "--local-buffer-multiplier 1,2 "
+                    "--top-k 100 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_sram_noc_constrained_schedule_evidence_for_source(
     *,
     item_id: str,
@@ -6317,6 +6390,7 @@ def _build_payload(
         "decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule",
         "decoder_attention_kv_sram_noc_constrained_schedule",
         "decoder_attention_kv_endpoint_sram_noc_constrained_schedule",
+        "decoder_attention_kv_endpoint_sram_noc_full_search_schedule",
         "decoder_attention_kv_onchip_service_schedule",
         "decoder_attention_sram_profile",
         "decoder_attention_noc_profile",
@@ -6429,6 +6503,10 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_sram_noc_constrained_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_endpoint_sram_noc_constrained_schedule":
             decoder_evidence = _decoder_attention_kv_endpoint_sram_noc_constrained_schedule_evidence(
+                item_id=item_id,
+            )
+        elif abstraction_layer_name == "decoder_attention_kv_endpoint_sram_noc_full_search_schedule":
+            decoder_evidence = _decoder_attention_kv_endpoint_sram_noc_full_search_schedule_evidence(
                 item_id=item_id,
             )
         elif abstraction_layer_name == "decoder_attention_kv_onchip_service_schedule":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5635,6 +5635,63 @@ def test_generate_l2_campaign_task_adds_endpoint_sram_noc_constrained_schedule_e
             )
 
 
+def test_generate_l2_campaign_task_adds_endpoint_sram_noc_full_search_schedule_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_endpoint_sram_noc_full_search_schedule",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_kv_endpoint_sram_noc_full_search_schedule" in command_names
+            assert "attention_kv_dense_tile_endpoint_topology_scheduler_pairs" in decoder_inputs
+            assert "attention_kv_endpoint_measured_l1_costs" in decoder_inputs
+            assert "attention_sram_profile" in decoder_inputs
+            assert "attention_kv_endpoint_sram_noc_full_search_schedule_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py" in run
+            assert "--topology-pairs-json" in run
+            assert "--topology-derived-json" not in run
+            assert "l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1.json" in run
+            assert "llama7b_attention_local_costs_all_measured_endpoint_v1.json" in run
+            assert "--sram-bank-port-bytes-per-cycle 32" in run
+            assert "--endpoint-port-bytes-per-cycle 32,64,128" in run
+            assert "--topology-row-limit 128" in run
+            assert "--noc-bandwidth-bytes-per-cycle" not in run
+            assert "--noc-hops" not in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.expected_outputs == expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_endpoint_sram_noc_full_search_schedule__"
+                    "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_onchip_service_schedule_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/README.md
@@ -1,0 +1,11 @@
+# Endpoint SRAM/NoC Full-Search Schedule
+
+This proposal checks whether practical SRAM-bank and endpoint service caps change
+the selected Llama7B attention architecture point.
+
+The previous endpoint SRAM/NoC constrained item applied caps only to retained
+frontier rows from the topology-derived schedule. This item regenerates the full
+endpoint-measured topology-derived schedule from the topology/scheduler pair
+matrix, applies practical caps during ranking, and reports whether the best
+topology/scheduler, die area, SRAM split, or service bottleneck moves.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by: developer_agent
+- approved_utc: 2026-06-09T06:25:00Z
+- allowed_evaluations:
+  - l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1
+- note: Full endpoint topology-regeneration search with practical SRAM-bank, local-buffer, and endpoint service caps.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1",
+  "source_commit": "TBD_AFTER_MERGE",
+  "source_commit_note": "Dispatch should use the merge commit for the proposal implementation so the evaluator has the full-search generator hook and CLI.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Regenerate endpoint-measured Llama7B topology-derived dense-tile schedule rows and apply practical SRAM-bank, local-buffer, and endpoint service caps before ranking.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_endpoint_sram_noc_full_search_schedule",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_sram_noc_constrained_schedule_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1",
+        "l2_decoder_attention_sram_profile_v1",
+        "l2_decoder_attention_kv_endpoint_sram_noc_constrained_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "cap_aware_full_search_over_endpoint_topology_schedule",
+        "reason": "The result should show whether practical SRAM-bank and endpoint caps change the best topology/scheduler point compared with retained-frontier cap postprocessing."
+      }
+    }
+  ]
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1",
+  "created_utc": "2026-06-09T06:25:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Endpoint SRAM/NoC full-search Llama7B attention schedule",
+  "hypothesis": "Applying practical SRAM-bank service, local tile-buffer capacity, and endpoint injection/ejection caps during full regeneration of the endpoint topology-derived Llama7B dense-tile schedule may change the selected topology/scheduler point compared with retained-frontier postprocessing.",
+  "direct_comparison": {
+    "primary_question": "Does cap-aware full regeneration select a different best Llama7B endpoint topology/scheduler point than retained-frontier SRAM/NoC postprocessing?",
+    "include": [
+      "Use the endpoint topology/scheduler pair matrix merged from l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1.",
+      "Use the measured SRAM tile-buffer profile l2_decoder_attention_sram_profile_v1.",
+      "Regenerate endpoint topology-derived schedule rows over the same Llama7B sweep as the endpoint topology-derived item.",
+      "Apply practical endpoint port width/count, endpoint efficiency, SRAM bank efficiency, and local buffer multiplier before ranking.",
+      "Report the best cap-aware row and compare its topology, scheduler, service cap source, and latency with the retained-frontier cap result."
+    ],
+    "exclude": [
+      "Do not change HBM/DRAM bandwidth, frequency, or service policy.",
+      "Do not introduce new KV sharing or precision/quality changes.",
+      "Do not run new physical closure in this L2 scheduler item.",
+      "Do not reintroduce independent abstract NoC bandwidth or hop sweeps."
+    ],
+    "follow_on_broad_sweep": [
+      "If the selected topology changes, use the cap-aware result as the next Llama7B frontier baseline.",
+      "If endpoint or SRAM-bank service remains dominant, promote a detailed SRAM/endpoint arbitration and buffering model for that topology family.",
+      "After on-chip service is consistent, revisit HBM/DRAM only as a separate scoped item."
+    ]
+  },
+  "expected_benefit": [
+    "Remove retained-frontier bias from the practical SRAM/endpoint constrained ranking.",
+    "Identify whether topology service, endpoint injection/ejection, or SRAM-bank read service controls the cap-aware full search.",
+    "Provide a firmer Llama7B frontier input for the detailed SRAM/NoC scheduler model."
+  ],
+  "risks": [
+    "This remains analytic service-envelope evidence, not cycle-accurate SRAM arbitration.",
+    "The full regeneration expands many rows and can be slower than retained-frontier postprocessing.",
+    "Endpoint caps are parametric until endpoint queues and arbitration are embodied in RTL."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "endpoint_sram_noc_full_search_dense_tile_schedule",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1",
+        "l2_decoder_attention_sram_profile_v1",
+        "l2_decoder_attention_kv_endpoint_sram_noc_constrained_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "cap_aware_full_search_over_endpoint_topology_schedule",
+        "reason": "The result should report whether the best cap-aware full-search row differs from the retained-frontier SRAM/NoC constrained row."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs__l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_sram_noc_constrained_schedule__l2_decoder_attention_kv_endpoint_sram_noc_constrained_schedule_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_constrained_schedule_v1/analysis_report.md",
+    "npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/quality_gate.md
@@ -1,0 +1,33 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1`
+- `title`: `Endpoint SRAM/NoC full-search Llama7B attention schedule`
+
+## Why This Gate Is Required
+- Retained-frontier postprocessing can miss architecture points that become better only after practical SRAM/endpoint caps are applied.
+- The Llama7B frontier should be selected from a cap-aware search before we decide whether SRAM endpoint service changes the best topology.
+
+## Reference
+- endpoint_topology_pairs_ref: `l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1`
+- sram_profile_ref: `l2_decoder_attention_sram_profile_v1`
+- retained_cap_ref: `l2_decoder_attention_kv_endpoint_sram_noc_constrained_schedule_llama7b_v1`
+
+## Checks
+- metric: source mode
+  - threshold: report records `full_topology_regeneration`
+- metric: generated rows
+  - threshold: nonzero successful output
+- metric: cap-source accounting
+  - threshold: report includes practical NoC cap-source counts
+- metric: endpoint topology input
+  - threshold: command consumes the endpoint topology/scheduler pair matrix
+- metric: retained topology input
+  - threshold: command does not consume `--topology-derived-json`
+- metric: abstract NoC knobs
+  - threshold: generated task command must not include independent `--noc-bandwidth-bytes-per-cycle` or `--noc-hops`
+
+## Result
+- status: pending
+- note: Final quality decision waits for evaluator output.
+

--- a/npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py
@@ -10,13 +10,14 @@ import math
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from npu.eval import estimate_llm_decoder_attention_kv_clustered_schedule as clustered  # noqa: E402
+from npu.eval import estimate_llm_decoder_attention_kv_topology_derived_schedule as topology_derived  # noqa: E402
 
 
 JsonDict = dict[str, Any]
@@ -34,6 +35,21 @@ def _int_list(value: str) -> list[int]:
     if not items or any(item <= 0 for item in items):
         raise argparse.ArgumentTypeError("expected comma-separated positive integers")
     return items
+
+
+def _nonnegative_int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item < 0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated nonnegative integers")
+    return items
+
+
+def _optional_str_list(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _profile_list(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
 
 
 def _load_json(path: Path) -> JsonDict:
@@ -306,15 +322,116 @@ def _update_best(target: dict[tuple[Any, ...], JsonDict], keys: tuple[str, ...],
         target[key] = row
 
 
+def _iter_generated_topology_rows(
+    args: argparse.Namespace,
+    *,
+    repo_root: Path,
+    stats: dict[str, Any],
+) -> Iterable[JsonDict]:
+    topology_payload = _load_json(repo_root / args.topology_pairs_json)
+    topology_rows = topology_derived._topology_service_rows(topology_payload, limit=args.topology_row_limit)
+    candidates = clustered._load_compute_candidates(
+        repo_root=repo_root,
+        tag_substring=args.tag_substring,
+        compute_source=args.compute_source,
+    )
+    if args.compute_arch_list:
+        allowed = set(args.compute_arch_list)
+        candidates = [candidate for candidate in candidates if str(candidate["compute_arch"]) in allowed]
+    if not candidates:
+        raise RuntimeError("no measured compute candidates matched")
+    measured_l1_profiles = clustered._load_measured_l1_profiles(
+        repo_root=repo_root,
+        costs_path=repo_root / args.measured_l1_costs if args.measured_l1_costs else None,
+        profile_names=args.measured_l1_profile,
+    )
+
+    stats.update(
+        {
+            "source_mode": "full_topology_regeneration",
+            "source_model": "llm_decoder_attention_kv_topology_derived_schedule_llama7b_v1",
+            "topology_pairs_summary": topology_payload.get("summary", {}),
+            "topology_service_rows_used": len(topology_rows),
+            "topology_generated_row_count": 0,
+            "topology_skipped_area_budget_count": 0,
+        }
+    )
+    for service in topology_rows:
+        cluster_count = int(service["cluster_count"])
+        bank_count = int(service["bank_count"])
+        local_sram_fraction = float(service["local_sram_fraction"])
+        reduction_strategy = str(service["reduction_strategy"])
+        noc_bw = topology_derived._equivalent_raw_noc_bandwidth(service)
+        noc_hops = max(1, int(service["worst_hops"]))
+        for sequence_length in args.sequence_length_list:
+            for die_area_mm2 in args.die_area_mm2_list:
+                for sram_area_fraction in args.sram_area_fraction:
+                    for logic_area_fraction in args.logic_area_fraction:
+                        for usable_sram_fraction in args.usable_sram_fraction:
+                            for tile_tokens in args.tile_tokens_list:
+                                for command_cycles_per_tile in args.command_cycles_per_tile:
+                                    for command_cycles_per_wave in args.command_cycles_per_wave:
+                                        for reducer_setup_cycles in args.reducer_setup_cycles:
+                                            for reduction_cycle_multiplier in args.reduction_cycle_multiplier:
+                                                for measured_l1_profile in measured_l1_profiles:
+                                                    for candidate in candidates:
+                                                        row = clustered._shape_row(
+                                                            candidate=candidate,
+                                                            die_area_mm2=die_area_mm2,
+                                                            sram_area_fraction=sram_area_fraction,
+                                                            logic_area_fraction=logic_area_fraction,
+                                                            reserved_area_fraction=args.reserved_area_fraction,
+                                                            sequence_length=sequence_length,
+                                                            usable_sram_fraction=usable_sram_fraction,
+                                                            local_sram_fraction=local_sram_fraction,
+                                                            tile_tokens=tile_tokens,
+                                                            bank_count=bank_count,
+                                                            cluster_count=cluster_count,
+                                                            noc_bandwidth_bytes_per_cycle=noc_bw,
+                                                            noc_hops=noc_hops,
+                                                            reduction_strategy=reduction_strategy,
+                                                            vector_ops_per_mac=args.vector_ops_per_mac,
+                                                            reduction_scalar_bytes=args.reduction_scalar_bytes,
+                                                            command_cycles_per_tile=command_cycles_per_tile,
+                                                            command_cycles_per_wave=command_cycles_per_wave,
+                                                            reducer_setup_cycles=reducer_setup_cycles,
+                                                            reduction_cycle_multiplier=reduction_cycle_multiplier,
+                                                            measured_l1_profile=measured_l1_profile,
+                                                        )
+                                                        if row is None:
+                                                            stats["topology_skipped_area_budget_count"] += 1
+                                                            continue
+                                                        stats["topology_generated_row_count"] += 1
+                                                        yield topology_derived._annotate_topology(row, service)
+
+
+def _source_rows(args: argparse.Namespace, *, repo_root: Path, stats: dict[str, Any]) -> Iterable[JsonDict]:
+    if args.topology_pairs_json:
+        yield from _iter_generated_topology_rows(args, repo_root=repo_root, stats=stats)
+        return
+    if not args.topology_derived_json:
+        raise RuntimeError("one of --topology-derived-json or --topology-pairs-json is required")
+    source_payload = _load_json(repo_root / args.topology_derived_json)
+    rows = _dedupe_rows(source_payload, limit=args.frontier_row_limit)
+    stats.update(
+        {
+            "source_mode": "retained_topology_rows",
+            "source_model": source_payload.get("model"),
+            "retained_source_row_count": len(rows),
+        }
+    )
+    yield from rows
+
+
 def build_report(args: argparse.Namespace) -> JsonDict:
     repo_root = args.repo_root
-    source_payload = _load_json(repo_root / args.topology_derived_json)
     sram_caps = _sram_profile_caps(_load_json(repo_root / args.sram_profile_json))
-    source_rows = _dedupe_rows(source_payload, limit=args.frontier_row_limit)
+    source_stats: dict[str, Any] = {}
 
     best: JsonDict | None = None
     top_heap: list[tuple[float, int, JsonDict]] = []
     heap_counter = 0
+    source_rows_used = 0
     generated = 0
     infeasible = Counter()
     dominance = Counter()
@@ -323,7 +440,8 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     best_by_endpoint: dict[tuple[Any, ...], JsonDict] = {}
     best_by_die: dict[tuple[Any, ...], JsonDict] = {}
 
-    for row in source_rows:
+    for row in _source_rows(args, repo_root=repo_root, stats=source_stats):
+        source_rows_used += 1
         for local_buffer_multiplier in args.local_buffer_multiplier:
             for sram_bank_efficiency in args.sram_bank_efficiency:
                 for endpoint_port_bytes_per_cycle in args.endpoint_port_bytes_per_cycle:
@@ -372,11 +490,25 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     return {
         "version": 1,
         "model": "llm_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1",
-        "topology_derived_json": str(args.topology_derived_json),
+        "topology_derived_json": str(args.topology_derived_json or ""),
+        "topology_pairs_json": str(args.topology_pairs_json or ""),
         "sram_profile_json": str(args.sram_profile_json),
-        "source_model": source_payload.get("model"),
+        "source_model": source_stats.get("source_model"),
         "inputs": {
             "frontier_row_limit": args.frontier_row_limit,
+            "topology_row_limit": args.topology_row_limit,
+            "sequence_length_list": args.sequence_length_list,
+            "die_area_mm2_list": args.die_area_mm2_list,
+            "sram_area_fraction": args.sram_area_fraction,
+            "logic_area_fraction": args.logic_area_fraction,
+            "reserved_area_fraction": args.reserved_area_fraction,
+            "usable_sram_fraction": args.usable_sram_fraction,
+            "tile_tokens_list": args.tile_tokens_list,
+            "compute_source": args.compute_source,
+            "compute_arch_list": args.compute_arch_list,
+            "tag_substring": args.tag_substring,
+            "measured_l1_costs": str(args.measured_l1_costs),
+            "measured_l1_profile": args.measured_l1_profile,
             "sram_bank_port_bytes_per_cycle": args.sram_bank_port_bytes_per_cycle,
             "sram_read_ports_per_bank": args.sram_read_ports_per_bank,
             "sram_bank_efficiency": args.sram_bank_efficiency,
@@ -387,8 +519,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         },
         "sram_caps": sram_caps,
         "sweep_summary": {
-            "source_rows_used": len(source_rows),
+            "source_rows_used": source_rows_used,
             "generated_row_count": generated,
+            **source_stats,
             "infeasible_counts": dict(sorted(infeasible.items())),
             "dominant_tile_resource_counts": dict(sorted(dominance.items())),
             "practical_noc_cap_source_counts": dict(sorted(cap_sources.items())),
@@ -399,7 +532,11 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "best_by_endpoint": sorted(best_by_endpoint.values(), key=lambda row: row["latency_us"])[:100],
         "best_by_die": sorted(best_by_die.values(), key=lambda row: (row["sequence_length"], row["die_area_mm2"])),
         "assumptions": [
-            "Input rows are retained frontier rows from the topology-derived scheduler, not a full re-search of all generated rows.",
+            (
+                "Input rows are regenerated from the topology/scheduler pair matrix before practical SRAM/NoC caps are applied."
+                if args.topology_pairs_json
+                else "Input rows are retained frontier rows from the topology-derived scheduler, not a full re-search of all generated rows."
+            ),
             "SRAM bank service is capped by measured 256-bit tile-buffer bank width unless overridden by the CLI.",
             "NoC service is capped by the minimum of topology aggregate payload service, endpoint injection/ejection service, and practical SRAM bank read service.",
             "Local tile-buffer capacity is required per cluster; full KV-cache residency remains the higher-level HBM/SRAM capacity model from the source schedule.",
@@ -464,9 +601,29 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--repo-root", type=Path, default=Path("."))
-    ap.add_argument("--topology-derived-json", required=True, type=Path)
+    ap.add_argument("--topology-derived-json", type=Path)
+    ap.add_argument("--topology-pairs-json", type=Path)
     ap.add_argument("--sram-profile-json", required=True, type=Path)
     ap.add_argument("--frontier-row-limit", type=int, default=256)
+    ap.add_argument("--tag-substring", default="npu_dense_gemm_tile_v2_scale_hier")
+    ap.add_argument("--compute-source", choices=["legacy_npu_block", "dense_gemm_tile", "all"], default="dense_gemm_tile")
+    ap.add_argument("--compute-arch-list", type=_optional_str_list, default=["dense_gemm_16x8_k1_p1"])
+    ap.add_argument("--sequence-length-list", type=_int_list, default=[131072])
+    ap.add_argument("--die-area-mm2-list", type=_float_list, default=[800, 1200])
+    ap.add_argument("--sram-area-fraction", type=_float_list, default=[0.35, 0.4, 0.5, 0.6])
+    ap.add_argument("--logic-area-fraction", type=_float_list, default=[0.3, 0.4, 0.5])
+    ap.add_argument("--reserved-area-fraction", type=float, default=0.1)
+    ap.add_argument("--usable-sram-fraction", type=_float_list, default=[0.7])
+    ap.add_argument("--tile-tokens-list", type=_int_list, default=[512, 1024])
+    ap.add_argument("--topology-row-limit", type=int, default=128)
+    ap.add_argument("--vector-ops-per-mac", type=float, default=0.125)
+    ap.add_argument("--reduction-scalar-bytes", type=int, default=2)
+    ap.add_argument("--command-cycles-per-tile", type=_nonnegative_int_list, default=[0, 4, 16])
+    ap.add_argument("--command-cycles-per-wave", type=_nonnegative_int_list, default=[0, 16, 64])
+    ap.add_argument("--reducer-setup-cycles", type=_nonnegative_int_list, default=[0, 64, 256])
+    ap.add_argument("--reduction-cycle-multiplier", type=_float_list, default=[1.0, 2.0, 4.0])
+    ap.add_argument("--measured-l1-costs", default="")
+    ap.add_argument("--measured-l1-profile", type=_profile_list, default=["hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10"])
     ap.add_argument("--sram-bank-port-bytes-per-cycle", type=float, default=32.0)
     ap.add_argument("--sram-read-ports-per-bank", type=int, default=1)
     ap.add_argument("--sram-bank-efficiency", type=_float_list, default=[0.70, 0.85])
@@ -478,6 +635,8 @@ def main() -> int:
     ap.add_argument("--out", required=True, type=Path)
     ap.add_argument("--out-md", required=True, type=Path)
     args = ap.parse_args()
+    if not args.topology_derived_json and not args.topology_pairs_json:
+        ap.error("one of --topology-derived-json or --topology-pairs-json is required")
 
     payload = build_report(args)
     args.out.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- let the SRAM/NoC constrained estimator regenerate endpoint topology-derived schedule rows from topology/scheduler pairs before applying practical caps
- add the control-plane generator hook and proposal for the full-search Llama7B endpoint SRAM/NoC job
- cover the new task command contract with a generator regression test

## Tests
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py control_plane/control_plane/services/l2_task_generator.py
- PYTHONPATH=/tmp/rtlgen-endpoint-full-sram/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- tiny full-regeneration estimator smoke with --topology-row-limit 2