### PR TITLE
npu: prepare q8 recip-lut softmax frontier search

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4636,6 +4636,47 @@ def _decoder_attention_kv_endpoint_sram_noc_full_search_schedule_evidence(
     *,
     item_id: str,
 ) -> dict[str, Any]:
+    return _decoder_attention_kv_endpoint_sram_noc_full_search_schedule_evidence_with_profiles(
+        item_id=item_id,
+        profile_list="hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10",
+        scope=(
+            "Regenerate the endpoint-measured Llama7B dense-tile topology-derived schedule "
+            "from the full topology/scheduler pair matrix, then apply practical SRAM-bank, "
+            "local-buffer, and endpoint injection/ejection caps before ranking. This checks "
+            "whether practical on-chip service caps change the best topology/scheduler point."
+        ),
+    )
+
+
+def _decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_schedule_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    return _decoder_attention_kv_endpoint_sram_noc_full_search_schedule_evidence_with_profiles(
+        item_id=item_id,
+        profile_list=(
+            "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q8,"
+            "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10,"
+            "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q12"
+        ),
+        build_recip_lut_costs=True,
+        scope=(
+            "Regenerate the endpoint-measured Llama7B dense-tile topology-derived schedule "
+            "from the full topology/scheduler pair matrix, then apply practical SRAM-bank, "
+            "local-buffer, and endpoint injection/ejection caps while ranking q8/q10/q12 "
+            "reciprocal-LUT softmax local-cost profiles. This folds the merged reciprocal-LUT "
+            "precision frontier into the SRAM/NoC constrained architecture search."
+        ),
+    )
+
+
+def _decoder_attention_kv_endpoint_sram_noc_full_search_schedule_evidence_with_profiles(
+    *,
+    item_id: str,
+    profile_list: str,
+    scope: str,
+    build_recip_lut_costs: bool = False,
+) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__{item_id}.json"
     report = f"{base}/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__{item_id}.md"
@@ -4646,62 +4687,83 @@ def _decoder_attention_kv_endpoint_sram_noc_full_search_schedule_evidence(
     endpoint_measured_costs = (
         "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_endpoint_v1.json"
     )
+    measured_costs = endpoint_measured_costs
+    generated_costs = (
+        f"runs/campaigns/npu/l1_measured_costs/"
+        f"llama7b_attention_local_costs_endpoint_recip_lut_q8_q10_q12__{item_id}.json"
+    )
+    if build_recip_lut_costs:
+        measured_costs = generated_costs
     sram_profile = f"{base}/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    commands: list[dict[str, str]] = []
+    expected_outputs = [out, report]
+    if build_recip_lut_costs:
+        expected_outputs.insert(0, generated_costs)
+        commands.append(
+            {
+                "name": "build_decoder_attention_recip_lut_local_costs",
+                "run": (
+                    "python3 npu/eval/build_llama7b_attention_recip_lut_local_costs.py "
+                    "--repo-root . "
+                    f"--base-costs {endpoint_measured_costs} "
+                    "--template-profile hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10 "
+                    "--bits-list 8,10,12 "
+                    f"--out {generated_costs}"
+                ),
+            }
+        )
+    commands.append(
+        {
+            "name": "estimate_decoder_attention_kv_endpoint_sram_noc_full_search_schedule",
+            "run": (
+                "python3 npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py "
+                "--repo-root . "
+                f"--topology-pairs-json {endpoint_topology_pairs} "
+                f"--sram-profile-json {sram_profile} "
+                "--compute-source dense_gemm_tile "
+                "--compute-arch-list dense_gemm_16x8_k1_p1 "
+                "--tag-substring npu_dense_gemm_tile_v2_scale_hier "
+                "--sequence-length-list 131072 "
+                "--die-area-mm2-list 800,1200 "
+                "--sram-area-fraction 0.35,0.4,0.5,0.6 "
+                "--logic-area-fraction 0.3,0.4,0.5 "
+                "--reserved-area-fraction 0.1 "
+                "--usable-sram-fraction 0.7 "
+                "--tile-tokens-list 512,1024 "
+                "--topology-row-limit 128 "
+                "--vector-ops-per-mac 0.125 "
+                "--reduction-scalar-bytes 2 "
+                "--command-cycles-per-tile 0,4,16 "
+                "--command-cycles-per-wave 0,16,64 "
+                "--reducer-setup-cycles 0,64,256 "
+                "--reduction-cycle-multiplier 1,2,4 "
+                f"--measured-l1-costs {measured_costs} "
+                f"--measured-l1-profile {profile_list} "
+                "--sram-bank-port-bytes-per-cycle 32 "
+                "--sram-read-ports-per-bank 1 "
+                "--sram-bank-efficiency 0.70,0.85 "
+                "--endpoint-port-bytes-per-cycle 32,64,128 "
+                "--endpoint-ports-per-cluster 1,2 "
+                "--endpoint-efficiency 0.70,0.85 "
+                "--local-buffer-multiplier 1,2 "
+                "--top-k 100 "
+                f"--out {out} "
+                f"--out-md {report}"
+            ),
+        }
+    )
     return {
         "inputs": {
             "attention_kv_dense_tile_endpoint_topology_scheduler_pairs": endpoint_topology_pairs,
-            "attention_kv_endpoint_measured_l1_costs": endpoint_measured_costs,
+            "attention_kv_endpoint_measured_l1_costs": measured_costs,
+            "attention_kv_endpoint_base_measured_l1_costs": endpoint_measured_costs,
             "attention_sram_profile": sram_profile,
             "attention_kv_endpoint_sram_noc_full_search_schedule_out": out,
             "attention_kv_endpoint_sram_noc_full_search_schedule_report": report,
-            "attention_kv_endpoint_sram_noc_full_search_schedule_scope": (
-                "Regenerate the endpoint-measured Llama7B dense-tile topology-derived schedule "
-                "from the full topology/scheduler pair matrix, then apply practical SRAM-bank, "
-                "local-buffer, and endpoint injection/ejection caps before ranking. This checks "
-                "whether practical on-chip service caps change the best topology/scheduler point."
-            ),
+            "attention_kv_endpoint_sram_noc_full_search_schedule_scope": scope,
         },
-        "commands": [
-            {
-                "name": "estimate_decoder_attention_kv_endpoint_sram_noc_full_search_schedule",
-                "run": (
-                    "python3 npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py "
-                    "--repo-root . "
-                    f"--topology-pairs-json {endpoint_topology_pairs} "
-                    f"--sram-profile-json {sram_profile} "
-                    "--compute-source dense_gemm_tile "
-                    "--compute-arch-list dense_gemm_16x8_k1_p1 "
-                    "--tag-substring npu_dense_gemm_tile_v2_scale_hier "
-                    "--sequence-length-list 131072 "
-                    "--die-area-mm2-list 800,1200 "
-                    "--sram-area-fraction 0.35,0.4,0.5,0.6 "
-                    "--logic-area-fraction 0.3,0.4,0.5 "
-                    "--reserved-area-fraction 0.1 "
-                    "--usable-sram-fraction 0.7 "
-                    "--tile-tokens-list 512,1024 "
-                    "--topology-row-limit 128 "
-                    "--vector-ops-per-mac 0.125 "
-                    "--reduction-scalar-bytes 2 "
-                    "--command-cycles-per-tile 0,4,16 "
-                    "--command-cycles-per-wave 0,16,64 "
-                    "--reducer-setup-cycles 0,64,256 "
-                    "--reduction-cycle-multiplier 1,2,4 "
-                    f"--measured-l1-costs {endpoint_measured_costs} "
-                    "--measured-l1-profile hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10 "
-                    "--sram-bank-port-bytes-per-cycle 32 "
-                    "--sram-read-ports-per-bank 1 "
-                    "--sram-bank-efficiency 0.70,0.85 "
-                    "--endpoint-port-bytes-per-cycle 32,64,128 "
-                    "--endpoint-ports-per-cluster 1,2 "
-                    "--endpoint-efficiency 0.70,0.85 "
-                    "--local-buffer-multiplier 1,2 "
-                    "--top-k 100 "
-                    f"--out {out} "
-                    f"--out-md {report}"
-                ),
-            },
-        ],
-        "expected_outputs": [out, report],
+        "commands": commands,
+        "expected_outputs": expected_outputs,
     }
 
 
@@ -7044,6 +7106,7 @@ def _build_payload(
         "decoder_attention_kv_sram_noc_constrained_schedule",
         "decoder_attention_kv_endpoint_sram_noc_constrained_schedule",
         "decoder_attention_kv_endpoint_sram_noc_full_search_schedule",
+        "decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_schedule",
         "decoder_attention_kv_onchip_service_schedule",
         "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_kv_endpoint_ready_valid_service",
@@ -7175,6 +7238,12 @@ def _build_payload(
         elif abstraction_layer_name == "decoder_attention_kv_endpoint_sram_noc_full_search_schedule":
             decoder_evidence = _decoder_attention_kv_endpoint_sram_noc_full_search_schedule_evidence(
                 item_id=item_id,
+            )
+        elif abstraction_layer_name == "decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_schedule":
+            decoder_evidence = (
+                _decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_schedule_evidence(
+                    item_id=item_id,
+                )
             )
         elif abstraction_layer_name == "decoder_attention_kv_onchip_service_schedule":
             decoder_evidence = _decoder_attention_kv_onchip_service_schedule_evidence(item_id=item_id)

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6205,6 +6205,7 @@ def test_generate_l2_campaign_task_adds_endpoint_sram_noc_full_search_schedule_e
             assert "--topology-derived-json" not in run
             assert "l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1.json" in run
             assert "llama7b_attention_local_costs_all_measured_endpoint_v1.json" in run
+            assert "--measured-l1-profile hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10" in run
             assert "--sram-bank-port-bytes-per-cycle 32" in run
             assert "--endpoint-port-bytes-per-cycle 32,64,128" in run
             assert "--topology-row-limit 128" in run
@@ -6216,6 +6217,80 @@ def test_generate_l2_campaign_task_adds_endpoint_sram_noc_full_search_schedule_e
                 output.endswith(
                     "decoder_attention_kv_endpoint_sram_noc_full_search_schedule__"
                     "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
+def test_generate_l2_campaign_task_adds_endpoint_sram_noc_full_search_softmax_recip_lut_schedule_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_schedule",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            build_run = commands[0]["run"]
+            run = commands[1]["run"]
+
+            assert "build_decoder_attention_recip_lut_local_costs" in command_names
+            assert "estimate_decoder_attention_kv_endpoint_sram_noc_full_search_schedule" in command_names
+            assert "attention_kv_dense_tile_endpoint_topology_scheduler_pairs" in decoder_inputs
+            assert "attention_kv_endpoint_measured_l1_costs" in decoder_inputs
+            assert "attention_kv_endpoint_base_measured_l1_costs" in decoder_inputs
+            assert "attention_sram_profile" in decoder_inputs
+            assert "attention_kv_endpoint_sram_noc_full_search_schedule_out" in decoder_inputs
+            assert "build_llama7b_attention_recip_lut_local_costs.py" in build_run
+            assert "llama7b_attention_local_costs_all_measured_endpoint_v1.json" in build_run
+            assert "--bits-list 8,10,12" in build_run
+            assert "estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py" in run
+            assert "--topology-pairs-json" in run
+            assert "--topology-derived-json" not in run
+            assert "llama7b_attention_local_costs_endpoint_recip_lut_q8_q10_q12__" in run
+            assert (
+                "--measured-l1-profile "
+                "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q8,"
+                "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10,"
+                "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q12"
+            ) in run
+            assert "--sram-bank-port-bytes-per-cycle 32" in run
+            assert "--endpoint-port-bytes-per-cycle 32,64,128" in run
+            assert "--noc-bandwidth-bytes-per-cycle" not in run
+            assert "--noc-hops" not in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.expected_outputs == expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_endpoint_sram_noc_full_search_schedule__"
+                    "l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+            assert any(
+                output.endswith(
+                    "llama7b_attention_local_costs_endpoint_recip_lut_q8_q10_q12__"
+                    "l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1.json"
                 )
                 for output in expected_outputs
             )

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -21,8 +21,11 @@ than free or heuristic assumptions.
    - Scope: score max, exponent approximation, sum accumulation, reciprocal
      normalization, and normalized weight output.
    - First measurement: `l1_decoder_attention_softmax_weight_generator_v1`.
-   - First L2 consumer: add the selected measured softmax profile as per-cluster
-     local overhead and rerun the clustered schedule.
+   - Current follow-up: `prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1`
+     measures the missing standalone q8 reciprocal-LUT softmax-weight profile
+     and reruns the endpoint SRAM/NoC full search across q8/q10/q12 local-cost
+     profiles. This keeps the standalone softmax-weight accounting boundary
+     separate from the wider composed dual-stream datapath evidence.
 
 2. SRAM timing and energy
    - Scope: tile-local score/value buffering, KV tile reads, partial-value

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1/design_brief.md
@@ -1,0 +1,24 @@
+# Llama7B Endpoint SRAM/NoC Softmax Recip-LUT Frontier
+
+## Purpose
+
+Remove the current q10-only softmax local-cost assumption from the endpoint
+SRAM/NoC full-search Llama7B frontier.
+
+## Boundary
+
+The current Llama7B local-cost file models one measured full-value datapath, one
+standalone softmax-weight generator, one FIFO, one router, and one endpoint per
+cluster. The merged composed reciprocal-LUT PPA result is useful frontier
+evidence, but it covers a wider composed datapath boundary. This proposal first
+measures q8 under the standalone softmax-weight boundary, then lets the L2
+frontier compare q8/q10/q12 consistently.
+
+## Execution Order
+
+1. Run `l1_decoder_attention_softmax_weight_generator_q8_v1`.
+2. Merge the q8 metrics artifact.
+3. Run `l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1`.
+
+The L2 job builds a temporary q8/q10/q12 local-cost profile file from committed
+metrics before running the full-search scheduler.

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1/evaluation_requests.json
@@ -1,0 +1,47 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1",
+  "source_commit": "TBD_AFTER_MERGE",
+  "source_commit_note": "Dispatch the L1 q8 item after this proposal/config PR is merged. Dispatch the L2 item only after q8 metrics are merged, because the L2 builder consumes the q8 metrics.csv artifact.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_softmax_weight_generator_q8_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure q8 standalone reciprocal-LUT attention softmax-weight generator PPA under the same boundary as q10/q12/q16.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_softmax_weight_generator",
+      "comparison_role": "softmax_recip_lut_q8_local_cost_profile",
+      "configs": [
+        "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q8_wrapper/config_attention_softmax_weight_int8_r8_acc24_recip_q8.json"
+      ],
+      "sweep_path": "runs/designs/activations/sweeps/nangate45_attention_softmax_weight_generator_v1.json",
+      "out_root": "runs/designs/activations",
+      "expected_outputs": [
+        "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q8_wrapper/metrics.csv"
+      ],
+      "expected_result": {
+        "direction": "measure_q8_softmax_weight_profile",
+        "reason": "The result should provide q8 standalone reciprocal-LUT softmax-weight PPA for the same local-cost boundary used by the current Llama7B endpoint scheduler."
+      }
+    },
+    {
+      "item_id": "l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Regenerate the endpoint SRAM/NoC full-search Llama7B frontier while ranking q8/q10/q12 reciprocal-LUT softmax local-cost profiles.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_schedule",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_softmax_weight_generator_q8_v1",
+        "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1",
+        "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_q8_q10_q12_softmax_profiles_in_endpoint_sram_noc_frontier",
+        "reason": "The result should show the best practical endpoint SRAM/NoC topology/scheduler point and the selected reciprocal-LUT softmax precision profile."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1/proposal.json
@@ -1,0 +1,80 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1",
+  "created_utc": "2026-06-17T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B endpoint SRAM/NoC frontier with reciprocal-LUT softmax profiles",
+  "hypothesis": "The current endpoint SRAM/NoC full-search frontier is still fixed to the q10 standalone softmax-weight profile. Measuring q8 under the same standalone softmax-weight boundary and rerunning the endpoint full search across q8/q10/q12 will expose whether the lower-cost q8 reciprocal-LUT point changes the best Llama7B token-throughput, energy, area, and precision tradeoff.",
+  "direct_comparison": {
+    "primary_question": "After q8 standalone reciprocal-LUT softmax PPA is available, does the practical endpoint SRAM/NoC full search select q8, q10, or q12 as the best measured softmax precision point?",
+    "include": [
+      "new q8 standalone attention softmax-weight generator PPA under the existing q10/q12/q16 flow",
+      "generated q8/q10/q12 endpoint local-cost profile file using the same local datapath, FIFO, router, and endpoint boundary",
+      "endpoint SRAM/NoC full-search regeneration over the existing topology/scheduler pair matrix",
+      "practical SRAM bank service, endpoint port, local-buffer, command, and reducer sensitivity",
+      "precision profile selected in the best and top-ranked rows"
+    ],
+    "exclude": [
+      "do not use composed dual-stream metrics as a drop-in replacement for standalone softmax-weight cost",
+      "do not change HBM/DRAM bandwidth or service policy",
+      "do not introduce KV sharing or other precision changes beyond softmax reciprocal width",
+      "do not run new dense GEMM tile PPA"
+    ],
+    "follow_on_broad_sweep": [
+      "if q8 is selected, promote it as the current softmax cost profile only after quality gates remain acceptable",
+      "if q10 or q12 is selected, retain q8 as PPA-only evidence and keep the selected profile in the Llama7B frontier",
+      "after precision selection, proceed to the detailed on-chip SRAM/endpoint arbitration model for the selected topology"
+    ]
+  },
+  "expected_benefit": [
+    "remove the q10-only softmax precision assumption from the endpoint SRAM/NoC frontier",
+    "keep the local-cost accounting boundary consistent with previous Llama7B schedule models",
+    "turn the merged reciprocal-LUT quality/PPA result into a directly ranked Llama7B architecture choice"
+  ],
+  "risks": [
+    "q8 standalone softmax-weight PPA must be measured before the L2 rerun can execute",
+    "the L2 search remains a service-envelope model, not cycle-accurate SRAM/NoC RTL",
+    "quality evidence is still proxy-level and must not be interpreted as final Llama7B perplexity"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l1_sweep",
+      "evaluation_mode": "frontier_detail",
+      "objective": "softmax_recip_lut_q8_standalone_weight_generator_ppa",
+      "cost_class": "small",
+      "expected_result": {
+        "direction": "measure_q8_softmax_weight_profile",
+        "reason": "The result should provide q8 standalone reciprocal-LUT softmax-weight PPA under the same boundary as the existing q10/q12/q16 profiles."
+      }
+    },
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "endpoint_sram_noc_full_search_softmax_recip_lut_precision_frontier",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_softmax_weight_generator_q8_v1",
+        "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1",
+        "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_q8_q10_q12_softmax_profiles_in_endpoint_sram_noc_frontier",
+        "reason": "The result should report which reciprocal-LUT softmax precision profile is selected when practical endpoint SRAM/NoC caps are applied."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json",
+    "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_endpoint_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_quality__l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/build_llama7b_attention_recip_lut_local_costs.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py",
+    "docs/proposals/prop_l1_decoder_attention_softmax_recip_lut_frontier_v1/analysis_report.md"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1/quality_gate.md
@@ -1,0 +1,27 @@
+# Quality Gate
+
+## Proposal
+
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1`
+- `title`: `Llama7B endpoint SRAM/NoC frontier with reciprocal-LUT softmax profiles`
+
+## Checks
+
+- q8 standalone PPA
+  - `runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q8_wrapper/metrics.csv`
+  - at least one `ok` row
+- generated local-cost file
+  - includes exactly the q8/q10/q12 profiles selected by the L2 item
+  - cites the metrics path used for each softmax profile
+- L2 full search
+  - consumes `--topology-pairs-json`, not `--topology-derived-json`
+  - does not reintroduce independent `--noc-bandwidth-bytes-per-cycle` or `--noc-hops`
+  - reports `measured_l1_profile` in the best row
+- precision accounting
+  - selected profile must be interpreted together with the reciprocal-LUT quality
+    gate, not as final Llama7B perplexity evidence
+
+## Local Smoke Commands
+
+- `python3 npu/eval/build_llama7b_attention_recip_lut_local_costs.py --repo-root . --base-costs runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_endpoint_v1.json --template-profile hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10 --bits-list 10,12 --out /tmp/recip_lut_costs_q10_q12.json`
+- `PYTHONPATH=control_plane pytest control_plane/control_plane/tests/test_l2_task_generator.py -k endpoint_sram_noc_full_search`

--- a/npu/eval/build_llama7b_attention_recip_lut_local_costs.py
+++ b/npu/eval/build_llama7b_attention_recip_lut_local_costs.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Build Llama7B attention local-cost profiles for reciprocal-LUT softmax choices."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+
+def _safe_float(value: Any) -> float | None:
+    if value in ("", None):
+        return None
+    try:
+        return float(str(value).strip())
+    except ValueError:
+        return None
+
+
+def _load_metrics_rows(path: Path) -> list[dict[str, str]]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    text = re.sub(r"result\.json(?=[A-Za-z0-9_])", "result.json\n", text)
+    lines = text.splitlines()
+    if not lines:
+        return []
+    reader = csv.DictReader(lines)
+    csv_rows = list(reader)
+    good_rows = [row for row in csv_rows if None not in row]
+    if reader.fieldnames and good_rows and len(good_rows) == len(csv_rows):
+        return [{str(key): str(value or "") for key, value in row.items()} for row in good_rows]
+
+    header = lines[0].split(",")
+    rows: list[dict[str, str]] = [{str(key): str(value or "") for key, value in row.items()} for row in good_rows]
+    prefix_len = max(len(header) - 2, 0)
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        parts = line.split(",", prefix_len)
+        if len(parts) < prefix_len + 1:
+            continue
+        front = parts[:prefix_len]
+        rest = parts[prefix_len]
+        if "," in rest:
+            params_json, result_path = rest.rsplit(",", 1)
+        else:
+            params_json, result_path = rest, ""
+        params_json = params_json.strip()
+        if len(params_json) >= 2 and params_json[0] == '"' and params_json[-1] == '"':
+            params_json = params_json[1:-1].replace('""', '"')
+        values = front + [params_json, result_path]
+        if len(values) == len(header):
+            rows.append(dict(zip(header, values)))
+    return rows
+
+
+def _best_ok_metrics(path: Path) -> JsonDict:
+    rows = [row for row in _load_metrics_rows(path) if str(row.get("status", "")).strip() == "ok"]
+    if not rows:
+        raise SystemExit(f"no ok metrics rows found: {path}")
+
+    def sort_key(row: dict[str, str]) -> tuple[float, float, float, str]:
+        area = _safe_float(row.get("die_area"))
+        if area is None:
+            area = _safe_float(row.get("instance_area_um2"))
+        return (
+            _safe_float(row.get("critical_path_ns")) or float("inf"),
+            area or float("inf"),
+            _safe_float(row.get("total_power_mw")) or float("inf"),
+            str(row.get("param_hash", "")),
+        )
+
+    row = sorted(rows, key=sort_key)[0]
+    area = _safe_float(row.get("die_area"))
+    if area is None:
+        area = _safe_float(row.get("instance_area_um2"))
+    return {
+        "clock_ns": _safe_float(row.get("critical_path_ns")) or 0.0,
+        "area_um2": area or 0.0,
+        "power_mw": _safe_float(row.get("total_power_mw")) or 0.0,
+        "param_hash": str(row.get("param_hash", "")),
+        "tag": str(row.get("tag", "")),
+    }
+
+
+def _find_profile(payload: JsonDict, name: str) -> JsonDict:
+    profiles = payload.get("profiles", [])
+    if not isinstance(profiles, list):
+        raise SystemExit("base costs must contain a list-valued profiles field")
+    for profile in profiles:
+        if isinstance(profile, dict) and profile.get("name") == name:
+            return profile
+    raise SystemExit(f"profile template not found: {name}")
+
+
+def _profile_for_bits(template: JsonDict, *, bits: int, metrics_csv: str, metrics: JsonDict) -> JsonDict:
+    profile = deepcopy(template)
+    profile["name"] = re.sub(r"_q\d+$", f"_q{bits}", str(template["name"]))
+    profile["description"] = re.sub(r"q\d+ reciprocal", f"q{bits} reciprocal", str(template.get("description", "")))
+    profile["description"] = re.sub(r"q\d+ reciprocal", f"q{bits} reciprocal", profile["description"])
+    softmax = dict(profile.get("softmax_weight_generator", {}))
+    softmax["design"] = f"attention_softmax_weight_int8_r8_acc24_recip_q{bits}_wrapper"
+    softmax["clock_ns"] = round(float(metrics["clock_ns"]), 6)
+    softmax["area_um2"] = round(float(metrics["area_um2"]), 6)
+    softmax["power_mw"] = round(float(metrics["power_mw"]), 6)
+    softmax["metrics_csv"] = metrics_csv
+    softmax["param_hash"] = metrics["param_hash"]
+    softmax["tag"] = metrics["tag"]
+    profile["softmax_weight_generator"] = softmax
+    return profile
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--base-costs", required=True)
+    parser.add_argument("--template-profile", required=True)
+    parser.add_argument("--bits-list", default="8,10,12")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root)
+    base_path = repo_root / args.base_costs
+    payload = json.loads(base_path.read_text(encoding="utf-8"))
+    template = _find_profile(payload, args.template_profile)
+    bits_values = [int(value.strip()) for value in args.bits_list.split(",") if value.strip()]
+
+    profiles: list[JsonDict] = []
+    metric_refs: dict[str, str] = {}
+    for bits in bits_values:
+        metrics_csv = (
+            f"runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q{bits}_wrapper/metrics.csv"
+        )
+        metrics = _best_ok_metrics(repo_root / metrics_csv)
+        profiles.append(_profile_for_bits(template, bits=bits, metrics_csv=metrics_csv, metrics=metrics))
+        metric_refs[f"q{bits}"] = metrics_csv
+
+    out_payload = {
+        "version": 0.1,
+        "name": "llama7b_attention_local_costs_endpoint_recip_lut_q8_q10_q12_v1",
+        "platform": payload.get("platform", "nangate45"),
+        "core_utilization": payload.get("core_utilization"),
+        "scope": (
+            "Per-cluster L1 costs for endpoint SRAM/NoC Llama7B search using the same "
+            "local datapath/FIFO/router/endpoint boundary as the endpoint all-measured "
+            "cost file, but sweeping q8/q10/q12 standalone reciprocal-LUT softmax-weight "
+            "generator profiles built from merged metrics.csv artifacts."
+        ),
+        "source_costs": args.base_costs,
+        "source_template_profile": args.template_profile,
+        "softmax_metric_refs": metric_refs,
+        "profiles": profiles,
+    }
+
+    out_path = repo_root / args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(out_payload, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q8_wrapper/config_attention_softmax_weight_int8_r8_acc24_recip_q8.json
+++ b/runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q8_wrapper/config_attention_softmax_weight_int8_r8_acc24_recip_q8.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "scores",
+      "dimensions": 1,
+      "bit_width": 8,
+      "signed": true
+    }
+  ],
+  "operations": [
+    {
+      "type": "softmax_rowwise",
+      "module_name": "attention_softmax_weight_int8_r8_acc24_recip_q8",
+      "operand": "scores",
+      "options": {
+        "impl": "shift_exp",
+        "normalization_mode": "reciprocal_quantized",
+        "reciprocal_bits": 8,
+        "reciprocal_lut_bucket_shift": 4,
+        "row_elems": 8,
+        "max_shift": 7,
+        "accum_bits": 24,
+        "output_scale": 127
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary\n- add q8 standalone reciprocal-LUT softmax-weight config under the existing q10/q12/q16 boundary\n- add a local-cost builder that materializes q8/q10/q12 endpoint profiles from committed metrics before L2 scheduling\n- add a new L2 generator abstraction for endpoint SRAM/NoC full search across q8/q10/q12 softmax profiles\n- document the two-stage L1 then L2 plan for the Llama7B abstraction-closure path\n\n## Validation\n- python3 -m py_compile npu/eval/build_llama7b_attention_recip_lut_local_costs.py control_plane/control_plane/services/l2_task_generator.py\n- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'endpoint_sram_noc_full_search'\n- python3 npu/eval/build_llama7b_attention_recip_lut_local_costs.py --repo-root . --base-costs runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_endpoint_v1.json --template-profile hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10 --bits-list 10,12 --out /tmp/recip_lut_costs_q10_q12.json\n- python3 scripts/validate_runs.py --skip_eval_queue\n\n## Dispatch Plan After Merge\n1. Dispatch l1_decoder_attention_softmax_weight_generator_q8_v1.\n2. After q8 metrics merge, dispatch l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1.\n