### PR TITLE
Make 7B native quality job evidence-only

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5964,6 +5964,7 @@ def _decoder_attention_kv_model_native_quality_7b_evidence(*, item_id: str) -> d
             },
         ],
         "expected_outputs": [out, report],
+        "evidence_only": True,
     }
 
 
@@ -7226,6 +7227,7 @@ def _build_payload(
         },
     }
     abstraction_layer_name = str(abstraction_layer or "").strip()
+    evidence_only = False
     if abstraction_layer_name in {
         "decoder_probability_path",
         "decoder_probability_sweep",
@@ -7606,9 +7608,34 @@ def _build_payload(
             decoder_evidence = _decoder_probability_sweep_evidence(item_id=item_id)
         else:
             decoder_evidence = _decoder_probability_path_evidence(item_id=item_id)
-        commands = [*decoder_evidence["commands"], *commands]
-        expected_outputs = _uniq([*expected_outputs, *decoder_evidence["expected_outputs"]])
-        task_inputs["decoder_contract"] = decoder_evidence["inputs"]
+        evidence_only = bool(decoder_evidence.get("evidence_only"))
+        if evidence_only:
+            commands = [
+                *decoder_evidence["commands"],
+                {
+                    "name": "validate_runs",
+                    "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+                },
+            ]
+            expected_outputs = _uniq(list(decoder_evidence["expected_outputs"]))
+            task_inputs = {"decoder_contract": decoder_evidence["inputs"]}
+        else:
+            commands = [*decoder_evidence["commands"], *commands]
+            expected_outputs = _uniq([*expected_outputs, *decoder_evidence["expected_outputs"]])
+            task_inputs["decoder_contract"] = decoder_evidence["inputs"]
+
+    acceptance = [
+        "Populate metrics.csv for all referenced design dirs",
+        "Write campaign summary outputs under the campaign output directory",
+        "Keep result_path/work_result_json fields repo-portable",
+        "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing",
+    ]
+    if evidence_only:
+        acceptance = [
+            "Write all declared decoder evidence artifacts",
+            "Keep evidence artifact paths repo-portable",
+            "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing",
+        ]
 
     payload = {
         "version": 0.1,
@@ -7627,12 +7654,7 @@ def _build_payload(
             "inputs": task_inputs,
             "commands": commands,
             "expected_outputs": expected_outputs,
-            "acceptance": [
-                "Populate metrics.csv for all referenced design dirs",
-                "Write campaign summary outputs under the campaign output directory",
-                "Keep result_path/work_result_json fields repo-portable",
-                "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing",
-            ],
+            "acceptance": acceptance,
         },
         "handoff": {
             "branch": f"eval/{item_id}/<session_id>",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3687,8 +3687,9 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
 
             work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
             decoder_inputs = work_item.input_manifest["decoder_contract"]
-            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+            assert [command["name"] for command in work_item.command_manifest] == [
                 "evaluate_decoder_attention_kv_model_native_quality_7b",
+                "validate_runs",
             ]
             run = work_item.command_manifest[0]["run"]
             assert "RTLGEN_MODEL_NATIVE_7B_MODEL_ID" in run
@@ -3706,12 +3707,24 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
                 "decoder_attention_kv_model_native_quality_7b__"
                 "l2_decoder_attention_kv_model_native_quality_7b_v1.json"
             )
+            assert "generated_campaign" not in work_item.input_manifest
             assert decoder_inputs["attention_kv_trace_calibration"].endswith(
                 "decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json"
             )
             assert "7B-class trained checkpoint" in decoder_inputs["attention_kv_model_native_quality_7b_scope"]
             assert "RTLGEN_MODEL_NATIVE_7B_MODEL_ID" in decoder_inputs["attention_kv_model_native_quality_7b_scope"]
-            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.expected_outputs == [
+                (
+                    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                    "decoder_attention_kv_model_native_quality_7b__"
+                    "l2_decoder_attention_kv_model_native_quality_7b_v1.json"
+                ),
+                (
+                    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                    "decoder_attention_kv_model_native_quality_7b__"
+                    "l2_decoder_attention_kv_model_native_quality_7b_v1.md"
+                ),
+            ]
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "decoder_attention_kv_model_native_quality_7b",
             }


### PR DESCRIPTION
## Summary\n- mark `decoder_attention_kv_model_native_quality_7b` as an evidence-only L2 path\n- omit generated campaign inputs, run_campaign/report commands, metrics.csv expectations, and campaign output expectations for this precision gate\n- keep only the model-native quality command plus `validate_runs --skip_eval_queue`\n\n## Test\n- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "model_native_quality"`\n\n## Evaluation note\nThis does not run evaluation. After merge, the remote-assigned `l2_decoder_attention_kv_model_native_quality_7b_v1` item should be refreshed to this source commit so it remains precision-only.