### PR TITLE
npu: add softmax input pipeline candidate

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1/evaluation_requests.json
@@ -1,0 +1,32 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds softmax_pipeline_stages and the no-hash softmax_pipe1 design config.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the composed Q8/K8/V6 dual-stream attention datapath with equivalence-only hash folding disabled, one registered softmax input stage, and aligned value-stream payload delay.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "softmax_input_pipeline_stage",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_nohash_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_nohash_ppa_v1"
+      ],
+      "expected_result": {
+        "direction": "pipeline_softmax_weight_path",
+        "reason": "The result should show whether the no-hash composed datapath critical path is removed by a normal score/softmax pipeline boundary."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+  "kind": "diagnostic",
+  "title": "Composed dual-stream attention softmax pipe1 PPA",
+  "layer": "layer1",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "status": "proposed",
+  "motivation": [
+    "The no-hash composed dual-stream PPA run moved the final-stage critical path into the real softmax weight storage path.",
+    "The reported path starts at seed_state and ends at u_softmax/weights, indicating the MAC/score generation and softmax weight calculation are currently in one timing span.",
+    "A one-stage softmax input pipeline, with aligned value-stream payload delay, tests whether ordinary staging removes this datapath timing bottleneck."
+  ],
+  "direct_comparison": {
+    "primary_question": "How much PPA improvement comes from inserting one softmax input pipeline stage in the no-hash composed dual-stream attention datapath?",
+    "baseline": "l1_decoder_attention_dual_stream_composed_nohash_ppa_v1",
+    "candidate": "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "expected_result": {
+    "direction": "pipeline_softmax_weight_path",
+    "reason": "Use the result to decide whether the current ~23 ns no-hash path is primarily missing staging or requires a deeper softmax algorithm/circuit change."
+  },
+  "required_inputs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+    "l1_decoder_attention_dual_stream_composed_nohash_ppa_v1"
+  ],
+  "evaluation_requests": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "softmax_input_pipeline_stage",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_nohash_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_nohash_ppa_v1"
+      ]
+    }
+  ],
+  "source_files": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "npu/eval/extract_openroad_timing_summary.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -28,6 +28,8 @@ def main() -> int:
     total_macs = int(manifest["total_macs"])
     streams = int(manifest["streams"])
     equivalence_hash = bool(manifest.get("equivalence_hash", False))
+    softmax_pipeline_stages = int(manifest.get("softmax_pipeline_stages", 0))
+    value_alignment_delay_stages = int(manifest.get("value_alignment_delay_stages", 0))
     if streams != 2:
         raise SystemExit(f"expected 2 streams, found {streams}")
     if f"module {top_name} " not in top_text:
@@ -43,6 +45,30 @@ def main() -> int:
         raise SystemExit("expected exactly one shared softmax instance")
     if "stream_buf_0" not in top_text or "stream_buf_1" not in top_text:
         raise SystemExit("missing dual stream buffer registers")
+    if softmax_pipeline_stages:
+        if softmax_pipeline_stages != 1:
+            raise SystemExit(f"unsupported softmax_pipeline_stages={softmax_pipeline_stages}")
+        if value_alignment_delay_stages != softmax_pipeline_stages + 1:
+            raise SystemExit(
+                "value alignment delay must match the softmax input stage plus the registered softmax output latency"
+            )
+        for token in (
+            "softmax_scores_pipe_0",
+            ".scores(softmax_scores_pipe_0)",
+            "stream_buf_0_pipe_1",
+            "stream_buf_1_pipe_1",
+            ".stream_data(stream_buf_0_pipe_1)",
+            ".stream_data(stream_buf_1_pipe_1)",
+            ".score_mix(score_mix_0_pipe_1)",
+            ".score_mix(score_mix_1_pipe_1)",
+        ):
+            if token not in top_text:
+                raise SystemExit(f"missing softmax pipeline alignment token: {token}")
+    else:
+        if value_alignment_delay_stages != 0:
+            raise SystemExit("value alignment delay must be 0 when softmax pipeline is disabled")
+        if "softmax_scores_pipe_0" in top_text:
+            raise SystemExit("softmax pipeline register present when disabled")
     if equivalence_hash:
         if "result_hash <=" not in top_text:
             raise SystemExit("result_hash is not updated")
@@ -78,6 +104,8 @@ def main() -> int:
                 "total_macs": total_macs,
                 "value_streams": value_instances,
                 "equivalence_hash": equivalence_hash,
+                "softmax_pipeline_stages": softmax_pipeline_stages,
+                "value_alignment_delay_stages": value_alignment_delay_stages,
             },
             indent=2,
             sort_keys=True,

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -51,6 +51,7 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     partials = _as_int(comp, "partials", 8)
     partials_per_cycle = _as_int(comp, "partials_per_cycle", 2)
     stream_buffer_bits = _as_int(comp, "stream_buffer_bits", 1024)
+    softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
     if streams != 2:
         raise SystemExit("attention_dual_stream_composed.streams must be 2 for the current dual-stream harness")
     if array_m < 1 or array_m > 16:
@@ -69,6 +70,8 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.partials_per_cycle must be in [1, partials]")
     if stream_buffer_bits < 128 or stream_buffer_bits > 4096:
         raise SystemExit("attention_dual_stream_composed.stream_buffer_bits must be in [128, 4096]")
+    if softmax_pipeline_stages < 0 or softmax_pipeline_stages > 1:
+        raise SystemExit("attention_dual_stream_composed.softmax_pipeline_stages must be in [0, 1]")
     return comp
 
 
@@ -234,6 +237,8 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     accum_bits = _as_int(comp, "softmax_accum_bits", 24)
     stream_buffer_bits = _as_int(comp, "stream_buffer_bits", 1024)
     equivalence_hash = _as_bool(comp, "equivalence_hash", False)
+    softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
+    value_delay_stages = softmax_pipeline_stages + 1 if softmax_pipeline_stages else 0
     macs_per_stream = array_m * array_n * k_unroll
     streams = 2
     total_macs = streams * macs_per_stream
@@ -249,6 +254,34 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
         )
         for stream in range(streams)
     ]
+    softmax_pipe_regs = ""
+    softmax_pipe_reset = ""
+    softmax_pipe_update = ""
+    softmax_scores_for_softmax = "softmax_scores"
+    if softmax_pipeline_stages:
+        softmax_pipe_regs = f"  reg [{row_elems * 8 - 1}:0] softmax_scores_pipe_0;\n"
+        softmax_pipe_reset = f"      softmax_scores_pipe_0 <= {{{row_elems * 8}{{1'b0}}}};\n"
+        softmax_pipe_update = "      softmax_scores_pipe_0 <= softmax_scores;\n"
+        softmax_scores_for_softmax = "softmax_scores_pipe_0"
+
+    value_pipe_regs: list[str] = []
+    value_pipe_reset: list[str] = []
+    value_pipe_update: list[str] = []
+    value_stream_data_for_value = [f"stream_buf_{stream}" for stream in range(streams)]
+    score_mix_for_value = [f"score_mix_{stream}" for stream in range(streams)]
+    if value_delay_stages:
+        for stream in range(streams):
+            for stage in range(value_delay_stages):
+                value_pipe_regs.append(f"  reg [{stream_buffer_bits - 1}:0] stream_buf_{stream}_pipe_{stage};")
+                value_pipe_regs.append(f"  reg [23:0] score_mix_{stream}_pipe_{stage};")
+                value_pipe_reset.append(f"      stream_buf_{stream}_pipe_{stage} <= {{{stream_buffer_bits}{{1'b0}}}};")
+                value_pipe_reset.append(f"      score_mix_{stream}_pipe_{stage} <= 24'h0;")
+                source_stream = f"stream_buf_{stream}" if stage == 0 else f"stream_buf_{stream}_pipe_{stage - 1}"
+                source_score = f"score_mix_{stream}" if stage == 0 else f"score_mix_{stream}_pipe_{stage - 1}"
+                value_pipe_update.append(f"      stream_buf_{stream}_pipe_{stage} <= {source_stream};")
+                value_pipe_update.append(f"      score_mix_{stream}_pipe_{stage} <= {source_score};")
+            value_stream_data_for_value[stream] = f"stream_buf_{stream}_pipe_{value_delay_stages - 1}"
+            score_mix_for_value[stream] = f"score_mix_{stream}_pipe_{value_delay_stages - 1}"
 
     mac_wires: list[str] = []
     mac_insts: list[str] = []
@@ -359,6 +392,8 @@ module {top_name} (
   reg [31:0] seed_state;
   reg [15:0] cycle_ctr;
 {chr(10).join(stream_regs)}
+{softmax_pipe_regs.rstrip()}
+{chr(10).join(value_pipe_regs)}
 
 {chr(10).join(mac_wires)}
 
@@ -379,23 +414,23 @@ module {top_name} (
 
   {softmax_name} u_softmax (
     .clk(clk),
-    .scores(softmax_scores),
+    .scores({softmax_scores_for_softmax}),
     .weights(softmax_weights){softmax_hash_conn}
   );
 
   {value_name} u_value_stream_0 (
     .clk(clk),
-    .stream_data(stream_buf_0),
+    .stream_data({value_stream_data_for_value[0]}),
     .weights(softmax_weights),
-    .score_mix(score_mix_0),
+    .score_mix({score_mix_for_value[0]}),
     .value_accum(value_accum_0){value_hash_conn_0}
   );
 
   {value_name} u_value_stream_1 (
     .clk(clk),
-    .stream_data(stream_buf_1),
+    .stream_data({value_stream_data_for_value[1]}),
     .weights(softmax_weights),
-    .score_mix(score_mix_1),
+    .score_mix({score_mix_for_value[1]}),
     .value_accum(value_accum_1){value_hash_conn_1}
   );
 
@@ -407,11 +442,15 @@ module {top_name} (
       done <= 1'b0;
 {reset_ppa_outputs.rstrip()}
 {chr(10).join(stream_reset)}
+{softmax_pipe_reset.rstrip()}
+{chr(10).join(value_pipe_reset)}
     end else begin
       seed_state <= {{seed_state[30:0], seed_state[31] ^ seed_state[21] ^ seed_state[1] ^ seed_state[0]}} ^ seed;
       cycle_ctr <= cycle_ctr + 16'h1;
       done <= start;
 {chr(10).join(stream_update)}
+{softmax_pipe_update.rstrip()}
+{chr(10).join(value_pipe_update)}
       if (start) begin
 {update_outputs.rstrip()}
       end
@@ -461,6 +500,8 @@ endmodule
         "partials_per_cycle": partials_per_cycle,
         "stream_buffer_bits_per_stream": stream_buffer_bits,
         "equivalence_hash": equivalence_hash,
+        "softmax_pipeline_stages": softmax_pipeline_stages,
+        "value_alignment_delay_stages": value_delay_stages,
         "components": {
             "compute": "two signed-int8 dense GEMM streams",
             "softmax_weight": "one shared rowwise int8 shift-exp reciprocal-normalized generator",

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/README.md
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/README.md
@@ -1,0 +1,5 @@
+# Composed Dual-Stream Attention No-Hash Softmax Pipe1
+
+This design keeps equivalence-only hash folding disabled and inserts one register stage on the shared softmax score input. The value-stream payload and score-mix inputs are delayed by two stages, accounting for the new input register plus the existing registered softmax weight output.
+
+The point is intended to test whether the no-hash critical path from `seed_state` into `u_softmax/weights[...]` is removable by ordinary pipeline staging.

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1/config.json
@@ -1,0 +1,19 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pipe1",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "softmax_row_elems": 8,
+    "softmax_accum_bits": 24,
+    "reciprocal_bits": 10,
+    "value_bits": 6,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -4,7 +4,12 @@ import sys
 from pathlib import Path
 
 
-def _write_config(config_path: Path, *, equivalence_hash: bool | None = None) -> None:
+def _write_config(
+    config_path: Path,
+    *,
+    equivalence_hash: bool | None = None,
+    softmax_pipeline_stages: int | None = None,
+) -> None:
     comp = {
         "streams": 2,
         "array_m": 2,
@@ -21,6 +26,8 @@ def _write_config(config_path: Path, *, equivalence_hash: bool | None = None) ->
     }
     if equivalence_hash is not None:
         comp["equivalence_hash"] = equivalence_hash
+    if softmax_pipeline_stages is not None:
+        comp["softmax_pipeline_stages"] = softmax_pipeline_stages
     config_path.parent.mkdir(parents=True)
     config_path.write_text(
         json.dumps(
@@ -81,6 +88,8 @@ def test_attention_dual_stream_composed_generator_ppa_guard_and_syntax(tmp_path:
     assert manifest["softmax_row_elems"] == 4
     assert manifest["value_lanes_per_stream"] == 4
     assert manifest["equivalence_hash"] is False
+    assert manifest["softmax_pipeline_stages"] == 0
+    assert manifest["value_alignment_delay_stages"] == 0
     assert "u_softmax" in top_text
     assert "u_value_stream_0" in top_text
     assert "u_value_stream_1" in top_text
@@ -89,6 +98,7 @@ def test_attention_dual_stream_composed_generator_ppa_guard_and_syntax(tmp_path:
     assert "score_mix_0_out" in top_text
     assert "result_hash" not in top_text
     assert "softmax_weight_hash" not in top_text
+    assert "softmax_scores_pipe_0" not in top_text
 
 
 def test_attention_dual_stream_composed_generator_equivalence_hash_mode(tmp_path: Path) -> None:
@@ -104,3 +114,21 @@ def test_attention_dual_stream_composed_generator_equivalence_hash_mode(tmp_path
     assert "value_hash_0" in top_text
     assert "compute_fold" in top_text
     assert "softmax_weights_out" not in top_text
+
+
+def test_attention_dual_stream_composed_generator_softmax_pipeline(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_pipeline"
+    config_path = design_dir / "config.json"
+    _write_config(config_path, softmax_pipeline_stages=1)
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["equivalence_hash"] is False
+    assert manifest["softmax_pipeline_stages"] == 1
+    assert manifest["value_alignment_delay_stages"] == 2
+    assert "reg [31:0] softmax_scores_pipe_0" in top_text
+    assert ".scores(softmax_scores_pipe_0)" in top_text
+    assert "stream_buf_0_pipe_1" in top_text
+    assert "score_mix_1_pipe_1" in top_text
+    assert ".stream_data(stream_buf_0_pipe_1)" in top_text
+    assert ".score_mix(score_mix_1_pipe_1)" in top_text


### PR DESCRIPTION
## Summary
- add optional softmax_pipeline_stages=1 support to the composed dual-stream attention generator
- delay value-stream payload and score-mix inputs by two stages for the pipelined schedule
- add guard/test coverage and a no-hash softmax-pipe1 PPA design config
- add an L1 proposal to compare against the no-hash baseline from PR #854

## Tests
- PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/pytest -q tests/test_attention_dual_stream_composed_generator.py
- python3 scripts/validate_runs.py --skip_eval_queue
- generated pipe1 RTL passed guard and iverilog -g2012 syntax check