### PR TITLE
[codex] Preserve precision profiles in on-chip frontier ranking

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -627,7 +627,9 @@ def _decoder_frontier_recommendation(
 
 
 def _decoder_frontier_profile_recommendations(evidence_payload: dict[str, Any]) -> list[dict[str, Any]]:
-    rows = evidence_payload.get("top_rows")
+    rows = evidence_payload.get("best_by_profile")
+    if not isinstance(rows, list) or not rows:
+        rows = evidence_payload.get("top_rows")
     if not isinstance(rows, list):
         return []
     result: list[dict[str, Any]] = []
@@ -641,7 +643,7 @@ def _decoder_frontier_profile_recommendations(evidence_payload: dict[str, Any]) 
         seen_profiles.add(profile)
         entry: dict[str, Any] = {
             "profile": profile,
-            "rank_in_decoder_frontier": index,
+            "rank_in_decoder_frontier": row.get("rank_in_decoder_frontier", index),
             "best_arch_id": _decoder_frontier_arch_id(row),
             "best_macro_mode": str(row.get("compute_source", "")).strip() or "decoder_frontier",
         }

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1244,6 +1244,40 @@ def test_consume_l2_result_frontier_onchip_service_overrides_generic_recommendat
                                 "dominant_tile_resource": "shared_path",
                             }
                         ],
+                        "best_by_profile": [
+                            {
+                                "measured_l1_profile": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q8",
+                                "rank_in_decoder_frontier": 1,
+                                "topology": "mesh2d",
+                                "scheduler_policy": "locality_aware",
+                                "schedule_policy": "prefetch_overlap",
+                                "reduction_strategy": "cluster_tree",
+                                "bank_arbiter_policy": "locality_first",
+                                "cluster_count": 16,
+                                "bank_count": 64,
+                                "compute_source": "dense_gemm_tile",
+                                "compute_arch": "dense_gemm_16x8_k1_p1",
+                                "latency_us": 3222.903773,
+                                "total_cycles": 538848,
+                                "dominant_tile_resource": "shared_path",
+                            },
+                            {
+                                "measured_l1_profile": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10",
+                                "rank_in_decoder_frontier": 2,
+                                "topology": "mesh2d",
+                                "scheduler_policy": "locality_aware",
+                                "schedule_policy": "prefetch_overlap",
+                                "reduction_strategy": "cluster_tree",
+                                "bank_arbiter_policy": "locality_first",
+                                "cluster_count": 16,
+                                "bank_count": 64,
+                                "compute_source": "dense_gemm_tile",
+                                "compute_arch": "dense_gemm_16x8_k1_p1",
+                                "latency_us": 3222.903773,
+                                "total_cycles": 538848,
+                                "dominant_tile_resource": "shared_path",
+                            },
+                        ],
                     },
                     indent=2,
                 )
@@ -1299,6 +1333,11 @@ def test_consume_l2_result_frontier_onchip_service_overrides_generic_recommendat
             assert recommendation["bank_arbiter_policy"] == "locality_first"
             assert recommendation["latency_us"] == 3222.903773
             assert recommendation["legacy_campaign_recommendation"]["arch_id"] == "fp16_nm1_demo"
+            assert result.profile_count == 2
+            assert [row["profile"] for row in decision_payload["objective_profiles"]] == [
+                "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q8",
+                "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10",
+            ]
             assert decision_payload["proposal_assessment"]["outcome"] == "onchip_service_schedule_recorded"
             assert decision_payload["source_refs"][
                 "decoder_attention_kv_endpoint_full_onchip_service_schedule_out"

--- a/npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import argparse
-import heapq
 import json
 import math
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -21,6 +21,9 @@ from npu.eval import estimate_llm_decoder_attention_kv_sram_noc_constrained_sche
 
 
 JsonDict = dict[str, Any]
+
+
+_PROFILE_PRECISION_RE = re.compile(r"_q(\d+)(?:\D|$)")
 
 
 def _float_list(value: str) -> list[float]:
@@ -275,10 +278,33 @@ def _annotate_service(
     return out
 
 
+def _float_key(row: JsonDict, field: str) -> float:
+    try:
+        return float(row.get(field, math.inf))
+    except Exception:
+        return math.inf
+
+
+def _profile_precision_bits(row: JsonDict) -> int:
+    match = _PROFILE_PRECISION_RE.search(str(row.get("measured_l1_profile", "")))
+    return int(match.group(1)) if match else 0
+
+
+def _objective_key(row: JsonDict) -> tuple[float, float, float, float, int, str]:
+    return (
+        _float_key(row, "latency_us"),
+        _float_key(row, "total_cycles"),
+        _float_key(row, "logic_power_mw"),
+        _float_key(row, "logic_area_used_um2"),
+        -_profile_precision_bits(row),
+        str(row.get("measured_l1_profile", "")),
+    )
+
+
 def _update_best(target: dict[tuple[Any, ...], JsonDict], keys: tuple[str, ...], row: JsonDict) -> None:
     key = tuple(row.get(item) for item in keys)
     current = target.get(key)
-    if current is None or float(row["latency_us"]) < float(current["latency_us"]):
+    if current is None or _objective_key(row) < _objective_key(current):
         target[key] = row
 
 
@@ -291,11 +317,12 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     generated = 0
     dominance = Counter()
     schedule_counts = Counter()
-    top_heap: list[tuple[float, int, JsonDict]] = []
-    heap_counter = 0
+    generated_rows: list[JsonDict] = []
     best_by_policy: dict[tuple[Any, ...], JsonDict] = {}
     best_by_topology: dict[tuple[Any, ...], JsonDict] = {}
     best_by_queue: dict[tuple[Any, ...], JsonDict] = {}
+    best_by_profile: dict[tuple[Any, ...], JsonDict] = {}
+    generated_latencies: list[float] = []
 
     for row in source_rows:
         for schedule_policy in args.schedule_policy:
@@ -322,16 +349,14 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                                     generated += 1
                                     dominance[str(out["dominant_tile_resource"])] += 1
                                     schedule_counts[str(out["schedule_policy"])] += 1
-                                    if best is None or float(out["latency_us"]) < float(best["latency_us"]):
+                                    latency_us = float(out["latency_us"])
+                                    generated_latencies.append(latency_us)
+                                    generated_rows.append(out)
+                                    if best is None or _objective_key(out) < _objective_key(best):
                                         best = out
-                                    entry = (-float(out["latency_us"]), heap_counter, out)
-                                    heap_counter += 1
-                                    if len(top_heap) < args.top_k:
-                                        heapq.heappush(top_heap, entry)
-                                    elif entry[0] > top_heap[0][0]:
-                                        heapq.heapreplace(top_heap, entry)
                                     _update_best(best_by_policy, ("schedule_policy", "bank_arbiter_policy"), out)
                                     _update_best(best_by_topology, ("topology", "scheduler_policy", "reduction_strategy"), out)
+                                    _update_best(best_by_profile, ("measured_l1_profile",), out)
                                     _update_best(
                                         best_by_queue,
                                         ("endpoint_queue_depth_bytes", "bank_queue_depth_bytes", "router_latency_cycles_per_hop"),
@@ -339,7 +364,15 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                                     )
     if best is None:
         raise RuntimeError("no on-chip service rows generated")
-    top_rows = [entry[2] for entry in sorted(top_heap, key=lambda entry: (entry[2]["latency_us"], entry[1]))]
+    top_rows = sorted(generated_rows, key=_objective_key)[: args.top_k]
+    sorted_latencies = sorted(generated_latencies)
+    profile_rows: list[JsonDict] = []
+    for row in sorted(best_by_profile.values(), key=_objective_key):
+        profile_row = dict(row)
+        latency = float(profile_row["latency_us"])
+        profile_row["rank_in_decoder_frontier"] = 1 + sum(1 for item in sorted_latencies if item < latency)
+        profile_row["same_latency_row_count"] = sum(1 for item in sorted_latencies if item == latency)
+        profile_rows.append(profile_row)
     return {
         "version": 1,
         "model": "llm_decoder_attention_kv_onchip_service_schedule_llama7b_v1",
@@ -363,9 +396,10 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         },
         "best": best,
         "top_rows": top_rows,
-        "best_by_policy": sorted(best_by_policy.values(), key=lambda row: row["latency_us"])[:100],
-        "best_by_topology": sorted(best_by_topology.values(), key=lambda row: row["latency_us"])[:100],
-        "best_by_queue": sorted(best_by_queue.values(), key=lambda row: row["latency_us"])[:100],
+        "best_by_profile": profile_rows,
+        "best_by_policy": sorted(best_by_policy.values(), key=_objective_key)[:100],
+        "best_by_topology": sorted(best_by_topology.values(), key=_objective_key)[:100],
+        "best_by_queue": sorted(best_by_queue.values(), key=_objective_key)[:100],
         "assumptions": [
             "This pass refines on-chip SRAM/NoC service only; HBM/DRAM cycles and bandwidth fields are inherited from the input row.",
             "SRAM bank arbitration is modeled as per-cycle service under a named policy, not as placed SRAM macro RTL.",
@@ -393,11 +427,25 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         "{packet_payload_bytes} | {latency_us} | {latency_slowdown_vs_sram_noc_cap} | "
         "{latency_slowdown_vs_topology_derived} | {dominant_tile_resource} |".format(**best),
         "",
+        "## Best By Precision Profile",
+        "",
+        "| profile | frontier rank | latency us | area um2 | power mW | schedule | bank policy | resource |",
+        "|---|---:|---:|---:|---:|---|---|---|",
+    ]
+    for row in payload.get("best_by_profile", []):
+        lines.append(
+            "| {measured_l1_profile} | {rank_in_decoder_frontier} | {latency_us} | {logic_area_used_um2} | "
+            "{logic_power_mw} | {schedule_policy} | {bank_arbiter_policy} | {dominant_tile_resource} |".format(**row)
+        )
+    lines.extend(
+        [
+            "",
         "## Best By Policy",
         "",
         "| schedule | bank policy | latency us | vs cap | shared service cycles | exposed shared | resource |",
         "|---|---|---:|---:|---:|---:|---|",
-    ]
+        ]
+    )
     for row in payload["best_by_policy"][:30]:
         lines.append(
             "| {schedule_policy} | {bank_arbiter_policy} | {latency_us} | {latency_slowdown_vs_sram_noc_cap} | "

--- a/npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py
@@ -84,6 +84,7 @@ def _dedupe_rows(payload: JsonDict, *, limit: int) -> list[JsonDict]:
         ),
     ):
         key = (
+            str(row.get("measured_l1_profile")),
             str(row.get("topology")),
             str(row.get("scheduler_policy")),
             str(row.get("reduction_strategy")),

--- a/tests/test_llm_decoder_attention_kv_onchip_service_schedule.py
+++ b/tests/test_llm_decoder_attention_kv_onchip_service_schedule.py
@@ -1,0 +1,28 @@
+from npu.eval import estimate_llm_decoder_attention_kv_onchip_service_schedule as onchip
+
+
+def test_objective_key_breaks_latency_ties_with_power_area_then_precision() -> None:
+    q8 = {
+        "measured_l1_profile": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q8",
+        "latency_us": 10.0,
+        "total_cycles": 100,
+        "logic_power_mw": 5.0,
+        "logic_area_used_um2": 1000.0,
+    }
+    q12 = {
+        "measured_l1_profile": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q12",
+        "latency_us": 10.0,
+        "total_cycles": 100,
+        "logic_power_mw": 4.0,
+        "logic_area_used_um2": 900.0,
+    }
+    same_ppa_higher_precision = {
+        "measured_l1_profile": "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10",
+        "latency_us": 10.0,
+        "total_cycles": 100,
+        "logic_power_mw": 5.0,
+        "logic_area_used_um2": 1000.0,
+    }
+
+    assert onchip._objective_key(q12) < onchip._objective_key(q8)
+    assert onchip._objective_key(same_ppa_higher_precision) < onchip._objective_key(q8)

--- a/tests/test_llm_decoder_attention_kv_sram_noc_constrained_schedule.py
+++ b/tests/test_llm_decoder_attention_kv_sram_noc_constrained_schedule.py
@@ -1,0 +1,42 @@
+from npu.eval import estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule as schedule
+
+
+def _row(profile: str, latency_us: float) -> dict[str, object]:
+    return {
+        "measured_l1_profile": profile,
+        "latency_us": latency_us,
+        "topology": "mesh2d",
+        "scheduler_policy": "locality_aware",
+        "reduction_strategy": "cluster_tree",
+        "bank_placement": "per_cluster_local",
+        "cluster_count": 16,
+        "bank_count": 64,
+        "link_width_bits": 2048,
+        "virtual_channels": 4,
+        "sram_area_fraction": 0.35,
+        "compute_logic_area_fraction": 0.5,
+        "tile_tokens": 1024,
+        "command_cycles_per_tile": 0,
+        "command_cycles_per_wave": 0,
+        "reducer_setup_cycles": 0,
+        "reduction_cycle_multiplier": 1.0,
+        "compute_replica_count": 856,
+    }
+
+
+def test_dedupe_rows_keeps_distinct_precision_profiles() -> None:
+    payload = {
+        "top_rows": [
+            _row("hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q8", 10.0),
+            _row("hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10", 10.0),
+            _row("hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q12", 10.0),
+        ]
+    }
+
+    rows = schedule._dedupe_rows(payload, limit=10)
+
+    assert [row["measured_l1_profile"] for row in rows] == [
+        "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q8",
+        "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q10",
+        "hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q12",
+    ]


### PR DESCRIPTION
## Summary

This fixes precision-profile coverage in the reciprocal-LUT Llama7B on-chip service frontier path.

Root cause: `_dedupe_rows` treated rows with different `measured_l1_profile` as identical if their architecture fields matched, so q10 could be discarded before the on-chip service sweep. The on-chip service estimator also only emitted a truncated global `top_rows` list, which could hide non-q8 profile winners behind latency ties.

Changes:

- preserve `measured_l1_profile` in SRAM/NoC source-row dedupe
- add deterministic on-chip objective ordering: latency, cycles, power, area, then higher precision
- emit `best_by_profile` and a Markdown precision-profile table
- teach the L2 result consumer to prefer `best_by_profile` for decision `objective_profiles`
- add focused tests for profile-aware dedupe, objective tie-breaking, and decision profile extraction

Smoke on the current reciprocal-LUT source now keeps q8/q10/q12 visible. With the deterministic tie-breaker, q12 becomes the best tied-latency profile for this run:

- q12: `3222.903773 us`, `399591889.5248 um2`, `8123.59136 mW`
- q10: `3222.903773 us`, `399995594.68 um2`, `8132.9456 mW`
- q8: `3222.903773 us`, `399967698.4688 um2`, `8132.97568 mW`

## Validation

- `PYTHONPATH=/tmp/rtlgen-profile-coverage/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py`
- `PYTHONPATH=/tmp/rtlgen-profile-coverage /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_attention_kv_sram_noc_constrained_schedule.py tests/test_llm_decoder_attention_kv_onchip_service_schedule.py`
- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_sram_noc_constrained_schedule.py npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py control_plane/control_plane/services/l2_result_consumer.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- smoke: `python3 npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py --repo-root . --sram-noc-constrained-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_sram_noc_full_search_schedule__l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1_r2.json --frontier-row-limit 32 --top-k 10 --out /tmp/onchip_profile_coverage.json --out-md /tmp/onchip_profile_coverage.md`
