### PR TITLE
docs: propose recip-lut endpoint onchip service run

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/README.md
@@ -1,0 +1,9 @@
+# Endpoint Full On-Chip Service With Reciprocal-LUT Softmax
+
+This proposal reruns the explicit endpoint/SRAM/NoC on-chip service schedule
+against the corrected q8/q10/q12 reciprocal-LUT endpoint full-search frontier.
+
+The goal is to reduce the current on-chip service abstraction after the softmax
+precision frontier was folded into the Llama7B endpoint SRAM/NoC search. HBM and
+DRAM service remain inherited unchanged in this item.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/analysis_report.md
@@ -1,0 +1,4 @@
+# Analysis Report
+
+Pending evaluator output for `l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1`.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-17T04:20:00Z
+- allowed_evaluations:
+  - l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1
+- note: Apply explicit SRAM-bank, endpoint queue, packet, router-latency, and scheduling policy model to the corrected reciprocal-LUT endpoint full-search Llama7B frontier.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1",
+  "source_commit": "76e9b109cae5a15b5318e8b081b9ae0bc8bf31b3",
+  "source_commit_note": "Dispatch should use the merge commit that routes softmax_recip_lut endpoint full on-chip service jobs to the corrected q8/q10/q12 full-search source.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Apply explicit on-chip SRAM bank, endpoint queue, bank queue, packet payload, router latency, scheduling, and overlap policies to the corrected reciprocal-LUT endpoint full-search Llama7B frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_endpoint_full_onchip_service_schedule",
+      "comparison_role": "frontier_revision",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "refine_recip_lut_endpoint_frontier_with_explicit_onchip_service_policies",
+        "reason": "The result should identify the best explicit on-chip service policy and selected q8/q10/q12 profile without changing HBM/DRAM assumptions."
+      },
+      "status": "pending"
+    }
+  ]
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/implementation_summary.md
@@ -1,0 +1,5 @@
+# Implementation Summary
+
+- Added after PR #877 so `softmax_recip_lut` endpoint full on-chip service jobs consume the corrected q8/q10/q12 full-search source.
+- The requested item keeps HBM/DRAM inherited unchanged and only refines on-chip SRAM/NoC service scheduling.
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/promotion_gate.md
@@ -1,0 +1,8 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1",
+  "created_utc": "2026-06-17T04:20:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Endpoint full on-chip service for reciprocal-LUT softmax Llama7B frontier",
+  "hypothesis": "Applying explicit endpoint queue, bank queue, packet payload, router hop latency, SRAM bank arbitration, wave staggering, and prefetch-overlap policies to the corrected q8/q10/q12 reciprocal-LUT endpoint full-search frontier will reduce the on-chip service abstraction and show whether the selected precision/topology point remains stable.",
+  "direct_comparison": {
+    "primary_question": "Does the corrected q8/q10/q12 endpoint full-search frontier remain best under explicit on-chip SRAM/NoC service scheduling?",
+    "include": [
+      "Use l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1_r2 as the source frontier.",
+      "Sweep static_wave, staggered_wave, and prefetch_overlap scheduling.",
+      "Sweep round_robin, locality_first, and age_based SRAM bank arbitration.",
+      "Sweep endpoint queue depth, bank queue depth, packet payload, router hop latency, and prefetch overlap.",
+      "Report latency movement and selected q8/q10/q12 profile under explicit on-chip service."
+    ],
+    "exclude": [
+      "Do not change HBM/DRAM bandwidth, frequency, or service policy.",
+      "Do not introduce new precision quality assumptions.",
+      "Do not run new physical closure in this L2 scheduler item.",
+      "Do not use the older endpoint full-search source without reciprocal-LUT softmax."
+    ],
+    "follow_on_broad_sweep": [
+      "If the selected profile or topology moves, use this result as the next Llama7B frontier baseline.",
+      "If the same family remains best, run endpoint/router/SRAM ready-valid service against this revised on-chip frontier.",
+      "Treat HBM/DRAM as a separate later item."
+    ]
+  },
+  "expected_benefit": [
+    "Keeps the on-chip service model aligned with the latest reciprocal-LUT softmax frontier.",
+    "Identifies whether explicit endpoint queues and bank arbitration change the best Llama7B point.",
+    "Provides the next least-abstract on-chip-service baseline before RTL endpoint/router/SRAM composition."
+  ],
+  "risks": [
+    "This remains an analytic service simulator, not router/SRAM RTL.",
+    "Queue and arbitration policies are parameterized approximations.",
+    "HBM/DRAM service remains inherited and abstract by design."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "endpoint_full_onchip_service_schedule_softmax_recip_lut",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "refine_recip_lut_endpoint_frontier_with_explicit_onchip_service_policies",
+        "reason": "The result should report explicit on-chip service policy movement relative to the corrected q8/q10/q12 endpoint full-search frontier."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_kv_endpoint_sram_noc_softmax_recip_lut_frontier_v1/analysis_report.md",
+    "docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_v1/analysis_report.md",
+    "npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py"
+  ]
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1/quality_gate.md
@@ -1,0 +1,20 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_full_onchip_service_softmax_recip_lut_v1`
+- `title`: `Endpoint full on-chip service for reciprocal-LUT softmax Llama7B frontier`
+
+## Checks
+- metric: source artifact
+  - threshold: command consumes `decoder_attention_kv_endpoint_sram_noc_full_search_schedule__...softmax_recip_lut...v1_r2.json`
+- metric: old source artifact
+  - threshold: command does not consume `l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1.json`
+- metric: policy sweep
+  - threshold: report includes schedule policy, bank arbiter policy, endpoint queue depth, bank queue depth, packet payload, and router hop latency
+- metric: HBM/DRAM
+  - threshold: report states HBM/DRAM service is inherited unchanged
+
+## Result
+- status: pending
+- note: Final quality decision waits for evaluator output.
+


### PR DESCRIPTION
## Summary\n- Add a proposal workspace for rerunning endpoint full on-chip service scheduling on the corrected q8/q10/q12 reciprocal-LUT endpoint full-search frontier.\n- Requested item: l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1.\n- The item keeps HBM/DRAM inherited unchanged and only refines explicit on-chip SRAM/NoC service policy.\n\n## Verification\n- python3 -m json.tool proposal.json and evaluation_requests.json\n- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_docs_paths.py\n- git diff --check