### PR TITLE
Add endpoint full-search on-chip service job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4799,6 +4799,53 @@ def _decoder_attention_kv_onchip_service_schedule_evidence(
     }
 
 
+def _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__{item_id}.md"
+    endpoint_full_search = (
+        f"{base}/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__"
+        "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_endpoint_sram_noc_full_search_schedule": endpoint_full_search,
+            "attention_kv_endpoint_full_onchip_service_schedule_out": out,
+            "attention_kv_endpoint_full_onchip_service_schedule_report": report,
+            "attention_kv_endpoint_full_onchip_service_schedule_scope": (
+                "Refine the cap-aware endpoint full-search Llama7B frontier with explicit "
+                "on-chip service policy parameters: SRAM bank arbitration, endpoint queue depth, "
+                "bank queue depth, packet payload, router hop latency, schedule staggering, and "
+                "prefetch overlap. HBM/DRAM service is intentionally inherited unchanged."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_endpoint_full_onchip_service_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py "
+                    "--repo-root . "
+                    f"--sram-noc-constrained-json {endpoint_full_search} "
+                    "--frontier-row-limit 128 "
+                    "--schedule-policy static_wave,staggered_wave,prefetch_overlap "
+                    "--bank-arbiter-policy round_robin,locality_first,age_based "
+                    "--endpoint-queue-depth-bytes 2048,8192,32768 "
+                    "--bank-queue-depth-bytes 2048,8192,32768 "
+                    "--router-latency-cycles-per-hop 1,2 "
+                    "--packet-payload-bytes 32,64,128 "
+                    "--prefetch-overlap-fraction 0,0.25,0.5 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_sram_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_sram_profile__{item_id}.json"
@@ -6392,6 +6439,7 @@ def _build_payload(
         "decoder_attention_kv_endpoint_sram_noc_constrained_schedule",
         "decoder_attention_kv_endpoint_sram_noc_full_search_schedule",
         "decoder_attention_kv_onchip_service_schedule",
+        "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_sram_profile",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
@@ -6511,6 +6559,10 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_kv_onchip_service_schedule":
             decoder_evidence = _decoder_attention_kv_onchip_service_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_endpoint_full_onchip_service_schedule":
+            decoder_evidence = _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
+                item_id=item_id,
+            )
         elif abstraction_layer_name == "decoder_attention_sram_profile":
             decoder_evidence = _decoder_attention_sram_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5740,3 +5740,56 @@ def test_generate_l2_campaign_task_adds_onchip_service_schedule_evidence() -> No
                 )
                 for output in expected_outputs
             )
+
+
+def test_generate_l2_campaign_task_adds_endpoint_full_onchip_service_schedule_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_endpoint_full_onchip_service_schedule",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_kv_endpoint_full_onchip_service_schedule" in command_names
+            assert "attention_kv_endpoint_sram_noc_full_search_schedule" in decoder_inputs
+            assert "attention_kv_endpoint_full_onchip_service_schedule_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_onchip_service_schedule.py" in run
+            assert "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json" in run
+            assert "l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2.json" not in run
+            assert "--schedule-policy static_wave,staggered_wave,prefetch_overlap" in run
+            assert "--endpoint-queue-depth-bytes 2048,8192,32768" in run
+            assert "--router-latency-cycles-per-hop 1,2" in run
+            assert "--noc-bandwidth-bytes-per-cycle" not in run
+            assert "--data-rate-mtps" not in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.expected_outputs == expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_endpoint_full_onchip_service_schedule__"
+                    "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/README.md
@@ -1,0 +1,10 @@
+# Endpoint Full-Search On-Chip Service Schedule
+
+This proposal applies the explicit on-chip service model to the current
+cap-aware endpoint full-search Llama7B frontier.
+
+The input is the finalized endpoint SRAM/NoC full-search schedule. The output
+should report the best policy for SRAM bank arbitration, endpoint queues, bank
+queues, packet payload, router hop latency, wave staggering, and prefetch
+overlap while inheriting HBM/DRAM service unchanged.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by: developer_agent
+- approved_utc: 2026-06-09T07:05:00Z
+- allowed_evaluations:
+  - l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1
+- note: Apply explicit SRAM-bank, endpoint queue, packet, router-latency, and scheduling policy model to the endpoint full-search Llama7B frontier.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1",
+  "source_commit": "TBD_AFTER_MERGE",
+  "source_commit_note": "Dispatch should use the merge commit for the proposal implementation so the evaluator has the endpoint-full on-chip service generator hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Apply explicit on-chip SRAM bank, endpoint queue, bank queue, packet payload, router latency, scheduling, and overlap policies to the endpoint full-search Llama7B frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_endpoint_full_onchip_service_schedule",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "refine_endpoint_full_search_frontier_with_explicit_onchip_service_policies",
+        "reason": "The result should identify the best explicit on-chip service policy and report movement versus the endpoint SRAM/NoC full-search cap-aware frontier without changing HBM/DRAM assumptions."
+      }
+    }
+  ]
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/proposal.json
@@ -1,0 +1,65 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1",
+  "created_utc": "2026-06-09T07:05:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Endpoint full-search on-chip service Llama7B schedule",
+  "hypothesis": "Applying explicit endpoint queue, bank queue, packet payload, router hop latency, SRAM bank arbitration, wave staggering, and prefetch-overlap policies to the endpoint full-search Llama7B frontier will reduce the remaining on-chip service abstraction and may move the selected policy or latency.",
+  "direct_comparison": {
+    "primary_question": "How does the current cap-aware endpoint full-search Llama7B frontier move under explicit on-chip service policy modeling?",
+    "include": [
+      "Use l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1 as the source frontier.",
+      "Sweep static_wave, staggered_wave, and prefetch_overlap scheduling.",
+      "Sweep round_robin, locality_first, and age_based SRAM bank arbitration.",
+      "Sweep endpoint queue depth, bank queue depth, packet payload, router hop latency, and prefetch overlap.",
+      "Report latency movement versus the endpoint full-search cap-aware result."
+    ],
+    "exclude": [
+      "Do not change HBM/DRAM bandwidth, frequency, or service policy.",
+      "Do not introduce new precision, KV sharing, or quality assumptions.",
+      "Do not run new physical closure in this L2 scheduler item.",
+      "Do not reintroduce independent abstract NoC bandwidth or hop sweeps."
+    ],
+    "follow_on_broad_sweep": [
+      "If the explicit on-chip model changes the selected family, use the result as the next Llama7B frontier baseline.",
+      "If the same family remains best, the next abstraction to reduce is RTL-level endpoint/router/SRAM ready-valid equivalence for that selected policy.",
+      "Treat HBM/DRAM as a separate later item."
+    ]
+  },
+  "expected_benefit": [
+    "Use the most recent endpoint full-search frontier rather than the older retained SRAM/NoC cap source.",
+    "Identify whether explicit endpoint queues, bank queues, packet payload, router latency, and overlap policy change the best Llama7B point.",
+    "Provide the least-abstract current on-chip-service baseline before moving to RTL endpoint/router/SRAM composition."
+  ],
+  "risks": [
+    "This is still an analytic service simulator, not router/SRAM RTL.",
+    "The queue and arbitration policies are parameterized approximations.",
+    "HBM/DRAM service remains inherited and abstract by design."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "endpoint_full_onchip_service_schedule",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "refine_endpoint_full_search_frontier_with_explicit_onchip_service_policies",
+        "reason": "The result should report explicit on-chip service policy movement relative to the endpoint full-search frontier."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_v1/analysis_report.md",
+    "npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/quality_gate.md
@@ -1,0 +1,27 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1`
+- `title`: `Endpoint full-search on-chip service Llama7B schedule`
+
+## Why This Gate Is Required
+- The current best Llama7B point is selected by practical SRAM/endpoint caps but still uses a compact service-envelope model.
+- The next least-abstract comparison should model endpoint queues, bank queues, packet payload, router hop latency, SRAM bank arbitration, and overlap policy explicitly.
+
+## Reference
+- endpoint_full_search_ref: `l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1`
+
+## Checks
+- metric: source artifact
+  - threshold: command consumes `decoder_attention_kv_endpoint_sram_noc_full_search_schedule__...llama7b_v1.json`
+- metric: old source artifact
+  - threshold: command does not consume `l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1_r2.json`
+- metric: policy sweep
+  - threshold: report includes schedule policy, bank arbiter policy, endpoint queue depth, bank queue depth, packet payload, and router hop latency
+- metric: HBM/DRAM
+  - threshold: report states HBM/DRAM service is inherited unchanged
+
+## Result
+- status: pending
+- note: Final quality decision waits for evaluator output.
+


### PR DESCRIPTION
## Summary
- add a generator hook for explicit on-chip service modeling from the endpoint full-search SRAM/NoC frontier
- add proposal gates for the endpoint full on-chip service Llama7B job
- add a generator regression test so the job consumes the endpoint full-search artifact, not the older SRAM/NoC constrained source

## Tests
- python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py
- PYTHONPATH=/tmp/rtlgen-endpoint-full-onchip/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue