### PR TITLE
control_plane: route endpoint onchip service evidence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -445,6 +445,12 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("attention_local_sram_capacity_out", "attention_local_sram_capacity_report"),
     ("attention_kv_measured_sram_rebalance_out", "attention_kv_measured_sram_rebalance_report"),
     ("attention_kv_measured_hbm_service_out", "attention_kv_measured_hbm_service_report"),
+    ("attention_kv_onchip_service_schedule_out", "attention_kv_onchip_service_schedule_report"),
+    (
+        "attention_kv_endpoint_full_onchip_service_schedule_out",
+        "attention_kv_endpoint_full_onchip_service_schedule_report",
+    ),
+    ("attention_kv_endpoint_ready_valid_service_out", "attention_kv_endpoint_ready_valid_service_report"),
     ("attention_kv_hbm_closed_onchip_schedule_out", "attention_kv_hbm_closed_onchip_schedule_report"),
     ("attention_kv_subtile_pipeline_schedule_out", "attention_kv_subtile_pipeline_schedule_report"),
     ("attention_kv_dual_stream_physical_feasibility_out", "attention_kv_dual_stream_physical_feasibility_report"),
@@ -557,6 +563,8 @@ def _decoder_frontier_recommendation(
 ) -> dict[str, Any] | None:
     best = evidence_payload.get("best")
     if not isinstance(best, dict) or not best:
+        best = evidence_payload.get("source_best")
+    if not isinstance(best, dict) or not best:
         return None
     model = str(evidence_payload.get("model", "")).strip()
     if not model.startswith("llm_decoder_"):
@@ -580,7 +588,9 @@ def _decoder_frontier_recommendation(
         "measured_l1_profile",
         "topology",
         "scheduler_policy",
+        "schedule_policy",
         "reduction_strategy",
+        "bank_arbiter_policy",
         "cluster_count",
         "bank_count",
         "active_clusters",
@@ -602,6 +612,12 @@ def _decoder_frontier_recommendation(
         "practical_noc_cap_source",
         "practical_per_cluster_noc_effective_bytes_per_cycle",
         "endpoint_bytes_per_cycle_per_cluster",
+        "latency_slowdown_vs_sram_noc_cap",
+        "endpoint_queue_depth_bytes",
+        "bank_queue_depth_bytes",
+        "router_latency_cycles_per_hop",
+        "packet_payload_bytes",
+        "onchip_shared_service_cycles",
         "tile_tokens",
         "tile_waves",
     ):
@@ -741,6 +757,63 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         ):
             if key in best_dict:
                 parts.append(f"{key}={best_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_kv_onchip_service_schedule_llama7b_v1":
+        best = evidence_payload.get("best")
+        best_dict = dict(best) if isinstance(best, dict) else {}
+        outcome = "onchip_service_schedule_recorded"
+        parts = [
+            f"Decoder on-chip SRAM/NoC service evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "measured_l1_profile",
+            "latency_us",
+            "latency_slowdown_vs_sram_noc_cap",
+            "total_cycles",
+            "topology",
+            "scheduler_policy",
+            "schedule_policy",
+            "bank_arbiter_policy",
+            "cluster_count",
+            "bank_count",
+            "endpoint_queue_depth_bytes",
+            "bank_queue_depth_bytes",
+            "router_latency_cycles_per_hop",
+            "packet_payload_bytes",
+            "onchip_shared_service_cycles",
+            "dominant_tile_resource",
+        ):
+            if key in best_dict:
+                parts.append(f"{key}={best_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_endpoint_ready_valid_service_probe_v1":
+        source_best = evidence_payload.get("source_best")
+        source_best_dict = dict(source_best) if isinstance(source_best, dict) else {}
+        decision = str(evidence_payload.get("decision", "")).strip()
+        outcome = decision or "endpoint_ready_valid_service_recorded"
+        parts = [
+            f"Decoder endpoint ready/valid service evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        rtl_probe = evidence_payload.get("rtl_probe")
+        if isinstance(rtl_probe, dict):
+            for key in ("passed", "cycles", "max_endpoint_occupancy", "max_bank_occupancy", "stall_cycles"):
+                if key in rtl_probe:
+                    parts.append(f"rtl_{key}={rtl_probe.get(key)}")
+        for key in (
+            "latency_us",
+            "schedule_policy",
+            "bank_arbiter_policy",
+            "endpoint_queue_depth_bytes",
+            "bank_queue_depth_bytes",
+            "router_latency_cycles_per_hop",
+            "packet_payload_bytes",
+        ):
+            if key in source_best_dict:
+                parts.append(f"{key}={source_best_dict.get(key)}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4868,10 +4868,16 @@ def _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__{item_id}.json"
     report = f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__{item_id}.md"
-    endpoint_full_search = (
-        f"{base}/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__"
-        "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json"
-    )
+    if "softmax_recip_lut" in item_id:
+        endpoint_full_search = (
+            f"{base}/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__"
+            "l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1_r2.json"
+        )
+    else:
+        endpoint_full_search = (
+            f"{base}/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__"
+            "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json"
+        )
     return {
         "inputs": {
             "attention_kv_endpoint_sram_noc_full_search_schedule": endpoint_full_search,

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1168,6 +1168,146 @@ def test_consume_l2_result_frontier_endpoint_sram_noc_overrides_generic_recommen
             ] == report_rel
 
 
+def test_consume_l2_result_frontier_onchip_service_overrides_generic_recommendation() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_endpoint_onchip_service_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_endpoint_onchip_service_v1",
+                        "kind": "architecture",
+                        "title": "Endpoint on-chip service",
+                        "direct_comparison": {
+                            "primary_question": "Which explicit on-chip service policy is selected?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_endpoint_onchip.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_endpoint_onchip.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_kv_onchip_service_schedule_llama7b_v1",
+                        "best": {
+                            "measured_l1_profile": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10",
+                            "topology": "mesh2d",
+                            "scheduler_policy": "locality_aware",
+                            "schedule_policy": "prefetch_overlap",
+                            "reduction_strategy": "cluster_tree",
+                            "bank_arbiter_policy": "locality_first",
+                            "cluster_count": 16,
+                            "bank_count": 64,
+                            "compute_source": "dense_gemm_tile",
+                            "compute_arch": "dense_gemm_16x8_k1_p1",
+                            "latency_us": 3222.903773,
+                            "total_cycles": 538848,
+                            "latency_slowdown_vs_sram_noc_cap": 0.993155,
+                            "endpoint_queue_depth_bytes": 32768,
+                            "bank_queue_depth_bytes": 32768,
+                            "router_latency_cycles_per_hop": 1,
+                            "packet_payload_bytes": 128,
+                            "onchip_shared_service_cycles": 1987,
+                            "dominant_tile_resource": "shared_path",
+                        },
+                        "top_rows": [
+                            {
+                                "measured_l1_profile": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10",
+                                "topology": "mesh2d",
+                                "scheduler_policy": "locality_aware",
+                                "schedule_policy": "prefetch_overlap",
+                                "reduction_strategy": "cluster_tree",
+                                "bank_arbiter_policy": "locality_first",
+                                "cluster_count": 16,
+                                "bank_count": 64,
+                                "compute_source": "dense_gemm_tile",
+                                "compute_arch": "dense_gemm_16x8_k1_p1",
+                                "latency_us": 3222.903773,
+                                "total_cycles": 538848,
+                                "dominant_tile_resource": "shared_path",
+                            }
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# endpoint onchip\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_endpoint_onchip",
+                campaign_dir_rel="runs/campaigns/npu/endpoint_onchip_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_endpoint_onchip_service_v1",
+                comparison={"role": "frontier_revision"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use explicit on-chip service evidence for next architecture selection.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_kv_endpoint_full_onchip_service_schedule",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_kv_endpoint_full_onchip_service_schedule_out": evidence_rel,
+                    "attention_kv_endpoint_full_onchip_service_schedule_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            result = consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            recommendation = decision_payload["recommendation"]
+            assert result.recommended_arch_id == (
+                "mesh2d_locality_aware_cluster_tree_c16_b64_dense_gemm_16x8_k1_p1"
+            )
+            assert recommendation["source"] == "decoder_evidence"
+            assert recommendation["macro_mode"] == "dense_gemm_tile"
+            assert recommendation["schedule_policy"] == "prefetch_overlap"
+            assert recommendation["bank_arbiter_policy"] == "locality_first"
+            assert recommendation["latency_us"] == 3222.903773
+            assert recommendation["legacy_campaign_recommendation"]["arch_id"] == "fp16_nm1_demo"
+            assert decision_payload["proposal_assessment"]["outcome"] == "onchip_service_schedule_recorded"
+            assert decision_payload["source_refs"][
+                "decoder_attention_kv_endpoint_full_onchip_service_schedule_out"
+            ] == evidence_rel
+            assert decision_payload["source_refs"][
+                "decoder_attention_kv_endpoint_full_onchip_service_schedule_report"
+            ] == report_rel
+
+
 def test_consume_l2_result_frontier_attention_local_sram_capacity_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6399,6 +6399,52 @@ def test_generate_l2_campaign_task_adds_endpoint_full_onchip_service_schedule_ev
             )
 
 
+def test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_full_onchip_source() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_endpoint_full_onchip_service_schedule",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "attention_kv_endpoint_sram_noc_full_search_schedule" in decoder_inputs
+            assert (
+                "l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1_r2.json"
+                in run
+            )
+            assert "l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json" not in run
+            assert work_item.expected_outputs == expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_endpoint_full_onchip_service_schedule__"
+                    "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_endpoint_ready_valid_service_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary\n- Recognize on-chip service, endpoint full on-chip service, and endpoint ready/valid evidence in the L2 result consumer.\n- Publish decoder-native recommendations for explicit on-chip SRAM/NoC service results instead of falling back to generic campaign placeholders.\n- Route softmax-recip-LUT endpoint full on-chip service jobs to the corrected q8/q10/q12 full-search source artifact.\n\n## Verification\n- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py\n- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_endpoint_full_onchip_service_schedule_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_full_onchip_source control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_endpoint_ready_valid_service_evidence\n- python3 npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py --repo-root . --sram-noc-constrained-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1_r2.json --frontier-row-limit 32 --top-k 10 --out /tmp/endpoint_onchip_recip_lut_smoke.json --out-md /tmp/endpoint_onchip_recip_lut_smoke.md\n- python3 scripts/validate_runs.py --skip_eval_queue\n- git diff --check\n- py_compile l2_result_consumer.py and l2_task_generator.py\n\nSmoke result on the corrected r2 source: best latency 3222.903773 us, q8, prefetch_overlap, locality_first, shared_path dominated.