### PR TITLE
Report worker source reconciliation progress

### DIFF
--- a/control_plane/control_plane/services/worker_daemon.py
+++ b/control_plane/control_plane/services/worker_daemon.py
@@ -17,7 +17,8 @@ from control_plane.services.source_reconciler import (
     reconcile_service_repo_source,
     reexec_current_process,
 )
-from control_plane.services.lease_service import expire_stale_leases
+from control_plane.models.worker_machines import WorkerMachine
+from control_plane.services.lease_service import expire_stale_leases, upsert_worker_machine
 from control_plane.services.worker_service import run_worker
 from control_plane.workers.executor import WorkerConfig, WorkerLoopResult
 
@@ -60,6 +61,40 @@ def _dispose_session_engine(session_factory: sessionmaker, logger: Callable[[str
 
 def _is_retryable_db_error(exc: Exception) -> bool:
     return isinstance(exc, (OperationalError, DBAPIError))
+
+
+def _record_daemon_progress(
+    session_factory: sessionmaker,
+    *,
+    config: WorkerDaemonConfig,
+    progress: dict[str, object],
+    logger: Callable[[str], None],
+) -> None:
+    """Persist daemon-level progress for work that happens before a lease exists."""
+
+    try:
+        with session_factory() as session:
+            machine = (
+                session.query(WorkerMachine)
+                .filter(WorkerMachine.machine_key == config.worker.machine_key)
+                .one_or_none()
+            )
+            capabilities = dict(machine.capabilities or {}) if machine is not None else {}
+            if not capabilities:
+                capabilities.update(config.worker.capabilities or {})
+            capabilities["last_progress"] = progress
+            upsert_worker_machine(
+                session,
+                machine_key=config.worker.machine_key,
+                hostname=config.worker.hostname,
+                executor_kind=config.worker.executor_kind,
+                capabilities=capabilities,
+                role=config.worker.machine_role,
+                slot_capacity=config.worker.slot_capacity,
+            )
+            session.commit()
+    except Exception as exc:  # pragma: no cover - progress reporting must not stop work
+        logger(f"worker-daemon progress_update_error phase={progress.get('phase')} error={exc}")
 
 
 def _run_parallel_batch(
@@ -114,6 +149,18 @@ def _reconcile_next_item_source(
         return None
 
     required_sha = str(item.source_commit or "").strip()
+    _record_daemon_progress(
+        session_factory,
+        config=config,
+        logger=logger,
+        progress={
+            "phase": "source_reconcile",
+            "status": "checking",
+            "item_id": item.item_id,
+            "required_sha": required_sha,
+            "update_ref": config.source_update_ref,
+        },
+    )
     try:
         result = reconcile_service_repo_source(
             repo_root=config.worker.repo_root,
@@ -125,6 +172,18 @@ def _reconcile_next_item_source(
         logger(
             "worker-daemon source_reconcile_error "
             f"item_id={item.item_id} required_sha={required_sha} error={exc}"
+        )
+        _record_daemon_progress(
+            session_factory,
+            config=config,
+            logger=logger,
+            progress={
+                "phase": "source_reconcile_error",
+                "status": "error",
+                "item_id": item.item_id,
+                "required_sha": required_sha,
+                "error": str(exc),
+            },
         )
         return WorkerLoopResult(
             status="source_reconcile_error",
@@ -140,6 +199,21 @@ def _reconcile_next_item_source(
         f"item_id={item.item_id} status={result.status} "
         f"required_sha={result.required_sha} current_sha={result.current_sha} "
         f"relation={result.source_commit_relation} message={result.message or ''}"
+    )
+    _record_daemon_progress(
+        session_factory,
+        config=config,
+        logger=logger,
+        progress={
+            "phase": "source_reconcile",
+            "status": result.status,
+            "item_id": item.item_id,
+            "required_sha": result.required_sha,
+            "current_sha": result.current_sha,
+            "relation": result.source_commit_relation,
+            "message": result.message,
+            "restart_required": result.restart_required,
+        },
     )
     if result.status == "updated" and result.restart_required and config.restart_on_source_update:
         logger("worker-daemon source_reconcile reexec reason=service_repo_updated")

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -19,9 +19,11 @@ from control_plane.models.run_events import RunEvent
 from control_plane.models.runs import Run
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
+from control_plane.models.worker_machines import WorkerMachine
 from control_plane.services.completion_service import CompletionProcessResult, CompletionProcessingError
 from control_plane.services.lease_service import upsert_worker_machine
 from control_plane.services.scheduler import assign_work_item
+from control_plane.services.source_reconciler import SourceReconciliationError, SourceReconciliationResult
 from control_plane.services.worker_daemon import WorkerDaemonConfig, run_worker_daemon
 from control_plane.workers.checkout import CheckoutInfo
 from control_plane.workers.executor import (
@@ -391,6 +393,113 @@ def test_worker_daemon_updates_service_repo_before_leasing_required_source() -> 
         with Session(engine) as session:
             item = session.query(WorkItem).filter_by(item_id="daemon_item_source_update").one()
             assert item.state == WorkItemState.READY
+
+
+def test_worker_daemon_records_blocked_source_reconcile_progress() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            _seed_ready_work_item(
+                session,
+                item_id="daemon_item_source_blocked",
+                repo_root=repo_root,
+                assigned_machine_key="daemon-worker-source-blocked",
+                source_commit="deadbeef",
+            )
+
+        session_factory = build_session_factory(engine)
+        with patch(
+            "control_plane.services.worker_daemon.reconcile_service_repo_source",
+            return_value=SourceReconciliationResult(
+                status="blocked",
+                required_sha="deadbeef",
+                current_sha="cafebabe",
+                source_commit_relation="missing",
+                message="required source commit is not reachable",
+            ),
+        ):
+            result = run_worker_daemon(
+                session_factory,
+                config=WorkerDaemonConfig(
+                    worker=WorkerConfig(
+                        repo_root=str(repo_root),
+                        machine_key="daemon-worker-source-blocked",
+                        capabilities={"platform": "nangate45", "flow": "openroad"},
+                        capability_filter={"platform": "nangate45", "flow": "openroad"},
+                        heartbeat_seconds=1,
+                    ),
+                    poll_seconds=0,
+                    max_polls=1,
+                    auto_update_source=True,
+                    restart_on_source_update=False,
+                ),
+            )
+
+        assert [row.status for row in result.results] == ["source_blocked"]
+        with Session(engine) as session:
+            machine = session.query(WorkerMachine).filter_by(machine_key="daemon-worker-source-blocked").one()
+            progress = machine.capabilities["last_progress"]
+            assert progress["phase"] == "source_reconcile"
+            assert progress["status"] == "blocked"
+            assert progress["item_id"] == "daemon_item_source_blocked"
+            assert progress["required_sha"] == "deadbeef"
+            assert progress["current_sha"] == "cafebabe"
+            assert progress["relation"] == "missing"
+
+
+def test_worker_daemon_records_source_reconcile_error_progress() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            _seed_ready_work_item(
+                session,
+                item_id="daemon_item_source_error",
+                repo_root=repo_root,
+                assigned_machine_key="daemon-worker-source-error",
+                source_commit="deadbeef",
+            )
+
+        session_factory = build_session_factory(engine)
+        with patch(
+            "control_plane.services.worker_daemon.reconcile_service_repo_source",
+            side_effect=SourceReconciliationError("fetch failed"),
+        ):
+            result = run_worker_daemon(
+                session_factory,
+                config=WorkerDaemonConfig(
+                    worker=WorkerConfig(
+                        repo_root=str(repo_root),
+                        machine_key="daemon-worker-source-error",
+                        capabilities={"platform": "nangate45", "flow": "openroad"},
+                        capability_filter={"platform": "nangate45", "flow": "openroad"},
+                        heartbeat_seconds=1,
+                    ),
+                    poll_seconds=0,
+                    max_polls=1,
+                    auto_update_source=True,
+                    restart_on_source_update=False,
+                ),
+            )
+
+        assert [row.status for row in result.results] == ["source_reconcile_error"]
+        with Session(engine) as session:
+            machine = session.query(WorkerMachine).filter_by(machine_key="daemon-worker-source-error").one()
+            progress = machine.capabilities["last_progress"]
+            assert progress["phase"] == "source_reconcile_error"
+            assert progress["status"] == "error"
+            assert progress["item_id"] == "daemon_item_source_error"
+            assert progress["required_sha"] == "deadbeef"
+            assert progress["error"] == "fetch failed"
 
 
 def test_worker_daemon_executes_two_items_with_concurrency() -> None:


### PR DESCRIPTION
## Summary
- persist daemon-level `last_progress` while source reconciliation runs before lease acquisition
- report blocked source reconciliation and source reconciliation exceptions through worker machine capabilities
- add worker-daemon coverage for blocked/error source reconciliation progress

## Validation
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_worker_daemon.py -k source`
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_worker_daemon.py`
- `PYTHONPATH=.:control_plane python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

## Context
This should make the evaluator-side pre-lease source reconciliation blocker visible in the API/dashboard for the q12/PWL PPA item, instead of leaving a fresh heartbeat with stale command progress from an older run.