### PR TITLE
Propose segmented NoC primitive follow-on

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/README.md
@@ -1,0 +1,5 @@
+# Segmented/Narrower NoC Router/FIFO Follow-On
+
+This proposal scopes the next Layer-1 NoC slice after the endpoint/router/SRAM composition audit closed endpoint PPA and recorded flat 2048-bit router/FIFO boundary failures.
+
+The measurement reuses existing 128-bit and 256-bit NoC primitive configs under a new proposal-linked sweep. The result is lane-level PPA evidence for the next composition model, not a placed aggregate 2048-bit network wrapper.

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/analysis_report.md
@@ -1,0 +1,23 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1`
+- `candidate_id`: pending evaluation
+
+## Evaluations Consumed
+- `l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r3`
+- source commit: `c68dce07a65dc284ac5ee3051beedd2e06b5c109`
+
+## Baseline Comparison
+- Baseline lane primitives: existing `l1_noc_router_p4_w128_wrapper`, `l1_noc_router_p4_w256_wrapper`, `l1_noc_fifo_w128_d16_wrapper`, and `l1_noc_fifo_w256_d16_wrapper`.
+- Boundary evidence: flat `l1_noc_router_p4_w2048_wrapper` and `l1_noc_fifo_w2048_d16_wrapper` failed at utilization 40/50/60.
+
+## Result
+- Pending L1 sweep.
+
+## Failures and Caveats
+- This proposal measures lane primitives only; it does not prove a placed aggregate 2048-bit network wrapper.
+- Scheduler and pipeline composition remain L2 follow-on work after lane PPA is refreshed.
+
+## Recommendation
+- Run the requested L1 sweep, then re-run composition with segmented or narrower-link NoC interpretation.

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/design_brief.md
@@ -1,0 +1,32 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1`
+- `title`: `Measure segmented/narrower NoC router/FIFO alternatives for Llama7B endpoint composition`
+
+## Problem
+- The selected Llama7B endpoint composition uses a 2048-bit link, but flat 2048-bit router/FIFO primitives failed physical boundary runs. Continuing to use flat 2048-bit PPA would overstate closure.
+
+## Hypothesis
+- 128-bit and 256-bit lane primitives can provide concrete PPA inputs for segmented or narrower scheduled NoC interpretations while avoiding the known flat 2048-bit failure point.
+
+## Evaluation Scope
+- Direct comparison set: 128-bit and 256-bit router/FIFO primitive wrappers.
+- Evaluation mode: `frontier_closure`.
+- Dependency: `l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r3` must be merged.
+- Excluded first-stage comparison: placed aggregate segmented NoC wrapper RTL.
+- Follow-on: re-rank the composition using 16x128, 8x256, and narrower-link schedule interpretations.
+
+## Knowledge Inputs
+- PR #896 composition audit.
+- `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r3.json`
+- Existing NoC primitive metrics under `runs/designs/noc`.
+
+## Candidate Direction
+- Refresh proposal-linked lane primitive PPA evidence under a dedicated sweep tag.
+
+## Direction Gate
+- status: pending
+- approved_by:
+- approved_utc:
+- note: Ready for L1 sweep dispatch after merge.

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - `l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1`
+- note: Run only the bounded 128/256-bit router/FIFO lane primitive sweep.

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/evaluation_requests.json
@@ -1,0 +1,30 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1",
+  "source_commit": "c68dce07a65dc284ac5ee3051beedd2e06b5c109",
+  "source_commit_note": "Dispatch should use the merge commit containing PR #896 or newer; the follow-on reuses the existing NoC primitive generator stack.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure proposal-linked 128/256-bit NoC router and FIFO lane primitives for the Llama7B endpoint path after flat 2048-bit router/FIFO boundary failures.",
+      "evaluation_mode": "frontier_closure",
+      "abstraction_layer": "architecture_block",
+      "status": "pending",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r3"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [
+        "runs/designs/noc/l1_noc_router_p4_w128_wrapper/config_l1_noc_router_p4_w128.json",
+        "runs/designs/noc/l1_noc_router_p4_w256_wrapper/config_l1_noc_router_p4_w256.json",
+        "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/config_l1_noc_fifo_w128_d16.json",
+        "runs/designs/noc/l1_noc_fifo_w256_d16_wrapper/config_l1_noc_fifo_w256_d16.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_memory_noc_primitives/sweeps/nangate45_segmented_router_fifo_frontier.json",
+      "platform": "nangate45",
+      "out_root": "runs/designs/noc",
+      "notes": "This is the segmented_or_narrower_router_ppa_required and segmented_or_narrower_fifo_ppa_required follow-on from the latest endpoint/router/SRAM composition result."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/implementation_summary.md
@@ -1,0 +1,28 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1`
+- Measure segmented/narrower NoC router/FIFO alternatives for Llama7B endpoint composition.
+
+## Scope
+- Added a Layer-1 proposal and dedicated Nangate45 sweep for existing 128/256-bit NoC router/FIFO primitive configs.
+- Did not add a new aggregate segmented NoC RTL wrapper.
+- Did not change the control-plane generator because existing `l1_memory_noc_primitive` support covers these configs.
+
+## Files Changed
+- `docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/`
+- `runs/campaigns/noc/l1_memory_noc_primitives/sweeps/nangate45_segmented_router_fifo_frontier.json`
+
+## Local Validation
+- `python3 -m json.tool` on new proposal/sweep JSON files.
+- In-memory L1 generator smoke for `l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1`.
+- `python3 scripts/validate_runs.py --skip_eval_queue`.
+- `git diff --check`.
+
+## Evaluation Request
+- Requested item: `l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1`.
+- Cost class: small L1 OpenROAD sweep over four existing NoC primitive configs and three utilization points.
+- Baseline: prior `l1_memory_noc_primitives_nangate45_macro_frontier` w128/w256 metrics and flat w2048 boundary failure.
+
+## Risks
+- Lane primitive PPA still needs a composition/rerank step before it can replace the failed flat 2048-bit primitive in the selected architecture.

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1",
+  "candidate_id": "",
+  "decision": "pending",
+  "reason": "Awaiting L1 segmented/narrower NoC lane primitive sweep.",
+  "evidence_refs": [
+    "item:l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1"
+  ],
+  "next_action": "Dispatch l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1 after this proposal merges.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action: promote only after the L1 sweep records complete lane primitive evidence and a follow-on L2 composition/rerank consumes it.
+- note: This proposal alone does not close aggregate NoC composition.

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/proposal.json
@@ -1,0 +1,35 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1",
+  "title": "Measure segmented/narrower NoC router/FIFO alternatives for Llama7B endpoint composition",
+  "status": "proposed",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "motivation": "The latest Llama7B endpoint/router/SRAM composition audit closed endpoint PPA at 1024 bits but showed flat 2048-bit router and FIFO points failed boundary runs at core utilization 40/50/60. The remaining NoC closure path is therefore segmented lane composition or narrower scheduled links, not another flat 2048-bit retry.",
+  "hypothesis": "Fresh proposal-linked 128-bit and 256-bit router/FIFO PPA points will provide concrete lane costs for the next composition model, allowing the architecture search to compare 16x128, 8x256, and narrower scheduled-link interpretations without assuming a physically feasible flat 2048-bit primitive.",
+  "expected_behavior": {
+    "functional": "Existing deterministic L1 NoC primitive generation paths are used with narrower link widths to preserve behavioral comparability.",
+    "timing_model": "Measured routed router and FIFO wrappers at 128/256-bit widths expose lane-level costs, arbitration pressure, and datapath timing for composition scaling.",
+    "physical_model": "Layer-1 macro-style OpenROAD runs stay macro-preserving with the same Nangate45 density/period policy as the existing NoC primitive baseline."
+  },
+  "comparison_points": [
+    "l1_noc_router_p4_w128_wrapper",
+    "l1_noc_router_p4_w256_wrapper",
+    "l1_noc_fifo_w128_d16_wrapper",
+    "l1_noc_fifo_w256_d16_wrapper"
+  ],
+  "upstream_evidence": [
+    "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r3"
+  ],
+  "expected_benefit": [
+    "Provide current, proposal-linked lane-width alternatives after flat 2048-bit router/FIFO boundary failures.",
+    "Quantify whether segmented/narrow alternatives are enough to close required follow-on composition gaps before introducing a placed aggregate NoC wrapper.",
+    "Create a bounded next step that reuses known OpenROAD infrastructure and the already validated 40/50/60 utilization envelope."
+  ],
+  "risks": [
+    "This measures lane primitives, not a placed aggregate 2048-bit network wrapper.",
+    "Scheduler/pipeline effects are not represented here; this is primitive-level PPA evidence for the next composition model.",
+    "Full local SRAM capacity accounting remains a separate closure item."
+  ],
+  "created_utc": "2026-06-17T08:34:31.120746Z"
+}

--- a/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/quality_gate.md
@@ -1,0 +1,25 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1`
+- `title`: `Measure segmented/narrower NoC router/FIFO alternatives for Llama7B endpoint composition`
+
+## Why This Gate Is Required
+- The composition audit must not treat failed flat 2048-bit router/FIFO PPA as feasible. This gate provides bounded lane-level alternatives for the next composition model.
+
+## Reference
+- baseline_ref: `l1_decoder_attention_endpoint_router_wide_ppa_v1`
+- reference_ref: `l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r3`
+
+## Checks
+- metric: generated metrics rows
+  - threshold: status recorded for all four requested primitive wrappers at all sweep points.
+- metric: boundary interpretation
+  - threshold: flat 2048-bit router/FIFO are not retried as the selected closure path.
+
+## Local Commands
+- command: `python3 scripts/validate_runs.py --skip_eval_queue`
+
+## Result
+- status: pending
+- note: Awaiting L1 sweep.

--- a/runs/campaigns/noc/l1_memory_noc_primitives/sweeps/nangate45_segmented_router_fifo_frontier.json
+++ b/runs/campaigns/noc/l1_memory_noc_primitives/sweeps/nangate45_segmented_router_fifo_frontier.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "l1_memory_noc_primitives_nangate45_segmented_router_fifo_frontier",
+  "flow_params": {
+    "CLOCK_PERIOD": [1.0],
+    "CORE_UTILIZATION": [40, 50, 60],
+    "PLACE_DENSITY": [0.52]
+  }
+}


### PR DESCRIPTION
## Summary
- add a Layer-1 proposal for segmented/narrower NoC router/FIFO follow-on after the flat 2048-bit boundary failure
- add a Nangate45 segmented router/FIFO sweep using existing 128/256-bit router and FIFO primitive configs
- keep the scope to proposal-linked lane primitive PPA evidence, not an aggregate 2048-bit NoC wrapper

## Verification
- python3 -m json.tool on new proposal/sweep JSON files
- in-memory L1 generator smoke for l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check