### PR TITLE
npu: add softmax split and replacement candidates

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/evaluation_requests.json
@@ -1,0 +1,58 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds softmax split1 and pow2sum implementations and design configs.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the composed Q8/K8/V6 dual-stream attention datapath with exact divider-based softmax split by one internal exp/sum pipeline stage.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "exact_softmax_split_pipeline",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1"
+      ],
+      "expected_result": {
+        "direction": "split_exact_softmax",
+        "reason": "This isolates whether the exact softmax bottleneck is the pre-divider max/sum logic or the divider/output half."
+      },
+      "status": "pending"
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the composed Q8/K8/V6 dual-stream attention datapath with divider-free power-of-two softmax sum normalization.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "softmax_divider_replacement",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1"
+      ],
+      "expected_result": {
+        "direction": "replace_exact_divider",
+        "reason": "This measures the PPA upside of removing sum division before spending quality-evaluation effort on the approximation."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/proposal.json
@@ -1,0 +1,94 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1",
+  "kind": "diagnostic",
+  "title": "Composed dual-stream attention softmax split vs replacement frontier",
+  "layer": "layer1",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "status": "proposed",
+  "motivation": [
+    "The softmax-pipe1 PPA result only improved critical path from 23.1995 ns to 22.7935 ns.",
+    "The final-stage path still starts inside the registered softmax input and ends at u_softmax/weights, so the softmax weight generator remains the bottleneck.",
+    "We need to separate the cost of exact arithmetic staging from the cost of replacing the divider-based normalization."
+  ],
+  "direct_comparison": {
+    "primary_question": "Is the softmax bottleneck better addressed by splitting the exact softmax datapath or by replacing exact sum division with a cheaper approximation?",
+    "baseline": "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+    "candidates": [
+      "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1",
+      "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "candidate_plans": {
+    "split": {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1",
+      "description": "Keep exact divider-based normalization but add one internal softmax register between exp/sum and divide/output.",
+      "quality_risk": "low arithmetic risk relative to the current approximation, but adds one cycle of softmax latency."
+    },
+    "replace": {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+      "description": "Replace the exact divide by a power-of-two denominator derived from sum_weight, preserving rough row scaling while removing the divider.",
+      "quality_risk": "higher arithmetic risk; requires a later L2 quality/equivalence gate if PPA is promising."
+    }
+  },
+  "required_inputs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/config.json",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+    "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1"
+  ],
+  "evaluation_requests": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "exact_softmax_split_pipeline",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1"
+      ]
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "softmax_divider_replacement",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1"
+      ]
+    }
+  ],
+  "source_files": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "npu/eval/extract_openroad_timing_summary.py",
+    "control_plane/control_plane/services/l1_task_generator.py"
+  ]
+}

--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -28,7 +28,10 @@ def main() -> int:
     total_macs = int(manifest["total_macs"])
     streams = int(manifest["streams"])
     equivalence_hash = bool(manifest.get("equivalence_hash", False))
+    softmax_impl = str(manifest.get("softmax_impl", "exact_div"))
     softmax_pipeline_stages = int(manifest.get("softmax_pipeline_stages", 0))
+    softmax_internal_pipeline_stages = int(manifest.get("softmax_internal_pipeline_stages", 0))
+    softmax_latency_stages = int(manifest.get("softmax_latency_stages", 1))
     value_alignment_delay_stages = int(manifest.get("value_alignment_delay_stages", 0))
     if streams != 2:
         raise SystemExit(f"expected 2 streams, found {streams}")
@@ -45,23 +48,33 @@ def main() -> int:
         raise SystemExit("expected exactly one shared softmax instance")
     if "stream_buf_0" not in top_text or "stream_buf_1" not in top_text:
         raise SystemExit("missing dual stream buffer registers")
+    if softmax_impl not in {"exact_div", "pow2sum"}:
+        raise SystemExit(f"unsupported softmax_impl={softmax_impl}")
+    if softmax_latency_stages != 1 + softmax_internal_pipeline_stages:
+        raise SystemExit("softmax latency must equal output register latency plus internal pipeline stages")
     if softmax_pipeline_stages:
         if softmax_pipeline_stages != 1:
             raise SystemExit(f"unsupported softmax_pipeline_stages={softmax_pipeline_stages}")
-        if value_alignment_delay_stages != softmax_pipeline_stages + 1:
+        if value_alignment_delay_stages != softmax_pipeline_stages + softmax_latency_stages:
             raise SystemExit(
-                "value alignment delay must match the softmax input stage plus the registered softmax output latency"
+                "value alignment delay must match the softmax input stage plus softmax module latency"
             )
-        for token in (
+        required_tokens = [
             "softmax_scores_pipe_0",
             ".scores(softmax_scores_pipe_0)",
-            "stream_buf_0_pipe_1",
-            "stream_buf_1_pipe_1",
-            ".stream_data(stream_buf_0_pipe_1)",
-            ".stream_data(stream_buf_1_pipe_1)",
-            ".score_mix(score_mix_0_pipe_1)",
-            ".score_mix(score_mix_1_pipe_1)",
-        ):
+        ]
+        last_stage = value_alignment_delay_stages - 1
+        required_tokens.extend(
+            [
+                f"stream_buf_0_pipe_{last_stage}",
+                f"stream_buf_1_pipe_{last_stage}",
+                f".stream_data(stream_buf_0_pipe_{last_stage})",
+                f".stream_data(stream_buf_1_pipe_{last_stage})",
+                f".score_mix(score_mix_0_pipe_{last_stage})",
+                f".score_mix(score_mix_1_pipe_{last_stage})",
+            ]
+        )
+        for token in required_tokens:
             if token not in top_text:
                 raise SystemExit(f"missing softmax pipeline alignment token: {token}")
     else:
@@ -69,6 +82,16 @@ def main() -> int:
             raise SystemExit("value alignment delay must be 0 when softmax pipeline is disabled")
         if "softmax_scores_pipe_0" in top_text:
             raise SystemExit("softmax pipeline register present when disabled")
+    if softmax_internal_pipeline_stages:
+        for token in ("exp_weight_q", "sum_weight_q"):
+            if token not in top_text:
+                raise SystemExit(f"missing split softmax pipeline token: {token}")
+    if softmax_impl == "pow2sum":
+        for token in ("denom_shift", "lane_scaled"):
+            if token not in top_text:
+                raise SystemExit(f"missing replacement softmax token: {token}")
+        if "/ sum_weight" in top_text or "/ sum_weight_q" in top_text:
+            raise SystemExit("pow2sum replacement must not contain a sum_weight divider")
     if equivalence_hash:
         if "result_hash <=" not in top_text:
             raise SystemExit("result_hash is not updated")
@@ -104,7 +127,10 @@ def main() -> int:
                 "total_macs": total_macs,
                 "value_streams": value_instances,
                 "equivalence_hash": equivalence_hash,
+                "softmax_impl": softmax_impl,
                 "softmax_pipeline_stages": softmax_pipeline_stages,
+                "softmax_internal_pipeline_stages": softmax_internal_pipeline_stages,
+                "softmax_latency_stages": softmax_latency_stages,
                 "value_alignment_delay_stages": value_alignment_delay_stages,
             },
             indent=2,

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -38,6 +38,10 @@ def _as_bool(config: dict[str, Any], key: str, default: bool) -> bool:
     return bool(value)
 
 
+def _as_str(config: dict[str, Any], key: str, default: str) -> str:
+    return str(config.get(key, default)).strip()
+
+
 def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     comp = cfg.get("attention_dual_stream_composed")
     if not isinstance(comp, dict):
@@ -52,6 +56,8 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     partials_per_cycle = _as_int(comp, "partials_per_cycle", 2)
     stream_buffer_bits = _as_int(comp, "stream_buffer_bits", 1024)
     softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
+    softmax_internal_pipeline_stages = _as_int(comp, "softmax_internal_pipeline_stages", 0)
+    softmax_impl = _as_str(comp, "softmax_impl", "exact_div")
     if streams != 2:
         raise SystemExit("attention_dual_stream_composed.streams must be 2 for the current dual-stream harness")
     if array_m < 1 or array_m > 16:
@@ -72,6 +78,12 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.stream_buffer_bits must be in [128, 4096]")
     if softmax_pipeline_stages < 0 or softmax_pipeline_stages > 1:
         raise SystemExit("attention_dual_stream_composed.softmax_pipeline_stages must be in [0, 1]")
+    if softmax_internal_pipeline_stages < 0 or softmax_internal_pipeline_stages > 1:
+        raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages must be in [0, 1]")
+    if softmax_impl not in {"exact_div", "pow2sum"}:
+        raise SystemExit("attention_dual_stream_composed.softmax_impl must be exact_div or pow2sum")
+    if softmax_internal_pipeline_stages and softmax_impl != "exact_div":
+        raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages requires exact_div")
     return comp
 
 
@@ -95,6 +107,8 @@ def _softmax_module(
     accum_bits: int,
     reciprocal_bits: int,
     equivalence_hash: bool,
+    implementation: str,
+    internal_pipeline_stages: int,
 ) -> str:
     data_width = row_elems * 8
     product_bits = accum_bits + 8
@@ -103,6 +117,151 @@ def _softmax_module(
     hash_init = f"    next_hash = 32'h5a5a_0101 ^ 32'h{reciprocal_bits & 0xFFFF:04x};\n" if equivalence_hash else ""
     hash_update = "      next_hash = {next_hash[23:0], next_hash[31:24]} ^ {24'h0, lane_out};\n" if equivalence_hash else ""
     hash_seq = "    weight_hash <= next_hash;\n" if equivalence_hash else ""
+    if internal_pipeline_stages:
+        return f"""(* keep_hierarchy = 1 *)
+module {module_name} (
+    input  wire                  clk,
+    input  wire [{data_width - 1}:0] scores,
+    output reg  [{data_width - 1}:0] weights{hash_port}
+);
+  localparam integer ROW_ELEMS = {row_elems};
+  localparam integer ACCUM_BITS = {accum_bits};
+  localparam integer PRODUCT_BITS = {product_bits};
+  localparam integer MAX_SHIFT = 7;
+  localparam integer OUTPUT_SCALE = 127;
+  localparam integer RECIPROCAL_BITS = {reciprocal_bits};
+
+  integer i;
+  integer signed lane_val;
+  integer signed row_max;
+  integer delta;
+  reg [ACCUM_BITS-1:0] exp_weight [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight;
+  reg [ACCUM_BITS-1:0] exp_weight_q [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight_q;
+  reg [PRODUCT_BITS-1:0] numer;
+  reg [7:0] lane_out;
+  reg [{data_width - 1}:0] next_weights;
+{hash_reg.rstrip()}
+
+  always @(*) begin
+    row_max = -(1 << 7);
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*8) +: 8]);
+      if (lane_val > row_max)
+        row_max = lane_val;
+    end
+
+    sum_weight = {{ACCUM_BITS{{1'b0}}}};
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*8) +: 8]);
+      delta = row_max - lane_val;
+      if (delta < 0)
+        delta = 0;
+      if (delta > MAX_SHIFT)
+        delta = MAX_SHIFT;
+      exp_weight[i] = ({{{{(ACCUM_BITS-1){{1'b0}}}}, 1'b1}} << (MAX_SHIFT - delta));
+      sum_weight = sum_weight + exp_weight[i];
+    end
+  end
+
+  always @(*) begin
+    next_weights = {{{data_width}{{1'b0}}}};
+{hash_init.rstrip()}
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      numer = (exp_weight_q[i] * OUTPUT_SCALE) + (sum_weight_q >> 1);
+      if (sum_weight_q != 0)
+        lane_out = numer / sum_weight_q;
+      else
+        lane_out = 8'h00;
+      if (lane_out > 8'd127)
+        lane_out = 8'd127;
+      next_weights[(i*8) +: 8] = lane_out;
+{hash_update.rstrip()}
+    end
+  end
+
+  always @(posedge clk) begin
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      exp_weight_q[i] <= exp_weight[i];
+    end
+    sum_weight_q <= sum_weight;
+    weights <= next_weights;
+{hash_seq.rstrip()}
+  end
+endmodule
+"""
+    if implementation == "pow2sum":
+        return f"""(* keep_hierarchy = 1 *)
+module {module_name} (
+    input  wire                  clk,
+    input  wire [{data_width - 1}:0] scores,
+    output reg  [{data_width - 1}:0] weights{hash_port}
+);
+  localparam integer ROW_ELEMS = {row_elems};
+  localparam integer ACCUM_BITS = {accum_bits};
+  localparam integer PRODUCT_BITS = {product_bits};
+  localparam integer MAX_SHIFT = 7;
+  localparam integer OUTPUT_SCALE = 127;
+  localparam integer RECIPROCAL_BITS = {reciprocal_bits};
+
+  integer i;
+  integer signed lane_val;
+  integer signed row_max;
+  integer delta;
+  integer denom_shift;
+  reg [ACCUM_BITS-1:0] exp_weight [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight;
+  reg [PRODUCT_BITS-1:0] lane_scaled;
+  reg [7:0] lane_out;
+  reg [{data_width - 1}:0] next_weights;
+{hash_reg.rstrip()}
+
+  always @(*) begin
+    row_max = -(1 << 7);
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*8) +: 8]);
+      if (lane_val > row_max)
+        row_max = lane_val;
+    end
+
+    sum_weight = {{ACCUM_BITS{{1'b0}}}};
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*8) +: 8]);
+      delta = row_max - lane_val;
+      if (delta < 0)
+        delta = 0;
+      if (delta > MAX_SHIFT)
+        delta = MAX_SHIFT;
+      exp_weight[i] = ({{{{(ACCUM_BITS-1){{1'b0}}}}, 1'b1}} << (MAX_SHIFT - delta));
+      sum_weight = sum_weight + exp_weight[i];
+    end
+
+    denom_shift = 0;
+    for (i = 0; i < ACCUM_BITS; i = i + 1) begin
+      if (sum_weight > ({{{{(ACCUM_BITS-1){{1'b0}}}}, 1'b1}} << i))
+        denom_shift = i + 1;
+    end
+
+    next_weights = {{{data_width}{{1'b0}}}};
+{hash_init.rstrip()}
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_scaled = (exp_weight[i] * OUTPUT_SCALE) >> denom_shift;
+      if (lane_scaled > 8'd127)
+        lane_out = 8'd127;
+      else
+        lane_out = lane_scaled[7:0];
+      next_weights[(i*8) +: 8] = lane_out;
+{hash_update.rstrip()}
+    end
+  end
+
+  always @(posedge clk) begin
+    weights <= next_weights;
+{hash_seq.rstrip()}
+  end
+endmodule
+"""
     return f"""(* keep_hierarchy = 1 *)
 module {module_name} (
     input  wire                  clk,
@@ -238,7 +397,10 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     stream_buffer_bits = _as_int(comp, "stream_buffer_bits", 1024)
     equivalence_hash = _as_bool(comp, "equivalence_hash", False)
     softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
-    value_delay_stages = softmax_pipeline_stages + 1 if softmax_pipeline_stages else 0
+    softmax_internal_pipeline_stages = _as_int(comp, "softmax_internal_pipeline_stages", 0)
+    softmax_impl = _as_str(comp, "softmax_impl", "exact_div")
+    softmax_latency_stages = 1 + softmax_internal_pipeline_stages
+    value_delay_stages = softmax_pipeline_stages + softmax_latency_stages if softmax_pipeline_stages else 0
     macs_per_stream = array_m * array_n * k_unroll
     streams = 2
     total_macs = streams * macs_per_stream
@@ -469,6 +631,8 @@ endmodule
                 accum_bits=accum_bits,
                 reciprocal_bits=reciprocal_bits,
                 equivalence_hash=equivalence_hash,
+                implementation=softmax_impl,
+                internal_pipeline_stages=softmax_internal_pipeline_stages,
             ),
             _value_stream_module(
                 module_name=value_name,
@@ -500,7 +664,10 @@ endmodule
         "partials_per_cycle": partials_per_cycle,
         "stream_buffer_bits_per_stream": stream_buffer_bits,
         "equivalence_hash": equivalence_hash,
+        "softmax_impl": softmax_impl,
         "softmax_pipeline_stages": softmax_pipeline_stages,
+        "softmax_internal_pipeline_stages": softmax_internal_pipeline_stages,
+        "softmax_latency_stages": softmax_latency_stages,
         "value_alignment_delay_stages": value_delay_stages,
         "components": {
             "compute": "two signed-int8 dense GEMM streams",

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/README.md
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/README.md
@@ -1,0 +1,5 @@
+# Composed Dual-Stream Attention No-Hash Softmax Pow2Sum
+
+This candidate replaces the exact divider-based softmax normalization with a power-of-two denominator selected from the exp-weight sum. It keeps the max-shift exp approximation and one registered softmax input stage, but removes the `numer / sum_weight` divider.
+
+The point is a PPA/architecture probe. If the physical result is attractive, it needs a separate quality/equivalence study before promotion into the Llama7B model path.

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum/config.json
@@ -1,0 +1,20 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_pow2sum",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "softmax_row_elems": 8,
+    "softmax_accum_bits": 24,
+    "reciprocal_bits": 10,
+    "value_bits": 6,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "pow2sum"
+  }
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/README.md
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/README.md
@@ -1,0 +1,5 @@
+# Composed Dual-Stream Attention No-Hash Softmax Split1
+
+This candidate keeps the exact divider-based softmax approximation but splits the shared softmax block into an exp/sum register stage followed by the divide/output stage. Value-stream payload and score-mix inputs are delayed by three stages to stay aligned with the registered softmax weights.
+
+The point tests whether the current critical path is dominated by the front half of softmax or by the divider/output half.

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1/config.json
@@ -1,0 +1,21 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_split1",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "softmax_row_elems": 8,
+    "softmax_accum_bits": 24,
+    "reciprocal_bits": 10,
+    "value_bits": 6,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_internal_pipeline_stages": 1,
+    "softmax_impl": "exact_div"
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -9,6 +9,8 @@ def _write_config(
     *,
     equivalence_hash: bool | None = None,
     softmax_pipeline_stages: int | None = None,
+    softmax_internal_pipeline_stages: int | None = None,
+    softmax_impl: str | None = None,
 ) -> None:
     comp = {
         "streams": 2,
@@ -28,6 +30,10 @@ def _write_config(
         comp["equivalence_hash"] = equivalence_hash
     if softmax_pipeline_stages is not None:
         comp["softmax_pipeline_stages"] = softmax_pipeline_stages
+    if softmax_internal_pipeline_stages is not None:
+        comp["softmax_internal_pipeline_stages"] = softmax_internal_pipeline_stages
+    if softmax_impl is not None:
+        comp["softmax_impl"] = softmax_impl
     config_path.parent.mkdir(parents=True)
     config_path.write_text(
         json.dumps(
@@ -88,7 +94,10 @@ def test_attention_dual_stream_composed_generator_ppa_guard_and_syntax(tmp_path:
     assert manifest["softmax_row_elems"] == 4
     assert manifest["value_lanes_per_stream"] == 4
     assert manifest["equivalence_hash"] is False
+    assert manifest["softmax_impl"] == "exact_div"
     assert manifest["softmax_pipeline_stages"] == 0
+    assert manifest["softmax_internal_pipeline_stages"] == 0
+    assert manifest["softmax_latency_stages"] == 1
     assert manifest["value_alignment_delay_stages"] == 0
     assert "u_softmax" in top_text
     assert "u_value_stream_0" in top_text
@@ -125,6 +134,8 @@ def test_attention_dual_stream_composed_generator_softmax_pipeline(tmp_path: Pat
     manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
     assert manifest["equivalence_hash"] is False
     assert manifest["softmax_pipeline_stages"] == 1
+    assert manifest["softmax_internal_pipeline_stages"] == 0
+    assert manifest["softmax_latency_stages"] == 1
     assert manifest["value_alignment_delay_stages"] == 2
     assert "reg [31:0] softmax_scores_pipe_0" in top_text
     assert ".scores(softmax_scores_pipe_0)" in top_text
@@ -132,3 +143,40 @@ def test_attention_dual_stream_composed_generator_softmax_pipeline(tmp_path: Pat
     assert "score_mix_1_pipe_1" in top_text
     assert ".stream_data(stream_buf_0_pipe_1)" in top_text
     assert ".score_mix(score_mix_1_pipe_1)" in top_text
+
+
+def test_attention_dual_stream_composed_generator_softmax_split_pipeline(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_split"
+    config_path = design_dir / "config.json"
+    _write_config(config_path, softmax_pipeline_stages=1, softmax_internal_pipeline_stages=1)
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["softmax_impl"] == "exact_div"
+    assert manifest["softmax_pipeline_stages"] == 1
+    assert manifest["softmax_internal_pipeline_stages"] == 1
+    assert manifest["softmax_latency_stages"] == 2
+    assert manifest["value_alignment_delay_stages"] == 3
+    assert "exp_weight_q" in top_text
+    assert "sum_weight_q" in top_text
+    assert ".stream_data(stream_buf_0_pipe_2)" in top_text
+    assert ".score_mix(score_mix_1_pipe_2)" in top_text
+    assert "lane_out = numer / sum_weight_q" in top_text
+
+
+def test_attention_dual_stream_composed_generator_softmax_pow2sum_replacement(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_pow2sum"
+    config_path = design_dir / "config.json"
+    _write_config(config_path, softmax_pipeline_stages=1, softmax_impl="pow2sum")
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["softmax_impl"] == "pow2sum"
+    assert manifest["softmax_pipeline_stages"] == 1
+    assert manifest["softmax_internal_pipeline_stages"] == 0
+    assert manifest["softmax_latency_stages"] == 1
+    assert manifest["value_alignment_delay_stages"] == 2
+    assert "denom_shift" in top_text
+    assert "lane_scaled" in top_text
+    assert "/ sum_weight" not in top_text
+    assert ".stream_data(stream_buf_0_pipe_1)" in top_text


### PR DESCRIPTION
## Summary
- add an exact split softmax candidate that registers exp/sum before the divide/output stage
- add a pow2sum replacement candidate that removes `numer / sum_weight`
- align value-stream payload delay to the selected softmax latency
- add guard/test coverage and L1 proposal entries for both PPA jobs

## Local Checks
- PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/pytest -q tests/test_attention_dual_stream_composed_generator.py
- python3 scripts/validate_runs.py --skip_eval_queue
- generated split1 and pow2sum full-size RTL passed guard and iverilog -g2012 syntax checks
