### PR TITLE
[codex] add wide NoC primitive firstpass sweep

### DIFF
--- a/runs/campaigns/noc/l1_memory_noc_primitives/sweeps/nangate45_wide_frontier_firstpass.json
+++ b/runs/campaigns/noc/l1_memory_noc_primitives/sweeps/nangate45_wide_frontier_firstpass.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "l1_memory_noc_wide_frontier_firstpass",
+  "flow_params": {
+    "CLOCK_PERIOD": [1.0],
+    "CORE_UTILIZATION": [40],
+    "PLACE_DENSITY": [0.52]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a conservative first-pass Nangate45 sweep for the wide endpoint/router/FIFO primitives needed by the Llama7B endpoint/router/SRAM composition audit.

The existing proposal and configs already identify the required points:
- 1024-bit on-chip service endpoint
- 2048-bit NoC router
- 2048-bit NoC FIFO

This sweep keeps the same clock and placement density as the prior narrow NoC primitive run, but starts with `CORE_UTILIZATION=40` only to establish feasibility before expanding to denser points.

## Validation

- `python -m json.tool runs/campaigns/noc/l1_memory_noc_primitives/sweeps/nangate45_wide_frontier_firstpass.json`
- `git diff --check`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py`
