### PR TITLE
Add local SRAM capacity profile

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4975,6 +4975,50 @@ def _decoder_attention_sram_profile_evidence(*, item_id: str) -> dict[str, Any]:
     }
 
 
+def _decoder_attention_local_sram_capacity_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_local_sram_capacity__{item_id}.json"
+    report = f"{base}/decoder_attention_local_sram_capacity__{item_id}.md"
+    arch = "runs/designs/sram/llama7b_attention_local_capacity_v1/arch.yml"
+    sram_metrics = "runs/designs/sram/llama7b_attention_local_capacity_v1/sram_metrics.json"
+    sram_summary = "runs/designs/sram/llama7b_attention_local_capacity_v1/sram_metrics_summary.json"
+    source = (
+        f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__"
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_endpoint_full_onchip_service_schedule": source,
+            "attention_local_sram_capacity_out": out,
+            "attention_local_sram_capacity_report": report,
+            "attention_local_sram_capacity_arch": arch,
+            "attention_local_sram_capacity_metrics_json": sram_metrics,
+            "attention_local_sram_capacity_summary_json": sram_summary,
+            "attention_local_sram_capacity_scope": (
+                "Measure a chunked CACTI SRAM profile for the selected per-cluster local "
+                "capacity in the Llama7B endpoint full on-chip frontier. This closes local "
+                "capacity area/access estimates; HBM/DRAM and endpoint/router PPA remain separate."
+            ),
+        },
+        "commands": [
+            {
+                "name": "measure_decoder_attention_local_sram_capacity",
+                "run": (
+                    "python3 npu/eval/measure_llm_decoder_attention_local_sram_capacity.py "
+                    f"--source-json {source} "
+                    f"--out {out} "
+                    f"--report {report} "
+                    f"--arch-out {arch} "
+                    "--sram-id llama7b_attention_local_capacity_v1 "
+                    "--width-bits 1024 "
+                    "--run-cacti"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report, arch, sram_metrics, sram_summary],
+    }
+
+
 def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
@@ -6533,6 +6577,7 @@ def _build_payload(
         "decoder_attention_kv_endpoint_ready_valid_service",
         "decoder_attention_kv_endpoint_router_sram_composition",
         "decoder_attention_sram_profile",
+        "decoder_attention_local_sram_capacity",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
@@ -6665,6 +6710,8 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_sram_profile":
             decoder_evidence = _decoder_attention_sram_profile_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_local_sram_capacity":
+            decoder_evidence = _decoder_attention_local_sram_capacity_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":
             decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5114,6 +5114,55 @@ def test_generate_l2_campaign_task_adds_attention_sram_profile_evidence() -> Non
             assert "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json" in expected_outputs
 
 
+def test_generate_l2_campaign_task_adds_attention_local_sram_capacity_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_local_sram_capacity_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_local_sram_capacity",
+                    evaluation_mode="profile_measurement",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "measure_decoder_attention_local_sram_capacity" in command_names
+            assert "attention_kv_endpoint_full_onchip_service_schedule" in decoder_inputs
+            assert "attention_local_sram_capacity_metrics_json" in decoder_inputs
+            assert "measure_llm_decoder_attention_local_sram_capacity.py" in run
+            assert "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json" in run
+            assert "--width-bits 1024" in run
+            assert "--noc-bandwidth-bytes-per-cycle" not in run
+            assert "--data-rate-mtps" not in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_local_sram_capacity__"
+                    "l2_decoder_attention_local_sram_capacity_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+            assert "runs/designs/sram/llama7b_attention_local_capacity_v1/sram_metrics.json" in expected_outputs
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/README.md
@@ -1,0 +1,7 @@
+# Local SRAM Capacity Profile
+
+This proposal measures the full selected local SRAM capacity pool from the
+current Llama7B attention frontier using chunked CACTI SRAM macro estimates.
+
+This is separate from the tile-local SRAM profile and from the wide
+endpoint/router/FIFO PPA sweep.

--- a/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+Dispatch one L2 campaign item:
+
+- `l2_decoder_attention_local_sram_capacity_llama7b_v1`
+
+The evaluator must use the implementation commit containing
+`npu/eval/measure_llm_decoder_attention_local_sram_capacity.py` and the
+`decoder_attention_local_sram_capacity` generator hook.

--- a/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_local_sram_capacity_v1",
+  "source_commit": null,
+  "source_commit_note": "Dispatch should use the merge commit containing the local SRAM capacity profile generator hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_local_sram_capacity_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure chunked local SRAM capacity macro profile for the selected Llama7B endpoint service frontier.",
+      "evaluation_mode": "profile_measurement",
+      "abstraction_layer": "decoder_attention_local_sram_capacity",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_selected_local_sram_capacity_macro_profile",
+        "reason": "The result should report per-cluster and all-cluster SRAM area/access/energy and budget fit."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/proposal.json
@@ -1,0 +1,64 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_local_sram_capacity_v1",
+  "created_utc": "2026-06-09T12:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Local SRAM capacity profile for Llama7B attention frontier",
+  "hypothesis": "The selected per-cluster local SRAM capacity from the Llama7B endpoint full on-chip frontier can be represented by a small set of chunked SRAM macros whose CACTI area fits the selected SRAM area budget.",
+  "direct_comparison": {
+    "primary_question": "How much area and access time does the selected local SRAM capacity pool require when represented as concrete SRAM macro chunks?",
+    "include": [
+      "Use l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1 as the source frontier.",
+      "Use selected local_capacity_bytes_per_cluster and active_clusters.",
+      "Generate power-of-two SRAM capacity chunks at 1024-bit word width.",
+      "Run CACTI and report per-cluster and all-cluster area, energy, and access time."
+    ],
+    "exclude": [
+      "Do not change HBM/DRAM bandwidth or service policy.",
+      "Do not model endpoint/router/FIFO PPA in this item.",
+      "Do not run a new architecture sweep.",
+      "Do not claim SRAM floorplan closure from CACTI macro estimates alone."
+    ],
+    "follow_on_broad_sweep": [
+      "Feed the measured local-capacity area and access time back into the Llama7B endpoint service model.",
+      "Combine with the wide endpoint/router/FIFO L1 PPA results once available.",
+      "Keep HBM/DRAM as a later separate item."
+    ]
+  },
+  "expected_benefit": [
+    "Closes the largest remaining local SRAM capacity abstraction identified by the composition audit.",
+    "Separates tile-local buffer SRAM evidence from full local-capacity pool evidence.",
+    "Provides area budget pressure for the selected local_sram_fraction."
+  ],
+  "risks": [
+    "CACTI estimates are not placed SRAM compiler macros.",
+    "Chunking policy affects capacity overhead and access estimates.",
+    "The result does not include NoC or HBM service."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "profile_measurement",
+      "objective": "local_sram_capacity_profile",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_selected_local_sram_capacity_macro_profile",
+        "reason": "The result should report chunked SRAM capacity, CACTI metrics, and whether the all-cluster local capacity fits the selected SRAM area budget."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/measure_llm_decoder_attention_local_sram_capacity.py",
+    "npu/synth/sram_ppa.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_local_sram_capacity_v1/quality_gate.md
@@ -1,0 +1,18 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_local_sram_capacity_v1`
+- `title`: `Local SRAM capacity profile for Llama7B attention frontier`
+
+## Checks
+- metric: source frontier
+  - threshold: command consumes endpoint full on-chip schedule result
+- metric: capacity
+  - threshold: report includes local capacity bytes per cluster and allocated bytes per cluster
+- metric: CACTI
+  - threshold: report includes SRAM metrics summary and budget fit
+- metric: scope
+  - threshold: HBM/DRAM and endpoint/router/FIFO PPA remain out of scope
+
+## Result
+- status: pending

--- a/npu/eval/measure_llm_decoder_attention_local_sram_capacity.py
+++ b/npu/eval/measure_llm_decoder_attention_local_sram_capacity.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Measure chunked local SRAM capacity needed by the selected Llama7B frontier."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.synth.aggregate_sram_metrics import summarize_metrics  # noqa: E402
+
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _next_power_of_two(value: int) -> int:
+    if value <= 1:
+        return 1
+    return 1 << (value - 1).bit_length()
+
+
+def _largest_power_of_two_leq(value: int) -> int:
+    if value <= 1:
+        return 1
+    return 1 << (value.bit_length() - 1)
+
+
+def _chunk_capacity(*, logical_bytes: int, min_chunk_bytes: int, max_chunk_bytes: int) -> list[int]:
+    if logical_bytes <= 0:
+        raise ValueError("logical_bytes must be positive")
+    remaining = logical_bytes
+    chunks: list[int] = []
+    while remaining > 0:
+        if remaining <= min_chunk_bytes:
+            chunks.append(max(min_chunk_bytes, _next_power_of_two(remaining)))
+            break
+        chunk = min(max_chunk_bytes, _largest_power_of_two_leq(remaining))
+        chunk = max(chunk, min_chunk_bytes)
+        chunks.append(chunk)
+        remaining -= chunk
+    return chunks
+
+
+def _arch_payload(*, chunks: list[int], width_bits: int, pdk: str, tech_node_nm: int) -> JsonDict:
+    word_bytes = width_bits // 8
+    return {
+        "schema_version": "0.2-draft",
+        "platform": {
+            "target_pdk": pdk,
+            "tech_node_nm": tech_node_nm,
+        },
+        "memory": {
+            "instances": [
+                {
+                    "name": f"local_capacity_chunk_{idx:02d}_{chunk_bytes // 1024}kib",
+                    "depth": chunk_bytes // word_bytes,
+                    "width": width_bits,
+                    "banks": 1,
+                    "port": "1r1w",
+                }
+                for idx, chunk_bytes in enumerate(chunks)
+            ]
+        },
+    }
+
+
+def _build_profile(
+    *,
+    source: JsonDict,
+    sram_metrics_summary: JsonDict | None,
+    sram_metrics_json: str | None,
+    chunks: list[int],
+    width_bits: int,
+    min_chunk_bytes: int,
+    max_chunk_bytes: int,
+) -> JsonDict:
+    best = source.get("best", source)
+    active_clusters = int(best["active_clusters"])
+    local_capacity_bytes_per_cluster = int(best["local_capacity_bytes_per_cluster"])
+    allocated_bytes_per_cluster = sum(chunks)
+    sram_budget_area_um2 = float(best["die_area_mm2"]) * 1_000_000.0 * float(best["sram_area_fraction"])
+
+    per_cluster_summary = sram_metrics_summary or {}
+    total_area_um2 = float(per_cluster_summary.get("total_area_um2", 0.0)) * active_clusters
+    total_read_energy_pj = float(per_cluster_summary.get("total_read_energy_pj", 0.0)) * active_clusters
+    total_write_energy_pj = float(per_cluster_summary.get("total_write_energy_pj", 0.0)) * active_clusters
+    return {
+        "version": 1,
+        "model": "llama7b_proxy",
+        "profile": "decoder_attention_local_sram_capacity",
+        "source_item": "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1",
+        "selected_frontier": {
+            "latency_us": best["latency_us"],
+            "active_clusters": active_clusters,
+            "cluster_count": best["cluster_count"],
+            "bank_count": best["bank_count"],
+            "local_sram_fraction": best["local_sram_fraction"],
+            "sram_area_fraction": best["sram_area_fraction"],
+            "local_capacity_bytes_per_cluster": local_capacity_bytes_per_cluster,
+            "local_capacity_mib_total": best.get("local_capacity_mib"),
+            "die_area_mm2": best["die_area_mm2"],
+        },
+        "chunking": {
+            "width_bits": width_bits,
+            "word_bytes": width_bits // 8,
+            "min_chunk_bytes": min_chunk_bytes,
+            "max_chunk_bytes": max_chunk_bytes,
+            "chunks_bytes": chunks,
+            "chunk_count_per_cluster": len(chunks),
+            "allocated_bytes_per_cluster": allocated_bytes_per_cluster,
+            "capacity_overhead": round(allocated_bytes_per_cluster / local_capacity_bytes_per_cluster, 6),
+            "allocated_bytes_all_clusters": allocated_bytes_per_cluster * active_clusters,
+        },
+        "sram_metrics_json": sram_metrics_json,
+        "per_cluster_sram_metrics_summary": per_cluster_summary,
+        "all_cluster_sram_metrics_summary": {
+            "total_area_um2": total_area_um2,
+            "total_read_energy_pj": total_read_energy_pj,
+            "total_write_energy_pj": total_write_energy_pj,
+            "max_access_time_ns": per_cluster_summary.get("max_access_time_ns"),
+            "active_clusters": active_clusters,
+        },
+        "budget_check": {
+            "sram_budget_area_um2": sram_budget_area_um2,
+            "total_area_um2": total_area_um2,
+            "area_fraction_of_sram_budget": round(total_area_um2 / max(1.0, sram_budget_area_um2), 6),
+            "fits_sram_budget": total_area_um2 <= sram_budget_area_um2 if total_area_um2 else None,
+        },
+        "remaining_abstractions": [
+            "CACTI estimates are macro-level SRAM access/energy estimates, not a placed SRAM compiler floorplan.",
+            "The profile models local-capacity SRAM chunks only; HBM/DRAM service remains separate.",
+            "NoC arbitration and endpoint/router PPA are measured by separate closure items.",
+        ],
+    }
+
+
+def _write_report(payload: JsonDict, report: Path) -> None:
+    selected = payload["selected_frontier"]
+    chunking = payload["chunking"]
+    budget = payload["budget_check"]
+    lines = [
+        "# Llama7B Local SRAM Capacity Profile",
+        "",
+        "## Selected Frontier",
+        f"- active_clusters: `{selected['active_clusters']}`",
+        f"- local_capacity_bytes_per_cluster: `{selected['local_capacity_bytes_per_cluster']}`",
+        f"- local_sram_fraction: `{selected['local_sram_fraction']}`",
+        f"- sram_area_fraction: `{selected['sram_area_fraction']}`",
+        "",
+        "## Chunking",
+        f"- width_bits: `{chunking['width_bits']}`",
+        f"- chunk_count_per_cluster: `{chunking['chunk_count_per_cluster']}`",
+        f"- allocated_bytes_per_cluster: `{chunking['allocated_bytes_per_cluster']}`",
+        f"- capacity_overhead: `{chunking['capacity_overhead']}`",
+        f"- chunks_bytes: `{chunking['chunks_bytes']}`",
+        "",
+        "## Budget",
+        f"- total_area_um2: `{budget['total_area_um2']}`",
+        f"- sram_budget_area_um2: `{budget['sram_budget_area_um2']}`",
+        f"- area_fraction_of_sram_budget: `{budget['area_fraction_of_sram_budget']}`",
+        f"- fits_sram_budget: `{budget['fits_sram_budget']}`",
+        "",
+        "## Remaining Abstractions",
+    ]
+    for item in payload["remaining_abstractions"]:
+        lines.append(f"- {item}")
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument("--arch-out", type=Path, required=True)
+    parser.add_argument("--sram-id", default="llama7b_attention_local_capacity_v1")
+    parser.add_argument("--width-bits", type=int, default=1024)
+    parser.add_argument("--min-chunk-bytes", type=int, default=16 * 1024)
+    parser.add_argument("--max-chunk-bytes", type=int, default=16 * 1024 * 1024)
+    parser.add_argument("--pdk", default="nangate45")
+    parser.add_argument("--tech-node-nm", type=int, default=45)
+    parser.add_argument("--run-cacti", action="store_true")
+    args = parser.parse_args()
+
+    if args.width_bits % 8 != 0:
+        raise SystemExit("--width-bits must be a multiple of 8")
+    source = _load_json(args.source_json)
+    best = source.get("best", source)
+    local_capacity_bytes_per_cluster = int(best["local_capacity_bytes_per_cluster"])
+    chunks = _chunk_capacity(
+        logical_bytes=local_capacity_bytes_per_cluster,
+        min_chunk_bytes=args.min_chunk_bytes,
+        max_chunk_bytes=args.max_chunk_bytes,
+    )
+    args.arch_out.parent.mkdir(parents=True, exist_ok=True)
+    args.arch_out.write_text(
+        yaml.safe_dump(
+            _arch_payload(chunks=chunks, width_bits=args.width_bits, pdk=args.pdk, tech_node_nm=args.tech_node_nm),
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    sram_metrics_summary = None
+    sram_metrics_json = None
+    if args.run_cacti:
+        subprocess.run(
+            [
+                sys.executable,
+                "npu/synth/sram_ppa.py",
+                str(args.arch_out),
+                "--id",
+                args.sram_id,
+            ],
+            cwd=_REPO_ROOT,
+            check=True,
+        )
+        metrics_path = Path("runs/designs/sram") / args.sram_id / "sram_metrics.json"
+        sram_metrics_json = str(metrics_path)
+        sram_metrics_summary = summarize_metrics(_REPO_ROOT / metrics_path)
+        summary_path = _REPO_ROOT / "runs/designs/sram" / args.sram_id / "sram_metrics_summary.json"
+        summary_path.write_text(json.dumps(sram_metrics_summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    payload = _build_profile(
+        source=source,
+        sram_metrics_summary=sram_metrics_summary,
+        sram_metrics_json=sram_metrics_json,
+        chunks=chunks,
+        width_bits=args.width_bits,
+        min_chunk_bytes=args.min_chunk_bytes,
+        max_chunk_bytes=args.max_chunk_bytes,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a chunked local SRAM capacity profile for the selected Llama7B attention frontier
- wire decoder_attention_local_sram_capacity into the L2 task generator
- add proposal docs and generator coverage

## Validation
- python3 -m py_compile npu/eval/measure_llm_decoder_attention_local_sram_capacity.py control_plane/control_plane/services/l2_task_generator.py
- PYTHONPATH=/tmp/rtlgen-local-sram-capacity/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 npu/eval/measure_llm_decoder_attention_local_sram_capacity.py --source-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json --out /tmp/local_sram_capacity2.json --report /tmp/local_sram_capacity2.md --arch-out /tmp/local_sram_capacity2_arch.yml