### PR TITLE
control_plane: add int8 compute feasibility substitution

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -623,11 +623,15 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
     if model in {
         "llm_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
         "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+        "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
     }:
         diagnosis = evidence_payload.get("diagnosis")
         diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
         outcome = str(diagnosis_dict.get("decision") or "dual_stream_physical_feasibility_recorded")
         prefix = (
+            "Decoder mixed-precision int8-compute physical feasibility evidence"
+            if model == "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1"
+            else
             "Decoder mixed-precision physical feasibility evidence"
             if model == "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1"
             else "Decoder dual-stream physical feasibility evidence"
@@ -643,6 +647,10 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "best_requested_logic_slack_um2",
             "best_requested_compute_area_over_budget_um2",
             "best_requested_required_compute_density_gain",
+            "best_requested_compute_substitution_enabled",
+            "best_requested_substituted_compute_arch",
+            "best_requested_substituted_compute_area_um2",
+            "best_requested_compute_clock_ok",
             "best_feasible_mode",
             "best_feasible_latency_us",
             "recommended_next_step",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5344,6 +5344,68 @@ def _decoder_attention_mixed_precision_physical_feasibility_evidence(*, item_id:
     }
 
 
+def _decoder_attention_mixed_precision_int8_compute_physical_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_precision_int8_compute_physical_feasibility__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_precision_int8_compute_physical_feasibility__{item_id}.md"
+    subtile_pipeline = (
+        f"{base}/decoder_attention_kv_subtile_pipeline_schedule__"
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
+    )
+    quality_gate = (
+        f"{base}/decoder_attention_mixed_precision_quality__"
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
+    )
+    mixed_full_value_tile_metrics = (
+        "runs/designs/activations/"
+        "attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/metrics.csv"
+    )
+    softmax_weight_metrics = (
+        "runs/designs/activations/"
+        "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
+    )
+    int8_dense_compute_metrics = "runs/designs/npu_blocks/npu_dense_gemm_tile_int8_16x8_k1_p1/metrics.csv"
+    return {
+        "inputs": {
+            "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
+            "attention_mixed_precision_quality": quality_gate,
+            "attention_kv_mixed_precision_full_value_tile_metrics": mixed_full_value_tile_metrics,
+            "attention_kv_softmax_weight_metrics": softmax_weight_metrics,
+            "attention_int8_dense_compute_metrics": int8_dense_compute_metrics,
+            "attention_mixed_precision_int8_compute_physical_feasibility_out": out,
+            "attention_mixed_precision_int8_compute_physical_feasibility_report": report,
+            "attention_mixed_precision_int8_compute_physical_feasibility_scope": (
+                "Substitute the measured signed-int8 dense GEMM tile into the "
+                "quality-gated Q8/K8/V6 mixed-precision dual-stream physical model. "
+                "Keep the upstream schedule fixed to test whether measured int8 compute "
+                "closes the dual_mac area gap before spending another PPA run."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py "
+                    f"--subtile-pipeline-json {subtile_pipeline} "
+                    f"--full-value-tile-metrics {mixed_full_value_tile_metrics} "
+                    f"--softmax-weight-metrics {softmax_weight_metrics} "
+                    f"--quality-gate-json {quality_gate} "
+                    "--precision-profile q8_k8_v6_a24_s24_w16_int8_compute "
+                    "--model-name llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1 "
+                    "--frontier-row-limit 8 "
+                    "--buffer-area-um2-per-byte 0.0 "
+                    f"--compute-block-metrics {int8_dense_compute_metrics} "
+                    "--compute-block-macs-per-cycle 128 "
+                    "--compute-arch-name dense_gemm_int8_16x8_k1_p1 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_noc_profile_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_noc_profile__{item_id}.json"
@@ -6910,6 +6972,7 @@ def _build_payload(
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_mixed_precision_physical_feasibility",
+        "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
         "decoder_attention_noc_profile",
         "decoder_attention_kv_quality_gate",
         "decoder_attention_kv_quality_proxy",
@@ -7058,6 +7121,10 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_precision_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_physical_feasibility":
             decoder_evidence = _decoder_attention_mixed_precision_physical_feasibility_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_precision_int8_compute_physical_feasibility":
+            decoder_evidence = _decoder_attention_mixed_precision_int8_compute_physical_feasibility_evidence(
+                item_id=item_id,
+            )
         elif abstraction_layer_name == "decoder_attention_noc_profile":
             decoder_evidence = _decoder_attention_noc_profile_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_quality_gate":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -17,12 +17,34 @@ from control_plane.models.enums import ExecutorType, FlowName, LayerName, RunSta
 from control_plane.models.runs import Run
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
-from control_plane.services.l2_result_consumer import Layer2ConsumeRequest, consume_l2_result
+from control_plane.services.l2_result_consumer import Layer2ConsumeRequest, _decoder_evidence_summary, consume_l2_result
 
 
 def _write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def test_decoder_evidence_summary_recognizes_mixed_precision_int8_compute_physical_feasibility() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/int8_compute.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+            "diagnosis": {
+                "decision": "dual_stream_feasible",
+                "precision_profile": "q8_k8_v6_a24_s24_w16_int8_compute",
+                "best_requested_mode": "dual_mac",
+                "best_requested_compute_substitution_enabled": True,
+                "best_requested_substituted_compute_arch": "dense_gemm_int8_16x8_k1_p1",
+                "best_requested_substituted_compute_area_um2": 89654016.0,
+                "best_requested_compute_clock_ok": True,
+            },
+        },
+    )
+
+    assert outcome == "dual_stream_feasible"
+    assert "int8-compute physical feasibility" in summary
+    assert "best_requested_substituted_compute_arch=dense_gemm_int8_16x8_k1_p1" in summary
 
 
 def _seed_succeeded_l2_campaign(session: Session, repo_root: Path) -> tuple[str, str]:

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5494,6 +5494,61 @@ def test_generate_l2_campaign_task_adds_attention_mixed_precision_physical_feasi
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_mixed_precision_int8_compute_physical_feasibility_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_mixed_precision_int8_compute_physical_feasibility" in command_names
+            assert "attention_kv_subtile_pipeline_schedule" in decoder_inputs
+            assert "attention_mixed_precision_quality" in decoder_inputs
+            assert "attention_kv_mixed_precision_full_value_tile_metrics" in decoder_inputs
+            assert "attention_int8_dense_compute_metrics" in decoder_inputs
+            assert "attention_mixed_precision_int8_compute_physical_feasibility_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py" in run
+            assert "npu_dense_gemm_tile_int8_16x8_k1_p1/metrics.csv" in run
+            assert "--compute-block-macs-per-cycle 128" in run
+            assert "--compute-arch-name dense_gemm_int8_16x8_k1_p1" in run
+            assert "--precision-profile q8_k8_v6_a24_s24_w16_int8_compute" in run
+            assert (
+                "--model-name llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1"
+                in run
+            )
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_mixed_precision_int8_compute_physical_feasibility__"
+                    "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+  "source_commit": null,
+  "source_commit_note": "Dispatch should use the merge commit containing the int8 dense compute substitution abstraction.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Substitute measured signed-int8 dense GEMM compute into the Q8/K8/V6 Llama7B dual-stream physical feasibility model and report whether dual_mac now fits the physical compute budget.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+      "depends_on": [
+        "l1_npu_dense_gemm_tile_int8_v1",
+        "l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1"
+      ],
+      "expected_result": {
+        "direction": "close_dual_stream_area_gap_with_int8_compute",
+        "reason": "The job should report whether measured int8 dense compute removes the dual_mac compute-area deficit under the same quality-gated mixed-precision schedule."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1/proposal.json
@@ -1,0 +1,58 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+  "kind": "architecture",
+  "title": "Mixed-precision attention with int8 dense compute physical feasibility",
+  "layer": "layer2",
+  "abstraction_layer": "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+  "status": "proposed",
+  "motivation": [
+    "The Q8/K8/V6 mixed-precision local datapath was quality-approved but still left dual_mac blocked when dense compute used the measured FP16 tile area.",
+    "Layer 1 has now measured signed-int8 dense GEMM tile PPA at the same 16x8, k1 throughput shape.",
+    "We need to determine whether substituting measured int8 dense compute closes the dual_mac physical area gap under the current Llama7B sub-tile schedule before launching another full PPA iteration."
+  ],
+  "direct_comparison": {
+    "primary_question": "Does measured int8 dense compute make the Q8/K8/V6 dual_mac Llama7B schedule physically feasible under the same schedule?",
+    "baseline": "l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+    "candidate": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+    "metrics": [
+      "decision",
+      "best_requested_area_fit",
+      "best_requested_compute_area_over_budget_um2",
+      "best_requested_required_compute_density_gain",
+      "best_requested_substituted_compute_area_um2",
+      "best_feasible_mode",
+      "best_feasible_latency_us"
+    ]
+  },
+  "expected_result": {
+    "direction": "close_dual_stream_area_gap_with_int8_compute",
+    "reason": "The measured int8 16x8 dense GEMM tile is substantially smaller than the FP16 dense tile, so dual_mac should move from area-blocked to feasible if the remaining abstractions are not dominant."
+  },
+  "required_inputs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_subtile_pipeline_schedule__l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_quality__l2_decoder_attention_mixed_precision_quality_llama7b_v1.json",
+    "runs/designs/activations/attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/metrics.csv",
+    "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv",
+    "runs/designs/npu_blocks/npu_dense_gemm_tile_int8_16x8_k1_p1/metrics.csv"
+  ],
+  "evaluation_requests": [
+    {
+      "item_id": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+      "depends_on": [
+        "l1_npu_dense_gemm_tile_int8_v1",
+        "l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1"
+      ]
+    }
+  ],
+  "source_files": [
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "control_plane/control_plane/services/l2_result_consumer.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import math
 import sys
 from pathlib import Path
 from typing import Any
@@ -37,6 +38,32 @@ def _best_ok_metrics(path: Path) -> JsonDict:
     return {
         "metrics_csv": str(path),
         "critical_path_ns": float(best["critical_path_ns"]),
+        "die_area_um2": float(best["die_area"]),
+        "total_power_mw": float(best["total_power_mw"]),
+        "param_hash": best.get("param_hash", ""),
+        "tag": best.get("tag", ""),
+        "result_path": best.get("result_path", ""),
+    }
+
+
+def _best_ok_compute_metrics(path: Path) -> JsonDict:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = [row for row in csv.DictReader(handle) if row.get("status") == "ok"]
+    if not rows:
+        raise RuntimeError(f"no status=ok compute metrics rows in {path}")
+    best = min(
+        rows,
+        key=lambda row: (
+            float(row.get("critical_path_ns") or "inf"),
+            float(row.get("instance_area_um2") or row.get("die_area") or "inf"),
+            float(row.get("total_power_mw") or "inf"),
+        ),
+    )
+    block_area = float(best.get("instance_area_um2") or best["die_area"])
+    return {
+        "metrics_csv": str(path),
+        "critical_path_ns": float(best["critical_path_ns"]),
+        "block_area_um2": block_area,
         "die_area_um2": float(best["die_area"]),
         "total_power_mw": float(best["total_power_mw"]),
         "param_hash": best.get("param_hash", ""),
@@ -78,6 +105,9 @@ def _row_with_budget(
     *,
     full_value_tile: JsonDict,
     softmax_weight: JsonDict,
+    compute_block: JsonDict | None,
+    compute_block_macs_per_cycle: int | None,
+    compute_arch_name: str | None,
     buffer_area_um2_per_byte: float,
     precision_profile: str,
 ) -> JsonDict:
@@ -105,7 +135,27 @@ def _row_with_budget(
         - current_softmax_area
     )
 
-    compute_area_required = current_compute_area * compute_multiplier
+    compute_substitution_enabled = compute_block is not None
+    if compute_block is None:
+        base_compute_area = current_compute_area
+        base_compute_power = float(source_row.get("compute_power_mw", source_row.get("measured_block_power_mw", 0.0)))
+        target_replica_count = int(source_row["compute_replica_count"])
+        target_block_area = float(source_row["measured_block_area_um2"])
+        target_block_macs = int(source_row["measured_block_macs_per_cycle"])
+        target_block_clock = float(source_row["measured_block_clock_ns"])
+        target_block_power = float(source_row.get("measured_block_power_mw", 0.0))
+        target_arch = str(source_row.get("compute_arch", ""))
+    else:
+        target_block_area = float(compute_block["block_area_um2"])
+        target_block_macs = int(compute_block_macs_per_cycle or source_row["measured_block_macs_per_cycle"])
+        target_replica_count = int(math.ceil(float(source_row["macs_per_cycle"]) / max(1, target_block_macs)))
+        base_compute_area = target_replica_count * target_block_area
+        target_block_clock = float(compute_block["critical_path_ns"])
+        target_block_power = float(compute_block["total_power_mw"])
+        base_compute_power = target_replica_count * target_block_power
+        target_arch = str(compute_arch_name or source_row.get("compute_arch", ""))
+
+    compute_area_required = base_compute_area * compute_multiplier
     logic_used_required = current_logic_used + (compute_area_required - current_compute_area) + (
         selected_l1_overhead - current_l1_overhead
     )
@@ -114,8 +164,11 @@ def _row_with_budget(
     required_compute_density_gain = (
         compute_area_required / max(1.0, compute_budget - selected_l1_overhead)
     )
-    replica_count_budgeted = int(current_compute_area // max(1.0, float(source_row["measured_block_area_um2"])))
-    replica_count_required = int(source_row["compute_replica_count"] * compute_multiplier)
+    if compute_block is None:
+        replica_count_budgeted = int(current_compute_area // max(1.0, target_block_area))
+    else:
+        replica_count_budgeted = int(max(0.0, compute_budget - selected_l1_overhead) // max(1.0, target_block_area))
+    replica_count_required = int(math.ceil(target_replica_count * compute_multiplier))
     replica_shortfall = max(0, replica_count_required - replica_count_budgeted)
     area_fit = logic_slack_required >= 0.0
     buffer_fit = required_buffer_bytes <= available_local_capacity
@@ -152,6 +205,17 @@ def _row_with_budget(
             "selected_l1_overhead_area_um2": round(selected_l1_overhead, 6),
             "compute_area_required_um2": round(compute_area_required, 6),
             "compute_area_multiplier_required": compute_multiplier,
+            "compute_substitution_enabled": compute_substitution_enabled,
+            "source_compute_arch": source_row.get("compute_arch"),
+            "substituted_compute_arch": target_arch if compute_substitution_enabled else None,
+            "substituted_compute_metrics_csv": compute_block["metrics_csv"] if compute_block else None,
+            "substituted_block_area_um2": round(target_block_area, 6) if compute_substitution_enabled else None,
+            "substituted_block_clock_ns": round(target_block_clock, 6) if compute_substitution_enabled else None,
+            "substituted_block_power_mw": round(target_block_power, 6) if compute_substitution_enabled else None,
+            "substituted_block_macs_per_cycle": target_block_macs if compute_substitution_enabled else None,
+            "substituted_compute_replica_count": target_replica_count if compute_substitution_enabled else None,
+            "substituted_compute_area_um2": round(base_compute_area, 6) if compute_substitution_enabled else None,
+            "substituted_compute_power_mw": round(base_compute_power, 6) if compute_substitution_enabled else None,
             "logic_area_used_required_um2": round(logic_used_required, 6),
             "logic_area_slack_required_um2": round(logic_slack_required, 6),
             "compute_area_over_budget_um2": round(compute_area_over_budget, 6),
@@ -161,6 +225,7 @@ def _row_with_budget(
             "replica_count_shortfall": replica_shortfall,
             "local_datapath_clock_ok": float(full_value_tile["critical_path_ns"]) <= float(source_row["clock_ns"]),
             "softmax_weight_clock_ok": float(softmax_weight["critical_path_ns"]) <= float(source_row["clock_ns"]),
+            "compute_clock_ok": target_block_clock <= float(source_row["clock_ns"]),
             "area_fit": area_fit,
             "buffer_fit": buffer_fit,
             "physical_feasible": feasible,
@@ -177,12 +242,16 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     source_rows = _source_rows(source, limit=args.frontier_row_limit)
     full_value_tile = _best_ok_metrics(args.full_value_tile_metrics)
     softmax_weight = _best_ok_metrics(args.softmax_weight_metrics)
+    compute_block = _best_ok_compute_metrics(args.compute_block_metrics) if args.compute_block_metrics else None
     quality_gate = _load_json(args.quality_gate_json) if args.quality_gate_json else None
     rows = [
         _row_with_budget(
             row,
             full_value_tile=full_value_tile,
             softmax_weight=softmax_weight,
+            compute_block=compute_block,
+            compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
+            compute_arch_name=args.compute_arch_name,
             buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
             precision_profile=args.precision_profile,
         )
@@ -206,6 +275,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "frontier_row_limit": args.frontier_row_limit,
             "full_value_tile_metrics": str(args.full_value_tile_metrics),
             "softmax_weight_metrics": str(args.softmax_weight_metrics),
+            "compute_block_metrics": str(args.compute_block_metrics) if args.compute_block_metrics else None,
+            "compute_block_macs_per_cycle": args.compute_block_macs_per_cycle,
+            "compute_arch_name": args.compute_arch_name,
             "quality_gate_json": str(args.quality_gate_json) if args.quality_gate_json else None,
             "precision_profile": args.precision_profile,
             "buffer_area_um2_per_byte": args.buffer_area_um2_per_byte,
@@ -230,6 +302,10 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "best_requested_logic_slack_um2": best_requested.get("logic_area_slack_required_um2"),
             "best_requested_compute_area_over_budget_um2": best_requested.get("compute_area_over_budget_um2"),
             "best_requested_required_compute_density_gain": best_requested.get("required_compute_density_gain"),
+            "best_requested_compute_substitution_enabled": best_requested.get("compute_substitution_enabled"),
+            "best_requested_substituted_compute_arch": best_requested.get("substituted_compute_arch"),
+            "best_requested_substituted_compute_area_um2": best_requested.get("substituted_compute_area_um2"),
+            "best_requested_compute_clock_ok": best_requested.get("compute_clock_ok"),
             "best_feasible_mode": best_feasible.get("compute_mode") if best_feasible else None,
             "best_feasible_latency_us": best_feasible.get("latency_us") if best_feasible else None,
             "best_area_fit_mode": best_area_fit.get("compute_mode") if best_area_fit else None,
@@ -249,6 +325,12 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "Measured full-value tile and softmax-weight generator PPA are used for local datapath overhead only.",
             "The dense GEMM compute array is treated as already packed into the current logic budget; extra dual-stream compute must fit that same budget to be feasible.",
             "Buffer capacity is checked against measured local SRAM bytes; an optional buffer-area proxy can be added for sensitivity but defaults to zero to avoid double-counting measured local SRAM.",
+            (
+                "When compute-block substitution is enabled, measured block area/power/clock replace the source dense compute block, "
+                "but the upstream schedule latency is not recomputed; this is an area-feasibility substitution and a conservative latency view when the substituted block clock is no slower than the source clock."
+            )
+            if compute_block
+            else "No compute-block substitution was requested; dense compute area comes from the source schedule.",
         ],
     }
 
@@ -268,6 +350,9 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         f"- best requested logic slack um2: `{diag['best_requested_logic_slack_um2']}`",
         f"- best requested compute area over budget um2: `{diag['best_requested_compute_area_over_budget_um2']}`",
         f"- best requested required compute density gain: `{diag['best_requested_required_compute_density_gain']}`",
+        f"- best requested compute substitution: `{diag['best_requested_compute_substitution_enabled']}`",
+        f"- best requested substituted compute arch: `{diag['best_requested_substituted_compute_arch']}`",
+        f"- best requested substituted compute area um2: `{diag['best_requested_substituted_compute_area_um2']}`",
         f"- recommended next step: `{diag['recommended_next_step']}`",
         "",
         "## Best Requested",
@@ -301,6 +386,9 @@ def main() -> int:
     parser.add_argument("--subtile-pipeline-json", type=Path, required=True)
     parser.add_argument("--full-value-tile-metrics", type=Path, required=True)
     parser.add_argument("--softmax-weight-metrics", type=Path, required=True)
+    parser.add_argument("--compute-block-metrics", type=Path)
+    parser.add_argument("--compute-block-macs-per-cycle", type=int)
+    parser.add_argument("--compute-arch-name")
     parser.add_argument("--quality-gate-json", type=Path)
     parser.add_argument("--precision-profile", default="exact_q8_kv8_v16_s24_w16")
     parser.add_argument(

--- a/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from npu.eval.estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility import build_report
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_metrics(path: Path, *, die_area: float, power_mw: float, instance_area: float | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    headers = ["status", "critical_path_ns", "die_area", "total_power_mw", "param_hash", "tag", "result_path"]
+    if instance_area is not None:
+        headers.insert(3, "instance_area_um2")
+    values = {
+        "status": "ok",
+        "critical_path_ns": "1.0",
+        "die_area": str(die_area),
+        "instance_area_um2": str(instance_area if instance_area is not None else die_area),
+        "total_power_mw": str(power_mw),
+        "param_hash": "abc",
+        "tag": "unit",
+        "result_path": "results/unit",
+    }
+    path.write_text(",".join(headers) + "\n" + ",".join(values[key] for key in headers) + "\n", encoding="utf-8")
+
+
+def _args(tmp_path: Path, *, source: Path, compute_metrics: Path | None = None) -> argparse.Namespace:
+    full_value = tmp_path / "full_value.csv"
+    softmax = tmp_path / "softmax.csv"
+    _write_metrics(full_value, die_area=10.0, power_mw=0.1)
+    _write_metrics(softmax, die_area=2.0, power_mw=0.02)
+    return argparse.Namespace(
+        subtile_pipeline_json=source,
+        full_value_tile_metrics=full_value,
+        softmax_weight_metrics=softmax,
+        compute_block_metrics=compute_metrics,
+        compute_block_macs_per_cycle=128 if compute_metrics else None,
+        compute_arch_name="dense_gemm_int8_16x8_k1_p1" if compute_metrics else None,
+        quality_gate_json=None,
+        precision_profile="q8_k8_v6_a24_s24_w16_int8_compute" if compute_metrics else "q8_k8_v6_a24_s24_w16",
+        model_name="unit",
+        frontier_row_limit=8,
+        buffer_area_um2_per_byte=0.0,
+    )
+
+
+def test_compute_block_substitution_can_close_dual_stream_area_gap(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    _write_json(
+        source,
+        {
+            "model": "unit_source",
+            "best_by_compute_mode": [
+                {
+                    "compute_mode": "dual_mac",
+                    "latency_us": 10.0,
+                    "latency_speedup_vs_hbm_closed_source": 2.0,
+                    "tile_service_cycles": 12,
+                    "cluster_count": 1,
+                    "compute_area_multiplier": 2.0,
+                    "compute_area_um2": 200.0,
+                    "compute_budget_um2": 250.0,
+                    "measured_l1_overhead_area_um2": 20.0,
+                    "local_datapath_area_um2": 5.0,
+                    "softmax_weight_generator_area_um2": 1.0,
+                    "logic_area_used_um2": 220.0,
+                    "required_stream_buffer_bytes": 16,
+                    "available_local_capacity_bytes": 32,
+                    "measured_block_area_um2": 200.0,
+                    "measured_block_clock_ns": 3.0,
+                    "measured_block_macs_per_cycle": 128,
+                    "measured_block_power_mw": 4.0,
+                    "compute_replica_count": 1,
+                    "compute_arch": "dense_gemm_16x8_k1_p1",
+                    "macs_per_cycle": 128,
+                    "clock_ns": 3.0,
+                }
+            ],
+        },
+    )
+    compute_metrics = tmp_path / "int8_compute.csv"
+    _write_metrics(compute_metrics, die_area=100.0, instance_area=50.0, power_mw=0.5)
+
+    baseline = build_report(_args(tmp_path, source=source))
+    substituted = build_report(_args(tmp_path, source=source, compute_metrics=compute_metrics))
+
+    assert baseline["diagnosis"]["decision"] == "dual_stream_area_blocked"
+    assert baseline["best_requested"]["compute_substitution_enabled"] is False
+    assert baseline["best_requested"]["area_fit"] is False
+
+    assert substituted["diagnosis"]["decision"] == "dual_stream_feasible"
+    assert substituted["best_requested"]["compute_substitution_enabled"] is True
+    assert substituted["best_requested"]["substituted_compute_arch"] == "dense_gemm_int8_16x8_k1_p1"
+    assert substituted["best_requested"]["substituted_compute_replica_count"] == 1
+    assert substituted["best_requested"]["substituted_compute_area_um2"] == 50.0
+    assert substituted["best_requested"]["compute_area_required_um2"] == 100.0
+    assert substituted["best_requested"]["area_fit"] is True
+    assert substituted["best_requested"]["compute_clock_ok"] is True


### PR DESCRIPTION
## Summary
- add optional compute-block substitution to the dual-stream physical feasibility estimator
- add an L2 abstraction/job hook for Q8/K8/V6 mixed precision with measured int8 dense GEMM compute
- register the new evidence model in the result consumer and add focused tests/proposal docs

## Sanity result from current merged data
Running the estimator locally with `npu_dense_gemm_tile_int8_16x8_k1_p1/metrics.csv` flips the mixed-precision dual_mac result to feasible:
- decision: `dual_stream_feasible`
- best requested mode: `dual_mac`
- latency: `1575.373891 us` under the existing fixed schedule
- substituted base compute area: `89654016.0 um2`
- required dual compute area: `179308032.0 um2`
- logic slack: `216592520.1716 um2`
- required compute density gain: `0.452912`

This is intentionally an area-feasibility substitution: the upstream schedule latency is not recomputed in this PR.

## Tests
- `PYTHONPATH=/tmp/rtlgen-int8-l2-substitution/control_plane:/tmp/rtlgen-int8-l2-substitution /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_mixed_precision_physical_feasibility_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_mixed_precision_int8_compute_physical_feasibility_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_mixed_precision_int8_compute_physical_feasibility control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_mixed_precision_physical_feasibility_uses_decoder_evidence -q`
- `python3 scripts/validate_runs.py --skip_eval_queue`