### PR TITLE
Add dual-stream attention physical feasibility job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -447,6 +447,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("attention_kv_measured_hbm_service_out", "attention_kv_measured_hbm_service_report"),
     ("attention_kv_hbm_closed_onchip_schedule_out", "attention_kv_hbm_closed_onchip_schedule_report"),
     ("attention_kv_subtile_pipeline_schedule_out", "attention_kv_subtile_pipeline_schedule_report"),
+    ("attention_kv_dual_stream_physical_feasibility_out", "attention_kv_dual_stream_physical_feasibility_report"),
 )
 
 
@@ -614,6 +615,29 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         ):
             if key in best_dict:
                 parts.append(f"{key}={best_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(diagnosis_dict.get("decision") or "dual_stream_physical_feasibility_recorded")
+        parts = [
+            f"Decoder dual-stream physical feasibility evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "best_requested_mode",
+            "best_requested_latency_us",
+            "best_requested_area_fit",
+            "best_requested_logic_slack_um2",
+            "best_requested_compute_area_over_budget_um2",
+            "best_requested_required_compute_density_gain",
+            "best_feasible_mode",
+            "best_feasible_latency_us",
+            "recommended_next_step",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5197,6 +5197,55 @@ def _decoder_attention_kv_subtile_pipeline_schedule_evidence(*, item_id: str) ->
     }
 
 
+def _decoder_attention_kv_dual_stream_physical_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_dual_stream_physical_feasibility__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_dual_stream_physical_feasibility__{item_id}.md"
+    subtile_pipeline = (
+        f"{base}/decoder_attention_kv_subtile_pipeline_schedule__"
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
+    )
+    full_value_tile_metrics = (
+        "runs/designs/activations/"
+        "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/metrics.csv"
+    )
+    softmax_weight_metrics = (
+        "runs/designs/activations/"
+        "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
+    )
+    return {
+        "inputs": {
+            "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
+            "attention_kv_full_value_tile_metrics": full_value_tile_metrics,
+            "attention_kv_softmax_weight_metrics": softmax_weight_metrics,
+            "attention_kv_dual_stream_physical_feasibility_out": out,
+            "attention_kv_dual_stream_physical_feasibility_report": report,
+            "attention_kv_dual_stream_physical_feasibility_scope": (
+                "Apply measured full-value attention tile and softmax-weight-generator PPA to the "
+                "sub-tile pipeline schedule. Report whether the optimistic dual_mac schedule fits "
+                "the existing Llama7B logic budget, how much compute density/area is missing, and "
+                "which area-neutral fallback remains legal."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_dual_stream_physical_feasibility",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py "
+                    f"--subtile-pipeline-json {subtile_pipeline} "
+                    f"--full-value-tile-metrics {full_value_tile_metrics} "
+                    f"--softmax-weight-metrics {softmax_weight_metrics} "
+                    "--frontier-row-limit 8 "
+                    "--buffer-area-um2-per-byte 0.0 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
@@ -6760,6 +6809,7 @@ def _build_payload(
         "decoder_attention_kv_measured_hbm_service",
         "decoder_attention_kv_hbm_closed_onchip_schedule",
         "decoder_attention_kv_subtile_pipeline_schedule",
+        "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
@@ -6902,6 +6952,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_hbm_closed_onchip_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_subtile_pipeline_schedule":
             decoder_evidence = _decoder_attention_kv_subtile_pipeline_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
+            decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":
             decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1560,6 +1560,121 @@ def test_consume_l2_result_frontier_attention_subtile_pipeline_schedule_uses_dec
             assert decision_payload["source_refs"]["decoder_attention_kv_subtile_pipeline_schedule_report"] == report_rel
 
 
+def test_consume_l2_result_frontier_attention_dual_stream_physical_feasibility_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_dual_stream_feasibility_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_dual_stream_feasibility_v1",
+                        "kind": "architecture",
+                        "title": "Attention dual-stream physical feasibility",
+                        "direct_comparison": {
+                            "primary_question": "Does the dual-stream schedule fit the current logic budget?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_dual_stream_physical_feasibility__l2_attention_dual_stream_feasibility_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_dual_stream_physical_feasibility__l2_attention_dual_stream_feasibility_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+                        "diagnosis": {
+                            "decision": "dual_stream_area_blocked",
+                            "best_requested_mode": "dual_mac",
+                            "best_requested_latency_us": 1575.37,
+                            "best_requested_area_fit": False,
+                            "best_requested_logic_slack_um2": -398874400.0,
+                            "best_requested_compute_area_over_budget_um2": 398874400.0,
+                            "best_requested_required_compute_density_gain": 2.011,
+                            "best_feasible_mode": "split_mac",
+                            "best_feasible_latency_us": 2042.38,
+                            "recommended_next_step": "measure a denser dual-stream fused attention datapath",
+                        },
+                        "best_requested": {
+                            "compute_mode": "dual_mac",
+                            "physical_feasible": False,
+                        },
+                        "best_feasible": {
+                            "compute_mode": "split_mac",
+                            "physical_feasible": True,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# dual stream feasibility\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_dual_stream_feasibility",
+                campaign_dir_rel="runs/campaigns/npu/attention_dual_stream_feasibility_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_dual_stream_feasibility_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use physical feasibility pressure to choose the next RTL/PPA target.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_kv_dual_stream_physical_feasibility",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_kv_dual_stream_physical_feasibility_out": evidence_rel,
+                    "attention_kv_dual_stream_physical_feasibility_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "dual_stream_area_blocked"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert assessment["decoder_quality"]["diagnosis"]["best_requested_mode"] == "dual_mac"
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_kv_dual_stream_physical_feasibility"
+            )
+            assert decision_payload["source_refs"]["decoder_attention_kv_dual_stream_physical_feasibility_out"] == evidence_rel
+            assert decision_payload["source_refs"]["decoder_attention_kv_dual_stream_physical_feasibility_report"] == report_rel
+
+
 def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5348,6 +5348,55 @@ def test_generate_l2_campaign_task_adds_attention_subtile_pipeline_schedule_evid
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_dual_stream_physical_feasibility_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_dual_stream_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_kv_dual_stream_physical_feasibility" in command_names
+            assert "attention_kv_subtile_pipeline_schedule" in decoder_inputs
+            assert "attention_kv_full_value_tile_metrics" in decoder_inputs
+            assert "attention_kv_softmax_weight_metrics" in decoder_inputs
+            assert "attention_kv_dual_stream_physical_feasibility_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py" in run
+            assert "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json" in run
+            assert "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/metrics.csv" in run
+            assert "--buffer-area-um2-per-byte 0.0" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_dual_stream_physical_feasibility__"
+                    "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_dual_stream_physical_feasibility_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dual_stream_physical_feasibility_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dual_stream_physical_feasibility_v1",
+  "source_commit": "TBD_AFTER_MERGE",
+  "source_commit_note": "Dispatch should use the merge commit containing the dual-stream physical feasibility estimator and control-plane hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Check whether the optimistic dual_mac sub-tile attention schedule fits the measured Llama7B logic budget.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_dual_stream_physical_feasibility",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_dual_stream_physical_feasibility",
+        "reason": "The result should decide whether dual_mac is physically feasible under the current measured logic budget and quantify the density/area gap if it is not."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_dual_stream_physical_feasibility_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_dual_stream_physical_feasibility_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_dual_stream_physical_feasibility_v1",
+  "created_utc": "2026-06-11T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Physical feasibility of dual-stream Llama7B attention pipeline",
+  "hypothesis": "The sub-tile pipeline sweep selected dual_mac as the fastest Llama7B attention schedule, but that candidate is only useful if its duplicated QK/V compute resources fit the measured 45nm logic budget. This item should convert the optimistic schedule into a budget-aware decision before requesting a larger RTL/PPA target.",
+  "direct_comparison": {
+    "primary_question": "Can the dual_mac sub-tile attention schedule be promoted under the current measured logic budget, or is the area-neutral split_mac fallback the current valid frontier?",
+    "include": [
+      "Consume l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1 as the source schedule.",
+      "Use measured full-value attention tile and softmax-weight-generator metrics for local datapath overhead.",
+      "Check required stream-buffer bytes against the measured local SRAM capacity.",
+      "Report best requested mode, best feasible mode, latency, speedup, logic slack, compute area over budget, required compute density gain, replica shortfall, and clock checks."
+    ],
+    "exclude": [
+      "Do not claim that dual_mac is physically feasible unless the doubled compute area fits the same logic budget.",
+      "Do not re-run OpenROAD PPA in this item.",
+      "Do not change HBM, SRAM, NoC, KV sharing, or numerical-quality assumptions.",
+      "Do not treat optional buffer-area proxy as a replacement for measured SRAM capacity."
+    ],
+    "follow_on_broad_sweep": [
+      "If dual_mac is blocked, evaluate a denser fused dual-stream attention datapath or recompute schedules with fewer replicas.",
+      "If the area-neutral fallback is the only feasible row, keep split_mac as the conservative frontier and move circuit work to compute-density improvements.",
+      "If dual_mac fits, promote it into a measured RTL/PPA wrapper and ready/valid equivalence target."
+    ]
+  },
+  "expected_benefit": [
+    "Prevents an analytic scheduling result from being mistaken for a physically valid architecture point.",
+    "Quantifies the compute-density gap needed to make the faster schedule real.",
+    "Identifies whether the next evaluator time should be spent on dual-stream datapath PPA or on compute-density/replica-count redesign."
+  ],
+  "risks": [
+    "The feasibility model still uses measured constituent blocks rather than a fused placed dual-stream macro.",
+    "The dense compute-array scaling is first-order and should be replaced once a fused datapath PPA exists.",
+    "Clock closure is checked only against existing constituent block metrics."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "dual_stream_physical_feasibility",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_dual_stream_physical_feasibility",
+        "reason": "The result should decide whether dual_mac is physically feasible under the current measured logic budget and quantify the density/area gap if it is not."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_subtile_pipeline_schedule__l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py",
+    "runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/metrics.csv",
+    "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Check physical feasibility of the dual-stream sub-tile attention schedule."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _best_ok_metrics(path: Path) -> JsonDict:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = [row for row in csv.DictReader(handle) if row.get("status") == "ok"]
+    if not rows:
+        raise RuntimeError(f"no status=ok metrics rows in {path}")
+    best = min(
+        rows,
+        key=lambda row: (
+            float(row.get("critical_path_ns") or "inf"),
+            float(row.get("die_area") or "inf"),
+            float(row.get("total_power_mw") or "inf"),
+        ),
+    )
+    return {
+        "metrics_csv": str(path),
+        "critical_path_ns": float(best["critical_path_ns"]),
+        "die_area_um2": float(best["die_area"]),
+        "total_power_mw": float(best["total_power_mw"]),
+        "param_hash": best.get("param_hash", ""),
+        "tag": best.get("tag", ""),
+        "result_path": best.get("result_path", ""),
+    }
+
+
+def _source_rows(payload: JsonDict, *, limit: int) -> list[JsonDict]:
+    rows = list(payload.get("best_by_compute_mode") or [])
+    if isinstance(payload.get("best"), dict):
+        rows.insert(0, payload["best"])
+    deduped: list[JsonDict] = []
+    seen: set[str] = set()
+    for row in rows:
+        key = json.dumps(
+            {
+                "compute_mode": row.get("compute_mode"),
+                "latency_us": row.get("latency_us"),
+                "tile_service_cycles": row.get("tile_service_cycles"),
+                "subtile_count": row.get("subtile_count"),
+                "subtile_buffer_count": row.get("subtile_buffer_count"),
+                "prefetch_distance": row.get("prefetch_distance"),
+                "normalize_strategy": row.get("normalize_strategy"),
+            },
+            sort_keys=True,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(row)
+        if len(deduped) >= limit:
+            break
+    return deduped
+
+
+def _row_with_budget(
+    source_row: JsonDict,
+    *,
+    full_value_tile: JsonDict,
+    softmax_weight: JsonDict,
+    buffer_area_um2_per_byte: float,
+) -> JsonDict:
+    clusters = int(source_row["cluster_count"])
+    compute_multiplier = float(source_row.get("compute_area_multiplier", 1.0))
+    current_compute_area = float(source_row["compute_area_um2"])
+    compute_budget = float(source_row["compute_budget_um2"])
+    current_l1_overhead = float(source_row["measured_l1_overhead_area_um2"])
+    current_local_datapath_area = float(source_row["local_datapath_area_um2"])
+    current_softmax_area = float(source_row["softmax_weight_generator_area_um2"])
+    current_logic_used = float(source_row["logic_area_used_um2"])
+    required_buffer_bytes = int(source_row.get("required_stream_buffer_bytes", source_row.get("tile_local_buffer_bytes", 0)))
+    available_local_capacity = int(source_row.get("available_local_capacity_bytes", source_row.get("local_capacity_bytes_per_cluster", 0)))
+
+    measured_stream_area = float(full_value_tile["die_area_um2"])
+    measured_softmax_area = float(softmax_weight["die_area_um2"])
+    stream_buffer_area = required_buffer_bytes * buffer_area_um2_per_byte
+    selected_local_datapath_area = compute_multiplier * measured_stream_area
+    selected_softmax_area = measured_softmax_area
+    selected_l1_overhead = current_l1_overhead + clusters * (
+        selected_local_datapath_area
+        + selected_softmax_area
+        + stream_buffer_area
+        - current_local_datapath_area
+        - current_softmax_area
+    )
+
+    compute_area_required = current_compute_area * compute_multiplier
+    logic_used_required = current_logic_used + (compute_area_required - current_compute_area) + (
+        selected_l1_overhead - current_l1_overhead
+    )
+    logic_slack_required = compute_budget - logic_used_required
+    compute_area_over_budget = max(0.0, logic_used_required - compute_budget)
+    required_compute_density_gain = (
+        compute_area_required / max(1.0, compute_budget - selected_l1_overhead)
+    )
+    replica_count_budgeted = int(current_compute_area // max(1.0, float(source_row["measured_block_area_um2"])))
+    replica_count_required = int(source_row["compute_replica_count"] * compute_multiplier)
+    replica_shortfall = max(0, replica_count_required - replica_count_budgeted)
+    area_fit = logic_slack_required >= 0.0
+    buffer_fit = required_buffer_bytes <= available_local_capacity
+    feasible = area_fit and buffer_fit
+
+    if feasible:
+        adjusted_latency_us = float(source_row["latency_us"])
+        adjusted_tile_service_cycles = int(source_row["tile_service_cycles"])
+        adjusted_speedup = float(source_row["latency_speedup_vs_hbm_closed_source"])
+    else:
+        adjusted_latency_us = None
+        adjusted_tile_service_cycles = None
+        adjusted_speedup = None
+        if compute_multiplier > 1.0:
+            # If the doubled stream cannot fit, the nearest already-measured same-area schedule is split_mac.
+            adjusted_latency_us = None
+
+    out = dict(source_row)
+    out.update(
+        {
+            "dual_stream_physical_model": "measured_full_value_tile_budget_v1",
+            "measured_full_value_tile_metrics_csv": full_value_tile["metrics_csv"],
+            "measured_full_value_tile_area_um2": measured_stream_area,
+            "measured_full_value_tile_clock_ns": full_value_tile["critical_path_ns"],
+            "measured_full_value_tile_power_mw": full_value_tile["total_power_mw"],
+            "measured_softmax_weight_metrics_csv": softmax_weight["metrics_csv"],
+            "measured_softmax_weight_area_um2": measured_softmax_area,
+            "measured_softmax_weight_clock_ns": softmax_weight["critical_path_ns"],
+            "measured_softmax_weight_power_mw": softmax_weight["total_power_mw"],
+            "stream_buffer_area_um2_per_byte": buffer_area_um2_per_byte,
+            "stream_buffer_area_um2_per_cluster": round(stream_buffer_area, 6),
+            "selected_local_datapath_area_um2_per_cluster": round(selected_local_datapath_area, 6),
+            "selected_l1_overhead_area_um2": round(selected_l1_overhead, 6),
+            "compute_area_required_um2": round(compute_area_required, 6),
+            "compute_area_multiplier_required": compute_multiplier,
+            "logic_area_used_required_um2": round(logic_used_required, 6),
+            "logic_area_slack_required_um2": round(logic_slack_required, 6),
+            "compute_area_over_budget_um2": round(compute_area_over_budget, 6),
+            "required_compute_density_gain": round(required_compute_density_gain, 6),
+            "replica_count_required": replica_count_required,
+            "replica_count_budgeted_at_current_compute_area": replica_count_budgeted,
+            "replica_count_shortfall": replica_shortfall,
+            "local_datapath_clock_ok": float(full_value_tile["critical_path_ns"]) <= float(source_row["clock_ns"]),
+            "softmax_weight_clock_ok": float(softmax_weight["critical_path_ns"]) <= float(source_row["clock_ns"]),
+            "area_fit": area_fit,
+            "buffer_fit": buffer_fit,
+            "physical_feasible": feasible,
+            "adjusted_latency_us_if_feasible": adjusted_latency_us,
+            "adjusted_tile_service_cycles_if_feasible": adjusted_tile_service_cycles,
+            "adjusted_speedup_if_feasible": adjusted_speedup,
+        }
+    )
+    return out
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    source = _load_json(args.subtile_pipeline_json)
+    source_rows = _source_rows(source, limit=args.frontier_row_limit)
+    full_value_tile = _best_ok_metrics(args.full_value_tile_metrics)
+    softmax_weight = _best_ok_metrics(args.softmax_weight_metrics)
+    rows = [
+        _row_with_budget(
+            row,
+            full_value_tile=full_value_tile,
+            softmax_weight=softmax_weight,
+            buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
+        )
+        for row in source_rows
+    ]
+    feasible_rows = [row for row in rows if row["physical_feasible"]]
+    best_feasible = min(feasible_rows, key=lambda row: float(row["latency_us"])) if feasible_rows else None
+    best_requested = min(rows, key=lambda row: float(row["latency_us"]))
+    best_area_fit = min(
+        (row for row in rows if row["area_fit"]),
+        key=lambda row: float(row["latency_us"]),
+        default=None,
+    )
+    decision = "dual_stream_feasible" if best_feasible and best_feasible.get("compute_mode") == "dual_mac" else "dual_stream_area_blocked"
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+        "subtile_pipeline_json": str(args.subtile_pipeline_json),
+        "source_model": source.get("model"),
+        "inputs": {
+            "frontier_row_limit": args.frontier_row_limit,
+            "full_value_tile_metrics": str(args.full_value_tile_metrics),
+            "softmax_weight_metrics": str(args.softmax_weight_metrics),
+            "buffer_area_um2_per_byte": args.buffer_area_um2_per_byte,
+        },
+        "diagnosis": {
+            "decision": decision,
+            "source_rows_used": len(source_rows),
+            "physical_feasible_rows": len(feasible_rows),
+            "best_requested_mode": best_requested.get("compute_mode"),
+            "best_requested_latency_us": best_requested.get("latency_us"),
+            "best_requested_area_fit": best_requested.get("area_fit"),
+            "best_requested_logic_slack_um2": best_requested.get("logic_area_slack_required_um2"),
+            "best_requested_compute_area_over_budget_um2": best_requested.get("compute_area_over_budget_um2"),
+            "best_requested_required_compute_density_gain": best_requested.get("required_compute_density_gain"),
+            "best_feasible_mode": best_feasible.get("compute_mode") if best_feasible else None,
+            "best_feasible_latency_us": best_feasible.get("latency_us") if best_feasible else None,
+            "best_area_fit_mode": best_area_fit.get("compute_mode") if best_area_fit else None,
+            "best_area_fit_latency_us": best_area_fit.get("latency_us") if best_area_fit else None,
+            "recommended_next_step": (
+                "measure a denser dual-stream fused attention datapath or reduce compute replicas before promoting dual_mac"
+                if decision == "dual_stream_area_blocked"
+                else "promote dual-stream schedule into a measured RTL/PPA wrapper"
+            ),
+        },
+        "best_requested": best_requested,
+        "best_feasible": best_feasible,
+        "best_area_fit": best_area_fit,
+        "rows": rows,
+        "assumptions": [
+            "The dual_mac schedule requires an explicit compute_area_multiplier from the sub-tile scheduler.",
+            "Measured full-value tile and softmax-weight generator PPA are used for local datapath overhead only.",
+            "The dense GEMM compute array is treated as already packed into the current logic budget; extra dual-stream compute must fit that same budget to be feasible.",
+            "Buffer capacity is checked against measured local SRAM bytes; an optional buffer-area proxy can be added for sensitivity but defaults to zero to avoid double-counting measured local SRAM.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    diag = payload["diagnosis"]
+    best = payload["best_requested"]
+    lines = [
+        "# Llama7B Dual-Stream Physical Feasibility",
+        "",
+        f"- decision: `{diag['decision']}`",
+        f"- source rows used: `{diag['source_rows_used']}`",
+        f"- physical feasible rows: `{diag['physical_feasible_rows']}`",
+        f"- best requested mode: `{diag['best_requested_mode']}`",
+        f"- best requested latency us: `{diag['best_requested_latency_us']}`",
+        f"- best requested logic slack um2: `{diag['best_requested_logic_slack_um2']}`",
+        f"- best requested compute area over budget um2: `{diag['best_requested_compute_area_over_budget_um2']}`",
+        f"- best requested required compute density gain: `{diag['best_requested_required_compute_density_gain']}`",
+        f"- recommended next step: `{diag['recommended_next_step']}`",
+        "",
+        "## Best Requested",
+        "",
+        "| mode | latency us | speedup | area fit | buffer fit | logic slack um2 | area over budget | density gain | required replicas | budget replicas | req buffer bytes |",
+        "|---|---:|---:|---|---|---:|---:|---:|---:|---:|---:|",
+        "| {compute_mode} | {latency_us} | {latency_speedup_vs_hbm_closed_source} | {area_fit} | "
+        "{buffer_fit} | {logic_area_slack_required_um2} | {compute_area_over_budget_um2} | "
+        "{required_compute_density_gain} | {replica_count_required} | "
+        "{replica_count_budgeted_at_current_compute_area} | {required_stream_buffer_bytes} |".format(**best),
+        "",
+        "## Rows",
+        "",
+        "| mode | latency us | area fit | feasible | logic slack um2 | local datapath/cluster | compute area required |",
+        "|---|---:|---|---|---:|---:|---:|",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {compute_mode} | {latency_us} | {area_fit} | {physical_feasible} | "
+            "{logic_area_slack_required_um2} | {selected_local_datapath_area_um2_per_cluster} | "
+            "{compute_area_required_um2} |".format(**row)
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--subtile-pipeline-json", type=Path, required=True)
+    parser.add_argument("--full-value-tile-metrics", type=Path, required=True)
+    parser.add_argument("--softmax-weight-metrics", type=Path, required=True)
+    parser.add_argument("--frontier-row-limit", type=int, default=8)
+    parser.add_argument("--buffer-area-um2-per-byte", type=float, default=0.0)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "out": str(args.out), "out_md": str(args.out_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an L2 estimator that turns the sub-tile pipeline dual_mac result into a physical budget check
- wire the estimator into l2 task generation/result consumption and proposal metadata
- add regression coverage for task generation and evidence consumption

## Local result
Smoke run on the merged subtile pipeline artifact reports decision=dual_stream_area_blocked. The optimistic dual_mac row has latency 1575.373891 us, but needs about 398874400 um2 more logic area and a 2.011289x compute-density gain. The area-neutral feasible fallback is split_mac at 2042.378179 us.

## Tests
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py
- PYTHONPATH=/tmp/rtlgen-dual-stream-attn/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py -q
- python3 scripts/validate_runs.py --skip_eval_queue