### PR TITLE
npu: add composed dual-stream attention PPA harness

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -506,6 +506,60 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "attention_dual_stream_composed" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                f"dual-stream attention config must live under repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=f"{design_dir}/metrics.csv",
+            commands=[
+                {
+                    "name": "build_generator",
+                    "run": _with_oss_cad_path("cmake -S . -B build && cmake --build build --target rtlgen"),
+                },
+                {
+                    "name": "generate_attention_dual_stream_composed_rtl",
+                    "run": _with_oss_cad_path(
+                        (
+                        "python3 npu/rtlgen/gen_attention_dual_stream_composed.py "
+                        f"--config {config_rel} "
+                        f"--out {design_dir}/verilog"
+                        )
+                    ),
+                },
+                {
+                    "name": "check_attention_dual_stream_composed_guard",
+                    "run": (
+                        "python3 npu/eval/check_attention_dual_stream_composed_guard.py "
+                        f"--design-dir {design_dir}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        (
+                        "python3 npu/synth/run_block_sweep.py "
+                        f"--design_dir {design_dir} "
+                        "--platform {platform} "
+                        f"--top {top_name} "
+                        f"--sweep {{sweep_path}} "
+                        f"--out_root {out_root} "
+                        + (f"--make_target {make_target} " if make_target else "")
+                        + "--skip_existing"
+                        )
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "compute" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -411,6 +411,69 @@ def _write_example_dense_gemm_tile_repo(repo_root: Path) -> tuple[str, str]:
     )
 
 
+def _write_example_dual_stream_composed_repo(repo_root: Path) -> tuple[str, str]:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_dual_stream_composed_smoke"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_dual_stream_composed_smoke",
+                "attention_dual_stream_composed": {
+                    "streams": 2,
+                    "array_m": 2,
+                    "array_n": 2,
+                    "k_unroll": 1,
+                    "softmax_row_elems": 4,
+                    "softmax_accum_bits": 16,
+                    "reciprocal_bits": 10,
+                    "value_bits": 6,
+                    "value_lanes": 4,
+                    "partials": 4,
+                    "partials_per_cycle": 2,
+                    "stream_buffer_bits": 128,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_dual_stream_composed_v1"
+        / "sweeps"
+        / "nangate45_dual_stream_composed_hier.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "flow_params": {
+                    "CLOCK_PERIOD": [10.0],
+                    "DIE_AREA": ["0 0 1200 1200"],
+                    "CORE_AREA": ["50 50 1150 1150"],
+                    "SYNTH_HIERARCHICAL": [1],
+                    "SYNTH_KEEP_MODULES": [
+                        "int8_mac_s8s8_acc24 attention_softmax_weight_int8_r8_acc24_recip_q10_like"
+                    ],
+                },
+                "tag_prefix": "attention_dual_stream_composed_v1",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return (
+        str(config_path.relative_to(repo_root)),
+        str(sweep_path.relative_to(repo_root)),
+    )
+
+
 
 def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
     with tempfile.TemporaryDirectory() as td:
@@ -1081,6 +1144,59 @@ def test_generate_l1_sweep_task_supports_dense_gemm_tile_configs() -> None:
             ]
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "architecture_block"
+            }
+
+
+def test_generate_l1_sweep_task_supports_attention_dual_stream_composed_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_dual_stream_composed_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_dual_stream_composed_datapath",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "build_generator",
+                "generate_attention_dual_stream_composed_rtl",
+                "check_attention_dual_stream_composed_guard",
+                "run_block_sweep",
+                "build_runs_index",
+                "validate",
+            ]
+            assert work_item.command_manifest[1]["run"] == (
+                "export PATH=/oss-cad-suite/bin:$PATH && "
+                "python3 npu/rtlgen/gen_attention_dual_stream_composed.py "
+                "--config runs/designs/npu_blocks/attention_dual_stream_composed_smoke/config.json "
+                "--out runs/designs/npu_blocks/attention_dual_stream_composed_smoke/verilog"
+            )
+            assert work_item.command_manifest[2]["run"] == (
+                "python3 npu/eval/check_attention_dual_stream_composed_guard.py "
+                "--design-dir runs/designs/npu_blocks/attention_dual_stream_composed_smoke"
+            )
+            assert "--top attention_dual_stream_composed_smoke" in work_item.command_manifest[3]["run"]
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_dual_stream_composed_smoke/metrics.csv"
+            ]
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_dual_stream_composed_datapath"
             }
 
 

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_ppa_v1/evaluation_requests.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_ppa_v1",
+  "source_commit": null,
+  "source_commit_note": "Dispatch should use the merge commit containing the composed dual-stream generator and L1 task hook.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the composed local dual-stream attention datapath containing two int8 dense compute streams, shared int8 softmax-weight generation, two Q8/V6 full-value streams, stream buffers, and local control.",
+      "evaluation_mode": "frontier_closure",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "composition_overhead_anchor",
+      "paired_baseline_item_id": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "depends_on": [
+        "l1_npu_dense_gemm_tile_int8_v1",
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1"
+      ],
+      "expected_result": {
+        "direction": "measure_composition_overhead",
+        "reason": "The result should quantify whether composing the feasible int8 dual-stream datapath adds enough area, power, or delay overhead to change the Llama7B frontier conclusion."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_ppa_v1/proposal.json
@@ -1,0 +1,59 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_ppa_v1",
+  "kind": "architecture",
+  "title": "Composed dual-stream attention datapath PPA",
+  "layer": "layer1",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "status": "proposed",
+  "motivation": [
+    "The L2 int8-compute substitution result made the Q8/K8/V6 dual_mac schedule physically feasible, but it still substituted independently measured blocks into an analytic schedule model.",
+    "The next abstraction to remove is the local composed datapath/control cost of two int8 compute streams feeding shared softmax weights and two full-value streams.",
+    "A bounded Layer 1 PPA wrapper can measure the composed block before building a larger scheduler/SRAM/NoC wrapper."
+  ],
+  "direct_comparison": {
+    "primary_question": "How much PPA overhead appears when the int8 dense compute, softmax-weight, full-value streams, buffers, and local control are synthesized as one dual-stream block?",
+    "baseline": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+    "candidate": "l1_decoder_attention_dual_stream_composed_ppa_v1",
+    "metrics": [
+      "critical_path_ns",
+      "instance_area_um2",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count"
+    ]
+  },
+  "expected_result": {
+    "direction": "measure_composition_overhead",
+    "reason": "Use measured composed datapath PPA to replace the current sum-of-parts area and clock assumptions in the Llama7B attention frontier."
+  },
+  "required_inputs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+    "l1_npu_dense_gemm_tile_int8_v1",
+    "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1"
+  ],
+  "evaluation_requests": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_ppa_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "frontier_closure",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "composition_overhead_anchor",
+      "paired_baseline_item_id": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "depends_on": [
+        "l1_npu_dense_gemm_tile_int8_v1",
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1"
+      ]
+    }
+  ],
+  "source_files": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Check generated composed dual-stream attention RTL before PPA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", required=True)
+    args = parser.parse_args()
+
+    design_dir = Path(args.design_dir)
+    manifest_path = design_dir / "verilog" / "attention_dual_stream_composed_manifest.json"
+    top_path = design_dir / "verilog" / "top.v"
+    if not manifest_path.exists():
+        raise SystemExit(f"missing manifest: {manifest_path}")
+    if not top_path.exists():
+        raise SystemExit(f"missing generated RTL: {top_path}")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    top_text = top_path.read_text(encoding="utf-8")
+    top_name = str(manifest["top_name"])
+    total_macs = int(manifest["total_macs"])
+    streams = int(manifest["streams"])
+    if streams != 2:
+        raise SystemExit(f"expected 2 streams, found {streams}")
+    if f"module {top_name} " not in top_text:
+        raise SystemExit(f"missing top module {top_name}")
+
+    mac_instances = len(re.findall(r"\bu_mac_\d{4}\s*\(", top_text))
+    if mac_instances != total_macs:
+        raise SystemExit(f"MAC instance count mismatch: expected {total_macs}, found {mac_instances}")
+    value_instances = len(re.findall(r"\bu_value_stream_\d+\s*\(", top_text))
+    if value_instances != 2:
+        raise SystemExit(f"value stream count mismatch: expected 2, found {value_instances}")
+    if len(re.findall(r"\bu_softmax\s*\(", top_text)) != 1:
+        raise SystemExit("expected exactly one shared softmax instance")
+    if "stream_buf_0" not in top_text or "stream_buf_1" not in top_text:
+        raise SystemExit("missing dual stream buffer registers")
+    if "result_hash <=" not in top_text:
+        raise SystemExit("result_hash is not updated")
+
+    fold_match = re.search(r"\bwire\s+\[31:0\]\s+compute_fold\s*=\s*(.*?);", top_text, flags=re.DOTALL)
+    if fold_match is None:
+        raise SystemExit("missing compute_fold assignment")
+    fold_expr = fold_match.group(1)
+    missing_macs = [f"mac_r_{idx:04d}" for idx in range(total_macs) if f"mac_r_{idx:04d}" not in fold_expr]
+    if missing_macs:
+        raise SystemExit(f"MAC outputs are not visible in compute fold: {missing_macs[:8]}")
+    for token in ("softmax_weight_hash", "value_hash_0", "value_hash_1", "value_accum_0", "value_accum_1"):
+        if token not in top_text:
+            raise SystemExit(f"missing result visibility token: {token}")
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "design_dir": str(design_dir),
+                "top_name": top_name,
+                "streams": streams,
+                "total_macs": total_macs,
+                "value_streams": value_instances,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Generate a composed dual-stream attention datapath PPA harness.
+
+The generated top keeps the external boundary narrow while composing the local
+datapath pieces used by the Llama7B mixed-precision dual-stream feasibility
+model: two int8 dense compute streams, a shared int8 softmax-weight generator,
+two q8/v6 full-value streams, stream buffers, and simple start/done control.
+Every internal result is folded into a visible hash to prevent dead-code
+elimination during synthesis.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_int(config: dict[str, Any], key: str, default: int) -> int:
+    return int(config.get(key, default))
+
+
+def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
+    comp = cfg.get("attention_dual_stream_composed")
+    if not isinstance(comp, dict):
+        raise SystemExit("config must contain attention_dual_stream_composed object")
+    streams = _as_int(comp, "streams", 2)
+    array_m = _as_int(comp, "array_m", 16)
+    array_n = _as_int(comp, "array_n", 8)
+    k_unroll = _as_int(comp, "k_unroll", 1)
+    row_elems = _as_int(comp, "softmax_row_elems", 8)
+    value_lanes = _as_int(comp, "value_lanes", 16)
+    partials = _as_int(comp, "partials", 8)
+    partials_per_cycle = _as_int(comp, "partials_per_cycle", 2)
+    stream_buffer_bits = _as_int(comp, "stream_buffer_bits", 1024)
+    if streams != 2:
+        raise SystemExit("attention_dual_stream_composed.streams must be 2 for the current dual-stream harness")
+    if array_m < 1 or array_m > 16:
+        raise SystemExit("attention_dual_stream_composed.array_m must be in [1, 16]")
+    if array_n < 1 or array_n > 16:
+        raise SystemExit("attention_dual_stream_composed.array_n must be in [1, 16]")
+    if k_unroll < 1 or k_unroll > 4:
+        raise SystemExit("attention_dual_stream_composed.k_unroll must be in [1, 4]")
+    if row_elems < 1 or row_elems > 16:
+        raise SystemExit("attention_dual_stream_composed.softmax_row_elems must be in [1, 16]")
+    if value_lanes < 1 or value_lanes > 32:
+        raise SystemExit("attention_dual_stream_composed.value_lanes must be in [1, 32]")
+    if partials < 1 or partials > 16:
+        raise SystemExit("attention_dual_stream_composed.partials must be in [1, 16]")
+    if partials_per_cycle < 1 or partials_per_cycle > partials:
+        raise SystemExit("attention_dual_stream_composed.partials_per_cycle must be in [1, partials]")
+    if stream_buffer_bits < 128 or stream_buffer_bits > 4096:
+        raise SystemExit("attention_dual_stream_composed.stream_buffer_bits must be in [128, 4096]")
+    return comp
+
+
+def _int8_mac_module() -> str:
+    return """module int8_mac_s8s8_acc24 (
+    input  wire signed [7:0]  A,
+    input  wire signed [7:0]  B,
+    input  wire signed [23:0] C,
+    output wire signed [23:0] R
+);
+  wire signed [15:0] product = A * B;
+  assign R = {{8{product[15]}}, product} + C;
+endmodule
+"""
+
+
+def _softmax_module(*, module_name: str, row_elems: int, accum_bits: int, reciprocal_bits: int) -> str:
+    data_width = row_elems * 8
+    product_bits = accum_bits + 8
+    return f"""(* keep_hierarchy = 1 *)
+module {module_name} (
+    input  wire                  clk,
+    input  wire [{data_width - 1}:0] scores,
+    output reg  [{data_width - 1}:0] weights,
+    output reg  [31:0]          weight_hash
+);
+  localparam integer ROW_ELEMS = {row_elems};
+  localparam integer ACCUM_BITS = {accum_bits};
+  localparam integer PRODUCT_BITS = {product_bits};
+  localparam integer MAX_SHIFT = 7;
+  localparam integer OUTPUT_SCALE = 127;
+  localparam integer RECIPROCAL_BITS = {reciprocal_bits};
+
+  integer i;
+  integer signed lane_val;
+  integer signed row_max;
+  integer delta;
+  reg [ACCUM_BITS-1:0] exp_weight [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight;
+  reg [PRODUCT_BITS-1:0] numer;
+  reg [7:0] lane_out;
+  reg [{data_width - 1}:0] next_weights;
+  reg [31:0] next_hash;
+
+  always @(*) begin
+    row_max = -(1 << 7);
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*8) +: 8]);
+      if (lane_val > row_max)
+        row_max = lane_val;
+    end
+
+    sum_weight = {{ACCUM_BITS{{1'b0}}}};
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*8) +: 8]);
+      delta = row_max - lane_val;
+      if (delta < 0)
+        delta = 0;
+      if (delta > MAX_SHIFT)
+        delta = MAX_SHIFT;
+      exp_weight[i] = ({{{{(ACCUM_BITS-1){{1'b0}}}}, 1'b1}} << (MAX_SHIFT - delta));
+      sum_weight = sum_weight + exp_weight[i];
+    end
+
+    next_weights = {{{data_width}{{1'b0}}}};
+      next_hash = 32'h5a5a_0101 ^ 32'h{reciprocal_bits & 0xFFFF:04x};
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      numer = (exp_weight[i] * OUTPUT_SCALE) + (sum_weight >> 1);
+      if (sum_weight != 0)
+        lane_out = numer / sum_weight;
+      else
+        lane_out = 8'h00;
+      if (lane_out > 8'd127)
+        lane_out = 8'd127;
+      next_weights[(i*8) +: 8] = lane_out;
+      next_hash = {{next_hash[23:0], next_hash[31:24]}} ^ {{24'h0, lane_out}};
+    end
+  end
+
+  always @(posedge clk) begin
+    weights <= next_weights;
+    weight_hash <= next_hash;
+  end
+endmodule
+"""
+
+
+def _value_stream_module(*, module_name: str, row_elems: int, value_lanes: int, stream_buffer_bits: int) -> str:
+    acc_bits = 40
+    product_bits = 16
+    fold_terms = ["32'h0000_0000"]
+    product_lines: list[str] = []
+    for lane in range(value_lanes):
+        product_lines.extend(
+            [
+                f"  wire signed [5:0] value_{lane:02d} = stream_data[{(lane * 6) % (stream_buffer_bits - 5)} +: 6];",
+                f"  wire signed [7:0] weight_{lane:02d} = weights[{(lane % row_elems) * 8} +: 8];",
+                f"  wire signed [{product_bits - 1}:0] product_{lane:02d} = value_{lane:02d} * weight_{lane:02d};",
+            ]
+        )
+        fold_terms.append(f"{{16'h0, product_{lane:02d}}}")
+    sum_terms = [
+        f"{{{{{acc_bits - product_bits}{{product_{lane:02d}[{product_bits - 1}]}}}}, product_{lane:02d}}}"
+        for lane in range(value_lanes)
+    ]
+    sum_expr = " +\n      ".join(sum_terms)
+    fold_expr = " ^\n      ".join(fold_terms)
+    score_ext = f"{{{{{acc_bits - 24}{{score_mix[23]}}}}, score_mix}}"
+    return f"""(* keep_hierarchy = 1 *)
+module {module_name} (
+    input  wire                  clk,
+    input  wire [{stream_buffer_bits - 1}:0] stream_data,
+    input  wire [{row_elems * 8 - 1}:0] weights,
+    input  wire [23:0]           score_mix,
+    output reg  [{acc_bits - 1}:0] value_accum,
+    output reg  [31:0]           value_hash
+);
+{chr(10).join(product_lines)}
+  wire signed [{acc_bits - 1}:0] product_sum =
+      {sum_expr};
+  wire [31:0] product_fold =
+      {fold_expr};
+
+  always @(posedge clk) begin
+    value_accum <= product_sum + {score_ext};
+    value_hash <= product_fold ^ value_accum[31:0] ^ {{8'h0, score_mix}};
+  end
+endmodule
+"""
+
+
+def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> None:
+    top_name = str(cfg.get("top_name", "attention_dual_stream_composed_top")).strip()
+    array_m = _as_int(comp, "array_m", 16)
+    array_n = _as_int(comp, "array_n", 8)
+    k_unroll = _as_int(comp, "k_unroll", 1)
+    row_elems = _as_int(comp, "softmax_row_elems", 8)
+    value_lanes = _as_int(comp, "value_lanes", 16)
+    partials = _as_int(comp, "partials", 8)
+    partials_per_cycle = _as_int(comp, "partials_per_cycle", 2)
+    reciprocal_bits = _as_int(comp, "reciprocal_bits", 10)
+    accum_bits = _as_int(comp, "softmax_accum_bits", 24)
+    stream_buffer_bits = _as_int(comp, "stream_buffer_bits", 1024)
+    macs_per_stream = array_m * array_n * k_unroll
+    streams = 2
+    total_macs = streams * macs_per_stream
+    softmax_name = "attention_softmax_weight_int8_r8_acc24_recip_q10_like"
+    value_name = "attention_full_value_stream_q8v6_p8_ppc2"
+
+    stream_regs = [f"  reg [{stream_buffer_bits - 1}:0] stream_buf_{stream};" for stream in range(streams)]
+    stream_reset = [f"      stream_buf_{stream} <= {{{stream_buffer_bits}{{1'b0}}}};" for stream in range(streams)]
+    stream_update = [
+        (
+            f"      stream_buf_{stream} <= {{stream_buf_{stream}[{stream_buffer_bits - 33}:0], "
+            f"seed_state ^ result_hash ^ 32'h{0x13572468 ^ stream:08x}}};"
+        )
+        for stream in range(streams)
+    ]
+
+    mac_wires: list[str] = []
+    mac_insts: list[str] = []
+    score_lane_terms: list[list[str]] = [[] for _ in range(row_elems)]
+    score_mix_terms = [["24'h000000"] for _ in range(streams)]
+    compute_fold_terms = ["32'h0000_0000"]
+    for stream in range(streams):
+        for idx in range(macs_per_stream):
+            row = idx // (array_n * k_unroll)
+            col = (idx // k_unroll) % array_n
+            ku = idx % k_unroll
+            flat = stream * macs_per_stream + idx
+            const_a = (0x3D ^ ((stream + 1) * 0x17) ^ ((row + 1) * 0x13) ^ ((col + 1) * 0x27) ^ (ku * 0x41)) & 0xFF
+            const_b = (0x21 ^ ((stream + 1) * 0x2B) ^ ((row + 1) * 0x1D) ^ ((col + 1) * 0xA3) ^ (ku * 0x55)) & 0xFF
+            const_c = (0x001011 ^ ((stream + 1) * 0x0101) ^ ((row + 1) * 0x0007) ^ ((col + 1) * 0x000B) ^ (ku * 0x0013)) & 0xFFFFFF
+            mac_wires.extend(
+                [
+                    f"  wire signed [7:0] mac_a_{flat:04d} = seed_state[7:0] ^ stream_buf_{stream}[{(idx * 7) % (stream_buffer_bits - 7)} +: 8] ^ 8'h{const_a:02x} ^ cycle_ctr[7:0];",
+                    f"  wire signed [7:0] mac_b_{flat:04d} = seed_state[15:8] ^ stream_buf_{stream}[{(idx * 11) % (stream_buffer_bits - 7)} +: 8] ^ 8'h{const_b:02x} ^ cycle_ctr[15:8];",
+                    f"  wire signed [23:0] mac_c_{flat:04d} = {{8'h00, result_hash[15:0]}} ^ stream_buf_{stream}[{(idx * 13) % (stream_buffer_bits - 23)} +: 24] ^ 24'h{const_c:06x};",
+                    f"  wire signed [23:0] mac_r_{flat:04d};",
+                ]
+            )
+            mac_insts.append(
+                f"""  int8_mac_s8s8_acc24 u_mac_{flat:04d} (
+    .A(mac_a_{flat:04d}),
+    .B(mac_b_{flat:04d}),
+    .C(mac_c_{flat:04d}),
+    .R(mac_r_{flat:04d})
+  );"""
+            )
+            score_lane_terms[idx % row_elems].append(f"mac_r_{flat:04d}[7:0]")
+            score_mix_terms[stream].append(f"mac_r_{flat:04d}")
+            compute_fold_terms.append(f"{{8'h00, mac_r_{flat:04d}}}")
+
+    score_assigns = []
+    for lane, terms in enumerate(score_lane_terms):
+        expr = " ^ ".join(terms or ["8'h00"])
+        score_assigns.append(f"  wire [7:0] score_lane_{lane:02d} = {expr};")
+    score_row_concat = ", ".join(f"score_lane_{lane:02d}" for lane in reversed(range(row_elems)))
+    compute_fold_expr = " ^\n      ".join(compute_fold_terms)
+    score_mix_exprs = [" ^\n      ".join(terms) for terms in score_mix_terms]
+
+    top_text = f"""// Auto-generated by npu/rtlgen/gen_attention_dual_stream_composed.py
+(* keep_hierarchy = 1 *)
+module {top_name} (
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire        start,
+    input  wire [31:0] seed,
+    output reg         done,
+    output reg  [31:0] result_hash
+);
+  localparam integer STREAMS = {streams};
+  localparam integer ARRAY_M = {array_m};
+  localparam integer ARRAY_N = {array_n};
+  localparam integer K_UNROLL = {k_unroll};
+  localparam integer MACS_PER_STREAM = {macs_per_stream};
+  localparam integer TOTAL_MACS = {total_macs};
+  localparam integer SOFTMAX_ROW_ELEMS = {row_elems};
+  localparam integer VALUE_LANES = {value_lanes};
+  localparam integer PARTIALS = {partials};
+  localparam integer PARTIALS_PER_CYCLE = {partials_per_cycle};
+  localparam integer STREAM_BUFFER_BITS = {stream_buffer_bits};
+
+  reg [31:0] seed_state;
+  reg [15:0] cycle_ctr;
+{chr(10).join(stream_regs)}
+
+{chr(10).join(mac_wires)}
+
+{chr(10).join(mac_insts)}
+
+{chr(10).join(score_assigns)}
+  wire [{row_elems * 8 - 1}:0] softmax_scores = {{{score_row_concat}}};
+  wire [{row_elems * 8 - 1}:0] softmax_weights;
+  wire [31:0] softmax_weight_hash;
+  wire [31:0] compute_fold =
+      {compute_fold_expr};
+  wire [23:0] score_mix_0 =
+      {score_mix_exprs[0]};
+  wire [23:0] score_mix_1 =
+      {score_mix_exprs[1]};
+  wire [39:0] value_accum_0;
+  wire [39:0] value_accum_1;
+  wire [31:0] value_hash_0;
+  wire [31:0] value_hash_1;
+
+  {softmax_name} u_softmax (
+    .clk(clk),
+    .scores(softmax_scores),
+    .weights(softmax_weights),
+    .weight_hash(softmax_weight_hash)
+  );
+
+  {value_name} u_value_stream_0 (
+    .clk(clk),
+    .stream_data(stream_buf_0),
+    .weights(softmax_weights),
+    .score_mix(score_mix_0),
+    .value_accum(value_accum_0),
+    .value_hash(value_hash_0)
+  );
+
+  {value_name} u_value_stream_1 (
+    .clk(clk),
+    .stream_data(stream_buf_1),
+    .weights(softmax_weights),
+    .score_mix(score_mix_1),
+    .value_accum(value_accum_1),
+    .value_hash(value_hash_1)
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      seed_state <= 32'h0000_0001;
+      cycle_ctr <= 16'h0;
+      result_hash <= 32'h0;
+      done <= 1'b0;
+{chr(10).join(stream_reset)}
+    end else begin
+      seed_state <= {{seed_state[30:0], seed_state[31] ^ seed_state[21] ^ seed_state[1] ^ seed_state[0]}} ^ seed;
+      cycle_ctr <= cycle_ctr + 16'h1;
+      done <= start;
+{chr(10).join(stream_update)}
+      if (start) begin
+        result_hash <= result_hash ^ compute_fold ^ softmax_weight_hash ^ value_hash_0 ^ value_hash_1 ^
+                       value_accum_0[31:0] ^ value_accum_1[31:0] ^ {{16'h0, cycle_ctr}};
+      end
+    end
+  end
+endmodule
+"""
+
+    out_path.mkdir(parents=True, exist_ok=True)
+    rtl = "\n\n".join(
+        [
+            _int8_mac_module(),
+            _softmax_module(module_name=softmax_name, row_elems=row_elems, accum_bits=accum_bits, reciprocal_bits=reciprocal_bits),
+            _value_stream_module(module_name=value_name, row_elems=row_elems, value_lanes=value_lanes, stream_buffer_bits=stream_buffer_bits),
+            top_text,
+        ]
+    )
+    (out_path / "top.v").write_text(rtl, encoding="utf-8")
+    manifest = {
+        "version": 0.1,
+        "generator": "npu/rtlgen/gen_attention_dual_stream_composed.py",
+        "top_name": top_name,
+        "streams": streams,
+        "array_m": array_m,
+        "array_n": array_n,
+        "k_unroll": k_unroll,
+        "macs_per_stream": macs_per_stream,
+        "total_macs": total_macs,
+        "softmax_row_elems": row_elems,
+        "softmax_accum_bits": accum_bits,
+        "reciprocal_bits": reciprocal_bits,
+        "value_bits": 6,
+        "value_lanes_per_stream": value_lanes,
+        "partials": partials,
+        "partials_per_cycle": partials_per_cycle,
+        "stream_buffer_bits_per_stream": stream_buffer_bits,
+        "components": {
+            "compute": "two signed-int8 dense GEMM streams",
+            "softmax_weight": "one shared rowwise int8 shift-exp reciprocal-normalized generator",
+            "full_value": "two q8/v6 weighted-value streams",
+            "control": "start/done, seed LFSR, per-stream buffer registers, result hash",
+        },
+        "datapath_guard": "all MAC, softmax, and value stream outputs fold into result_hash",
+    }
+    (out_path / "attention_dual_stream_composed_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_path / "config.json").write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    cfg = _load_json(Path(args.config))
+    comp = _validate(cfg)
+    _write_top(cfg=cfg, comp=comp, out_path=Path(args.out))
+    print(f"attention-dual-stream-composed: wrote RTL to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json
@@ -1,0 +1,30 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.30,
+      0.40
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_int8_r8_acc24_recip_q10_like attention_full_value_stream_q8v6_p8_ppc2"
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1"
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2/README.md
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2/README.md
@@ -1,0 +1,13 @@
+# Composed Dual-Stream Attention Datapath
+
+This design measures a bounded local datapath composition for the Llama7B mixed-precision dual-stream attention frontier.
+
+The generated top uses a narrow self-stimulating PPA harness and contains:
+
+- two signed-int8 16x8 dense GEMM streams,
+- one shared row-8 int8 softmax-weight generator,
+- two q8/v6 full-value stream datapaths,
+- per-stream buffer registers and start/done control,
+- a result hash that folds every compute, softmax, and value stream output.
+
+This is not a full global scheduler/SRAM/NoC measurement. It is the next physical anchor after the int8-compute substitution model showed `dual_mac` feasibility.

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2/config.json
@@ -1,0 +1,17 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "softmax_row_elems": 8,
+    "softmax_accum_bits": 24,
+    "reciprocal_bits": 10,
+    "value_bits": 6,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -1,0 +1,76 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_attention_dual_stream_composed_generator_guard_and_syntax(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_smoke"
+    config_path = design_dir / "config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_dual_stream_composed_smoke",
+                "attention_dual_stream_composed": {
+                    "streams": 2,
+                    "array_m": 2,
+                    "array_n": 2,
+                    "k_unroll": 1,
+                    "softmax_row_elems": 4,
+                    "softmax_accum_bits": 16,
+                    "reciprocal_bits": 10,
+                    "value_bits": 6,
+                    "value_lanes": 4,
+                    "partials": 4,
+                    "partials_per_cycle": 2,
+                    "stream_buffer_bits": 128,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "npu/rtlgen/gen_attention_dual_stream_composed.py",
+            "--config",
+            str(config_path),
+            "--out",
+            str(design_dir / "verilog"),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_dual_stream_composed_guard.py",
+            "--design-dir",
+            str(design_dir),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "/oss-cad-suite/bin/iverilog",
+            "-g2012",
+            "-o",
+            str(design_dir / "simv"),
+            str(design_dir / "verilog" / "top.v"),
+        ],
+        check=True,
+    )
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    top_text = (design_dir / "verilog" / "top.v").read_text(encoding="utf-8")
+    assert manifest["streams"] == 2
+    assert manifest["total_macs"] == 8
+    assert manifest["softmax_row_elems"] == 4
+    assert manifest["value_lanes_per_stream"] == 4
+    assert "u_softmax" in top_text
+    assert "u_value_stream_0" in top_text
+    assert "u_value_stream_1" in top_text
+    assert "result_hash <=" in top_text


### PR DESCRIPTION
## Summary
- add a generated composed dual-stream attention datapath PPA harness
- compose two int8 dense compute streams, one shared int8 softmax-weight generator, two Q8/V6 full-value streams, stream buffers, and local start/done/hash control
- add a guard that verifies all compute/value/softmax outputs remain visible to synthesis
- add L1 task-generator support, a concrete Nangate45 sweep, and proposal docs for dispatch

## Scope
This measures the local dual-stream datapath composition after the int8-compute feasibility result. It intentionally does not include the full global scheduler, SRAM hierarchy, or NoC.

## Tests
- `python3 npu/rtlgen/gen_attention_dual_stream_composed.py --config runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2/config.json --out /tmp/dual_stream_guard_tmp/verilog`
- `python3 npu/eval/check_attention_dual_stream_composed_guard.py --design-dir /tmp/dual_stream_guard_tmp`
- `/oss-cad-suite/bin/iverilog -g2012 -o /tmp/dual_stream_guard_tmp/simv /tmp/dual_stream_guard_tmp/verilog/top.v`
- `PYTHONPATH=/tmp/rtlgen-dual-stream-compose /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_attention_dual_stream_composed_generator.py -q`
- `PYTHONPATH=/tmp/rtlgen-dual-stream-compose/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_supports_attention_dual_stream_composed_configs -q`
- `python3 scripts/validate_runs.py --skip_eval_queue`