### PR TITLE
[codex] Route reciprocal LUT endpoint composition sources

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4914,6 +4914,24 @@ def _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
     }
 
 
+def _decoder_attention_kv_endpoint_full_onchip_service_source(*, item_id: str) -> str:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    if "softmax_recip_lut" in item_id:
+        source_item = "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2"
+    else:
+        source_item = "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1"
+    return f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__{source_item}.json"
+
+
+def _decoder_attention_kv_endpoint_ready_valid_source(*, item_id: str) -> str:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    if "softmax_recip_lut" in item_id:
+        source_item = "l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1"
+    else:
+        source_item = "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1"
+    return f"{base}/decoder_attention_kv_endpoint_ready_valid_service__{source_item}.json"
+
+
 def _decoder_attention_kv_endpoint_ready_valid_service_evidence(
     *,
     item_id: str,
@@ -4921,10 +4939,7 @@ def _decoder_attention_kv_endpoint_ready_valid_service_evidence(
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_endpoint_ready_valid_service__{item_id}.json"
     report = f"{base}/decoder_attention_kv_endpoint_ready_valid_service__{item_id}.md"
-    endpoint_onchip = (
-        f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__"
-        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
-    )
+    endpoint_onchip = _decoder_attention_kv_endpoint_full_onchip_service_source(item_id=item_id)
     return {
         "inputs": {
             "attention_kv_endpoint_full_onchip_service_schedule": endpoint_onchip,
@@ -4960,14 +4975,8 @@ def _decoder_attention_kv_endpoint_router_sram_composition_evidence(
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_endpoint_router_sram_composition__{item_id}.json"
     report = f"{base}/decoder_attention_kv_endpoint_router_sram_composition__{item_id}.md"
-    endpoint_ready_valid = (
-        f"{base}/decoder_attention_kv_endpoint_ready_valid_service__"
-        "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1.json"
-    )
-    endpoint_onchip = (
-        f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__"
-        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
-    )
+    endpoint_ready_valid = _decoder_attention_kv_endpoint_ready_valid_source(item_id=item_id)
+    endpoint_onchip = _decoder_attention_kv_endpoint_full_onchip_service_source(item_id=item_id)
     sram_summary = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics_summary.json"
     sram_metrics = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json"
     return {

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6495,6 +6495,52 @@ def test_generate_l2_campaign_task_adds_endpoint_ready_valid_service_evidence() 
             )
 
 
+def test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_ready_valid_source() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_endpoint_ready_valid_service",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "attention_kv_endpoint_full_onchip_service_schedule" in decoder_inputs
+            assert (
+                "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2.json"
+                in run
+            )
+            assert "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json" not in run
+            assert work_item.expected_outputs == expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_endpoint_ready_valid_service__"
+                    "l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_endpoint_router_sram_composition_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -6543,6 +6589,58 @@ def test_generate_l2_campaign_task_adds_endpoint_router_sram_composition_evidenc
                 output.endswith(
                     "decoder_attention_kv_endpoint_router_sram_composition__"
                     "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
+def test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_router_sram_sources() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_endpoint_router_sram_composition",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "attention_kv_endpoint_ready_valid_service" in decoder_inputs
+            assert "attention_kv_endpoint_full_onchip_service_schedule" in decoder_inputs
+            assert (
+                "l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1.json"
+                in run
+            )
+            assert (
+                "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2.json"
+                in run
+            )
+            assert "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1.json" not in run
+            assert "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json" not in run
+            assert work_item.expected_outputs == expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_endpoint_router_sram_composition__"
+                    "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1.json"
                 )
                 for output in expected_outputs
             )


### PR DESCRIPTION
## Summary

Route reciprocal-LUT endpoint follow-on jobs to the corrected profile-complete frontier.

Root cause: the ready/valid and endpoint/router/SRAM composition task generators still hard-coded the older non-recip-LUT sources:

- `l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1`
- `l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1`

After #881-#883, the current Llama7B reciprocal-LUT frontier is `l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2`, with q12 selected and q8/q10/q12 visible. This PR makes `softmax_recip_lut` ready-valid/composition items consume that corrected source and produce matching reciprocal-LUT output artifacts.

## Validation

- `PYTHONPATH=/tmp/rtlgen-next-composition/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_full_onchip_source control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_endpoint_ready_valid_service_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_ready_valid_source control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_endpoint_router_sram_composition_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_router_sram_sources`
- `python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
