### PR TITLE
Add configurable 7B native KV quality job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5924,6 +5924,49 @@ def _decoder_attention_kv_model_native_quality_evidence(*, item_id: str) -> dict
     }
 
 
+def _decoder_attention_kv_model_native_quality_7b_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_model_native_quality_7b__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_model_native_quality_7b__{item_id}.md"
+    trace_calibration = f"{base}/decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json"
+    return {
+        "inputs": {
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_trace_calibration": trace_calibration,
+            "attention_kv_model_native_quality_7b_scope": (
+                "Run a 7B-class trained checkpoint through teacher-forced decode while feeding back "
+                "KV8/KV4-quantized past_key_values. The default checkpoint is a public native-GQA "
+                "7B-class model, but the evaluator may set RTLGEN_MODEL_NATIVE_7B_MODEL_ID and "
+                "RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE to test an exact LLaMA-family or "
+                "access-controlled checkpoint. This is a real-checkpoint precision gate, not PPA."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_kv_model_native_quality_7b",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_kv_quant.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--kv-bits-list 8,4 "
+                    "--kv-granularity-list tensor "
+                    "--max-prompts 8 "
+                    "--generation-steps 8 "
+                    "--topk 5 "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_model_native_recovery_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_model_native_recovery__{item_id}.json"
@@ -7282,6 +7325,7 @@ def _build_payload(
         "decoder_attention_kv_native_gqa_proxy",
         "decoder_attention_kv_trace_calibration",
         "decoder_attention_kv_model_native_quality",
+        "decoder_attention_kv_model_native_quality_7b",
         "decoder_attention_kv_model_native_recovery",
         "decoder_output_projection_producer_memory_hierarchy",
         "decoder_output_projection_weight_store_feasibility",
@@ -7452,6 +7496,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_trace_calibration_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_model_native_quality":
             decoder_evidence = _decoder_attention_kv_model_native_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_model_native_quality_7b":
+            decoder_evidence = _decoder_attention_kv_model_native_quality_7b_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_model_native_recovery":
             decoder_evidence = _decoder_attention_kv_model_native_recovery_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_output_projection_producer_memory_hierarchy":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3654,6 +3654,69 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_quality_7b() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_model_native_quality_7b_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_model_native_quality_7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_model_native_quality_7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_model_native_quality_7b",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "evaluate_decoder_attention_kv_model_native_quality_7b",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "RTLGEN_MODEL_NATIVE_7B_MODEL_ID" in run
+            assert "mistralai/Mistral-7B-v0.1" in run
+            assert "RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE" in run
+            assert run.startswith("bash -lc '")
+            assert "run_hf_eval_python.sh" in run
+            assert "evaluate_llm_decoder_model_native_kv_quant.py" in run
+            assert "--model-id \"$MODEL_ID\"" in run
+            assert "--expected-gqa-group-size \"$EXPECTED_GQA\"" in run
+            assert "--kv-bits-list 8,4" in run
+            assert "--kv-granularity-list tensor" in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_model_native_quality_7b__"
+                "l2_decoder_attention_kv_model_native_quality_7b_v1.json"
+            )
+            assert decoder_inputs["attention_kv_trace_calibration"].endswith(
+                "decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json"
+            )
+            assert "7B-class trained checkpoint" in decoder_inputs["attention_kv_model_native_quality_7b_scope"]
+            assert "RTLGEN_MODEL_NATIVE_7B_MODEL_ID" in decoder_inputs["attention_kv_model_native_quality_7b_scope"]
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_model_native_quality_7b",
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_recovery() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary\n- add a new L2 abstraction layer, `decoder_attention_kv_model_native_quality_7b`, for real-checkpoint KV8/KV4 quality evaluation on a 7B-class model\n- default the job to `mistralai/Mistral-7B-v0.1` with expected GQA group size 4, while allowing evaluator overrides via `RTLGEN_MODEL_NATIVE_7B_MODEL_ID` and `RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE`\n- preserve the existing TinyLlama native quality/recovery paths unchanged\n\n## Test\n- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "model_native_quality"`\n\n## Evaluation note\nThis only adds the generator path. The actual model-native quality run should be dispatched to the remote evaluator, not the devcontainer/local worker.