### PR TITLE
npu: add hbm closed onchip schedule job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -445,6 +445,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("attention_local_sram_capacity_out", "attention_local_sram_capacity_report"),
     ("attention_kv_measured_sram_rebalance_out", "attention_kv_measured_sram_rebalance_report"),
     ("attention_kv_measured_hbm_service_out", "attention_kv_measured_hbm_service_report"),
+    ("attention_kv_hbm_closed_onchip_schedule_out", "attention_kv_hbm_closed_onchip_schedule_report"),
 )
 
 
@@ -554,6 +555,32 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "controller_service_cycles",
             "tile_attention_cycles",
             "hbm_byte_share",
+        ):
+            if key in best_dict:
+                parts.append(f"{key}={best_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1":
+        best = evidence_payload.get("best")
+        best_dict = dict(best) if isinstance(best, dict) else {}
+        outcome = "hbm_closed_onchip_schedule_recorded"
+        parts = [
+            f"Decoder HBM-closed on-chip schedule evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "latency_us",
+            "latency_slowdown_vs_hbm_closed_source",
+            "dominant_tile_resource",
+            "schedule_policy",
+            "bank_arbiter_policy",
+            "endpoint_queue_depth_bytes",
+            "bank_queue_depth_bytes",
+            "router_latency_cycles_per_hop",
+            "packet_payload_bytes",
+            "tile_hbm_cycles",
+            "tile_attention_cycles",
+            "onchip_shared_service_cycles",
         ):
             if key in best_dict:
                 parts.append(f"{key}={best_dict.get(key)}")

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5111,6 +5111,49 @@ def _decoder_attention_kv_measured_hbm_service_evidence(*, item_id: str) -> dict
     }
 
 
+def _decoder_attention_kv_hbm_closed_onchip_schedule_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_hbm_closed_onchip_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_hbm_closed_onchip_schedule__{item_id}.md"
+    measured_hbm = (
+        f"{base}/decoder_attention_kv_measured_hbm_service__"
+        "l2_decoder_attention_kv_measured_hbm_service_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_measured_hbm_service": measured_hbm,
+            "attention_kv_hbm_closed_onchip_schedule_out": out,
+            "attention_kv_hbm_closed_onchip_schedule_report": report,
+            "attention_kv_hbm_closed_onchip_schedule_scope": (
+                "Re-sweep explicit on-chip SRAM/NoC service knobs on top of the measured-HBM "
+                "Llama7B frontier: schedule policy, bank arbitration, endpoint queue depth, "
+                "bank queue depth, router hop latency, packet payload, and prefetch overlap. "
+                "HBM controller service cycles, compute PPA, and measured SRAM quantities are inherited."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_hbm_closed_onchip_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_hbm_closed_onchip_schedule.py "
+                    f"--measured-hbm-service-json {measured_hbm} "
+                    "--frontier-row-limit 64 "
+                    "--schedule-policy static_wave,staggered_wave,prefetch_overlap "
+                    "--bank-arbiter-policy round_robin,locality_first,age_based "
+                    "--endpoint-queue-depth-bytes 1024,2048,8192,32768 "
+                    "--bank-queue-depth-bytes 1024,2048,8192,32768 "
+                    "--router-latency-cycles-per-hop 1,2,4 "
+                    "--packet-payload-bytes 64,128,256 "
+                    "--prefetch-overlap-fraction 0,0.25,0.5,0.75 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
@@ -6672,6 +6715,7 @@ def _build_payload(
         "decoder_attention_local_sram_capacity",
         "decoder_attention_kv_measured_sram_rebalance",
         "decoder_attention_kv_measured_hbm_service",
+        "decoder_attention_kv_hbm_closed_onchip_schedule",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
@@ -6810,6 +6854,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_measured_sram_rebalance_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_measured_hbm_service":
             decoder_evidence = _decoder_attention_kv_measured_hbm_service_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_hbm_closed_onchip_schedule":
+            decoder_evidence = _decoder_attention_kv_hbm_closed_onchip_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":
             decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1329,6 +1329,120 @@ def test_consume_l2_result_frontier_attention_measured_hbm_service_uses_decoder_
             assert decision_payload["source_refs"]["decoder_attention_kv_measured_hbm_service_report"] == report_rel
 
 
+def test_consume_l2_result_frontier_attention_hbm_closed_onchip_schedule_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_hbm_closed_onchip_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_hbm_closed_onchip_v1",
+                        "kind": "architecture",
+                        "title": "Attention HBM closed onchip schedule",
+                        "direct_comparison": {
+                            "primary_question": "Does re-sweeping on-chip service change the HBM-closed frontier?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_hbm_closed_onchip_schedule__l2_attention_hbm_closed_onchip_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_hbm_closed_onchip_schedule__l2_attention_hbm_closed_onchip_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1",
+                        "sweep_summary": {
+                            "generated_row_count": 128,
+                            "best_latency_us": 2138.84136,
+                            "best_latency_slowdown_vs_hbm_closed_source": 1.0,
+                        },
+                        "best": {
+                            "latency_us": 2138.84136,
+                            "latency_slowdown_vs_hbm_closed_source": 1.0,
+                            "dominant_tile_resource": "tile_attention",
+                            "schedule_policy": "prefetch_overlap",
+                            "bank_arbiter_policy": "locality_first",
+                            "endpoint_queue_depth_bytes": 2048,
+                            "bank_queue_depth_bytes": 2048,
+                            "router_latency_cycles_per_hop": 1,
+                            "packet_payload_bytes": 128,
+                            "tile_hbm_cycles": 1301,
+                            "tile_attention_cycles": 1354,
+                            "onchip_shared_service_cycles": 197,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# hbm closed onchip schedule\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_hbm_closed_onchip",
+                campaign_dir_rel="runs/campaigns/npu/attention_hbm_closed_onchip_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_hbm_closed_onchip_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use HBM-closed on-chip service pressure to choose the next frontier.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_kv_hbm_closed_onchip_schedule",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_kv_hbm_closed_onchip_schedule_out": evidence_rel,
+                    "attention_kv_hbm_closed_onchip_schedule_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "hbm_closed_onchip_schedule_recorded"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert assessment["decoder_quality"]["best"]["schedule_policy"] == "prefetch_overlap"
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_kv_hbm_closed_onchip_schedule"
+            )
+            assert decision_payload["source_refs"]["decoder_attention_kv_hbm_closed_onchip_schedule_out"] == evidence_rel
+            assert decision_payload["source_refs"]["decoder_attention_kv_hbm_closed_onchip_schedule_report"] == report_rel
+
+
 def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5256,6 +5256,52 @@ def test_generate_l2_campaign_task_adds_attention_measured_hbm_service_evidence(
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_hbm_closed_onchip_schedule_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_hbm_closed_onchip_schedule",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_kv_hbm_closed_onchip_schedule" in command_names
+            assert "attention_kv_measured_hbm_service" in decoder_inputs
+            assert "attention_kv_hbm_closed_onchip_schedule_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_hbm_closed_onchip_schedule.py" in run
+            assert "l2_decoder_attention_kv_measured_hbm_service_llama7b_v1.json" in run
+            assert "--router-latency-cycles-per-hop 1,2,4" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_hbm_closed_onchip_schedule__"
+                    "l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_hbm_closed_onchip_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_hbm_closed_onchip_schedule_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_hbm_closed_onchip_schedule_v1",
+  "source_commit": null,
+  "source_commit_note": "Dispatch should use the merge commit containing the HBM-closed on-chip schedule estimator and generator hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Re-sweep explicit SRAM/NoC service scheduling on top of the measured-HBM Llama7B attention frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_hbm_closed_onchip_schedule",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_measured_hbm_service_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_measured_hbm_service_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_hbm_closed_onchip_schedule_frontier",
+        "reason": "The result should report best latency, slowdown versus the measured-HBM source, dominant resource, queue/router schedule parameters, HBM cycles, attention cycles, and shared-service cycles."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_hbm_closed_onchip_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_hbm_closed_onchip_schedule_v1/proposal.json
@@ -1,0 +1,65 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_hbm_closed_onchip_schedule_v1",
+  "created_utc": "2026-06-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "HBM-closed on-chip schedule closure for Llama7B attention frontier",
+  "hypothesis": "The current measured-HBM Llama7B attention frontier remains stable, or exposes a new NoC/SRAM bottleneck, when on-chip service policy knobs are re-swept instead of inherited from the older measured-SRAM frontier.",
+  "direct_comparison": {
+    "primary_question": "Does reoptimizing explicit SRAM/NoC service on top of the measured-HBM frontier change latency or the dominant resource?",
+    "include": [
+      "Use l2_decoder_attention_kv_measured_hbm_service_llama7b_v1 as the source frontier.",
+      "Re-sweep schedule policy, bank arbitration, endpoint queue depth, bank queue depth, router hop latency, packet payload, and prefetch overlap.",
+      "Keep HBM controller service cycles, compute PPA, measured SRAM capacity, endpoint/router/FIFO primitive PPA, and KV quality assumptions inherited.",
+      "Report best latency, slowdown versus the HBM-closed source row, dominant resource, queue penalties, and shared-service cycles."
+    ],
+    "exclude": [
+      "Do not generate or PPA a full NoC RTL implementation in this item.",
+      "Do not change HBM channel/burst/row parameters in this item.",
+      "Do not change SRAM packing, compute replica count, or KV sharing quality assumptions.",
+      "Do not resolve the wide endpoint router/fifo PPA boundary item."
+    ],
+    "follow_on_broad_sweep": [
+      "If NoC/SRAM service becomes dominant, split into concrete endpoint/router topology RTL and scheduler jobs.",
+      "If tile compute remains dominant, move to compute density or full-chip scheduling under the measured-memory frontier.",
+      "If HBM and NoC are both close to the tile-compute cycles, prioritize an integrated whole-layer schedule model."
+    ]
+  },
+  "expected_benefit": [
+    "Removes inheritance bias from the measured-HBM frontier's on-chip schedule knobs.",
+    "Identifies whether endpoint queue depth, packet payload, or router hop latency materially changes the selected point.",
+    "Clarifies whether the next frontier item should target NoC RTL, compute density, or integrated scheduling."
+  ],
+  "risks": [
+    "This remains an analytic on-chip service simulator, not a routed NoC implementation.",
+    "The search can choose optimistic queue/schedule combinations that still need ready/valid and RTL validation.",
+    "Area and power of larger queues are inherited from coarse primitive estimates rather than remeasured per selected setting."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "hbm_closed_onchip_schedule_frontier",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_measured_hbm_service_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_hbm_closed_onchip_schedule_frontier",
+        "reason": "The result should report best latency, slowdown versus the measured-HBM source, dominant resource, queue/router schedule parameters, HBM cycles, attention cycles, and shared-service cycles."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_hbm_service__l2_decoder_attention_kv_measured_hbm_service_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_hbm_closed_onchip_schedule.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_measured_hbm_service.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_hbm_closed_onchip_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_hbm_closed_onchip_schedule.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Re-sweep on-chip service knobs on top of the HBM-closed Llama7B frontier."""
+
+from __future__ import annotations
+
+import argparse
+import heapq
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval import estimate_llm_decoder_attention_kv_onchip_service_schedule as onchip  # noqa: E402
+
+JsonDict = dict[str, Any]
+
+
+def _float_list(value: str) -> list[float]:
+    items = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item < 0.0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated nonnegative floats")
+    return items
+
+
+def _int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return items
+
+
+def _str_list(value: str) -> list[str]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated names")
+    return items
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _source_rows(payload: JsonDict, *, limit: int) -> list[JsonDict]:
+    rows = list(payload.get("top_rows") or [])
+    if not rows and isinstance(payload.get("best"), dict):
+        rows = [payload["best"]]
+    deduped: list[JsonDict] = []
+    seen: set[str] = set()
+    for row in rows:
+        key = json.dumps(
+            {
+                "latency_us": row.get("latency_us"),
+                "cluster_count": row.get("cluster_count"),
+                "active_clusters": row.get("active_clusters"),
+                "topology": row.get("topology"),
+                "tile_hbm_cycles": row.get("tile_hbm_cycles"),
+                "controller_service_cycles": row.get("controller_service_cycles"),
+                "channel_count": row.get("channel_count"),
+                "channel_bandwidth_bytes_per_cycle": row.get("channel_bandwidth_bytes_per_cycle"),
+                "burst_bytes": row.get("burst_bytes"),
+                "hbm_outstanding": row.get("hbm_outstanding"),
+                "row_hit_rate": row.get("row_hit_rate"),
+                "scheduler_efficiency": row.get("scheduler_efficiency"),
+            },
+            sort_keys=True,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(row)
+        if len(deduped) >= limit:
+            break
+    return deduped
+
+
+def _push_top(heap: list[tuple[float, int, JsonDict]], row: JsonDict, *, counter: int, limit: int) -> None:
+    entry = (-float(row["latency_us"]), counter, row)
+    if len(heap) < limit:
+        heapq.heappush(heap, entry)
+    elif entry[0] > heap[0][0]:
+        heapq.heapreplace(heap, entry)
+
+
+def _best_update(target: dict[tuple[Any, ...], JsonDict], keys: tuple[str, ...], row: JsonDict) -> None:
+    key = tuple(row.get(item) for item in keys)
+    current = target.get(key)
+    if current is None or float(row["latency_us"]) < float(current["latency_us"]):
+        target[key] = row
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    source = _load_json(args.measured_hbm_service_json)
+    source_rows = _source_rows(source, limit=args.frontier_row_limit)
+    if not source_rows:
+        raise RuntimeError("no HBM-closed source rows found")
+
+    best: JsonDict | None = None
+    generated = 0
+    heap_counter = 0
+    top_heap: list[tuple[float, int, JsonDict]] = []
+    dominance = Counter()
+    schedule_counts = Counter()
+    hbm_counts = Counter()
+    best_by_policy: dict[tuple[Any, ...], JsonDict] = {}
+    best_by_queue: dict[tuple[Any, ...], JsonDict] = {}
+    best_by_hbm_service: dict[tuple[Any, ...], JsonDict] = {}
+
+    for source_row in source_rows:
+        for schedule_policy in args.schedule_policy:
+            for bank_policy in args.bank_arbiter_policy:
+                for endpoint_queue_depth_bytes in args.endpoint_queue_depth_bytes:
+                    for bank_queue_depth_bytes in args.bank_queue_depth_bytes:
+                        for router_latency_cycles_per_hop in args.router_latency_cycles_per_hop:
+                            for packet_payload_bytes in args.packet_payload_bytes:
+                                for prefetch_overlap_fraction in args.prefetch_overlap_fraction:
+                                    if schedule_policy != "prefetch_overlap" and prefetch_overlap_fraction != 0.0:
+                                        continue
+                                    if schedule_policy == "prefetch_overlap" and prefetch_overlap_fraction <= 0.0:
+                                        continue
+                                    row = onchip._annotate_service(
+                                        source_row,
+                                        schedule_policy=schedule_policy,
+                                        bank_arbiter_policy=bank_policy,
+                                        endpoint_queue_depth_bytes=endpoint_queue_depth_bytes,
+                                        bank_queue_depth_bytes=bank_queue_depth_bytes,
+                                        router_latency_cycles_per_hop=router_latency_cycles_per_hop,
+                                        packet_payload_bytes=packet_payload_bytes,
+                                        prefetch_overlap_fraction=prefetch_overlap_fraction,
+                                    )
+                                    row.update(
+                                        {
+                                            "hbm_closed_onchip_schedule_model": (
+                                                "hbm_closed_cycle_stepped_sram_bank_endpoint_router_v1"
+                                            ),
+                                            "source_latency_us": source_row.get("latency_us"),
+                                            "source_dominant_tile_resource": source_row.get("dominant_tile_resource"),
+                                            "source_onchip_shared_service_cycles": source_row.get(
+                                                "onchip_shared_service_cycles"
+                                            ),
+                                            "source_tile_memory_cycles": source_row.get("tile_memory_cycles"),
+                                            "source_tile_service_cycles": source_row.get("tile_service_cycles"),
+                                            "latency_slowdown_vs_hbm_closed_source": round(
+                                                float(row["latency_us"])
+                                                / max(1e-9, float(source_row.get("latency_us", row["latency_us"]))),
+                                                6,
+                                            ),
+                                        }
+                                    )
+                                    generated += 1
+                                    dominance[str(row["dominant_tile_resource"])] += 1
+                                    schedule_counts[str(row["schedule_policy"])] += 1
+                                    hbm_counts[str(row.get("dominant_tile_resource") == "hbm")] += 1
+                                    if best is None or float(row["latency_us"]) < float(best["latency_us"]):
+                                        best = row
+                                    _push_top(top_heap, row, counter=heap_counter, limit=args.top_k)
+                                    heap_counter += 1
+                                    _best_update(best_by_policy, ("schedule_policy", "bank_arbiter_policy"), row)
+                                    _best_update(
+                                        best_by_queue,
+                                        (
+                                            "endpoint_queue_depth_bytes",
+                                            "bank_queue_depth_bytes",
+                                            "router_latency_cycles_per_hop",
+                                            "packet_payload_bytes",
+                                        ),
+                                        row,
+                                    )
+                                    _best_update(
+                                        best_by_hbm_service,
+                                        (
+                                            "channel_count",
+                                            "channel_bandwidth_bytes_per_cycle",
+                                            "burst_bytes",
+                                            "hbm_outstanding",
+                                            "row_hit_rate",
+                                            "scheduler_efficiency",
+                                        ),
+                                        row,
+                                    )
+
+    if best is None:
+        raise RuntimeError("no HBM-closed on-chip schedule rows generated")
+    top_rows = [entry[2] for entry in sorted(top_heap, key=lambda entry: (entry[2]["latency_us"], entry[1]))]
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1",
+        "measured_hbm_service_json": str(args.measured_hbm_service_json),
+        "source_model": source.get("model"),
+        "inputs": {
+            "frontier_row_limit": args.frontier_row_limit,
+            "schedule_policy": args.schedule_policy,
+            "bank_arbiter_policy": args.bank_arbiter_policy,
+            "endpoint_queue_depth_bytes": args.endpoint_queue_depth_bytes,
+            "bank_queue_depth_bytes": args.bank_queue_depth_bytes,
+            "router_latency_cycles_per_hop": args.router_latency_cycles_per_hop,
+            "packet_payload_bytes": args.packet_payload_bytes,
+            "prefetch_overlap_fraction": args.prefetch_overlap_fraction,
+        },
+        "sweep_summary": {
+            "source_rows_used": len(source_rows),
+            "generated_row_count": generated,
+            "dominant_tile_resource_counts": dict(sorted(dominance.items())),
+            "schedule_policy_counts": dict(sorted(schedule_counts.items())),
+            "hbm_dominant_counts": dict(sorted(hbm_counts.items())),
+            "best_latency_us": best["latency_us"],
+            "best_latency_slowdown_vs_hbm_closed_source": best["latency_slowdown_vs_hbm_closed_source"],
+            "best_dominant_tile_resource": best["dominant_tile_resource"],
+        },
+        "best": best,
+        "top_rows": top_rows,
+        "best_by_policy": sorted(best_by_policy.values(), key=lambda row: row["latency_us"])[:100],
+        "best_by_queue": sorted(best_by_queue.values(), key=lambda row: row["latency_us"])[:100],
+        "best_by_hbm_service": sorted(best_by_hbm_service.values(), key=lambda row: row["latency_us"])[:100],
+        "assumptions": [
+            "HBM service cycles and controller parameters are inherited from the measured-HBM service source rows.",
+            "This pass re-sweeps SRAM bank arbitration, endpoint queues, bank queues, packet payload, router hop latency, schedule staggering, and prefetch overlap.",
+            "The model is still an analytic on-chip service simulator; it does not generate or prove full NoC RTL.",
+            "Compute, measured SRAM capacity, local datapath PPA, endpoint/router/FIFO primitive PPA, and KV quality assumptions are inherited unchanged.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best"]
+    lines = [
+        "# Llama7B HBM-Closed On-Chip Schedule Closure",
+        "",
+        f"- source rows used: `{payload['sweep_summary']['source_rows_used']}`",
+        f"- generated rows: `{payload['sweep_summary']['generated_row_count']}`",
+        f"- dominant resources: `{payload['sweep_summary']['dominant_tile_resource_counts']}`",
+        "",
+        "## Best",
+        "",
+        "| latency us | vs HBM source | resource | schedule | bank policy | endpoint q | bank q | router hop | packet | hbm cycles | shared service | exposed shared |",
+        "|---:|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|",
+        "| {latency_us} | {latency_slowdown_vs_hbm_closed_source} | {dominant_tile_resource} | "
+        "{schedule_policy} | {bank_arbiter_policy} | {endpoint_queue_depth_bytes} | "
+        "{bank_queue_depth_bytes} | {router_latency_cycles_per_hop} | {packet_payload_bytes} | "
+        "{tile_hbm_cycles} | {onchip_shared_service_cycles} | {onchip_exposed_shared_cycles} |".format(**best),
+        "",
+        "## Best By Policy",
+        "",
+        "| schedule | bank policy | latency us | vs source | resource | shared service | exposed shared |",
+        "|---|---|---:|---:|---|---:|---:|",
+    ]
+    for row in payload["best_by_policy"][:30]:
+        lines.append(
+            "| {schedule_policy} | {bank_arbiter_policy} | {latency_us} | "
+            "{latency_slowdown_vs_hbm_closed_source} | {dominant_tile_resource} | "
+            "{onchip_shared_service_cycles} | {onchip_exposed_shared_cycles} |".format(**row)
+        )
+    lines.extend(
+        [
+            "",
+            "## Best By Queue/Router",
+            "",
+            "| endpoint q | bank q | router hop | packet | latency us | penalties | resource |",
+            "|---:|---:|---:|---:|---:|---|---|",
+        ]
+    )
+    for row in payload["best_by_queue"][:30]:
+        penalties = f"endpoint={row['onchip_endpoint_queue_penalty_cycles']},bank={row['onchip_bank_queue_penalty_cycles']}"
+        lines.append(
+            "| {endpoint_queue_depth_bytes} | {bank_queue_depth_bytes} | {router_latency_cycles_per_hop} | "
+            "{packet_payload_bytes} | {latency_us} | {penalties} | {dominant_tile_resource} |".format(
+                **row,
+                penalties=penalties,
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--measured-hbm-service-json", type=Path, required=True)
+    parser.add_argument("--frontier-row-limit", type=int, default=64)
+    parser.add_argument("--schedule-policy", type=_str_list, default=["static_wave", "staggered_wave", "prefetch_overlap"])
+    parser.add_argument("--bank-arbiter-policy", type=_str_list, default=["round_robin", "locality_first", "age_based"])
+    parser.add_argument("--endpoint-queue-depth-bytes", type=_int_list, default=[1024, 2048, 8192, 32768])
+    parser.add_argument("--bank-queue-depth-bytes", type=_int_list, default=[1024, 2048, 8192, 32768])
+    parser.add_argument("--router-latency-cycles-per-hop", type=_int_list, default=[1, 2, 4])
+    parser.add_argument("--packet-payload-bytes", type=_int_list, default=[64, 128, 256])
+    parser.add_argument("--prefetch-overlap-fraction", type=_float_list, default=[0.0, 0.25, 0.5, 0.75])
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "out": str(args.out), "out_md": str(args.out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an HBM-closed on-chip schedule estimator for the Llama7B attention frontier
- wire the new decoder evidence contract through L2 task generation and result consumption
- add proposal docs and focused generator/consumer tests

## Validation
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_hbm_closed_onchip_schedule.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py
- PYTHONPATH=/tmp/rtlgen-noc-tight-frontier/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py -q
- python3 scripts/validate_runs.py --skip_eval_queue
- local smoke: 103680 generated rows, best latency 2138.84136 us, dominant resource tile_attention