### PR TITLE
Add mixed precision attention full-value tile PPA proposal

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_mixed_precision_full_value_tile_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_mixed_precision_full_value_tile_v1/evaluation_requests.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_mixed_precision_full_value_tile_v1",
+  "source_commit": "TBD_AFTER_MERGE",
+  "source_commit_note": "Dispatch should use the merge commit containing the mixed-precision full-value attention tile configs.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_mixed_precision_full_value_tile_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for Q8/K8/V6 and Q8/K8/V8 mixed-precision full-value attention tiles selected by the Llama7B proxy quality gate.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "attention_kv_full_value_tile",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l1_decoder_attention_full_value_tile_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_full_value_tile_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [
+        "runs/designs/activations/attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/config_attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40.json",
+        "runs/designs/activations/attention_kv_full_value_hd64_kv8_v8_tl16_b128_p8_ppc2_w24_a40_wrapper/config_attention_kv_full_value_hd64_kv8_v8_tl16_b128_p8_ppc2_w24_a40.json"
+      ],
+      "sweep_path": "runs/campaigns/activations/attention_kv_full_value_tile/sweeps/nangate45_macro_frontier.json",
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use measured mixed-precision local tile PPA to decide whether to update the dual-stream feasibility model or pursue compute-array density instead."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_mixed_precision_full_value_tile_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_mixed_precision_full_value_tile_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_mixed_precision_full_value_tile_v1",
+  "created_utc": "2026-06-11T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "ppa",
+  "abstraction_layer": "attention_kv_full_value_tile",
+  "title": "Mixed-precision full-value attention tile PPA",
+  "hypothesis": "The Llama7B-shape mixed-precision quality proxy found Q8/K8/V6 with 24-bit score and 16-bit softmax weights as the lowest-cost proxy-passing candidate. Measuring this local full-value attention tile against a Q8/K8/V8 comparator will show whether the quality-approved mixed-precision path provides enough local PPA density improvement to revisit the area-blocked dual_mac schedule.",
+  "direct_comparison": {
+    "primary_question": "How much PPA improvement does the proxy-passing Q8/K8/V6 full-value attention tile provide versus the safer Q8/K8/V8 comparator and the existing Q8/V16 full-value anchor?",
+    "include": [
+      "Q8/K8/V6, score24, softmax-weight16, weighted-value22, hd64 tl16 p8 ppc2",
+      "Q8/K8/V8, score24, softmax-weight16, weighted-value24, hd64 tl16 p8 ppc2",
+      "same macro-style Nangate45 sweep as the existing full-value attention tile",
+      "core utilization 50 and 60",
+      "reference to l2_decoder_attention_mixed_precision_quality_llama7b_v1 as the quality gate"
+    ],
+    "exclude": [
+      "do not claim final Llama7B quality from this PPA item",
+      "do not change Q/K precision below 8 bits because q6 was risky in the proxy",
+      "do not re-run the full L2 scheduler in this item",
+      "do not measure a complete SRAM/NoC/producer-integrated attention subsystem"
+    ]
+  },
+  "expected_benefit": [
+    "turns the mixed-precision quality candidate into measured local datapath PPA",
+    "separates V6 density benefit from the safer V8 mixed-precision comparator",
+    "provides the missing measured input for a follow-up L2 feasibility update"
+  ],
+  "risks": [
+    "the wrapper uses deterministic internal stimulus and remains a local datapath macro proxy",
+    "score24/weight16 proxy passing is not final model-native Llama7B validation",
+    "the local tile area may be too small relative to the dense compute array area gap to change the top-level conclusion alone"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_mixed_precision_full_value_tile_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for Q8/K8/V6 and Q8/K8/V8 mixed-precision full-value attention tiles selected by the Llama7B proxy quality gate.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "attention_kv_full_value_tile",
+      "cost_class": "medium",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l1_decoder_attention_full_value_tile_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_full_value_tile_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use measured mixed-precision local tile PPA to decide whether to update the dual-stream feasibility model or pursue compute-array density instead."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/designs/activations/attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_quality__l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "scripts/generate_design.py",
+    "runs/campaigns/activations/attention_kv_full_value_tile/sweeps/nangate45_macro_frontier.json",
+    "runs/designs/activations/attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/config_attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40.json",
+    "runs/designs/activations/attention_kv_full_value_hd64_kv8_v8_tl16_b128_p8_ppc2_w24_a40_wrapper/config_attention_kv_full_value_hd64_kv8_v8_tl16_b128_p8_ppc2_w24_a40.json"
+  ]
+}

--- a/runs/designs/activations/attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/config_attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40.json
+++ b/runs/designs/activations/attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/config_attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [{"name": "kv_fragment", "dimensions": 1, "bit_width": 8, "signed": true, "kind": "int"}],
+  "operations": [{
+    "type": "attention_kv_full_value_tile",
+    "module_name": "attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40",
+    "operand": "kv_fragment",
+    "options": {
+      "head_dim": 64,
+      "kv_bits": 8,
+      "tile_lanes": 16,
+      "stream_bytes_per_cycle": 128,
+      "score_bits": 24,
+      "value_bits": 6,
+      "softmax_weight_bits": 16,
+      "weighted_value_bits": 22,
+      "reducer_lanes": 16,
+      "stat_bits": 16,
+      "partials": 8,
+      "partials_per_cycle": 2,
+      "reducer_accum_bits": 40,
+      "counter_bits": 32,
+      "signed_inputs": true,
+      "signed_values": true
+    }
+  }]
+}

--- a/runs/designs/activations/attention_kv_full_value_hd64_kv8_v8_tl16_b128_p8_ppc2_w24_a40_wrapper/config_attention_kv_full_value_hd64_kv8_v8_tl16_b128_p8_ppc2_w24_a40.json
+++ b/runs/designs/activations/attention_kv_full_value_hd64_kv8_v8_tl16_b128_p8_ppc2_w24_a40_wrapper/config_attention_kv_full_value_hd64_kv8_v8_tl16_b128_p8_ppc2_w24_a40.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [{"name": "kv_fragment", "dimensions": 1, "bit_width": 8, "signed": true, "kind": "int"}],
+  "operations": [{
+    "type": "attention_kv_full_value_tile",
+    "module_name": "attention_kv_full_value_hd64_kv8_v8_tl16_b128_p8_ppc2_w24_a40",
+    "operand": "kv_fragment",
+    "options": {
+      "head_dim": 64,
+      "kv_bits": 8,
+      "tile_lanes": 16,
+      "stream_bytes_per_cycle": 128,
+      "score_bits": 24,
+      "value_bits": 8,
+      "softmax_weight_bits": 16,
+      "weighted_value_bits": 24,
+      "reducer_lanes": 16,
+      "stat_bits": 16,
+      "partials": 8,
+      "partials_per_cycle": 2,
+      "reducer_accum_bits": 40,
+      "counter_bits": 32,
+      "signed_inputs": true,
+      "signed_values": true
+    }
+  }]
+}


### PR DESCRIPTION
## Summary
- add L1 proposal for mixed-precision full-value attention tile PPA
- add q8/k8/v6/a24/s24/w16 density candidate config
- add q8/k8/v8/a24/s24/w16 safety comparator config

## Validation
- python3 -m json.tool on proposal/request/config JSON files
- python3 scripts/validate_runs.py --skip_eval_queue
- built rtlgen from current worktree and generated both new designs successfully

Note: the checked-in / older bin/rtlgen path in the devcontainer did not know attention_kv_tile; validation used the current-source build under ./build/rtlgen, matching what CI/evaluator should rebuild from master.