### PR TITLE
npu: add measured sram rebalance frontier job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -443,6 +443,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("producer_softmax_event_ablation_out", "producer_softmax_event_ablation_report"),
     ("attention_kv_memory_out", "attention_kv_memory_report"),
     ("attention_local_sram_capacity_out", "attention_local_sram_capacity_report"),
+    ("attention_kv_measured_sram_rebalance_out", "attention_kv_measured_sram_rebalance_report"),
 )
 
 
@@ -505,6 +506,9 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
         "per_cluster_sram_metrics_summary",
         "all_cluster_sram_metrics_summary",
         "remaining_abstractions",
+        "best",
+        "sweep_summary",
+        "assumptions",
     ):
         if key in evidence_payload:
             brief[key] = evidence_payload[key]
@@ -512,6 +516,27 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, Any]) -> tuple[str, str]:
+    model = str(evidence_payload.get("model", "")).strip()
+    if model == "llm_decoder_attention_kv_measured_sram_rebalance_llama7b_v1":
+        best = evidence_payload.get("best")
+        best_dict = dict(best) if isinstance(best, dict) else {}
+        outcome = "measured_sram_rebalance_recorded"
+        parts = [
+            f"Decoder measured-SRAM rebalance evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "latency_us",
+            "hbm_byte_share",
+            "measured_shared_sram_capacity_mib",
+            "local_capacity_bytes_per_cluster",
+            "abstract_local_capacity_bytes_per_cluster_replaced",
+            "dominant_tile_resource",
+        ):
+            if key in best_dict:
+                parts.append(f"{key}={best_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
     profile = str(evidence_payload.get("profile", "")).strip()
     if profile == "decoder_attention_local_sram_capacity":
         budget_check = evidence_payload.get("budget_check")

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5019,6 +5019,55 @@ def _decoder_attention_local_sram_capacity_evidence(*, item_id: str) -> dict[str
     }
 
 
+def _decoder_attention_kv_measured_sram_rebalance_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_measured_sram_rebalance__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_measured_sram_rebalance__{item_id}.md"
+    endpoint_schedule = (
+        f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__"
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
+    )
+    composition = (
+        f"{base}/decoder_attention_kv_endpoint_router_sram_composition__"
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1.json"
+    )
+    local_capacity = (
+        f"{base}/decoder_attention_local_sram_capacity__"
+        "l2_decoder_attention_local_sram_capacity_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_endpoint_full_onchip_service_schedule": endpoint_schedule,
+            "attention_kv_endpoint_router_sram_composition": composition,
+            "attention_local_sram_capacity": local_capacity,
+            "attention_kv_measured_sram_rebalance_out": out,
+            "attention_kv_measured_sram_rebalance_report": report,
+            "attention_kv_measured_sram_rebalance_scope": (
+                "Replace the abstract local/shared SRAM capacity fields in the selected "
+                "Llama7B endpoint service frontier with measured tile-local SRAM area and "
+                "CACTI packed shared-SRAM capacity under the same die SRAM budget. HBM/DRAM "
+                "bandwidth and compute PPA remain inherited from the source frontier."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_measured_sram_rebalance",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_measured_sram_rebalance.py "
+                    "--repo-root . "
+                    f"--endpoint-schedule-json {endpoint_schedule} "
+                    f"--composition-json {composition} "
+                    f"--local-sram-capacity-json {local_capacity} "
+                    "--frontier-row-limit 64 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
@@ -6578,6 +6627,7 @@ def _build_payload(
         "decoder_attention_kv_endpoint_router_sram_composition",
         "decoder_attention_sram_profile",
         "decoder_attention_local_sram_capacity",
+        "decoder_attention_kv_measured_sram_rebalance",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
@@ -6712,6 +6762,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_sram_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_local_sram_capacity":
             decoder_evidence = _decoder_attention_local_sram_capacity_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_measured_sram_rebalance":
+            decoder_evidence = _decoder_attention_kv_measured_sram_rebalance_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":
             decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1112,6 +1112,116 @@ def test_consume_l2_result_frontier_attention_local_sram_capacity_uses_decoder_e
             assert decision_payload["source_refs"]["decoder_attention_local_sram_capacity_summary_json"] == summary_rel
 
 
+def test_consume_l2_result_frontier_attention_measured_sram_rebalance_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_measured_sram_rebalance_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_measured_sram_rebalance_v1",
+                        "kind": "architecture",
+                        "title": "Attention measured SRAM rebalance",
+                        "direct_comparison": {
+                            "primary_question": "What is the frontier when SRAM capacity uses measured CACTI area?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_measured_sram_rebalance__l2_attention_measured_sram_rebalance_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_measured_sram_rebalance__l2_attention_measured_sram_rebalance_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_kv_measured_sram_rebalance_llama7b_v1",
+                        "sweep_summary": {
+                            "generated_row_count": 8,
+                            "best_latency_us": 2138.84136,
+                            "best_hbm_byte_share": 0.983398438,
+                        },
+                        "best": {
+                            "latency_us": 2138.84136,
+                            "hbm_byte_share": 0.983398438,
+                            "measured_shared_sram_capacity_mib": 68.0,
+                            "local_capacity_bytes_per_cluster": 614656,
+                            "abstract_local_capacity_bytes_per_cluster_replaced": 19140624,
+                            "dominant_tile_resource": "tile_attention",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# measured sram rebalance\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_measured_sram_rebalance",
+                campaign_dir_rel="runs/campaigns/npu/attention_measured_sram_rebalance_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_measured_sram_rebalance_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use measured SRAM capacity pressure to choose the next frontier.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_kv_measured_sram_rebalance",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_kv_measured_sram_rebalance_out": evidence_rel,
+                    "attention_kv_measured_sram_rebalance_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "measured_sram_rebalance_recorded"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert assessment["decoder_quality"]["best"]["hbm_byte_share"] == 0.983398438
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_kv_measured_sram_rebalance"
+            )
+            assert decision_payload["source_refs"]["decoder_attention_kv_measured_sram_rebalance_out"] == evidence_rel
+            assert (
+                decision_payload["source_refs"]["decoder_attention_kv_measured_sram_rebalance_report"] == report_rel
+            )
+
+
 def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5163,6 +5163,53 @@ def test_generate_l2_campaign_task_adds_attention_local_sram_capacity_evidence()
             assert "runs/designs/sram/llama7b_attention_local_capacity_v1/sram_metrics.json" in expected_outputs
 
 
+def test_generate_l2_campaign_task_adds_attention_measured_sram_rebalance_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_measured_sram_rebalance",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_kv_measured_sram_rebalance" in command_names
+            assert "attention_kv_endpoint_full_onchip_service_schedule" in decoder_inputs
+            assert "attention_kv_endpoint_router_sram_composition" in decoder_inputs
+            assert "attention_local_sram_capacity" in decoder_inputs
+            assert "attention_kv_measured_sram_rebalance_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_measured_sram_rebalance.py" in run
+            assert "l2_decoder_attention_local_sram_capacity_llama7b_v1.json" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_measured_sram_rebalance__"
+                    "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_sram_rebalance_v1",
+  "source_commit": "TBD_AFTER_MERGE",
+  "source_commit_note": "Dispatch should use the merge commit containing the measured SRAM rebalance estimator and generator hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recompute the Llama7B endpoint service frontier with measured tile-local SRAM area and packed shared-SRAM capacity.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_measured_sram_rebalance",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1",
+        "l2_decoder_attention_local_sram_capacity_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_measured_sram_rebalanced_frontier",
+        "reason": "The result should report best latency, HBM byte share, packed shared-SRAM capacity, and the replaced abstract local capacity."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_sram_rebalance_v1",
+  "created_utc": "2026-06-09T12:15:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Measured SRAM rebalance for Llama7B attention endpoint frontier",
+  "hypothesis": "The current Llama7B endpoint frontier changes materially when the abstract local/shared SRAM capacity model is replaced by CACTI-derived tile-local SRAM area and packed shared-SRAM capacity under the selected die SRAM budget.",
+  "direct_comparison": {
+    "primary_question": "What is the best endpoint service schedule after replacing abstract local/shared SRAM capacity with measured SRAM capacity under the same SRAM area budget?",
+    "include": [
+      "Use l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1 as the source schedule frontier.",
+      "Use l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1 for measured tile-local SRAM area and required tile-local capacity.",
+      "Use l2_decoder_attention_local_sram_capacity_llama7b_v1 for CACTI SRAM macro density and access references.",
+      "Replace the abstract per-cluster local capacity pool with measured tile-local buffer capacity.",
+      "Pack the remaining SRAM area budget into shared SRAM macro chunks and recompute endpoint service timing."
+    ],
+    "exclude": [
+      "Do not change the inherited HBM/DRAM bandwidth model in this item.",
+      "Do not claim routed SRAM compiler floorplan closure from CACTI macro estimates.",
+      "Do not replace the pending wide router/FIFO L1 PPA closure item.",
+      "Do not change model quality assumptions for GQA/MQA in this item."
+    ],
+    "follow_on_broad_sweep": [
+      "If the best row becomes HBM dominated, plan the HBM/DRAM item separately.",
+      "If the best row stays NoC/shared-SRAM dominated, plan tighter router/FIFO width and SRAM bank PPA.",
+      "Use the measured SRAM-capacity frontier as the next architecture baseline."
+    ]
+  },
+  "expected_benefit": [
+    "Removes the largest optimistic SRAM capacity abstraction exposed by the local capacity profile.",
+    "Separates required tile-local buffering from an unrealistically large local-capacity pool.",
+    "Shows whether the frontier shifts toward HBM, compute, or on-chip shared path under practical SRAM area."
+  ],
+  "risks": [
+    "Shared SRAM packing is still macro-level CACTI evidence, not a routed SRAM floorplan.",
+    "The HBM/DRAM service model is inherited and remains abstract.",
+    "The source schedule may include quality-sensitive KV sharing settings; this item records but does not resolve quality impact."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "measured_sram_rebalanced_endpoint_schedule",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1",
+        "l2_decoder_attention_local_sram_capacity_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_measured_sram_rebalanced_frontier",
+        "reason": "The result should report best latency, HBM byte share, packed shared-SRAM capacity, and the replaced abstract local capacity."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_measured_sram_rebalance.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py",
+    "npu/eval/measure_llm_decoder_attention_local_sram_capacity.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_measured_sram_rebalance.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_measured_sram_rebalance.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Rebalance Llama7B attention schedules with measured SRAM capacity.
+
+This pass takes the current endpoint/on-chip service frontier and replaces the
+abstract SRAM capacity fields with CACTI-derived tile-local SRAM area plus a
+packed shared-SRAM capacity under the selected die SRAM budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval import estimate_llm_decoder_attention_kv_onchip_service_schedule as onchip  # noqa: E402
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _ceil_div(numerator: int | float, denominator: int | float) -> int:
+    if numerator <= 0:
+        return 0
+    return int(math.ceil(float(numerator) / max(1.0, float(denominator))))
+
+
+def _macro_library(capacity_payload: JsonDict) -> list[JsonDict]:
+    metrics_json = capacity_payload.get("sram_metrics_json")
+    if not metrics_json:
+        raise ValueError("capacity payload is missing sram_metrics_json")
+    metrics_path = Path(str(metrics_json))
+    if not metrics_path.is_absolute():
+        metrics_path = _REPO_ROOT / metrics_path
+    metrics = _load_json(metrics_path)
+    instances = metrics.get("instances")
+    if not isinstance(instances, list) or not instances:
+        raise ValueError(f"no SRAM macro instances in {metrics_path}")
+    macros: list[JsonDict] = []
+    for entry in instances:
+        instance = entry.get("instance") if isinstance(entry, dict) else None
+        metric = entry.get("metrics") if isinstance(entry, dict) else None
+        if not isinstance(instance, dict) or not isinstance(metric, dict):
+            continue
+        size_bytes = int(instance.get("size_bytes", 0))
+        area_um2 = float(metric.get("area_um2", 0.0))
+        if size_bytes <= 0 or area_um2 <= 0.0:
+            continue
+        macros.append(
+            {
+                "name": str(instance.get("name", f"sram_{size_bytes}")),
+                "size_bytes": size_bytes,
+                "area_um2": area_um2,
+                "access_time_ns": float(metric.get("access_time_ns", 0.0)),
+                "read_energy_pj": float(metric.get("read_energy_pj", 0.0)),
+                "write_energy_pj": float(metric.get("write_energy_pj", 0.0)),
+                "bytes_per_um2": size_bytes / area_um2,
+            }
+        )
+    if not macros:
+        raise ValueError(f"no usable SRAM macros in {metrics_path}")
+    return sorted(macros, key=lambda item: (item["bytes_per_um2"], item["size_bytes"]), reverse=True)
+
+
+def _pack_capacity(*, area_budget_um2: float, macros: list[JsonDict]) -> JsonDict:
+    remaining = max(0.0, float(area_budget_um2))
+    selected: list[JsonDict] = []
+    total_bytes = 0
+    total_area = 0.0
+    total_read = 0.0
+    total_write = 0.0
+    max_access = 0.0
+    for macro in macros:
+        count = int(math.floor((remaining + 1e-6) / float(macro["area_um2"])))
+        if count <= 0:
+            continue
+        area = count * float(macro["area_um2"])
+        size = count * int(macro["size_bytes"])
+        selected.append(
+            {
+                "name": macro["name"],
+                "count": count,
+                "size_bytes_each": int(macro["size_bytes"]),
+                "area_um2_each": float(macro["area_um2"]),
+                "size_bytes_total": size,
+                "area_um2_total": area,
+            }
+        )
+        total_bytes += size
+        total_area += area
+        total_read += count * float(macro["read_energy_pj"])
+        total_write += count * float(macro["write_energy_pj"])
+        max_access = max(max_access, float(macro["access_time_ns"]))
+        remaining -= area
+    return {
+        "area_budget_um2": round(area_budget_um2, 6),
+        "used_area_um2": round(total_area, 6),
+        "unused_area_um2": round(max(0.0, remaining), 6),
+        "capacity_bytes": total_bytes,
+        "capacity_mib": round(total_bytes / (1024 * 1024), 6),
+        "read_energy_pj": round(total_read, 6),
+        "write_energy_pj": round(total_write, 6),
+        "max_access_time_ns": round(max_access, 6),
+        "selected_macros": selected,
+    }
+
+
+def _row_shared_budget_um2(row: JsonDict, composition: JsonDict) -> tuple[float, float, int]:
+    active_clusters = max(1, int(row.get("active_clusters", row.get("cluster_count", 1))))
+    sram_budget = float(row["die_area_mm2"]) * 1_000_000.0 * float(row["sram_area_fraction"])
+    quantities = composition.get("composition_quantities")
+    if not isinstance(quantities, dict):
+        raise ValueError("composition payload missing composition_quantities")
+    tile_area_per_cluster = float(quantities["tile_sram_total_area_um2_for_active_clusters"]) / max(
+        1, int(composition["selected_frontier"]["active_clusters"])
+    )
+    tile_area = tile_area_per_cluster * active_clusters
+    return max(0.0, sram_budget - tile_area), tile_area, active_clusters
+
+
+def _rebalance_row(
+    row: JsonDict,
+    *,
+    composition: JsonDict,
+    capacity_payload: JsonDict,
+    macros: list[JsonDict],
+) -> JsonDict:
+    shared_budget_um2, tile_area_um2, active_clusters = _row_shared_budget_um2(row, composition)
+    shared_pack = _pack_capacity(area_budget_um2=shared_budget_um2, macros=macros)
+    quantities = composition["composition_quantities"]
+    tile_local_bytes_per_cluster = int(quantities["tile_sram_allocated_bytes_per_cluster"])
+    kv_cache_bytes = int(round(float(row["kv_cache_mib"]) * 1024.0 * 1024.0))
+    shared_resident_bytes = min(kv_cache_bytes, int(shared_pack["capacity_bytes"]))
+    shared_byte_share = shared_resident_bytes / kv_cache_bytes if kv_cache_bytes else 0.0
+    local_byte_share = float(row.get("local_byte_share", 0.0))
+    hbm_byte_share = max(0.0, 1.0 - shared_byte_share)
+
+    full_tile_bytes = onchip._full_tile_bytes(row)
+    per_cluster_hbm_bpc = float(row.get("per_cluster_hbm_bytes_per_cycle", row.get("effective_hbm_bytes_per_cycle", 1.0)))
+    tile_hbm_cycles = _ceil_div(full_tile_bytes * hbm_byte_share, per_cluster_hbm_bpc)
+
+    out = dict(row)
+    out.update(
+        {
+            "measured_sram_rebalance_model": "cacti_tile_local_shared_capacity_v1",
+            "abstract_local_capacity_bytes_per_cluster_replaced": int(row.get("local_capacity_bytes_per_cluster", 0)),
+            "local_capacity_bytes_per_cluster": tile_local_bytes_per_cluster,
+            "local_capacity_mib": round(tile_local_bytes_per_cluster * active_clusters / (1024 * 1024), 6),
+            "measured_tile_local_sram_area_um2": round(tile_area_um2, 6),
+            "measured_shared_sram_budget_um2": round(shared_budget_um2, 6),
+            "measured_shared_sram_used_area_um2": shared_pack["used_area_um2"],
+            "measured_shared_sram_capacity_bytes": shared_pack["capacity_bytes"],
+            "measured_shared_sram_capacity_mib": shared_pack["capacity_mib"],
+            "measured_shared_sram_pack": shared_pack,
+            "shared_capacity_mib": shared_pack["capacity_mib"],
+            "shared_byte_share": round(shared_byte_share, 9),
+            "hbm_byte_share": round(hbm_byte_share, 9),
+            "local_byte_share": round(local_byte_share, 9),
+            "tile_hbm_cycles": tile_hbm_cycles,
+            "measured_sram_capacity_source": capacity_payload.get("source_item"),
+            "measured_sram_budget_fits": True,
+        }
+    )
+    return out
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    repo_root = args.repo_root
+    source_payload = _load_json(repo_root / args.endpoint_schedule_json)
+    composition = _load_json(repo_root / args.composition_json)
+    capacity_payload = _load_json(repo_root / args.local_sram_capacity_json)
+    macros = _macro_library(capacity_payload)
+
+    source_rows = list(source_payload.get("top_rows") or [])
+    if not source_rows:
+        best = source_payload.get("best")
+        if isinstance(best, dict):
+            source_rows = [best]
+    source_rows = source_rows[: args.frontier_row_limit]
+    if not source_rows:
+        raise RuntimeError("no source schedule rows found")
+
+    rows: list[JsonDict] = []
+    for row in source_rows:
+        rebased = _rebalance_row(row, composition=composition, capacity_payload=capacity_payload, macros=macros)
+        rows.append(
+            onchip._annotate_service(
+                rebased,
+                schedule_policy=str(rebased["schedule_policy"]),
+                bank_arbiter_policy=str(rebased["bank_arbiter_policy"]),
+                endpoint_queue_depth_bytes=int(rebased["endpoint_queue_depth_bytes"]),
+                bank_queue_depth_bytes=int(rebased["bank_queue_depth_bytes"]),
+                router_latency_cycles_per_hop=int(rebased["router_latency_cycles_per_hop"]),
+                packet_payload_bytes=int(rebased["packet_payload_bytes"]),
+                prefetch_overlap_fraction=float(rebased["prefetch_overlap_fraction"]),
+            )
+        )
+
+    rows_sorted = sorted(rows, key=lambda item: float(item["latency_us"]))
+    best = rows_sorted[0]
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_kv_measured_sram_rebalance_llama7b_v1",
+        "endpoint_schedule_json": str(args.endpoint_schedule_json),
+        "composition_json": str(args.composition_json),
+        "local_sram_capacity_json": str(args.local_sram_capacity_json),
+        "sweep_summary": {
+            "source_rows_used": len(source_rows),
+            "generated_row_count": len(rows),
+            "best_latency_us": best["latency_us"],
+            "best_hbm_byte_share": best["hbm_byte_share"],
+            "best_shared_capacity_mib": best["measured_shared_sram_capacity_mib"],
+            "best_replaced_local_capacity_bytes_per_cluster": best["abstract_local_capacity_bytes_per_cluster_replaced"],
+            "best_tile_local_capacity_bytes_per_cluster": best["local_capacity_bytes_per_cluster"],
+        },
+        "best": best,
+        "top_rows": rows_sorted[: args.top_k],
+        "sram_macro_library": macros,
+        "assumptions": [
+            "Tile-local SRAM area is taken from the endpoint/router/SRAM composition audit.",
+            "The remaining SRAM area budget is packed into shared SRAM using the CACTI macro chunks from the local-capacity profile.",
+            "The abstract per-cluster local-capacity pool is replaced by measured tile-local buffer capacity.",
+            "HBM/DRAM bandwidth and compute PPA remain inherited from the source schedule.",
+            "Shared SRAM packing is a macro-level CACTI estimate, not a placed memory compiler floorplan.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best"]
+    lines = [
+        "# Llama7B Measured-SRAM Rebalanced Endpoint Schedule",
+        "",
+        f"- source rows used: `{payload['sweep_summary']['source_rows_used']}`",
+        f"- generated rows: `{payload['sweep_summary']['generated_row_count']}`",
+        "",
+        "## Best",
+        "",
+        "| topology | schedule | clusters | link bits | latency us | hbm share | shared MiB | tile local B/cluster | replaced local B/cluster | resource |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---|",
+        "| {topology} | {schedule_policy} | {cluster_count} | {link_width_bits} | {latency_us} | "
+        "{hbm_byte_share} | {measured_shared_sram_capacity_mib} | {local_capacity_bytes_per_cluster} | "
+        "{abstract_local_capacity_bytes_per_cluster_replaced} | {dominant_tile_resource} |".format(**best),
+        "",
+        "## Top Rows",
+        "",
+        "| rank | topology | schedule | bank policy | latency us | hbm share | shared MiB | resource |",
+        "|---:|---|---|---|---:|---:|---:|---|",
+    ]
+    for idx, row in enumerate(payload["top_rows"][:30], start=1):
+        lines.append(
+            "| {rank} | {topology} | {schedule_policy} | {bank_arbiter_policy} | {latency_us} | "
+            "{hbm_byte_share} | {measured_shared_sram_capacity_mib} | {dominant_tile_resource} |".format(
+                rank=idx,
+                **row,
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--endpoint-schedule-json", type=Path, required=True)
+    parser.add_argument("--composition-json", type=Path, required=True)
+    parser.add_argument("--local-sram-capacity-json", type=Path, required=True)
+    parser.add_argument("--frontier-row-limit", type=int, default=64)
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "out": str(args.out), "out_md": str(args.out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- Add an L2 estimator that rebalances the Llama7B endpoint schedule using measured tile-local SRAM area and CACTI-packed shared SRAM capacity.\n- Add generator and result-consumer support for decoder_attention_kv_measured_sram_rebalance evidence.\n- Add proposal/evaluation request docs for the follow-on job.\n\n## Smoke result\n- best latency: 2138.84136 us\n- HBM byte share: 0.983398438\n- packed shared SRAM: 68.0 MiB\n- tile-local capacity: 614656 B/cluster\n- replaced abstract local capacity: 19140624 B/cluster\n- dominant resource: tile_attention\n\n## Validation\n- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_measured_sram_rebalance.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py\n- PYTHONPATH=/tmp/rtlgen-measured-sram-rebalance/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py -q\n- python3 scripts/validate_runs.py --skip_eval_queue\n- estimator smoke command documented in local run output