### PR TITLE
Add q12 PWL composed attention softmax point

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/README.md
@@ -1,0 +1,16 @@
+# Composed Q12/PWL Softmax Datapath
+
+This proposal measures the concrete PPA cost of replacing the current composed
+dual-stream S8/W8 softmax datapath with an in-wrapper q12/PWL reciprocal
+softmax. The target is the Llama7B attention frontier where the current q8
+reciprocal-LUT composed wrapper is best on PPA but remains risky under the
+Llama7B-shape quality proxy.
+
+## Requested Item
+
+- `l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1`
+
+## Key Artifacts
+
+- `runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json`
+- `runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q12_pwl.json`

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/analysis_report.md
@@ -1,0 +1,22 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1`
+- `candidate_id`: `l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1`
+
+## Evaluations Consumed
+- Pending: this proposal creates the PPA item.
+
+## Baseline Comparison
+- Baseline PPA: `l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3`
+- Baseline L2 schedule substitution: `l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1`
+
+## Result
+- Pending evaluation.
+
+## Failures and Caveats
+- The q8 S8/W8 reciprocal-LUT composed point remains PPA-best but quality-risky under the current proxy.
+- This q12/PWL point is intended to measure the concrete physical cost of reducing that softmax precision risk.
+
+## Recommendation
+- Dispatch the L1 PPA item after merge.

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/design_brief.md
@@ -1,0 +1,7 @@
+# Composed Q12/PWL Softmax Datapath
+
+- `proposal_id`: `prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1`
+- `candidate_id`: `l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1`
+- `scope`: Layer-1 PPA for a composed dual-stream attention datapath with q12/PWL reciprocal softmax.
+
+The current composed reciprocal-LUT variant frontier selected the q8 S8/W8 softmax wrapper on latency and area, but the Llama7B-shape proxy marks that precision family as risky. This point keeps the same two int8 compute streams and q8/v6 value streams, while replacing the S8/W8 softmax with an in-wrapper q12 PWL reciprocal softmax.

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - task summary
+- note:

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/evaluation_requests.json
@@ -1,0 +1,30 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds q12/PWL composed softmax generation and the q12/PWL design config.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Run a Layer1 nangate45 OpenROAD sweep for 1 configs using nangate45_dual_stream_composed_hier_q12_pwl.json and record lightweight design metrics for comparison.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q12_pwl_softmax_quality_risk_reduction",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q12_pwl.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_quality_safer_composed_softmax_cost",
+        "reason": "The current q8 reciprocal-LUT composed point is PPA-best but quality-risky; this job measures the actual composed cost of the safer q12/PWL softmax alternative."
+      },
+      "status": "pending"
+    }
+  ],
+  "source_commit": "7b7eba905ab87b1e8489baf66aaafc22a22b35f3"
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/implementation_summary.md
@@ -1,0 +1,32 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1`
+- title: Composed dual-stream attention q12/PWL softmax datapath
+
+## Scope
+- Added `pwl_recip_lut` support to the composed dual-stream attention RTL generator.
+- Parameterized composed softmax score and weight row widths.
+- Updated the composed datapath guard to validate q12/PWL reciprocal softmax structure.
+- Added one full-size q12/PWL composed design config and one matching Nangate45 sweep.
+
+## Files Changed
+- `npu/rtlgen/gen_attention_dual_stream_composed.py`
+- `npu/eval/check_attention_dual_stream_composed_guard.py`
+- `tests/test_attention_dual_stream_composed_generator.py`
+- `runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json`
+- `runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q12_pwl.json`
+
+## Local Validation
+- `PYTHONPATH=. pytest -q tests/test_attention_dual_stream_composed_generator.py`
+- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l1_task_generator.py -k 'attention_dual_stream_composed_configs'`
+- `PYTHONPATH=.:control_plane python3 scripts/validate_runs.py --skip_eval_queue`
+- Full-size q12/PWL generated RTL passed `check_attention_dual_stream_composed_guard.py` and iverilog elaboration.
+
+## Evaluation Request
+- Measure `l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1`.
+- Compare against `l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3` and the L2 q8 reciprocal-LUT composed frontier.
+
+## Risks
+- This is a PPA measurement for a safer softmax datapath, not final Llama7B checkpoint quality evidence.
+- A follow-on L2 result must substitute the measured q12/PWL composed metrics into the Llama7B schedule before promotion.

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1",
+  "candidate_id": "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+  "decision": "iterate",
+  "reason": "PPA evidence is pending. Dispatch the q12/PWL composed softmax measurement after this proposal is merged.",
+  "evidence_refs": [],
+  "next_action": "dispatch l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action:
+- note:

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1",
+  "kind": "frontier_followup",
+  "title": "Composed dual-stream attention q12/PWL softmax datapath",
+  "layer": "layer1",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "status": "proposed",
+  "motivation": [
+    "The composed q8/q10/q12 reciprocal-LUT frontier selected the q8 wrapper on PPA, but the Llama7B-shape proxy marks every Q8/K8/V6/S8/W8 RTL softmax variant as mixed_precision_risky.",
+    "The earlier mixed-precision proxy accepts Q8/K8/V6 with wider softmax score/weight precision, so the next frontier measurement should use a concrete wider softmax datapath instead of extrapolating from standalone softmax blocks.",
+    "This proposal adds and measures one composed wrapper with q12 PWL score handling, 12-bit softmax weights, and q12 reciprocal normalization inside the same dual-stream attention datapath."
+  ],
+  "direct_comparison": {
+    "primary_question": "What PPA cost is paid when the composed dual-stream attention datapath replaces the risky S8/W8 softmax with a concrete q12/PWL reciprocal softmax?",
+    "baselines": [
+      "l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
+      "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3"
+    ],
+    "candidates": [
+      "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "required_inputs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q12_pwl.json"
+  ],
+  "evaluation_requests": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q12_pwl_softmax_quality_risk_reduction",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q12_pwl.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_quality_safer_composed_softmax_cost",
+        "reason": "The current q8 reciprocal-LUT composed point is PPA-best but quality-risky; this job measures the actual composed cost of the safer q12/PWL softmax alternative."
+      }
+    }
+  ],
+  "source_files": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "tests/test_attention_dual_stream_composed_generator.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q12_pwl.json"
+  ],
+  "created_utc": "2026-06-17T22:08:28.097270Z"
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/quality_gate.md
@@ -1,0 +1,6 @@
+# Quality Gate
+
+- `proposal_id`: `prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1`
+- `candidate_id`: `l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1`
+
+This job is a physical-cost measurement for a safer softmax datapath, not final Llama7B perplexity evidence. Promotion beyond PPA still requires a follow-on quality gate that compares the q12/PWL composed softmax behavior against the accepted mixed-precision proxy or a model-native checkpoint run.

--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -33,6 +33,8 @@ def main() -> int:
     softmax_internal_pipeline_stages = int(manifest.get("softmax_internal_pipeline_stages", 0))
     softmax_latency_stages = int(manifest.get("softmax_latency_stages", 1))
     value_alignment_delay_stages = int(manifest.get("value_alignment_delay_stages", 0))
+    softmax_score_bits = int(manifest.get("softmax_score_bits", 8))
+    softmax_weight_bits = int(manifest.get("softmax_weight_bits", 8))
     if streams != 2:
         raise SystemExit(f"expected 2 streams, found {streams}")
     if f"module {top_name} " not in top_text:
@@ -48,8 +50,12 @@ def main() -> int:
         raise SystemExit("expected exactly one shared softmax instance")
     if "stream_buf_0" not in top_text or "stream_buf_1" not in top_text:
         raise SystemExit("missing dual stream buffer registers")
-    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut"}:
+    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut", "pwl_recip_lut"}:
         raise SystemExit(f"unsupported softmax_impl={softmax_impl}")
+    if not 2 <= softmax_score_bits <= 24:
+        raise SystemExit(f"unsupported softmax_score_bits={softmax_score_bits}")
+    if not 2 <= softmax_weight_bits <= 24:
+        raise SystemExit(f"unsupported softmax_weight_bits={softmax_weight_bits}")
     if softmax_latency_stages != 1 + softmax_internal_pipeline_stages:
         raise SystemExit("softmax latency must equal output register latency plus internal pipeline stages")
     if softmax_pipeline_stages:
@@ -100,6 +106,21 @@ def main() -> int:
             raise SystemExit("reciprocal-LUT replacement must not contain pow2 denominator shift logic")
         if "/ sum_weight" in top_text or "/ sum_weight_q" in top_text:
             raise SystemExit("reciprocal-LUT replacement must not contain a sum_weight divider")
+    if softmax_impl == "pwl_recip_lut":
+        if softmax_score_bits < 12 or softmax_weight_bits < 12:
+            raise SystemExit("PWL reciprocal softmax should keep at least 12-bit scores and weights")
+        for token in (
+            "function [ACCUM_BITS-1:0] pwl_weight",
+            "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut",
+            "reciprocal_bucket",
+            "lane_scaled",
+        ):
+            if token not in top_text:
+                raise SystemExit(f"missing PWL reciprocal softmax token: {token}")
+        if "denom_shift" in top_text:
+            raise SystemExit("PWL reciprocal softmax must not contain pow2 denominator shift logic")
+        if "/ sum_weight" in top_text or "/ sum_weight_q" in top_text:
+            raise SystemExit("PWL reciprocal softmax must not contain a sum_weight divider")
     if equivalence_hash:
         if "result_hash <=" not in top_text:
             raise SystemExit("result_hash is not updated")
@@ -136,6 +157,8 @@ def main() -> int:
                 "value_streams": value_instances,
                 "equivalence_hash": equivalence_hash,
                 "softmax_impl": softmax_impl,
+                "softmax_score_bits": softmax_score_bits,
+                "softmax_weight_bits": softmax_weight_bits,
                 "softmax_pipeline_stages": softmax_pipeline_stages,
                 "softmax_internal_pipeline_stages": softmax_internal_pipeline_stages,
                 "softmax_latency_stages": softmax_latency_stages,

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +59,10 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
     softmax_internal_pipeline_stages = _as_int(comp, "softmax_internal_pipeline_stages", 0)
     softmax_impl = _as_str(comp, "softmax_impl", "exact_div")
+    softmax_score_bits = _as_int(comp, "softmax_score_bits", 8)
+    softmax_weight_bits = _as_int(comp, "softmax_weight_bits", 8)
+    softmax_input_frac_bits = _as_int(comp, "softmax_input_frac_bits", 0)
+    softmax_reciprocal_lut_bucket_shift = _as_int(comp, "softmax_reciprocal_lut_bucket_shift", 0)
     if streams != 2:
         raise SystemExit("attention_dual_stream_composed.streams must be 2 for the current dual-stream harness")
     if array_m < 1 or array_m > 16:
@@ -80,10 +85,22 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.softmax_pipeline_stages must be in [0, 1]")
     if softmax_internal_pipeline_stages < 0 or softmax_internal_pipeline_stages > 1:
         raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages must be in [0, 1]")
-    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut"}:
-        raise SystemExit("attention_dual_stream_composed.softmax_impl must be exact_div, pow2sum, or recip_lut")
+    if softmax_score_bits < 2 or softmax_score_bits > 24:
+        raise SystemExit("attention_dual_stream_composed.softmax_score_bits must be in [2, 24]")
+    if softmax_weight_bits < 2 or softmax_weight_bits > 24:
+        raise SystemExit("attention_dual_stream_composed.softmax_weight_bits must be in [2, 24]")
+    if softmax_input_frac_bits < 0 or softmax_input_frac_bits > 16:
+        raise SystemExit("attention_dual_stream_composed.softmax_input_frac_bits must be in [0, 16]")
+    if softmax_reciprocal_lut_bucket_shift < 0 or softmax_reciprocal_lut_bucket_shift > 12:
+        raise SystemExit("attention_dual_stream_composed.softmax_reciprocal_lut_bucket_shift must be in [0, 12]")
+    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut", "pwl_recip_lut"}:
+        raise SystemExit(
+            "attention_dual_stream_composed.softmax_impl must be exact_div, pow2sum, recip_lut, or pwl_recip_lut"
+        )
     if softmax_internal_pipeline_stages and softmax_impl != "exact_div":
         raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages requires exact_div")
+    if softmax_impl == "pwl_recip_lut" and softmax_internal_pipeline_stages:
+        raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages is not supported for pwl_recip_lut")
     return comp
 
 
@@ -106,34 +123,194 @@ def _softmax_module(
     row_elems: int,
     accum_bits: int,
     reciprocal_bits: int,
+    score_bits: int,
+    weight_bits: int,
+    input_frac_bits: int,
+    reciprocal_lut_bucket_shift: int,
     equivalence_hash: bool,
     implementation: str,
     internal_pipeline_stages: int,
 ) -> str:
-    data_width = row_elems * 8
-    product_bits = accum_bits + 8
+    score_row_width = row_elems * score_bits
+    weight_row_width = row_elems * weight_bits
+    output_scale = (1 << weight_bits) - 1
+    shift_exp_max_weight = 128
+    pwl_max_weight = output_scale
+    max_weight = pwl_max_weight if implementation == "pwl_recip_lut" else shift_exp_max_weight
+    product_bits = accum_bits + weight_bits
     hash_port = ",\n    output reg  [31:0]          weight_hash" if equivalence_hash else ""
     hash_reg = "  reg [31:0] next_hash;\n" if equivalence_hash else ""
     hash_init = f"    next_hash = 32'h5a5a_0101 ^ 32'h{reciprocal_bits & 0xFFFF:04x};\n" if equivalence_hash else ""
-    hash_update = "      next_hash = {next_hash[23:0], next_hash[31:24]} ^ {24'h0, lane_out};\n" if equivalence_hash else ""
+    hash_update = (
+        f"      next_hash = {{next_hash[23:0], next_hash[31:24]}} ^ "
+        f"{{{{{max(0, 32 - weight_bits)}{{1'b0}}}}, lane_out[{min(weight_bits, 32) - 1}:0]}};\n"
+        if equivalence_hash
+        else ""
+    )
     hash_seq = "    weight_hash <= next_hash;\n" if equivalence_hash else ""
-    max_sum_weight = row_elems * 128
+    max_sum_weight = row_elems * max_weight
     recip_lut_cases = "\n".join(
-        f"      {accum_bits}'d{denom}: reciprocal_lut = {reciprocal_bits + 8}'d{((127 << reciprocal_bits) + (denom >> 1)) // denom};"
+        f"      {accum_bits}'d{denom}: reciprocal_lut = {reciprocal_bits + weight_bits}'d{((output_scale << reciprocal_bits) + (denom >> 1)) // denom};"
         for denom in range(1, max_sum_weight + 1)
     )
+    if implementation == "pwl_recip_lut":
+        reciprocal_bucket_step = 1 << reciprocal_lut_bucket_shift
+        max_bucket = (max_sum_weight + reciprocal_bucket_step - 1) >> reciprocal_lut_bucket_shift
+        recip_lut_cases = "\n".join(
+            f"      {accum_bits}'d{bucket}: reciprocal_lut = {reciprocal_bits + weight_bits}'d{((output_scale << reciprocal_bits) + ((bucket << reciprocal_lut_bucket_shift) >> 1)) // (bucket << reciprocal_lut_bucket_shift)};"
+            for bucket in range(1, max_bucket + 1)
+        )
+        input_scale = 1 << input_frac_bits
+        x2 = 2 * input_scale
+        x4 = 4 * input_scale
+        x8 = 8 * input_scale
+        y0 = output_scale
+        # Rounded exp anchors match src/rtlgen/rtl_operations.cpp.
+        y2 = int(math.exp(-2.0) * output_scale + 0.5)
+        y4 = int(math.exp(-4.0) * output_scale + 0.5)
+        y8 = int(math.exp(-8.0) * output_scale + 0.5)
+        return f"""(* keep_hierarchy = 1 *)
+module {module_name} (
+    input  wire                  clk,
+    input  wire [{score_row_width - 1}:0] scores,
+    output reg  [{weight_row_width - 1}:0] weights{hash_port}
+);
+  localparam integer ROW_ELEMS = {row_elems};
+  localparam integer SCORE_BITS = {score_bits};
+  localparam integer WEIGHT_BITS = {weight_bits};
+  localparam integer ACCUM_BITS = {accum_bits};
+  localparam integer PRODUCT_BITS = {product_bits};
+  localparam integer OUTPUT_SCALE = {output_scale};
+  localparam integer RECIPROCAL_BITS = {reciprocal_bits};
+  localparam integer RECIPROCAL_WIDTH = {reciprocal_bits + weight_bits};
+  localparam integer RECIP_BUCKET_SHIFT = {reciprocal_lut_bucket_shift};
+  localparam integer PWL_X2 = {x2};
+  localparam integer PWL_X4 = {x4};
+  localparam integer PWL_X8 = {x8};
+  localparam integer PWL_Y0 = {y0};
+  localparam integer PWL_Y2 = {y2};
+  localparam integer PWL_Y4 = {y4};
+  localparam integer PWL_Y8 = {y8};
+
+  integer i;
+  integer signed lane_val;
+  integer signed row_max;
+  integer delta;
+  reg [ACCUM_BITS-1:0] exp_weight [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight;
+  reg [ACCUM_BITS-1:0] reciprocal_bucket;
+  reg [RECIPROCAL_WIDTH-1:0] reciprocal_q;
+  reg [PRODUCT_BITS+RECIPROCAL_WIDTH-1:0] lane_scaled;
+  reg [WEIGHT_BITS-1:0] lane_out;
+  reg [{weight_row_width - 1}:0] next_weights;
+{hash_reg.rstrip()}
+
+  function [ACCUM_BITS-1:0] pwl_weight;
+    input integer delta_in;
+    integer clamped_delta;
+    integer seg_x0;
+    integer seg_width;
+    integer y0_seg;
+    integer y1_seg;
+    integer ydiff;
+    reg [63:0] interp_num;
+    begin
+      clamped_delta = delta_in;
+      if (clamped_delta < 0)
+        clamped_delta = 0;
+      if (clamped_delta > PWL_X8) begin
+        pwl_weight = {{ACCUM_BITS{{1'b0}}}};
+      end else if (clamped_delta == PWL_X8) begin
+        pwl_weight = PWL_Y8;
+      end else begin
+        if (clamped_delta <= PWL_X2) begin
+          seg_x0 = 0;
+          seg_width = PWL_X2;
+          y0_seg = PWL_Y0;
+          y1_seg = PWL_Y2;
+        end else if (clamped_delta <= PWL_X4) begin
+          seg_x0 = PWL_X2;
+          seg_width = PWL_X4 - PWL_X2;
+          y0_seg = PWL_Y2;
+          y1_seg = PWL_Y4;
+        end else begin
+          seg_x0 = PWL_X4;
+          seg_width = PWL_X8 - PWL_X4;
+          y0_seg = PWL_Y4;
+          y1_seg = PWL_Y8;
+        end
+        ydiff = y0_seg - y1_seg;
+        interp_num = ((clamped_delta - seg_x0) * ydiff) + (seg_width >> 1);
+        pwl_weight = y0_seg - (interp_num / seg_width);
+      end
+    end
+  endfunction
+
+  function [RECIPROCAL_WIDTH-1:0] reciprocal_lut;
+    input [ACCUM_BITS-1:0] bucket;
+    begin
+      case (bucket)
+      {accum_bits}'d0: reciprocal_lut = {{RECIPROCAL_WIDTH{{1'b0}}}};
+{recip_lut_cases}
+      default: reciprocal_lut = {{RECIPROCAL_WIDTH{{1'b0}}}};
+      endcase
+    end
+  endfunction
+
+  always @(*) begin
+    row_max = -(1 << (SCORE_BITS - 1));
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
+      if (lane_val > row_max)
+        row_max = lane_val;
+    end
+
+    sum_weight = {{ACCUM_BITS{{1'b0}}}};
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
+      delta = row_max - lane_val;
+      if (delta < 0)
+        delta = 0;
+      exp_weight[i] = pwl_weight(delta);
+      sum_weight = sum_weight + exp_weight[i];
+    end
+
+    reciprocal_bucket = (sum_weight + {accum_bits}'d{reciprocal_bucket_step - 1}) >> RECIP_BUCKET_SHIFT;
+    reciprocal_q = reciprocal_lut(reciprocal_bucket);
+    next_weights = {{{weight_row_width}{{1'b0}}}};
+{hash_init.rstrip()}
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_scaled = (exp_weight[i] * reciprocal_q) + ({{{{(PRODUCT_BITS+RECIPROCAL_WIDTH-1){{1'b0}}}}, 1'b1}} << (RECIPROCAL_BITS - 1));
+      lane_scaled = lane_scaled >> RECIPROCAL_BITS;
+      if (lane_scaled > OUTPUT_SCALE)
+        lane_out = OUTPUT_SCALE;
+      else
+        lane_out = lane_scaled[WEIGHT_BITS-1:0];
+      next_weights[(i*WEIGHT_BITS) +: WEIGHT_BITS] = lane_out;
+{hash_update.rstrip()}
+    end
+  end
+
+  always @(posedge clk) begin
+    weights <= next_weights;
+{hash_seq.rstrip()}
+  end
+endmodule
+"""
     if internal_pipeline_stages:
         return f"""(* keep_hierarchy = 1 *)
 module {module_name} (
     input  wire                  clk,
-    input  wire [{data_width - 1}:0] scores,
-    output reg  [{data_width - 1}:0] weights{hash_port}
+    input  wire [{score_row_width - 1}:0] scores,
+    output reg  [{weight_row_width - 1}:0] weights{hash_port}
 );
   localparam integer ROW_ELEMS = {row_elems};
+  localparam integer SCORE_BITS = {score_bits};
+  localparam integer WEIGHT_BITS = {weight_bits};
   localparam integer ACCUM_BITS = {accum_bits};
   localparam integer PRODUCT_BITS = {product_bits};
   localparam integer MAX_SHIFT = 7;
-  localparam integer OUTPUT_SCALE = 127;
+  localparam integer OUTPUT_SCALE = {output_scale};
   localparam integer RECIPROCAL_BITS = {reciprocal_bits};
 
   integer i;
@@ -145,21 +322,21 @@ module {module_name} (
   reg [ACCUM_BITS-1:0] exp_weight_q [0:ROW_ELEMS-1];
   reg [ACCUM_BITS-1:0] sum_weight_q;
   reg [PRODUCT_BITS-1:0] numer;
-  reg [7:0] lane_out;
-  reg [{data_width - 1}:0] next_weights;
+  reg [WEIGHT_BITS-1:0] lane_out;
+  reg [{weight_row_width - 1}:0] next_weights;
 {hash_reg.rstrip()}
 
   always @(*) begin
-    row_max = -(1 << 7);
+    row_max = -(1 << (SCORE_BITS - 1));
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
-      lane_val = $signed(scores[(i*8) +: 8]);
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
       if (lane_val > row_max)
         row_max = lane_val;
     end
 
     sum_weight = {{ACCUM_BITS{{1'b0}}}};
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
-      lane_val = $signed(scores[(i*8) +: 8]);
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
       delta = row_max - lane_val;
       if (delta < 0)
         delta = 0;
@@ -171,17 +348,17 @@ module {module_name} (
   end
 
   always @(*) begin
-    next_weights = {{{data_width}{{1'b0}}}};
+    next_weights = {{{weight_row_width}{{1'b0}}}};
 {hash_init.rstrip()}
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
       numer = (exp_weight_q[i] * OUTPUT_SCALE) + (sum_weight_q >> 1);
       if (sum_weight_q != 0)
         lane_out = numer / sum_weight_q;
       else
-        lane_out = 8'h00;
-      if (lane_out > 8'd127)
-        lane_out = 8'd127;
-      next_weights[(i*8) +: 8] = lane_out;
+        lane_out = {{WEIGHT_BITS{{1'b0}}}};
+      if (lane_out > OUTPUT_SCALE)
+        lane_out = OUTPUT_SCALE;
+      next_weights[(i*WEIGHT_BITS) +: WEIGHT_BITS] = lane_out;
 {hash_update.rstrip()}
     end
   end
@@ -200,14 +377,16 @@ endmodule
         return f"""(* keep_hierarchy = 1 *)
 module {module_name} (
     input  wire                  clk,
-    input  wire [{data_width - 1}:0] scores,
-    output reg  [{data_width - 1}:0] weights{hash_port}
+    input  wire [{score_row_width - 1}:0] scores,
+    output reg  [{weight_row_width - 1}:0] weights{hash_port}
 );
   localparam integer ROW_ELEMS = {row_elems};
+  localparam integer SCORE_BITS = {score_bits};
+  localparam integer WEIGHT_BITS = {weight_bits};
   localparam integer ACCUM_BITS = {accum_bits};
   localparam integer PRODUCT_BITS = {product_bits};
   localparam integer MAX_SHIFT = 7;
-  localparam integer OUTPUT_SCALE = 127;
+  localparam integer OUTPUT_SCALE = {output_scale};
   localparam integer RECIPROCAL_BITS = {reciprocal_bits};
 
   integer i;
@@ -218,21 +397,21 @@ module {module_name} (
   reg [ACCUM_BITS-1:0] exp_weight [0:ROW_ELEMS-1];
   reg [ACCUM_BITS-1:0] sum_weight;
   reg [PRODUCT_BITS-1:0] lane_scaled;
-  reg [7:0] lane_out;
-  reg [{data_width - 1}:0] next_weights;
+  reg [WEIGHT_BITS-1:0] lane_out;
+  reg [{weight_row_width - 1}:0] next_weights;
 {hash_reg.rstrip()}
 
   always @(*) begin
-    row_max = -(1 << 7);
+    row_max = -(1 << (SCORE_BITS - 1));
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
-      lane_val = $signed(scores[(i*8) +: 8]);
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
       if (lane_val > row_max)
         row_max = lane_val;
     end
 
     sum_weight = {{ACCUM_BITS{{1'b0}}}};
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
-      lane_val = $signed(scores[(i*8) +: 8]);
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
       delta = row_max - lane_val;
       if (delta < 0)
         delta = 0;
@@ -248,15 +427,15 @@ module {module_name} (
         denom_shift = i + 1;
     end
 
-    next_weights = {{{data_width}{{1'b0}}}};
+    next_weights = {{{weight_row_width}{{1'b0}}}};
 {hash_init.rstrip()}
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
       lane_scaled = (exp_weight[i] * OUTPUT_SCALE) >> denom_shift;
-      if (lane_scaled > 8'd127)
-        lane_out = 8'd127;
+      if (lane_scaled > OUTPUT_SCALE)
+        lane_out = OUTPUT_SCALE;
       else
-        lane_out = lane_scaled[7:0];
-      next_weights[(i*8) +: 8] = lane_out;
+        lane_out = lane_scaled[WEIGHT_BITS-1:0];
+      next_weights[(i*WEIGHT_BITS) +: WEIGHT_BITS] = lane_out;
 {hash_update.rstrip()}
     end
   end
@@ -271,16 +450,18 @@ endmodule
         return f"""(* keep_hierarchy = 1 *)
 module {module_name} (
     input  wire                  clk,
-    input  wire [{data_width - 1}:0] scores,
-    output reg  [{data_width - 1}:0] weights{hash_port}
+    input  wire [{score_row_width - 1}:0] scores,
+    output reg  [{weight_row_width - 1}:0] weights{hash_port}
 );
   localparam integer ROW_ELEMS = {row_elems};
+  localparam integer SCORE_BITS = {score_bits};
+  localparam integer WEIGHT_BITS = {weight_bits};
   localparam integer ACCUM_BITS = {accum_bits};
   localparam integer PRODUCT_BITS = {product_bits};
   localparam integer MAX_SHIFT = 7;
-  localparam integer OUTPUT_SCALE = 127;
+  localparam integer OUTPUT_SCALE = {output_scale};
   localparam integer RECIPROCAL_BITS = {reciprocal_bits};
-  localparam integer RECIPROCAL_WIDTH = {reciprocal_bits + 8};
+  localparam integer RECIPROCAL_WIDTH = {reciprocal_bits + weight_bits};
 
   integer i;
   integer signed lane_val;
@@ -290,8 +471,8 @@ module {module_name} (
   reg [ACCUM_BITS-1:0] sum_weight;
   reg [RECIPROCAL_WIDTH-1:0] reciprocal_q;
   reg [PRODUCT_BITS+RECIPROCAL_WIDTH-1:0] lane_scaled;
-  reg [7:0] lane_out;
-  reg [{data_width - 1}:0] next_weights;
+  reg [WEIGHT_BITS-1:0] lane_out;
+  reg [{weight_row_width - 1}:0] next_weights;
 {hash_reg.rstrip()}
 
   function [RECIPROCAL_WIDTH-1:0] reciprocal_lut;
@@ -305,16 +486,16 @@ module {module_name} (
   endfunction
 
   always @(*) begin
-    row_max = -(1 << 7);
+    row_max = -(1 << (SCORE_BITS - 1));
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
-      lane_val = $signed(scores[(i*8) +: 8]);
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
       if (lane_val > row_max)
         row_max = lane_val;
     end
 
     sum_weight = {{ACCUM_BITS{{1'b0}}}};
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
-      lane_val = $signed(scores[(i*8) +: 8]);
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
       delta = row_max - lane_val;
       if (delta < 0)
         delta = 0;
@@ -325,16 +506,16 @@ module {module_name} (
     end
 
     reciprocal_q = reciprocal_lut(sum_weight);
-    next_weights = {{{data_width}{{1'b0}}}};
+    next_weights = {{{weight_row_width}{{1'b0}}}};
 {hash_init.rstrip()}
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
       lane_scaled = (exp_weight[i] * reciprocal_q) + ({{{{(PRODUCT_BITS+RECIPROCAL_WIDTH-1){{1'b0}}}}, 1'b1}} << (RECIPROCAL_BITS - 1));
       lane_scaled = lane_scaled >> RECIPROCAL_BITS;
-      if (lane_scaled > 8'd127)
-        lane_out = 8'd127;
+      if (lane_scaled > OUTPUT_SCALE)
+        lane_out = OUTPUT_SCALE;
       else
-        lane_out = lane_scaled[7:0];
-      next_weights[(i*8) +: 8] = lane_out;
+        lane_out = lane_scaled[WEIGHT_BITS-1:0];
+      next_weights[(i*WEIGHT_BITS) +: WEIGHT_BITS] = lane_out;
 {hash_update.rstrip()}
     end
   end
@@ -348,14 +529,16 @@ endmodule
     return f"""(* keep_hierarchy = 1 *)
 module {module_name} (
     input  wire                  clk,
-    input  wire [{data_width - 1}:0] scores,
-    output reg  [{data_width - 1}:0] weights{hash_port}
+    input  wire [{score_row_width - 1}:0] scores,
+    output reg  [{weight_row_width - 1}:0] weights{hash_port}
 );
   localparam integer ROW_ELEMS = {row_elems};
+  localparam integer SCORE_BITS = {score_bits};
+  localparam integer WEIGHT_BITS = {weight_bits};
   localparam integer ACCUM_BITS = {accum_bits};
   localparam integer PRODUCT_BITS = {product_bits};
   localparam integer MAX_SHIFT = 7;
-  localparam integer OUTPUT_SCALE = 127;
+  localparam integer OUTPUT_SCALE = {output_scale};
   localparam integer RECIPROCAL_BITS = {reciprocal_bits};
 
   integer i;
@@ -365,21 +548,21 @@ module {module_name} (
   reg [ACCUM_BITS-1:0] exp_weight [0:ROW_ELEMS-1];
   reg [ACCUM_BITS-1:0] sum_weight;
   reg [PRODUCT_BITS-1:0] numer;
-  reg [7:0] lane_out;
-  reg [{data_width - 1}:0] next_weights;
+  reg [WEIGHT_BITS-1:0] lane_out;
+  reg [{weight_row_width - 1}:0] next_weights;
 {hash_reg.rstrip()}
 
   always @(*) begin
-    row_max = -(1 << 7);
+    row_max = -(1 << (SCORE_BITS - 1));
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
-      lane_val = $signed(scores[(i*8) +: 8]);
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
       if (lane_val > row_max)
         row_max = lane_val;
     end
 
     sum_weight = {{ACCUM_BITS{{1'b0}}}};
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
-      lane_val = $signed(scores[(i*8) +: 8]);
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
       delta = row_max - lane_val;
       if (delta < 0)
         delta = 0;
@@ -389,17 +572,17 @@ module {module_name} (
       sum_weight = sum_weight + exp_weight[i];
     end
 
-    next_weights = {{{data_width}{{1'b0}}}};
+    next_weights = {{{weight_row_width}{{1'b0}}}};
 {hash_init.rstrip()}
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
       numer = (exp_weight[i] * OUTPUT_SCALE) + (sum_weight >> 1);
       if (sum_weight != 0)
         lane_out = numer / sum_weight;
       else
-        lane_out = 8'h00;
-      if (lane_out > 8'd127)
-        lane_out = 8'd127;
-      next_weights[(i*8) +: 8] = lane_out;
+        lane_out = {{WEIGHT_BITS{{1'b0}}}};
+      if (lane_out > OUTPUT_SCALE)
+        lane_out = OUTPUT_SCALE;
+      next_weights[(i*WEIGHT_BITS) +: WEIGHT_BITS] = lane_out;
 {hash_update.rstrip()}
     end
   end
@@ -416,23 +599,26 @@ def _value_stream_module(
     *,
     module_name: str,
     row_elems: int,
+    weight_bits: int,
     value_lanes: int,
     stream_buffer_bits: int,
     equivalence_hash: bool,
 ) -> str:
     acc_bits = 40
-    product_bits = 16
+    product_bits = 6 + weight_bits + 1
     fold_terms = ["32'h0000_0000"]
     product_lines: list[str] = []
+    fold_pad_bits = max(0, 32 - product_bits)
     for lane in range(value_lanes):
         product_lines.extend(
             [
                 f"  wire signed [5:0] value_{lane:02d} = stream_data[{(lane * 6) % (stream_buffer_bits - 5)} +: 6];",
-                f"  wire signed [7:0] weight_{lane:02d} = weights[{(lane % row_elems) * 8} +: 8];",
-                f"  wire signed [{product_bits - 1}:0] product_{lane:02d} = value_{lane:02d} * weight_{lane:02d};",
+                f"  wire [{weight_bits - 1}:0] weight_{lane:02d} = weights[{(lane % row_elems) * weight_bits} +: {weight_bits}];",
+                f"  wire signed [{weight_bits}:0] weight_{lane:02d}_signed = {{1'b0, weight_{lane:02d}}};",
+                f"  wire signed [{product_bits - 1}:0] product_{lane:02d} = value_{lane:02d} * weight_{lane:02d}_signed;",
             ]
         )
-        fold_terms.append(f"{{16'h0, product_{lane:02d}}}")
+        fold_terms.append(f"{{{{{fold_pad_bits}{{1'b0}}}}, product_{lane:02d}}}")
     sum_terms = [
         f"{{{{{acc_bits - product_bits}{{product_{lane:02d}[{product_bits - 1}]}}}}, product_{lane:02d}}}"
         for lane in range(value_lanes)
@@ -449,7 +635,7 @@ def _value_stream_module(
 module {module_name} (
     input  wire                  clk,
     input  wire [{stream_buffer_bits - 1}:0] stream_data,
-    input  wire [{row_elems * 8 - 1}:0] weights,
+    input  wire [{row_elems * weight_bits - 1}:0] weights,
     input  wire [23:0]           score_mix,
     output reg  [{acc_bits - 1}:0] value_accum{hash_port}
 );
@@ -477,6 +663,10 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     partials_per_cycle = _as_int(comp, "partials_per_cycle", 2)
     reciprocal_bits = _as_int(comp, "reciprocal_bits", 10)
     accum_bits = _as_int(comp, "softmax_accum_bits", 24)
+    softmax_score_bits = _as_int(comp, "softmax_score_bits", 8)
+    softmax_weight_bits = _as_int(comp, "softmax_weight_bits", 8)
+    softmax_input_frac_bits = _as_int(comp, "softmax_input_frac_bits", 0)
+    softmax_reciprocal_lut_bucket_shift = _as_int(comp, "softmax_reciprocal_lut_bucket_shift", 0)
     stream_buffer_bits = _as_int(comp, "stream_buffer_bits", 1024)
     equivalence_hash = _as_bool(comp, "equivalence_hash", False)
     softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
@@ -487,7 +677,13 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     macs_per_stream = array_m * array_n * k_unroll
     streams = 2
     total_macs = streams * macs_per_stream
-    softmax_name = "attention_softmax_weight_int8_r8_acc24_recip_q10_like"
+    softmax_score_row_width = row_elems * softmax_score_bits
+    softmax_weight_row_width = row_elems * softmax_weight_bits
+    softmax_name = (
+        "attention_softmax_weight_q12_pwl_recip_like"
+        if softmax_impl == "pwl_recip_lut"
+        else "attention_softmax_weight_int8_r8_acc24_recip_q10_like"
+    )
     value_name = "attention_full_value_stream_q8v6_p8_ppc2"
 
     stream_regs = [f"  reg [{stream_buffer_bits - 1}:0] stream_buf_{stream};" for stream in range(streams)]
@@ -504,8 +700,8 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     softmax_pipe_update = ""
     softmax_scores_for_softmax = "softmax_scores"
     if softmax_pipeline_stages:
-        softmax_pipe_regs = f"  reg [{row_elems * 8 - 1}:0] softmax_scores_pipe_0;\n"
-        softmax_pipe_reset = f"      softmax_scores_pipe_0 <= {{{row_elems * 8}{{1'b0}}}};\n"
+        softmax_pipe_regs = f"  reg [{softmax_score_row_width - 1}:0] softmax_scores_pipe_0;\n"
+        softmax_pipe_reset = f"      softmax_scores_pipe_0 <= {{{softmax_score_row_width}{{1'b0}}}};\n"
         softmax_pipe_update = "      softmax_scores_pipe_0 <= softmax_scores;\n"
         softmax_scores_for_softmax = "softmax_scores_pipe_0"
 
@@ -558,14 +754,14 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     .R(mac_r_{flat:04d})
   );"""
             )
-            score_lane_terms[idx % row_elems].append(f"mac_r_{flat:04d}[7:0]")
+            score_lane_terms[idx % row_elems].append(f"mac_r_{flat:04d}[{softmax_score_bits - 1}:0]")
             score_mix_terms[stream].append(f"mac_r_{flat:04d}")
             compute_fold_terms.append(f"{{8'h00, mac_r_{flat:04d}}}")
 
     score_assigns = []
     for lane, terms in enumerate(score_lane_terms):
-        expr = " ^ ".join(terms or ["8'h00"])
-        score_assigns.append(f"  wire [7:0] score_lane_{lane:02d} = {expr};")
+        expr = " ^ ".join(terms or [f"{softmax_score_bits}'h0"])
+        score_assigns.append(f"  wire [{softmax_score_bits - 1}:0] score_lane_{lane:02d} = {expr};")
     score_row_concat = ", ".join(f"score_lane_{lane:02d}" for lane in reversed(range(row_elems)))
     compute_fold_expr = " ^\n      ".join(compute_fold_terms)
     score_mix_exprs = [" ^\n      ".join(terms) for terms in score_mix_terms]
@@ -581,7 +777,7 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     else:
         top_ports.extend(
             [
-                f"    output reg  [{row_elems * 8 - 1}:0] softmax_weights_out",
+                f"    output reg  [{softmax_weight_row_width - 1}:0] softmax_weights_out",
                 "    output reg  [39:0] value_accum_0_out",
                 "    output reg  [39:0] value_accum_1_out",
                 "    output reg  [23:0] score_mix_0_out",
@@ -597,7 +793,7 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     value_hash_conn_0 = ",\n    .value_hash(value_hash_0)" if equivalence_hash else ""
     value_hash_conn_1 = ",\n    .value_hash(value_hash_1)" if equivalence_hash else ""
     reset_hash = "      result_hash <= 32'h0;\n" if equivalence_hash else ""
-    reset_ppa_outputs = "" if equivalence_hash else f"""      softmax_weights_out <= {{{row_elems * 8}{{1'b0}}}};
+    reset_ppa_outputs = "" if equivalence_hash else f"""      softmax_weights_out <= {{{softmax_weight_row_width}{{1'b0}}}};
       value_accum_0_out <= 40'h0;
       value_accum_1_out <= 40'h0;
       score_mix_0_out <= 24'h0;
@@ -645,8 +841,8 @@ module {top_name} (
 {chr(10).join(mac_insts)}
 
 {chr(10).join(score_assigns)}
-  wire [{row_elems * 8 - 1}:0] softmax_scores = {{{score_row_concat}}};
-  wire [{row_elems * 8 - 1}:0] softmax_weights;
+  wire [{softmax_score_row_width - 1}:0] softmax_scores = {{{score_row_concat}}};
+  wire [{softmax_weight_row_width - 1}:0] softmax_weights;
 {softmax_hash_wire.rstrip()}
 {compute_fold_wire.rstrip()}
   wire [23:0] score_mix_0 =
@@ -713,6 +909,10 @@ endmodule
                 row_elems=row_elems,
                 accum_bits=accum_bits,
                 reciprocal_bits=reciprocal_bits,
+                score_bits=softmax_score_bits,
+                weight_bits=softmax_weight_bits,
+                input_frac_bits=softmax_input_frac_bits,
+                reciprocal_lut_bucket_shift=softmax_reciprocal_lut_bucket_shift,
                 equivalence_hash=equivalence_hash,
                 implementation=softmax_impl,
                 internal_pipeline_stages=softmax_internal_pipeline_stages,
@@ -720,6 +920,7 @@ endmodule
             _value_stream_module(
                 module_name=value_name,
                 row_elems=row_elems,
+                weight_bits=softmax_weight_bits,
                 value_lanes=value_lanes,
                 stream_buffer_bits=stream_buffer_bits,
                 equivalence_hash=equivalence_hash,
@@ -740,6 +941,10 @@ endmodule
         "total_macs": total_macs,
         "softmax_row_elems": row_elems,
         "softmax_accum_bits": accum_bits,
+        "softmax_score_bits": softmax_score_bits,
+        "softmax_weight_bits": softmax_weight_bits,
+        "softmax_input_frac_bits": softmax_input_frac_bits,
+        "softmax_reciprocal_lut_bucket_shift": softmax_reciprocal_lut_bucket_shift,
         "reciprocal_bits": reciprocal_bits,
         "value_bits": 6,
         "value_lanes_per_stream": value_lanes,
@@ -754,7 +959,11 @@ endmodule
         "value_alignment_delay_stages": value_delay_stages,
         "components": {
             "compute": "two signed-int8 dense GEMM streams",
-            "softmax_weight": "one shared rowwise int8 shift-exp reciprocal-normalized generator",
+            "softmax_weight": (
+                "one shared q12 PWL reciprocal-normalized generator"
+                if softmax_impl == "pwl_recip_lut"
+                else "one shared rowwise int8 shift-exp reciprocal-normalized generator"
+            ),
             "full_value": "two q8/v6 weighted-value streams",
             "control": "start/done, seed LFSR, per-stream buffer registers",
         },

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q12_pwl.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q12_pwl.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q12_pwl"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q12_pwl"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.30,
+      0.40
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q12_pwl_recip_like attention_full_value_stream_q8v6_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_q12_pwl"
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json
@@ -1,0 +1,24 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 12,
+    "softmax_weight_bits": 12,
+    "softmax_input_frac_bits": 8,
+    "softmax_accum_bits": 28,
+    "reciprocal_bits": 12,
+    "softmax_reciprocal_lut_bucket_shift": 8,
+    "value_bits": 6,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "pwl_recip_lut"
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -11,6 +11,10 @@ def _write_config(
     softmax_pipeline_stages: int | None = None,
     softmax_internal_pipeline_stages: int | None = None,
     softmax_impl: str | None = None,
+    softmax_score_bits: int | None = None,
+    softmax_weight_bits: int | None = None,
+    softmax_input_frac_bits: int | None = None,
+    softmax_reciprocal_lut_bucket_shift: int | None = None,
 ) -> None:
     comp = {
         "streams": 2,
@@ -34,6 +38,14 @@ def _write_config(
         comp["softmax_internal_pipeline_stages"] = softmax_internal_pipeline_stages
     if softmax_impl is not None:
         comp["softmax_impl"] = softmax_impl
+    if softmax_score_bits is not None:
+        comp["softmax_score_bits"] = softmax_score_bits
+    if softmax_weight_bits is not None:
+        comp["softmax_weight_bits"] = softmax_weight_bits
+    if softmax_input_frac_bits is not None:
+        comp["softmax_input_frac_bits"] = softmax_input_frac_bits
+    if softmax_reciprocal_lut_bucket_shift is not None:
+        comp["softmax_reciprocal_lut_bucket_shift"] = softmax_reciprocal_lut_bucket_shift
     config_path.parent.mkdir(parents=True)
     config_path.write_text(
         json.dumps(
@@ -200,3 +212,31 @@ def test_attention_dual_stream_composed_generator_softmax_recip_lut_replacement(
     assert "/ sum_weight_q" not in top_text
     assert "denom_shift" not in top_text
     assert ".stream_data(stream_buf_0_pipe_1)" in top_text
+
+
+def test_attention_dual_stream_composed_generator_q12_pwl_softmax(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_q12_pwl"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="pwl_recip_lut",
+        softmax_score_bits=12,
+        softmax_weight_bits=12,
+        softmax_input_frac_bits=8,
+        softmax_reciprocal_lut_bucket_shift=8,
+    )
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["softmax_impl"] == "pwl_recip_lut"
+    assert manifest["softmax_score_bits"] == 12
+    assert manifest["softmax_weight_bits"] == 12
+    assert manifest["softmax_input_frac_bits"] == 8
+    assert manifest["softmax_reciprocal_lut_bucket_shift"] == 8
+    assert "attention_softmax_weight_q12_pwl_recip_like" in top_text
+    assert "function [ACCUM_BITS-1:0] pwl_weight" in top_text
+    assert "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut" in top_text
+    assert "wire [47:0] softmax_weights" in top_text
+    assert "wire [11:0] score_lane_00" in top_text
+    assert "wire [11:0] weight_00" in top_text


### PR DESCRIPTION
## Summary
- add q12/PWL reciprocal softmax support to the composed dual-stream attention generator
- parameterize composed softmax score/weight widths and value-stream weight wiring
- add a full-size q12/PWL composed datapath config, OpenROAD sweep, and proposal for L1 PPA measurement

## Validation
- PYTHONPATH=. pytest -q tests/test_attention_dual_stream_composed_generator.py
- PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l1_task_generator.py -k 'attention_dual_stream_composed_configs'
- PYTHONPATH=.:control_plane python3 scripts/validate_runs.py --skip_eval_queue
- full-size q12/PWL RTL generation + composed guard + iverilog elaboration

## Next job after merge
Dispatch l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1 to measure the concrete composed q12/PWL softmax PPA cost against the current q8 reciprocal-LUT composed frontier.