### PR TITLE
Add wide endpoint/router/FIFO PPA proposal

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/README.md
@@ -1,0 +1,11 @@
+# Wide Endpoint/Router/FIFO PPA
+
+This proposal measures the wide on-chip primitive anchors required by the
+current Llama7B attention frontier:
+
+- `l1_onchip_endpoint_w1024_b4_eq16_bq16_wrapper`
+- `l1_noc_router_p4_w2048_wrapper`
+- `l1_noc_fifo_w2048_d16_wrapper`
+
+These are the concrete PPA points identified by the endpoint/router/SRAM
+composition audit before the on-chip service result can be treated as closed.

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+Dispatch one L1 sweep item:
+
+- `l1_decoder_attention_endpoint_router_wide_ppa_v1`
+
+Use `runs/campaigns/noc/l1_memory_noc_primitives/sweeps/nangate45_macro_frontier.json`
+with the three wide primitive configs under `runs/designs/noc`.

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/evaluation_requests.json
@@ -1,0 +1,15 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_endpoint_router_wide_ppa_v1",
+  "source_commit": null,
+  "source_commit_note": "Dispatch should use the merge commit containing the wide endpoint/router/FIFO config files.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_endpoint_router_wide_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for 1024-bit endpoint and 2048-bit router/FIFO primitive anchors required by the Llama7B endpoint/router/SRAM composition audit.",
+      "evaluation_mode": "frontier_closure",
+      "abstraction_layer": "architecture_block",
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/proposal.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_endpoint_router_wide_ppa_v1",
+  "title": "Measure wide endpoint/router/FIFO PPA anchors for Llama7B attention frontier",
+  "status": "proposed",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "motivation": "The current Llama7B endpoint/router/SRAM composition audit found that the selected frontier uses a 1024-bit endpoint packet and 2048-bit link, while existing PPA anchors are only 128-bit endpoint/router/FIFO wrappers. Wide primitive PPA is required before the on-chip service result can be treated as physically backed rather than lane-scaled.",
+  "hypothesis": "The 1024-bit endpoint and 2048-bit router/FIFO primitives will remain physically feasible as hierarchy-preserved macro-style blocks, but their area and timing may be materially worse than linear scaling from the 128-bit anchors.",
+  "expected_behavior": {
+    "functional": "The generated primitives expose synthesis-visible counters and deterministic activity.",
+    "timing_model": "The endpoint measures finite queue and bank-queue width cost; the router/FIFO measure wide flit datapath and buffering cost.",
+    "physical_model": "The sweep uses macro-style L1 wrappers with hierarchy preserved and avoids chip-level pad assumptions."
+  },
+  "comparison_points": [
+    "l1_onchip_endpoint_w1024_b4_eq16_bq16_wrapper",
+    "l1_noc_router_p4_w2048_wrapper",
+    "l1_noc_fifo_w2048_d16_wrapper"
+  ],
+  "upstream_evidence": [
+    "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1"
+  ],
+  "risks": [
+    "Wide endpoint/FIFO memories may synthesize as large register arrays unless memory inference is effective.",
+    "The 2048-bit router is still a primitive PPA anchor, not a full routed mesh implementation.",
+    "This does not close the full local SRAM capacity pool; that remains a separate SRAM macro profile item."
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_wide_ppa_v1/quality_gate.md
@@ -1,0 +1,18 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_attention_endpoint_router_wide_ppa_v1`
+- `title`: `Measure wide endpoint/router/FIFO PPA anchors for Llama7B attention frontier`
+
+## Checks
+- metric: endpoint width
+  - threshold: measure `l1_onchip_endpoint_w1024_b4_eq16_bq16_wrapper`
+- metric: router width
+  - threshold: measure `l1_noc_router_p4_w2048_wrapper`
+- metric: FIFO width
+  - threshold: measure `l1_noc_fifo_w2048_d16_wrapper`
+- metric: scope
+  - threshold: keep full local SRAM capacity and HBM/DRAM out of this L1 item
+
+## Result
+- status: pending

--- a/runs/designs/noc/l1_noc_fifo_w2048_d16_wrapper/config_l1_noc_fifo_w2048_d16.json
+++ b/runs/designs/noc/l1_noc_fifo_w2048_d16_wrapper/config_l1_noc_fifo_w2048_d16.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "flit",
+      "dimensions": 1,
+      "bit_width": 2048,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_noc_fifo_w2048_d16",
+      "operand": "flit",
+      "options": {
+        "primitive": "fifo",
+        "flit_bits": 2048,
+        "depth": 16,
+        "ports": 4,
+        "counter_bits": 32
+      }
+    }
+  ]
+}

--- a/runs/designs/noc/l1_noc_router_p4_w2048_wrapper/config_l1_noc_router_p4_w2048.json
+++ b/runs/designs/noc/l1_noc_router_p4_w2048_wrapper/config_l1_noc_router_p4_w2048.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "flit",
+      "dimensions": 1,
+      "bit_width": 2048,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_noc_router_p4_w2048",
+      "operand": "flit",
+      "options": {
+        "primitive": "router",
+        "flit_bits": 2048,
+        "depth": 4,
+        "ports": 4,
+        "counter_bits": 32
+      }
+    }
+  ]
+}

--- a/runs/designs/noc/l1_onchip_endpoint_w1024_b4_eq16_bq16_wrapper/config_l1_onchip_endpoint_w1024_b4_eq16_bq16.json
+++ b/runs/designs/noc/l1_onchip_endpoint_w1024_b4_eq16_bq16_wrapper/config_l1_onchip_endpoint_w1024_b4_eq16_bq16.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "flit",
+      "dimensions": 1,
+      "bit_width": 1024,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_onchip_endpoint_w1024_b4_eq16_bq16",
+      "operand": "flit",
+      "options": {
+        "primitive": "endpoint",
+        "flit_bits": 1024,
+        "banks": 4,
+        "endpoint_depth": 16,
+        "bank_queue_depth": 16,
+        "depth": 16,
+        "ports": 4,
+        "counter_bits": 32
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add concrete L1 configs for the Llama7B frontier wide endpoint/router/FIFO PPA gaps
- add proposal docs for measuring endpoint w1024, router p4 w2048, and FIFO w2048 d16

## Validation
- python3 scripts/generate_design.py runs/designs/noc/l1_onchip_endpoint_w1024_b4_eq16_bq16_wrapper/config_l1_onchip_endpoint_w1024_b4_eq16_bq16.json nangate45 --force_gen True
- iverilog -g2012 -s l1_onchip_endpoint_w1024_b4_eq16_bq16_wrapper -t null /orfs/flow/designs/src/l1_onchip_endpoint_w1024_b4_eq16_bq16_wrapper/*.v
- python3 scripts/generate_design.py runs/designs/noc/l1_noc_router_p4_w2048_wrapper/config_l1_noc_router_p4_w2048.json nangate45 --force_gen True
- iverilog -g2012 -s l1_noc_router_p4_w2048_wrapper -t null /orfs/flow/designs/src/l1_noc_router_p4_w2048_wrapper/*.v
- python3 scripts/generate_design.py runs/designs/noc/l1_noc_fifo_w2048_d16_wrapper/config_l1_noc_fifo_w2048_d16.json nangate45 --force_gen True
- iverilog -g2012 -s l1_noc_fifo_w2048_d16_wrapper -t null /orfs/flow/designs/src/l1_noc_fifo_w2048_d16_wrapper/*.v
- python3 scripts/run_sweep.py --configs runs/designs/noc/l1_onchip_endpoint_w1024_b4_eq16_bq16_wrapper/config_l1_onchip_endpoint_w1024_b4_eq16_bq16.json runs/designs/noc/l1_noc_router_p4_w2048_wrapper/config_l1_noc_router_p4_w2048.json runs/designs/noc/l1_noc_fifo_w2048_d16_wrapper/config_l1_noc_fifo_w2048_d16.json --platform nangate45 --sweep runs/campaigns/noc/l1_memory_noc_primitives/sweeps/nangate45_macro_frontier.json --out_root /tmp/rtlgen-wide-onchip-dryrun --dry_run
- python3 scripts/validate_runs.py --skip_eval_queue