### PR TITLE
Preserve worker progress diagnostics

### DIFF
--- a/control_plane/control_plane/services/lease_service.py
+++ b/control_plane/control_plane/services/lease_service.py
@@ -96,7 +96,14 @@ def upsert_worker_machine(
     machine.executor_kind = executor_kind or machine.executor_kind
     machine.role = role or machine.role
     machine.slot_capacity = max(1, int(slot_capacity))
-    machine.capabilities = capabilities if capabilities is not None else machine.capabilities
+    if capabilities is not None:
+        current_capabilities = dict(machine.capabilities or {})
+        next_capabilities = dict(capabilities)
+        if not next_capabilities:
+            next_capabilities = current_capabilities
+        elif isinstance(current_capabilities.get("last_progress"), dict) and "last_progress" not in next_capabilities:
+            next_capabilities["last_progress"] = current_capabilities["last_progress"]
+        machine.capabilities = next_capabilities
     machine.active = True
     machine.last_seen_at = now
     session.flush()

--- a/control_plane/control_plane/services/worker_daemon.py
+++ b/control_plane/control_plane/services/worker_daemon.py
@@ -82,6 +82,7 @@ def _record_daemon_progress(
             capabilities = dict(machine.capabilities or {}) if machine is not None else {}
             if not capabilities:
                 capabilities.update(config.worker.capabilities or {})
+            capabilities.update(config.worker.capability_filter or {})
             capabilities["last_progress"] = progress
             upsert_worker_machine(
                 session,

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -132,6 +132,30 @@ def test_heartbeat_updates_expiry_and_machine_progress() -> None:
         assert lease.machine.capabilities["last_progress"]["phase"] == "run_campaign"
 
 
+def test_upsert_worker_machine_does_not_clear_progress_with_empty_capabilities() -> None:
+    with make_session() as session:
+        from control_plane.services.lease_service import upsert_worker_machine
+
+        machine = upsert_worker_machine(
+            session,
+            machine_key="machine-1",
+            capabilities={
+                "platform": "nangate45",
+                "flow": "openroad",
+                "last_progress": {"phase": "worker_poll", "status": "no_work"},
+            },
+        )
+        session.commit()
+
+        upsert_worker_machine(session, machine_key=machine.machine_key, capabilities={})
+        session.commit()
+        session.refresh(machine)
+
+        assert machine.capabilities["platform"] == "nangate45"
+        assert machine.capabilities["flow"] == "openroad"
+        assert machine.capabilities["last_progress"] == {"phase": "worker_poll", "status": "no_work"}
+
+
 def test_expire_stale_leases_requeues_assigned_nonterminal_work_as_ready() -> None:
     with make_session() as session:
         _, item_b = seed_ready_items(session)

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -327,6 +327,39 @@ def test_worker_daemon_emits_positive_poll_logs() -> None:
             assert progress["poll"] == 2
 
 
+def test_worker_daemon_persists_capability_filter_with_poll_progress() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    session_factory = build_session_factory(engine)
+
+    with patch(
+        "control_plane.services.worker_daemon._run_parallel_batch",
+        return_value=[WorkerLoopResult(status="no_work", summary="no work available")],
+    ), patch("control_plane.services.worker_daemon.time.sleep"):
+        run_worker_daemon(
+            session_factory,
+            config=WorkerDaemonConfig(
+                worker=WorkerConfig(
+                    repo_root="/tmp/repo",
+                    machine_key="daemon-worker-filter-progress",
+                    hostname="daemon-host",
+                    capability_filter={"platform": "nangate45", "flow": "openroad"},
+                ),
+                poll_seconds=0,
+                max_polls=1,
+                stop_on_no_work=True,
+                run_scheduler_maintenance=False,
+            ),
+        )
+
+    with Session(engine) as session:
+        machine = session.query(WorkerMachine).filter_by(machine_key="daemon-worker-filter-progress").one()
+        assert machine.capabilities["platform"] == "nangate45"
+        assert machine.capabilities["flow"] == "openroad"
+        assert machine.capabilities["last_progress"]["phase"] == "worker_poll"
+        assert machine.capabilities["last_progress"]["status"] == "no_work"
+
+
 def _init_git_repo(repo_root: Path) -> None:
     subprocess.run(["git", "init", str(repo_root)], check=True, capture_output=True, text=True)
     subprocess.run(["git", "-C", str(repo_root), "config", "user.email", "tester@example.com"], check=True)


### PR DESCRIPTION
## Summary\n- preserve existing worker-machine capabilities/progress when an upsert receives an empty capabilities dict\n- include the worker capability filter in persisted daemon progress, matching daemon launches that use `--capability-filter-json`\n- add regressions for preserving `last_progress` and persisting filter capabilities on no-work poll progress\n\n## Test\n- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_leases.py -k "upsert_worker_machine_does_not_clear_progress or heartbeat_updates"`\n- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_worker_daemon.py -k "capability_filter_with_poll_progress or emits_positive_poll_logs"`\n\n## Why\nA fresh heartbeat with empty `last_progress` is currently ambiguous. This makes the diagnostics harder to erase and makes persisted worker rows reflect capability-filter-only daemon launches.