### PR TITLE
[codex] route composed datapath feasibility

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -468,6 +468,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_precision_int8_compute_physical_feasibility_out",
         "attention_mixed_precision_int8_compute_physical_feasibility_report",
     ),
+    (
+        "attention_composed_datapath_physical_feasibility_out",
+        "attention_composed_datapath_physical_feasibility_report",
+    ),
 )
 
 
@@ -948,12 +952,15 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
         "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
         "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
     }:
         diagnosis = evidence_payload.get("diagnosis")
         diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
         outcome = str(diagnosis_dict.get("decision") or "dual_stream_physical_feasibility_recorded")
         prefix = (
-            "Decoder mixed-precision int8-compute physical feasibility evidence"
+            "Decoder composed dual-stream physical feasibility evidence"
+            if model == "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
+            else "Decoder mixed-precision int8-compute physical feasibility evidence"
             if "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility" in model
             else
             "Decoder mixed-precision physical feasibility evidence"
@@ -967,6 +974,8 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "precision_profile",
             "best_requested_mode",
             "best_requested_latency_us",
+            "best_requested_adjusted_latency_us_if_feasible",
+            "best_requested_adjusted_speedup_vs_hbm_closed_source",
             "best_requested_area_fit",
             "best_requested_logic_slack_um2",
             "best_requested_compute_area_over_budget_um2",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5350,6 +5350,62 @@ def _decoder_attention_kv_dual_stream_physical_feasibility_evidence(*, item_id: 
     }
 
 
+def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_composed_datapath_physical_feasibility__{item_id}.json"
+    report = f"{base}/decoder_attention_composed_datapath_physical_feasibility__{item_id}.md"
+    subtile_pipeline = _decoder_attention_kv_dual_stream_physical_feasibility_source(item_id=item_id)
+    quality_gate = f"{base}/decoder_attention_mixed_precision_quality__l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
+    full_value_tile_metrics = (
+        "runs/designs/activations/"
+        "attention_kv_full_value_hd64_kv8_v6_tl16_b128_p8_ppc2_w22_a40_wrapper/metrics.csv"
+    )
+    softmax_weight_metrics = (
+        "runs/designs/activations/"
+        "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
+    )
+    composed_dual_stream_metrics = (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv"
+    )
+    return {
+        "inputs": {
+            "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
+            "attention_mixed_precision_quality": quality_gate,
+            "attention_kv_full_value_tile_metrics": full_value_tile_metrics,
+            "attention_kv_softmax_weight_metrics": softmax_weight_metrics,
+            "attention_kv_composed_dual_stream_metrics": composed_dual_stream_metrics,
+            "attention_composed_datapath_physical_feasibility_out": out,
+            "attention_composed_datapath_physical_feasibility_report": report,
+            "attention_composed_datapath_physical_feasibility_scope": (
+                "Use the composed dual-stream RTL wrapper PPA (q8/k8/v6 softmax-recip-q10 with two int8 streams) "
+                "as a bounded next-step feasibility model, replacing separate full-value/softmax substitutions "
+                "while keeping the upstream source schedule."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_composed_datapath_physical_feasibility",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py "
+                    f"--subtile-pipeline-json {subtile_pipeline} "
+                    f"--full-value-tile-metrics {full_value_tile_metrics} "
+                    f"--softmax-weight-metrics {softmax_weight_metrics} "
+                    f"--composed-dual-stream-metrics {composed_dual_stream_metrics} "
+                    f"--quality-gate-json {quality_gate} "
+                    "--precision-profile q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute "
+                    "--model-name llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1 "
+                    "--frontier-row-limit 8 "
+                    "--buffer-area-um2-per-byte 0.0 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -7175,6 +7231,7 @@ def _build_payload(
         "decoder_attention_kv_measured_hbm_service",
         "decoder_attention_kv_hbm_closed_onchip_schedule",
         "decoder_attention_kv_subtile_pipeline_schedule",
+        "decoder_attention_composed_datapath_physical_feasibility",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -7329,6 +7386,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_hbm_closed_onchip_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_subtile_pipeline_schedule":
             decoder_evidence = _decoder_attention_kv_subtile_pipeline_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_composed_datapath_physical_feasibility":
+            decoder_evidence = _decoder_attention_composed_datapath_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -69,6 +69,27 @@ def test_decoder_evidence_summary_recognizes_softmax_recip_lut_mixed_precision_i
     assert "best_requested_substituted_compute_arch=dense_gemm_int8_16x8_k1_p1" in summary
 
 
+def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/composed_datapath.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
+            "diagnosis": {
+                "decision": "dual_stream_feasible",
+                "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+                "best_requested_mode": "dual_mac",
+                "best_requested_adjusted_latency_us_if_feasible": 1637.2,
+                "best_requested_adjusted_speedup_vs_hbm_closed_source": 9.62,
+                "best_requested_substituted_compute_arch": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_q10",
+            },
+        },
+    )
+
+    assert outcome == "dual_stream_feasible"
+    assert "composed dual-stream physical feasibility" in summary
+    assert "best_requested_adjusted_latency_us_if_feasible=1637.2" in summary
+
+
 def _seed_succeeded_l2_campaign(session: Session, repo_root: Path) -> tuple[str, str]:
     campaign_dir = repo_root / "runs" / "campaigns" / "npu" / "demo_campaign"
     schedule_rel = "runs/campaigns/npu/demo_campaign/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml"
@@ -2202,6 +2223,139 @@ def test_consume_l2_result_frontier_attention_dual_stream_physical_feasibility_u
             )
             assert decision_payload["source_refs"]["decoder_attention_kv_dual_stream_physical_feasibility_out"] == evidence_rel
             assert decision_payload["source_refs"]["decoder_attention_kv_dual_stream_physical_feasibility_report"] == report_rel
+
+
+def test_consume_l2_result_frontier_attention_composed_datapath_physical_feasibility_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_composed_datapath_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_composed_datapath_v1",
+                        "kind": "architecture",
+                        "title": "Attention composed dual-stream physical datapath feasibility",
+                        "direct_comparison": {
+                            "primary_question": "Can a measured dual-stream composed wrapper satisfy the dual_mac area budget?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_attention_composed_datapath_physical_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_attention_composed_datapath_physical_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
+                        "diagnosis": {
+                            "decision": "dual_stream_feasible",
+                            "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+                            "best_requested_mode": "dual_mac",
+                            "best_requested_latency_us": 1575.37,
+                            "best_requested_adjusted_latency_us_if_feasible": 1637.2,
+                            "best_requested_adjusted_speedup_vs_hbm_closed_source": 9.62,
+                            "best_requested_area_fit": True,
+                            "best_requested_logic_slack_um2": 1000.0,
+                            "best_requested_compute_area_over_budget_um2": 0.0,
+                            "best_requested_required_compute_density_gain": 1.2,
+                            "best_requested_compute_substitution_enabled": True,
+                            "best_requested_substituted_compute_arch": (
+                                "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_q10"
+                            ),
+                            "best_requested_substituted_compute_area_um2": 12345.0,
+                            "best_requested_compute_clock_ok": True,
+                            "best_feasible_mode": "dual_mac",
+                            "best_feasible_latency_us": 2088.86,
+                            "best_feasible_source_latency_us": 1575.37,
+                            "recommended_next_step": "promote composed dual-stream wrapper into RTL/PPA flow.",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# composed dual-stream physical feasibility\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_composed_datapath_physical",
+                campaign_dir_rel="runs/campaigns/npu/attention_composed_datapath_physical_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_composed_datapath_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use composed dual-stream physical datapath feasibility to choose next RTL/PPA target.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_composed_datapath_physical_feasibility",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_composed_datapath_physical_feasibility_out": evidence_rel,
+                    "attention_composed_datapath_physical_feasibility_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "dual_stream_feasible"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert "best_requested_adjusted_latency_us_if_feasible=1637.2" in assessment["summary"]
+            assert "best_feasible_latency_us=2088.86" in assessment["summary"]
+            assert (
+                assessment["decoder_quality"]["diagnosis"]["best_feasible_latency_us"] == 2088.86
+            )
+            assert (
+                assessment["decoder_quality"]["diagnosis"]["best_feasible_source_latency_us"] == 1575.37
+            )
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_composed_datapath_physical_feasibility"
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_composed_datapath_physical_feasibility_out"] == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_composed_datapath_physical_feasibility_report"
+                ]
+                == report_rel
+            )
 
 
 def test_consume_l2_result_frontier_attention_mixed_precision_quality_uses_decoder_evidence() -> None:

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5697,6 +5697,60 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_dual_stream_physical_f
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_physical_feasibility_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            run = commands[0]["run"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in command_names
+            assert "attention_kv_subtile_pipeline_schedule" in decoder_inputs
+            assert "attention_kv_composed_dual_stream_metrics" in decoder_inputs
+            assert "attention_composed_datapath_physical_feasibility_out" in decoder_inputs
+            assert "attention_composed_datapath_physical_feasibility_report" in decoder_inputs
+            assert "estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py" in run
+            assert (
+                "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv"
+                in run
+            )
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
+                in run
+            )
+            assert "--precision-profile q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute" in run
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1.json"
+                )
+                for output in expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1/design_brief.md
@@ -1,0 +1,45 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1`
+- `title`: Softmax-recip composed dual-stream datapath feasibility for Llama7B attention
+
+## Problem
+The abstract int8-compute feasibility result recovered the `dual_mac` schedule at
+`1575.373891 us`, but that result did not use the measured composed
+dual-stream wrapper clock. The measured q10 composed wrapper has a slower
+critical path than the source schedule clock, so the frontier ranking must use
+the effective composed-clock latency.
+
+## Hypothesis
+If the measured composed wrapper clock penalty is small enough, the int8
+dual-MAC point remains the best least-abstract frontier. If it is not, the
+physically safer frontier may revert to the split/shared-MAC fallback until the
+composed pipeline is retimed or partitioned.
+
+## Evaluation Scope
+- Direct comparison: abstract int8 dual-MAC versus measured-clock composed
+  dual-MAC versus prior split/shared-MAC fallback.
+- Evaluation mode: `frontier_detail`.
+- Dependencies: merged softmax-recip subtile schedule, int8 feasibility result,
+  measured composed wrapper PPA, and existing precision-quality gates.
+- Excluded: new HBM/SRAM/NoC assumptions, new KV sharing, and real checkpoint
+  quality/perplexity.
+
+## Knowledge Inputs
+- `npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py`
+- measured q10 composed dual-stream softmax-recip wrapper `metrics.csv`
+- softmax-recip subtile pipeline schedule result
+- mixed-precision and reciprocal-LUT quality decision references
+
+## Candidate Direction
+Convert the current abstract int8 dual-MAC feasibility row into a
+composed-clock physical feasibility row while preserving source latency as a
+diagnostic field.
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-17T21:30:00Z
+- note: Required before using the abstract int8 dual-MAC point as the
+  least-abstract Llama7B attention frontier.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1/evaluation_requests.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1",
+  "source_commit": "pending",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "LLM-oriented attention-tail stress campaign with measured composed dual-stream softmax-recip datapath clock substitution.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3",
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+        "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_softmax_recip_composed_datapath_physical_feasibility",
+        "reason": "Quantify whether measured composed wrapper area and clock keep the softmax-recip int8 dual-MAC point ahead of the split/shared-MAC fallback."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1",
+  "created_utc": "2026-06-17T21:30:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Softmax-recip composed dual-stream datapath feasibility for Llama7B attention",
+  "hypothesis": "The abstract int8-compute dual-MAC feasibility point should only remain the frontier if the measured composed dual-stream wrapper clock and area still beat the split/shared-MAC fallback under the same Llama7B attention schedule assumptions.",
+  "direct_comparison": {
+    "primary_question": "After substituting the measured q10 composed dual-stream softmax-recip wrapper, what is the physically effective dual-MAC latency and does it remain the best least-abstract frontier?",
+    "include": [
+      "Use l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1 as the source schedule.",
+      "Use the measured q10 composed dual-stream softmax-recip wrapper metrics as a combined local datapath, softmax, stream-buffer, and int8 compute wrapper.",
+      "Scale feasible source latency by measured wrapper clock divided by source schedule clock.",
+      "Report effective latency separately from the source schedule latency.",
+      "Compare against the abstract int8-compute dual-MAC result and the prior split/shared-MAC fallback."
+    ],
+    "exclude": [
+      "Do not change the HBM, SRAM, NoC, KV sharing, or Llama7B workload assumptions.",
+      "Do not treat the source schedule latency as final if measured wrapper clock is slower.",
+      "Do not claim full Llama7B quality closure; this consumes the existing mixed-precision quality gate and reciprocal-LUT decision references."
+    ],
+    "follow_on_broad_sweep": [
+      "If composed-clock dual-MAC is slower than split/shared MAC, measure a split/shared composed wrapper or optimize composed pipeline timing.",
+      "If composed-clock dual-MAC remains best, promote it as the current least-abstract attention frontier before expanding memory/NoC detail.",
+      "Run real checkpoint quality or perplexity once the architecture point is stable enough for precision validation."
+    ]
+  },
+  "expected_benefit": [
+    "Prevents the 1575 us abstract int8-compute point from being ranked without measured composed wrapper timing.",
+    "Quantifies the penalty from composed RTL clock integration.",
+    "Clarifies whether the current best least-abstract point is composed dual-MAC or the split/shared-MAC fallback."
+  ],
+  "risks": [
+    "The result is still an L2 composition of measured wrapper metrics and schedule rows, not a full whole-attention RTL PPA integration.",
+    "The quality gate uses the current small-benchmark mixed-precision evidence, not real Llama7B checkpoint perplexity.",
+    "The composed wrapper count assumes regular replication and may still need layout-level hierarchy validation."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "softmax_recip_composed_datapath_physical_feasibility",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3",
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_mixed_precision_quality_llama7b_v1",
+        "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_softmax_recip_composed_datapath_physical_feasibility",
+        "reason": "The result should decide whether the measured composed dual-stream softmax-recip wrapper preserves the abstract dual-MAC advantage after clock scaling."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_int8_compute_physical_feasibility__l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_dual_stream_physical_feasibility__l2_decoder_attention_kv_dual_stream_physical_feasibility_softmax_recip_lut_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_subtile_pipeline_schedule__l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1.json",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1/quality_gate.md
@@ -1,0 +1,21 @@
+# Quality Gate
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_v1`
+- `candidate_id`: `l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1`
+
+## Required Evidence
+- The generated command must consume the measured q10 composed dual-stream
+  softmax-recip wrapper metrics.
+- The JSON result must report effective `best_feasible_latency_us` after
+  composed clock scaling.
+- The JSON result must preserve `best_feasible_source_latency_us` for the
+  original schedule latency.
+- The result consumer must record the composed evidence and source references.
+
+## Pass Criteria
+- `decision` is recorded.
+- Effective latency is not silently replaced by source schedule latency when a
+  composed wrapper clock is present.
+- Existing mixed-precision quality and reciprocal-LUT decision references are
+  preserved as input evidence.

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -18,6 +18,13 @@ if str(_REPO_ROOT) not in sys.path:
 JsonDict = dict[str, Any]
 
 
+def _effective_latency_us(row: JsonDict) -> float:
+    value = row.get("adjusted_latency_us_if_feasible")
+    if value is None:
+        value = row.get("latency_us")
+    return float(value)
+
+
 def _load_json(path: Path) -> JsonDict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -105,6 +112,7 @@ def _row_with_budget(
     *,
     full_value_tile: JsonDict,
     softmax_weight: JsonDict,
+    composed_dual_stream: JsonDict | None,
     compute_block: JsonDict | None,
     compute_block_macs_per_cycle: int | None,
     compute_arch_name: str | None,
@@ -124,19 +132,54 @@ def _row_with_budget(
 
     measured_stream_area = float(full_value_tile["die_area_um2"])
     measured_softmax_area = float(softmax_weight["die_area_um2"])
+    source_clock_ns = float(source_row["clock_ns"])
+    use_composed_dual_stream = composed_dual_stream is not None
+    if use_composed_dual_stream:
+        composed_area = float(composed_dual_stream.get("block_area_um2") or composed_dual_stream["die_area_um2"])
+        composed_clock_ns = float(composed_dual_stream["critical_path_ns"])
+        composed_power = float(composed_dual_stream["total_power_mw"])
+        source_block_macs_per_cycle = int(source_row["measured_block_macs_per_cycle"])
+        composed_replica_count = int(
+            math.ceil(float(source_row["macs_per_cycle"]) / max(1, source_block_macs_per_cycle))
+        )
+    else:
+        composed_area = 0.0
+        composed_clock_ns = 0.0
+        composed_power = 0.0
+        composed_replica_count = 0
     stream_buffer_area = required_buffer_bytes * buffer_area_um2_per_byte
-    selected_local_datapath_area = compute_multiplier * measured_stream_area
-    selected_softmax_area = measured_softmax_area
-    selected_l1_overhead = current_l1_overhead + clusters * (
-        selected_local_datapath_area
-        + selected_softmax_area
-        + stream_buffer_area
-        - current_local_datapath_area
-        - current_softmax_area
-    )
 
-    compute_substitution_enabled = compute_block is not None
-    if compute_block is None:
+    if use_composed_dual_stream:
+        # The composed wrapper contains both int8 streams, reciprocal-LUT softmax, and stream-buffer/control.
+        # Replace local+softmax+compute through a single measured area term.
+        selected_local_datapath_area = 0.0
+        selected_softmax_area = 0.0
+        selected_l1_overhead = current_l1_overhead + clusters * (
+            stream_buffer_area - current_local_datapath_area - current_softmax_area
+        )
+    else:
+        selected_local_datapath_area = compute_multiplier * measured_stream_area
+        selected_softmax_area = measured_softmax_area
+        selected_l1_overhead = current_l1_overhead + clusters * (
+            selected_local_datapath_area
+            + selected_softmax_area
+            + stream_buffer_area
+            - current_local_datapath_area
+            - current_softmax_area
+        )
+
+    compute_substitution_enabled = use_composed_dual_stream or (compute_block is not None)
+    if use_composed_dual_stream:
+        target_block_area = composed_area
+        target_block_macs = int(source_row["macs_per_cycle"])
+        target_replica_count = composed_replica_count
+        base_compute_area = target_replica_count * target_block_area
+        base_compute_power = target_replica_count * composed_power
+        target_block_clock = composed_clock_ns
+        target_block_power = composed_power
+        target_arch = "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10"
+        compute_area_required = base_compute_area
+    elif compute_block is None:
         base_compute_area = current_compute_area
         base_compute_power = float(source_row.get("compute_power_mw", source_row.get("measured_block_power_mw", 0.0)))
         target_replica_count = int(source_row["compute_replica_count"])
@@ -145,6 +188,7 @@ def _row_with_budget(
         target_block_clock = float(source_row["measured_block_clock_ns"])
         target_block_power = float(source_row.get("measured_block_power_mw", 0.0))
         target_arch = str(source_row.get("compute_arch", ""))
+        compute_area_required = base_compute_area * compute_multiplier
     else:
         target_block_area = float(compute_block["block_area_um2"])
         target_block_macs = int(compute_block_macs_per_cycle or source_row["measured_block_macs_per_cycle"])
@@ -154,8 +198,7 @@ def _row_with_budget(
         target_block_power = float(compute_block["total_power_mw"])
         base_compute_power = target_replica_count * target_block_power
         target_arch = str(compute_arch_name or source_row.get("compute_arch", ""))
-
-    compute_area_required = base_compute_area * compute_multiplier
+        compute_area_required = base_compute_area * compute_multiplier
     logic_used_required = current_logic_used + (compute_area_required - current_compute_area) + (
         selected_l1_overhead - current_l1_overhead
     )
@@ -164,20 +207,26 @@ def _row_with_budget(
     required_compute_density_gain = (
         compute_area_required / max(1.0, compute_budget - selected_l1_overhead)
     )
-    if compute_block is None:
+    if compute_block is None and not use_composed_dual_stream:
         replica_count_budgeted = int(current_compute_area // max(1.0, target_block_area))
     else:
         replica_count_budgeted = int(max(0.0, compute_budget - selected_l1_overhead) // max(1.0, target_block_area))
-    replica_count_required = int(math.ceil(target_replica_count * compute_multiplier))
+    replica_count_required = int(
+        math.ceil(target_replica_count * (compute_multiplier if not use_composed_dual_stream else 1.0))
+    )
     replica_shortfall = max(0, replica_count_required - replica_count_budgeted)
     area_fit = logic_slack_required >= 0.0
     buffer_fit = required_buffer_bytes <= available_local_capacity
     feasible = area_fit and buffer_fit
 
     if feasible:
-        adjusted_latency_us = float(source_row["latency_us"])
+        if use_composed_dual_stream and composed_clock_ns > 0.0 and source_clock_ns > 0.0:
+            adjusted_latency_us = float(source_row["latency_us"]) * composed_clock_ns / source_clock_ns
+            adjusted_speedup = float(source_row["latency_speedup_vs_hbm_closed_source"]) * source_clock_ns / composed_clock_ns
+        else:
+            adjusted_latency_us = float(source_row["latency_us"])
+            adjusted_speedup = float(source_row["latency_speedup_vs_hbm_closed_source"])
         adjusted_tile_service_cycles = int(source_row["tile_service_cycles"])
-        adjusted_speedup = float(source_row["latency_speedup_vs_hbm_closed_source"])
     else:
         adjusted_latency_us = None
         adjusted_tile_service_cycles = None
@@ -189,7 +238,11 @@ def _row_with_budget(
     out = dict(source_row)
     out.update(
         {
-            "dual_stream_physical_model": "measured_full_value_tile_budget_v1",
+            "dual_stream_physical_model": (
+                "measured_dual_stream_composed_budget_v1"
+                if use_composed_dual_stream
+                else "measured_full_value_tile_budget_v1"
+            ),
             "precision_profile": precision_profile,
             "measured_full_value_tile_metrics_csv": full_value_tile["metrics_csv"],
             "measured_full_value_tile_area_um2": measured_stream_area,
@@ -199,6 +252,17 @@ def _row_with_budget(
             "measured_softmax_weight_area_um2": measured_softmax_area,
             "measured_softmax_weight_clock_ns": softmax_weight["critical_path_ns"],
             "measured_softmax_weight_power_mw": softmax_weight["total_power_mw"],
+            **(
+                {
+                    "measured_dual_stream_composed_metrics_csv": composed_dual_stream["metrics_csv"],
+                    "measured_dual_stream_composed_area_um2": composed_area,
+                    "measured_dual_stream_composed_clock_ns": composed_clock_ns,
+                    "measured_dual_stream_composed_power_mw": composed_power,
+                    "measured_dual_stream_composed_required_replicas": composed_replica_count,
+                }
+                if use_composed_dual_stream
+                else {}
+            ),
             "stream_buffer_area_um2_per_byte": buffer_area_um2_per_byte,
             "stream_buffer_area_um2_per_cluster": round(stream_buffer_area, 6),
             "selected_local_datapath_area_um2_per_cluster": round(selected_local_datapath_area, 6),
@@ -208,7 +272,11 @@ def _row_with_budget(
             "compute_substitution_enabled": compute_substitution_enabled,
             "source_compute_arch": source_row.get("compute_arch"),
             "substituted_compute_arch": target_arch if compute_substitution_enabled else None,
-            "substituted_compute_metrics_csv": compute_block["metrics_csv"] if compute_block else None,
+            "substituted_compute_metrics_csv": (
+                composed_dual_stream["metrics_csv"]
+                if use_composed_dual_stream
+                else compute_block["metrics_csv"] if compute_block else None
+            ),
             "substituted_block_area_um2": round(target_block_area, 6) if compute_substitution_enabled else None,
             "substituted_block_clock_ns": round(target_block_clock, 6) if compute_substitution_enabled else None,
             "substituted_block_power_mw": round(target_block_power, 6) if compute_substitution_enabled else None,
@@ -242,6 +310,11 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     source_rows = _source_rows(source, limit=args.frontier_row_limit)
     full_value_tile = _best_ok_metrics(args.full_value_tile_metrics)
     softmax_weight = _best_ok_metrics(args.softmax_weight_metrics)
+    composed_dual_stream = (
+        _best_ok_compute_metrics(args.composed_dual_stream_metrics)
+        if getattr(args, "composed_dual_stream_metrics", None)
+        else None
+    )
     compute_block = _best_ok_compute_metrics(args.compute_block_metrics) if args.compute_block_metrics else None
     quality_gate = _load_json(args.quality_gate_json) if args.quality_gate_json else None
     rows = [
@@ -249,6 +322,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             row,
             full_value_tile=full_value_tile,
             softmax_weight=softmax_weight,
+            composed_dual_stream=composed_dual_stream,
             compute_block=compute_block,
             compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
             compute_arch_name=args.compute_arch_name,
@@ -258,14 +332,30 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         for row in source_rows
     ]
     feasible_rows = [row for row in rows if row["physical_feasible"]]
-    best_feasible = min(feasible_rows, key=lambda row: float(row["latency_us"])) if feasible_rows else None
+    best_feasible = min(feasible_rows, key=_effective_latency_us) if feasible_rows else None
     best_requested = min(rows, key=lambda row: float(row["latency_us"]))
     best_area_fit = min(
         (row for row in rows if row["area_fit"]),
-        key=lambda row: float(row["latency_us"]),
+        key=_effective_latency_us,
         default=None,
     )
     decision = "dual_stream_feasible" if best_feasible and best_feasible.get("compute_mode") == "dual_mac" else "dual_stream_area_blocked"
+    assumptions = [
+        "The dual_mac schedule requires an explicit compute_area_multiplier from the sub-tile scheduler.",
+        "Measured full-value tile and softmax-weight generator PPA are used for local datapath overhead only.",
+        "The dense GEMM compute array is treated as already packed into the current logic budget; extra dual-stream compute must fit that same budget to be feasible.",
+        "Buffer capacity is checked against measured local SRAM bytes; an optional buffer-area proxy can be added for sensitivity but defaults to zero to avoid double-counting measured local SRAM.",
+    ]
+    if composed_dual_stream:
+        assumptions.append(
+            "When composed dual-stream wrapper substitution is enabled, full-value and softmax measurements are treated as folded into the measured dual-stream RTL wrapper, and wrapper clock is used to scale feasible latency if it differs from source schedule clock."
+        )
+    elif compute_block:
+        assumptions.append(
+            "When compute-block substitution is enabled, measured block area/power/clock replace the source dense compute block, but the upstream schedule latency is not recomputed; this is an area-feasibility substitution and a conservative latency view when the substituted block clock is no slower than the source clock."
+        )
+    else:
+        assumptions.append("No compute-block substitution was requested; dense compute area comes from the source schedule.")
     return {
         "version": 1,
         "model": args.model_name,
@@ -275,6 +365,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "frontier_row_limit": args.frontier_row_limit,
             "full_value_tile_metrics": str(args.full_value_tile_metrics),
             "softmax_weight_metrics": str(args.softmax_weight_metrics),
+            "composed_dual_stream_metrics": (
+                str(args.composed_dual_stream_metrics) if args.composed_dual_stream_metrics else None
+            ),
             "compute_block_metrics": str(args.compute_block_metrics) if args.compute_block_metrics else None,
             "compute_block_macs_per_cycle": args.compute_block_macs_per_cycle,
             "compute_arch_name": args.compute_arch_name,
@@ -298,6 +391,10 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "physical_feasible_rows": len(feasible_rows),
             "best_requested_mode": best_requested.get("compute_mode"),
             "best_requested_latency_us": best_requested.get("latency_us"),
+            "best_requested_adjusted_latency_us_if_feasible": best_requested.get("adjusted_latency_us_if_feasible"),
+            "best_requested_speedup_vs_hbm_closed_source": best_requested.get("latency_speedup_vs_hbm_closed_source"),
+            "best_requested_adjusted_speedup_vs_hbm_closed_source": best_requested.get("adjusted_speedup_if_feasible"),
+            "best_requested_adjusted_tile_service_cycles": best_requested.get("adjusted_tile_service_cycles_if_feasible"),
             "best_requested_area_fit": best_requested.get("area_fit"),
             "best_requested_logic_slack_um2": best_requested.get("logic_area_slack_required_um2"),
             "best_requested_compute_area_over_budget_um2": best_requested.get("compute_area_over_budget_um2"),
@@ -307,9 +404,11 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "best_requested_substituted_compute_area_um2": best_requested.get("substituted_compute_area_um2"),
             "best_requested_compute_clock_ok": best_requested.get("compute_clock_ok"),
             "best_feasible_mode": best_feasible.get("compute_mode") if best_feasible else None,
-            "best_feasible_latency_us": best_feasible.get("latency_us") if best_feasible else None,
+            "best_feasible_latency_us": _effective_latency_us(best_feasible) if best_feasible else None,
+            "best_feasible_source_latency_us": best_feasible.get("latency_us") if best_feasible else None,
             "best_area_fit_mode": best_area_fit.get("compute_mode") if best_area_fit else None,
-            "best_area_fit_latency_us": best_area_fit.get("latency_us") if best_area_fit else None,
+            "best_area_fit_latency_us": _effective_latency_us(best_area_fit) if best_area_fit else None,
+            "best_area_fit_source_latency_us": best_area_fit.get("latency_us") if best_area_fit else None,
             "recommended_next_step": (
                 "measure a denser dual-stream fused attention datapath or reduce compute replicas before promoting dual_mac"
                 if decision == "dual_stream_area_blocked"
@@ -320,18 +419,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "best_feasible": best_feasible,
         "best_area_fit": best_area_fit,
         "rows": rows,
-        "assumptions": [
-            "The dual_mac schedule requires an explicit compute_area_multiplier from the sub-tile scheduler.",
-            "Measured full-value tile and softmax-weight generator PPA are used for local datapath overhead only.",
-            "The dense GEMM compute array is treated as already packed into the current logic budget; extra dual-stream compute must fit that same budget to be feasible.",
-            "Buffer capacity is checked against measured local SRAM bytes; an optional buffer-area proxy can be added for sensitivity but defaults to zero to avoid double-counting measured local SRAM.",
-            (
-                "When compute-block substitution is enabled, measured block area/power/clock replace the source dense compute block, "
-                "but the upstream schedule latency is not recomputed; this is an area-feasibility substitution and a conservative latency view when the substituted block clock is no slower than the source clock."
-            )
-            if compute_block
-            else "No compute-block substitution was requested; dense compute area comes from the source schedule.",
-        ],
+        "assumptions": assumptions,
     }
 
 
@@ -386,6 +474,7 @@ def main() -> int:
     parser.add_argument("--subtile-pipeline-json", type=Path, required=True)
     parser.add_argument("--full-value-tile-metrics", type=Path, required=True)
     parser.add_argument("--softmax-weight-metrics", type=Path, required=True)
+    parser.add_argument("--composed-dual-stream-metrics", type=Path)
     parser.add_argument("--compute-block-metrics", type=Path)
     parser.add_argument("--compute-block-macs-per-cycle", type=int)
     parser.add_argument("--compute-arch-name")


### PR DESCRIPTION
## Summary
- add a composed dual-stream datapath feasibility route for the softmax-recip Llama7B attention frontier
- let the estimator consume measured q10 composed wrapper metrics and scale feasible latency by measured wrapper clock
- preserve source schedule latency separately so ranking uses effective composed-clock latency
- add proposal docs and focused generator/result-consumer regression tests

## Why
The previous int8 feasibility result recovered the abstract `dual_mac` schedule at about `1575.37 us`, but that did not account for the measured composed wrapper critical path. This change records the measured-clock effective latency separately so the next frontier decision can compare composed dual-MAC against the split/shared-MAC fallback without silently ranking the source latency.

## Validation
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k composed`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -k composed`
- `git diff --check HEAD~1 HEAD`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
