### PR TITLE
[codex] route recip lut variant frontier

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -953,6 +953,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
         "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
         "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
     }:
         diagnosis = evidence_payload.get("diagnosis")
         diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
@@ -965,6 +966,8 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             else
             "Decoder mixed-precision physical feasibility evidence"
             if model == "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1"
+            else "Decoder composed dual-stream physical feasibility evidence (softmax-recip LUT variant frontier)"
+            if model == "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
             else "Decoder dual-stream physical feasibility evidence"
         )
         parts = [
@@ -983,6 +986,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "best_requested_compute_substitution_enabled",
             "best_requested_substituted_compute_arch",
             "best_requested_substituted_compute_area_um2",
+            "best_requested_substituted_compute_variant_label",
             "best_requested_compute_clock_ok",
             "best_feasible_mode",
             "best_feasible_latency_us",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5368,6 +5368,30 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         "runs/designs/npu_blocks/"
         "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv"
     )
+    variant_frontier = "variant_frontier" in item_id
+    if variant_frontier:
+        composed_dual_stream_metrics = (
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/metrics.csv,"
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv,"
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/metrics.csv"
+        )
+    composed_dual_stream_metrics_flags = " ".join(
+        f"--composed-dual-stream-metrics {path}"
+        for path in composed_dual_stream_metrics.split(",")
+    )
+    model_name = (
+        "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
+        if variant_frontier
+        else "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
+    )
+    precision_profile = (
+        "q8_k8_v6_a24_s8_w8_recip_lut_variant_int8_compute"
+        if variant_frontier
+        else "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
+    )
     return {
         "inputs": {
             "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
@@ -5391,10 +5415,10 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
                     f"--subtile-pipeline-json {subtile_pipeline} "
                     f"--full-value-tile-metrics {full_value_tile_metrics} "
                     f"--softmax-weight-metrics {softmax_weight_metrics} "
-                    f"--composed-dual-stream-metrics {composed_dual_stream_metrics} "
+                    f"{composed_dual_stream_metrics_flags} "
                     f"--quality-gate-json {quality_gate} "
-                    "--precision-profile q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute "
-                    "--model-name llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1 "
+                    f"--precision-profile {precision_profile} "
+                    f"--model-name {model_name} "
                     "--frontier-row-limit 8 "
                     "--buffer-area-um2-per-byte 0.0 "
                     f"--out {out} "

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -90,6 +90,27 @@ def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibil
     assert "best_requested_adjusted_latency_us_if_feasible=1637.2" in summary
 
 
+def test_decoder_evidence_summary_recognizes_composed_datapath_recip_lut_variant_frontier_model() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/composed_datapath_frontier.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
+            "diagnosis": {
+                "decision": "dual_stream_feasible",
+                "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+                "best_requested_mode": "dual_mac",
+                "best_requested_adjusted_latency_us_if_feasible": 1200.0,
+                "best_requested_substituted_compute_variant_label": "q12",
+                "best_requested_substituted_compute_arch": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12",
+            },
+        },
+    )
+
+    assert outcome == "dual_stream_feasible"
+    assert "composed dual-stream physical feasibility evidence (softmax-recip LUT variant frontier)" in summary
+    assert "best_requested_substituted_compute_variant_label=q12" in summary
+
+
 def _seed_succeeded_l2_campaign(session: Session, repo_root: Path) -> tuple[str, str]:
     campaign_dir = repo_root / "runs" / "campaigns" / "npu" / "demo_campaign"
     schedule_rel = "runs/campaigns/npu/demo_campaign/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5751,6 +5751,68 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_physical_fea
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_variant_frontier_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
+                in run
+            )
+            composed_dual_stream_metrics = decoder_inputs["attention_kv_composed_dual_stream_metrics"]
+            assert set(
+                composed_dual_stream_metrics.split(",")
+            ) == {
+                "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/metrics.csv",
+                "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv",
+                "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/metrics.csv",
+            }
+            assert (
+                "--composed-dual-stream-metrics runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/metrics.csv "
+                in run
+            )
+            assert (
+                "--composed-dual-stream-metrics runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv "
+                in run
+            )
+            assert (
+                "--composed-dual-stream-metrics runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/metrics.csv "
+                in run
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1/design_brief.md
@@ -1,0 +1,30 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1`
+- `title`: Composed reciprocal-LUT softmax variant frontier for Llama7B attention
+
+## Problem
+The current composed datapath feasibility result uses the q10 reciprocal-LUT
+wrapper only. Existing PPA data also includes q8 and q12 reciprocal-LUT
+wrappers, and the measured q8 wrapper has lower area, power, and critical path
+than q10. The frontier should compare these measured variants directly instead
+of keeping q10 as an implicit fixed choice.
+
+## Evaluation Scope
+- Compare q8/q10/q12 measured composed dual-stream reciprocal-LUT wrappers.
+- Keep the upstream softmax-recip subtile schedule fixed.
+- Keep the existing proxy quality/equivalence evidence as provenance.
+- Report source latency and effective measured-wrapper latency separately.
+
+## Exclusions
+- No new OpenROAD run.
+- No memory/NoC/HBM assumption changes.
+- No claim of final real-checkpoint Llama7B quality closure.
+
+## Direction Gate
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-06-17T21:45:00Z
+- note: Required because q8/q10/q12 measured wrapper PPA is already available
+  and materially changes the composed frontier ranking.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1",
+  "source_commit": "pending",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Select the best measured q8/q10/q12 reciprocal-LUT composed dual-stream wrapper for the Llama7B attention frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3",
+        "l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_composed_recip_lut_variant_frontier",
+        "reason": "Identify whether q8, q10, or q12 reciprocal-LUT composed wrapper is the best measured datapath point."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1/proposal.json
@@ -1,0 +1,63 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1",
+  "created_utc": "2026-06-17T21:45:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Composed reciprocal-LUT softmax variant frontier for Llama7B attention",
+  "hypothesis": "The current composed q10 reciprocal-LUT frontier may not be the best measured datapath point because q8 and q12 wrapper PPA are already available and have different clock, area, power, and precision-risk tradeoffs.",
+  "direct_comparison": {
+    "primary_question": "Among measured q8/q10/q12 reciprocal-LUT composed dual-stream wrappers, which gives the best effective Llama7B attention latency under the same subtile schedule and quality evidence?",
+    "include": [
+      "Use l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1 as the source schedule.",
+      "Use measured q8, q10, and q12 composed dual-stream reciprocal-LUT wrapper metrics.",
+      "Scale each source schedule row by each wrapper clock and select by effective feasible latency, area, and power.",
+      "Report the selected reciprocal-LUT variant label and preserve source schedule latency."
+    ],
+    "exclude": [
+      "Do not run new OpenROAD PPA; this consumes already-measured wrapper metrics.",
+      "Do not change HBM, SRAM, NoC, KV sharing, or Llama7B workload assumptions.",
+      "Do not treat the proxy precision gate as final real-checkpoint Llama7B quality."
+    ]
+  },
+  "expected_benefit": [
+    "Avoids locking the composed frontier to q10 when q8 may have better measured clock, area, and power.",
+    "Makes precision-risk provenance explicit in the frontier ranking.",
+    "Improves the current least-abstract attention datapath latency estimate if a faster measured variant is acceptable."
+  ],
+  "risks": [
+    "The quality evidence is still proxy/equivalence evidence, not final Llama7B checkpoint perplexity.",
+    "The job remains an L2 composition of measured wrappers and schedule rows rather than full whole-attention RTL integration.",
+    "Selecting q8 should remain provisional until real-model precision validation confirms no quality regression."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "composed_recip_lut_variant_frontier",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3",
+        "l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_composed_recip_lut_variant_frontier",
+        "reason": "The result should identify the best measured q8/q10/q12 reciprocal-LUT composed wrapper variant and update the least-abstract Llama7B attention frontier."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/metrics.csv",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q12/metrics.csv",
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1_r3.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1/quality_gate.md
@@ -1,0 +1,17 @@
+# Quality Gate
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_v1`
+- `candidate_id`: `l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1`
+
+## Required Evidence
+- The generated command consumes q8, q10, and q12 composed wrapper metrics.
+- The result reports the selected reciprocal-LUT variant label.
+- Effective latency is based on measured wrapper clock, not source schedule
+  latency.
+- Existing reciprocal-LUT quality evidence is preserved as provenance.
+
+## Pass Criteria
+- A physically feasible best row is recorded.
+- The selected variant label is present in the diagnosis and summary.
+- The baseline q10 composed route continues to work unchanged.

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -7,6 +7,7 @@ import argparse
 import csv
 import json
 import math
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -77,6 +78,55 @@ def _best_ok_compute_metrics(path: Path) -> JsonDict:
         "tag": best.get("tag", ""),
         "result_path": best.get("result_path", ""),
     }
+
+
+def _infer_composed_precision_profile(path: Path) -> str:
+    path_text = str(path)
+    match = re.search(r"softmax_recip_lut_(q\d+)", path_text)
+    if match:
+        return match.group(1)
+    if path.stem and path.stem != "metrics":
+        return path.stem
+    return path.parent.name or path.stem
+
+
+def _compose_variant_name(path: Path) -> str:
+    return path.parent.name
+
+
+def _parse_composed_metric_inputs(values: Any) -> list[Path]:
+    if not values:
+        return []
+    raw_values = values
+    if isinstance(raw_values, (str, Path)):
+        raw_values = [raw_values]
+    elif not isinstance(raw_values, (list, tuple)):
+        raise TypeError(f"invalid composed metric input: {type(raw_values)!r}")
+    paths: list[Path] = []
+    for value in raw_values:
+        value_text = str(value)
+        for piece in value_text.split(","):
+            piece = piece.strip()
+            if not piece:
+                continue
+            paths.append(Path(piece))
+    if not paths:
+        return []
+    return paths
+
+
+def _load_composed_variants(paths: list[Path]) -> list[JsonDict]:
+    variants: list[JsonDict] = []
+    for path in paths:
+        metrics = _best_ok_compute_metrics(path)
+        metrics.update(
+            {
+                "composed_variant_label": _infer_composed_precision_profile(path),
+                "composed_variant_name": _compose_variant_name(path),
+            }
+        )
+        variants.append(metrics)
+    return variants
 
 
 def _source_rows(payload: JsonDict, *, limit: int) -> list[JsonDict]:
@@ -177,7 +227,10 @@ def _row_with_budget(
         base_compute_power = target_replica_count * composed_power
         target_block_clock = composed_clock_ns
         target_block_power = composed_power
-        target_arch = "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10"
+        target_arch = str(
+            composed_dual_stream.get("composed_variant_name")
+            or "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10"
+        )
         compute_area_required = base_compute_area
     elif compute_block is None:
         base_compute_area = current_compute_area
@@ -259,6 +312,9 @@ def _row_with_budget(
                     "measured_dual_stream_composed_clock_ns": composed_clock_ns,
                     "measured_dual_stream_composed_power_mw": composed_power,
                     "measured_dual_stream_composed_required_replicas": composed_replica_count,
+                    "measured_dual_stream_composed_precision_profile": composed_dual_stream[
+                        "composed_variant_label"
+                    ],
                 }
                 if use_composed_dual_stream
                 else {}
@@ -284,6 +340,9 @@ def _row_with_budget(
             "substituted_compute_replica_count": target_replica_count if compute_substitution_enabled else None,
             "substituted_compute_area_um2": round(base_compute_area, 6) if compute_substitution_enabled else None,
             "substituted_compute_power_mw": round(base_compute_power, 6) if compute_substitution_enabled else None,
+            "substituted_compute_variant_label": (
+                composed_dual_stream["composed_variant_label"] if use_composed_dual_stream else None
+            ),
             "logic_area_used_required_um2": round(logic_used_required, 6),
             "logic_area_slack_required_um2": round(logic_slack_required, 6),
             "compute_area_over_budget_um2": round(compute_area_over_budget, 6),
@@ -305,38 +364,69 @@ def _row_with_budget(
     return out
 
 
+def _effective_selection_key(row: JsonDict) -> tuple[float, float, float, str]:
+    substituted_area = row.get("substituted_compute_area_um2")
+    substituted_power = row.get("substituted_compute_power_mw")
+    if substituted_area is None:
+        substituted_area = row.get("compute_area_required_um2")
+    if substituted_area is None:
+        substituted_area = float("inf")
+    if substituted_power is None:
+        substituted_power = float("inf")
+    return (
+        _effective_latency_us(row),
+        float(substituted_area),
+        float(substituted_power),
+        str(row.get("compute_mode", "")),
+    )
+
+
 def build_report(args: argparse.Namespace) -> JsonDict:
     source = _load_json(args.subtile_pipeline_json)
     source_rows = _source_rows(source, limit=args.frontier_row_limit)
     full_value_tile = _best_ok_metrics(args.full_value_tile_metrics)
     softmax_weight = _best_ok_metrics(args.softmax_weight_metrics)
-    composed_dual_stream = (
-        _best_ok_compute_metrics(args.composed_dual_stream_metrics)
-        if getattr(args, "composed_dual_stream_metrics", None)
-        else None
-    )
+    composed_dual_stream_metrics = _parse_composed_metric_inputs(getattr(args, "composed_dual_stream_metrics", None))
+    composed_variants = _load_composed_variants(composed_dual_stream_metrics) if composed_dual_stream_metrics else []
     compute_block = _best_ok_compute_metrics(args.compute_block_metrics) if args.compute_block_metrics else None
     quality_gate = _load_json(args.quality_gate_json) if args.quality_gate_json else None
-    rows = [
-        _row_with_budget(
-            row,
-            full_value_tile=full_value_tile,
-            softmax_weight=softmax_weight,
-            composed_dual_stream=composed_dual_stream,
-            compute_block=compute_block,
-            compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
-            compute_arch_name=args.compute_arch_name,
-            buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
-            precision_profile=args.precision_profile,
-        )
-        for row in source_rows
-    ]
+    rows: list[JsonDict] = []
+    for row in source_rows:
+        if composed_variants:
+            for composed_dual_stream in composed_variants:
+                rows.append(
+                    _row_with_budget(
+                        row,
+                        full_value_tile=full_value_tile,
+                        softmax_weight=softmax_weight,
+                        composed_dual_stream=composed_dual_stream,
+                        compute_block=compute_block,
+                        compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
+                        compute_arch_name=args.compute_arch_name,
+                        buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
+                        precision_profile=args.precision_profile,
+                    )
+                )
+        else:
+            rows.append(
+                _row_with_budget(
+                    row,
+                    full_value_tile=full_value_tile,
+                    softmax_weight=softmax_weight,
+                    composed_dual_stream=None,
+                    compute_block=compute_block,
+                    compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
+                    compute_arch_name=args.compute_arch_name,
+                    buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
+                    precision_profile=args.precision_profile,
+                )
+            )
     feasible_rows = [row for row in rows if row["physical_feasible"]]
-    best_feasible = min(feasible_rows, key=_effective_latency_us) if feasible_rows else None
-    best_requested = min(rows, key=lambda row: float(row["latency_us"]))
+    best_requested = min(rows, key=_effective_selection_key) if rows else None
+    best_feasible = min(feasible_rows, key=_effective_selection_key) if feasible_rows else None
     best_area_fit = min(
         (row for row in rows if row["area_fit"]),
-        key=_effective_latency_us,
+        key=_effective_selection_key,
         default=None,
     )
     decision = "dual_stream_feasible" if best_feasible and best_feasible.get("compute_mode") == "dual_mac" else "dual_stream_area_blocked"
@@ -346,7 +436,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "The dense GEMM compute array is treated as already packed into the current logic budget; extra dual-stream compute must fit that same budget to be feasible.",
         "Buffer capacity is checked against measured local SRAM bytes; an optional buffer-area proxy can be added for sensitivity but defaults to zero to avoid double-counting measured local SRAM.",
     ]
-    if composed_dual_stream:
+    if composed_variants:
         assumptions.append(
             "When composed dual-stream wrapper substitution is enabled, full-value and softmax measurements are treated as folded into the measured dual-stream RTL wrapper, and wrapper clock is used to scale feasible latency if it differs from source schedule clock."
         )
@@ -366,7 +456,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "full_value_tile_metrics": str(args.full_value_tile_metrics),
             "softmax_weight_metrics": str(args.softmax_weight_metrics),
             "composed_dual_stream_metrics": (
-                str(args.composed_dual_stream_metrics) if args.composed_dual_stream_metrics else None
+                [str(path) for path in composed_dual_stream_metrics] if composed_dual_stream_metrics else None
             ),
             "compute_block_metrics": str(args.compute_block_metrics) if args.compute_block_metrics else None,
             "compute_block_macs_per_cycle": args.compute_block_macs_per_cycle,
@@ -401,6 +491,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "best_requested_required_compute_density_gain": best_requested.get("required_compute_density_gain"),
             "best_requested_compute_substitution_enabled": best_requested.get("compute_substitution_enabled"),
             "best_requested_substituted_compute_arch": best_requested.get("substituted_compute_arch"),
+            "best_requested_substituted_compute_variant_label": best_requested.get("substituted_compute_variant_label"),
             "best_requested_substituted_compute_area_um2": best_requested.get("substituted_compute_area_um2"),
             "best_requested_compute_clock_ok": best_requested.get("compute_clock_ok"),
             "best_feasible_mode": best_feasible.get("compute_mode") if best_feasible else None,
@@ -440,26 +531,30 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         f"- best requested required compute density gain: `{diag['best_requested_required_compute_density_gain']}`",
         f"- best requested compute substitution: `{diag['best_requested_compute_substitution_enabled']}`",
         f"- best requested substituted compute arch: `{diag['best_requested_substituted_compute_arch']}`",
+        f"- best requested substituted compute variant: `{diag['best_requested_substituted_compute_variant_label']}`",
         f"- best requested substituted compute area um2: `{diag['best_requested_substituted_compute_area_um2']}`",
         f"- recommended next step: `{diag['recommended_next_step']}`",
         "",
         "## Best Requested",
         "",
-        "| mode | latency us | speedup | area fit | buffer fit | logic slack um2 | area over budget | density gain | required replicas | budget replicas | req buffer bytes |",
-        "|---|---:|---:|---|---|---:|---:|---:|---:|---:|---:|",
-        "| {compute_mode} | {latency_us} | {latency_speedup_vs_hbm_closed_source} | {area_fit} | "
-        "{buffer_fit} | {logic_area_slack_required_um2} | {compute_area_over_budget_um2} | "
+        "| mode | latency us | speedup | area fit | buffer fit | substituted variant | logic slack um2 | area over budget | "
+        "density gain | required replicas | budget replicas | req buffer bytes |",
+        "|---|---:|---:|---|---|---|---:|---:|---:|---:|---:|---:|",
+        "| {compute_mode} | {latency_us} | {latency_speedup_vs_hbm_closed_source} | {area_fit} | {buffer_fit} | "
+        "{substituted_compute_variant_label} | "
+        "{logic_area_slack_required_um2} | {compute_area_over_budget_um2} | "
         "{required_compute_density_gain} | {replica_count_required} | "
         "{replica_count_budgeted_at_current_compute_area} | {required_stream_buffer_bytes} |".format(**best),
         "",
         "## Rows",
         "",
-        "| mode | latency us | area fit | feasible | logic slack um2 | local datapath/cluster | compute area required |",
-        "|---|---:|---|---|---:|---:|---:|",
+        "| mode | latency us | area fit | feasible | substituted variant | logic slack um2 | local datapath/cluster | compute area required |",
+        "|---|---:|---|---|---|---:|---:|---:|",
     ]
     for row in payload["rows"]:
         lines.append(
             "| {compute_mode} | {latency_us} | {area_fit} | {physical_feasible} | "
+            "{substituted_compute_variant_label} | "
             "{logic_area_slack_required_um2} | {selected_local_datapath_area_um2_per_cluster} | "
             "{compute_area_required_um2} |".format(**row)
         )
@@ -474,7 +569,7 @@ def main() -> int:
     parser.add_argument("--subtile-pipeline-json", type=Path, required=True)
     parser.add_argument("--full-value-tile-metrics", type=Path, required=True)
     parser.add_argument("--softmax-weight-metrics", type=Path, required=True)
-    parser.add_argument("--composed-dual-stream-metrics", type=Path)
+    parser.add_argument("--composed-dual-stream-metrics", type=Path, action="append")
     parser.add_argument("--compute-block-metrics", type=Path)
     parser.add_argument("--compute-block-macs-per-cycle", type=int)
     parser.add_argument("--compute-arch-name")

--- a/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -30,7 +30,13 @@ def _write_metrics(path: Path, *, die_area: float, power_mw: float, instance_are
     path.write_text(",".join(headers) + "\n" + ",".join(values[key] for key in headers) + "\n", encoding="utf-8")
 
 
-def _args(tmp_path: Path, *, source: Path, compute_metrics: Path | None = None) -> argparse.Namespace:
+def _args(
+    tmp_path: Path,
+    *,
+    source: Path,
+    compute_metrics: Path | None = None,
+    composed_metrics: list[str] | None = None,
+) -> argparse.Namespace:
     full_value = tmp_path / "full_value.csv"
     softmax = tmp_path / "softmax.csv"
     _write_metrics(full_value, die_area=10.0, power_mw=0.1)
@@ -40,6 +46,7 @@ def _args(tmp_path: Path, *, source: Path, compute_metrics: Path | None = None) 
         full_value_tile_metrics=full_value,
         softmax_weight_metrics=softmax,
         compute_block_metrics=compute_metrics,
+        composed_dual_stream_metrics=composed_metrics,
         compute_block_macs_per_cycle=128 if compute_metrics else None,
         compute_arch_name="dense_gemm_int8_16x8_k1_p1" if compute_metrics else None,
         quality_gate_json=None,
@@ -102,3 +109,96 @@ def test_compute_block_substitution_can_close_dual_stream_area_gap(tmp_path: Pat
     assert substituted["best_requested"]["compute_area_required_um2"] == 100.0
     assert substituted["best_requested"]["area_fit"] is True
     assert substituted["best_requested"]["compute_clock_ok"] is True
+
+
+def test_multi_composed_wrapper_variants_use_effective_variant_clock(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    _write_json(
+        source,
+        {
+            "model": "unit_source",
+            "best_by_compute_mode": [
+                {
+                    "compute_mode": "dual_mac",
+                    "latency_us": 100.0,
+                    "latency_speedup_vs_hbm_closed_source": 4.0,
+                    "tile_service_cycles": 12,
+                    "cluster_count": 1,
+                    "compute_area_multiplier": 1.0,
+                    "compute_area_um2": 120.0,
+                    "compute_budget_um2": 1000.0,
+                    "measured_l1_overhead_area_um2": 20.0,
+                    "local_datapath_area_um2": 10.0,
+                    "softmax_weight_generator_area_um2": 5.0,
+                    "logic_area_used_um2": 150.0,
+                    "required_stream_buffer_bytes": 16,
+                    "available_local_capacity_bytes": 32,
+                    "measured_block_area_um2": 120.0,
+                    "measured_block_clock_ns": 4.0,
+                    "measured_block_macs_per_cycle": 128,
+                    "measured_block_power_mw": 4.0,
+                    "compute_replica_count": 1,
+                    "compute_arch": "dense_gemm_16x8_k1_p1",
+                    "macs_per_cycle": 128,
+                    "clock_ns": 4.0,
+                }
+            ],
+        },
+    )
+    metrics_q8 = tmp_path / "q8.csv"
+    metrics_q10 = tmp_path / "q10.csv"
+    metrics_q12 = tmp_path / "q12.csv"
+    _write_metrics(metrics_q8, die_area=30.0, power_mw=0.7, instance_area=28.0)
+    # Override critical paths by rewriting files with explicit values.
+    metrics_q8.write_text(
+        "\n".join(
+            [
+                "status,critical_path_ns,die_area,instance_area_um2,total_power_mw,param_hash,tag,result_path",
+                "ok,12.0,30.0,28.0,0.8,abc,q8,results/q8",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    metrics_q10.write_text(
+        "\n".join(
+            [
+                "status,critical_path_ns,die_area,instance_area_um2,total_power_mw,param_hash,tag,result_path",
+                "ok,4.0,28.0,26.0,0.5,abc,q10,results/q10",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    metrics_q12.write_text(
+        "\n".join(
+            [
+                "status,critical_path_ns,die_area,instance_area_um2,total_power_mw,param_hash,tag,result_path",
+                "ok,2.0,26.0,24.0,0.4,abc,q12,results/q12",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = build_report(
+        _args(
+            tmp_path,
+            source=source,
+            composed_metrics=[
+                str(metrics_q8),
+                str(metrics_q10),
+                str(metrics_q12),
+            ],
+        )
+    )
+
+    assert len(result["rows"]) == 3
+    assert result["inputs"]["composed_dual_stream_metrics"] == [str(metrics_q8), str(metrics_q10), str(metrics_q12)]
+    assert (
+        result["diagnosis"]["best_requested_substituted_compute_variant_label"]
+        == "q12"
+    )
+    # source schedule latency is 100 us, so the q12 clock is 2/4 => 50 us
+    assert result["diagnosis"]["best_requested_adjusted_latency_us_if_feasible"] == 50.0
+    assert result["diagnosis"]["best_feasible_latency_us"] == 50.0


### PR DESCRIPTION
## Summary
- add multi-wrapper composed datapath feasibility support for q8/q10/q12 reciprocal-LUT metrics
- add a variant-frontier L2 route for `l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1`
- report the selected reciprocal-LUT variant label and preserve source/effective latency separation
- add proposal docs and focused estimator/generator/consumer tests

## Why
The current composed datapath result hard-codes the q10 reciprocal-LUT wrapper. Existing measured q8/q10/q12 wrapper PPA shows different clock, area, and power, so the frontier should compare those measured datapath points directly before we treat q10 as the least-abstract choice.

A local real-data dry run selected q8:
- effective latency: `2045.3705757403322 us`
- source schedule latency: `1575.373891 us`
- selected arch: `attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8`

## Validation
- `PYTHONPATH=.:control_plane pytest -q tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py -k "compute_block_substitution_can_close_dual_stream_area_gap or multi_composed_wrapper_variants_use_effective_variant_clock"`
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "adds_attention_composed_datapath_variant_frontier_evidence or adds_attention_composed_datapath_physical_feasibility_evidence"`
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k "recognizes_composed_datapath_recip_lut_variant_frontier_model or recognizes_composed_datapath_physical_feasibility"`
- `git diff --check HEAD~1 HEAD`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
