### PR TITLE
Add mixed-precision attention physical feasibility job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -449,6 +449,7 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("attention_kv_subtile_pipeline_schedule_out", "attention_kv_subtile_pipeline_schedule_report"),
     ("attention_kv_dual_stream_physical_feasibility_out", "attention_kv_dual_stream_physical_feasibility_report"),
     ("attention_mixed_precision_quality_out", "attention_mixed_precision_quality_report"),
+    ("attention_mixed_precision_physical_feasibility_out", "attention_mixed_precision_physical_feasibility_report"),
 )
 
 
@@ -619,14 +620,23 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 
-    if model == "llm_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1":
+    if model in {
+        "llm_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+        "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+    }:
         diagnosis = evidence_payload.get("diagnosis")
         diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
         outcome = str(diagnosis_dict.get("decision") or "dual_stream_physical_feasibility_recorded")
+        prefix = (
+            "Decoder mixed-precision physical feasibility evidence"
+            if model == "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1"
+            else "Decoder dual-stream physical feasibility evidence"
+        )
         parts = [
-            f"Decoder dual-stream physical feasibility evidence recorded from {evidence_ref}: decision={outcome}",
+            f"{prefix} recorded from {evidence_ref}: decision={outcome}",
         ]
         for key in (
+            "precision_profile",
             "best_requested_mode",
             "best_requested_latency_us",
             "best_requested_area_fit",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5287,6 +5287,63 @@ def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict
     }
 
 
+def _decoder_attention_mixed_precision_physical_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_precision_physical_feasibility__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_precision_physical_feasibility__{item_id}.md"
+    subtile_pipeline = (
+        f"{base}/decoder_attention_kv_subtile_pipeline_schedule__"
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
+    )
+    quality_gate = (
+        f"{base}/decoder_attention_mixed_precision_quality__"
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
+    )
+    mixed_full_value_tile_metrics = (
+        "runs/designs/activations/"
+        "attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/metrics.csv"
+    )
+    softmax_weight_metrics = (
+        "runs/designs/activations/"
+        "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
+    )
+    return {
+        "inputs": {
+            "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
+            "attention_mixed_precision_quality": quality_gate,
+            "attention_kv_mixed_precision_full_value_tile_metrics": mixed_full_value_tile_metrics,
+            "attention_kv_softmax_weight_metrics": softmax_weight_metrics,
+            "attention_mixed_precision_physical_feasibility_out": out,
+            "attention_mixed_precision_physical_feasibility_report": report,
+            "attention_mixed_precision_physical_feasibility_scope": (
+                "Apply measured Q8/K8/V6 full-value attention tile PPA, gated by the "
+                "Llama7B-shape mixed-precision quality proxy, to the dual-stream physical "
+                "feasibility model. Report whether local datapath area savings change the "
+                "dual_mac fit or the remaining compute-density gap."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_mixed_precision_physical_feasibility",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py "
+                    f"--subtile-pipeline-json {subtile_pipeline} "
+                    f"--full-value-tile-metrics {mixed_full_value_tile_metrics} "
+                    f"--softmax-weight-metrics {softmax_weight_metrics} "
+                    f"--quality-gate-json {quality_gate} "
+                    "--precision-profile q8_k8_v6_a24_s24_w16 "
+                    "--model-name llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1 "
+                    "--frontier-row-limit 8 "
+                    "--buffer-area-um2-per-byte 0.0 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
@@ -6852,6 +6909,7 @@ def _build_payload(
         "decoder_attention_kv_subtile_pipeline_schedule",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
+        "decoder_attention_mixed_precision_physical_feasibility",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
@@ -6998,6 +7056,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":
             decoder_evidence = _decoder_attention_mixed_precision_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_precision_physical_feasibility":
+            decoder_evidence = _decoder_attention_mixed_precision_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_noc_profile":
             decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1782,6 +1782,120 @@ def test_consume_l2_result_frontier_attention_mixed_precision_quality_uses_decod
             assert decision_payload["source_refs"]["decoder_attention_mixed_precision_quality_report"] == report_rel
 
 
+def test_consume_l2_result_frontier_attention_mixed_precision_physical_feasibility_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_mixed_precision_physical_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_mixed_precision_physical_v1",
+                        "kind": "architecture",
+                        "title": "Attention mixed precision physical feasibility",
+                        "direct_comparison": {
+                            "primary_question": "Does the measured mixed-precision datapath change feasibility?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_precision_physical_feasibility__l2_attention_mixed_precision_physical_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_precision_physical_feasibility__l2_attention_mixed_precision_physical_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+                        "diagnosis": {
+                            "decision": "dual_stream_area_blocked",
+                            "precision_profile": "q8_k8_v6_a24_s24_w16",
+                            "best_requested_mode": "dual_mac",
+                            "best_requested_latency_us": 1575.37,
+                            "best_requested_area_fit": False,
+                            "best_requested_logic_slack_um2": -398800000.0,
+                            "best_requested_compute_area_over_budget_um2": 398800000.0,
+                            "best_requested_required_compute_density_gain": 2.01,
+                            "best_feasible_mode": "split_mac",
+                            "best_feasible_latency_us": 2042.38,
+                            "recommended_next_step": "target compute array density",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# mixed precision physical feasibility\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_mixed_precision_physical",
+                campaign_dir_rel="runs/campaigns/npu/attention_mixed_precision_physical_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_mixed_precision_physical_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use mixed-precision physical feasibility to choose the next PPA target.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_mixed_precision_physical_feasibility",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_mixed_precision_physical_feasibility_out": evidence_rel,
+                    "attention_mixed_precision_physical_feasibility_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "dual_stream_area_blocked"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert "precision_profile=q8_k8_v6_a24_s24_w16" in assessment["summary"]
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_mixed_precision_physical_feasibility"
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_mixed_precision_physical_feasibility_out"]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_mixed_precision_physical_feasibility_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_frontier_synthesis_prefers_synthesis_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5444,6 +5444,56 @@ def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_eviden
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_mixed_precision_physical_feasibility_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_mixed_precision_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_mixed_precision_physical_feasibility" in command_names
+            assert "attention_kv_subtile_pipeline_schedule" in decoder_inputs
+            assert "attention_mixed_precision_quality" in decoder_inputs
+            assert "attention_kv_mixed_precision_full_value_tile_metrics" in decoder_inputs
+            assert "attention_mixed_precision_physical_feasibility_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py" in run
+            assert "attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/metrics.csv" in run
+            assert "l2_decoder_attention_mixed_precision_quality_llama7b_v1.json" in run
+            assert "--precision-profile q8_k8_v6_a24_s24_w16" in run
+            assert "--model-name llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_mixed_precision_physical_feasibility__"
+                    "l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+  "source_commit": "TBD_AFTER_MERGE",
+  "source_commit_note": "Dispatch should use the merge commit containing the new mixed-precision physical feasibility abstraction.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recompute Llama7B dual-stream physical feasibility using the measured q8/k8/v6 full-value attention tile PPA and the mixed-precision quality gate.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_precision_physical_feasibility",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+      "depends_on": [
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+        "l1_decoder_attention_mixed_precision_full_value_tile_v1"
+      ],
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use measured mixed-precision physical feasibility to decide whether the remaining frontier work is local datapath precision or compute-array density/fusion."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1/proposal.json
@@ -1,0 +1,55 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+  "kind": "architecture",
+  "title": "Mixed-precision attention physical feasibility",
+  "layer": "layer2",
+  "abstraction_layer": "decoder_attention_mixed_precision_physical_feasibility",
+  "status": "proposed",
+  "motivation": [
+    "The Llama7B-shape mixed-precision proxy selected q8_k8_v6_a24_s24_w16 as the lowest-cost passing candidate.",
+    "Layer 1 PPA measured the q8/k8/v6 full-value attention tile, but the Llama7B physical feasibility model still uses the exact/full-value tile metrics.",
+    "We need to quantify whether replacing only the local full-value tile with the measured mixed-precision tile changes the dual-stream area decision or leaves the compute-array density gap dominant."
+  ],
+  "direct_comparison": {
+    "primary_question": "Does quality-approved q8/k8/v6 local datapath PPA make the dual_mac Llama7B schedule physically feasible?",
+    "baseline": "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+    "candidate": "l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+    "metrics": [
+      "decision",
+      "best_requested_required_compute_density_gain",
+      "best_requested_compute_area_over_budget_um2",
+      "best_feasible_mode",
+      "best_feasible_latency_us"
+    ]
+  },
+  "expected_result": {
+    "direction": "iterate",
+    "reason": "If the remaining density gap is still near 2x, prioritize compute-array density/fused datapath work rather than more local V-bit sweeps."
+  },
+  "required_inputs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_subtile_pipeline_schedule__l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_quality__l2_decoder_attention_mixed_precision_quality_llama7b_v1.json",
+    "runs/designs/activations/attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/metrics.csv",
+    "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
+  ],
+  "evaluation_requests": [
+    {
+      "item_id": "l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_precision_physical_feasibility",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+      "depends_on": [
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+        "l1_decoder_attention_mixed_precision_full_value_tile_v1"
+      ]
+    }
+  ],
+  "source_files": [
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "control_plane/control_plane/services/l2_result_consumer.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -79,6 +79,7 @@ def _row_with_budget(
     full_value_tile: JsonDict,
     softmax_weight: JsonDict,
     buffer_area_um2_per_byte: float,
+    precision_profile: str,
 ) -> JsonDict:
     clusters = int(source_row["cluster_count"])
     compute_multiplier = float(source_row.get("compute_area_multiplier", 1.0))
@@ -136,6 +137,7 @@ def _row_with_budget(
     out.update(
         {
             "dual_stream_physical_model": "measured_full_value_tile_budget_v1",
+            "precision_profile": precision_profile,
             "measured_full_value_tile_metrics_csv": full_value_tile["metrics_csv"],
             "measured_full_value_tile_area_um2": measured_stream_area,
             "measured_full_value_tile_clock_ns": full_value_tile["critical_path_ns"],
@@ -175,12 +177,14 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     source_rows = _source_rows(source, limit=args.frontier_row_limit)
     full_value_tile = _best_ok_metrics(args.full_value_tile_metrics)
     softmax_weight = _best_ok_metrics(args.softmax_weight_metrics)
+    quality_gate = _load_json(args.quality_gate_json) if args.quality_gate_json else None
     rows = [
         _row_with_budget(
             row,
             full_value_tile=full_value_tile,
             softmax_weight=softmax_weight,
             buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
+            precision_profile=args.precision_profile,
         )
         for row in source_rows
     ]
@@ -195,17 +199,29 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     decision = "dual_stream_feasible" if best_feasible and best_feasible.get("compute_mode") == "dual_mac" else "dual_stream_area_blocked"
     return {
         "version": 1,
-        "model": "llm_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+        "model": args.model_name,
         "subtile_pipeline_json": str(args.subtile_pipeline_json),
         "source_model": source.get("model"),
         "inputs": {
             "frontier_row_limit": args.frontier_row_limit,
             "full_value_tile_metrics": str(args.full_value_tile_metrics),
             "softmax_weight_metrics": str(args.softmax_weight_metrics),
+            "quality_gate_json": str(args.quality_gate_json) if args.quality_gate_json else None,
+            "precision_profile": args.precision_profile,
             "buffer_area_um2_per_byte": args.buffer_area_um2_per_byte,
         },
+        "quality_gate": {
+            "decision": (quality_gate or {}).get("diagnosis", {}).get("decision"),
+            "best_low_cost_candidate": (quality_gate or {}).get("diagnosis", {}).get("best_low_cost_candidate"),
+            "best_low_cost_decision": (quality_gate or {}).get("diagnosis", {}).get("best_low_cost_decision"),
+            "best_quality_candidate": (quality_gate or {}).get("diagnosis", {}).get("best_quality_candidate"),
+            "best_quality_decision": (quality_gate or {}).get("diagnosis", {}).get("best_quality_decision"),
+        }
+        if quality_gate
+        else None,
         "diagnosis": {
             "decision": decision,
+            "precision_profile": args.precision_profile,
             "source_rows_used": len(source_rows),
             "physical_feasible_rows": len(feasible_rows),
             "best_requested_mode": best_requested.get("compute_mode"),
@@ -244,6 +260,7 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         "# Llama7B Dual-Stream Physical Feasibility",
         "",
         f"- decision: `{diag['decision']}`",
+        f"- precision profile: `{diag['precision_profile']}`",
         f"- source rows used: `{diag['source_rows_used']}`",
         f"- physical feasible rows: `{diag['physical_feasible_rows']}`",
         f"- best requested mode: `{diag['best_requested_mode']}`",
@@ -284,6 +301,12 @@ def main() -> int:
     parser.add_argument("--subtile-pipeline-json", type=Path, required=True)
     parser.add_argument("--full-value-tile-metrics", type=Path, required=True)
     parser.add_argument("--softmax-weight-metrics", type=Path, required=True)
+    parser.add_argument("--quality-gate-json", type=Path)
+    parser.add_argument("--precision-profile", default="exact_q8_kv8_v16_s24_w16")
+    parser.add_argument(
+        "--model-name",
+        default="llm_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
+    )
     parser.add_argument("--frontier-row-limit", type=int, default=8)
     parser.add_argument("--buffer-area-um2-per-byte", type=float, default=0.0)
     parser.add_argument("--out", type=Path, required=True)


### PR DESCRIPTION
## Summary
- add L2 abstraction for mixed-precision attention physical feasibility
- reuse the dual-stream physical feasibility estimator with explicit precision profile/model name inputs
- point the new job at measured q8/k8/v6 full-value tile PPA and the mixed-precision quality gate
- teach the result consumer to summarize the new model and evidence pair

## Local result sanity check
Using merged artifacts, the q8/k8/v6 profile remains area-blocked: required density gain improves only from about 2.011x to 2.004x, so compute-array density/fusion remains the likely frontier.

## Validation
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 -m json.tool on new proposal/request JSON
- pytest focused generator/consumer tests for the new abstraction