### PR TITLE
Repair assigned dispatch-pending items

### DIFF
--- a/control_plane/control_plane/services/dispatcher_service.py
+++ b/control_plane/control_plane/services/dispatcher_service.py
@@ -105,6 +105,14 @@ def auto_dispatch_item(
     if work_item.state in {WorkItemState.MERGED, WorkItemState.SUPERSEDED}:
         return AutoDispatchItemResult(item_id=item_id, status="skipped", reason=f"terminal_state:{work_item.state.value}")
     if work_item.assigned_machine_key:
+        if work_item.state in {WorkItemState.DRAFT, WorkItemState.DISPATCH_PENDING}:
+            assigned = assign_work_item(session, item_id=item_id, machine_key=work_item.assigned_machine_key)
+            return AutoDispatchItemResult(
+                item_id=item_id,
+                status="assigned",
+                machine_key=assigned.assigned_machine_key,
+                reason=assigned.state,
+            )
         return AutoDispatchItemResult(
             item_id=item_id,
             status="skipped",

--- a/control_plane/control_plane/tests/test_dispatcher_service.py
+++ b/control_plane/control_plane/tests/test_dispatcher_service.py
@@ -132,6 +132,35 @@ def test_auto_dispatch_item_assigns_single_matching_machine() -> None:
         assert item.state == WorkItemState.READY
 
 
+def test_auto_dispatch_item_repairs_assigned_dispatch_pending_item() -> None:
+    with make_session() as session:
+        upsert_worker_machine(
+            session,
+            machine_key="eval-a",
+            hostname="eval-a",
+            role="evaluator",
+            slot_capacity=1,
+            capabilities={"platform": "nangate45", "flow": "openroad"},
+        )
+        _seed_ready_item(session, item_id="item_a", platform="nangate45", priority=5)
+        item = session.query(WorkItem).filter_by(item_id="item_a").one()
+        item.assigned_machine_key = "eval-a"
+        item.state = WorkItemState.DISPATCH_PENDING
+        session.commit()
+
+        result = auto_dispatch_item(session, item_id="item_a", machine_key="eval-a")
+
+        assert result == AutoDispatchItemResult(
+            item_id="item_a",
+            status="assigned",
+            machine_key="eval-a",
+            reason="ready",
+        )
+        session.refresh(item)
+        assert item.assigned_machine_key == "eval-a"
+        assert item.state == WorkItemState.READY
+
+
 def test_auto_dispatch_item_skips_when_multiple_eligible_machines() -> None:
     with make_session() as session:
         upsert_worker_machine(


### PR DESCRIPTION
## Summary\n- repair assigned items that were re-applied back to `DISPATCH_PENDING` by promoting them to `READY` during auto-dispatch\n- add dispatcher regression coverage for an already-assigned pending item\n\n## Test\n- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_dispatcher_service.py`\n\n## Why\nRe-applying a source-pinned remote job can preserve `assigned_machine_key` while resetting state to `DISPATCH_PENDING`. Before this fix, `auto_dispatch_item` skipped it as `already_assigned`, leaving it invisible to worker lease selection.