### PR TITLE
runs: raise reciprocal LUT sweep memory cap

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/proposal.json
@@ -36,7 +36,7 @@
   "candidate_plans": {
     "recip_lut": {
       "item_id": "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1",
-      "description": "Replace exact sum division by a generated fixed-point reciprocal table for sum_weight, then multiply-shift each exp lane. Sweep q8/q10/q12 reciprocal widths under the same composed dual-stream harness using a reciprocal-specific flow sweep that raises SYNTH_MEMORY_MAX_BITS for the intended table ROM.",
+      "description": "Replace exact sum division by a generated fixed-point reciprocal table for sum_weight, then multiply-shift each exp lane. Sweep q8/q10/q12 reciprocal widths under the same composed dual-stream harness using a reciprocal-specific flow sweep that raises SYNTH_MEMORY_MAX_BITS for the intended q12-sized table ROM.",
       "quality_risk": "low softmax-specific risk relative to pow2sum because local proxy q12 matches exact RTL-mode quality; still blocked by the broader Q8/K8/V6 mixed-precision quality gate until model-native or QAT recovery is shown."
     },
     "recip_lut_quality": {

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_recip_lut.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_recip_lut.json
@@ -26,7 +26,7 @@
       "int8_mac_s8s8_acc24 attention_softmax_weight_int8_r8_acc24_recip_q10_like attention_full_value_stream_q8v6_p8_ppc2"
     ],
     "SYNTH_MEMORY_MAX_BITS": [
-      32768
+      65536
     ]
   },
   "tag_prefix": "attention_dual_stream_composed_v1"


### PR DESCRIPTION
## Summary
- raise the reciprocal-LUT composed-attention sweep SYNTH_MEMORY_MAX_BITS from 32768 to 65536
- clarify that the override is sized for the q12 reciprocal table case

## Diagnosis
Retry r2 proved the previous cap fixed q8, but q10/q12 still failed immediately with flow_failed rows. q8 produced valid PPA while q10/q12 did not. The q12 generated reciprocal table is larger than the 32768-bit cap, so the flow needs a cap sized for the widest requested reciprocal LUT.

## Validation
- python3 -m json.tool on updated sweep/proposal JSON
- q12 dry-run shows SYNTH_MEMORY_MAX_BITS=65536 for both density points
- local q12 timeout probe passed the prior memory guard, completed Yosys synthesis and floorplan, then timed out during placement as intended for a short local check
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_supports_attention_dual_stream_composed_configs -q