### PR TITLE
npu: add reciprocal LUT softmax frontier

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5329,6 +5329,49 @@ def _decoder_attention_softmax_pow2sum_quality_evidence(*, item_id: str) -> dict
     }
 
 
+def _decoder_attention_softmax_recip_lut_quality_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.md"
+    dual_stream_feasibility = (
+        f"{base}/decoder_attention_kv_dual_stream_physical_feasibility__"
+        "l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_dual_stream_physical_feasibility": dual_stream_feasibility,
+            "attention_mixed_precision_quality_out": out,
+            "attention_mixed_precision_quality_report": report,
+            "attention_mixed_precision_quality_scope": (
+                "Compare Q8/K8/V6/S8/W8 RTL-style exact int8 softmax, pow2sum, and "
+                "fixed-point reciprocal-LUT normalization on the Llama7B-shape native-GQA "
+                "attention proxy. This gates whether reciprocal-LUT removes divider PPA "
+                "cost without adding softmax-specific quality loss."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_softmax_recip_lut_quality",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py "
+                    f"--dual-stream-feasibility {dual_stream_feasibility} "
+                    "--attention-heads 32 "
+                    "--kv-heads 4 "
+                    "--head-dim 128 "
+                    "--sequence-length-list 64,128 "
+                    "--regime-list native_correlated_queries,native_retrieval,native_low_margin,native_random "
+                    "--seed-count 2 "
+                    "--candidate-spec-list q8:k8:v6:a24:s8:w8 "
+                    "--softmax-mode-list rtl_exact,rtl_pow2sum,rtl_recip_lut_q8,rtl_recip_lut_q10,rtl_recip_lut_q12 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_mixed_precision_physical_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_physical_feasibility__{item_id}.json"
@@ -7014,6 +7057,7 @@ def _build_payload(
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
+        "decoder_attention_softmax_recip_lut_quality",
         "decoder_attention_mixed_precision_physical_feasibility",
         "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
         "decoder_attention_noc_profile",
@@ -7164,6 +7208,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_precision_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_softmax_pow2sum_quality":
             decoder_evidence = _decoder_attention_softmax_pow2sum_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_softmax_recip_lut_quality":
+            decoder_evidence = _decoder_attention_softmax_recip_lut_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_physical_feasibility":
             decoder_evidence = _decoder_attention_mixed_precision_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_int8_compute_physical_feasibility":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5491,6 +5491,53 @@ def test_generate_l2_campaign_task_adds_attention_softmax_pow2sum_quality_eviden
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_softmax_recip_lut_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_softmax_recip_lut_quality",
+                    evaluation_mode="quality_equivalence_gate",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_softmax_recip_lut_quality" in command_names
+            assert "attention_kv_dual_stream_physical_feasibility" in decoder_inputs
+            assert "attention_mixed_precision_quality_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_mixed_precision_quality.py" in run
+            assert "--candidate-spec-list q8:k8:v6:a24:s8:w8" in run
+            assert "--softmax-mode-list rtl_exact,rtl_pow2sum,rtl_recip_lut_q8,rtl_recip_lut_q10,rtl_recip_lut_q12" in run
+            assert "--seed-count 2" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_mixed_precision_quality__"
+                    "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_physical_feasibility_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/evaluation_requests.json
@@ -1,0 +1,56 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_softmax_recip_lut_frontier_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds reciprocal-LUT softmax generation, quality proxy support, and q8/q10/q12 design configs.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for composed Q8/K8/V6 dual-stream attention datapaths using fixed-point reciprocal-LUT softmax normalization at q8/q10/q12 reciprocal widths.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "softmax_reciprocal_lut_replacement",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/metrics.csv"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+        "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1"
+      ],
+      "expected_result": {
+        "direction": "reciprocal_lut_middle_ground",
+        "reason": "This tests whether a concrete divider-free reciprocal table sits between pow2sum and exact division in PPA while preserving exact-like normalization."
+      },
+      "status": "pending"
+    },
+    {
+      "item_id": "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the Llama7B-shape quality/equivalence gate comparing exact, pow2sum, and q8/q10/q12 reciprocal-LUT softmax normalization for Q8/K8/V6/S8/W8 attention.",
+      "evaluation_mode": "quality_equivalence_gate",
+      "abstraction_layer": "decoder_attention_softmax_recip_lut_quality",
+      "comparison_role": "softmax_reciprocal_lut_quality_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1",
+        "l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "quality_gate_recip_lut",
+        "reason": "The reciprocal-LUT result should distinguish softmax-normalization error from the already known mixed-precision quantization error."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/proposal.json
@@ -1,0 +1,100 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_softmax_recip_lut_frontier_v1",
+  "kind": "frontier_followup",
+  "title": "Composed dual-stream attention reciprocal-LUT softmax frontier",
+  "layer": "layer1",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "status": "proposed",
+  "motivation": [
+    "Exact divider-based softmax split1 improved the composed critical path to 16.1489 ns but still missed the 10 ns target.",
+    "The divider-free pow2sum replacement reached 6.4411 ns, but its Llama7B-shape quality proxy had large softmax-specific KL and cannot be promoted as-is.",
+    "A fixed-point reciprocal LUT removes the general divider while approximating exact 127/sum_weight normalization more closely than pow2sum."
+  ],
+  "direct_comparison": {
+    "primary_question": "Can a bounded reciprocal-LUT softmax normalization keep exact-like quality while preserving most of the divider-free PPA gain?",
+    "baselines": [
+      "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1",
+      "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+      "l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1"
+    ],
+    "candidates": [
+      "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1",
+      "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report",
+      "top1_match",
+      "retrieval_hit",
+      "output_cosine",
+      "kl_divergence"
+    ]
+  },
+  "candidate_plans": {
+    "recip_lut": {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1",
+      "description": "Replace exact sum division by a generated fixed-point reciprocal table for sum_weight, then multiply-shift each exp lane. Sweep q8/q10/q12 reciprocal widths under the same composed dual-stream harness.",
+      "quality_risk": "low softmax-specific risk relative to pow2sum because local proxy q12 matches exact RTL-mode quality; still blocked by the broader Q8/K8/V6 mixed-precision quality gate until model-native or QAT recovery is shown."
+    },
+    "recip_lut_quality": {
+      "item_id": "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1",
+      "description": "Run the Llama7B-shape native-GQA quality proxy comparing rtl_exact, rtl_pow2sum, and rtl_recip_lut_q8/q10/q12 for the same Q8/K8/V6/S8/W8 candidate.",
+      "quality_risk": "This gate separates softmax-normalization error from the already-known mixed-precision compute/value quantization error."
+    }
+  },
+  "required_inputs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/config.json",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/config.json",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+    "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1",
+    "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1"
+  ],
+  "evaluation_requests": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "softmax_reciprocal_lut_replacement",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/metrics.csv"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1",
+        "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1"
+      ]
+    },
+    {
+      "item_id": "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "quality_equivalence_gate",
+      "abstraction_layer": "decoder_attention_softmax_recip_lut_quality",
+      "comparison_role": "softmax_reciprocal_lut_quality_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1",
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1",
+        "l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1"
+      ]
+    }
+  ],
+  "source_files": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -48,7 +48,7 @@ def main() -> int:
         raise SystemExit("expected exactly one shared softmax instance")
     if "stream_buf_0" not in top_text or "stream_buf_1" not in top_text:
         raise SystemExit("missing dual stream buffer registers")
-    if softmax_impl not in {"exact_div", "pow2sum"}:
+    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut"}:
         raise SystemExit(f"unsupported softmax_impl={softmax_impl}")
     if softmax_latency_stages != 1 + softmax_internal_pipeline_stages:
         raise SystemExit("softmax latency must equal output register latency plus internal pipeline stages")
@@ -92,6 +92,14 @@ def main() -> int:
                 raise SystemExit(f"missing replacement softmax token: {token}")
         if "/ sum_weight" in top_text or "/ sum_weight_q" in top_text:
             raise SystemExit("pow2sum replacement must not contain a sum_weight divider")
+    if softmax_impl == "recip_lut":
+        for token in ("function [RECIPROCAL_WIDTH-1:0] reciprocal_lut", "reciprocal_q", "lane_scaled"):
+            if token not in top_text:
+                raise SystemExit(f"missing reciprocal-LUT softmax token: {token}")
+        if "denom_shift" in top_text:
+            raise SystemExit("reciprocal-LUT replacement must not contain pow2 denominator shift logic")
+        if "/ sum_weight" in top_text or "/ sum_weight_q" in top_text:
+            raise SystemExit("reciprocal-LUT replacement must not contain a sum_weight divider")
     if equivalence_hash:
         if "result_hash <=" not in top_text:
             raise SystemExit("result_hash is not updated")

--- a/npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py
+++ b/npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py
@@ -120,8 +120,19 @@ def _quantize_logits(logits: Vector, bits: int) -> Vector:
     return _dequantize(qvector, scale)
 
 
+def _rtl_reciprocal_bits(mode: str) -> int | None:
+    prefix = "rtl_recip_lut_q"
+    if not mode.startswith(prefix):
+        return None
+    bits = int(mode[len(prefix) :])
+    if bits <= 0 or bits > 24:
+        raise ValueError(f"unsupported reciprocal LUT bit width in softmax mode: {mode}")
+    return bits
+
+
 def _rtl_quantized_softmax(logits: Vector, *, score_bits: int, weight_bits: int, mode: str) -> Vector:
-    if mode not in {"rtl_exact", "rtl_pow2sum"}:
+    reciprocal_bits = _rtl_reciprocal_bits(mode)
+    if mode not in {"rtl_exact", "rtl_pow2sum"} and reciprocal_bits is None:
         raise ValueError(f"unsupported RTL softmax mode: {mode}")
     if weight_bits > 8:
         raise ValueError("RTL softmax modes model the int8 softmax weight block; weight_bits must be <= 8")
@@ -144,12 +155,19 @@ def _rtl_quantized_softmax(logits: Vector, *, score_bits: int, weight_bits: int,
         return _softmax(logits)
     if mode == "rtl_exact":
         lanes = [min(output_scale, ((weight * output_scale) + (sum_weight >> 1)) // sum_weight) for weight in exp_weights]
-    else:
+    elif mode == "rtl_pow2sum":
         denom_shift = 0
         for index in range(32):
             if sum_weight > (1 << index):
                 denom_shift = index + 1
         lanes = [min(output_scale, (weight * output_scale) >> denom_shift) for weight in exp_weights]
+    else:
+        assert reciprocal_bits is not None
+        reciprocal_q = ((output_scale << reciprocal_bits) + (sum_weight >> 1)) // sum_weight
+        lanes = [
+            min(output_scale, ((weight * reciprocal_q) + (1 << (reciprocal_bits - 1))) >> reciprocal_bits)
+            for weight in exp_weights
+        ]
     return [lane / float(output_scale) for lane in lanes]
 
 
@@ -341,7 +359,11 @@ def build_report(
     candidate_specs: list[str],
     softmax_mode_list: list[str],
 ) -> JsonDict:
-    unsupported_modes = sorted(set(softmax_mode_list) - {"float_quantized", "rtl_exact", "rtl_pow2sum"})
+    unsupported_modes = sorted(
+        mode
+        for mode in set(softmax_mode_list)
+        if mode not in {"float_quantized", "rtl_exact", "rtl_pow2sum"} and _rtl_reciprocal_bits(mode) is None
+    )
     if unsupported_modes:
         raise ValueError(f"unsupported softmax modes: {unsupported_modes}")
     candidates = [
@@ -516,7 +538,7 @@ def build_report(
             "This is a Llama7B-shape synthetic native-GQA attention proxy, not measured Llama7B perplexity or task accuracy.",
             "The proxy uses 32 attention heads, 4 KV heads, and head_dim 128 by default to match the current GQA8 Llama7B frontier assumption.",
             "Q/K/V use per-vector symmetric quantization; accumulator saturation models fixed-width integer dot products.",
-            "The rtl_exact and rtl_pow2sum modes model the int8 row-softmax RTL: score quantization, clipped exp powers, 127-scale output weights, and either exact or power-of-two sum normalization.",
+            "The rtl_exact, rtl_pow2sum, and rtl_recip_lut_qN modes model the int8 row-softmax RTL: score quantization, clipped exp powers, 127-scale output weights, and exact, power-of-two, or fixed-point reciprocal-LUT normalization.",
             "Passing this proxy is only a gate for mixed-precision RTL/PPA and later real-checkpoint validation.",
         ],
     }

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -80,8 +80,8 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.softmax_pipeline_stages must be in [0, 1]")
     if softmax_internal_pipeline_stages < 0 or softmax_internal_pipeline_stages > 1:
         raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages must be in [0, 1]")
-    if softmax_impl not in {"exact_div", "pow2sum"}:
-        raise SystemExit("attention_dual_stream_composed.softmax_impl must be exact_div or pow2sum")
+    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut"}:
+        raise SystemExit("attention_dual_stream_composed.softmax_impl must be exact_div, pow2sum, or recip_lut")
     if softmax_internal_pipeline_stages and softmax_impl != "exact_div":
         raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages requires exact_div")
     return comp
@@ -117,6 +117,11 @@ def _softmax_module(
     hash_init = f"    next_hash = 32'h5a5a_0101 ^ 32'h{reciprocal_bits & 0xFFFF:04x};\n" if equivalence_hash else ""
     hash_update = "      next_hash = {next_hash[23:0], next_hash[31:24]} ^ {24'h0, lane_out};\n" if equivalence_hash else ""
     hash_seq = "    weight_hash <= next_hash;\n" if equivalence_hash else ""
+    max_sum_weight = row_elems * 128
+    recip_lut_cases = "\n".join(
+        f"      {accum_bits}'d{denom}: reciprocal_lut = {reciprocal_bits + 8}'d{((127 << reciprocal_bits) + (denom >> 1)) // denom};"
+        for denom in range(1, max_sum_weight + 1)
+    )
     if internal_pipeline_stages:
         return f"""(* keep_hierarchy = 1 *)
 module {module_name} (
@@ -247,6 +252,84 @@ module {module_name} (
 {hash_init.rstrip()}
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
       lane_scaled = (exp_weight[i] * OUTPUT_SCALE) >> denom_shift;
+      if (lane_scaled > 8'd127)
+        lane_out = 8'd127;
+      else
+        lane_out = lane_scaled[7:0];
+      next_weights[(i*8) +: 8] = lane_out;
+{hash_update.rstrip()}
+    end
+  end
+
+  always @(posedge clk) begin
+    weights <= next_weights;
+{hash_seq.rstrip()}
+  end
+endmodule
+"""
+    if implementation == "recip_lut":
+        return f"""(* keep_hierarchy = 1 *)
+module {module_name} (
+    input  wire                  clk,
+    input  wire [{data_width - 1}:0] scores,
+    output reg  [{data_width - 1}:0] weights{hash_port}
+);
+  localparam integer ROW_ELEMS = {row_elems};
+  localparam integer ACCUM_BITS = {accum_bits};
+  localparam integer PRODUCT_BITS = {product_bits};
+  localparam integer MAX_SHIFT = 7;
+  localparam integer OUTPUT_SCALE = 127;
+  localparam integer RECIPROCAL_BITS = {reciprocal_bits};
+  localparam integer RECIPROCAL_WIDTH = {reciprocal_bits + 8};
+
+  integer i;
+  integer signed lane_val;
+  integer signed row_max;
+  integer delta;
+  reg [ACCUM_BITS-1:0] exp_weight [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight;
+  reg [RECIPROCAL_WIDTH-1:0] reciprocal_q;
+  reg [PRODUCT_BITS+RECIPROCAL_WIDTH-1:0] lane_scaled;
+  reg [7:0] lane_out;
+  reg [{data_width - 1}:0] next_weights;
+{hash_reg.rstrip()}
+
+  function [RECIPROCAL_WIDTH-1:0] reciprocal_lut;
+    input [ACCUM_BITS-1:0] denom;
+    begin
+      case (denom)
+{recip_lut_cases}
+      default: reciprocal_lut = {{RECIPROCAL_WIDTH{{1'b0}}}};
+      endcase
+    end
+  endfunction
+
+  always @(*) begin
+    row_max = -(1 << 7);
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*8) +: 8]);
+      if (lane_val > row_max)
+        row_max = lane_val;
+    end
+
+    sum_weight = {{ACCUM_BITS{{1'b0}}}};
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*8) +: 8]);
+      delta = row_max - lane_val;
+      if (delta < 0)
+        delta = 0;
+      if (delta > MAX_SHIFT)
+        delta = MAX_SHIFT;
+      exp_weight[i] = ({{{{(ACCUM_BITS-1){{1'b0}}}}, 1'b1}} << (MAX_SHIFT - delta));
+      sum_weight = sum_weight + exp_weight[i];
+    end
+
+    reciprocal_q = reciprocal_lut(sum_weight);
+    next_weights = {{{data_width}{{1'b0}}}};
+{hash_init.rstrip()}
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_scaled = (exp_weight[i] * reciprocal_q) + ({{{{(PRODUCT_BITS+RECIPROCAL_WIDTH-1){{1'b0}}}}, 1'b1}} << (RECIPROCAL_BITS - 1));
+      lane_scaled = lane_scaled >> RECIPROCAL_BITS;
       if (lane_scaled > 8'd127)
         lane_out = 8'd127;
       else

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/config.json
@@ -1,0 +1,20 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "softmax_row_elems": 8,
+    "softmax_accum_bits": 24,
+    "reciprocal_bits": 10,
+    "value_bits": 6,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "recip_lut"
+  }
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/config.json
@@ -1,0 +1,20 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "softmax_row_elems": 8,
+    "softmax_accum_bits": 24,
+    "reciprocal_bits": 12,
+    "value_bits": 6,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "recip_lut"
+  }
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/config.json
@@ -1,0 +1,20 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "softmax_row_elems": 8,
+    "softmax_accum_bits": 24,
+    "reciprocal_bits": 8,
+    "value_bits": 6,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "recip_lut"
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -180,3 +180,23 @@ def test_attention_dual_stream_composed_generator_softmax_pow2sum_replacement(tm
     assert "lane_scaled" in top_text
     assert "/ sum_weight" not in top_text
     assert ".stream_data(stream_buf_0_pipe_1)" in top_text
+
+
+def test_attention_dual_stream_composed_generator_softmax_recip_lut_replacement(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_recip_lut"
+    config_path = design_dir / "config.json"
+    _write_config(config_path, softmax_pipeline_stages=1, softmax_impl="recip_lut")
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["softmax_impl"] == "recip_lut"
+    assert manifest["softmax_pipeline_stages"] == 1
+    assert manifest["softmax_internal_pipeline_stages"] == 0
+    assert manifest["softmax_latency_stages"] == 1
+    assert manifest["value_alignment_delay_stages"] == 2
+    assert "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut" in top_text
+    assert "reciprocal_q = reciprocal_lut(sum_weight)" in top_text
+    assert "/ sum_weight" not in top_text
+    assert "/ sum_weight_q" not in top_text
+    assert "denom_shift" not in top_text
+    assert ".stream_data(stream_buf_0_pipe_1)" in top_text

--- a/tests/test_llm_decoder_attention_mixed_precision_quality.py
+++ b/tests/test_llm_decoder_attention_mixed_precision_quality.py
@@ -1,0 +1,21 @@
+from npu.eval.estimate_llm_decoder_attention_mixed_precision_quality import build_report
+
+
+def test_attention_mixed_precision_quality_accepts_recip_lut_softmax_modes() -> None:
+    report = build_report(
+        dual_stream_feasibility=None,
+        attention_heads=2,
+        kv_heads=1,
+        head_dim=8,
+        sequence_length_list=[8],
+        regime_list=["native_correlated_queries"],
+        seed_count=1,
+        candidate_specs=["q8:k8:v6:a24:s8:w8"],
+        softmax_mode_list=["rtl_exact", "rtl_pow2sum", "rtl_recip_lut_q10", "rtl_recip_lut_q12"],
+    )
+
+    modes = {row["softmax_mode"] for row in report["candidate_summary"]}
+    assert modes == {"rtl_exact", "rtl_pow2sum", "rtl_recip_lut_q10", "rtl_recip_lut_q12"}
+    assert report["sweep_summary"]["candidate_count"] == 4
+    assert report["sweep_summary"]["metric_row_count"] == 8
+    assert "rtl_recip_lut_qN" in report["assumptions"][3]


### PR DESCRIPTION
## Summary
- add a concrete divider-free recip_lut softmax normalization mode to the composed dual-stream attention generator
- model matching rtl_recip_lut_q8, rtl_recip_lut_q10, and rtl_recip_lut_q12 modes in the Llama7B-shape mixed-precision quality proxy
- add q8/q10/q12 PPA configs and a proposal/request pair for the reciprocal-LUT frontier jobs
- add control-plane support for the reciprocal-LUT quality gate abstraction

## Local quality precheck
For q8:k8:v6:a24:s8:w8 on the existing Llama7B-shape proxy:
- rtl_exact: top1 0.998047, retrieval 1.0, cosine 0.861212, KL 0.741326
- rtl_pow2sum: top1 0.998047, retrieval 1.0, cosine 0.859392, KL 7.446566
- rtl_recip_lut_q8/q10: top1 0.998047, retrieval 1.0, cosine 0.861204, KL 0.741282
- rtl_recip_lut_q12: top1 0.998047, retrieval 1.0, cosine 0.861212, KL 0.741326

This does not clear the broader mixed-precision quality gate, but it indicates reciprocal-LUT does not add the pow2sum-specific softmax KL damage.

## Verification
- PYTHONPATH=/tmp/rtlgen-daemons-current/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_attention_dual_stream_composed_generator.py tests/test_llm_decoder_attention_mixed_precision_quality.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_softmax_recip_lut_quality_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_softmax_pow2sum_quality_evidence -q
- generated and guarded full-size q8/q10/q12 recip_lut configs
- python3 scripts/build_runs_index.py && python3 scripts/validate_runs.py --skip_eval_queue
