### PR TITLE
runs: allow reciprocal LUT sweep memory table

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/evaluation_requests.json
@@ -15,7 +15,7 @@
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/config.json",
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_recip_lut.json",
       "out_root": "runs/designs/npu_blocks",
       "expected_outputs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/metrics.csv",

--- a/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/proposal.json
@@ -36,7 +36,7 @@
   "candidate_plans": {
     "recip_lut": {
       "item_id": "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1",
-      "description": "Replace exact sum division by a generated fixed-point reciprocal table for sum_weight, then multiply-shift each exp lane. Sweep q8/q10/q12 reciprocal widths under the same composed dual-stream harness.",
+      "description": "Replace exact sum division by a generated fixed-point reciprocal table for sum_weight, then multiply-shift each exp lane. Sweep q8/q10/q12 reciprocal widths under the same composed dual-stream harness using a reciprocal-specific flow sweep that raises SYNTH_MEMORY_MAX_BITS for the intended table ROM.",
       "quality_risk": "low softmax-specific risk relative to pow2sum because local proxy q12 matches exact RTL-mode quality; still blocked by the broader Q8/K8/V6 mixed-precision quality gate until model-native or QAT recovery is shown."
     },
     "recip_lut_quality": {
@@ -49,7 +49,7 @@
     "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/config.json",
     "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/config.json",
     "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/config.json",
-    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_recip_lut.json",
     "l1_decoder_attention_dual_stream_composed_softmax_split1_ppa_v1",
     "l1_decoder_attention_dual_stream_composed_softmax_pow2sum_ppa_v1"
   ],
@@ -66,7 +66,7 @@
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/config.json",
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_recip_lut.json",
       "out_root": "runs/designs/npu_blocks",
       "expected_outputs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/metrics.csv",
@@ -95,6 +95,7 @@
     "npu/rtlgen/gen_attention_dual_stream_composed.py",
     "npu/eval/check_attention_dual_stream_composed_guard.py",
     "npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py",
-    "control_plane/control_plane/services/l2_task_generator.py"
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_recip_lut.json"
   ]
 }

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_recip_lut.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_recip_lut.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.30,
+      0.40
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_int8_r8_acc24_recip_q10_like attention_full_value_stream_q8v6_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      32768
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1"
+}


### PR DESCRIPTION
## Summary
- add a reciprocal-LUT-specific composed attention sweep with SYNTH_MEMORY_MAX_BITS=32768
- retarget the reciprocal-LUT proposal/evaluation request to that sweep
- document that the override is for the intended generated reciprocal table ROM

## Diagnosis
The failed remote run in #866 reached all commands but produced only flow_failed metrics. Local reproduction showed Yosys infers the generated reciprocal table as a 2048x15 memory in attention_softmax_weight_int8_r8_acc24_recip_q10_like, then OpenROAD aborts before memory_map with SYNTH_MEMORY_MAX_BITS=4096. With the reciprocal-specific override, q8 synthesis passes the memory guard and reaches physical placement.

## Validation
- python3 -m json.tool on updated proposal/evaluation/sweep JSON
- python3 npu/synth/run_block_sweep.py --design_dir runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8 --platform nangate45 --top attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8 --sweep runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_recip_lut.json --out_root runs/designs/npu_blocks --dry_run
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_attention_dual_stream_composed_generator.py tests/test_llm_decoder_attention_mixed_precision_quality.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_softmax_recip_lut_quality_evidence -q
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_supports_attention_dual_stream_composed_configs control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_records_requested_item_in_proposal_evaluation_requests -q
- local q8 OpenROAD probe with SYNTH_MEMORY_MAX_BITS=32768 passed the original memory-guard failure and reached global placement; stopped before full PPA because remote evaluator should run the full sweep