### PR TITLE
[codex] add softmax recip hbm service task

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5167,10 +5167,11 @@ def _decoder_attention_kv_measured_hbm_service_evidence(*, item_id: str) -> dict
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_measured_hbm_service__{item_id}.json"
     report = f"{base}/decoder_attention_kv_measured_hbm_service__{item_id}.md"
-    measured_sram = (
-        f"{base}/decoder_attention_kv_measured_sram_rebalance__"
-        "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1.json"
-    )
+    if "softmax_recip_lut" in item_id:
+        source_item = "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1"
+    else:
+        source_item = "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1"
+    measured_sram = f"{base}/decoder_attention_kv_measured_sram_rebalance__{source_item}.json"
     return {
         "inputs": {
             "attention_kv_measured_sram_rebalance": measured_sram,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5326,6 +5326,59 @@ def test_generate_l2_campaign_task_adds_attention_measured_hbm_service_evidence(
             )
 
 
+def test_generate_l2_campaign_task_adds_softmax_recip_lut_measured_hbm_service_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_measured_hbm_service",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_kv_measured_hbm_service" in command_names
+            assert "attention_kv_measured_sram_rebalance" in decoder_inputs
+            assert "attention_kv_measured_hbm_service_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_measured_hbm_service.py" in run
+            assert (
+                "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json"
+                in run
+            )
+            assert (
+                "l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1.json"
+                not in run
+            )
+            assert "--channel-count 4,8,16" in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_measured_hbm_service__"
+                    "l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_hbm_closed_onchip_schedule_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_v1",
+  "source_commit": "303319a1cc3d665bb4c924fa1335e956da506d05",
+  "source_commit_note": "Dispatch should use the merge commit containing the softmax-recip measured-SRAM result plus the measured-HBM generator hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recompute the softmax-recip measured-SRAM Llama7B attention frontier with explicit HBM controller service parameters.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_measured_hbm_service",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_measured_hbm_service_frontier",
+        "reason": "The result should report best latency, effective HBM bytes/cycle, source-vs-derived HBM efficiency, controller service cycles, and dominant resource."
+      },
+      "status": "planned",
+      "notes": "Use the softmax-recip measured-SRAM frontier from PR #903 so the HBM service audit follows the current Llama7B frontier."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_v1/proposal.json
@@ -1,0 +1,65 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_v1",
+  "created_utc": "2026-06-17T11:35:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Measured HBM service closure for the softmax-recip Llama7B attention frontier",
+  "hypothesis": "The softmax-recip measured-SRAM Llama7B endpoint frontier remains valid, or its bottleneck shifts, when the inherited scalar HBM bandwidth is replaced by an explicit channel, burst, row-hit, and outstanding-request service model.",
+  "direct_comparison": {
+    "primary_question": "Does explicit HBM controller service change the softmax-recip measured-SRAM Llama7B attention frontier latency or dominant resource?",
+    "include": [
+      "Use l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1 as the source frontier.",
+      "Sweep channel count, per-channel payload bandwidth, burst size, outstanding request window, request overhead, row-hit rate, row-miss penalty, and scheduler efficiency.",
+      "Recompute endpoint service timing while inheriting compute, SRAM, endpoint, and NoC parameters from the measured-SRAM frontier.",
+      "Report effective HBM bytes/cycle versus the source scalar HBM assumption."
+    ],
+    "exclude": [
+      "Do not model full DRAM timing, refresh, bank groups, address mapping, or turnarounds.",
+      "Do not change SRAM packing, softmax reciprocal-LUT settings, or compute PPA in this item.",
+      "Do not resolve model-quality risk for KV sharing.",
+      "Do not replace the pending wide router/FIFO PPA closure item."
+    ],
+    "follow_on_broad_sweep": [
+      "If HBM becomes dominant, explore HBM stack/channel scaling and KV compression/quality-backed variants.",
+      "If tile compute remains dominant, return to compute density and tile scheduling under the measured memory assumptions.",
+      "Use this result as the next practical-memory baseline for Llama7B attention exploration."
+    ]
+  },
+  "expected_benefit": [
+    "Reduces the largest remaining memory-service abstraction after measured SRAM rebalance.",
+    "Checks whether the previous inherited HBM bandwidth was overly optimistic.",
+    "Separates HBM-controller service pressure from NoC/SRAM and compute pressure."
+  ],
+  "risks": [
+    "This is still an analytic HBM service bound, not a full DRAM timing simulator.",
+    "HBM channel bandwidth is expressed in core cycles and needs later calibration to a concrete interface clocking plan.",
+    "Controller area and power are not measured in this item."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "softmax_recip_lut_measured_hbm_service_frontier",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_measured_hbm_service_frontier",
+        "reason": "The result should report best latency, effective HBM bytes/cycle, source-vs-derived HBM efficiency, controller service cycles, and dominant resource."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_measured_hbm_service.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_measured_sram_rebalance.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_onchip_service_schedule.py"
+  ]
+}


### PR DESCRIPTION
## Summary
- route softmax-recip measured-HBM service jobs to the newly merged softmax measured-SRAM rebalance artifact
- keep legacy measured-HBM service jobs on the existing non-softmax measured-SRAM source
- add a distinct softmax-recip HBM-service proposal and request item

## Validation
- `PYTHONPATH=/tmp/rtlgen-hbm-proposal/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k measured_hbm_service`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- direct estimator run on the softmax measured-SRAM source: latency `2138.84136 us`, effective HBM `792.596465 B/cycle`, source scalar HBM `41341.3632 B/cycle`, derived efficiency `0.019172`, controller service `1301` cycles, tile attention `1354` cycles

## Next
After merge, dispatch `l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_llama7b_v1`.