### PR TITLE
Consume segmented NoC evidence in composition audit

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4988,6 +4988,9 @@ def _decoder_attention_kv_endpoint_router_sram_composition_evidence(
     sram_summary = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics_summary.json"
     sram_metrics = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json"
     wide_l1_promotion = "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_endpoint_router_wide_ppa_v1.json"
+    segmented_l1_promotion = (
+        "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1.json"
+    )
     return {
         "inputs": {
             "attention_kv_endpoint_ready_valid_service": endpoint_ready_valid,
@@ -4996,6 +4999,7 @@ def _decoder_attention_kv_endpoint_router_sram_composition_evidence(
             "attention_kv_tile_sram_metrics_summary": sram_summary,
             "attention_kv_tile_sram_metrics": sram_metrics,
             "attention_kv_endpoint_router_wide_l1_promotion": wide_l1_promotion,
+            "attention_kv_endpoint_router_segmented_noc_l1_promotion": segmented_l1_promotion,
             "attention_kv_endpoint_router_sram_composition_out": out,
             "attention_kv_endpoint_router_sram_composition_report": report,
             "attention_kv_endpoint_router_sram_composition_scope": (
@@ -5017,6 +5021,7 @@ def _decoder_attention_kv_endpoint_router_sram_composition_evidence(
                     f"--sram-summary-json {sram_summary} "
                     f"--sram-metrics-json {sram_metrics} "
                     f"--wide-l1-promotion-json {wide_l1_promotion} "
+                    f"--segmented-l1-promotion-json {segmented_l1_promotion} "
                     f"--out {out} "
                     f"--out-md {report}"
                 ),

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6577,6 +6577,7 @@ def test_generate_l2_campaign_task_adds_endpoint_router_sram_composition_evidenc
             assert "attention_kv_endpoint_full_onchip_service_schedule" in decoder_inputs
             assert "attention_kv_tile_sram_metrics_summary" in decoder_inputs
             assert "attention_kv_endpoint_router_wide_l1_promotion" in decoder_inputs
+            assert "attention_kv_endpoint_router_segmented_noc_l1_promotion" in decoder_inputs
             assert "attention_kv_local_sram_capacity" in decoder_inputs
             assert "attention_kv_endpoint_router_sram_composition_out" in decoder_inputs
             assert "audit_llm_decoder_attention_endpoint_router_sram_composition.py" in run
@@ -6587,6 +6588,10 @@ def test_generate_l2_campaign_task_adds_endpoint_router_sram_composition_evidenc
             assert "l2_decoder_attention_local_sram_capacity_llama7b_v1.json" in run
             assert "--wide-l1-promotion-json" in run
             assert "l1_decoder_attention_endpoint_router_wide_ppa_v1.json" in run
+            assert "--segmented-l1-promotion-json" in run
+            assert (
+                "l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1.json" in run
+            )
             assert "--noc-bandwidth-bytes-per-cycle" not in run
             assert "--data-rate-mtps" not in run
             assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
@@ -6645,6 +6650,8 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_router_sram_s
             assert "l2_decoder_attention_local_sram_capacity_llama7b_v1.json" in run
             assert "attention_kv_endpoint_router_wide_l1_promotion" in decoder_inputs
             assert "l1_decoder_attention_endpoint_router_wide_ppa_v1.json" in run
+            assert "attention_kv_endpoint_router_segmented_noc_l1_promotion" in decoder_inputs
+            assert "l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1.json" in run
             assert "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1.json" not in run
             assert "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json" not in run
             assert work_item.expected_outputs == expected_outputs

--- a/npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py
+++ b/npu/eval/audit_llm_decoder_attention_endpoint_router_sram_composition.py
@@ -88,6 +88,51 @@ def _best_promotion_metric(promotion: JsonDict | None, *, design_contains: str) 
     return min(matches, key=lambda item: (float(item["critical_path_ns"]), float(item["area_um2"])))
 
 
+def _best_segmented_router_fifo_metric(
+    promotion: JsonDict | None,
+    *,
+    design_contains: str,
+    target_width_bits: int,
+    allowed_lane_width_bits: tuple[int, ...] = (128, 256),
+) -> JsonDict | None:
+    if not promotion:
+        return None
+    proposals = promotion.get("proposals")
+    if not isinstance(proposals, list):
+        return None
+    candidates: list[JsonDict] = []
+    for proposal in proposals:
+        if not isinstance(proposal, dict):
+            continue
+        metric = _metrics_from_promotion_proposal(proposal)
+        if not metric:
+            continue
+        width_bits = metric.get("width_bits")
+        if not isinstance(width_bits, int) or width_bits <= 0:
+            continue
+        if width_bits not in allowed_lane_width_bits:
+            continue
+        if target_width_bits % width_bits != 0:
+            continue
+        if design_contains not in str(metric.get("design", "")):
+            continue
+        lane_count = target_width_bits // width_bits
+        metric["lane_count_for_link"] = lane_count
+        metric["aggregate_area_um2"] = float(metric["area_um2"]) * lane_count
+        metric["aggregate_power_mw"] = float(metric["power_mw"]) * lane_count
+        candidates.append(metric)
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda item: (
+            float(item["aggregate_area_um2"]),
+            float(item["aggregate_power_mw"]),
+            float(item["critical_path_ns"]),
+        ),
+    )
+
+
 def _promotion_boundary_rows(promotion: JsonDict | None, *, design_contains: str) -> list[JsonDict]:
     if not promotion:
         return []
@@ -172,6 +217,7 @@ def _build_payload(
     sram_summary: JsonDict,
     sram_metrics: JsonDict,
     wide_l1_promotion: JsonDict | None = None,
+    segmented_l1_promotion: JsonDict | None = None,
     local_sram_capacity: JsonDict | None = None,
 ) -> JsonDict:
     best = endpoint_onchip["best"]
@@ -181,6 +227,30 @@ def _build_payload(
     link_width_bits = int(best["link_width_bits"])
     router_metrics = _best_metrics(repo_root / best["noc_router_metrics_csv"])
     fifo_metrics = _best_metrics(repo_root / best["noc_fifo_metrics_csv"])
+    router_segmented_metrics = _best_segmented_router_fifo_metric(
+        segmented_l1_promotion,
+        design_contains="noc_router",
+        target_width_bits=link_width_bits,
+    )
+    fifo_segmented_metrics = _best_segmented_router_fifo_metric(
+        segmented_l1_promotion,
+        design_contains="noc_fifo",
+        target_width_bits=link_width_bits,
+    )
+    if router_segmented_metrics and (
+        not router_metrics
+        or not router_metrics.get("width_bits")
+        or int(router_metrics["width_bits"]) != link_width_bits
+    ):
+        router_segmented_metrics["source"] = "segmented_l1_promotion"
+        router_metrics = router_segmented_metrics
+    if fifo_segmented_metrics and (
+        not fifo_metrics
+        or not fifo_metrics.get("width_bits")
+        or int(fifo_metrics["width_bits"]) != link_width_bits
+    ):
+        fifo_segmented_metrics["source"] = "segmented_l1_promotion"
+        fifo_metrics = fifo_segmented_metrics
     endpoint_metrics = (
         _best_promotion_metric(wide_l1_promotion, design_contains="onchip_endpoint")
         or _best_metrics(repo_root / best["onchip_endpoint_metrics_csv"])
@@ -232,6 +302,8 @@ def _build_payload(
         local_sram_budget.get("fits_sram_budget") if isinstance(local_sram_budget, dict) else None
     )
 
+    router_uses_segmented = router_metrics.get("source") == "segmented_l1_promotion" if router_metrics else False
+    fifo_uses_segmented = fifo_metrics.get("source") == "segmented_l1_promotion" if fifo_metrics else False
     closure_flags = {
         "ready_valid_endpoint_passed": endpoint_ready_valid["decision"] == "ready_valid_endpoint_policy_passed",
         "endpoint_ppa_width_matches_ready_valid_width": endpoint_ppa_width == packet_bits,
@@ -249,16 +321,29 @@ def _build_payload(
             if local_sram_capacity_present
             else "full_local_capacity_sram_macro_profile_missing"
         )
-    if router_boundary and not closure_flags["router_ppa_width_matches_link_width"]:
-        requires_follow_on = [
-            "segmented_or_narrower_router_ppa_required" if item == "router_ppa_width_matches_link_width" else item
-            for item in requires_follow_on
-        ]
-    if fifo_boundary and not closure_flags["fifo_ppa_width_matches_link_width"]:
-        requires_follow_on = [
-            "segmented_or_narrower_fifo_ppa_required" if item == "fifo_ppa_width_matches_link_width" else item
-            for item in requires_follow_on
-        ]
+    if (
+        "router_ppa_width_matches_link_width" in requires_follow_on
+        and not closure_flags["router_ppa_width_matches_link_width"]
+    ):
+        requires_follow_on.remove("router_ppa_width_matches_link_width")
+        if not router_uses_segmented:
+            if router_boundary:
+                requires_follow_on.append("segmented_or_narrower_router_ppa_required")
+            else:
+                requires_follow_on.append("router_ppa_width_matches_link_width")
+    if (
+        "fifo_ppa_width_matches_link_width" in requires_follow_on
+        and not closure_flags["fifo_ppa_width_matches_link_width"]
+    ):
+        requires_follow_on.remove("fifo_ppa_width_matches_link_width")
+        if not fifo_uses_segmented:
+            if fifo_boundary:
+                requires_follow_on.append("segmented_or_narrower_fifo_ppa_required")
+            else:
+                requires_follow_on.append("fifo_ppa_width_matches_link_width")
+
+    router_measured_at_link_width = closure_flags["router_ppa_width_matches_link_width"] and link_width_bits == 2048
+    fifo_measured_at_link_width = closure_flags["fifo_ppa_width_matches_link_width"] and link_width_bits == 2048
 
     closure_diagnosis = {
         "endpoint": (
@@ -268,20 +353,36 @@ def _build_payload(
         ),
         "router": (
             "measured_at_link_width"
-            if closure_flags["router_ppa_width_matches_link_width"]
+            if router_measured_at_link_width
             else (
-                "flat_link_width_boundary_failed"
-                if router_boundary and router_boundary.get("status") == "failed"
-                else "ppa_width_mismatch_or_missing"
+                "lane_composed_segmented_evidence_available_while_flat_2048_failed"
+                if router_boundary and router_uses_segmented
+                else (
+                    "ppa_width_matches_non_2048_link_width"
+                    if closure_flags["router_ppa_width_matches_link_width"]
+                    else (
+                        "flat_link_width_boundary_failed"
+                        if router_boundary and router_boundary.get("status") == "failed"
+                        else "ppa_width_mismatch_or_missing"
+                    )
+                )
             )
         ),
         "fifo": (
             "measured_at_link_width"
-            if closure_flags["fifo_ppa_width_matches_link_width"]
+            if fifo_measured_at_link_width
             else (
-                "flat_link_width_boundary_failed"
-                if fifo_boundary and fifo_boundary.get("status") == "failed"
-                else "ppa_width_mismatch_or_missing"
+                "lane_composed_segmented_evidence_available_while_flat_2048_failed"
+                if fifo_boundary and fifo_uses_segmented
+                else (
+                    "ppa_width_matches_non_2048_link_width"
+                    if closure_flags["fifo_ppa_width_matches_link_width"]
+                    else (
+                        "flat_link_width_boundary_failed"
+                        if fifo_boundary and fifo_boundary.get("status") == "failed"
+                        else "ppa_width_mismatch_or_missing"
+                    )
+                )
             )
         ),
         "local_sram_capacity": (
@@ -306,31 +407,41 @@ def _build_payload(
             }
         )
     if not closure_flags["router_ppa_width_matches_link_width"]:
-        recommended_next_l1_points.append(
-            {
-                "primitive": "segmented_noc_router",
-                "reason": (
-                    "flat 2048-bit router failed physical boundary runs; measure lane-composed or narrower-link "
-                    "router/scheduler pairs instead of retrying the same flat primitive"
-                )
-                if router_boundary
-                else "selected link width lacks matching router PPA",
-                "parameters": {"ports": 4, "aggregate_flit_bits": link_width_bits, "candidate_lane_bits": [128, 256]},
-            }
-        )
+        if not router_uses_segmented:
+            recommended_next_l1_points.append(
+                {
+                    "primitive": "segmented_noc_router",
+                    "reason": (
+                        "flat 2048-bit router failed physical boundary runs; measure lane-composed or narrower-link "
+                        "router/scheduler pairs instead of retrying the same flat primitive"
+                    )
+                    if router_boundary
+                    else "selected link width lacks matching router PPA",
+                    "parameters": {
+                        "ports": 4,
+                        "aggregate_flit_bits": link_width_bits,
+                        "candidate_lane_bits": [128, 256],
+                    },
+                }
+            )
     if not closure_flags["fifo_ppa_width_matches_link_width"]:
-        recommended_next_l1_points.append(
-            {
-                "primitive": "segmented_noc_fifo",
-                "reason": (
-                    "flat 2048-bit FIFO failed physical boundary runs; measure lane-composed or narrower-link "
-                    "FIFO/scheduler pairs instead of retrying the same flat primitive"
-                )
-                if fifo_boundary
-                else "selected link width lacks matching FIFO PPA",
-                "parameters": {"depth": 16, "aggregate_flit_bits": link_width_bits, "candidate_lane_bits": [128, 256]},
-            }
-        )
+        if not fifo_uses_segmented:
+            recommended_next_l1_points.append(
+                {
+                    "primitive": "segmented_noc_fifo",
+                    "reason": (
+                        "flat 2048-bit FIFO failed physical boundary runs; measure lane-composed or narrower-link "
+                        "FIFO/scheduler pairs instead of retrying the same flat primitive"
+                    )
+                    if fifo_boundary
+                    else "selected link width lacks matching FIFO PPA",
+                    "parameters": {
+                        "depth": 16,
+                        "aggregate_flit_bits": link_width_bits,
+                        "candidate_lane_bits": [128, 256],
+                    },
+                }
+            )
     if not closure_flags["tile_sram_capacity_covers_selected_local_capacity"]:
         if local_sram_capacity_present:
             local_capacity_reason = (
@@ -362,7 +473,17 @@ def _build_payload(
             "Endpoint ready/valid behavior is verified at the selected width, but matching endpoint PPA is not yet available."
         )
     if not closure_flags["router_ppa_width_matches_link_width"] or not closure_flags["fifo_ppa_width_matches_link_width"]:
-        if router_boundary or fifo_boundary:
+        router_or_fifo_segmented = router_uses_segmented or fifo_uses_segmented
+        if router_or_fifo_segmented:
+            if router_boundary or fifo_boundary:
+                remaining_abstractions.append(
+                    "Lane-composed/segmented NoC PPA metrics are available for router/FIFO while flat 2048-bit boundary evidence failed."
+                )
+            else:
+                remaining_abstractions.append(
+                    "Lane-composed/segmented NoC PPA metrics are available for router/FIFO."
+                )
+        elif router_boundary or fifo_boundary:
             remaining_abstractions.append(
                 "Router/FIFO PPA cannot use the failed flat 2048-bit primitive; lane-composed or narrower-link NoC PPA remains open."
             )
@@ -395,6 +516,7 @@ def _build_payload(
             "endpoint_ready_valid": "l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1",
             "sram_profile": "llama7b_attention_tile_buffers_v1",
             "wide_l1_promotion": wide_l1_promotion.get("item_id") if wide_l1_promotion else None,
+            "segmented_l1_promotion": segmented_l1_promotion.get("item_id") if segmented_l1_promotion else None,
             "local_sram_capacity": local_sram_capacity.get("source_item") if isinstance(local_sram_capacity, dict) else None,
         },
         "selected_frontier": {
@@ -543,6 +665,7 @@ def main() -> int:
     parser.add_argument("--sram-summary-json", type=Path, required=True)
     parser.add_argument("--sram-metrics-json", type=Path, required=True)
     parser.add_argument("--wide-l1-promotion-json", type=Path)
+    parser.add_argument("--segmented-l1-promotion-json", type=Path)
     parser.add_argument("--local-sram-capacity-json", type=Path)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
@@ -560,6 +683,9 @@ def main() -> int:
         sram_summary=_load_json(rooted(args.sram_summary_json)),
         sram_metrics=_load_json(rooted(args.sram_metrics_json)),
         wide_l1_promotion=_load_json(rooted(args.wide_l1_promotion_json)) if args.wide_l1_promotion_json else None,
+        segmented_l1_promotion=_load_json(rooted(args.segmented_l1_promotion_json))
+        if args.segmented_l1_promotion_json
+        else None,
         local_sram_capacity=_load_json(rooted(args.local_sram_capacity_json)) if args.local_sram_capacity_json else None,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_llm_decoder_attention_endpoint_router_sram_composition_audit.py
+++ b/tests/test_llm_decoder_attention_endpoint_router_sram_composition_audit.py
@@ -21,6 +21,13 @@ def _build_payload(
     *,
     repo_root: Path,
     local_sram_capacity: dict | None,
+    wide_l1_promotion: dict | None = None,
+    segmented_l1_promotion: dict | None = None,
+    router_metrics_design: str = "noc_router_w2048",
+    fifo_metrics_design: str = "noc_fifo_w2048",
+    endpoint_metrics_design: str = "onchip_endpoint_w512",
+    link_width_bits: int = 2048,
+    local_capacity_bytes_per_cluster: int = 1024,
 ) -> audit.JsonDict:
     endpoint_ready_valid = {
         "decision": "ready_valid_endpoint_policy_passed",
@@ -43,7 +50,7 @@ def _build_payload(
             "bank_arbiter_policy": "locality_first",
             "cluster_count": 16,
             "bank_count": 64,
-            "link_width_bits": 2048,
+            "link_width_bits": link_width_bits,
             "packet_payload_bytes": 64,
             "local_sram_fraction": 0.25,
             "sram_area_fraction": 0.35,
@@ -52,7 +59,7 @@ def _build_payload(
             "noc_router_metrics_csv": "runs/designs/test/router_metrics.csv",
             "noc_fifo_metrics_csv": "runs/designs/test/fifo_metrics.csv",
             "onchip_endpoint_metrics_csv": "runs/designs/test/onchip_endpoint_metrics.csv",
-            "local_capacity_bytes_per_cluster": 1024,
+            "local_capacity_bytes_per_cluster": local_capacity_bytes_per_cluster,
             "die_area_mm2": 0.8,
         }
     }
@@ -70,21 +77,21 @@ def _build_payload(
 
     _write_metrics_csv(
         repo_root / "runs/designs/test/router_metrics.csv",
-        design="noc_router_w2048",
+        design=router_metrics_design,
         critical_path_ns=4.1,
         die_area=120.0,
         power_mw=0.12,
     )
     _write_metrics_csv(
         repo_root / "runs/designs/test/fifo_metrics.csv",
-        design="noc_fifo_w2048",
+        design=fifo_metrics_design,
         critical_path_ns=4.2,
         die_area=110.0,
         power_mw=0.11,
     )
     _write_metrics_csv(
         repo_root / "runs/designs/test/onchip_endpoint_metrics.csv",
-        design="onchip_endpoint_w512",
+        design=endpoint_metrics_design,
         critical_path_ns=3.5,
         die_area=90.0,
         power_mw=0.09,
@@ -96,7 +103,8 @@ def _build_payload(
         endpoint_onchip=endpoint_onchip,
         sram_summary=sram_summary,
         sram_metrics=sram_metrics,
-        wide_l1_promotion=None,
+        wide_l1_promotion=wide_l1_promotion,
+        segmented_l1_promotion=segmented_l1_promotion,
         local_sram_capacity=local_sram_capacity,
     )
 
@@ -132,3 +140,103 @@ def test_endpoint_router_sram_composition_audit_without_local_sram_capacity_fall
     assert payload["required_follow_on_ppa"] == ["full_local_capacity_sram_macro_profile_missing"]
     assert payload["measured_primitives"]["local_sram_capacity"] is None
     assert payload["source_items"]["local_sram_capacity"] is None
+
+
+def test_endpoint_router_sram_composition_audit_uses_segmented_noc_promotion_for_router_fifo_width_fallback(
+    tmp_path: Path,
+) -> None:
+    wide_l1_promotion = {
+        "item_id": "l1_decoder_attention_endpoint_router_wide_ppa_v1",
+        "boundary_evidence": {
+            "rows": [
+                {"design": "l1_noc_router_p4_w2048_wrapper", "status": "failed"},
+                {"design": "l1_noc_fifo_w2048_d16_wrapper", "status": "failed"},
+            ]
+        },
+    }
+    segmented_l1_promotion = {
+        "item_id": "l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1",
+        "proposals": [
+            {
+                "metrics_ref": {
+                    "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w128_wrapper/metrics.csv",
+                },
+                "metric_summary": {
+                    "critical_path_ns": 1.0,
+                    "die_area": 100.0,
+                    "total_power_mw": 1.0,
+                },
+            },
+            {
+                "metrics_ref": {
+                    "metrics_csv": "runs/designs/noc/l1_noc_router_p4_w256_wrapper/metrics.csv",
+                },
+                "metric_summary": {
+                    "critical_path_ns": 0.5,
+                    "die_area": 80.0,
+                    "total_power_mw": 1.0,
+                },
+            },
+            {
+                "metrics_ref": {
+                    "metrics_csv": "runs/designs/noc/l1_noc_fifo_w128_d16_wrapper/metrics.csv",
+                },
+                "metric_summary": {
+                    "critical_path_ns": 1.4,
+                    "die_area": 200.0,
+                    "total_power_mw": 2.0,
+                },
+            },
+            {
+                "metrics_ref": {
+                    "metrics_csv": "runs/designs/noc/l1_noc_fifo_w256_d16_wrapper/metrics.csv",
+                },
+                "metric_summary": {
+                    "critical_path_ns": 1.5,
+                    "die_area": 180.0,
+                    "total_power_mw": 2.0,
+                },
+            },
+        ],
+    }
+    local_sram_capacity = {
+        "source_item": "l2_decoder_attention_local_sram_capacity_llama7b_v1",
+        "budget_check": {
+            "fits_sram_budget": True,
+            "total_area_um2": 10.0,
+            "sram_budget_area_um2": 20.0,
+            "area_fraction_of_sram_budget": 0.5,
+        },
+        "chunking": {
+            "allocated_bytes_per_cluster": 1024,
+        },
+    }
+    payload = _build_payload(
+        repo_root=tmp_path,
+        local_sram_capacity=local_sram_capacity,
+        wide_l1_promotion=wide_l1_promotion,
+        segmented_l1_promotion=segmented_l1_promotion,
+        router_metrics_design="noc_router_w1024",
+        fifo_metrics_design="noc_fifo_w1024",
+        local_capacity_bytes_per_cluster=256,
+    )
+
+    assert payload["measured_primitives"]["router"]["source"] == "segmented_l1_promotion"
+    assert payload["measured_primitives"]["fifo"]["source"] == "segmented_l1_promotion"
+    assert payload["measured_primitives"]["router"]["width_bits"] == 256
+    assert payload["measured_primitives"]["fifo"]["width_bits"] == 256
+    assert payload["composition_quantities"]["router_lanes_for_link"] == 8
+    assert payload["composition_quantities"]["fifo_lanes_for_link"] == 8
+    assert payload["source_items"]["segmented_l1_promotion"] == "l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1"
+    assert payload["closure_diagnosis"]["router"] == (
+        "lane_composed_segmented_evidence_available_while_flat_2048_failed"
+    )
+    assert payload["closure_diagnosis"]["fifo"] == (
+        "lane_composed_segmented_evidence_available_while_flat_2048_failed"
+    )
+    assert payload["required_follow_on_ppa"] == []
+    assert payload["decision"] == "endpoint_router_sram_composition_closed_for_selected_policy"
+    assert not any(item["primitive"] == "segmented_noc_router" for item in payload["recommended_next_l1_points"])
+    assert not any(item["primitive"] == "segmented_noc_fifo" for item in payload["recommended_next_l1_points"])
+    assert any("Lane-composed/segmented NoC PPA metrics are available" in item for item in payload["remaining_abstractions"])
+    assert "lane-composed or narrower-link NoC PPA remains open" not in str(payload["remaining_abstractions"])


### PR DESCRIPTION
## Summary
- wires the segmented NoC L1 promotion into endpoint/router/SRAM composition audits
- uses segmented 128/256-bit router/FIFO lane evidence when flat 2048-bit router/FIFO evidence failed
- ranks segmented lane candidates by aggregate 2048-bit area and power before timing
- removes router/FIFO follow-on requirements when segmented lane evidence is available

## Real audit check
Against the current Llama7B softmax-recip-lut composition evidence:
- router: 256-bit segmented lane, 8 lanes for 2048-bit aggregate, 26394.8288 um2 aggregate area
- fifo: 256-bit segmented lane, 8 lanes for 2048-bit aggregate, 94238.7698 um2 aggregate area
- required_follow_on_ppa: capacity_rebalance_or_smaller_local_sram_required

## Validation
- py_compile on modified audit/generator/test files
- focused pytest: tests/test_llm_decoder_attention_endpoint_router_sram_composition_audit.py and control_plane/control_plane/tests/test_l2_task_generator.py with endpoint_router_sram filters
- direct audit run with wide + segmented L1 promotions and local SRAM capacity evidence
