### PR TITLE
Add endpoint router SRAM composition audit

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4885,6 +4885,57 @@ def _decoder_attention_kv_endpoint_ready_valid_service_evidence(
     }
 
 
+def _decoder_attention_kv_endpoint_router_sram_composition_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_endpoint_router_sram_composition__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_endpoint_router_sram_composition__{item_id}.md"
+    endpoint_ready_valid = (
+        f"{base}/decoder_attention_kv_endpoint_ready_valid_service__"
+        "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1.json"
+    )
+    endpoint_onchip = (
+        f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__"
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
+    )
+    sram_summary = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics_summary.json"
+    sram_metrics = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json"
+    return {
+        "inputs": {
+            "attention_kv_endpoint_ready_valid_service": endpoint_ready_valid,
+            "attention_kv_endpoint_full_onchip_service_schedule": endpoint_onchip,
+            "attention_kv_tile_sram_metrics_summary": sram_summary,
+            "attention_kv_tile_sram_metrics": sram_metrics,
+            "attention_kv_endpoint_router_sram_composition_out": out,
+            "attention_kv_endpoint_router_sram_composition_report": report,
+            "attention_kv_endpoint_router_sram_composition_scope": (
+                "Audit the selected endpoint service frontier against concrete endpoint, router, FIFO, "
+                "and SRAM evidence. Quantify width/lane replication gaps and identify the exact L1 PPA "
+                "points needed before treating the on-chip endpoint/router/SRAM composition as closed. "
+                "HBM/DRAM service remains inherited unchanged."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_kv_endpoint_router_sram_composition",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py "
+                    "--repo-root . "
+                    f"--endpoint-ready-valid-json {endpoint_ready_valid} "
+                    f"--endpoint-onchip-json {endpoint_onchip} "
+                    f"--sram-summary-json {sram_summary} "
+                    f"--sram-metrics-json {sram_metrics} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_sram_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_sram_profile__{item_id}.json"
@@ -6480,6 +6531,7 @@ def _build_payload(
         "decoder_attention_kv_onchip_service_schedule",
         "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_kv_endpoint_ready_valid_service",
+        "decoder_attention_kv_endpoint_router_sram_composition",
         "decoder_attention_sram_profile",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
@@ -6605,6 +6657,10 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_kv_endpoint_ready_valid_service":
             decoder_evidence = _decoder_attention_kv_endpoint_ready_valid_service_evidence(
+                item_id=item_id,
+            )
+        elif abstraction_layer_name == "decoder_attention_kv_endpoint_router_sram_composition":
+            decoder_evidence = _decoder_attention_kv_endpoint_router_sram_composition_evidence(
                 item_id=item_id,
             )
         elif abstraction_layer_name == "decoder_attention_sram_profile":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5843,3 +5843,56 @@ def test_generate_l2_campaign_task_adds_endpoint_ready_valid_service_evidence() 
                 )
                 for output in expected_outputs
             )
+
+
+def test_generate_l2_campaign_task_adds_endpoint_router_sram_composition_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_endpoint_router_sram_composition",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "audit_decoder_attention_kv_endpoint_router_sram_composition" in command_names
+            assert "attention_kv_endpoint_ready_valid_service" in decoder_inputs
+            assert "attention_kv_endpoint_full_onchip_service_schedule" in decoder_inputs
+            assert "attention_kv_tile_sram_metrics_summary" in decoder_inputs
+            assert "attention_kv_endpoint_router_sram_composition_out" in decoder_inputs
+            assert "audit_llm_decoder_attention_endpoint_router_sram_composition.py" in run
+            assert "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1.json" in run
+            assert "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json" in run
+            assert "llama7b_attention_tile_buffers_v1/sram_metrics_summary.json" in run
+            assert "--noc-bandwidth-bytes-per-cycle" not in run
+            assert "--data-rate-mtps" not in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.expected_outputs == expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_endpoint_router_sram_composition__"
+                    "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/README.md
@@ -1,0 +1,8 @@
+# Endpoint Router/SRAM Composition Audit
+
+This proposal audits the current Llama7B on-chip frontier against concrete
+endpoint ready/valid evidence, measured NoC router/FIFO PPA, and measured
+tile-local SRAM metrics.
+
+The purpose is to prevent narrow primitive PPA from being treated as a closed
+wide-link implementation. HBM/DRAM service remains intentionally out of scope.

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+Dispatch one L2 campaign item:
+
+- `l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1`
+
+The evaluator must use the implementation commit containing
+`npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py` and
+the `decoder_attention_kv_endpoint_router_sram_composition` generator hook.

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1",
+  "source_commit": null,
+  "source_commit_note": "Dispatch should use the merge commit for the proposal implementation so the evaluator has the endpoint/router/SRAM composition audit generator hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit the selected Llama7B endpoint service frontier against concrete endpoint ready-valid, NoC router/FIFO PPA, and tile SRAM metrics.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_endpoint_router_sram_composition",
+      "comparison_role": "frontier_validation",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "quantify_onchip_endpoint_router_sram_composition_gaps",
+        "reason": "The result should identify whether endpoint PPA width, router width, FIFO width, and SRAM capacity are closed or require follow-on PPA."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1",
+  "created_utc": "2026-06-09T08:25:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Endpoint router SRAM composition audit for Llama7B frontier",
+  "hypothesis": "The selected endpoint full on-chip Llama7B frontier still has concrete on-chip composition gaps caused by endpoint width, router/FIFO lane replication, and local SRAM capacity assumptions; quantifying them will identify the next physical PPA points needed before the result can be treated as closed.",
+  "direct_comparison": {
+    "primary_question": "Which endpoint/router/SRAM parts of the current Llama7B frontier are physically backed, lane-scaled, or still abstract?",
+    "include": [
+      "Use l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1 as the endpoint behavior source.",
+      "Use l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1 as the selected architecture source.",
+      "Use llama7b_attention_tile_buffers_v1 SRAM CACTI metrics for tile-local buffer evidence.",
+      "Compare selected packet and link widths against measured endpoint, router, and FIFO PPA widths.",
+      "Report exact follow-on L1 PPA points required for closure."
+    ],
+    "exclude": [
+      "Do not change HBM/DRAM bandwidth, frequency, or service policy.",
+      "Do not run a new architecture sweep.",
+      "Do not silently treat lane-scaled narrow-router PPA as physically equivalent to a wide-link router.",
+      "Do not claim full local SRAM capacity closure from tile-local buffer metrics alone."
+    ],
+    "follow_on_broad_sweep": [
+      "Measure the required endpoint/router/FIFO/local SRAM PPA points if the audit finds gaps.",
+      "Feed measured wide-link and local-capacity values back into the Llama7B service model.",
+      "Keep HBM/DRAM as a later separate item."
+    ]
+  },
+  "expected_benefit": [
+    "Prevents the dashboard from treating lane-scaled narrow primitives as fully concrete.",
+    "Identifies whether the current best point is robust after accounting for measured endpoint/router/SRAM evidence.",
+    "Creates a clear path to close the remaining on-chip abstractions before HBM/DRAM modeling."
+  ],
+  "risks": [
+    "This is an audit and scaled composition estimate, not a new placed wide-router or SRAM-capacity macro measurement.",
+    "The result may downgrade the current frontier confidence rather than improve latency.",
+    "Full NoC route scheduling is still outside this audit."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "endpoint_router_sram_composition_audit",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "quantify_onchip_endpoint_router_sram_composition_gaps",
+        "reason": "The result should report closure flags, lane replication quantities, SRAM coverage, and exact follow-on PPA points without changing HBM/DRAM assumptions."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_ready_valid_service__l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json",
+    "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics_summary.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py",
+    "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv",
+    "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv",
+    "runs/designs/noc/l1_onchip_endpoint_w128_b4_eq8_bq4_wrapper/metrics.csv"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1/quality_gate.md
@@ -1,0 +1,23 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_router_sram_composition_v1`
+- `title`: `Endpoint router SRAM composition audit for Llama7B frontier`
+
+## Why This Gate Is Required
+- The selected frontier uses a 128-byte endpoint packet and 2048-bit link, but current primitive metrics include narrower endpoint/router/FIFO wrappers.
+- The exploration should explicitly separate physically backed values from lane-scaled estimates.
+
+## Checks
+- metric: source artifacts
+  - threshold: command consumes endpoint ready-valid, endpoint full on-chip, and SRAM metrics artifacts
+- metric: width closure
+  - threshold: report includes endpoint, router, and FIFO width closure flags
+- metric: SRAM closure
+  - threshold: report distinguishes tile-local SRAM buffer coverage from full local-capacity SRAM closure
+- metric: HBM/DRAM
+  - threshold: report states HBM/DRAM service is inherited unchanged
+
+## Result
+- status: pending
+- note: Final quality decision waits for evaluator output.

--- a/npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py
+++ b/npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Audit endpoint/router/SRAM concreteness for the selected Llama7B attention frontier."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _ceil_div(numerator: int | float, denominator: int | float) -> int:
+    return int(math.ceil(float(numerator) / max(1.0, float(denominator))))
+
+
+def _parse_width_bits(path_or_design: str) -> int | None:
+    match = re.search(r"_w(\d+)(?:_|$)", path_or_design)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _best_metrics(metrics_csv: Path) -> JsonDict | None:
+    if not metrics_csv.exists():
+        return None
+    with metrics_csv.open(newline="", encoding="utf-8") as handle:
+        rows = [row for row in csv.DictReader(handle) if row.get("status") == "ok"]
+    if not rows:
+        return None
+    row = min(rows, key=lambda item: (float(item["critical_path_ns"]), float(item["die_area"])))
+    return {
+        "metrics_csv": str(metrics_csv),
+        "design": row.get("design", ""),
+        "critical_path_ns": float(row["critical_path_ns"]),
+        "area_um2": float(row["die_area"]),
+        "power_mw": float(row["total_power_mw"]),
+        "param_hash": row.get("param_hash", ""),
+        "tag": row.get("tag", ""),
+        "width_bits": _parse_width_bits(row.get("design", "") or str(metrics_csv)),
+    }
+
+
+def _sram_capacity_bytes(sram_metrics: JsonDict) -> int:
+    total = 0
+    for instance in sram_metrics.get("instances", []):
+        spec = instance.get("instance", {})
+        total += int(spec.get("size_bytes", 0))
+    return total
+
+
+def _build_payload(
+    *,
+    repo_root: Path,
+    endpoint_ready_valid: JsonDict,
+    endpoint_onchip: JsonDict,
+    sram_summary: JsonDict,
+    sram_metrics: JsonDict,
+) -> JsonDict:
+    best = endpoint_onchip["best"]
+    ready_params = endpoint_ready_valid["derived_rtl_parameters"]
+    packet_bits = int(ready_params["data_w"])
+    packet_payload_bytes = int(ready_params["packet_payload_bytes"])
+    link_width_bits = int(best["link_width_bits"])
+    router_metrics = _best_metrics(repo_root / best["noc_router_metrics_csv"])
+    fifo_metrics = _best_metrics(repo_root / best["noc_fifo_metrics_csv"])
+    endpoint_metrics = _best_metrics(repo_root / best["onchip_endpoint_metrics_csv"])
+
+    router_width = int(router_metrics["width_bits"]) if router_metrics and router_metrics.get("width_bits") else 0
+    fifo_width = int(fifo_metrics["width_bits"]) if fifo_metrics and fifo_metrics.get("width_bits") else 0
+    endpoint_ppa_width = (
+        int(endpoint_metrics["width_bits"]) if endpoint_metrics and endpoint_metrics.get("width_bits") else 0
+    )
+    router_lanes_for_link = _ceil_div(link_width_bits, router_width) if router_width else None
+    fifo_lanes_for_link = _ceil_div(link_width_bits, fifo_width) if fifo_width else None
+    router_lanes_for_packet = _ceil_div(packet_bits, router_width) if router_width else None
+    endpoint_width_ratio = _ceil_div(packet_bits, endpoint_ppa_width) if endpoint_ppa_width else None
+
+    active_clusters = int(best["active_clusters"])
+    sram_allocated_bytes = _sram_capacity_bytes(sram_metrics)
+    local_capacity_bytes_per_cluster = int(best["local_capacity_bytes_per_cluster"])
+    sram_budget_area_um2 = float(best["die_area_mm2"]) * 1_000_000.0 * float(best["sram_area_fraction"])
+    tile_sram_area_per_cluster_um2 = float(sram_summary.get("total_area_um2", 0.0))
+    tile_sram_total_area_um2 = tile_sram_area_per_cluster_um2 * active_clusters
+
+    scaled_router_area_per_cluster = (
+        float(router_metrics["area_um2"]) * router_lanes_for_link if router_metrics and router_lanes_for_link else None
+    )
+    scaled_fifo_area_per_cluster = (
+        float(fifo_metrics["area_um2"]) * fifo_lanes_for_link if fifo_metrics and fifo_lanes_for_link else None
+    )
+    scaled_endpoint_area_per_cluster = (
+        float(endpoint_metrics["area_um2"]) * endpoint_width_ratio if endpoint_metrics and endpoint_width_ratio else None
+    )
+    scaled_local_service_area_per_cluster = sum(
+        value
+        for value in [scaled_router_area_per_cluster, scaled_fifo_area_per_cluster, scaled_endpoint_area_per_cluster]
+        if value is not None
+    )
+
+    closure_flags = {
+        "ready_valid_endpoint_passed": endpoint_ready_valid["decision"] == "ready_valid_endpoint_policy_passed",
+        "endpoint_ppa_width_matches_ready_valid_width": endpoint_ppa_width == packet_bits,
+        "router_ppa_width_matches_link_width": router_width == link_width_bits,
+        "fifo_ppa_width_matches_link_width": fifo_width == link_width_bits,
+        "tile_sram_profile_fits_sram_area_budget": tile_sram_total_area_um2 <= sram_budget_area_um2,
+        "tile_sram_capacity_covers_selected_local_capacity": sram_allocated_bytes >= local_capacity_bytes_per_cluster,
+    }
+    requires_follow_on = [
+        name for name, closed in closure_flags.items() if not closed and name != "tile_sram_capacity_covers_selected_local_capacity"
+    ]
+    if not closure_flags["tile_sram_capacity_covers_selected_local_capacity"]:
+        requires_follow_on.append("full_local_capacity_sram_macro_profile_missing")
+
+    return {
+        "model": "llm_decoder_attention_endpoint_router_sram_composition_audit_v1",
+        "version": 1,
+        "source_items": {
+            "endpoint_onchip": "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1",
+            "endpoint_ready_valid": "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1",
+            "sram_profile": "llama7b_attention_tile_buffers_v1",
+        },
+        "selected_frontier": {
+            "latency_us": best["latency_us"],
+            "topology": best["topology"],
+            "scheduler_policy": best["scheduler_policy"],
+            "reduction_strategy": best["reduction_strategy"],
+            "schedule_policy": best["schedule_policy"],
+            "bank_arbiter_policy": best["bank_arbiter_policy"],
+            "cluster_count": best["cluster_count"],
+            "active_clusters": best["active_clusters"],
+            "bank_count": best["bank_count"],
+            "link_width_bits": link_width_bits,
+            "packet_payload_bytes": packet_payload_bytes,
+            "local_sram_fraction": best["local_sram_fraction"],
+            "sram_area_fraction": best["sram_area_fraction"],
+            "compute_logic_area_fraction": best["compute_logic_area_fraction"],
+            "dominant_tile_resource": best["dominant_tile_resource"],
+        },
+        "measured_primitives": {
+            "router": router_metrics,
+            "fifo": fifo_metrics,
+            "endpoint": endpoint_metrics,
+            "sram_summary": {
+                "total_area_um2": sram_summary.get("total_area_um2"),
+                "max_access_time_ns": sram_summary.get("max_access_time_ns"),
+                "total_read_energy_pj": sram_summary.get("total_read_energy_pj"),
+                "total_write_energy_pj": sram_summary.get("total_write_energy_pj"),
+                "allocated_bytes": sram_allocated_bytes,
+            },
+        },
+        "composition_quantities": {
+            "packet_bits": packet_bits,
+            "packet_payload_bytes": packet_payload_bytes,
+            "link_width_bits": link_width_bits,
+            "router_lanes_for_packet": router_lanes_for_packet,
+            "router_lanes_for_link": router_lanes_for_link,
+            "fifo_lanes_for_link": fifo_lanes_for_link,
+            "endpoint_width_ratio_vs_measured_ppa": endpoint_width_ratio,
+            "local_capacity_bytes_per_cluster": local_capacity_bytes_per_cluster,
+            "tile_sram_allocated_bytes_per_cluster": sram_allocated_bytes,
+            "tile_sram_capacity_fraction_of_selected_local_capacity": round(
+                sram_allocated_bytes / max(1, local_capacity_bytes_per_cluster),
+                6,
+            ),
+            "sram_budget_area_um2": sram_budget_area_um2,
+            "tile_sram_total_area_um2_for_active_clusters": tile_sram_total_area_um2,
+            "tile_sram_budget_area_fraction": round(tile_sram_total_area_um2 / max(1.0, sram_budget_area_um2), 6),
+            "scaled_router_area_per_cluster_um2": scaled_router_area_per_cluster,
+            "scaled_fifo_area_per_cluster_um2": scaled_fifo_area_per_cluster,
+            "scaled_endpoint_area_per_cluster_um2": scaled_endpoint_area_per_cluster,
+            "scaled_local_service_area_per_cluster_um2": scaled_local_service_area_per_cluster,
+            "scaled_local_service_area_all_clusters_um2": scaled_local_service_area_per_cluster * active_clusters,
+        },
+        "closure_flags": closure_flags,
+        "decision": (
+            "composition_requires_follow_on_ppa"
+            if requires_follow_on
+            else "endpoint_router_sram_composition_closed_for_selected_policy"
+        ),
+        "required_follow_on_ppa": requires_follow_on,
+        "recommended_next_l1_points": [
+            {
+                "primitive": "onchip_service_endpoint",
+                "reason": "ready/valid probe used DATA_W=1024 but selected PPA currently references w128 endpoint metrics",
+                "parameters": {
+                    "flit_bits": packet_bits,
+                    "banks": int(ready_params["banks"]),
+                    "endpoint_depth": int(ready_params["endpoint_queue_depth"]),
+                    "bank_queue_depth": int(ready_params["bank_queue_depth"]),
+                },
+            },
+            {
+                "primitive": "noc_router",
+                "reason": "selected link is 2048 bits but current PPA references w128 router metrics",
+                "parameters": {"ports": 4, "flit_bits": link_width_bits},
+            },
+            {
+                "primitive": "noc_fifo",
+                "reason": "selected link is 2048 bits but current PPA references w128 FIFO metrics",
+                "parameters": {"depth": 16, "flit_bits": link_width_bits},
+            },
+            {
+                "primitive": "local_sram_capacity",
+                "reason": "tile-local SRAM buffers are measured, but the selected local-capacity pool is still capacity-estimated",
+                "parameters": {
+                    "local_capacity_bytes_per_cluster": local_capacity_bytes_per_cluster,
+                    "active_clusters": active_clusters,
+                },
+            },
+        ],
+        "remaining_abstractions": [
+            "Router/FIFO PPA is lane-scaled from narrower measured primitives until wide-link L1 points are measured.",
+            "Endpoint ready/valid behavior is verified at 1024 bits, but endpoint PPA is still from the existing w128 wrapper.",
+            "Tile-local SRAM buffers have CACTI metrics, but the selected per-cluster local capacity pool is not yet a concrete SRAM macro set.",
+            "HBM/DRAM service remains inherited and intentionally outside this audit.",
+        ],
+    }
+
+
+def _write_report(payload: JsonDict, report: Path) -> None:
+    selected = payload["selected_frontier"]
+    quantities = payload["composition_quantities"]
+    flags = payload["closure_flags"]
+    lines = [
+        "# Endpoint Router/SRAM Composition Audit",
+        "",
+        "## Selected Frontier",
+        f"- latency_us: `{selected['latency_us']}`",
+        f"- topology: `{selected['topology']}`",
+        f"- clusters: `{selected['cluster_count']}`",
+        f"- banks: `{selected['bank_count']}`",
+        f"- link_width_bits: `{selected['link_width_bits']}`",
+        f"- packet_payload_bytes: `{selected['packet_payload_bytes']}`",
+        f"- dominant_tile_resource: `{selected['dominant_tile_resource']}`",
+        "",
+        "## Composition Quantities",
+        f"- packet_bits: `{quantities['packet_bits']}`",
+        f"- router_lanes_for_packet: `{quantities['router_lanes_for_packet']}`",
+        f"- router_lanes_for_link: `{quantities['router_lanes_for_link']}`",
+        f"- fifo_lanes_for_link: `{quantities['fifo_lanes_for_link']}`",
+        f"- endpoint_width_ratio_vs_measured_ppa: `{quantities['endpoint_width_ratio_vs_measured_ppa']}`",
+        f"- tile_sram_capacity_fraction_of_selected_local_capacity: `{quantities['tile_sram_capacity_fraction_of_selected_local_capacity']}`",
+        f"- tile_sram_budget_area_fraction: `{quantities['tile_sram_budget_area_fraction']}`",
+        "",
+        "## Closure Flags",
+    ]
+    for name, value in flags.items():
+        lines.append(f"- {name}: `{value}`")
+    lines.extend(
+        [
+            "",
+            "## Decision",
+            f"- decision: `{payload['decision']}`",
+            f"- required_follow_on_ppa: `{', '.join(payload['required_follow_on_ppa']) or 'none'}`",
+            "",
+            "## Recommended L1 Points",
+        ]
+    )
+    for item in payload["recommended_next_l1_points"]:
+        lines.append(f"- `{item['primitive']}`: {item['reason']}")
+    lines.extend(["", "## Remaining Abstractions"])
+    for item in payload["remaining_abstractions"]:
+        lines.append(f"- {item}")
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--endpoint-ready-valid-json", type=Path, required=True)
+    parser.add_argument("--endpoint-onchip-json", type=Path, required=True)
+    parser.add_argument("--sram-summary-json", type=Path, required=True)
+    parser.add_argument("--sram-metrics-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+
+    def rooted(path: Path) -> Path:
+        return path if path.is_absolute() else repo_root / path
+
+    payload = _build_payload(
+        repo_root=repo_root,
+        endpoint_ready_valid=_load_json(rooted(args.endpoint_ready_valid_json)),
+        endpoint_onchip=_load_json(rooted(args.endpoint_onchip_json)),
+        sram_summary=_load_json(rooted(args.sram_summary_json)),
+        sram_metrics=_load_json(rooted(args.sram_metrics_json)),
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_report(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Llama7B endpoint/router/SRAM composition audit script
- wire decoder_attention_kv_endpoint_router_sram_composition into the L2 task generator
- add proposal docs and generator coverage for the next on-chip abstraction audit

## Validation
- python3 -m py_compile npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py control_plane/control_plane/services/l2_task_generator.py
- PYTHONPATH=/tmp/rtlgen-endpoint-router-sram/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py --repo-root . --endpoint-ready-valid-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_ready_valid_service__l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1.json --endpoint-onchip-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json --sram-summary-json runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics_summary.json --sram-metrics-json runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json --out /tmp/router_sram_audit2.json --out-md /tmp/router_sram_audit2.md