### PR TITLE
[codex] Add reciprocal LUT endpoint closure proposals

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/README.md
@@ -1,0 +1,13 @@
+# Reciprocal-LUT Endpoint Ready/Valid Service
+
+This proposal closes one abstraction layer below the corrected Llama7B reciprocal-LUT
+endpoint full on-chip service frontier.
+
+The source frontier is:
+
+- item: `l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2`
+- selected profile: `hd64_kv8_full_value_p8_ppc2_noc128_softmax_int8_q12`
+- selected architecture: `mesh2d_locality_aware_cluster_tree_c16_b64_dense_gemm_16x8_k1_p1`
+
+The requested job derives concrete `onchip_service_endpoint` ready/valid queue
+parameters from that frontier and runs the finite-queue/backpressure probe.

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/analysis_report.md
@@ -1,0 +1,22 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1`
+- `candidate_id`: `l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1`
+
+## Evaluations Consumed
+- pending evaluator result
+
+## Baseline Comparison
+- baseline/source: `l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2`
+- key deltas: endpoint ready/valid queue behavior and backpressure counters
+
+## Result
+- pending
+
+## Failures and Caveats
+- HBM/DRAM service remains inherited.
+- Router/SRAM composition remains separate.
+
+## Recommendation
+- pending evaluator result

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/design_brief.md
@@ -1,0 +1,49 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1`
+- `title`: `Ready/valid endpoint service for reciprocal-LUT Llama7B frontier`
+
+## Problem
+The current selected Llama7B reciprocal-LUT endpoint frontier includes explicit
+on-chip service policy fields, but the endpoint queue/backpressure behavior is
+still represented analytically. The next abstraction to close is whether the
+selected endpoint queue sizes, packet payload, and producer/consumer rates are
+compatible with the concrete `onchip_service_endpoint` ready/valid model.
+
+## Hypothesis
+The selected q12 frontier remains the best point when endpoint queueing is
+checked with finite ready/valid queues, because the selected row already uses
+`prefetch_overlap`, `locality_first`, 2048-byte endpoint/bank queues, and a
+shared-path service bottleneck that should not require a different topology.
+
+## Evaluation Scope
+- direct comparison set:
+  - selected q12 reciprocal-LUT endpoint full on-chip service row
+  - concrete endpoint ready/valid finite-queue probe
+- evaluation modes:
+  - `frontier_detail`
+  - `frontier_closure`
+- dependency order:
+  - depends on merged `l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2`
+  - requires merged inputs and materialized refs
+- excluded first-stage comparisons:
+  - HBM/DRAM replacement
+  - full router/SRAM composition audit
+- follow-on broad sweep:
+  - endpoint/router/SRAM composition audit if the ready/valid probe succeeds
+
+## Knowledge Inputs
+- corrected r2 decision artifact for q12/q10/q8 profile coverage
+- `onchip_service_endpoint` RTL and ready/valid probe script
+- prior non-recip-LUT ready/valid result
+
+## Candidate Direction
+No architecture parameter is changed in this step. The step replaces a portion
+of the endpoint-service abstraction with a concrete ready/valid endpoint probe.
+
+## Direction Gate
+- status: approved
+- approved_by:
+- approved_utc:
+- note: focused closure step after corrected q12 reciprocal-LUT frontier

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - `l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1`
+- note: Ready/valid endpoint closure for the selected q12 reciprocal-LUT frontier.

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1",
+  "source_commit": "20959c07c8223d68dd3c957661b356b9003d8482",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Derive and probe concrete ready/valid endpoint queue behavior for the corrected q12 reciprocal-LUT Llama7B endpoint full on-chip service frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_endpoint_ready_valid_service",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_recip_lut_endpoint_ready_valid_service_for_selected_frontier",
+        "reason": "Use the corrected profile-complete q12 reciprocal-LUT endpoint on-chip frontier as the source for concrete ready/valid endpoint queue probing."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/implementation_summary.md
@@ -1,0 +1,25 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1`
+- ready/valid endpoint service for the reciprocal-LUT Llama7B frontier
+
+## Scope
+- Request a concrete endpoint ready/valid probe for the corrected q12 reciprocal-LUT frontier.
+- Do not change topology, compute array, HBM service, or SRAM sizing in this step.
+
+## Files Changed
+- proposal documentation
+- generated L2 work item after dispatch
+
+## Local Validation
+- generator routing was validated in PR #884 before dispatch
+
+## Evaluation Request
+- requested item: `l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1`
+- cost class: low
+- baseline/source: `l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2`
+
+## Risks
+- The evaluator must use source commit `20959c07` or newer.
+- The router/SRAM composition audit remains a separate closure step.

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Awaiting ready/valid endpoint service result.",
+  "evidence_refs": [
+    "item:l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1"
+  ],
+  "next_action": "If the ready/valid probe succeeds, dispatch endpoint/router/SRAM composition for the same reciprocal-LUT frontier.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/proposal.json
@@ -1,0 +1,60 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1",
+  "created_utc": "2026-06-17T04:55:25.100992Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Ready/valid endpoint service for reciprocal-LUT Llama7B frontier",
+  "hypothesis": "The selected q12 reciprocal-LUT endpoint full on-chip service frontier remains valid when endpoint queueing and producer/consumer backpressure are represented by the concrete onchip_service_endpoint ready/valid model.",
+  "direct_comparison": {
+    "primary_question": "Does the concrete endpoint ready/valid probe preserve the selected q12 reciprocal-LUT frontier without exposing a queue/backpressure bottleneck that changes the architecture conclusion?",
+    "include": [
+      "selected q12 reciprocal-LUT endpoint full on-chip service frontier",
+      "endpoint queue depth and bank queue depth from the selected source row",
+      "producer/consumer backpressure counters from the ready/valid probe"
+    ],
+    "exclude": [
+      "HBM/DRAM service replacement",
+      "full router/SRAM composition audit"
+    ],
+    "follow_on_broad_sweep": [
+      "endpoint/router/SRAM composition audit using this ready/valid output"
+    ]
+  },
+  "expected_benefit": [
+    "replace analytical endpoint queue assumptions with a concrete finite-queue ready/valid probe",
+    "reduce abstraction in the selected Llama7B reciprocal-LUT endpoint path"
+  ],
+  "risks": [
+    "ready/valid probe is still focused on endpoint service and does not close HBM/DRAM service",
+    "router/SRAM composition can still expose a replication or width gap"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "item_id": "l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1",
+      "evaluation_mode": "frontier_detail",
+      "objective": "ready_valid_endpoint_closure",
+      "cost_class": "low",
+      "abstraction_layer": "decoder_attention_kv_endpoint_ready_valid_service",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_recip_lut_endpoint_ready_valid_service_for_selected_frontier",
+        "reason": "Use the corrected profile-complete q12 reciprocal-LUT endpoint on-chip frontier as the source for concrete ready/valid endpoint queue probing."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2.json",
+    "npu/sim/rtl/onchip_service_endpoint.sv",
+    "npu/eval/probe_llm_decoder_attention_endpoint_ready_valid.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1/quality_gate.md
@@ -1,0 +1,27 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1`
+- `title`: `Ready/valid endpoint service for reciprocal-LUT Llama7B frontier`
+
+## Why This Gate Is Required
+The result determines whether the endpoint queue/backpressure part of the
+selected frontier can be treated as concrete enough for the follow-on
+endpoint/router/SRAM composition audit.
+
+## Reference
+- baseline_ref: `l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2`
+- reference_ref: prior non-recip-LUT ready/valid endpoint service
+
+## Checks
+- metric: ready_valid_probe_completed
+  - threshold: true
+- metric: endpoint_backpressure_reported
+  - threshold: present
+
+## Local Commands
+- command: generated L2 campaign task command
+
+## Result
+- status: pending
+- note: awaiting evaluator result

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/README.md
@@ -1,0 +1,5 @@
+# Reciprocal-LUT Endpoint/Router/SRAM Composition
+
+This proposal is the follow-on closure step after the reciprocal-LUT endpoint
+ready/valid probe. It audits the selected Llama7B q12 reciprocal-LUT frontier
+against concrete endpoint, router, FIFO, and SRAM evidence.

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/analysis_report.md
@@ -1,0 +1,21 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1`
+- `candidate_id`: `l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1`
+
+## Evaluations Consumed
+- pending ready/valid endpoint result
+
+## Baseline Comparison
+- baseline/source: `l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1`
+- key deltas: composition gaps, replicated endpoint/router/FIFO/SRAM area/power, and remaining abstraction flags
+
+## Result
+- pending
+
+## Failures and Caveats
+- HBM/DRAM service remains inherited.
+
+## Recommendation
+- pending evaluator result

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/design_brief.md
@@ -1,0 +1,47 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1`
+- `title`: `Endpoint/router/SRAM composition for reciprocal-LUT Llama7B frontier`
+
+## Problem
+The selected reciprocal-LUT Llama7B frontier still relies on a composition-level
+assumption that endpoint, router, FIFO, and SRAM evidence can be combined at the
+required width/replication without changing the bottleneck or selected point.
+
+## Hypothesis
+The endpoint/router/SRAM composition audit will confirm the q12 frontier remains
+selected, or it will identify the exact missing L1 PPA evidence needed before
+closing the on-chip abstraction.
+
+## Evaluation Scope
+- direct comparison set:
+  - reciprocal-LUT ready/valid endpoint result
+  - corrected q12 endpoint full on-chip service r2 result
+  - existing router/FIFO/endpoint/SRAM evidence
+- evaluation modes:
+  - `frontier_detail`
+  - `frontier_closure`
+- dependency order:
+  - depends on merged `l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1`
+  - requires merged inputs and materialized refs
+- excluded first-stage comparisons:
+  - HBM/DRAM service replacement
+- follow-on broad sweep:
+  - measured SRAM rebalance or HBM/DRAM service closure after composition
+
+## Knowledge Inputs
+- corrected q12 reciprocal-LUT endpoint frontier
+- endpoint ready/valid result
+- endpoint/router/FIFO/SRAM L1 evidence
+
+## Candidate Direction
+No new architecture point is introduced. The step reduces abstraction by
+auditing whether already measured L1 blocks compose cleanly for the selected
+frontier.
+
+## Direction Gate
+- status: approved
+- approved_by:
+- approved_utc:
+- note: follow-on closure after ready/valid result

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - `l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1`
+- note: Endpoint/router/SRAM composition closure after ready/valid result.

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1",
+  "source_commit": "20959c07c8223d68dd3c957661b356b9003d8482",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit endpoint/router/SRAM composition for the corrected q12 reciprocal-LUT Llama7B endpoint frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_endpoint_router_sram_composition",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_recip_lut_endpoint_router_sram_composition_for_selected_frontier",
+        "reason": "Use reciprocal-LUT ready/valid output and q12 endpoint service frontier to audit concrete endpoint/router/SRAM composition."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/implementation_summary.md
@@ -1,0 +1,24 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1`
+- endpoint/router/SRAM composition for the reciprocal-LUT Llama7B frontier
+
+## Scope
+- Request a composition audit after the reciprocal-LUT ready/valid endpoint result.
+- Do not replace HBM/DRAM service in this step.
+
+## Files Changed
+- proposal documentation
+
+## Local Validation
+- generator routing was validated in PR #884 before dispatch.
+
+## Evaluation Request
+- requested item: `l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1`
+- cost class: low
+- baseline/source: reciprocal-LUT ready/valid endpoint result
+
+## Risks
+- The audit may require additional L1 endpoint/router/FIFO/SRAM PPA runs.
+- HBM/DRAM remains inherited.

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Awaiting endpoint/router/SRAM composition audit.",
+  "evidence_refs": [
+    "item:l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1"
+  ],
+  "next_action": "If composition succeeds, continue to SRAM rebalance or HBM/DRAM service closure.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/proposal.json
@@ -1,0 +1,58 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1",
+  "created_utc": "2026-06-17T05:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Endpoint/router/SRAM composition for reciprocal-LUT Llama7B frontier",
+  "hypothesis": "The q12 reciprocal-LUT endpoint frontier remains selected when endpoint ready/valid service is composed with measured endpoint/router/FIFO/SRAM evidence.",
+  "direct_comparison": {
+    "primary_question": "Does concrete endpoint/router/SRAM composition expose a width, replication, queue, or SRAM area gap that changes the selected Llama7B reciprocal-LUT frontier?",
+    "include": [
+      "ready/valid endpoint service result for reciprocal-LUT q12 frontier",
+      "endpoint full on-chip service r2 result",
+      "router, FIFO, endpoint, and SRAM evidence paths"
+    ],
+    "exclude": [
+      "HBM/DRAM service replacement"
+    ],
+    "follow_on_broad_sweep": [
+      "measured SRAM rebalance or HBM/DRAM service closure if composition succeeds"
+    ]
+  },
+  "expected_benefit": [
+    "reduce the remaining on-chip endpoint/router/SRAM abstraction for the selected Llama7B frontier",
+    "identify exact L1 PPA gaps before treating the on-chip path as closed"
+  ],
+  "risks": [
+    "composition may reveal that additional L1 router/SRAM/endpoint PPA points are needed",
+    "HBM/DRAM service remains inherited after this step"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "item_id": "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1",
+      "evaluation_mode": "frontier_detail",
+      "objective": "endpoint_router_sram_composition_closure",
+      "cost_class": "low",
+      "abstraction_layer": "decoder_attention_kv_endpoint_router_sram_composition",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_recip_lut_endpoint_router_sram_composition_for_selected_frontier",
+        "reason": "Use the reciprocal-LUT ready/valid result and corrected q12 on-chip frontier to audit endpoint/router/SRAM composition."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py",
+    "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics_summary.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1/quality_gate.md
@@ -1,0 +1,26 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1`
+- `title`: `Endpoint/router/SRAM composition for reciprocal-LUT Llama7B frontier`
+
+## Why This Gate Is Required
+The result determines whether the on-chip endpoint/router/SRAM path can be
+treated as compositionally closed for the selected q12 Llama7B frontier.
+
+## Reference
+- baseline_ref: `l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1`
+- reference_ref: corrected q12 endpoint full on-chip service r2 result
+
+## Checks
+- metric: composition_audit_completed
+  - threshold: true
+- metric: remaining_l1_ppa_gaps
+  - threshold: reported
+
+## Local Commands
+- command: generated L2 campaign task command
+
+## Result
+- status: pending
+- note: awaiting evaluator result


### PR DESCRIPTION
## Summary

Add tracked proposal docs for the reciprocal-LUT Llama7B endpoint closure path:

- `prop_l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_v1`
- `prop_l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_v1`

The ready-valid item was already generated, but its proposal directory existed only as a local generated template. This PR replaces that placeholder with concrete proposal content and adds the dependent router/SRAM composition proposal before we dispatch that follow-on job.

This avoids the familiar artifact-sync failure mode where a completed job cannot link to a real developer-loop proposal.

## Validation

- JSON syntax checked for proposal/evaluation/promotion files
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
