### PR TITLE
Prepare q12 PWL composed softmax L2 frontier

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5364,12 +5364,18 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         "runs/designs/activations/"
         "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
     )
+    q12_pwl_frontier = "q12_pwl_softmax_frontier" in item_id
+    variant_frontier = "variant_frontier" in item_id
     composed_dual_stream_metrics = (
         "runs/designs/npu_blocks/"
         "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv"
     )
-    variant_frontier = "variant_frontier" in item_id
-    if variant_frontier:
+    if q12_pwl_frontier:
+        composed_dual_stream_metrics = (
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/metrics.csv"
+        )
+    elif variant_frontier:
         composed_dual_stream_metrics = (
             "runs/designs/npu_blocks/"
             "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q8/metrics.csv,"
@@ -5383,14 +5389,22 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         for path in composed_dual_stream_metrics.split(",")
     )
     model_name = (
-        "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
-        if variant_frontier
-        else "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
+        "llm_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1"
+        if q12_pwl_frontier
+        else (
+            "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
+            if variant_frontier
+            else "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
+        )
     )
     precision_profile = (
-        "q8_k8_v6_a24_s8_w8_recip_lut_variant_int8_compute"
-        if variant_frontier
-        else "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
+        "q8_k8_v6_a24_s12_w12_pwl_recip_q12_int8_compute"
+        if q12_pwl_frontier
+        else (
+            "q8_k8_v6_a24_s8_w8_recip_lut_variant_int8_compute"
+            if variant_frontier
+            else "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
+        )
     )
     return {
         "inputs": {
@@ -5402,7 +5416,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
             "attention_composed_datapath_physical_feasibility_out": out,
             "attention_composed_datapath_physical_feasibility_report": report,
             "attention_composed_datapath_physical_feasibility_scope": (
-                "Use the composed dual-stream RTL wrapper PPA (q8/k8/v6 softmax-recip-q10 with two int8 streams) "
+                "Use the composed dual-stream RTL wrapper PPA "
                 "as a bounded next-step feasibility model, replacing separate full-value/softmax substitutions "
                 "while keeping the upstream source schedule."
             ),

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5813,6 +5813,59 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_variant_fron
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_q12_pwl_frontier_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1"
+                in run
+            )
+            assert "--precision-profile q8_k8_v6_a24_s12_w12_pwl_recip_q12_int8_compute" in run
+            composed_dual_stream_metrics = decoder_inputs["attention_kv_composed_dual_stream_metrics"]
+            assert composed_dual_stream_metrics == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/metrics.csv"
+            )
+            assert (
+                "--composed-dual-stream-metrics runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/metrics.csv "
+                in run
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_v1/README.md
@@ -1,0 +1,21 @@
+# Q12/PWL Composed Softmax Frontier
+
+This proposal prepares the dependent Layer2 substitution job for the concrete
+q12/PWL reciprocal softmax composed attention wrapper.
+
+The prerequisite Layer1 item is:
+
+- `l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1`
+
+The Layer2 item prepared here is:
+
+- `l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1`
+
+It should run only after the q12/PWL wrapper metrics are materialized at:
+
+- `runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/metrics.csv`
+
+The job keeps the existing Llama7B subtile schedule, HBM/SRAM/NoC assumptions,
+and workload constant, then substitutes the measured q12/PWL composed wrapper
+clock, area, and power into the same feasibility estimator used by the current
+reciprocal-LUT composed frontier.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_v1",
+  "source_commit": "8056be02f4213315da61f6d34586e8cd42ea5baa",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Substitute the measured q12/PWL composed dual-stream attention wrapper into the Llama7B subtile schedule and rank latency, area, energy, and precision-risk against the current composed frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "frontier_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+        "l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_q12_pwl_composed_softmax_frontier",
+        "reason": "Identify whether the q12/PWL composed softmax wrapper improves precision-risk posture enough to justify its measured PPA cost in the Llama7B attention frontier."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_v1/proposal.json
@@ -1,0 +1,61 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_v1",
+  "created_utc": "2026-06-17T22:35:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Q12/PWL composed softmax frontier substitution for Llama7B attention",
+  "hypothesis": "The composed q12/PWL reciprocal softmax wrapper can reduce the precision risk of the current q8/q10/q12 reciprocal-LUT composed frontier, but it must be ranked with its measured clock, area, and power before it can replace the current Llama7B attention datapath point.",
+  "direct_comparison": {
+    "primary_question": "After the q12/PWL composed dual-stream wrapper PPA is measured, what Llama7B attention latency, area, energy, and precision-risk point does it produce under the same subtile schedule?",
+    "include": [
+      "Use l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1 as the source schedule.",
+      "Use the measured q12/PWL composed dual-stream wrapper metrics from l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1.",
+      "Scale source schedule rows by the measured q12/PWL wrapper clock and area.",
+      "Report the substituted wrapper label, adjusted feasible latency, area fit, power, and remaining precision-risk provenance."
+    ],
+    "exclude": [
+      "Do not run new OpenROAD PPA in this L2 job.",
+      "Do not change HBM, SRAM, NoC, KV sharing, or Llama7B workload assumptions.",
+      "Do not treat proxy quality as final real-checkpoint Llama7B quality."
+    ]
+  },
+  "expected_benefit": [
+    "Makes the q12/PWL precision-risk mitigation comparable to the current measured composed reciprocal-LUT frontier.",
+    "Allows the Llama7B frontier to move away from the risky s8/w8 softmax format if the measured PPA tradeoff is acceptable.",
+    "Keeps the dependency on a concrete RTL/PPA artifact explicit."
+  ],
+  "risks": [
+    "The prerequisite q12/PWL L1 PPA job is still waiting on the remote evaluator.",
+    "The result remains an L2 substitution of a measured wrapper into a schedule rather than full whole-attention RTL integration.",
+    "Real Llama7B checkpoint quality remains future work."
+  ],
+  "needs_mapper_change": true,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "q12_pwl_composed_softmax_frontier",
+      "cost_class": "small_after_l1_metrics",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+        "l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_q12_pwl_composed_softmax_frontier",
+        "reason": "The result should quantify whether the q12/PWL composed wrapper can become the least-abstract Llama7B attention datapath point once its measured PPA is available."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/metrics.csv",
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/proposal.json",
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -82,6 +82,8 @@ def _best_ok_compute_metrics(path: Path) -> JsonDict:
 
 def _infer_composed_precision_profile(path: Path) -> str:
     path_text = str(path)
+    if "softmax_q12_pwl_recip_q12" in path_text:
+        return "q12_pwl"
     match = re.search(r"softmax_recip_lut_(q\d+)", path_text)
     if match:
         return match.group(1)

--- a/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -202,3 +202,51 @@ def test_multi_composed_wrapper_variants_use_effective_variant_clock(tmp_path: P
     # source schedule latency is 100 us, so the q12 clock is 2/4 => 50 us
     assert result["diagnosis"]["best_requested_adjusted_latency_us_if_feasible"] == 50.0
     assert result["diagnosis"]["best_feasible_latency_us"] == 50.0
+
+
+def test_composed_q12_pwl_wrapper_variant_label_is_concise(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    _write_json(
+        source,
+        {
+            "model": "unit_source",
+            "best_by_compute_mode": [
+                {
+                    "compute_mode": "dual_mac",
+                    "latency_us": 100.0,
+                    "latency_speedup_vs_hbm_closed_source": 4.0,
+                    "tile_service_cycles": 12,
+                    "cluster_count": 1,
+                    "compute_area_multiplier": 1.0,
+                    "compute_area_um2": 120.0,
+                    "compute_budget_um2": 1000.0,
+                    "measured_l1_overhead_area_um2": 20.0,
+                    "local_datapath_area_um2": 10.0,
+                    "softmax_weight_generator_area_um2": 5.0,
+                    "logic_area_used_um2": 150.0,
+                    "required_stream_buffer_bytes": 16,
+                    "available_local_capacity_bytes": 32,
+                    "measured_block_area_um2": 120.0,
+                    "measured_block_clock_ns": 4.0,
+                    "measured_block_macs_per_cycle": 128,
+                    "measured_block_power_mw": 4.0,
+                    "compute_replica_count": 1,
+                    "compute_arch": "dense_gemm_16x8_k1_p1",
+                    "macs_per_cycle": 128,
+                    "clock_ns": 4.0,
+                }
+            ],
+        },
+    )
+    metrics = (
+        tmp_path
+        / "runs/designs/npu_blocks"
+        / "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12"
+        / "metrics.csv"
+    )
+    _write_metrics(metrics, die_area=30.0, power_mw=0.7, instance_area=28.0)
+
+    result = build_report(_args(tmp_path, source=source, composed_metrics=[str(metrics)]))
+
+    assert result["diagnosis"]["best_requested_substituted_compute_variant_label"] == "q12_pwl"
+    assert result["best_requested"]["substituted_compute_variant_label"] == "q12_pwl"


### PR DESCRIPTION
## Summary
- Add a q12/PWL composed-softmax L2 frontier item path that consumes the measured q12/PWL composed dual-stream metrics artifact.
- Label q12/PWL composed metrics as `q12_pwl` in the feasibility estimator output.
- Add proposal metadata for the dependent L2 job, gated on the L1 q12/PWL PPA result.

## Validation
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k 'composed_datapath'`
- `PYTHONPATH=. pytest -q tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py`
- `PYTHONPATH=.:control_plane python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

## Notes
- This does not dispatch the L2 job yet. It should run after `l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1` materializes metrics.