### PR TITLE
npu: add measured hbm service frontier job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -444,6 +444,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("attention_kv_memory_out", "attention_kv_memory_report"),
     ("attention_local_sram_capacity_out", "attention_local_sram_capacity_report"),
     ("attention_kv_measured_sram_rebalance_out", "attention_kv_measured_sram_rebalance_report"),
+    ("attention_kv_measured_hbm_service_out", "attention_kv_measured_hbm_service_report"),
 )
 
 
@@ -531,6 +532,28 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "local_capacity_bytes_per_cluster",
             "abstract_local_capacity_bytes_per_cluster_replaced",
             "dominant_tile_resource",
+        ):
+            if key in best_dict:
+                parts.append(f"{key}={best_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_kv_measured_hbm_service_llama7b_v1":
+        best = evidence_payload.get("best")
+        best_dict = dict(best) if isinstance(best, dict) else {}
+        outcome = "measured_hbm_service_recorded"
+        parts = [
+            f"Decoder measured-HBM service evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "latency_us",
+            "dominant_tile_resource",
+            "effective_hbm_bytes_per_cycle",
+            "source_effective_hbm_bytes_per_cycle",
+            "derived_hbm_efficiency_vs_source",
+            "controller_service_cycles",
+            "tile_attention_cycles",
+            "hbm_byte_share",
         ):
             if key in best_dict:
                 parts.append(f"{key}={best_dict.get(key)}")

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5068,6 +5068,49 @@ def _decoder_attention_kv_measured_sram_rebalance_evidence(*, item_id: str) -> d
     }
 
 
+def _decoder_attention_kv_measured_hbm_service_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_measured_hbm_service__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_measured_hbm_service__{item_id}.md"
+    measured_sram = (
+        f"{base}/decoder_attention_kv_measured_sram_rebalance__"
+        "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_measured_sram_rebalance": measured_sram,
+            "attention_kv_measured_hbm_service_out": out,
+            "attention_kv_measured_hbm_service_report": report,
+            "attention_kv_measured_hbm_service_scope": (
+                "Refine the measured-SRAM Llama7B endpoint frontier with an explicit HBM "
+                "channel/burst/row-hit/outstanding-request service model. Compute, SRAM, "
+                "endpoint, and NoC fields are inherited from the measured-SRAM rebalance item."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_measured_hbm_service",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_measured_hbm_service.py "
+                    f"--measured-sram-rebalance-json {measured_sram} "
+                    "--frontier-row-limit 16 "
+                    "--channel-count 4,8,16 "
+                    "--channel-bandwidth-bytes-per-cycle 256,512,1024 "
+                    "--burst-bytes 256,512,1024 "
+                    "--hbm-outstanding 4,8,16,32 "
+                    "--request-overhead-cycles 2,4,8 "
+                    "--row-hit-rate 0.5,0.75,0.9 "
+                    "--row-miss-penalty-cycles 8,16,32 "
+                    "--scheduler-efficiency 0.6,0.75,0.9 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
@@ -6628,6 +6671,7 @@ def _build_payload(
         "decoder_attention_sram_profile",
         "decoder_attention_local_sram_capacity",
         "decoder_attention_kv_measured_sram_rebalance",
+        "decoder_attention_kv_measured_hbm_service",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
@@ -6764,6 +6808,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_local_sram_capacity_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_measured_sram_rebalance":
             decoder_evidence = _decoder_attention_kv_measured_sram_rebalance_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_measured_hbm_service":
+            decoder_evidence = _decoder_attention_kv_measured_hbm_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":
             decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1222,6 +1222,113 @@ def test_consume_l2_result_frontier_attention_measured_sram_rebalance_uses_decod
             )
 
 
+def test_consume_l2_result_frontier_attention_measured_hbm_service_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_measured_hbm_service_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_measured_hbm_service_v1",
+                        "kind": "architecture",
+                        "title": "Attention measured HBM service",
+                        "direct_comparison": {
+                            "primary_question": "Does explicit HBM controller service change the frontier?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_measured_hbm_service__l2_attention_measured_hbm_service_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_measured_hbm_service__l2_attention_measured_hbm_service_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_kv_measured_hbm_service_llama7b_v1",
+                        "sweep_summary": {
+                            "generated_row_count": 64,
+                            "best_latency_us": 2138.84136,
+                            "best_derived_hbm_efficiency_vs_source": 0.019172,
+                        },
+                        "best": {
+                            "latency_us": 2138.84136,
+                            "dominant_tile_resource": "tile_attention",
+                            "effective_hbm_bytes_per_cycle": 792.596465,
+                            "source_effective_hbm_bytes_per_cycle": 41341.3632,
+                            "derived_hbm_efficiency_vs_source": 0.019172,
+                            "controller_service_cycles": 1301,
+                            "tile_attention_cycles": 1354,
+                            "hbm_byte_share": 0.983398438,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# measured hbm service\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_measured_hbm_service",
+                campaign_dir_rel="runs/campaigns/npu/attention_measured_hbm_service_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_measured_hbm_service_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use measured HBM service pressure to choose the next frontier.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_kv_measured_hbm_service",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_kv_measured_hbm_service_out": evidence_rel,
+                    "attention_kv_measured_hbm_service_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "measured_hbm_service_recorded"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert assessment["decoder_quality"]["best"]["derived_hbm_efficiency_vs_source"] == 0.019172
+            assert decision_payload["evaluation_record"]["abstraction_layer"] == "decoder_attention_kv_measured_hbm_service"
+            assert decision_payload["source_refs"]["decoder_attention_kv_measured_hbm_service_out"] == evidence_rel
+            assert decision_payload["source_refs"]["decoder_attention_kv_measured_hbm_service_report"] == report_rel
+
+
 def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5210,6 +5210,52 @@ def test_generate_l2_campaign_task_adds_attention_measured_sram_rebalance_eviden
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_measured_hbm_service_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_measured_hbm_service_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_measured_hbm_service",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_kv_measured_hbm_service" in command_names
+            assert "attention_kv_measured_sram_rebalance" in decoder_inputs
+            assert "attention_kv_measured_hbm_service_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_measured_hbm_service.py" in run
+            assert "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1.json" in run
+            assert "--channel-count 4,8,16" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_measured_hbm_service__"
+                    "l2_decoder_attention_kv_measured_hbm_service_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_hbm_service_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_hbm_service_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_hbm_service_v1",
+  "source_commit": "TBD_AFTER_MERGE",
+  "source_commit_note": "Dispatch should use the merge commit containing the measured HBM service estimator and generator hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_measured_hbm_service_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recompute the measured-SRAM Llama7B attention frontier with explicit HBM controller service parameters.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_measured_hbm_service",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_measured_hbm_service_frontier",
+        "reason": "The result should report best latency, effective HBM bytes/cycle, source-vs-derived HBM efficiency, controller service cycles, and dominant resource."
+      },
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_hbm_service_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_hbm_service_v1/proposal.json
@@ -1,0 +1,65 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_hbm_service_v1",
+  "created_utc": "2026-06-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Measured HBM service closure for Llama7B attention frontier",
+  "hypothesis": "The measured-SRAM Llama7B endpoint frontier remains valid, or its bottleneck shifts, when the inherited scalar HBM bandwidth is replaced by an explicit channel, burst, row-hit, and outstanding-request service model.",
+  "direct_comparison": {
+    "primary_question": "Does explicit HBM controller service change the measured-SRAM Llama7B attention frontier latency or dominant resource?",
+    "include": [
+      "Use l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1 as the source frontier.",
+      "Sweep channel count, per-channel payload bandwidth, burst size, outstanding request window, request overhead, row-hit rate, row-miss penalty, and scheduler efficiency.",
+      "Recompute endpoint service timing while inheriting compute, SRAM, endpoint, and NoC parameters from the measured-SRAM frontier.",
+      "Report effective HBM bytes/cycle versus the source scalar HBM assumption."
+    ],
+    "exclude": [
+      "Do not model full DRAM timing, refresh, bank groups, address mapping, or turnarounds.",
+      "Do not change SRAM packing or compute PPA in this item.",
+      "Do not resolve model-quality risk for KV sharing.",
+      "Do not replace the pending wide router/FIFO PPA closure item."
+    ],
+    "follow_on_broad_sweep": [
+      "If HBM becomes dominant, explore HBM stack/channel scaling and KV compression/quality-backed variants.",
+      "If tile compute remains dominant, return to compute density and tile scheduling under the measured memory assumptions.",
+      "Use this result as the next practical-memory baseline for Llama7B attention exploration."
+    ]
+  },
+  "expected_benefit": [
+    "Reduces the largest remaining memory-service abstraction after measured SRAM rebalance.",
+    "Checks whether the previous inherited HBM bandwidth was overly optimistic.",
+    "Separates HBM-controller service pressure from NoC/SRAM and compute pressure."
+  ],
+  "risks": [
+    "This is still an analytic HBM service bound, not a full DRAM timing simulator.",
+    "HBM channel bandwidth is expressed in core cycles and needs later calibration to a concrete interface clocking plan.",
+    "Controller area and power are not measured in this item."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "measured_hbm_service_frontier",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_measured_hbm_service_frontier",
+        "reason": "The result should report best latency, effective HBM bytes/cycle, source-vs-derived HBM efficiency, controller service cycles, and dominant resource."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_measured_hbm_service.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_measured_sram_rebalance.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_measured_hbm_service.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_measured_hbm_service.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Apply an explicit HBM service model to the measured-SRAM Llama7B frontier."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval import estimate_llm_decoder_attention_kv_onchip_service_schedule as onchip  # noqa: E402
+
+JsonDict = dict[str, Any]
+
+
+def _int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return items
+
+
+def _float_list(value: str) -> list[float]:
+    items = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0.0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive floats")
+    return items
+
+
+def _ceil_div(numerator: int | float, denominator: int | float) -> int:
+    if numerator <= 0:
+        return 0
+    return int(math.ceil(float(numerator) / max(1.0, float(denominator))))
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _hbm_service(
+    *,
+    tile_hbm_bytes: float,
+    channel_count: int,
+    channel_bandwidth_bytes_per_cycle: float,
+    burst_bytes: int,
+    hbm_outstanding: int,
+    request_overhead_cycles: int,
+    row_hit_rate: float,
+    row_miss_penalty_cycles: int,
+    scheduler_efficiency: float,
+) -> JsonDict:
+    payload_bw = channel_count * channel_bandwidth_bytes_per_cycle * scheduler_efficiency
+    payload_cycles = _ceil_div(tile_hbm_bytes, payload_bw)
+    burst_count = _ceil_div(tile_hbm_bytes, burst_bytes)
+    row_miss_count = int(math.ceil(burst_count * max(0.0, 1.0 - row_hit_rate)))
+    overhead_cycles = _ceil_div(burst_count, hbm_outstanding) * request_overhead_cycles
+    row_miss_cycles = _ceil_div(row_miss_count, hbm_outstanding) * row_miss_penalty_cycles
+    service_cycles = max(1, payload_cycles + overhead_cycles + row_miss_cycles)
+    return {
+        "tile_hbm_bytes": int(math.ceil(tile_hbm_bytes)),
+        "payload_hbm_bytes_per_cycle": round(payload_bw, 6),
+        "payload_cycles": payload_cycles,
+        "burst_count": burst_count,
+        "row_miss_count": row_miss_count,
+        "overhead_cycles": overhead_cycles,
+        "row_miss_cycles": row_miss_cycles,
+        "controller_service_cycles": service_cycles,
+        "effective_hbm_bytes_per_cycle": round(tile_hbm_bytes / service_cycles, 6),
+    }
+
+
+def _controller_row(
+    source_row: JsonDict,
+    *,
+    channel_count: int,
+    channel_bandwidth_bytes_per_cycle: float,
+    burst_bytes: int,
+    hbm_outstanding: int,
+    request_overhead_cycles: int,
+    row_hit_rate: float,
+    row_miss_penalty_cycles: int,
+    scheduler_efficiency: float,
+) -> JsonDict:
+    tile_hbm_bytes = onchip._full_tile_bytes(source_row) * float(source_row["hbm_byte_share"])
+    service = _hbm_service(
+        tile_hbm_bytes=tile_hbm_bytes,
+        channel_count=channel_count,
+        channel_bandwidth_bytes_per_cycle=channel_bandwidth_bytes_per_cycle,
+        burst_bytes=burst_bytes,
+        hbm_outstanding=hbm_outstanding,
+        request_overhead_cycles=request_overhead_cycles,
+        row_hit_rate=row_hit_rate,
+        row_miss_penalty_cycles=row_miss_penalty_cycles,
+        scheduler_efficiency=scheduler_efficiency,
+    )
+    raw_effective = float(source_row.get("effective_hbm_bytes_per_cycle", 0.0) or 0.0)
+    adjusted = dict(source_row)
+    adjusted.update(
+        {
+            "measured_hbm_service_model": "channel_burst_row_window_v1",
+            "source_effective_hbm_bytes_per_cycle": raw_effective,
+            "source_tile_hbm_cycles": int(source_row.get("tile_hbm_cycles", 0)),
+            "channel_count": channel_count,
+            "channel_bandwidth_bytes_per_cycle": channel_bandwidth_bytes_per_cycle,
+            "burst_bytes": burst_bytes,
+            "hbm_outstanding": hbm_outstanding,
+            "request_overhead_cycles": request_overhead_cycles,
+            "row_hit_rate": row_hit_rate,
+            "row_miss_penalty_cycles": row_miss_penalty_cycles,
+            "scheduler_efficiency": scheduler_efficiency,
+            "tile_hbm_cycles": service["controller_service_cycles"],
+            "effective_hbm_bytes_per_cycle": service["effective_hbm_bytes_per_cycle"],
+            "derived_hbm_efficiency_vs_source": round(
+                service["effective_hbm_bytes_per_cycle"] / raw_effective,
+                6,
+            )
+            if raw_effective > 0.0
+            else None,
+            **service,
+        }
+    )
+    return onchip._annotate_service(
+        adjusted,
+        schedule_policy=str(adjusted["schedule_policy"]),
+        bank_arbiter_policy=str(adjusted["bank_arbiter_policy"]),
+        endpoint_queue_depth_bytes=int(adjusted["endpoint_queue_depth_bytes"]),
+        bank_queue_depth_bytes=int(adjusted["bank_queue_depth_bytes"]),
+        router_latency_cycles_per_hop=int(adjusted["router_latency_cycles_per_hop"]),
+        packet_payload_bytes=int(adjusted["packet_payload_bytes"]),
+        prefetch_overlap_fraction=float(adjusted["prefetch_overlap_fraction"]),
+    )
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    source = _load_json(args.measured_sram_rebalance_json)
+    source_rows = list(source.get("top_rows") or [])
+    if not source_rows and isinstance(source.get("best"), dict):
+        source_rows = [source["best"]]
+    source_rows = source_rows[: args.frontier_row_limit]
+    if not source_rows:
+        raise RuntimeError("no source rows found")
+
+    rows: list[JsonDict] = []
+    for source_row in source_rows:
+        for channel_count in args.channel_count:
+            for channel_bw in args.channel_bandwidth_bytes_per_cycle:
+                for burst_bytes in args.burst_bytes:
+                    for hbm_outstanding in args.hbm_outstanding:
+                        for request_overhead in args.request_overhead_cycles:
+                            for row_hit_rate in args.row_hit_rate:
+                                for row_miss_penalty in args.row_miss_penalty_cycles:
+                                    for scheduler_efficiency in args.scheduler_efficiency:
+                                        rows.append(
+                                            _controller_row(
+                                                source_row,
+                                                channel_count=channel_count,
+                                                channel_bandwidth_bytes_per_cycle=channel_bw,
+                                                burst_bytes=burst_bytes,
+                                                hbm_outstanding=hbm_outstanding,
+                                                request_overhead_cycles=request_overhead,
+                                                row_hit_rate=row_hit_rate,
+                                                row_miss_penalty_cycles=row_miss_penalty,
+                                                scheduler_efficiency=scheduler_efficiency,
+                                            )
+                                        )
+    rows_sorted = sorted(rows, key=lambda item: float(item["latency_us"]))
+    dominance = Counter(str(row["dominant_tile_resource"]) for row in rows)
+    best = rows_sorted[0]
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_kv_measured_hbm_service_llama7b_v1",
+        "measured_sram_rebalance_json": str(args.measured_sram_rebalance_json),
+        "source_model": source.get("model"),
+        "sweep_summary": {
+            "source_rows_used": len(source_rows),
+            "generated_row_count": len(rows),
+            "best_latency_us": best["latency_us"],
+            "best_hbm_byte_share": best["hbm_byte_share"],
+            "best_effective_hbm_bytes_per_cycle": best["effective_hbm_bytes_per_cycle"],
+            "best_source_effective_hbm_bytes_per_cycle": best["source_effective_hbm_bytes_per_cycle"],
+            "best_derived_hbm_efficiency_vs_source": best["derived_hbm_efficiency_vs_source"],
+            "dominant_tile_resource_counts": dict(sorted(dominance.items())),
+        },
+        "best": best,
+        "top_rows": rows_sorted[: args.top_k],
+        "assumptions": [
+            "Payload cycles are bounded by channel_count * channel_bandwidth_bytes_per_cycle * scheduler_efficiency.",
+            "Burst command overhead and row-miss penalties are batched by the outstanding-request window.",
+            "The model refines HBM service on top of the measured-SRAM rebalance frontier; compute, SRAM, endpoint, and NoC parameters are inherited.",
+            "This is an analytic HBM service bound, not a full DRAM timing simulator with bank groups, refresh, turnarounds, or address mapping.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best"]
+    lines = [
+        "# Llama7B Measured-HBM Service Closure",
+        "",
+        f"- source rows used: `{payload['sweep_summary']['source_rows_used']}`",
+        f"- generated rows: `{payload['sweep_summary']['generated_row_count']}`",
+        f"- dominant resources: `{payload['sweep_summary']['dominant_tile_resource_counts']}`",
+        "",
+        "## Best",
+        "",
+        "| latency us | resource | hbm share | eff B/cyc | source eff B/cyc | eff/source | channels | ch B/cyc | burst | outstanding | row hit | sched eff | service cycles |",
+        "|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| {latency_us} | {dominant_tile_resource} | {hbm_byte_share} | {effective_hbm_bytes_per_cycle} | "
+        "{source_effective_hbm_bytes_per_cycle} | {derived_hbm_efficiency_vs_source} | {channel_count} | "
+        "{channel_bandwidth_bytes_per_cycle} | {burst_bytes} | {hbm_outstanding} | {row_hit_rate} | "
+        "{scheduler_efficiency} | {controller_service_cycles} |".format(**best),
+        "",
+        "## Top Rows",
+        "",
+        "| rank | latency us | resource | eff/source | channels | ch B/cyc | burst | outstanding | row hit | sched eff |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for index, row in enumerate(payload["top_rows"][:30], start=1):
+        lines.append(
+            "| {rank} | {latency_us} | {dominant_tile_resource} | {derived_hbm_efficiency_vs_source} | "
+            "{channel_count} | {channel_bandwidth_bytes_per_cycle} | {burst_bytes} | {hbm_outstanding} | "
+            "{row_hit_rate} | {scheduler_efficiency} |".format(rank=index, **row)
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--measured-sram-rebalance-json", type=Path, required=True)
+    parser.add_argument("--frontier-row-limit", type=int, default=16)
+    parser.add_argument("--channel-count", type=_int_list, default=[4, 8, 16])
+    parser.add_argument("--channel-bandwidth-bytes-per-cycle", type=_float_list, default=[256, 512, 1024])
+    parser.add_argument("--burst-bytes", type=_int_list, default=[256, 512, 1024])
+    parser.add_argument("--hbm-outstanding", type=_int_list, default=[4, 8, 16, 32])
+    parser.add_argument("--request-overhead-cycles", type=_int_list, default=[2, 4, 8])
+    parser.add_argument("--row-hit-rate", type=_float_list, default=[0.5, 0.75, 0.9])
+    parser.add_argument("--row-miss-penalty-cycles", type=_int_list, default=[8, 16, 32])
+    parser.add_argument("--scheduler-efficiency", type=_float_list, default=[0.6, 0.75, 0.9])
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "out": str(args.out), "out_md": str(args.out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- Add an L2 estimator that applies explicit HBM channel/burst/row-hit/outstanding-request service to the measured-SRAM Llama7B frontier.\n- Add generator and result-consumer support for decoder_attention_kv_measured_hbm_service evidence.\n- Add proposal/evaluation request docs for the follow-on job.\n\n## Smoke result\n- best latency: 2138.84136 us\n- dominant resource: tile_attention\n- HBM byte share: 0.983398438\n- effective HBM B/cycle: 792.596465\n- source effective HBM B/cycle: 41341.3632\n- derived/source HBM efficiency: 0.019172\n- controller service cycles: 1301\n- tile attention cycles: 1354\n\n## Validation\n- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_measured_hbm_service.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py\n- PYTHONPATH=/tmp/rtlgen-hbm-service-closure/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py -q\n- python3 scripts/validate_runs.py --skip_eval_queue\n- estimator smoke command completed locally