### PR TITLE
Add Llama7B attention mixed-precision quality gate

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -448,6 +448,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("attention_kv_hbm_closed_onchip_schedule_out", "attention_kv_hbm_closed_onchip_schedule_report"),
     ("attention_kv_subtile_pipeline_schedule_out", "attention_kv_subtile_pipeline_schedule_report"),
     ("attention_kv_dual_stream_physical_feasibility_out", "attention_kv_dual_stream_physical_feasibility_report"),
+    ("attention_mixed_precision_quality_out", "attention_mixed_precision_quality_report"),
 )
 
 
@@ -634,6 +635,28 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "best_requested_required_compute_density_gain",
             "best_feasible_mode",
             "best_feasible_latency_us",
+            "recommended_next_step",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_mixed_precision_quality_llama7b_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(diagnosis_dict.get("decision") or "mixed_precision_quality_recorded")
+        parts = [
+            f"Decoder attention mixed-precision quality evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "best_quality_candidate",
+            "best_quality_decision",
+            "best_low_cost_candidate",
+            "best_low_cost_decision",
+            "passing_candidate_count",
+            "borderline_candidate_count",
+            "dual_stream_required_compute_density_gain",
             "recommended_next_step",
         ):
             if key in diagnosis_dict:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5246,6 +5246,47 @@ def _decoder_attention_kv_dual_stream_physical_feasibility_evidence(*, item_id: 
     }
 
 
+def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.md"
+    dual_stream_feasibility = (
+        f"{base}/decoder_attention_kv_dual_stream_physical_feasibility__"
+        "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_dual_stream_physical_feasibility": dual_stream_feasibility,
+            "attention_mixed_precision_quality_out": out,
+            "attention_mixed_precision_quality_report": report,
+            "attention_mixed_precision_quality_scope": (
+                "Evaluate Llama7B-shape native-GQA attention sensitivity to mixed-precision Q/K/V, "
+                "dot-accumulator, score, and softmax-weight formats before promoting lower-area "
+                "attention compute primitives. This is a proxy quality gate, not final Llama7B perplexity."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_mixed_precision_quality",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py "
+                    f"--dual-stream-feasibility {dual_stream_feasibility} "
+                    "--attention-heads 32 "
+                    "--kv-heads 4 "
+                    "--head-dim 128 "
+                    "--sequence-length-list 64,128 "
+                    "--regime-list native_correlated_queries,native_retrieval,native_low_margin,native_random "
+                    "--seed-count 1 "
+                    "--candidate-spec-list q8:k8:v8:a24:s24:w16,q8:k8:v8:a20:s24:w16,q8:k8:v8:a24:s16:w12,q6:k8:v8:a24:s24:w16,q8:k8:v6:a24:s24:w16 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
@@ -6810,6 +6851,7 @@ def _build_payload(
         "decoder_attention_kv_hbm_closed_onchip_schedule",
         "decoder_attention_kv_subtile_pipeline_schedule",
         "decoder_attention_kv_dual_stream_physical_feasibility",
+        "decoder_attention_mixed_precision_quality",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
@@ -6954,6 +6996,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_subtile_pipeline_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":
+            decoder_evidence = _decoder_attention_mixed_precision_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":
             decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1675,6 +1675,113 @@ def test_consume_l2_result_frontier_attention_dual_stream_physical_feasibility_u
             assert decision_payload["source_refs"]["decoder_attention_kv_dual_stream_physical_feasibility_report"] == report_rel
 
 
+def test_consume_l2_result_frontier_attention_mixed_precision_quality_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_mixed_precision_quality_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_mixed_precision_quality_v1",
+                        "kind": "architecture",
+                        "title": "Attention mixed precision quality",
+                        "direct_comparison": {
+                            "primary_question": "Which mixed-precision attention candidates pass the proxy?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_precision_quality__l2_attention_mixed_precision_quality_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_precision_quality__l2_attention_mixed_precision_quality_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_mixed_precision_quality_llama7b_v1",
+                        "diagnosis": {
+                            "decision": "mixed_precision_quality_candidate_found",
+                            "best_quality_candidate": "q8_k8_v8_a24_s24_w16",
+                            "best_quality_decision": "mixed_precision_proxy_pass",
+                            "best_low_cost_candidate": "q8_k8_v6_a24_s24_w16",
+                            "best_low_cost_decision": "mixed_precision_proxy_pass",
+                            "passing_candidate_count": 3,
+                            "borderline_candidate_count": 1,
+                            "dual_stream_required_compute_density_gain": 2.011289,
+                            "recommended_next_step": "run PPA for the lowest-cost passing candidate",
+                        },
+                        "best_low_cost_candidate": {
+                            "candidate_id": "q8_k8_v6_a24_s24_w16",
+                            "decision": "mixed_precision_proxy_pass",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# mixed precision quality\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_mixed_precision_quality",
+                campaign_dir_rel="runs/campaigns/npu/attention_mixed_precision_quality_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_mixed_precision_quality_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use mixed-precision quality pressure to choose the next PPA target.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_mixed_precision_quality",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_mixed_precision_quality_out": evidence_rel,
+                    "attention_mixed_precision_quality_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "mixed_precision_quality_candidate_found"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert assessment["decoder_quality"]["diagnosis"]["best_low_cost_candidate"] == "q8_k8_v6_a24_s24_w16"
+            assert decision_payload["evaluation_record"]["abstraction_layer"] == "decoder_attention_mixed_precision_quality"
+            assert decision_payload["source_refs"]["decoder_attention_mixed_precision_quality_out"] == evidence_rel
+            assert decision_payload["source_refs"]["decoder_attention_mixed_precision_quality_report"] == report_rel
+
+
 def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5397,6 +5397,53 @@ def test_generate_l2_campaign_task_adds_attention_dual_stream_physical_feasibili
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_mixed_precision_quality",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_mixed_precision_quality" in command_names
+            assert "attention_kv_dual_stream_physical_feasibility" in decoder_inputs
+            assert "attention_mixed_precision_quality_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_mixed_precision_quality.py" in run
+            assert "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1.json" in run
+            assert "--candidate-spec-list q8:k8:v8:a24:s24:w16" in run
+            assert "q6:k8:v8:a24:s24:w16" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_mixed_precision_quality__"
+                    "l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_precision_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_precision_quality_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+  "source_commit": "TBD_AFTER_MERGE",
+  "source_commit_note": "Dispatch should use the merge commit containing the mixed-precision attention quality estimator and control-plane hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Screen mixed-precision attention arithmetic candidates against a Llama7B-shape quality proxy before PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_precision_quality",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the proxy-passing mixed-precision candidates to decide the next attention compute PPA target and the required follow-up model-quality gate."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_precision_quality_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_precision_quality_llama7b_v1/proposal.json
@@ -1,0 +1,72 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+  "created_utc": "2026-06-11T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_mixed_precision_quality",
+  "title": "Llama7B attention mixed-precision quality gate",
+  "hypothesis": "The dual-stream attention schedule is area-blocked under the current FP16 dense compute budget, so a lower-area mixed-precision compute primitive is only worth measuring if Llama7B-shape attention quality remains stable for the candidate Q/K/V, accumulator, score, and softmax-weight precisions.",
+  "direct_comparison": {
+    "primary_question": "Which mixed-precision attention arithmetic candidates are safe enough to become the next RTL/PPA target for the Llama7B frontier?",
+    "include": [
+      "Use the merged dual-stream physical-feasibility result as the hardware pressure input.",
+      "Use Llama7B-shape native-GQA dimensions: 32 attention heads, 4 KV heads, GQA8, and head_dim 128.",
+      "Sweep Q/K/V operand bits, fixed-width dot accumulator bits, score/logit precision, and softmax-weight precision.",
+      "Evaluate native correlated-query, retrieval, low-margin, and random regimes.",
+      "Report top-1 match, retrieval hit on retrieval-like regimes, KL divergence, output cosine, and RMSE.",
+      "Select the lowest-cost proxy-passing candidate and keep lower-bit controls as negative evidence."
+    ],
+    "exclude": [
+      "Do not claim final Llama7B perplexity or task accuracy.",
+      "Do not run Hugging Face 7B inference in this item.",
+      "Do not promote a mixed-precision circuit without a later RTL/PPA measurement and model-native quality gate.",
+      "Do not change GQA/KV-sharing quality assumptions."
+    ],
+    "follow_on_broad_sweep": [
+      "If Q8/K8/V6 or Q8/K8/V8 passes, request an L1/L2 PPA target for an attention-specific mixed-precision compute primitive.",
+      "If only borderline candidates pass, run a larger quality proxy or model-native checkpoint validation before PPA.",
+      "If all low-precision candidates fail, retreat to split_mac or pursue compute-density improvements that preserve FP16/BF16 semantics."
+    ]
+  },
+  "expected_benefit": [
+    "Links the mixed-precision density idea to an explicit Llama7B-shape quality gate.",
+    "Prevents lower-area compute from being promoted solely on PPA.",
+    "Identifies whether V precision, accumulator width, or score/weight precision is the first quality-sensitive point."
+  ],
+  "risks": [
+    "Synthetic Llama7B-shape attention proxy may not capture full model perplexity or long-context retrieval behavior.",
+    "The selected lowest-cost candidate still needs a real circuit and model-native validation.",
+    "One-seed, short-sequence defaults are intended for fast screening, not final acceptance."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Screen mixed-precision attention arithmetic candidates against a Llama7B-shape quality proxy before PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_precision_quality",
+      "cost_class": "low",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the proxy-passing mixed-precision candidates to decide the next attention compute PPA target and the required follow-up model-quality gate."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dual_stream_physical_feasibility__l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_native_gqa_proxy.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py
+++ b/npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Proxy-test mixed-precision attention arithmetic for the Llama7B frontier."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+Vector = list[float]
+Matrix = list[Vector]
+
+
+@dataclass(frozen=True)
+class Candidate:
+    candidate_id: str
+    q_bits: int
+    k_bits: int
+    v_bits: int
+    acc_bits: int
+    score_bits: int
+    weight_bits: int
+
+
+def _int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items or any(item <= 0 for item in items):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return items
+
+
+def _str_list(value: str) -> list[str]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated strings")
+    return items
+
+
+def _dot(a: Vector, b: Vector) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def _cosine(a: Vector, b: Vector) -> float:
+    aa = math.sqrt(max(0.0, _dot(a, a)))
+    bb = math.sqrt(max(0.0, _dot(b, b)))
+    if aa == 0.0 or bb == 0.0:
+        return 1.0 if aa == bb else 0.0
+    return _dot(a, b) / (aa * bb)
+
+
+def _rmse(a: Vector, b: Vector) -> float:
+    if not a:
+        return 0.0
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)) / len(a))
+
+
+def _softmax(logits: Vector) -> Vector:
+    top = max(logits)
+    exps = [math.exp(min(80.0, value - top)) for value in logits]
+    denom = sum(exps)
+    return [value / denom for value in exps]
+
+
+def _kl_divergence(reference: Vector, candidate: Vector) -> float:
+    eps = 1e-12
+    return sum(p * math.log(max(eps, p) / max(eps, q)) for p, q in zip(reference, candidate))
+
+
+def _weighted_sum(weights: Vector, values: Matrix) -> Vector:
+    if not values:
+        return []
+    out = [0.0 for _ in values[0]]
+    for weight, vector in zip(weights, values):
+        for index, value in enumerate(vector):
+            out[index] += weight * value
+    return out
+
+
+def _quantize_symmetric(vector: Vector, bits: int) -> tuple[list[int], float]:
+    if bits >= 16:
+        return [int(round(value * 1024.0)) for value in vector], 1.0 / 1024.0
+    levels = (1 << (bits - 1)) - 1
+    max_abs = max((abs(value) for value in vector), default=0.0)
+    if max_abs == 0.0:
+        return [0 for _ in vector], 1.0
+    scale = max_abs / levels
+    return [max(-levels, min(levels, int(round(value / scale)))) for value in vector], scale
+
+
+def _dequantize(qvector: list[int], scale: float) -> Vector:
+    return [value * scale for value in qvector]
+
+
+def _quantize_unsigned_probability(weights: Vector, bits: int) -> Vector:
+    if bits >= 16:
+        return list(weights)
+    levels = (1 << bits) - 1
+    quantized = [max(0, min(levels, int(round(weight * levels)))) for weight in weights]
+    denom = sum(quantized)
+    if denom <= 0:
+        return list(weights)
+    return [value / denom for value in quantized]
+
+
+def _quantize_vector_symmetric_float(vector: Vector, bits: int) -> Vector:
+    qvector, scale = _quantize_symmetric(vector, bits)
+    return _dequantize(qvector, scale)
+
+
+def _quantize_logits(logits: Vector, bits: int) -> Vector:
+    if bits >= 24:
+        return list(logits)
+    qvector, scale = _quantize_symmetric(logits, bits)
+    return _dequantize(qvector, scale)
+
+
+def _candidate_dot_from_quantized_query(q_int: list[int], q_scale: float, key: Vector, candidate: Candidate) -> float:
+    k_int, k_scale = _quantize_symmetric(key, candidate.k_bits)
+    acc = sum(q * k for q, k in zip(q_int, k_int))
+    signed_max = (1 << (candidate.acc_bits - 1)) - 1
+    signed_min = -(1 << (candidate.acc_bits - 1))
+    saturated = max(signed_min, min(signed_max, acc))
+    return saturated * q_scale * k_scale
+
+
+def _generate_native_gqa_case(
+    *,
+    rng: random.Random,
+    regime: str,
+    attention_heads: int,
+    kv_heads: int,
+    sequence_length: int,
+    head_dim: int,
+) -> tuple[list[Matrix], list[Matrix], list[Vector], list[int]]:
+    if attention_heads % kv_heads != 0:
+        raise ValueError("attention_heads must be divisible by kv_heads")
+    group_size = attention_heads // kv_heads
+    group_keys = [
+        [[rng.gauss(0.0, 1.0) for _ in range(head_dim)] for _ in range(sequence_length)]
+        for _ in range(kv_heads)
+    ]
+    group_values = [
+        [[rng.gauss(0.0, 1.0) for _ in range(head_dim)] for _ in range(sequence_length)]
+        for _ in range(kv_heads)
+    ]
+    keys_by_head: list[Matrix] = []
+    values_by_head: list[Matrix] = []
+    queries: list[Vector] = []
+    targets: list[int] = []
+    for head in range(attention_heads):
+        group = min(kv_heads - 1, head // group_size)
+        keys = group_keys[group]
+        values = group_values[group]
+        if regime == "native_retrieval":
+            target = (31 * head + 7 * group + 5) % sequence_length
+            query = [2.2 * value + rng.gauss(0.0, 0.10) for value in keys[target]]
+            values[target] = [3.0 if index == (head % head_dim) else 0.0 for index in range(head_dim)]
+        elif regime == "native_low_margin":
+            target = (19 * head + 11 * group + 3) % sequence_length
+            distractor = (target + max(1, sequence_length // 7)) % sequence_length
+            query = [
+                0.58 * keys[target][index] + 0.52 * keys[distractor][index] + rng.gauss(0.0, 0.12)
+                for index in range(head_dim)
+            ]
+        elif regime == "native_correlated_queries":
+            target = (17 * head + 13 * group) % sequence_length
+            query = [value + rng.gauss(0.0, 0.08) for value in keys[target]]
+        elif regime == "native_random":
+            target = (23 * head + 3 * group + 11) % sequence_length
+            query = [rng.gauss(0.0, 1.0) for _ in range(head_dim)]
+        else:
+            raise ValueError(f"unsupported regime: {regime}")
+        keys_by_head.append(keys)
+        values_by_head.append(values)
+        queries.append(query)
+        targets.append(target)
+    return keys_by_head, values_by_head, queries, targets
+
+
+def _reference_attention(keys: Matrix, values: Matrix, query: Vector, target: int) -> JsonDict:
+    scale = 1.0 / math.sqrt(len(query))
+    logits = [_dot(query, key) * scale for key in keys]
+    weights = _softmax(logits)
+    return {
+        "top1": max(range(len(weights)), key=lambda index: weights[index]),
+        "target": target,
+        "weights": weights,
+        "output": _weighted_sum(weights, values),
+    }
+
+
+def _candidate_attention(
+    keys: Matrix,
+    quantized_values: Matrix,
+    query: Vector,
+    target: int,
+    candidate: Candidate,
+) -> JsonDict:
+    scale = 1.0 / math.sqrt(len(query))
+    q_int, q_scale = _quantize_symmetric(query, candidate.q_bits)
+    logits = [_candidate_dot_from_quantized_query(q_int, q_scale, key, candidate) * scale for key in keys]
+    logits = _quantize_logits(logits, candidate.score_bits)
+    weights = _softmax(logits)
+    weights = _quantize_unsigned_probability(weights, candidate.weight_bits)
+    return {
+        "top1": max(range(len(weights)), key=lambda index: weights[index]),
+        "target": target,
+        "weights": weights,
+        "output": _weighted_sum(weights, quantized_values),
+    }
+
+
+def _parse_candidate_spec(spec: str) -> Candidate:
+    values: dict[str, int] = {}
+    for part in spec.split(":"):
+        if len(part) < 2:
+            raise ValueError(f"bad candidate spec part {part!r} in {spec!r}")
+        key = part[0]
+        value = int(part[1:])
+        values[key] = value
+    required = {"q", "k", "v", "a", "s", "w"}
+    missing = required - set(values)
+    if missing:
+        raise ValueError(f"candidate spec {spec!r} missing {sorted(missing)}")
+    return Candidate(
+        candidate_id=spec.replace(":", "_"),
+        q_bits=values["q"],
+        k_bits=values["k"],
+        v_bits=values["v"],
+        acc_bits=values["a"],
+        score_bits=values["s"],
+        weight_bits=values["w"],
+    )
+
+
+def _summarize(rows: list[JsonDict]) -> JsonDict:
+    out: JsonDict = {"sample_count": len(rows)}
+    for key in ("top1_match", "retrieval_hit", "kl_divergence", "output_cosine", "output_rmse"):
+        if key == "retrieval_hit":
+            source_rows = [
+                row for row in rows if row.get("regime") in {"native_retrieval", "native_correlated_queries"}
+            ]
+        else:
+            source_rows = rows
+        values = [float(row[key]) for row in source_rows]
+        out[f"mean_{key}"] = round(sum(values) / len(values), 6) if values else 0.0
+        out[f"min_{key}"] = round(min(values), 6) if values else 0.0
+        out[f"max_{key}"] = round(max(values), 6) if values else 0.0
+    return out
+
+
+def _decision(summary: JsonDict) -> str:
+    if (
+        float(summary["mean_top1_match"]) >= 0.995
+        and float(summary["mean_retrieval_hit"]) >= 0.995
+        and float(summary["mean_output_cosine"]) >= 0.999
+        and float(summary["max_kl_divergence"]) <= 0.02
+    ):
+        return "mixed_precision_proxy_pass"
+    if (
+        float(summary["mean_top1_match"]) >= 0.99
+        and float(summary["mean_retrieval_hit"]) >= 0.99
+        and float(summary["mean_output_cosine"]) >= 0.995
+    ):
+        return "mixed_precision_borderline"
+    return "mixed_precision_risky"
+
+
+def _candidate_cost_key(row: JsonDict) -> tuple[int, int, int, int, int, int]:
+    return (
+        int(row["q_bits"]) + int(row["k_bits"]) + int(row["v_bits"]),
+        int(row["acc_bits"]),
+        int(row["score_bits"]),
+        int(row["weight_bits"]),
+        int(row["q_bits"]),
+        int(row["v_bits"]),
+    )
+
+
+def build_report(
+    *,
+    dual_stream_feasibility: JsonDict | None,
+    attention_heads: int,
+    kv_heads: int,
+    head_dim: int,
+    sequence_length_list: list[int],
+    regime_list: list[str],
+    seed_count: int,
+    candidate_specs: list[str],
+) -> JsonDict:
+    candidates = [_parse_candidate_spec(spec) for spec in candidate_specs]
+    metric_rows: list[JsonDict] = []
+    for sequence_length in sequence_length_list:
+        for regime in regime_list:
+            for seed in range(seed_count):
+                rng = random.Random(
+                    0xA771000
+                    + sequence_length * 131
+                    + seed * 17
+                    + len(regime) * 19
+                    + attention_heads * 3
+                    + kv_heads * 5
+                    + head_dim
+                )
+                keys_by_head, values_by_head, queries, targets = _generate_native_gqa_case(
+                    rng=rng,
+                    regime=regime,
+                    attention_heads=attention_heads,
+                    kv_heads=kv_heads,
+                    sequence_length=sequence_length,
+                    head_dim=head_dim,
+                )
+                references = [
+                    _reference_attention(keys_by_head[head], values_by_head[head], queries[head], targets[head])
+                    for head in range(attention_heads)
+                ]
+                for candidate in candidates:
+                    quantized_values_by_head = [
+                        [_quantize_vector_symmetric_float(value, candidate.v_bits) for value in values_by_head[head]]
+                        for head in range(attention_heads)
+                    ]
+                    for head in range(attention_heads):
+                        cand = _candidate_attention(
+                            keys_by_head[head],
+                            quantized_values_by_head[head],
+                            queries[head],
+                            targets[head],
+                            candidate,
+                        )
+                        ref = references[head]
+                        metric_rows.append(
+                            {
+                                "candidate_id": candidate.candidate_id,
+                                "q_bits": candidate.q_bits,
+                                "k_bits": candidate.k_bits,
+                                "v_bits": candidate.v_bits,
+                                "acc_bits": candidate.acc_bits,
+                                "score_bits": candidate.score_bits,
+                                "weight_bits": candidate.weight_bits,
+                                "sequence_length": sequence_length,
+                                "regime": regime,
+                                "seed": seed,
+                                "head": head,
+                                "top1_match": 1.0 if cand["top1"] == ref["top1"] else 0.0,
+                                "retrieval_hit": 1.0 if cand["top1"] == ref["target"] else 0.0,
+                                "kl_divergence": _kl_divergence(ref["weights"], cand["weights"]),
+                                "output_cosine": _cosine(ref["output"], cand["output"]),
+                                "output_rmse": _rmse(ref["output"], cand["output"]),
+                            }
+                        )
+
+    candidate_summary: list[JsonDict] = []
+    for candidate in candidates:
+        rows = [row for row in metric_rows if row["candidate_id"] == candidate.candidate_id]
+        summary = _summarize(rows)
+        summary.update(
+            {
+                "candidate_id": candidate.candidate_id,
+                "q_bits": candidate.q_bits,
+                "k_bits": candidate.k_bits,
+                "v_bits": candidate.v_bits,
+                "acc_bits": candidate.acc_bits,
+                "score_bits": candidate.score_bits,
+                "weight_bits": candidate.weight_bits,
+                "decision": _decision(summary),
+            }
+        )
+        candidate_summary.append(summary)
+
+    regime_summary: list[JsonDict] = []
+    for candidate in candidates:
+        for regime in regime_list:
+            rows = [
+                row
+                for row in metric_rows
+                if row["candidate_id"] == candidate.candidate_id and row["regime"] == regime
+            ]
+            summary = _summarize(rows)
+            summary.update({"candidate_id": candidate.candidate_id, "regime": regime, "decision": _decision(summary)})
+            regime_summary.append(summary)
+
+    passing = [row for row in candidate_summary if row["decision"] == "mixed_precision_proxy_pass"]
+    borderline = [row for row in candidate_summary if row["decision"] == "mixed_precision_borderline"]
+    best_quality = max(
+        candidate_summary,
+        key=lambda row: (
+            float(row["mean_top1_match"]),
+            float(row["mean_retrieval_hit"]),
+            float(row["mean_output_cosine"]),
+            -float(row["mean_kl_divergence"]),
+        ),
+    )
+    best_low_cost_pass = min(passing, key=_candidate_cost_key) if passing else None
+    best_low_cost_candidate = best_low_cost_pass or (min(borderline, key=_candidate_cost_key) if borderline else None)
+    dual_diag = (dual_stream_feasibility or {}).get("diagnosis") or {}
+    diagnosis = {
+        "decision": (
+            "mixed_precision_quality_candidate_found"
+            if best_low_cost_pass
+            else "mixed_precision_quality_borderline"
+            if best_low_cost_candidate
+            else "mixed_precision_quality_blocked"
+        ),
+        "best_quality_candidate": best_quality["candidate_id"],
+        "best_quality_decision": best_quality["decision"],
+        "best_low_cost_candidate": best_low_cost_candidate.get("candidate_id") if best_low_cost_candidate else None,
+        "best_low_cost_decision": best_low_cost_candidate.get("decision") if best_low_cost_candidate else None,
+        "passing_candidate_count": len(passing),
+        "borderline_candidate_count": len(borderline),
+        "dual_stream_required_compute_density_gain": dual_diag.get("best_requested_required_compute_density_gain"),
+        "recommended_next_step": (
+            "run PPA for the lowest-cost passing mixed-precision attention compute primitive and keep a real-checkpoint Llama-class quality gate before promotion"
+            if best_low_cost_pass
+            else "do not promote lower precision compute yet; either use the borderline candidate only as a PPA lower bound or expand quality/model-native evaluation"
+            if best_low_cost_candidate
+            else "hold mixed-precision compute promotion and test safer precision or QAT/model-native recovery"
+        ),
+    }
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_mixed_precision_quality_llama7b_v1",
+        "inputs": {
+            "dual_stream_feasibility_model": (dual_stream_feasibility or {}).get("model", ""),
+            "attention_heads": attention_heads,
+            "kv_heads": kv_heads,
+            "gqa_group_size": attention_heads // kv_heads,
+            "head_dim": head_dim,
+            "sequence_length_list": sequence_length_list,
+            "regime_list": regime_list,
+            "seed_count": seed_count,
+            "candidate_specs": candidate_specs,
+        },
+        "sweep_summary": {
+            "metric_row_count": len(metric_rows),
+            "candidate_count": len(candidates),
+            "passing_candidate_count": len(passing),
+            "borderline_candidate_count": len(borderline),
+        },
+        "diagnosis": diagnosis,
+        "best_quality": best_quality,
+        "best_low_cost_candidate": best_low_cost_candidate,
+        "candidate_summary": sorted(candidate_summary, key=lambda row: (row["decision"], _candidate_cost_key(row))),
+        "regime_summary": sorted(regime_summary, key=lambda row: (row["candidate_id"], row["regime"])),
+        "metric_rows_sample": metric_rows[:200],
+        "assumptions": [
+            "This is a Llama7B-shape synthetic native-GQA attention proxy, not measured Llama7B perplexity or task accuracy.",
+            "The proxy uses 32 attention heads, 4 KV heads, and head_dim 128 by default to match the current GQA8 Llama7B frontier assumption.",
+            "Q/K/V use per-vector symmetric quantization; accumulator saturation models fixed-width integer dot products.",
+            "Passing this proxy is only a gate for mixed-precision RTL/PPA and later real-checkpoint validation.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    diag = payload["diagnosis"]
+    lines = [
+        "# Llama7B Attention Mixed-Precision Quality Proxy",
+        "",
+        f"- decision: `{diag['decision']}`",
+        f"- best quality candidate: `{diag['best_quality_candidate']}`",
+        f"- best low-cost candidate: `{diag['best_low_cost_candidate']}`",
+        f"- passing candidates: `{diag['passing_candidate_count']}`",
+        f"- borderline candidates: `{diag['borderline_candidate_count']}`",
+        f"- dual-stream required density gain: `{diag['dual_stream_required_compute_density_gain']}`",
+        f"- recommended next step: `{diag['recommended_next_step']}`",
+        "",
+        "## Candidate Summary",
+        "",
+        "| candidate | q | k | v | acc | score | weight | top1 | retrieval | cosine | kl | decision |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["candidate_summary"]:
+        lines.append(
+            "| {candidate_id} | {q_bits} | {k_bits} | {v_bits} | {acc_bits} | {score_bits} | {weight_bits} | "
+            "{mean_top1_match} | {mean_retrieval_hit} | {mean_output_cosine} | {mean_kl_divergence} | {decision} |".format(
+                **row
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Regime Summary",
+            "",
+            "| candidate | regime | top1 | retrieval | cosine | kl | decision |",
+            "|---|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for row in payload["regime_summary"]:
+        lines.append(
+            "| {candidate_id} | {regime} | {mean_top1_match} | {mean_retrieval_hit} | "
+            "{mean_output_cosine} | {mean_kl_divergence} | {decision} |".format(**row)
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dual-stream-feasibility")
+    ap.add_argument("--attention-heads", type=int, default=32)
+    ap.add_argument("--kv-heads", type=int, default=4)
+    ap.add_argument("--head-dim", type=int, default=128)
+    ap.add_argument("--sequence-length-list", type=_int_list, default=[64, 128])
+    ap.add_argument(
+        "--regime-list",
+        type=_str_list,
+        default=["native_correlated_queries", "native_retrieval", "native_low_margin", "native_random"],
+    )
+    ap.add_argument("--seed-count", type=int, default=1)
+    ap.add_argument(
+        "--candidate-spec-list",
+        type=_str_list,
+        default=[
+            "q8:k8:v8:a24:s24:w16",
+            "q8:k8:v8:a20:s24:w16",
+            "q8:k8:v8:a24:s16:w12",
+            "q6:k8:v8:a24:s24:w16",
+            "q8:k8:v6:a24:s24:w16",
+        ],
+    )
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    dual_stream = (
+        json.loads(Path(args.dual_stream_feasibility).read_text(encoding="utf-8"))
+        if args.dual_stream_feasibility
+        else None
+    )
+    payload = build_report(
+        dual_stream_feasibility=dual_stream,
+        attention_heads=args.attention_heads,
+        kv_heads=args.kv_heads,
+        head_dim=args.head_dim,
+        sequence_length_list=args.sequence_length_list,
+        regime_list=args.regime_list,
+        seed_count=args.seed_count,
+        candidate_specs=args.candidate_spec_list,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(Path(args.out_md), payload)
+    print(json.dumps({"ok": True, "out": args.out, "out_md": args.out_md}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Llama7B-shape mixed-precision attention quality proxy for Q/K/V bits, dot accumulator bits, score precision, and softmax-weight precision
- wire the new decoder_attention_mixed_precision_quality evidence item into L2 task generation and result consumption
- add proposal metadata and focused control-plane tests

## Local smoke result
Using the merged dual-stream feasibility artifact:
- decision=mixed_precision_quality_candidate_found
- best_quality_candidate=q8_k8_v8_a24_s24_w16
- best_low_cost_candidate=q8_k8_v6_a24_s24_w16
- passing_candidate_count=3
- borderline_candidate_count=1
- q6_k8_v8_a24_s24_w16 is risky

This is a proxy quality gate, not final Llama7B perplexity.

## Tests
- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py
- PYTHONPATH=/tmp/rtlgen-mixed-precision-quality/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py -q
- python3 scripts/validate_runs.py --skip_eval_queue