### PR TITLE
Clear stale worker progress on lease completion

### DIFF
--- a/control_plane/control_plane/services/lease_service.py
+++ b/control_plane/control_plane/services/lease_service.py
@@ -213,6 +213,18 @@ def heartbeat_lease(
     )
 
 
+def clear_worker_progress_for_item(machine, *, item_id: str) -> bool:
+    """Clear stale machine progress when it still points at a completed item."""
+
+    capabilities = dict(machine.capabilities or {})
+    progress = capabilities.get("last_progress")
+    if not isinstance(progress, dict) or progress.get("item_id") != item_id:
+        return False
+    capabilities.pop("last_progress", None)
+    machine.capabilities = capabilities
+    return True
+
+
 def _mark_run_abandoned(session: Session, *, run, now) -> None:
     if run.status in {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.CANCELED, RunStatus.TIMED_OUT}:
         return
@@ -256,6 +268,7 @@ def expire_stale_leases(session: Session) -> LeaseExpiryResult:
     requeued_count = 0
     for lease in leases:
         lease.status = LeaseStatus.EXPIRED
+        clear_worker_progress_for_item(lease.machine, item_id=lease.work_item.item_id)
         expired_count += 1
         work_item = lease.work_item
         latest_run = None

--- a/control_plane/control_plane/services/run_service.py
+++ b/control_plane/control_plane/services/run_service.py
@@ -16,6 +16,7 @@ from control_plane.models.enums import ArtifactStorageMode, ExecutorType, LeaseS
 from control_plane.models.run_events import RunEvent
 from control_plane.models.runs import Run
 from control_plane.models.worker_leases import WorkerLease
+from control_plane.services.lease_service import clear_worker_progress_for_item
 
 _TERMINAL_RUN_STATUSES = {
     RunStatus.SUCCEEDED,
@@ -317,6 +318,7 @@ def complete_run(
     if run.lease is not None and run.lease.status == LeaseStatus.ACTIVE:
         run.lease.status = LeaseStatus.RELEASED
         run.lease.last_heartbeat_at = utcnow()
+        clear_worker_progress_for_item(run.lease.machine, item_id=work_item.item_id)
 
     created_artifacts: list[Artifact] = []
     for item in artifacts or []:

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -155,6 +155,14 @@ def test_expire_stale_leases_requeues_assigned_nonterminal_work_as_ready() -> No
             started_at=utcnow(),
         )
         session.add(run)
+        lease.machine.capabilities = {
+            **(lease.machine.capabilities or {}),
+            "last_progress": {
+                "phase": "command_running",
+                "item_id": item_b.item_id,
+                "command_name": "run_sweep",
+            },
+        }
         lease.expires_at = utcnow().replace(year=2020)
         item_b.state = WorkItemState.RUNNING
         session.commit()
@@ -168,6 +176,7 @@ def test_expire_stale_leases_requeues_assigned_nonterminal_work_as_ready() -> No
         assert lease.status == LeaseStatus.EXPIRED
         assert item_b.state == WorkItemState.READY
         assert run.status == RunStatus.CANCELED
+        assert "last_progress" not in lease.machine.capabilities
         assert run.completed_at is not None
         assert run.failure_category == "lease_expired"
 

--- a/control_plane/control_plane/tests/test_run_service.py
+++ b/control_plane/control_plane/tests/test_run_service.py
@@ -113,6 +113,15 @@ def test_start_append_complete_run_lifecycle() -> None:
             event_payload={"command": "validate", "exit_code": 0},
         )
         assert event.event_type == "command_finished"
+        lease.machine.capabilities = {
+            **(lease.machine.capabilities or {}),
+            "last_progress": {
+                "phase": "command_running",
+                "item_id": work_item.item_id,
+                "command_name": "validate",
+            },
+        }
+        session.commit()
 
         completed = complete_run(
             session,
@@ -135,6 +144,7 @@ def test_start_append_complete_run_lifecycle() -> None:
         lease = session.query(WorkerLease).filter_by(lease_token=lease.lease_token).one()
         assert run.status.value == "succeeded"
         assert lease.status == LeaseStatus.RELEASED
+        assert "last_progress" not in lease.machine.capabilities
         assert work_item.state == WorkItemState.ARTIFACT_SYNC
         assert session.query(RunEvent).filter_by(run_id=run.id).count() == 3
 


### PR DESCRIPTION
## Summary
- clear `worker_machines.capabilities.last_progress` when a completed run releases its lease and the progress still points at that item
- clear the same item-scoped progress when stale active leases expire
- add run-service and lease-service regression coverage

## Validation
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_run_service.py control_plane/control_plane/tests/test_leases.py`
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_worker_daemon.py control_plane/control_plane/tests/test_run_service.py control_plane/control_plane/tests/test_leases.py`
- `PYTHONPATH=.:control_plane python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

## Context
This keeps canceled/released local rescue runs and expired worker leases from continuing to look like active command progress in the API/dashboard. It complements PR #921, which reports pre-lease source-reconciliation blockers.
