### PR TITLE
control_plane: consume endpoint router sram composition evidence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -451,6 +451,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_kv_endpoint_full_onchip_service_schedule_report",
     ),
     ("attention_kv_endpoint_ready_valid_service_out", "attention_kv_endpoint_ready_valid_service_report"),
+    (
+        "attention_kv_endpoint_router_sram_composition_out",
+        "attention_kv_endpoint_router_sram_composition_report",
+    ),
     ("attention_kv_hbm_closed_onchip_schedule_out", "attention_kv_hbm_closed_onchip_schedule_report"),
     ("attention_kv_subtile_pipeline_schedule_out", "attention_kv_subtile_pipeline_schedule_report"),
     ("attention_kv_dual_stream_physical_feasibility_out", "attention_kv_dual_stream_physical_feasibility_report"),
@@ -526,6 +530,11 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
         "per_cluster_sram_metrics_summary",
         "all_cluster_sram_metrics_summary",
         "remaining_abstractions",
+        "closure_flags",
+        "composition_quantities",
+        "measured_primitives",
+        "recommended_next_l1_points",
+        "required_follow_on_ppa",
         "best",
         "sweep_summary",
         "assumptions",
@@ -564,6 +573,8 @@ def _decoder_frontier_recommendation(
     best = evidence_payload.get("best")
     if not isinstance(best, dict) or not best:
         best = evidence_payload.get("source_best")
+    if not isinstance(best, dict) or not best:
+        best = evidence_payload.get("selected_frontier")
     if not isinstance(best, dict) or not best:
         return None
     model = str(evidence_payload.get("model", "")).strip()
@@ -620,6 +631,7 @@ def _decoder_frontier_recommendation(
         "onchip_shared_service_cycles",
         "tile_tokens",
         "tile_waves",
+        "link_width_bits",
     ):
         if key in best:
             recommendation[key] = best[key]
@@ -816,6 +828,56 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         ):
             if key in source_best_dict:
                 parts.append(f"{key}={source_best_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_endpoint_router_sram_composition_audit_v1":
+        decision = str(evidence_payload.get("decision", "")).strip()
+        outcome = decision or "endpoint_router_sram_composition_recorded"
+        selected_frontier = evidence_payload.get("selected_frontier")
+        selected = dict(selected_frontier) if isinstance(selected_frontier, dict) else {}
+        quantities = evidence_payload.get("composition_quantities")
+        quantity_dict = dict(quantities) if isinstance(quantities, dict) else {}
+        flags = evidence_payload.get("closure_flags")
+        flag_dict = dict(flags) if isinstance(flags, dict) else {}
+        follow_on = evidence_payload.get("required_follow_on_ppa")
+        required_follow_on = [str(item) for item in follow_on] if isinstance(follow_on, list) else []
+        parts = [
+            f"Decoder endpoint/router/SRAM composition evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "latency_us",
+            "topology",
+            "scheduler_policy",
+            "reduction_strategy",
+            "cluster_count",
+            "bank_count",
+            "link_width_bits",
+            "packet_payload_bytes",
+            "dominant_tile_resource",
+        ):
+            if key in selected:
+                parts.append(f"{key}={selected.get(key)}")
+        for key in (
+            "endpoint_width_ratio_vs_measured_ppa",
+            "router_lanes_for_link",
+            "fifo_lanes_for_link",
+            "tile_sram_capacity_fraction_of_selected_local_capacity",
+            "tile_sram_budget_area_fraction",
+        ):
+            if key in quantity_dict:
+                parts.append(f"{key}={quantity_dict.get(key)}")
+        for key in (
+            "ready_valid_endpoint_passed",
+            "endpoint_ppa_width_matches_ready_valid_width",
+            "router_ppa_width_matches_link_width",
+            "fifo_ppa_width_matches_link_width",
+            "tile_sram_capacity_covers_selected_local_capacity",
+        ):
+            if key in flag_dict:
+                parts.append(f"{key}={flag_dict.get(key)}")
+        if required_follow_on:
+            parts.append(f"required_follow_on_ppa={','.join(required_follow_on)}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1347,6 +1347,145 @@ def test_consume_l2_result_frontier_onchip_service_overrides_generic_recommendat
             ] == report_rel
 
 
+def test_consume_l2_result_frontier_endpoint_router_sram_composition_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_endpoint_router_sram_composition_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_endpoint_router_sram_composition_v1",
+                        "kind": "architecture",
+                        "title": "Endpoint/router/SRAM composition",
+                        "direct_comparison": {
+                            "primary_question": "Does concrete composition close the endpoint/router/SRAM abstraction?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_endpoint_router_sram_composition__l2_endpoint_composition.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_endpoint_router_sram_composition__l2_endpoint_composition.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "model": "llm_decoder_attention_endpoint_router_sram_composition_audit_v1",
+                        "decision": "composition_requires_follow_on_ppa",
+                        "selected_frontier": {
+                            "topology": "mesh2d",
+                            "scheduler_policy": "locality_aware",
+                            "reduction_strategy": "cluster_tree",
+                            "cluster_count": 16,
+                            "bank_count": 64,
+                            "latency_us": 3222.903773,
+                            "link_width_bits": 2048,
+                            "packet_payload_bytes": 128,
+                            "dominant_tile_resource": "shared_path",
+                        },
+                        "composition_quantities": {
+                            "endpoint_width_ratio_vs_measured_ppa": 8,
+                            "router_lanes_for_link": 16,
+                            "fifo_lanes_for_link": 16,
+                            "tile_sram_capacity_fraction_of_selected_local_capacity": 0.032113,
+                            "tile_sram_budget_area_fraction": 0.142156,
+                        },
+                        "closure_flags": {
+                            "ready_valid_endpoint_passed": True,
+                            "endpoint_ppa_width_matches_ready_valid_width": False,
+                            "router_ppa_width_matches_link_width": False,
+                            "fifo_ppa_width_matches_link_width": False,
+                            "tile_sram_capacity_covers_selected_local_capacity": False,
+                        },
+                        "required_follow_on_ppa": [
+                            "endpoint_ppa_width_matches_ready_valid_width",
+                            "router_ppa_width_matches_link_width",
+                            "fifo_ppa_width_matches_link_width",
+                            "full_local_capacity_sram_macro_profile_missing",
+                        ],
+                        "remaining_abstractions": [
+                            "Router/FIFO PPA is lane-scaled from narrower measured primitives.",
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# composition\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_endpoint_composition",
+                campaign_dir_rel="runs/campaigns/npu/endpoint_composition_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_endpoint_router_sram_composition_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "close_endpoint_router_sram_composition",
+                "expected_reason": "Use composition audit evidence for next L1 closure points.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_kv_endpoint_router_sram_composition",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_kv_endpoint_router_sram_composition_out": evidence_rel,
+                    "attention_kv_endpoint_router_sram_composition_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            result = consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            recommendation = decision_payload["recommendation"]
+            assessment = decision_payload["proposal_assessment"]
+            assert result.recommended_arch_id == "mesh2d_locality_aware_cluster_tree_c16_b64"
+            assert recommendation["source"] == "decoder_evidence"
+            assert recommendation["latency_us"] == 3222.903773
+            assert recommendation["link_width_bits"] == 2048
+            assert recommendation["legacy_campaign_recommendation"]["arch_id"] == "fp16_nm1_demo"
+            assert assessment["outcome"] == "composition_requires_follow_on_ppa"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert "router_lanes_for_link=16" in assessment["summary"]
+            assert "required_follow_on_ppa=endpoint_ppa_width_matches_ready_valid_width" in assessment["summary"]
+            assert assessment["decoder_quality"]["closure_flags"]["ready_valid_endpoint_passed"] is True
+            assert "required_follow_on_ppa" in assessment["decoder_quality"]
+            assert decision_payload["evaluation_record"]["outcome"] == "composition_requires_follow_on_ppa"
+            assert decision_payload["source_refs"][
+                "decoder_attention_kv_endpoint_router_sram_composition_out"
+            ] == evidence_rel
+            assert decision_payload["source_refs"][
+                "decoder_attention_kv_endpoint_router_sram_composition_report"
+            ] == report_rel
+
+
 def test_consume_l2_result_frontier_attention_local_sram_capacity_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- recognize endpoint/router/SRAM composition artifacts as decoder evidence
- promote the artifact decision, closure flags, required follow-on PPA list, and remaining abstractions into L2 decisions
- add focused consumer coverage for the composition closure path

## Validation
- PYTHONPATH=/tmp/rtlgen-composition-consumer-fix/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest /tmp/rtlgen-composition-consumer-fix/control_plane/control_plane/tests/test_l2_result_consumer.py -k "endpoint_router_sram_composition or endpoint_sram_noc_overrides or onchip_service_overrides" -q
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check
- python -m py_compile control_plane/control_plane/services/l2_result_consumer.py