### PR TITLE
control_plane: classify local sram capacity evidence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -442,6 +442,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("producer_cq_ablation_out", "producer_cq_ablation_report"),
     ("producer_softmax_event_ablation_out", "producer_softmax_event_ablation_report"),
     ("attention_kv_memory_out", "attention_kv_memory_report"),
+    ("attention_local_sram_capacity_out", "attention_local_sram_capacity_report"),
 )
 
 
@@ -473,6 +474,12 @@ def _decoder_evidence_paths(
         report_rel = str(decoder_contract.get(report_key, "")).strip()
         if report_rel and _resolve_path(repo_root=repo_root, path_text=report_rel).exists():
             source_refs[_decoder_source_ref_key(report_key)] = report_rel
+        evidence_prefix = out_key[: -len("_out")] if out_key.endswith("_out") else out_key
+        for suffix in ("arch", "metrics_json", "summary_json"):
+            aux_key = f"{evidence_prefix}_{suffix}"
+            aux_rel = str(decoder_contract.get(aux_key, "")).strip()
+            if aux_rel and _resolve_path(repo_root=repo_root, path_text=aux_rel).exists():
+                source_refs[_decoder_source_ref_key(aux_key)] = aux_rel
         return out_rel, source_refs
     return None, source_refs
 
@@ -491,6 +498,13 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
         "template_summaries",
         "sample_count",
         "source_sweep",
+        "profile",
+        "selected_frontier",
+        "chunking",
+        "budget_check",
+        "per_cluster_sram_metrics_summary",
+        "all_cluster_sram_metrics_summary",
+        "remaining_abstractions",
     ):
         if key in evidence_payload:
             brief[key] = evidence_payload[key]
@@ -498,6 +512,27 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, Any]) -> tuple[str, str]:
+    profile = str(evidence_payload.get("profile", "")).strip()
+    if profile == "decoder_attention_local_sram_capacity":
+        budget_check = evidence_payload.get("budget_check")
+        budget = dict(budget_check) if isinstance(budget_check, dict) else {}
+        fits_budget = bool(budget.get("fits_sram_budget"))
+        outcome = "local_sram_capacity_budget_passed" if fits_budget else "local_sram_capacity_budget_failed"
+        total_area_um2 = budget.get("total_area_um2")
+        budget_area_um2 = budget.get("sram_budget_area_um2")
+        area_fraction = budget.get("area_fraction_of_sram_budget")
+        parts = [
+            f"Decoder local SRAM capacity evidence recorded from {evidence_ref}: decision={outcome}",
+            f"fits_sram_budget={fits_budget}",
+        ]
+        if total_area_um2 is not None and budget_area_um2 is not None:
+            parts.append(f"total_area_um2={total_area_um2}")
+            parts.append(f"sram_budget_area_um2={budget_area_um2}")
+        if area_fraction is not None:
+            parts.append(f"area_fraction_of_sram_budget={area_fraction}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
     diagnosis = evidence_payload.get("diagnosis")
     diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
     decision = str(diagnosis_dict.get("decision", "")).strip() or "decoder_evidence_recorded"

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -991,6 +991,127 @@ def test_consume_l2_result_frontier_attention_kv_uses_decoder_evidence() -> None
             assert decision_payload["source_refs"]["decoder_attention_kv_memory_report"] == report_rel
 
 
+def test_consume_l2_result_frontier_attention_local_sram_capacity_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_local_sram_capacity_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_local_sram_capacity_v1",
+                        "kind": "architecture",
+                        "title": "Attention local SRAM capacity",
+                        "direct_comparison": {
+                            "primary_question": "Does selected local SRAM capacity fit the SRAM area budget?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_local_sram_capacity__l2_attention_local_sram_capacity_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_local_sram_capacity__l2_attention_local_sram_capacity_v1.md"
+            )
+            arch_rel = "runs/designs/sram/llama7b_attention_local_capacity_v1/arch.yml"
+            metrics_rel = "runs/designs/sram/llama7b_attention_local_capacity_v1/sram_metrics.json"
+            summary_rel = "runs/designs/sram/llama7b_attention_local_capacity_v1/sram_metrics_summary.json"
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "profile": "decoder_attention_local_sram_capacity",
+                        "budget_check": {
+                            "fits_sram_budget": False,
+                            "total_area_um2": 1306824061.5888963,
+                            "sram_budget_area_um2": 280000000.0,
+                            "area_fraction_of_sram_budget": 4.667229,
+                        },
+                        "selected_frontier": {
+                            "active_clusters": 16,
+                            "local_capacity_bytes_per_cluster": 19140624,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# local sram capacity\n")
+            _write(repo_root / arch_rel, "schema_version: 0.2-draft\n")
+            _write(repo_root / metrics_rel, "{}\n")
+            _write(repo_root / summary_rel, "{}\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_local_sram_capacity",
+                campaign_dir_rel="runs/campaigns/npu/attention_local_sram_capacity_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_local_sram_capacity_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "profile_measurement",
+                "expected_direction": "measure_selected_local_sram_capacity_macro_profile",
+                "expected_reason": "Report whether the selected local SRAM capacity fits the budget.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_local_sram_capacity",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_local_sram_capacity_out": evidence_rel,
+                    "attention_local_sram_capacity_report": report_rel,
+                    "attention_local_sram_capacity_arch": arch_rel,
+                    "attention_local_sram_capacity_metrics_json": metrics_rel,
+                    "attention_local_sram_capacity_summary_json": summary_rel,
+                }
+            }
+            work_item.expected_outputs = [
+                *(work_item.expected_outputs or []),
+                evidence_rel,
+                report_rel,
+                arch_rel,
+                metrics_rel,
+                summary_rel,
+            ]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "local_sram_capacity_budget_failed"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert assessment["decoder_quality"]["budget_check"]["area_fraction_of_sram_budget"] == 4.667229
+            assert decision_payload["evaluation_record"]["abstraction_layer"] == "decoder_attention_local_sram_capacity"
+            assert decision_payload["source_refs"]["decoder_attention_local_sram_capacity_out"] == evidence_rel
+            assert decision_payload["source_refs"]["decoder_attention_local_sram_capacity_report"] == report_rel
+            assert decision_payload["source_refs"]["decoder_attention_local_sram_capacity_arch"] == arch_rel
+            assert decision_payload["source_refs"]["decoder_attention_local_sram_capacity_metrics_json"] == metrics_rel
+            assert decision_payload["source_refs"]["decoder_attention_local_sram_capacity_summary_json"] == summary_rel
+
+
 def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary\n- Treat decoder attention local SRAM capacity output as decoder evidence instead of falling through to generic L2 paired-comparison scoring.\n- Record capacity budget pass/fail outcome and include SRAM arch/metrics refs in source_refs.\n- Add regression coverage for a budget-failed local SRAM capacity profile.\n\n## Validation\n- PYTHONPATH=/tmp/rtlgen-local-sram-capacity/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -q\n- python3 scripts/validate_runs.py --skip_eval_queue