### PR TITLE
npu: add pow2sum softmax quality gate

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5287,6 +5287,48 @@ def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict
     }
 
 
+def _decoder_attention_softmax_pow2sum_quality_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.md"
+    dual_stream_feasibility = (
+        f"{base}/decoder_attention_kv_dual_stream_physical_feasibility__"
+        "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_dual_stream_physical_feasibility": dual_stream_feasibility,
+            "attention_mixed_precision_quality_out": out,
+            "attention_mixed_precision_quality_report": report,
+            "attention_mixed_precision_quality_scope": (
+                "Compare the Q8/K8/V6/S8/W8 RTL-style exact int8 softmax path against the "
+                "divider-free pow2sum replacement on the Llama7B-shape native-GQA attention proxy. "
+                "This is a quality/equivalence gate for the pow2sum PPA result, not final Llama7B perplexity."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_softmax_pow2sum_quality",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py "
+                    f"--dual-stream-feasibility {dual_stream_feasibility} "
+                    "--attention-heads 32 "
+                    "--kv-heads 4 "
+                    "--head-dim 128 "
+                    "--sequence-length-list 64,128 "
+                    "--regime-list native_correlated_queries,native_retrieval,native_low_margin,native_random "
+                    "--seed-count 2 "
+                    "--candidate-spec-list q8:k8:v6:a24:s8:w8 "
+                    "--softmax-mode-list rtl_exact,rtl_pow2sum "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_mixed_precision_physical_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_physical_feasibility__{item_id}.json"
@@ -6971,6 +7013,7 @@ def _build_payload(
         "decoder_attention_kv_subtile_pipeline_schedule",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
+        "decoder_attention_softmax_pow2sum_quality",
         "decoder_attention_mixed_precision_physical_feasibility",
         "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
         "decoder_attention_noc_profile",
@@ -7119,6 +7162,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":
             decoder_evidence = _decoder_attention_mixed_precision_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_softmax_pow2sum_quality":
+            decoder_evidence = _decoder_attention_softmax_pow2sum_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_physical_feasibility":
             decoder_evidence = _decoder_attention_mixed_precision_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_int8_compute_physical_feasibility":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5444,6 +5444,53 @@ def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_eviden
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_softmax_pow2sum_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_softmax_pow2sum_quality",
+                    evaluation_mode="quality_equivalence_gate",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_softmax_pow2sum_quality" in command_names
+            assert "attention_kv_dual_stream_physical_feasibility" in decoder_inputs
+            assert "attention_mixed_precision_quality_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_mixed_precision_quality.py" in run
+            assert "--candidate-spec-list q8:k8:v6:a24:s8:w8" in run
+            assert "--softmax-mode-list rtl_exact,rtl_pow2sum" in run
+            assert "--seed-count 2" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_mixed_precision_quality__"
+                    "l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_physical_feasibility_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/evaluation_requests.json
@@ -57,6 +57,26 @@
       "merge_commit": "fa262f5a152222600c8f25c965768bbbafb14159",
       "merged_utc": "2026-06-16T02:24:02.035565Z",
       "notes": "Merged via PR #859 and merge fa262f5a152222600c8f25c965768bbbafb14159 at 2026-06-16T02:24:02.035565Z."
+    },
+    {
+      "item_id": "l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the Llama7B-shape quality/equivalence gate for the divider-free pow2sum softmax replacement against the same Q8/K8/V6/S8/W8 RTL-style exact softmax baseline.",
+      "evaluation_mode": "quality_equivalence_gate",
+      "abstraction_layer": "decoder_attention_softmax_pow2sum_quality",
+      "comparison_role": "softmax_replacement_quality_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "quality_gate_pow2sum",
+        "reason": "A 6.4411 ns pow2sum PPA result is only useful if the replacement does not materially damage Llama7B-shape attention top-1/retrieval/output quality versus RTL-style exact int8 softmax."
+      },
+      "status": "pending"
     }
   ],
   "source_commit": "eec17a523f8dd0e2419ab9afd77fe639f79a0daa"

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/proposal.json
@@ -15,7 +15,8 @@
     "baseline": "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1",
     "candidates": [
       "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1",
-      "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1"
+      "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+      "l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1"
     ],
     "metrics": [
       "critical_path_ns",
@@ -83,12 +84,26 @@
       "depends_on": [
         "l1_decoder_attention_dual_stream_composed_softmax_pipe1_ppa_v1"
       ]
+    },
+    {
+      "item_id": "l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "quality_equivalence_gate",
+      "abstraction_layer": "decoder_attention_softmax_pow2sum_quality",
+      "comparison_role": "softmax_replacement_quality_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1"
+      ]
     }
   ],
   "source_files": [
     "npu/rtlgen/gen_attention_dual_stream_composed.py",
     "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py",
     "npu/eval/extract_openroad_timing_summary.py",
-    "control_plane/control_plane/services/l1_task_generator.py"
+    "control_plane/control_plane/services/l1_task_generator.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
   ]
 }

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1/quality_gate.md
@@ -1,0 +1,32 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_attention_dual_stream_composed_softmax_frontier_v1`
+- `title`: Composed dual-stream attention softmax split vs replacement frontier
+
+## Why This Gate Is Required
+- The `pow2sum` replacement removes the softmax sum divider and improved PPA to 6.4411 ns, 5.49 mW, and 243160 um2.
+- That replacement changes normalization arithmetic, so it must not be promoted from PPA evidence alone.
+- The gate compares `rtl_exact` and `rtl_pow2sum` for the same Q8/K8/V6/S8/W8 attention proxy.
+
+## Reference
+- PPA candidate: `l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1`
+- prior mixed-precision quality baseline: `l2_decoder_attention_mixed_precision_quality_llama7b_v1`
+- gate item: `l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1`
+
+## Checks
+- metric: `mean_top1_match`
+  - threshold: `>= 0.995`
+- metric: `mean_retrieval_hit`
+  - threshold: `>= 0.995`
+- metric: `mean_output_cosine`
+  - threshold: `>= 0.999`
+- metric: `max_kl_divergence`
+  - threshold: `<= 0.02`
+
+## Local Command Shape
+- command: `python3 npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py --candidate-spec-list q8:k8:v6:a24:s8:w8 --softmax-mode-list rtl_exact,rtl_pow2sum ...`
+
+## Result
+- status: pending
+- note: This is a Llama7B-shape synthetic native-GQA quality/equivalence proxy, not final Llama7B perplexity or task accuracy.

--- a/npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py
+++ b/npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py
@@ -25,6 +25,7 @@ class Candidate:
     acc_bits: int
     score_bits: int
     weight_bits: int
+    softmax_mode: str = "float_quantized"
 
 
 def _int_list(value: str) -> list[int]:
@@ -119,6 +120,39 @@ def _quantize_logits(logits: Vector, bits: int) -> Vector:
     return _dequantize(qvector, scale)
 
 
+def _rtl_quantized_softmax(logits: Vector, *, score_bits: int, weight_bits: int, mode: str) -> Vector:
+    if mode not in {"rtl_exact", "rtl_pow2sum"}:
+        raise ValueError(f"unsupported RTL softmax mode: {mode}")
+    if weight_bits > 8:
+        raise ValueError("RTL softmax modes model the int8 softmax weight block; weight_bits must be <= 8")
+    qlogits, _scale = _quantize_symmetric(logits, score_bits)
+    if not qlogits:
+        return []
+    max_shift = 7
+    output_scale = (1 << weight_bits) - 1
+    row_max = max(qlogits)
+    exp_weights: list[int] = []
+    for value in qlogits:
+        delta = row_max - value
+        if delta < 0:
+            delta = 0
+        if delta > max_shift:
+            delta = max_shift
+        exp_weights.append(1 << (max_shift - delta))
+    sum_weight = sum(exp_weights)
+    if sum_weight <= 0:
+        return _softmax(logits)
+    if mode == "rtl_exact":
+        lanes = [min(output_scale, ((weight * output_scale) + (sum_weight >> 1)) // sum_weight) for weight in exp_weights]
+    else:
+        denom_shift = 0
+        for index in range(32):
+            if sum_weight > (1 << index):
+                denom_shift = index + 1
+        lanes = [min(output_scale, (weight * output_scale) >> denom_shift) for weight in exp_weights]
+    return [lane / float(output_scale) for lane in lanes]
+
+
 def _candidate_dot_from_quantized_query(q_int: list[int], q_scale: float, key: Vector, candidate: Candidate) -> float:
     k_int, k_scale = _quantize_symmetric(key, candidate.k_bits)
     acc = sum(q * k for q, k in zip(q_int, k_int))
@@ -204,9 +238,17 @@ def _candidate_attention(
     scale = 1.0 / math.sqrt(len(query))
     q_int, q_scale = _quantize_symmetric(query, candidate.q_bits)
     logits = [_candidate_dot_from_quantized_query(q_int, q_scale, key, candidate) * scale for key in keys]
-    logits = _quantize_logits(logits, candidate.score_bits)
-    weights = _softmax(logits)
-    weights = _quantize_unsigned_probability(weights, candidate.weight_bits)
+    if candidate.softmax_mode == "float_quantized":
+        logits = _quantize_logits(logits, candidate.score_bits)
+        weights = _softmax(logits)
+        weights = _quantize_unsigned_probability(weights, candidate.weight_bits)
+    else:
+        weights = _rtl_quantized_softmax(
+            logits,
+            score_bits=candidate.score_bits,
+            weight_bits=candidate.weight_bits,
+            mode=candidate.softmax_mode,
+        )
     return {
         "top1": max(range(len(weights)), key=lambda index: weights[index]),
         "target": target,
@@ -215,7 +257,7 @@ def _candidate_attention(
     }
 
 
-def _parse_candidate_spec(spec: str) -> Candidate:
+def _parse_candidate_spec(spec: str, *, softmax_mode: str = "float_quantized") -> Candidate:
     values: dict[str, int] = {}
     for part in spec.split(":"):
         if len(part) < 2:
@@ -228,13 +270,18 @@ def _parse_candidate_spec(spec: str) -> Candidate:
     if missing:
         raise ValueError(f"candidate spec {spec!r} missing {sorted(missing)}")
     return Candidate(
-        candidate_id=spec.replace(":", "_"),
+        candidate_id=(
+            spec.replace(":", "_")
+            if softmax_mode == "float_quantized"
+            else f"{spec.replace(':', '_')}_softmax_{softmax_mode}"
+        ),
         q_bits=values["q"],
         k_bits=values["k"],
         v_bits=values["v"],
         acc_bits=values["a"],
         score_bits=values["s"],
         weight_bits=values["w"],
+        softmax_mode=softmax_mode,
     )
 
 
@@ -292,8 +339,16 @@ def build_report(
     regime_list: list[str],
     seed_count: int,
     candidate_specs: list[str],
+    softmax_mode_list: list[str],
 ) -> JsonDict:
-    candidates = [_parse_candidate_spec(spec) for spec in candidate_specs]
+    unsupported_modes = sorted(set(softmax_mode_list) - {"float_quantized", "rtl_exact", "rtl_pow2sum"})
+    if unsupported_modes:
+        raise ValueError(f"unsupported softmax modes: {unsupported_modes}")
+    candidates = [
+        _parse_candidate_spec(spec, softmax_mode=softmax_mode)
+        for spec in candidate_specs
+        for softmax_mode in softmax_mode_list
+    ]
     metric_rows: list[JsonDict] = []
     for sequence_length in sequence_length_list:
         for regime in regime_list:
@@ -342,6 +397,7 @@ def build_report(
                                 "acc_bits": candidate.acc_bits,
                                 "score_bits": candidate.score_bits,
                                 "weight_bits": candidate.weight_bits,
+                                "softmax_mode": candidate.softmax_mode,
                                 "sequence_length": sequence_length,
                                 "regime": regime,
                                 "seed": seed,
@@ -367,6 +423,7 @@ def build_report(
                 "acc_bits": candidate.acc_bits,
                 "score_bits": candidate.score_bits,
                 "weight_bits": candidate.weight_bits,
+                "softmax_mode": candidate.softmax_mode,
                 "decision": _decision(summary),
             }
         )
@@ -381,7 +438,14 @@ def build_report(
                 if row["candidate_id"] == candidate.candidate_id and row["regime"] == regime
             ]
             summary = _summarize(rows)
-            summary.update({"candidate_id": candidate.candidate_id, "regime": regime, "decision": _decision(summary)})
+            summary.update(
+                {
+                    "candidate_id": candidate.candidate_id,
+                    "softmax_mode": candidate.softmax_mode,
+                    "regime": regime,
+                    "decision": _decision(summary),
+                }
+            )
             regime_summary.append(summary)
 
     passing = [row for row in candidate_summary if row["decision"] == "mixed_precision_proxy_pass"]
@@ -434,6 +498,7 @@ def build_report(
             "regime_list": regime_list,
             "seed_count": seed_count,
             "candidate_specs": candidate_specs,
+            "softmax_mode_list": softmax_mode_list,
         },
         "sweep_summary": {
             "metric_row_count": len(metric_rows),
@@ -451,6 +516,7 @@ def build_report(
             "This is a Llama7B-shape synthetic native-GQA attention proxy, not measured Llama7B perplexity or task accuracy.",
             "The proxy uses 32 attention heads, 4 KV heads, and head_dim 128 by default to match the current GQA8 Llama7B frontier assumption.",
             "Q/K/V use per-vector symmetric quantization; accumulator saturation models fixed-width integer dot products.",
+            "The rtl_exact and rtl_pow2sum modes model the int8 row-softmax RTL: score quantization, clipped exp powers, 127-scale output weights, and either exact or power-of-two sum normalization.",
             "Passing this proxy is only a gate for mixed-precision RTL/PPA and later real-checkpoint validation.",
         ],
     }
@@ -471,12 +537,12 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         "",
         "## Candidate Summary",
         "",
-        "| candidate | q | k | v | acc | score | weight | top1 | retrieval | cosine | kl | decision |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        "| candidate | softmax | q | k | v | acc | score | weight | top1 | retrieval | cosine | kl | decision |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
     for row in payload["candidate_summary"]:
         lines.append(
-            "| {candidate_id} | {q_bits} | {k_bits} | {v_bits} | {acc_bits} | {score_bits} | {weight_bits} | "
+            "| {candidate_id} | {softmax_mode} | {q_bits} | {k_bits} | {v_bits} | {acc_bits} | {score_bits} | {weight_bits} | "
             "{mean_top1_match} | {mean_retrieval_hit} | {mean_output_cosine} | {mean_kl_divergence} | {decision} |".format(
                 **row
             )
@@ -486,13 +552,13 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
             "",
             "## Regime Summary",
             "",
-            "| candidate | regime | top1 | retrieval | cosine | kl | decision |",
-            "|---|---|---:|---:|---:|---:|---|",
+            "| candidate | softmax | regime | top1 | retrieval | cosine | kl | decision |",
+            "|---|---|---|---:|---:|---:|---:|---|",
         ]
     )
     for row in payload["regime_summary"]:
         lines.append(
-            "| {candidate_id} | {regime} | {mean_top1_match} | {mean_retrieval_hit} | "
+            "| {candidate_id} | {softmax_mode} | {regime} | {mean_top1_match} | {mean_retrieval_hit} | "
             "{mean_output_cosine} | {mean_kl_divergence} | {decision} |".format(**row)
         )
     lines.extend(["", "## Assumptions", ""])
@@ -525,6 +591,7 @@ def main() -> int:
             "q8:k8:v6:a24:s24:w16",
         ],
     )
+    ap.add_argument("--softmax-mode-list", type=_str_list, default=["float_quantized"])
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
     args = ap.parse_args()
@@ -543,6 +610,7 @@ def main() -> int:
         regime_list=args.regime_list,
         seed_count=args.seed_count,
         candidate_specs=args.candidate_spec_list,
+        softmax_mode_list=args.softmax_mode_list,
     )
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add RTL-style softmax modes to the Llama7B-shape mixed-precision attention quality estimator
- add a control-plane L2 gate for `decoder_attention_softmax_pow2sum_quality`
- record the pow2sum quality/equivalence request in the softmax frontier proposal

## Local preview
Command shape matches the new task-generator command, using `q8:k8:v6:a24:s8:w8` and `rtl_exact,rtl_pow2sum`.

Preview outcome:
- `rtl_exact`: risky vs floating reference; top1 0.998047, retrieval 1.0, cosine 0.861212, max KL 1.667998
- `rtl_pow2sum`: risky vs floating reference; top1 0.998047, retrieval 1.0, cosine 0.859392, max KL 22.128092

Interpretation: pow2sum is strong PPA evidence but likely blocks direct promotion under the current strict quality proxy; it should be recorded by the evaluator before deciding the next approximation/QAT path.

## Verification
- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py control_plane/control_plane/services/l2_task_generator.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k 'mixed_precision_quality or softmax_pow2sum_quality'`
- `python3 scripts/validate_runs.py --skip_eval_queue`
