### PR TITLE
[codex] allow queue refresh without proposal rewrites

### DIFF
--- a/control_plane/control_plane/cli/generate_l1_sweep.py
+++ b/control_plane/control_plane/cli/generate_l1_sweep.py
@@ -36,6 +36,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--no-auto-dispatch", action="store_true")
     parser.add_argument("--dispatch-machine-key")
     parser.add_argument("--dispatch-freshness-seconds", type=int, default=120)
+    parser.add_argument("--no-update-proposal-files", action="store_true")
     args = parser.parse_args(argv)
 
     engine = build_engine(args.database_url)
@@ -65,6 +66,7 @@ def main(argv: list[str] | None = None) -> int:
                 trial_count=args.trial_count,
                 seed_start=args.seed_start,
                 stop_after_failures=args.stop_after_failures,
+                update_proposal_files=not args.no_update_proposal_files,
             ),
         )
         payload = dict(result.__dict__)

--- a/control_plane/control_plane/cli/generate_l2_campaign.py
+++ b/control_plane/control_plane/cli/generate_l2_campaign.py
@@ -41,6 +41,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--no-auto-dispatch", action="store_true")
     parser.add_argument("--dispatch-machine-key")
     parser.add_argument("--dispatch-freshness-seconds", type=int, default=120)
+    parser.add_argument("--no-update-proposal-files", action="store_true")
     args = parser.parse_args(argv)
 
     engine = build_engine(args.database_url)
@@ -75,6 +76,7 @@ def main(argv: list[str] | None = None) -> int:
                 depends_on_item_ids=args.depends_on_item_id,
                 requires_merged_inputs=args.requires_merged_inputs,
                 requires_materialized_refs=args.requires_materialized_refs,
+                update_proposal_files=not args.no_update_proposal_files,
             ),
         )
         payload = dict(result.__dict__)

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -49,6 +49,7 @@ class Layer1SweepGenerateRequest:
     trial_count: int = 1
     seed_start: int = 0
     stop_after_failures: int | None = None
+    update_proposal_files: bool = True
 
 
 @dataclass(frozen=True)
@@ -895,17 +896,18 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         repo_root=repo_root,
         required_sha=source_commit,
     )
-    _upsert_evaluation_request_entry(
-        repo_root=repo_root,
-        proposal_id=request.proposal_id,
-        proposal_path=proposal_path,
-        item_id=item_id,
-        task_type="l1_sweep",
-        objective=objective,
-        evaluation_mode=((payload.get("developer_loop") or {}).get("evaluation") or {}).get("mode") or "",
-        abstraction_layer=effective_abstraction_layer,
-        source_commit=source_commit,
-    )
+    if request.update_proposal_files:
+        _upsert_evaluation_request_entry(
+            repo_root=repo_root,
+            proposal_id=request.proposal_id,
+            proposal_path=proposal_path,
+            item_id=item_id,
+            task_type="l1_sweep",
+            objective=objective,
+            evaluation_mode=((payload.get("developer_loop") or {}).get("evaluation") or {}).get("mode") or "",
+            abstraction_layer=effective_abstraction_layer,
+            source_commit=source_commit,
+        )
 
     existing = session.query(WorkItem).filter(WorkItem.item_id == item_id).one_or_none()
     if existing is None:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -58,6 +58,7 @@ class Layer2CampaignGenerateRequest:
     depends_on_item_ids: list[str] | None = None
     requires_merged_inputs: bool = False
     requires_materialized_refs: bool = False
+    update_proposal_files: bool = True
 
 
 @dataclass(frozen=True)
@@ -7766,24 +7767,25 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
         explicit=request.requires_materialized_refs,
     )
     source_commit = _resolve_source_commit(repo_root, request.source_commit)
-    _upsert_requested_item_entry(
-        repo_root=repo_root,
-        proposal_id=request.proposal_id,
-        proposal_path=proposal_path,
-        item_id=item_id,
-        task_type='l2_campaign',
-        objective=objective,
-        evaluation_mode=effective_evaluation_mode,
-        abstraction_layer=effective_abstraction_layer,
-        comparison_role=effective_comparison_role,
-        paired_baseline_item_id=effective_paired_baseline_item_id,
-        depends_on_item_ids=effective_depends_on_item_ids,
-        requires_merged_inputs=effective_requires_merged_inputs,
-        requires_materialized_refs=effective_requires_materialized_refs,
-        expected_direction=request.expected_direction,
-        expected_reason=request.expected_reason,
-        source_commit=source_commit,
-    )
+    if request.update_proposal_files:
+        _upsert_requested_item_entry(
+            repo_root=repo_root,
+            proposal_id=request.proposal_id,
+            proposal_path=proposal_path,
+            item_id=item_id,
+            task_type='l2_campaign',
+            objective=objective,
+            evaluation_mode=effective_evaluation_mode,
+            abstraction_layer=effective_abstraction_layer,
+            comparison_role=effective_comparison_role,
+            paired_baseline_item_id=effective_paired_baseline_item_id,
+            depends_on_item_ids=effective_depends_on_item_ids,
+            requires_merged_inputs=effective_requires_merged_inputs,
+            requires_materialized_refs=effective_requires_materialized_refs,
+            expected_direction=request.expected_direction,
+            expected_reason=request.expected_reason,
+            source_commit=source_commit,
+        )
     expected_outputs = _build_expected_outputs(
         campaign=campaign,
         generated_campaign_path=generated_campaign_path,

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -927,6 +927,63 @@ def test_generate_l1_sweep_task_records_requested_item_in_proposal_evaluation_re
             assert (proposal_dir / name).exists()
 
 
+def test_generate_l1_sweep_task_can_refresh_db_without_updating_proposal_files() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        proposal_dir = repo_root / "docs" / "proposals" / "prop_l1_demo_v1"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        (proposal_dir / "proposal.json").write_text(
+            json.dumps({"proposal_id": "prop_l1_demo_v1", "abstraction_layer": "circuit_block"}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        evaluation_requests_path = proposal_dir / "evaluation_requests.json"
+        evaluation_requests_path.write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_l1_demo_v1",
+                    "source_commit": "previous",
+                    "requested_items": [],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        before = evaluation_requests_path.read_text(encoding="utf-8")
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    item_id="l1_demo_softmax_proposal_r1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l1_demo_v1",
+                    proposal_path="docs/proposals/prop_l1_demo_v1",
+                    abstraction_layer="circuit_block",
+                    update_proposal_files=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert work_item.source_commit == source_commit
+            assert work_item.task_request.source_commit == source_commit
+            assert work_item.task_request.request_payload["developer_loop"]["proposal_id"] == "prop_l1_demo_v1"
+
+        assert evaluation_requests_path.read_text(encoding="utf-8") == before
+
+
 def test_generate_l1_sweep_task_strips_placeholder_requested_items_from_template() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -4906,6 +4906,73 @@ def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() 
             }
 
 
+def test_generate_l2_campaign_task_can_refresh_db_without_updating_proposal_files() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        proposal_dir = repo_root / "docs" / "developer_loop" / "prop_l2_demo_v1"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        evaluation_requests_path = proposal_dir / "evaluation_requests.json"
+        evaluation_requests_path.write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_l2_demo_v1",
+                    "source_commit": "previous",
+                    "requested_items": [
+                        {
+                            "item_id": "l2_demo_candidate_r1",
+                            "task_type": "l2_campaign",
+                            "evaluation_mode": "paired_comparison",
+                            "abstraction_layer": "full_architecture",
+                            "paired_baseline_item_id": "l2_demo_baseline_r1",
+                            "depends_on_item_ids": ["l2_demo_baseline_r1"],
+                            "requires_merged_inputs": True,
+                            "requires_materialized_refs": True,
+                        }
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        before = evaluation_requests_path.read_text(encoding="utf-8")
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_demo_candidate_r1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_demo_v1",
+                    proposal_path="docs/developer_loop/prop_l2_demo_v1",
+                    update_proposal_files=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            payload = work_item.task_request.request_payload
+            assert result.status == "applied"
+            assert work_item.source_commit == source_commit
+            assert work_item.task_request.source_commit == source_commit
+            assert payload["developer_loop"]["evaluation"]["mode"] == "paired_comparison"
+            assert payload["developer_loop"]["abstraction"]["layer"] == "full_architecture"
+            assert payload["developer_loop"]["dependencies"] == {
+                "item_ids": ["l2_demo_baseline_r1"],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+        assert evaluation_requests_path.read_text(encoding="utf-8") == before
+
+
 def test_generate_l2_campaign_task_blocks_when_dependency_not_merged() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary

- add a request/CLI switch to refresh L1/L2 queue items without rewriting proposal files
- keep the default behavior unchanged so normal proposal scaffolding still records requested items
- add regression tests that prove DB source pins update while evaluation_requests.json stays unchanged

## Validation

- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_can_refresh_db_without_updating_proposal_files control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_can_refresh_db_without_updating_proposal_files
- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l1_task_generator.py::test_generate_l1_sweep_task_records_requested_item_in_proposal_evaluation_requests control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_creates_ready_work_item control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests
- git diff --check
