### PR TITLE
Route softmax recip int8 feasibility

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -947,13 +947,14 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         "llm_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
         "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
         "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
+        "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
     }:
         diagnosis = evidence_payload.get("diagnosis")
         diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
         outcome = str(diagnosis_dict.get("decision") or "dual_stream_physical_feasibility_recorded")
         prefix = (
             "Decoder mixed-precision int8-compute physical feasibility evidence"
-            if model == "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1"
+            if "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility" in model
             else
             "Decoder mixed-precision physical feasibility evidence"
             if model == "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1"

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5537,14 +5537,25 @@ def _decoder_attention_mixed_precision_int8_compute_physical_feasibility_evidenc
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_int8_compute_physical_feasibility__{item_id}.json"
     report = f"{base}/decoder_attention_mixed_precision_int8_compute_physical_feasibility__{item_id}.md"
-    subtile_pipeline = (
-        f"{base}/decoder_attention_kv_subtile_pipeline_schedule__"
-        "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
-    )
-    quality_gate = (
-        f"{base}/decoder_attention_mixed_precision_quality__"
-        "l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
-    )
+    if "softmax_recip_lut" in item_id:
+        subtile_pipeline_source = "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+        quality_gate_source = "l2_decoder_attention_mixed_precision_quality_llama7b_v1"
+        softmax_recip_quality_decision = (
+            "control_plane/shadow_exports/l2_decisions/"
+            "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3.json"
+        )
+        model_name = (
+            "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1"
+        )
+        precision_profile = "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
+    else:
+        subtile_pipeline_source = "l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1"
+        quality_gate_source = "l2_decoder_attention_mixed_precision_quality_llama7b_v1"
+        softmax_recip_quality_decision = None
+        model_name = "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1"
+        precision_profile = "q8_k8_v6_a24_s24_w16_int8_compute"
+    subtile_pipeline = f"{base}/decoder_attention_kv_subtile_pipeline_schedule__{subtile_pipeline_source}.json"
+    quality_gate = f"{base}/decoder_attention_mixed_precision_quality__{quality_gate_source}.json"
     mixed_full_value_tile_metrics = (
         "runs/designs/activations/"
         "attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/metrics.csv"
@@ -5558,6 +5569,11 @@ def _decoder_attention_mixed_precision_int8_compute_physical_feasibility_evidenc
         "inputs": {
             "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
             "attention_mixed_precision_quality": quality_gate,
+            **(
+                {"attention_softmax_recip_lut_quality_decision": softmax_recip_quality_decision}
+                if softmax_recip_quality_decision is not None
+                else {}
+            ),
             "attention_kv_mixed_precision_full_value_tile_metrics": mixed_full_value_tile_metrics,
             "attention_kv_softmax_weight_metrics": softmax_weight_metrics,
             "attention_int8_dense_compute_metrics": int8_dense_compute_metrics,
@@ -5579,8 +5595,8 @@ def _decoder_attention_mixed_precision_int8_compute_physical_feasibility_evidenc
                     f"--full-value-tile-metrics {mixed_full_value_tile_metrics} "
                     f"--softmax-weight-metrics {softmax_weight_metrics} "
                     f"--quality-gate-json {quality_gate} "
-                    "--precision-profile q8_k8_v6_a24_s24_w16_int8_compute "
-                    "--model-name llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1 "
+                    f"--precision-profile {precision_profile} "
+                    f"--model-name {model_name} "
                     "--frontier-row-limit 8 "
                     "--buffer-area-um2-per-byte 0.0 "
                     f"--compute-block-metrics {int8_dense_compute_metrics} "

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -32,6 +32,28 @@ def test_decoder_evidence_summary_recognizes_mixed_precision_int8_compute_physic
             "model": "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
             "diagnosis": {
                 "decision": "dual_stream_feasible",
+                "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+                "best_requested_mode": "dual_mac",
+                "best_requested_compute_substitution_enabled": True,
+                "best_requested_substituted_compute_arch": "dense_gemm_int8_16x8_k1_p1",
+                "best_requested_substituted_compute_area_um2": 89654016.0,
+                "best_requested_compute_clock_ok": True,
+            },
+        },
+    )
+
+    assert outcome == "dual_stream_feasible"
+    assert "int8-compute physical feasibility" in summary
+    assert "best_requested_substituted_compute_arch=dense_gemm_int8_16x8_k1_p1" in summary
+
+
+def test_decoder_evidence_summary_recognizes_softmax_recip_lut_mixed_precision_int8_compute_physical_feasibility() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/int8_compute_softmax_recip.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+            "diagnosis": {
+                "decision": "dual_stream_feasible",
                 "precision_profile": "q8_k8_v6_a24_s24_w16_int8_compute",
                 "best_requested_mode": "dual_mac",
                 "best_requested_compute_substitution_enabled": True,
@@ -2445,7 +2467,7 @@ def test_consume_l2_result_frontier_attention_mixed_precision_int8_compute_physi
                         "model": "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
                         "diagnosis": {
                             "decision": "dual_stream_feasible",
-                            "precision_profile": "q8_k8_v6_a24_s24_w16_int8_compute",
+                            "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
                             "best_requested_mode": "dual_mac",
                             "best_requested_latency_us": 1575.37,
                             "best_requested_area_fit": True,
@@ -2484,6 +2506,130 @@ def test_consume_l2_result_frontier_attention_mixed_precision_int8_compute_physi
                 "mode": "frontier_detail",
                 "expected_direction": "close_dual_stream_area_gap_with_int8_compute",
                 "expected_reason": "Use int8 compute physical feasibility to choose the next PPA target.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_mixed_precision_int8_compute_physical_feasibility_out": evidence_rel,
+                    "attention_mixed_precision_int8_compute_physical_feasibility_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "dual_stream_feasible"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert "best_requested_substituted_compute_arch=dense_gemm_int8_16x8_k1_p1" in assessment["summary"]
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_mixed_precision_int8_compute_physical_feasibility"
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_precision_int8_compute_physical_feasibility_out"
+                ]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_precision_int8_compute_physical_feasibility_report"
+                ]
+                == report_rel
+            )
+
+
+def test_consume_l2_result_frontier_attention_softmax_recip_lut_mixed_precision_int8_compute_physical_feasibility_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_int8_compute_softmax_recip_lut_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_int8_compute_softmax_recip_lut_v1",
+                        "kind": "architecture",
+                        "title": "Attention mixed precision int8 compute physical feasibility with softmax-recip LUT",
+                        "direct_comparison": {
+                            "primary_question": "Can softmax LUT help close the dual_mac gap with measured int8 compute?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_precision_int8_compute_physical_feasibility__"
+                "l2_attention_softmax_recip_lut_physical_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_precision_int8_compute_physical_feasibility__"
+                "l2_attention_softmax_recip_lut_physical_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+                        "diagnosis": {
+                            "decision": "dual_stream_feasible",
+                            "precision_profile": "q8_k8_v6_a24_s24_w16_int8_compute",
+                            "best_requested_mode": "dual_mac",
+                            "best_requested_latency_us": 1575.37,
+                            "best_requested_area_fit": True,
+                            "best_requested_logic_slack_um2": 216592520.17,
+                            "best_requested_compute_area_over_budget_um2": 0.0,
+                            "best_requested_required_compute_density_gain": 0.452912,
+                            "best_requested_compute_substitution_enabled": True,
+                            "best_requested_substituted_compute_arch": "dense_gemm_int8_16x8_k1_p1",
+                            "best_requested_substituted_compute_area_um2": 89654016.0,
+                            "best_requested_compute_clock_ok": True,
+                            "best_feasible_mode": "dual_mac",
+                            "best_feasible_latency_us": 1575.37,
+                            "recommended_next_step": "promote dual-stream schedule into a measured RTL/PPA wrapper",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# int8 compute physical feasibility\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_softmax_recip_lut_physical",
+                campaign_dir_rel="runs/campaigns/npu/attention_int8_compute_physical_softmax_recip_lut_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_int8_compute_softmax_recip_lut_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "close_dual_stream_area_gap_with_softmax_recip_lut_int8_compute",
+                "expected_reason": "Use softmax-recip LUT physical feasibility to choose the next PPA target.",
             }
             payload["developer_loop"]["abstraction"] = {
                 "layer": "decoder_attention_mixed_precision_int8_compute_physical_feasibility",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5943,6 +5943,83 @@ def test_generate_l2_campaign_task_adds_attention_mixed_precision_int8_compute_p
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_mixed_precision_int8_compute_physical_feasibility_with_softmax_recip_lut_quality_gate() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_mixed_precision_int8_compute_physical_feasibility" in command_names
+            assert (
+                decoder_inputs["attention_kv_subtile_pipeline_schedule"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_subtile_pipeline_schedule__"
+                "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1.json"
+            )
+            assert (
+                decoder_inputs["attention_mixed_precision_quality"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_quality__"
+                "l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
+            )
+            assert "attention_kv_mixed_precision_full_value_tile_metrics" in decoder_inputs
+            assert "attention_int8_dense_compute_metrics" in decoder_inputs
+            assert "attention_mixed_precision_int8_compute_physical_feasibility_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_softmax_recip_lut_quality_decision"]
+                == "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3.json"
+            )
+            assert "estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py" in run
+            assert (
+                "decoder_attention_kv_subtile_pipeline_schedule__"
+                "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1.json"
+                in run
+            )
+            assert (
+                "decoder_attention_mixed_precision_quality__l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
+                in run
+            )
+            assert (
+                "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3.json"
+                not in run
+            )
+            assert "--precision-profile q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute" in run
+            assert (
+                "--model-name llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1"
+                in run
+            )
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_mixed_precision_int8_compute_physical_feasibility__"
+                    "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_v1/README.md
@@ -1,0 +1,18 @@
+# Softmax reciprocal-LUT int8-compute feasibility
+
+This proposal checks whether the current softmax reciprocal-LUT Llama7B frontier can recover the
+`dual_mac` schedule after replacing the dense compute area model with measured signed-int8 GEMM PPA.
+
+The exact-Q8/V16 physical check left the current physically valid point at `split_mac`
+(`2042.378179 us`) because `dual_mac` exceeded the compute area budget. A dry-run with measured
+int8 dense compute reported `dual_stream_feasible` at `1575.373891 us`, but that result needs to be
+recorded through the control-plane job path.
+
+The generator uses the checked-in mixed-precision quality JSON for the estimator and separately records
+the finalized reciprocal-LUT quality decision:
+
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_quality__l2_decoder_attention_mixed_precision_quality_llama7b_v1.json`
+- `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3.json`
+
+The r3 reciprocal-LUT quality dataset JSON was referenced by review metadata but is not present in
+`origin/master`, so the routed estimator command must not depend on that missing path.

--- a/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_v1",
+  "source_commit_note": "Dispatch should use the merge commit that routes softmax_recip_lut item IDs through the mixed-precision int8-compute physical feasibility generator.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Substitute measured signed-int8 dense GEMM compute into the softmax reciprocal-LUT Llama7B dual-stream physical feasibility model and report whether dual_mac is physically feasible.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+      "comparison_role": "frontier_recovery",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dual_stream_physical_feasibility_softmax_recip_lut_llama7b_v1",
+      "depends_on": [
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_kv_dual_stream_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1"
+      ],
+      "expected_result": {
+        "direction": "recover_dual_mac_with_int8_compute",
+        "reason": "The job should record whether the current softmax-recip 1575.373891 us dual_mac schedule becomes physically feasible with measured int8 dense compute."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_v1",
+  "kind": "architecture",
+  "title": "Softmax reciprocal-LUT attention with int8 dense compute physical feasibility",
+  "layer": "layer2",
+  "abstraction_layer": "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+  "status": "proposed",
+  "motivation": [
+    "The softmax reciprocal-LUT sub-tile schedule improved latency to 1575.373891 us only when dual_mac was allowed, but the exact-Q8/V16 compute-area check blocked dual_mac and left split_mac as the current physical frontier.",
+    "The earlier mixed-precision int8-compute feasibility job showed that measured signed-int8 dense GEMM can make the same dual_mac schedule area-feasible in the non-softmax-recip path.",
+    "We need the same check on the current softmax-recip frontier before deciding whether the best Llama7B point should stay at split_mac or recover dual_mac through denser compute."
+  ],
+  "direct_comparison": {
+    "primary_question": "Does measured int8 dense compute make the softmax reciprocal-LUT dual_mac Llama7B schedule physically feasible under the current area budget?",
+    "baseline": "l2_decoder_attention_kv_dual_stream_physical_feasibility_softmax_recip_lut_llama7b_v1",
+    "candidate": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+    "metrics": [
+      "decision",
+      "precision_profile",
+      "best_requested_area_fit",
+      "best_requested_compute_area_over_budget_um2",
+      "best_requested_required_compute_density_gain",
+      "best_requested_substituted_compute_area_um2",
+      "best_feasible_mode",
+      "best_feasible_latency_us"
+    ]
+  },
+  "required_inputs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_subtile_pipeline_schedule__l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_quality__l2_decoder_attention_mixed_precision_quality_llama7b_v1.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3.json",
+    "runs/designs/activations/attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/metrics.csv",
+    "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv",
+    "runs/designs/npu_blocks/npu_dense_gemm_tile_int8_16x8_k1_p1/metrics.csv"
+  ],
+  "quality_position": {
+    "mixed_precision_gate": "Use the checked-in mixed-precision Q8/K8/V6 proxy JSON as the estimator quality gate.",
+    "softmax_recip_gate": "Carry the finalized reciprocal-LUT quality decision as a separate source reference because the historical r3 dataset JSON was referenced by review metadata but was not materialized into origin/master.",
+    "remaining_gap": "This remains a proxy quality gate, not real Llama7B checkpoint perplexity."
+  },
+  "expected_result": {
+    "direction": "recover_dual_mac_with_int8_compute",
+    "reason": "A dry-run estimator check on the current artifacts reported dual_stream_feasible at 1575.373891 us with measured int8 dense compute, so the queued job should record that result through the normal control-plane path."
+  },
+  "evaluation_requests": [
+    {
+      "item_id": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_precision_int8_compute_physical_feasibility",
+      "comparison_role": "frontier_recovery",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_dual_stream_physical_feasibility_softmax_recip_lut_llama7b_v1",
+      "depends_on": [
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_kv_dual_stream_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1"
+      ]
+    }
+  ],
+  "source_files": [
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "control_plane/control_plane/services/l2_result_consumer.py"
+  ]
+}


### PR DESCRIPTION
## Summary\n- route softmax_recip_lut mixed-int8 compute physical feasibility jobs to the softmax-recip subtile schedule\n- keep estimator quality gate on the checked-in mixed-precision quality JSON and record the reciprocal-LUT quality decision separately\n- recognize the softmax-recip int8-compute model in result finalization summaries\n- add proposal/evaluation request for the next Llama7B frontier-recovery job\n\n## Validation\n- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'mixed_precision_int8_compute_physical_feasibility'\n- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -k 'mixed_precision_int8_compute_physical_feasibility'\n- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue\n- git diff --check