### PR TITLE
Refresh q12 PWL L1 source requirement

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/evaluation_requests.json
@@ -26,5 +26,5 @@
       "status": "pending"
     }
   ],
-  "source_commit": "55a0f1af9e15c5707266edeb953abb1a53c437f5"
+  "source_commit": "042bd911f964e44c0fed924ea2b579a487dfc21c"
 }


### PR DESCRIPTION
## Summary
- align the q12/PWL L1 PPA evaluation request metadata with the re-applied DB item
- update the request source commit to `042bd911f964e44c0fed924ea2b579a487dfc21c`

## Validation
- `PYTHONPATH=.:control_plane python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

## Context
The DB item was re-applied with current master after #925 so the remote evaluator source reconciliation should pick up the latest worker daemon poll-progress diagnostics before running the q12/PWL PPA job.
