### PR TITLE
Report worker daemon idle poll progress

### DIFF
--- a/control_plane/control_plane/services/worker_daemon.py
+++ b/control_plane/control_plane/services/worker_daemon.py
@@ -126,6 +126,45 @@ def _run_parallel_batch(
     return results
 
 
+def _record_poll_result_progress(
+    session_factory: sessionmaker,
+    *,
+    config: WorkerDaemonConfig,
+    logger: Callable[[str], None],
+    poll_count: int,
+    batch: list[WorkerLoopResult],
+) -> None:
+    statuses = [row.status for row in batch]
+    if statuses and all(status == "no_work" for status in statuses):
+        _record_daemon_progress(
+            session_factory,
+            config=config,
+            logger=logger,
+            progress={
+                "phase": "worker_poll",
+                "status": "no_work",
+                "poll": poll_count,
+                "summary": batch[-1].summary if batch else "",
+            },
+        )
+        return
+    if any(status == "worker_error" for status in statuses):
+        _record_daemon_progress(
+            session_factory,
+            config=config,
+            logger=logger,
+            progress={
+                "phase": "worker_poll",
+                "status": "worker_error",
+                "poll": poll_count,
+                "results": [
+                    {"item_id": row.item_id, "status": row.status, "summary": row.summary}
+                    for row in batch
+                ],
+            },
+        )
+
+
 def _reconcile_next_item_source(
     session_factory: sessionmaker,
     *,
@@ -299,6 +338,13 @@ def run_worker_daemon(
             f"results={[{'item_id': row.item_id, 'status': row.status} for row in batch]}"
         )
         batch_no_work = all(result.status == "no_work" for result in batch)
+        _record_poll_result_progress(
+            session_factory,
+            config=config,
+            logger=logger,
+            poll_count=poll_count,
+            batch=batch,
+        )
         if batch_no_work:
             no_work_polls += 1
             if config.stop_on_no_work:

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -319,6 +319,12 @@ def test_worker_daemon_emits_positive_poll_logs() -> None:
         assert any("poll=1" in entry and "succeeded" in entry for entry in messages)
         assert any("poll=2" in entry and "no_work" in entry for entry in messages)
         assert any("worker-daemon exit" in entry for entry in messages)
+        with Session(engine) as session:
+            machine = session.query(WorkerMachine).filter_by(machine_key="daemon-worker-log").one()
+            progress = machine.capabilities["last_progress"]
+            assert progress["phase"] == "worker_poll"
+            assert progress["status"] == "no_work"
+            assert progress["poll"] == 2
 
 
 def _init_git_repo(repo_root: Path) -> None:


### PR DESCRIPTION
## Summary
- persist `worker_poll/no_work` progress when a daemon poll finds no eligible work
- persist `worker_poll/worker_error` progress for daemon-level batch errors
- extend worker-daemon regression coverage for the no-work progress record

## Why
When a machine heartbeat is fresh but it does not lease a scheduler-eligible item, the dashboard currently cannot distinguish stale status, no-work filtering, and a daemon that has not reached the updated loop. This makes the remote q12/PWL PPA dispatch blocker easier to diagnose after the evaluator updates.

## Validation
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_worker_daemon.py -k 'positive_poll_logs or source or db_disconnect'`
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_worker_daemon.py`
- `PYTHONPATH=.:control_plane python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
