### PR TITLE
Route softmax-recip dual-stream feasibility

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5295,14 +5295,20 @@ def _decoder_attention_kv_subtile_pipeline_schedule_evidence(*, item_id: str) ->
     }
 
 
+def _decoder_attention_kv_dual_stream_physical_feasibility_source(*, item_id: str) -> str:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    if "softmax_recip_lut" in item_id:
+        source_item = "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+    else:
+        source_item = "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1"
+    return f"{base}/decoder_attention_kv_subtile_pipeline_schedule__{source_item}.json"
+
+
 def _decoder_attention_kv_dual_stream_physical_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_dual_stream_physical_feasibility__{item_id}.json"
     report = f"{base}/decoder_attention_kv_dual_stream_physical_feasibility__{item_id}.md"
-    subtile_pipeline = (
-        f"{base}/decoder_attention_kv_subtile_pipeline_schedule__"
-        "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
-    )
+    subtile_pipeline = _decoder_attention_kv_dual_stream_physical_feasibility_source(item_id=item_id)
     full_value_tile_metrics = (
         "runs/designs/activations/"
         "attention_kv_full_value_hd64_kv8_tl16_b128_p8_ppc2_w24_a40_wrapper/metrics.csv"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5636,6 +5636,67 @@ def test_generate_l2_campaign_task_adds_attention_dual_stream_physical_feasibili
             )
 
 
+def test_generate_l2_campaign_task_adds_softmax_recip_lut_dual_stream_physical_feasibility_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_kv_dual_stream_physical_feasibility_softmax_recip_lut_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_kv_dual_stream_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_kv_dual_stream_physical_feasibility" in command_names
+            assert "attention_kv_subtile_pipeline_schedule" in decoder_inputs
+            assert "attention_kv_full_value_tile_metrics" in decoder_inputs
+            assert "attention_kv_softmax_weight_metrics" in decoder_inputs
+            assert "attention_kv_dual_stream_physical_feasibility_out" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py" in run
+            assert (
+                "decoder_attention_kv_subtile_pipeline_schedule__"
+                "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1.json"
+                in run
+            )
+            assert (
+                "decoder_attention_kv_subtile_pipeline_schedule__"
+                "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
+                not in run
+            )
+            assert (
+                decoder_inputs["attention_kv_subtile_pipeline_schedule"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_subtile_pipeline_schedule__"
+                "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1.json"
+            )
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_kv_dual_stream_physical_feasibility__"
+                    "l2_decoder_attention_kv_dual_stream_physical_feasibility_softmax_recip_lut_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- route softmax-recip dual-stream physical feasibility jobs to the softmax subtile pipeline artifact
- preserve the legacy non-softmax source path
- add a focused generator regression test for the softmax-recip feasibility item

## Validation
- PYTHONPATH=/workspaces/rtlgen-fresh-clean/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'dual_stream_physical_feasibility'
- PYTHONPATH=/workspaces/rtlgen-fresh-clean/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue
- git diff --check