### PR TITLE
[codex] flag stalled ready workers in operator status

### DIFF
--- a/control_plane/control_plane/api/routes_operator_status.py
+++ b/control_plane/control_plane/api/routes_operator_status.py
@@ -669,6 +669,11 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
         { key: "slot_capacity", label: "Slots" },
         { key: "active_slots", label: "Active" },
         { key: "assigned_ready", label: "Assigned Ready" },
+        { key: "worker_attention", label: "Worker Status", render: (value, row) => {
+          if (value) return `<span title='${escapeHtml(value)}'>attention</span>`;
+          const progress = row.last_progress || {};
+          return escapeHtml(progress.phase || progress.status || "");
+        } },
         { key: "last_seen_at", label: "Last Seen", render: (value) => escapeHtml(formatTime(value)) },
       ], payload.evaluator_machines || []);
       renderTable(tables.pendingSubmissions, [

--- a/control_plane/control_plane/services/operator_status.py
+++ b/control_plane/control_plane/services/operator_status.py
@@ -116,6 +116,7 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
 
     evaluator_machines = []
     stale_machine_cutoff = now - timedelta(hours=24)
+    fresh_machine_cutoff = now - timedelta(minutes=5)
     for machine in session.query(WorkerMachine).order_by(WorkerMachine.machine_key.asc()).all():
         active_slots = (
             session.query(WorkerLease)
@@ -130,6 +131,17 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
         last_seen_at = _as_comparable_utc(machine.last_seen_at)
         if active_slots == 0 and assigned_ready == 0 and last_seen_at is not None and last_seen_at < stale_machine_cutoff:
             continue
+        capabilities = dict(machine.capabilities or {})
+        last_progress = capabilities.get("last_progress")
+        if not isinstance(last_progress, dict):
+            last_progress = None
+        worker_attention = None
+        if active_slots == 0 and assigned_ready > 0 and last_seen_at is not None and last_seen_at >= fresh_machine_cutoff:
+            if last_progress is None:
+                worker_attention = "fresh_heartbeat_assigned_ready_without_progress"
+        heartbeat_age_seconds = None
+        if last_seen_at is not None:
+            heartbeat_age_seconds = max(0.0, (now - last_seen_at).total_seconds())
         evaluator_machines.append(
             {
                 "machine_key": machine.machine_key,
@@ -140,6 +152,10 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
                 "assigned_ready": assigned_ready,
                 "active": machine.active,
                 "last_seen_at": machine.last_seen_at.isoformat() if machine.last_seen_at else None,
+                "heartbeat_age_seconds": heartbeat_age_seconds,
+                "capabilities": capabilities,
+                "last_progress": last_progress,
+                "worker_attention": worker_attention,
             }
         )
 
@@ -354,6 +370,9 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
     ready_items = state_counts.get(WorkItemState.READY.value, 0)
     if ready_items:
         attention_flags.append(f"ready={ready_items}")
+    stalled_workers = sum(1 for row in evaluator_machines if row.get("worker_attention"))
+    if stalled_workers:
+        attention_flags.append(f"stalled_workers={stalled_workers}")
     if recent_resolver_cases:
         attention_flags.append(f"resolver_cases={len(recent_resolver_cases)}")
 

--- a/control_plane/control_plane/tests/test_operator_status.py
+++ b/control_plane/control_plane/tests/test_operator_status.py
@@ -375,6 +375,52 @@ def test_operator_status_reports_evaluator_machine_capacity() -> None:
         assert row["slot_capacity"] == 4
         assert row["assigned_ready"] == 1
         assert row["active_slots"] == 0
+        assert row["heartbeat_age_seconds"] is not None
+        assert row["capabilities"] == {"platform": "nangate45", "flow": "openroad"}
+        assert row["last_progress"] is None
+        assert row["worker_attention"] == "fresh_heartbeat_assigned_ready_without_progress"
+        assert "stalled_workers=1" in status.health_summary["message"]
+
+
+def test_operator_status_does_not_flag_assigned_ready_worker_with_progress() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    now = utcnow()
+    with Session(engine) as session:
+        machine = WorkerMachine(
+            machine_key="worker-progress",
+            hostname="eval-host",
+            executor_kind="local_process",
+            capabilities={
+                "flow": "openroad",
+                "platform": "nangate45",
+                "last_progress": {
+                    "phase": "source_reconcile",
+                    "status": "checking",
+                    "item_id": "assigned_ready",
+                },
+            },
+            role="evaluator",
+            slot_capacity=4,
+            last_seen_at=now,
+        )
+        session.add(machine)
+        session.flush()
+        ready_item = _seed_item(session, item_id="assigned_ready", state=WorkItemState.READY)
+        ready_item.assigned_machine_key = machine.machine_key
+        session.commit()
+
+        status = load_operator_status(session, OperatorStatusRequest(recent_limit=5))
+        row = next(r for r in status.evaluator_machines if r["machine_key"] == "worker-progress")
+        assert row["assigned_ready"] == 1
+        assert row["active_slots"] == 0
+        assert row["last_progress"] == {
+            "phase": "source_reconcile",
+            "status": "checking",
+            "item_id": "assigned_ready",
+        }
+        assert row["worker_attention"] is None
+        assert "stalled_workers=" not in status.health_summary["message"]
 
 
 def test_operator_status_marks_resumable_pending_submission(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- expose evaluator machine capabilities and last_progress in operator status
- flag fresh-heartbeat workers that have assigned READY work, no active lease, and no progress record
- add a Worker Status column to the dashboard machine table

## Why

The remote evaluator can currently show a fresh heartbeat while assigned READY jobs remain unclaimed. This patch makes that state explicit as `fresh_heartbeat_assigned_ready_without_progress` and adds `stalled_workers=N` to the health summary.

## Validation

- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_operator_status.py
- live status check against the current DB reports `stalled_workers=1` for eval-daemon-b7c2d9c80c1c
