### PR TITLE
npu: add subtile pipeline attention scheduler

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -446,6 +446,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("attention_kv_measured_sram_rebalance_out", "attention_kv_measured_sram_rebalance_report"),
     ("attention_kv_measured_hbm_service_out", "attention_kv_measured_hbm_service_report"),
     ("attention_kv_hbm_closed_onchip_schedule_out", "attention_kv_hbm_closed_onchip_schedule_report"),
+    ("attention_kv_subtile_pipeline_schedule_out", "attention_kv_subtile_pipeline_schedule_report"),
 )
 
 
@@ -581,6 +582,35 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "tile_hbm_cycles",
             "tile_attention_cycles",
             "onchip_shared_service_cycles",
+        ):
+            if key in best_dict:
+                parts.append(f"{key}={best_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1":
+        best = evidence_payload.get("best")
+        best_dict = dict(best) if isinstance(best, dict) else {}
+        outcome = "subtile_pipeline_schedule_recorded"
+        parts = [
+            f"Decoder sub-tile pipeline schedule evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "latency_us",
+            "latency_speedup_vs_hbm_closed_source",
+            "tile_service_cycles",
+            "pipeline_attention_cycles",
+            "dominant_tile_resource",
+            "compute_mode",
+            "compute_area_multiplier",
+            "normalize_strategy",
+            "subtile_count",
+            "subtile_buffer_count",
+            "prefetch_distance",
+            "required_stream_buffer_bytes",
+            "available_local_capacity_bytes",
+            "hbm_exposed_cycles",
+            "hbm_floor_gap_cycles",
         ):
             if key in best_dict:
                 parts.append(f"{key}={best_dict.get(key)}")

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5154,6 +5154,49 @@ def _decoder_attention_kv_hbm_closed_onchip_schedule_evidence(*, item_id: str) -
     }
 
 
+def _decoder_attention_kv_subtile_pipeline_schedule_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_subtile_pipeline_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_subtile_pipeline_schedule__{item_id}.md"
+    hbm_closed_onchip = (
+        f"{base}/decoder_attention_kv_hbm_closed_onchip_schedule__"
+        "l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_hbm_closed_onchip_schedule": hbm_closed_onchip,
+            "attention_kv_subtile_pipeline_schedule_out": out,
+            "attention_kv_subtile_pipeline_schedule_report": report,
+            "attention_kv_subtile_pipeline_schedule_scope": (
+                "Estimate sub-tile QK/softmax/V pipeline schedules on top of the measured-SRAM, "
+                "measured-HBM, HBM-closed on-chip Llama7B attention frontier. Sweep subtile count, "
+                "buffer count, prefetch distance, normalization strategy, and QK/V compute sharing "
+                "mode to separate schedule-only room from circuit-assisted pipeline room."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_subtile_pipeline_schedule",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py "
+                    f"--hbm-closed-onchip-schedule-json {hbm_closed_onchip} "
+                    "--frontier-row-limit 48 "
+                    "--subtile-count 1,2,4,8,16,32 "
+                    "--subtile-buffer-count 1,2,3,4 "
+                    "--prefetch-distance 0,1,2,3 "
+                    "--normalize-strategy full_tile_normalize,online_correction "
+                    "--compute-mode shared_mac,split_mac,dual_mac "
+                    "--softmax-latency-per-subtile 0,1,2,4 "
+                    "--online-rescale-penalty-cycles 0,1,2,4 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
@@ -6716,6 +6759,7 @@ def _build_payload(
         "decoder_attention_kv_measured_sram_rebalance",
         "decoder_attention_kv_measured_hbm_service",
         "decoder_attention_kv_hbm_closed_onchip_schedule",
+        "decoder_attention_kv_subtile_pipeline_schedule",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
@@ -6856,6 +6900,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_measured_hbm_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_hbm_closed_onchip_schedule":
             decoder_evidence = _decoder_attention_kv_hbm_closed_onchip_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_subtile_pipeline_schedule":
+            decoder_evidence = _decoder_attention_kv_subtile_pipeline_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":
             decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1443,6 +1443,123 @@ def test_consume_l2_result_frontier_attention_hbm_closed_onchip_schedule_uses_de
             assert decision_payload["source_refs"]["decoder_attention_kv_hbm_closed_onchip_schedule_report"] == report_rel
 
 
+def test_consume_l2_result_frontier_attention_subtile_pipeline_schedule_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_subtile_pipeline_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_subtile_pipeline_v1",
+                        "kind": "architecture",
+                        "title": "Attention subtile pipeline",
+                        "direct_comparison": {
+                            "primary_question": "How much can legal sub-tile pipelining improve the frontier?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_subtile_pipeline_schedule__l2_attention_subtile_pipeline_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_subtile_pipeline_schedule__l2_attention_subtile_pipeline_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1",
+                        "sweep_summary": {
+                            "generated_row_count": 128,
+                            "legal_row_count": 64,
+                            "best_latency_us": 1800.0,
+                            "best_latency_speedup_vs_hbm_closed_source": 1.18,
+                        },
+                        "best": {
+                            "latency_us": 1800.0,
+                            "latency_speedup_vs_hbm_closed_source": 1.18,
+                            "tile_service_cycles": 1000,
+                            "pipeline_attention_cycles": 1000,
+                            "dominant_tile_resource": "pipeline_attention",
+                            "compute_mode": "dual_mac",
+                            "compute_area_multiplier": 2.0,
+                            "normalize_strategy": "online_correction",
+                            "subtile_count": 8,
+                            "subtile_buffer_count": 2,
+                            "prefetch_distance": 1,
+                            "required_stream_buffer_bytes": 270336,
+                            "available_local_capacity_bytes": 614656,
+                            "hbm_floor_gap_cycles": -301,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# subtile pipeline\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_subtile_pipeline",
+                campaign_dir_rel="runs/campaigns/npu/attention_subtile_pipeline_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_subtile_pipeline_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use subtile-pipeline schedule pressure to choose the next RTL/PPA target.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_kv_subtile_pipeline_schedule",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_kv_subtile_pipeline_schedule_out": evidence_rel,
+                    "attention_kv_subtile_pipeline_schedule_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "subtile_pipeline_schedule_recorded"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert assessment["decoder_quality"]["best"]["compute_mode"] == "dual_mac"
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_kv_subtile_pipeline_schedule"
+            )
+            assert decision_payload["source_refs"]["decoder_attention_kv_subtile_pipeline_schedule_out"] == evidence_rel
+            assert decision_payload["source_refs"]["decoder_attention_kv_subtile_pipeline_schedule_report"] == report_rel
+
+
 def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5302,6 +5302,52 @@ def test_generate_l2_campaign_task_adds_attention_hbm_closed_onchip_schedule_evi
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_subtile_pipeline_schedule_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_subtile_pipeline_schedule",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_kv_subtile_pipeline_schedule" in command_names
+            assert "attention_kv_hbm_closed_onchip_schedule" in decoder_inputs
+            assert "attention_kv_subtile_pipeline_schedule_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py" in run
+            assert "l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1.json" in run
+            assert "--compute-mode shared_mac,split_mac,dual_mac" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_subtile_pipeline_schedule__"
+                    "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_subtile_pipeline_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_subtile_pipeline_schedule_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_subtile_pipeline_schedule_v1",
+  "source_commit": null,
+  "source_commit_note": "Dispatch should use the merge commit containing the sub-tile pipeline scheduler and control-plane hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Estimate legal sub-tile QK/softmax/V pipeline schedules on top of the HBM-closed Llama7B attention frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_subtile_pipeline_schedule",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_subtile_pipeline_schedule_frontier",
+        "reason": "The result should report schedule-only versus circuit-assisted speedup, legal buffer requirements, tile service cycles, HBM floor gap, and the selected follow-on RTL/PPA target."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_subtile_pipeline_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_subtile_pipeline_schedule_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_subtile_pipeline_schedule_v1",
+  "created_utc": "2026-06-11T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Sub-tile pipelined attention schedule for Llama7B frontier",
+  "hypothesis": "The current Llama7B attention frontier is tile-attention limited, but the latency can be reduced if QK, softmax/statistics, V accumulation, and HBM prefetch are scheduled as a legal sub-tile pipeline. The sweep should separate schedule-only room from circuit-assisted room that requires independent QK/V compute streams.",
+  "direct_comparison": {
+    "primary_question": "How much of the current tile-attention bottleneck can be removed by legal sub-tile pipelining before RTL/PPA work?",
+    "include": [
+      "Use l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1 as the source frontier.",
+      "Sweep subtile count, subtile buffer count, prefetch distance, full-tile versus online normalization, QK/V compute sharing mode, softmax subtile latency, and online rescale penalty.",
+      "Treat shared_mac as schedule-only, split_mac as area-neutral compute partitioning, and dual_mac as an area-increasing circuit-assisted candidate.",
+      "Reject rows whose required stream buffer exceeds the selected local capacity or whose prefetch distance exceeds available buffers.",
+      "Report best latency, speedup versus the HBM-closed source, tile service cycles, HBM floor gap, compute mode, normalization strategy, buffer requirement, and dominant resource."
+    ],
+    "exclude": [
+      "Do not claim RTL equivalence or PPA for the pipelined datapath in this item.",
+      "Do not change HBM controller service, measured SRAM capacity, endpoint/router/FIFO primitive PPA, or KV sharing quality assumptions.",
+      "Do not model a full online softmax numerical error bound; use the online correction mode only as a scheduling feasibility marker.",
+      "Do not promote dual_mac without a follow-on physical area/power measurement."
+    ],
+    "follow_on_broad_sweep": [
+      "If shared_mac gives little improvement, move to circuit-level QK/V pipeline or compute-density exploration.",
+      "If dual_mac gives large improvement, define a minimal RTL/PPA target for a pipelined QK-softmax-V tile datapath.",
+      "If all legal rows hit the HBM floor, return to HBM/NoC overlap and prefetch-buffer planning."
+    ]
+  },
+  "expected_benefit": [
+    "Quantifies whether scheduling alone can improve the frontier.",
+    "Identifies the smallest circuit assumption that would justify a pipelined attention RTL/PPA job.",
+    "Avoids spending evaluator time on broad physical sweeps before the schedule has enough analytic headroom."
+  ],
+  "risks": [
+    "The model is analytic and does not yet validate ready/valid behavior or numeric equivalence.",
+    "dual_mac carries an explicit area multiplier but not measured PPA.",
+    "The buffer model is conservative but still simplified relative to a placed SRAM/register-file design."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "subtile_pipeline_schedule_frontier",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_subtile_pipeline_schedule_frontier",
+        "reason": "The result should report schedule-only versus circuit-assisted speedup, legal buffer requirements, tile service cycles, HBM floor gap, and the selected follow-on RTL/PPA target."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_hbm_closed_onchip_schedule__l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_hbm_closed_onchip_schedule.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_clustered_schedule.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Estimate sub-tile pipelined QK/softmax/V schedules for the Llama7B attention frontier."""
+
+from __future__ import annotations
+
+import argparse
+import heapq
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+JsonDict = dict[str, Any]
+
+
+def _int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return items
+
+
+def _nonnegative_int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item < 0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated nonnegative integers")
+    return items
+
+
+def _str_list(value: str) -> list[str]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated names")
+    return items
+
+
+def _ceil_div(numerator: int | float, denominator: int | float) -> int:
+    if numerator <= 0:
+        return 0
+    return int(math.ceil(float(numerator) / max(1.0, float(denominator))))
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _source_rows(payload: JsonDict, *, limit: int) -> list[JsonDict]:
+    rows = list(payload.get("top_rows") or [])
+    if not rows and isinstance(payload.get("best"), dict):
+        rows = [payload["best"]]
+    deduped: list[JsonDict] = []
+    seen: set[str] = set()
+    for row in rows:
+        key = json.dumps(
+            {
+                "latency_us": row.get("latency_us"),
+                "cluster_count": row.get("cluster_count"),
+                "active_clusters": row.get("active_clusters"),
+                "tile_hbm_cycles": row.get("tile_hbm_cycles"),
+                "tile_attention_cycles": row.get("tile_attention_cycles"),
+                "tile_qk_cycles": row.get("tile_qk_cycles"),
+                "tile_stats_cycles": row.get("tile_stats_cycles"),
+                "tile_value_cycles": row.get("tile_value_cycles"),
+                "schedule_policy": row.get("schedule_policy"),
+                "bank_arbiter_policy": row.get("bank_arbiter_policy"),
+            },
+            sort_keys=True,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(row)
+        if len(deduped) >= limit:
+            break
+    return deduped
+
+
+def _compute_stage_cycles(row: JsonDict, *, subtiles: int, compute_mode: str) -> tuple[int, int]:
+    qk_base = int(row["tile_qk_cycles"])
+    value_base = int(row["tile_value_cycles"])
+    if compute_mode == "shared_mac":
+        scale = 1.0
+    elif compute_mode == "split_mac":
+        scale = 2.0
+    elif compute_mode == "dual_mac":
+        scale = 1.0
+    else:
+        raise ValueError(f"unknown compute mode: {compute_mode}")
+    return _ceil_div(qk_base * scale, subtiles), _ceil_div(value_base * scale, subtiles)
+
+
+def _subtile_buffer_bytes(row: JsonDict, *, subtiles: int, buffer_count: int, prefetch_distance: int) -> int:
+    full_tile_bytes = int(row.get("onchip_full_tile_bytes", row.get("tile_hbm_bytes", 0)))
+    subtile_payload = _ceil_div(full_tile_bytes, subtiles)
+    hidden_size = int(row.get("hidden_size", 4096))
+    attention_heads = int(row.get("attention_heads", 32))
+    scalar_bytes = 2
+    stats_bytes = attention_heads * 2 * scalar_bytes
+    partial_value_bytes = hidden_size * scalar_bytes
+    live_buffers = max(buffer_count, prefetch_distance + 1)
+    return live_buffers * subtile_payload + stats_bytes + partial_value_bytes
+
+
+def _scheduled_pipeline(
+    row: JsonDict,
+    *,
+    subtiles: int,
+    buffer_count: int,
+    prefetch_distance: int,
+    normalize_strategy: str,
+    compute_mode: str,
+    softmax_latency_per_subtile: int,
+    online_rescale_penalty_cycles: int,
+) -> JsonDict:
+    qk_sub, value_sub = _compute_stage_cycles(row, subtiles=subtiles, compute_mode=compute_mode)
+    stats_sub = _ceil_div(int(row["tile_stats_cycles"]), subtiles) + softmax_latency_per_subtile
+    hbm_sub = _ceil_div(int(row["tile_hbm_cycles"]), subtiles)
+    local_sub = _ceil_div(int(row.get("tile_local_sram_cycles", 0)), subtiles)
+    shared_sub = _ceil_div(int(row.get("tile_shared_path_cycles", 0)), subtiles)
+    memory_aux_sub = max(local_sub, shared_sub)
+
+    buffer_bytes = _subtile_buffer_bytes(
+        row,
+        subtiles=subtiles,
+        buffer_count=buffer_count,
+        prefetch_distance=prefetch_distance,
+    )
+    local_capacity = int(row.get("local_capacity_bytes_per_cluster", row.get("tile_local_buffer_bytes", 0)))
+    legal = buffer_bytes <= local_capacity and prefetch_distance < buffer_count
+    if normalize_strategy == "online_correction" and subtiles < 2:
+        legal = False
+
+    hbm_end = [max(0, index + 1 - prefetch_distance) * hbm_sub for index in range(subtiles)]
+    qk_end: list[int] = []
+    stats_end: list[int] = []
+    value_end: list[int] = []
+    shared_gemm_free = 0
+    qk_free = 0
+    value_free = 0
+    stats_free = 0
+
+    for index in range(subtiles):
+        # A prefetch distance of N means the scheduler tries to keep N later blocks in flight,
+        # but a block still cannot compute before its own payload has arrived.
+        qk_start = max(qk_free, hbm_end[index], index * memory_aux_sub)
+        if compute_mode == "shared_mac":
+            qk_start = max(qk_start, shared_gemm_free)
+        qk_done = qk_start + qk_sub
+        qk_end.append(qk_done)
+        qk_free = qk_done
+        if compute_mode == "shared_mac":
+            shared_gemm_free = qk_done
+
+        stats_start = max(stats_free, qk_done)
+        stats_done = stats_start + stats_sub
+        stats_end.append(stats_done)
+        stats_free = stats_done
+
+        if normalize_strategy == "full_tile_normalize":
+            continue
+        value_start = max(value_free, stats_done + online_rescale_penalty_cycles, hbm_end[index])
+        if compute_mode == "shared_mac":
+            value_start = max(value_start, shared_gemm_free)
+        value_done = value_start + value_sub
+        value_end.append(value_done)
+        value_free = value_done
+        if compute_mode == "shared_mac":
+            shared_gemm_free = value_done
+
+    if normalize_strategy == "full_tile_normalize":
+        all_stats_done = stats_end[-1]
+        for index in range(subtiles):
+            value_start = max(value_free, all_stats_done, hbm_end[index])
+            if compute_mode == "shared_mac":
+                value_start = max(value_start, shared_gemm_free)
+            value_done = value_start + value_sub
+            value_end.append(value_done)
+            value_free = value_done
+            if compute_mode == "shared_mac":
+                shared_gemm_free = value_done
+    elif normalize_strategy != "online_correction":
+        raise ValueError(f"unknown normalize strategy: {normalize_strategy}")
+
+    hbm_exposed_cycles = hbm_end[-1]
+    pipeline_cycles = max(value_end[-1], hbm_exposed_cycles, subtiles * memory_aux_sub)
+    residual_memory_cycles = max(int(row.get("tile_local_sram_cycles", 0)), int(row.get("tile_shared_path_cycles", 0)))
+    tile_service_cycles = max(pipeline_cycles, residual_memory_cycles)
+    layer_cycles = (
+        int(row["qkv_cycles"])
+        + int(row["tile_waves"]) * tile_service_cycles
+        + int(row.get("command_dispatch_cycles", 0))
+        + int(row["cross_tile_reduction_cycles"])
+        + int(row["kv_write_cycles"])
+    )
+    total_cycles = layer_cycles * int(row["layers"])
+    clock_ns = float(row["clock_ns"])
+    latency_us = round(total_cycles * clock_ns / 1000.0, 6)
+    compute_area_multiplier = {
+        "shared_mac": 1.0,
+        "split_mac": 1.0,
+        "dual_mac": 2.0,
+    }[compute_mode]
+    dominant = max(
+        {
+            "pipeline_attention": pipeline_cycles,
+            "hbm_exposed": hbm_exposed_cycles,
+            "local_sram": int(row.get("tile_local_sram_cycles", 0)),
+            "shared_path": int(row.get("tile_shared_path_cycles", 0)),
+            "cross_tile_reduction": int(row["cross_tile_reduction_cycles"]),
+        }.items(),
+        key=lambda item: item[1],
+    )[0]
+    out = dict(row)
+    out.update(
+        {
+            "subtile_pipeline_model": "qk_softmax_value_streaming_v1",
+            "subtile_count": subtiles,
+            "subtile_buffer_count": buffer_count,
+            "prefetch_distance": prefetch_distance,
+            "normalize_strategy": normalize_strategy,
+            "compute_mode": compute_mode,
+            "compute_area_multiplier": compute_area_multiplier,
+            "softmax_latency_per_subtile": softmax_latency_per_subtile,
+            "online_rescale_penalty_cycles": online_rescale_penalty_cycles,
+            "subtile_qk_cycles": qk_sub,
+            "subtile_stats_cycles": stats_sub,
+            "subtile_value_cycles": value_sub,
+            "subtile_hbm_cycles": hbm_sub,
+            "hbm_exposed_cycles": hbm_exposed_cycles,
+            "subtile_aux_memory_cycles": memory_aux_sub,
+            "required_stream_buffer_bytes": buffer_bytes,
+            "available_local_capacity_bytes": local_capacity,
+            "schedule_legal": legal,
+            "pipeline_attention_cycles": pipeline_cycles,
+            "pipeline_residual_memory_cycles": residual_memory_cycles,
+            "tile_attention_cycles": pipeline_cycles,
+            "tile_service_cycles": tile_service_cycles,
+            "tile_memory_cycles": max(int(row["tile_hbm_cycles"]), residual_memory_cycles),
+            "layer_cycles": layer_cycles,
+            "total_cycles": total_cycles,
+            "latency_us": latency_us,
+            "dominant_tile_resource": dominant,
+            "latency_speedup_vs_hbm_closed_source": round(float(row["latency_us"]) / max(1e-9, latency_us), 6),
+            "tile_service_speedup_vs_source": round(
+                float(row["tile_service_cycles"]) / max(1.0, float(tile_service_cycles)),
+                6,
+            ),
+            "hbm_floor_gap_cycles": tile_service_cycles - int(row["tile_hbm_cycles"]),
+        }
+    )
+    return out
+
+
+def _push_top(heap: list[tuple[float, int, JsonDict]], row: JsonDict, *, counter: int, limit: int) -> None:
+    entry = (-float(row["latency_us"]), counter, row)
+    if len(heap) < limit:
+        heapq.heappush(heap, entry)
+    elif entry[0] > heap[0][0]:
+        heapq.heapreplace(heap, entry)
+
+
+def _best_update(target: dict[tuple[Any, ...], JsonDict], keys: tuple[str, ...], row: JsonDict) -> None:
+    key = tuple(row.get(item) for item in keys)
+    current = target.get(key)
+    if current is None or float(row["latency_us"]) < float(current["latency_us"]):
+        target[key] = row
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    source = _load_json(args.hbm_closed_onchip_schedule_json)
+    source_rows = _source_rows(source, limit=args.frontier_row_limit)
+    if not source_rows:
+        raise RuntimeError("no HBM-closed on-chip source rows found")
+
+    generated = 0
+    legal_count = 0
+    best: JsonDict | None = None
+    heap_counter = 0
+    top_heap: list[tuple[float, int, JsonDict]] = []
+    dominance = Counter()
+    legal_by_mode = Counter()
+    best_by_compute_mode: dict[tuple[Any, ...], JsonDict] = {}
+    best_by_normalize_strategy: dict[tuple[Any, ...], JsonDict] = {}
+    best_by_subtile_count: dict[tuple[Any, ...], JsonDict] = {}
+
+    for source_row in source_rows:
+        for subtiles in args.subtile_count:
+            if subtiles > int(source_row["tile_tokens"]):
+                continue
+            for buffer_count in args.subtile_buffer_count:
+                for prefetch_distance in args.prefetch_distance:
+                    for normalize_strategy in args.normalize_strategy:
+                        for compute_mode in args.compute_mode:
+                            for softmax_latency in args.softmax_latency_per_subtile:
+                                for online_penalty in args.online_rescale_penalty_cycles:
+                                    row = _scheduled_pipeline(
+                                        source_row,
+                                        subtiles=subtiles,
+                                        buffer_count=buffer_count,
+                                        prefetch_distance=prefetch_distance,
+                                        normalize_strategy=normalize_strategy,
+                                        compute_mode=compute_mode,
+                                        softmax_latency_per_subtile=softmax_latency,
+                                        online_rescale_penalty_cycles=online_penalty,
+                                    )
+                                    generated += 1
+                                    if not bool(row["schedule_legal"]):
+                                        continue
+                                    legal_count += 1
+                                    dominance[str(row["dominant_tile_resource"])] += 1
+                                    legal_by_mode[str(row["compute_mode"])] += 1
+                                    if best is None or float(row["latency_us"]) < float(best["latency_us"]):
+                                        best = row
+                                    _push_top(top_heap, row, counter=heap_counter, limit=args.top_k)
+                                    heap_counter += 1
+                                    _best_update(best_by_compute_mode, ("compute_mode",), row)
+                                    _best_update(best_by_normalize_strategy, ("normalize_strategy", "compute_mode"), row)
+                                    _best_update(best_by_subtile_count, ("subtile_count", "compute_mode"), row)
+
+    if best is None:
+        raise RuntimeError("no legal sub-tile pipeline schedule rows generated")
+    top_rows = [entry[2] for entry in sorted(top_heap, key=lambda entry: (entry[2]["latency_us"], entry[1]))]
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1",
+        "hbm_closed_onchip_schedule_json": str(args.hbm_closed_onchip_schedule_json),
+        "source_model": source.get("model"),
+        "inputs": {
+            "frontier_row_limit": args.frontier_row_limit,
+            "subtile_count": args.subtile_count,
+            "subtile_buffer_count": args.subtile_buffer_count,
+            "prefetch_distance": args.prefetch_distance,
+            "normalize_strategy": args.normalize_strategy,
+            "compute_mode": args.compute_mode,
+            "softmax_latency_per_subtile": args.softmax_latency_per_subtile,
+            "online_rescale_penalty_cycles": args.online_rescale_penalty_cycles,
+        },
+        "sweep_summary": {
+            "source_rows_used": len(source_rows),
+            "generated_row_count": generated,
+            "legal_row_count": legal_count,
+            "dominant_tile_resource_counts": dict(sorted(dominance.items())),
+            "legal_compute_mode_counts": dict(sorted(legal_by_mode.items())),
+            "best_latency_us": best["latency_us"],
+            "best_latency_speedup_vs_hbm_closed_source": best["latency_speedup_vs_hbm_closed_source"],
+            "best_tile_service_cycles": best["tile_service_cycles"],
+            "best_hbm_floor_gap_cycles": best["hbm_floor_gap_cycles"],
+            "best_compute_mode": best["compute_mode"],
+            "best_normalize_strategy": best["normalize_strategy"],
+        },
+        "best": best,
+        "top_rows": top_rows,
+        "best_by_compute_mode": sorted(best_by_compute_mode.values(), key=lambda row: row["latency_us"])[:100],
+        "best_by_normalize_strategy": sorted(
+            best_by_normalize_strategy.values(),
+            key=lambda row: row["latency_us"],
+        )[:100],
+        "best_by_subtile_count": sorted(best_by_subtile_count.values(), key=lambda row: row["latency_us"])[:100],
+        "assumptions": [
+            "The source row is the measured-SRAM, measured-HBM, HBM-closed on-chip schedule frontier.",
+            "shared_mac keeps QK and V on one measured MAC resource; split_mac partitions the same resource; dual_mac models independent QK and V streams and therefore carries a compute_area_multiplier of 2.",
+            "full_tile_normalize requires all subtile stats before V starts; online_correction allows V to stream after each subtile stats result with an explicit rescale penalty.",
+            "A row is legal only if the required stream buffer fits local capacity and prefetch_distance is less than the available subtile buffer count.",
+            "This is a scheduling feasibility model, not RTL or PPA for the pipelined datapath.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best"]
+    lines = [
+        "# Llama7B Sub-Tile Pipelined Attention Schedule",
+        "",
+        f"- source rows used: `{payload['sweep_summary']['source_rows_used']}`",
+        f"- generated rows: `{payload['sweep_summary']['generated_row_count']}`",
+        f"- legal rows: `{payload['sweep_summary']['legal_row_count']}`",
+        f"- dominant resources: `{payload['sweep_summary']['dominant_tile_resource_counts']}`",
+        "",
+        "## Best",
+        "",
+        "| latency us | speedup | tile service | resource | mode | normalize | subtiles | buffers | prefetch | softmax/sub | rescale | area mult | hbm gap | req buffer |",
+        "|---:|---:|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| {latency_us} | {latency_speedup_vs_hbm_closed_source} | {tile_service_cycles} | "
+        "{dominant_tile_resource} | {compute_mode} | {normalize_strategy} | {subtile_count} | "
+        "{subtile_buffer_count} | {prefetch_distance} | {softmax_latency_per_subtile} | "
+        "{online_rescale_penalty_cycles} | {compute_area_multiplier} | {hbm_floor_gap_cycles} | "
+        "{required_stream_buffer_bytes} |".format(**best),
+        "",
+        "## Best By Compute Mode",
+        "",
+        "| mode | latency us | speedup | tile service | resource | normalize | subtiles | area mult | hbm gap |",
+        "|---|---:|---:|---:|---|---|---:|---:|---:|",
+    ]
+    for row in payload["best_by_compute_mode"]:
+        lines.append(
+            "| {compute_mode} | {latency_us} | {latency_speedup_vs_hbm_closed_source} | "
+            "{tile_service_cycles} | {dominant_tile_resource} | {normalize_strategy} | "
+            "{subtile_count} | {compute_area_multiplier} | {hbm_floor_gap_cycles} |".format(**row)
+        )
+    lines.extend(
+        [
+            "",
+            "## Best By Normalize Strategy",
+            "",
+            "| normalize | mode | latency us | speedup | tile service | subtiles | softmax/sub | rescale |",
+            "|---|---|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in payload["best_by_normalize_strategy"]:
+        lines.append(
+            "| {normalize_strategy} | {compute_mode} | {latency_us} | "
+            "{latency_speedup_vs_hbm_closed_source} | {tile_service_cycles} | {subtile_count} | "
+            "{softmax_latency_per_subtile} | {online_rescale_penalty_cycles} |".format(**row)
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hbm-closed-onchip-schedule-json", type=Path, required=True)
+    parser.add_argument("--frontier-row-limit", type=int, default=48)
+    parser.add_argument("--subtile-count", type=_int_list, default=[1, 2, 4, 8, 16, 32])
+    parser.add_argument("--subtile-buffer-count", type=_int_list, default=[1, 2, 3, 4])
+    parser.add_argument("--prefetch-distance", type=_nonnegative_int_list, default=[0, 1, 2, 3])
+    parser.add_argument("--normalize-strategy", type=_str_list, default=["full_tile_normalize", "online_correction"])
+    parser.add_argument("--compute-mode", type=_str_list, default=["shared_mac", "split_mac", "dual_mac"])
+    parser.add_argument("--softmax-latency-per-subtile", type=_nonnegative_int_list, default=[0, 1, 2, 4])
+    parser.add_argument("--online-rescale-penalty-cycles", type=_nonnegative_int_list, default=[0, 1, 2, 4])
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "out": str(args.out), "out_md": str(args.out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an analytic sub-tile QK/softmax/V pipeline scheduler for the Llama7B attention frontier
- wire the new decoder evidence contract through L2 task generation and result consumption
- add proposal docs and focused generator/consumer tests

## Smoke result
- generated rows: 18432
- legal rows: 6528
- best latency: 1575.373891 us
- best speedup vs HBM-closed source: 1.357672x
- best mode: dual_mac, online_correction, 8 subtiles, 4 buffers, prefetch distance 3
- shared_mac does not improve the frontier; split_mac gives 1.047231x

## Validation
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py
- PYTHONPATH=/tmp/rtlgen-pipelined-attn/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py -q
- python3 scripts/validate_runs.py --skip_eval_queue