### PR TITLE
Consume local SRAM capacity evidence in composition audit

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4923,6 +4923,13 @@ def _decoder_attention_kv_endpoint_full_onchip_service_source(*, item_id: str) -
     return f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__{source_item}.json"
 
 
+def _decoder_attention_local_sram_capacity_source(*, item_id: str) -> str:
+    _ = item_id
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    source_item = "l2_decoder_attention_local_sram_capacity_llama7b_v1"
+    return f"{base}/decoder_attention_local_sram_capacity__{source_item}.json"
+
+
 def _decoder_attention_kv_endpoint_ready_valid_source(*, item_id: str) -> str:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     if "softmax_recip_lut" in item_id:
@@ -4977,6 +4984,7 @@ def _decoder_attention_kv_endpoint_router_sram_composition_evidence(
     report = f"{base}/decoder_attention_kv_endpoint_router_sram_composition__{item_id}.md"
     endpoint_ready_valid = _decoder_attention_kv_endpoint_ready_valid_source(item_id=item_id)
     endpoint_onchip = _decoder_attention_kv_endpoint_full_onchip_service_source(item_id=item_id)
+    local_sram_capacity = _decoder_attention_local_sram_capacity_source(item_id=item_id)
     sram_summary = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics_summary.json"
     sram_metrics = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json"
     wide_l1_promotion = "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_endpoint_router_wide_ppa_v1.json"
@@ -4984,6 +4992,7 @@ def _decoder_attention_kv_endpoint_router_sram_composition_evidence(
         "inputs": {
             "attention_kv_endpoint_ready_valid_service": endpoint_ready_valid,
             "attention_kv_endpoint_full_onchip_service_schedule": endpoint_onchip,
+            "attention_kv_local_sram_capacity": local_sram_capacity,
             "attention_kv_tile_sram_metrics_summary": sram_summary,
             "attention_kv_tile_sram_metrics": sram_metrics,
             "attention_kv_endpoint_router_wide_l1_promotion": wide_l1_promotion,
@@ -5004,6 +5013,7 @@ def _decoder_attention_kv_endpoint_router_sram_composition_evidence(
                     "--repo-root . "
                     f"--endpoint-ready-valid-json {endpoint_ready_valid} "
                     f"--endpoint-onchip-json {endpoint_onchip} "
+                    f"--local-sram-capacity-json {local_sram_capacity} "
                     f"--sram-summary-json {sram_summary} "
                     f"--sram-metrics-json {sram_metrics} "
                     f"--wide-l1-promotion-json {wide_l1_promotion} "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6577,11 +6577,14 @@ def test_generate_l2_campaign_task_adds_endpoint_router_sram_composition_evidenc
             assert "attention_kv_endpoint_full_onchip_service_schedule" in decoder_inputs
             assert "attention_kv_tile_sram_metrics_summary" in decoder_inputs
             assert "attention_kv_endpoint_router_wide_l1_promotion" in decoder_inputs
+            assert "attention_kv_local_sram_capacity" in decoder_inputs
             assert "attention_kv_endpoint_router_sram_composition_out" in decoder_inputs
             assert "audit_llm_decoder_attention_endpoint_router_sram_composition.py" in run
             assert "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1.json" in run
             assert "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json" in run
             assert "llama7b_attention_tile_buffers_v1/sram_metrics_summary.json" in run
+            assert "--local-sram-capacity-json" in run
+            assert "l2_decoder_attention_local_sram_capacity_llama7b_v1.json" in run
             assert "--wide-l1-promotion-json" in run
             assert "l1_decoder_attention_endpoint_router_wide_ppa_v1.json" in run
             assert "--noc-bandwidth-bytes-per-cycle" not in run
@@ -6637,6 +6640,9 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_router_sram_s
                 "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2.json"
                 in run
             )
+            assert "attention_kv_local_sram_capacity" in decoder_inputs
+            assert "--local-sram-capacity-json" in run
+            assert "l2_decoder_attention_local_sram_capacity_llama7b_v1.json" in run
             assert "attention_kv_endpoint_router_wide_l1_promotion" in decoder_inputs
             assert "l1_decoder_attention_endpoint_router_wide_ppa_v1.json" in run
             assert "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1.json" not in run

--- a/npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py
+++ b/npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py
@@ -141,6 +141,29 @@ def _sram_capacity_bytes(sram_metrics: JsonDict) -> int:
     return total
 
 
+def _local_sram_capacity_evidence_summary(
+    local_sram_capacity: JsonDict | None,
+) -> tuple[JsonDict | None, JsonDict | None]:
+    if not isinstance(local_sram_capacity, dict):
+        return None, None
+    budget_check = local_sram_capacity.get("budget_check")
+    chunking = local_sram_capacity.get("chunking")
+    if not isinstance(budget_check, dict):
+        budget_check = None
+    if not isinstance(chunking, dict):
+        chunking = None
+    return budget_check, chunking
+
+
+def _local_sram_capacity_diagnosis(local_sram_budget: JsonDict | None) -> str:
+    if local_sram_budget is None:
+        return "full_local_capacity_sram_macro_profile_missing"
+    fits_budget = local_sram_budget.get("fits_sram_budget")
+    if isinstance(fits_budget, bool):
+        return "local_capacity_budget_passed" if fits_budget else "local_capacity_budget_failed"
+    return "local_capacity_budget_check_missing"
+
+
 def _build_payload(
     *,
     repo_root: Path,
@@ -149,6 +172,7 @@ def _build_payload(
     sram_summary: JsonDict,
     sram_metrics: JsonDict,
     wide_l1_promotion: JsonDict | None = None,
+    local_sram_capacity: JsonDict | None = None,
 ) -> JsonDict:
     best = endpoint_onchip["best"]
     ready_params = endpoint_ready_valid["derived_rtl_parameters"]
@@ -201,6 +225,12 @@ def _build_payload(
         for value in [scaled_router_area_per_cluster, scaled_fifo_area_per_cluster, scaled_endpoint_area_per_cluster]
         if value is not None
     )
+    local_sram_budget, local_sram_chunking = _local_sram_capacity_evidence_summary(local_sram_capacity)
+    local_sram_capacity_present = isinstance(local_sram_capacity, dict)
+    local_capacity_diagnosis = _local_sram_capacity_diagnosis(local_sram_budget)
+    local_capacity_fits_budget = (
+        local_sram_budget.get("fits_sram_budget") if isinstance(local_sram_budget, dict) else None
+    )
 
     closure_flags = {
         "ready_valid_endpoint_passed": endpoint_ready_valid["decision"] == "ready_valid_endpoint_policy_passed",
@@ -214,7 +244,11 @@ def _build_payload(
         name for name, closed in closure_flags.items() if not closed and name != "tile_sram_capacity_covers_selected_local_capacity"
     ]
     if not closure_flags["tile_sram_capacity_covers_selected_local_capacity"]:
-        requires_follow_on.append("full_local_capacity_sram_macro_profile_missing")
+        requires_follow_on.append(
+            "capacity_rebalance_or_smaller_local_sram_required"
+            if local_sram_capacity_present
+            else "full_local_capacity_sram_macro_profile_missing"
+        )
     if router_boundary and not closure_flags["router_ppa_width_matches_link_width"]:
         requires_follow_on = [
             "segmented_or_narrower_router_ppa_required" if item == "router_ppa_width_matches_link_width" else item
@@ -253,7 +287,7 @@ def _build_payload(
         "local_sram_capacity": (
             "covered_by_measured_tile_profile"
             if closure_flags["tile_sram_capacity_covers_selected_local_capacity"]
-            else "full_local_capacity_sram_macro_profile_missing"
+            else local_capacity_diagnosis
         ),
     }
 
@@ -298,10 +332,24 @@ def _build_payload(
             }
         )
     if not closure_flags["tile_sram_capacity_covers_selected_local_capacity"]:
+        if local_sram_capacity_present:
+            local_capacity_reason = (
+                "tile-local SRAM buffers are measured, and local-capacity CACTI evidence is available; "
+                "re-balance or reduce the selected local-capacity pool to resolve a local SRAM budget failure."
+                if local_capacity_fits_budget is False
+                else (
+                    "tile-local SRAM buffers are measured, and local-capacity CACTI evidence is available; "
+                    "consume measured local-capacity profiles in the next rebalance step."
+                )
+            )
+        else:
+            local_capacity_reason = (
+                "tile-local SRAM buffers are measured, but the selected local-capacity pool is still capacity-estimated"
+            )
         recommended_next_l1_points.append(
             {
                 "primitive": "local_sram_capacity",
-                "reason": "tile-local SRAM buffers are measured, but the selected local-capacity pool is still capacity-estimated",
+                "reason": local_capacity_reason,
                 "parameters": {
                     "local_capacity_bytes_per_cluster": local_capacity_bytes_per_cluster,
                     "active_clusters": active_clusters,
@@ -323,9 +371,20 @@ def _build_payload(
                 "Router/FIFO PPA is lane-scaled from narrower measured primitives until matching link-width or segmented L1 points are measured."
             )
     if not closure_flags["tile_sram_capacity_covers_selected_local_capacity"]:
-        remaining_abstractions.append(
-            "Tile-local SRAM buffers have CACTI metrics, but the selected per-cluster local capacity pool is not yet a concrete SRAM macro set."
-        )
+        if local_sram_capacity_present:
+            if local_capacity_fits_budget is False:
+                remaining_abstractions.append(
+                    "Tile-local SRAM buffers are measured, but measured local-capacity evidence already shows the selected per-cluster "
+                    "local SRAM pool exceeds the available shared SRAM budget."
+                )
+            else:
+                remaining_abstractions.append(
+                    "Tile-local SRAM buffers are measured, and concrete local-capacity evidence is available for the selected pool."
+                )
+        else:
+            remaining_abstractions.append(
+                "Tile-local SRAM buffers have CACTI metrics, but the selected per-cluster local capacity pool is not yet a concrete SRAM macro set."
+            )
     remaining_abstractions.append("HBM/DRAM service remains inherited and intentionally outside this audit.")
 
     return {
@@ -336,6 +395,7 @@ def _build_payload(
             "endpoint_ready_valid": "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1",
             "sram_profile": "llama7b_attention_tile_buffers_v1",
             "wide_l1_promotion": wide_l1_promotion.get("item_id") if wide_l1_promotion else None,
+            "local_sram_capacity": local_sram_capacity.get("source_item") if isinstance(local_sram_capacity, dict) else None,
         },
         "selected_frontier": {
             "latency_us": best["latency_us"],
@@ -365,6 +425,10 @@ def _build_payload(
                 "total_write_energy_pj": sram_summary.get("total_write_energy_pj"),
                 "allocated_bytes": sram_allocated_bytes,
             },
+            "local_sram_capacity": {
+                "budget_check": local_sram_budget,
+                "chunking": local_sram_chunking,
+            } if local_sram_capacity_present else None,
         },
         "boundary_evidence": {
             "router": router_boundary,
@@ -439,6 +503,19 @@ def _write_report(payload: JsonDict, report: Path) -> None:
     lines.extend(["", "## Closure Diagnosis"])
     for name, value in diagnosis.items():
         lines.append(f"- {name}: `{value}`")
+    local_sram_evidence = payload.get("measured_primitives", {}).get("local_sram_capacity", {})
+    local_sram_budget = local_sram_evidence.get("budget_check") if isinstance(local_sram_evidence, dict) else None
+    if isinstance(local_sram_budget, dict):
+        lines.extend(
+            [
+                "",
+                "## Local SRAM Capacity Budget",
+                f"- fits_sram_budget: `{local_sram_budget.get('fits_sram_budget')}`",
+                f"- total_area_um2: `{local_sram_budget.get('total_area_um2')}`",
+                f"- sram_budget_area_um2: `{local_sram_budget.get('sram_budget_area_um2')}`",
+                f"- area_fraction_of_sram_budget: `{local_sram_budget.get('area_fraction_of_sram_budget')}`",
+            ]
+        )
     lines.extend(
         [
             "",
@@ -466,6 +543,7 @@ def main() -> int:
     parser.add_argument("--sram-summary-json", type=Path, required=True)
     parser.add_argument("--sram-metrics-json", type=Path, required=True)
     parser.add_argument("--wide-l1-promotion-json", type=Path)
+    parser.add_argument("--local-sram-capacity-json", type=Path)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
     args = parser.parse_args()
@@ -482,6 +560,7 @@ def main() -> int:
         sram_summary=_load_json(rooted(args.sram_summary_json)),
         sram_metrics=_load_json(rooted(args.sram_metrics_json)),
         wide_l1_promotion=_load_json(rooted(args.wide_l1_promotion_json)) if args.wide_l1_promotion_json else None,
+        local_sram_capacity=_load_json(rooted(args.local_sram_capacity_json)) if args.local_sram_capacity_json else None,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_llm_decoder_attention_endpoint_router_sram_composition_audit.py
+++ b/tests/test_llm_decoder_attention_endpoint_router_sram_composition_audit.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+
+from npu.eval import audit_llm_decoder_attention_endpoint_router_sram_composition as audit
+
+
+def _write_metrics_csv(path: Path, *, design: str, critical_path_ns: float, die_area: float, power_mw: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "status,critical_path_ns,die_area,total_power_mw,design",
+                f"ok,{critical_path_ns},{die_area},{power_mw},{design}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_payload(
+    *,
+    repo_root: Path,
+    local_sram_capacity: dict | None,
+) -> audit.JsonDict:
+    endpoint_ready_valid = {
+        "decision": "ready_valid_endpoint_policy_passed",
+        "derived_rtl_parameters": {
+            "data_w": 512,
+            "packet_payload_bytes": 64,
+            "banks": 16,
+            "endpoint_queue_depth": 1024,
+            "bank_queue_depth": 1024,
+        },
+    }
+    endpoint_onchip = {
+        "best": {
+            "active_clusters": 1,
+            "latency_us": 3210.0,
+            "topology": "mesh2d",
+            "scheduler_policy": "locality_aware",
+            "reduction_strategy": "cluster_tree",
+            "schedule_policy": "prefetch_overlap",
+            "bank_arbiter_policy": "locality_first",
+            "cluster_count": 16,
+            "bank_count": 64,
+            "link_width_bits": 2048,
+            "packet_payload_bytes": 64,
+            "local_sram_fraction": 0.25,
+            "sram_area_fraction": 0.35,
+            "compute_logic_area_fraction": 0.5,
+            "dominant_tile_resource": "shared_path",
+            "noc_router_metrics_csv": "runs/designs/test/router_metrics.csv",
+            "noc_fifo_metrics_csv": "runs/designs/test/fifo_metrics.csv",
+            "onchip_endpoint_metrics_csv": "runs/designs/test/onchip_endpoint_metrics.csv",
+            "local_capacity_bytes_per_cluster": 1024,
+            "die_area_mm2": 0.8,
+        }
+    }
+    sram_summary = {
+        "total_area_um2": 128.0,
+        "max_access_time_ns": 3.1,
+        "total_read_energy_pj": 44.0,
+        "total_write_energy_pj": 52.0,
+    }
+    sram_metrics = {
+        "instances": [
+            {"instance": {"size_bytes": 256}},
+        ]
+    }
+
+    _write_metrics_csv(
+        repo_root / "runs/designs/test/router_metrics.csv",
+        design="noc_router_w2048",
+        critical_path_ns=4.1,
+        die_area=120.0,
+        power_mw=0.12,
+    )
+    _write_metrics_csv(
+        repo_root / "runs/designs/test/fifo_metrics.csv",
+        design="noc_fifo_w2048",
+        critical_path_ns=4.2,
+        die_area=110.0,
+        power_mw=0.11,
+    )
+    _write_metrics_csv(
+        repo_root / "runs/designs/test/onchip_endpoint_metrics.csv",
+        design="onchip_endpoint_w512",
+        critical_path_ns=3.5,
+        die_area=90.0,
+        power_mw=0.09,
+    )
+
+    return audit._build_payload(
+        repo_root=repo_root,
+        endpoint_ready_valid=endpoint_ready_valid,
+        endpoint_onchip=endpoint_onchip,
+        sram_summary=sram_summary,
+        sram_metrics=sram_metrics,
+        wide_l1_promotion=None,
+        local_sram_capacity=local_sram_capacity,
+    )
+
+
+def test_endpoint_router_sram_composition_audit_with_local_sram_capacity_budget_failure(tmp_path: Path) -> None:
+    local_sram_capacity = {
+        "source_item": "l2_decoder_attention_local_sram_capacity_llama7b_v1",
+        "budget_check": {
+            "fits_sram_budget": False,
+            "total_area_um2": 1306824061.5888963,
+            "sram_budget_area_um2": 280000000.0,
+            "area_fraction_of_sram_budget": 4.667229,
+        },
+        "chunking": {
+            "allocated_bytes_per_cluster": 2048,
+        },
+    }
+    payload = _build_payload(repo_root=tmp_path, local_sram_capacity=local_sram_capacity)
+
+    assert payload["closure_diagnosis"]["local_sram_capacity"] == "local_capacity_budget_failed"
+    assert payload["required_follow_on_ppa"] == ["capacity_rebalance_or_smaller_local_sram_required"]
+    assert payload["measured_primitives"]["local_sram_capacity"]["budget_check"]["fits_sram_budget"] is False
+    assert payload["source_items"]["local_sram_capacity"] == "l2_decoder_attention_local_sram_capacity_llama7b_v1"
+    assert any("exceeds the available shared SRAM budget" in item for item in payload["remaining_abstractions"])
+
+
+def test_endpoint_router_sram_composition_audit_without_local_sram_capacity_falls_back_to_macro_missing(
+    tmp_path: Path,
+) -> None:
+    payload = _build_payload(repo_root=tmp_path, local_sram_capacity=None)
+
+    assert payload["closure_diagnosis"]["local_sram_capacity"] == "full_local_capacity_sram_macro_profile_missing"
+    assert payload["required_follow_on_ppa"] == ["full_local_capacity_sram_macro_profile_missing"]
+    assert payload["measured_primitives"]["local_sram_capacity"] is None
+    assert payload["source_items"]["local_sram_capacity"] is None


### PR DESCRIPTION
Wires existing local SRAM capacity evidence into the endpoint/router/SRAM composition audit, reports measured budget pass/fail instead of treating it as missing, and adds focused regression coverage. Validated with py_compile, focused pytest, and a direct audit run against current Llama7B composition evidence.