### PR TITLE
docs: propose dual-stream no-hash ppa

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_nohash_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_nohash_ppa_v1/evaluation_requests.json
@@ -1,0 +1,33 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_nohash_ppa_v1",
+  "source_commit": "f5941407d6ab613b390653bdd49708cf34c6c903",
+  "source_commit_note": "Dispatch should use the merge commit that makes equivalence_hash opt-in and adds the no-hash PPA design config.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_nohash_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the composed Q8/K8/V6 dual-stream attention datapath with equivalence-only hash folding disabled and real datapath outputs exposed directly.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "production_like_ppa_without_equivalence_hash",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_timing_debug_final_stage_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_timing_debug_final_stage_v1"
+      ],
+      "expected_result": {
+        "direction": "remove_equivalence_instrumentation_from_ppa",
+        "reason": "The result should replace the hash-instrumented composed datapath timing when estimating production-like Llama7B attention performance."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_nohash_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_nohash_ppa_v1/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_nohash_ppa_v1",
+  "kind": "diagnostic",
+  "title": "Composed dual-stream attention no-hash PPA",
+  "layer": "layer1",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "status": "proposed",
+  "motivation": [
+    "The final-stage timing debug run showed the critical path dominated by seed/hash observability logic feeding softmax weight hash state.",
+    "That hash path exists for Verilog/perf-sim equivalence checks and is not production datapath logic.",
+    "The composed attention datapath should be remeasured with equivalence_hash disabled and real datapath outputs exposed directly."
+  ],
+  "direct_comparison": {
+    "primary_question": "What is the PPA of the composed Q8/K8/V6 dual-stream attention datapath when equivalence-only hash logic is disabled?",
+    "baseline": "l1_decoder_attention_dual_stream_composed_timing_debug_final_stage_v1",
+    "candidate": "l1_decoder_attention_dual_stream_composed_nohash_ppa_v1",
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "expected_result": {
+    "direction": "remove_equivalence_instrumentation_from_ppa",
+    "reason": "Use the no-hash result as the production-like composed datapath PPA input for the Llama7B attention frontier."
+  },
+  "required_inputs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+    "l1_decoder_attention_dual_stream_composed_timing_debug_final_stage_v1"
+  ],
+  "evaluation_requests": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_nohash_ppa_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "production_like_ppa_without_equivalence_hash",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_timing_debug_final_stage_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_timing_debug_final_stage_v1"
+      ]
+    }
+  ],
+  "source_files": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "npu/eval/extract_openroad_timing_summary.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the proposal-linked request for the no-hash composed dual-stream PPA rerun
- target the new nohash design config from #852
- keep expected artifacts to metrics.csv and timing_debug_report.md

## Verification
- /workspaces/RTLGen/control_plane/.venv/bin/python -m json.tool docs/proposals/prop_l1_decoder_attention_dual_stream_composed_nohash_ppa_v1/proposal.json
- /workspaces/RTLGen/control_plane/.venv/bin/python -m json.tool docs/proposals/prop_l1_decoder_attention_dual_stream_composed_nohash_ppa_v1/evaluation_requests.json
- python3 scripts/validate_runs.py --skip_eval_queue