### PR TITLE
Add 7B native KV quality proposal

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/README.md
@@ -1,0 +1,17 @@
+# 7B-Class Native KV Quality Gate
+
+This proposal stages a remote evaluator job for a real-checkpoint KV-cache
+quantization quality gate.
+
+The job runs `npu/eval/evaluate_llm_decoder_model_native_kv_quant.py` through
+`npu/eval/run_hf_eval_python.sh` and compares teacher-forced decode logits with
+KV8 and KV4 quantized `past_key_values`.
+
+Default model settings:
+
+- `RTLGEN_MODEL_NATIVE_7B_MODEL_ID`: defaults to `mistralai/Mistral-7B-v0.1`
+- `RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE`: defaults to `4`
+
+The evaluator can override those variables for an exact access-controlled
+LLaMA-family checkpoint. The work item is remote-only; it must not run on the
+devcontainer/local evaluator.

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/analysis_report.md
@@ -1,0 +1,36 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_kv_model_native_quality_7b_v1`
+- `candidate_id`: `l2_decoder_attention_kv_model_native_quality_7b_v1`
+
+## Evaluations Consumed
+- pending work item: `l2_decoder_attention_kv_model_native_quality_7b_v1`
+- source commit at initial staging: `78bf63f25a05b7798ee98e4607d4882f7a2ce468`
+- expected output:
+  `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_quality_7b__l2_decoder_attention_kv_model_native_quality_7b_v1.json`
+
+## Baseline Comparison
+- TinyLlama native quality accepted KV8 but rejected KV4 tensor quantization.
+- TinyLlama native recovery still rejected KV4 after `kv_head` and
+  `token_vector` scale granularity.
+- This run checks whether the same conclusion holds at a larger checkpoint
+  scale before the Llama7B frontier treats KV4 as promotable.
+
+## Result
+- status: pending remote evaluator result
+- decision rule:
+  - KV8 pass reinforces the conservative quality-backed frontier.
+  - KV4 pass opens a follow-up hardware metadata/QAT evaluation path.
+  - KV4 fail keeps KV4 as an unpromoted hardware-benefit experiment.
+
+## Failures and Caveats
+- Default model is a 7B-class native-GQA checkpoint, not exact Llama7B/GQA8.
+- Exact LLaMA-family runs may require evaluator-local credentials.
+- Teacher-forced prompts are a gate only; full perplexity and task accuracy
+  remain future work.
+
+## Recommendation
+- Wait for remote result.
+- Do not promote KV4 in the main Llama7B architecture ranking until this or a
+  stronger real-checkpoint quality gate passes.

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/design_brief.md
@@ -1,0 +1,58 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_model_native_quality_7b_v1`
+- `title`: `Evaluate 7B-class native KV quantization quality`
+
+## Problem
+- The current Llama7B architecture frontier still uses synthetic/proxy evidence
+  for the precision risk of low-bit KV cache.
+- TinyLlama native-GQA evidence accepts KV8 but rejects KV4, even after
+  scale-granularity recovery. We need a larger trained checkpoint before
+  deciding whether KV4 remains only a hardware-benefit experiment.
+
+## Hypothesis
+- A 7B-class native checkpoint quality run can either reinforce KV8 as the
+  conservative deployable point or expose enough KV4 stability to justify a
+  follow-up recovery/QAT path.
+
+## Evaluation Scope
+- direct comparison set:
+  - full-precision cache feedback versus KV8 and KV4 quantized cache feedback
+    during teacher-forced decode
+  - top-1 match, top-k contains, logit cosine, probability KL, reference margin,
+    and max absolute logit delta
+- evaluation modes:
+  - `frontier_detail`
+  - precision gate; not PPA and not broad ranking
+- dependency order:
+  - requires merged generator support from PR #927
+  - requires evaluator-local Hugging Face runtime/model access
+- excluded first-stage comparisons:
+  - QAT/fine-tuning recovery
+  - full perplexity/task-accuracy evaluation
+  - OpenROAD/PPA
+- follow-on broad sweep:
+  - if KV4 passes, price hardware scale metadata and rerun the Llama7B frontier
+  - if KV4 fails, keep the quality-backed frontier at KV8 and plan QAT or safer
+    quantization formats
+
+## Knowledge Inputs
+- TinyLlama native quality:
+  `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_quality__l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json`
+- TinyLlama native recovery:
+  `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json`
+- Llama7B quality gate:
+  `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_quality_gate__l2_decoder_attention_kv_quality_gate_llama7b_v1.json`
+
+## Candidate Direction
+- Add a source-pinned L2 work item using
+  `decoder_attention_kv_model_native_quality_7b`.
+- Default to `mistralai/Mistral-7B-v0.1` with GQA group size 4, while allowing
+  evaluator overrides for exact LLaMA-family checkpoints.
+
+## Direction Gate
+- status: approved_for_remote_dispatch
+- approved_by: developer_agent
+- approved_utc: 2026-06-19T13:54:00Z
+- note: remote evaluator only; do not run this model job in the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+- status: approved_for_remote_dispatch
+- approved_by: developer_agent
+- approved_utc: 2026-06-19T13:54:00Z
+- allowed_evaluations:
+  - `l2_decoder_attention_kv_model_native_quality_7b_v1`
+- note: Run only on the remote evaluator. The command may download or load a
+  7B-class Hugging Face checkpoint and must not consume this devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_model_native_quality_7b_v1",
+  "source_commit": "78bf63f25a05b7798ee98e4607d4882f7a2ce468",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_model_native_quality_7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a real 7B-class checkpoint through teacher-forced KV8/KV4 cache quantization to check whether the Llama7B proxy precision frontier holds on a larger native checkpoint.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_model_native_quality_7b",
+      "comparison_role": "precision_gate",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": ""
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/implementation_summary.md
@@ -1,0 +1,37 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_model_native_quality_7b_v1`
+- `title`: `Evaluate 7B-class native KV quantization quality`
+
+## Scope
+- Added generator support in PR #927 for the
+  `decoder_attention_kv_model_native_quality_7b` abstraction layer.
+- Staged a remote-only L2 work item that runs the existing native KV
+  quantization evaluator on a 7B-class checkpoint.
+- Did not modify RTL, PPA sweeps, or prior TinyLlama native quality/recovery
+  evidence.
+
+## Files Changed
+- `control_plane/control_plane/services/l2_task_generator.py`
+- `control_plane/control_plane/tests/test_l2_task_generator.py`
+- `docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/*`
+
+## Local Validation
+- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "model_native_quality"`
+- result: passed
+
+## Evaluation Request
+- requested remote task: `l2_decoder_attention_kv_model_native_quality_7b_v1`
+- cost class: medium/high depending on evaluator model cache
+- default model: `mistralai/Mistral-7B-v0.1`
+- evaluator overrides:
+  - `RTLGEN_MODEL_NATIVE_7B_MODEL_ID`
+  - `RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE`
+
+## Risks
+- Default Mistral-7B is 7B-class native GQA but not exact Llama7B/GQA8.
+- Exact LLaMA-family checkpoints may be gated and require evaluator-local
+  credentials.
+- The run remains a teacher-forced prompt gate, not full perplexity or task
+  accuracy.

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/promotion_decision.json
@@ -1,0 +1,14 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_model_native_quality_7b_v1",
+  "candidate_id": "l2_decoder_attention_kv_model_native_quality_7b_v1",
+  "decision": "pending_remote_result",
+  "reason": "The work item has been staged to collect 7B-class native checkpoint KV8/KV4 quality evidence before promoting or rejecting low-bit KV cache points in the Llama7B frontier.",
+  "evidence_refs": [
+    "item:l2_decoder_attention_kv_model_native_quality_7b_v1",
+    "pr:927",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_quality__l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json"
+  ],
+  "next_action": "Wait for the remote evaluator result, then update the precision frontier interpretation: keep KV8 conservative if KV4 fails, or schedule KV4 metadata/QAT follow-up if it passes.",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/promotion_gate.md
@@ -1,0 +1,10 @@
+# Promotion Gate
+
+- status: pending_remote_result
+- approved_by:
+- approved_utc:
+- action: Do not promote KV4 from the Llama7B precision frontier until this
+  larger native-checkpoint evidence is reviewed. KV8 may remain the conservative
+  quality-backed point if the run confirms TinyLlama behavior.
+- note: This gate decides precision-frontier interpretation only; it does not
+  merge PPA artifacts.

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_model_native_quality_7b_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/proposal.json
@@ -1,0 +1,60 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_model_native_quality_7b_v1",
+  "created_utc": "2026-06-19T13:54:18.996791Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Evaluate 7B-class native KV quantization quality",
+  "hypothesis": "The current Llama7B proxy frontier treats GQA8/KV8 as the conservative precision point and KV4 as a hardware-benefit experiment. A larger trained checkpoint should be evaluated directly before any KV4 or low-precision cache point is promoted.",
+  "direct_comparison": {
+    "primary_question": "Does teacher-forced decode on a real 7B-class checkpoint preserve next-token rankings when past_key_values are quantized to KV8 or KV4?",
+    "include": [
+      "KV8 and KV4 tensor-scale cache feedback on a 7B-class checkpoint",
+      "top-1 match, top-k contains, logit cosine, probability KL, and margin-sensitive deltas"
+    ],
+    "exclude": [
+      "PPA or OpenROAD synthesis",
+      "QAT or fine-tuning recovery",
+      "promotion of structural GQA/MQA changes without matching trained-checkpoint evidence"
+    ],
+    "follow_on_broad_sweep": [
+      "If KV4 fails, keep the deployable frontier at KV8 and schedule QAT or safer scale-granularity recovery.",
+      "If KV4 passes, price the scale metadata and rerun the Llama7B frontier ranking with the measured precision point."
+    ]
+  },
+  "expected_benefit": [
+    "Reduce precision abstraction by replacing synthetic proxy-only evidence with a real larger-checkpoint quality gate.",
+    "Prevent hardware-only KV4 speedups from entering the main frontier without model evidence."
+  ],
+  "risks": [
+    "The default public 7B-class checkpoint is Mistral-7B with GQA group size 4, not the exact GQA8 proxy shape.",
+    "Exact LLaMA-family checkpoints may require evaluator-local Hugging Face credentials and a different expected GQA group size.",
+    "The prompt set is still small and teacher-forced; it is a gate, not full perplexity or task accuracy."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "objective": "Run a real 7B-class checkpoint through teacher-forced KV8/KV4 cache quantization to check whether the Llama7B proxy precision frontier holds on a larger native checkpoint.",
+      "cost_class": "medium",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "The output is a precision gate used to decide whether KV8 remains the conservative frontier or KV4 deserves follow-up recovery."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_quality__l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_quality_gate__l2_decoder_attention_kv_quality_gate_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "script:npu/eval/evaluate_llm_decoder_model_native_kv_quant.py",
+    "source:transformers Mistral docs - Mistral 7B uses GQA",
+    "source:transformers Llama config docs - num_key_value_heads controls MHA/GQA/MQA"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_model_native_quality_7b_v1/quality_gate.md
@@ -1,0 +1,33 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_kv_model_native_quality_7b_v1`
+- `title`: `Evaluate 7B-class native KV quantization quality`
+
+## Why This Gate Is Required
+- KV-cache precision directly changes attention logits and therefore next-token
+  rankings. Proxy-only quality is not enough to promote KV4 in the Llama7B
+  frontier.
+
+## Reference
+- baseline_ref:
+  `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_quality__l2_decoder_attention_kv_model_native_quality_tinyllama_v1_r2.json`
+- recovery_ref:
+  `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_recovery__l2_decoder_attention_kv_model_native_recovery_tinyllama_v1.json`
+
+## Checks
+- KV8 top-1 match:
+  - threshold: `>= 0.995`
+- KV4 promotion:
+  - threshold: top-1 `>= 0.98` and top-k contains `>= 0.995`
+- model shape:
+  - threshold: reported GQA group size must match
+    `RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE`
+
+## Local Commands
+- none; this is a remote evaluator job.
+
+## Result
+- status: pending_remote_result
+- note: The queued job records the JSON/Markdown evidence used by the next
+  precision-frontier decision.


### PR DESCRIPTION
## Summary\n- add concrete proposal metadata for `l2_decoder_attention_kv_model_native_quality_7b_v1`\n- document the remote-only 7B-class native checkpoint quality gate and evaluator overrides\n- remove generated placeholder text from the proposal scaffold\n\n## Validation\n- `python3 -m json.tool` on proposal JSON files\n- placeholder grep returned no scaffold text\n\n## Evaluation note\nThe work item is already staged as remote-assigned. After this merges, I will refresh its source commit so artifact sync can resolve the proposal linkage.