### PR TITLE
[codex] add softmax recip sram rebalance task

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -4923,6 +4923,15 @@ def _decoder_attention_kv_endpoint_full_onchip_service_source(*, item_id: str) -
     return f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__{source_item}.json"
 
 
+def _decoder_attention_kv_endpoint_router_sram_composition_source(*, item_id: str) -> str:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    if "softmax_recip_lut" in item_id:
+        source_item = "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4"
+    else:
+        source_item = "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1"
+    return f"{base}/decoder_attention_kv_endpoint_router_sram_composition__{source_item}.json"
+
+
 def _decoder_attention_local_sram_capacity_source(*, item_id: str) -> str:
     _ = item_id
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
@@ -5118,18 +5127,9 @@ def _decoder_attention_kv_measured_sram_rebalance_evidence(*, item_id: str) -> d
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_measured_sram_rebalance__{item_id}.json"
     report = f"{base}/decoder_attention_kv_measured_sram_rebalance__{item_id}.md"
-    endpoint_schedule = (
-        f"{base}/decoder_attention_kv_endpoint_full_onchip_service_schedule__"
-        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
-    )
-    composition = (
-        f"{base}/decoder_attention_kv_endpoint_router_sram_composition__"
-        "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1.json"
-    )
-    local_capacity = (
-        f"{base}/decoder_attention_local_sram_capacity__"
-        "l2_decoder_attention_local_sram_capacity_llama7b_v1.json"
-    )
+    endpoint_schedule = _decoder_attention_kv_endpoint_full_onchip_service_source(item_id=item_id)
+    composition = _decoder_attention_kv_endpoint_router_sram_composition_source(item_id=item_id)
+    local_capacity = _decoder_attention_local_sram_capacity_source(item_id=item_id)
     return {
         "inputs": {
             "attention_kv_endpoint_full_onchip_service_schedule": endpoint_schedule,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5199,12 +5199,82 @@ def test_generate_l2_campaign_task_adds_attention_measured_sram_rebalance_eviden
             assert "attention_local_sram_capacity" in decoder_inputs
             assert "attention_kv_measured_sram_rebalance_out" in decoder_inputs
             assert "estimate_llm_decoder_attention_kv_measured_sram_rebalance.py" in run
+            assert (
+                "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
+                in run
+            )
+            assert (
+                "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1.json"
+                in run
+            )
+            assert (
+                "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2.json"
+                not in run
+            )
+            assert (
+                "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json"
+                not in run
+            )
             assert "l2_decoder_attention_local_sram_capacity_llama7b_v1.json" in run
             assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
             assert any(
                 output.endswith(
                     "decoder_attention_kv_measured_sram_rebalance__"
                     "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
+def test_generate_l2_campaign_task_adds_softmax_recip_lut_measured_sram_rebalance_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_measured_sram_rebalance",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert (
+                "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2.json"
+                in run
+            )
+            assert (
+                "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json"
+                in run
+            )
+            assert "l2_decoder_attention_local_sram_capacity_llama7b_v1.json" in run
+            assert (
+                "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1.json"
+                not in run
+            )
+            assert (
+                "l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1.json"
+                not in run
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_measured_sram_rebalance__"
+                    "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json"
                 )
                 for output in expected_outputs
             )

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_v1/evaluation_requests.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_v1",
+  "source_commit": "89ce5a16643cea7a100bbc51ca84096933eae601",
+  "source_commit_note": "Dispatch should use the merge commit containing the softmax-recip measured-SRAM rebalance generator hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recompute the softmax-recip-LUT Llama7B endpoint service frontier with measured tile-local SRAM area and packed shared-SRAM capacity.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_measured_sram_rebalance",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4",
+        "l2_decoder_attention_local_sram_capacity_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_measured_sram_rebalanced_frontier",
+        "reason": "The result should report best latency, HBM byte share, packed shared-SRAM capacity, and the replaced abstract local capacity."
+      },
+      "status": "planned",
+      "notes": "Use the current softmax-recip endpoint schedule plus r4 endpoint/router/SRAM composition evidence so the rebalance closes only the remaining local SRAM capacity abstraction."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_v1",
+  "created_utc": "2026-06-17T11:20:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Measured SRAM rebalance for the softmax-recip Llama7B attention endpoint frontier",
+  "hypothesis": "The current softmax-recip-LUT Llama7B endpoint frontier changes materially when the abstract local/shared SRAM capacity model is replaced by CACTI-derived tile-local SRAM area and packed shared-SRAM capacity under the selected die SRAM budget, while reusing the measured ready/valid endpoint and segmented NoC evidence.",
+  "direct_comparison": {
+    "primary_question": "What is the best endpoint service schedule after replacing abstract local/shared SRAM capacity with measured SRAM capacity under the same SRAM area budget?",
+    "include": [
+      "Use l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2 as the source schedule frontier.",
+      "Use l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4 for measured ready/valid endpoint, segmented NoC, tile-local SRAM area, and required tile-local capacity.",
+      "Use l2_decoder_attention_local_sram_capacity_llama7b_v1 for CACTI SRAM macro density and access references.",
+      "Replace the abstract per-cluster local capacity pool with measured tile-local buffer capacity.",
+      "Pack the remaining SRAM area budget into shared SRAM macro chunks and recompute endpoint service timing."
+    ],
+    "exclude": [
+      "Do not change the inherited HBM/DRAM bandwidth model in this item.",
+      "Do not claim routed SRAM compiler floorplan closure from CACTI macro estimates.",
+      "Do not reopen the already measured ready/valid endpoint or segmented router/FIFO lane evidence.",
+      "Do not change model quality assumptions for GQA/MQA in this item."
+    ],
+    "follow_on_broad_sweep": [
+      "If the best row becomes HBM dominated, plan the HBM/DRAM item separately.",
+      "If the best row stays NoC/shared-SRAM dominated, plan tighter router/FIFO width and SRAM bank PPA.",
+      "Use the measured SRAM-capacity frontier as the next architecture baseline."
+    ]
+  },
+  "expected_benefit": [
+    "Removes the largest optimistic SRAM capacity abstraction exposed by the local capacity profile.",
+    "Separates required tile-local buffering from an unrealistically large local-capacity pool.",
+    "Shows whether the frontier shifts toward HBM, compute, or on-chip shared path under practical SRAM area."
+  ],
+  "risks": [
+    "Shared SRAM packing is still macro-level CACTI evidence, not a routed SRAM floorplan.",
+    "The HBM/DRAM service model is inherited and remains abstract.",
+    "The source schedule may include quality-sensitive KV sharing settings; this item records but does not resolve quality impact."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "softmax_recip_lut_measured_sram_rebalanced_endpoint_schedule",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4",
+        "l2_decoder_attention_local_sram_capacity_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_measured_sram_rebalanced_frontier",
+        "reason": "The result should report best latency, HBM byte share, packed shared-SRAM capacity, and the replaced abstract local capacity."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_full_onchip_service_schedule__l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_measured_sram_rebalance.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py",
+    "npu/eval/measure_llm_decoder_attention_local_sram_capacity.py"
+  ]
+}


### PR DESCRIPTION
## Summary
- route softmax-recip measured-SRAM rebalance jobs to the current r2 endpoint schedule and r4 endpoint/router/SRAM composition evidence
- keep legacy measured-SRAM rebalance jobs on the existing non-softmax inputs
- add a distinct softmax-recip proposal so the old finalized SRAM rebalance proposal is not reused

## Validation
- `PYTHONPATH=/tmp/rtlgen-main-next/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest /tmp/rtlgen-main-next/control_plane/control_plane/tests/test_l2_task_generator.py -k measured_sram_rebalance`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- direct estimator smoke/full run on r2+r4 inputs: best latency `2138.84136 us`, HBM byte share `0.983398438`, shared SRAM `68.0 MiB`, tile-local SRAM `614656 B/cluster`

## Next
After merge, dispatch `l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1` to the remote evaluator from the merge commit.