### PR TITLE
[codex] stage 7b quality-backed hbm frontier

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3453,6 +3453,78 @@ def _decoder_attention_kv_physical_hbm_quality_backed_evidence(*, item_id: str) 
     }
 
 
+def _decoder_attention_kv_physical_hbm_quality_backed_7b_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_kv_physical_hbm_quality_backed_7b__{item_id}.json"
+    report = f"{base}/decoder_attention_kv_physical_hbm_quality_backed_7b__{item_id}.md"
+    native_quality_7b = (
+        f"{base}/decoder_attention_kv_model_native_quality_7b__"
+        "l2_decoder_attention_kv_model_native_quality_7b_v1.json"
+    )
+    physical_frontier = (
+        f"{base}/decoder_attention_kv_physical_hbm_frontier__"
+        "l2_decoder_attention_kv_physical_hbm_frontier_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_kv_model_native_quality_7b": native_quality_7b,
+            "attention_kv_physical_hbm_frontier": physical_frontier,
+            "attention_kv_memory_out": out,
+            "attention_kv_memory_report": report,
+            "attention_kv_physical_hbm_quality_backed_7b_out": out,
+            "attention_kv_physical_hbm_quality_backed_7b_report": report,
+            "attention_kv_physical_hbm_quality_backed_7b_scope": (
+                "7B-native-quality-backed physical-HBM frontier for llama7b_proxy decode. "
+                "Constrain the first rerank to native-GQA KV16 and KV8 until the 7B "
+                "teacher-forced quality gate proves whether KV4 survives top-1/top-k, "
+                "logit-cosine, KL, and margin-sensitive checks. MQA and other structural "
+                "KV sharing remain excluded without matching trained-checkpoint evidence."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_physical_hbm_quality_backed_7b",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py "
+                    "--label llama7b_proxy "
+                    "--sequence-length-list 32768,65536,131072 "
+                    "--die-area-mm2-list 100,200,400 "
+                    "--kv-sharing-list gqa8 "
+                    "--kv-bits-list 16,8 "
+                    "--stack-count-list 1,2,4,8 "
+                    "--pseudo-channels-per-stack-list 8,16 "
+                    "--pseudo-channel-width-bits-list 64 "
+                    "--data-rate-mtps-list 3200,6400,9000 "
+                    "--hbm-efficiency-list 0.35,0.55,0.75 "
+                    "--tile-tokens-list 512,1024 "
+                    "--prefetch-distance-tiles-list 4 "
+                    "--hbm-outstanding-list 8,16 "
+                    "--arbitration-efficiency-list 0.85 "
+                    "--virtual-channel-list 4 "
+                    "--prefetch-start-list during_qkv "
+                    "--sram-area-fraction 0.6 "
+                    "--usable-sram-fraction 0.7 "
+                    "--bitcell-area-um2-per-bit 0.02 "
+                    "--local-sram-fraction 0.25 "
+                    "--bank-count 16 "
+                    "--bank-bandwidth-bytes-per-cycle 1024 "
+                    "--bank-interleave-tokens 16 "
+                    "--bank-conflict-efficiency 0.75 "
+                    "--noc-bandwidth-bytes-per-cycle 16384 "
+                    "--noc-hops 1 "
+                    "--router-latency-cycles-per-hop 2 "
+                    "--macs-per-cycle 524288 "
+                    "--vector-ops-per-cycle 65536 "
+                    "--clock-ns 1.0 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_kv_physical_hbm_memory_noc_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_physical_hbm_memory_noc__{item_id}.json"
@@ -7282,6 +7354,7 @@ def _build_payload(
         "decoder_attention_kv_hbm_controller",
         "decoder_attention_kv_physical_hbm_frontier",
         "decoder_attention_kv_physical_hbm_quality_backed",
+        "decoder_attention_kv_physical_hbm_quality_backed_7b",
         "decoder_attention_kv_physical_hbm_memory_noc",
         "decoder_attention_kv_physical_hbm_compute_sensitivity",
         "decoder_attention_kv_compute_floor_gap",
@@ -7383,6 +7456,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_physical_hbm_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_quality_backed":
             decoder_evidence = _decoder_attention_kv_physical_hbm_quality_backed_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_quality_backed_7b":
+            decoder_evidence = _decoder_attention_kv_physical_hbm_quality_backed_7b_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_memory_noc":
             decoder_evidence = _decoder_attention_kv_physical_hbm_memory_noc_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_compute_sensitivity":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3091,6 +3091,73 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_qualit
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_quality_backed_7b() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+                    proposal_id="prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_physical_hbm_quality_backed_7b",
+                    expected_direction="iterate",
+                    comparison_role="frontier_synthesis",
+                    depends_on_item_ids=["l2_decoder_attention_kv_model_native_quality_7b_v1"],
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert [command["name"] for command in work_item.command_manifest[:1]] == [
+                "estimate_decoder_attention_kv_physical_hbm_quality_backed_7b",
+            ]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_attention_kv_physical_hbm_frontier.py" in run
+            assert "--kv-sharing-list gqa8" in run
+            assert "--kv-bits-list 16,8" in run
+            assert "--kv-bits-list 16,8,4" not in run
+            assert decoder_inputs["attention_kv_memory_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_physical_hbm_quality_backed_7b__"
+                "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_kv_model_native_quality_7b"].endswith(
+                "decoder_attention_kv_model_native_quality_7b__"
+                "l2_decoder_attention_kv_model_native_quality_7b_v1.json"
+            )
+            assert (
+                "7B-native-quality-backed physical-HBM"
+                in decoder_inputs["attention_kv_physical_hbm_quality_backed_7b_scope"]
+            )
+            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_kv_physical_hbm_quality_backed_7b",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": ["l2_decoder_attention_kv_model_native_quality_7b_v1"],
+                "requires_merged_inputs": False,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_memory_noc() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -45,6 +45,10 @@ than free or heuristic assumptions.
    - Scope: teacher-forced decode on a real 7B-class checkpoint with KV8/KV4
      cache quantization feedback.
    - Active gate: `l2_decoder_attention_kv_model_native_quality_7b_v1`.
+   - Prepared consumer:
+     `l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1`
+     reranks the conservative native-GQA KV16/KV8 physical-HBM frontier using
+     the 7B quality artifact instead of the older TinyLlama precision proxy.
    - Result use: keep KV8 as the conservative frontier unless KV4 survives
      top-1/top-k/logit-cosine/KL/margin-sensitive checks, or schedule a
      QAT/scale-granularity recovery job if KV4 fails but still looks valuable.

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/README.md
@@ -1,0 +1,5 @@
+# 7B-Native Quality-Backed HBM Frontier
+
+This proposal reranks the conservative Llama7B physical-HBM frontier after the
+7B-class native KV quality gate materializes. It keeps KV16/KV8 only for the
+first rerank and leaves any KV4-inclusive rerank to a separate recovery decision.

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending evaluation.

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/design_brief.md
@@ -1,0 +1,7 @@
+# Design Brief
+
+The existing quality-backed HBM frontier uses TinyLlama native quality evidence
+as the precision gate. The active `l2_decoder_attention_kv_model_native_quality_7b_v1`
+job will provide a larger-checkpoint gate. This proposal prepares the L2 rerank
+that consumes that artifact while preserving the conservative native-GQA KV16/KV8
+frontier until KV4 is explicitly reviewed.

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+Dispatch only after:
+
+- `l2_decoder_attention_kv_model_native_quality_7b_v1` has materialized the
+  7B native quality JSON/Markdown artifacts.
+- `l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1` remains
+  available as the TinyLlama-quality-backed baseline.
+
+The job is Layer 2 only and must not run OpenROAD/PPA.

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds decoder_attention_kv_physical_hbm_quality_backed_7b generator support.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerank the conservative native-GQA KV16/KV8 physical-HBM frontier using 7B-class native KV quality evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_physical_hbm_quality_backed_7b",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_model_native_quality_7b_v1",
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the 7B-native quality gate to decide whether KV8 remains the conservative deployable frontier or whether a KV4 recovery/rerank track should be opened."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/implementation_summary.md
@@ -1,0 +1,7 @@
+# Implementation Summary
+
+- Add `decoder_attention_kv_physical_hbm_quality_backed_7b` to the L2 task
+  generator.
+- Reuse the physical-HBM estimator with `gqa8` and `kv_bits=16,8`.
+- Attach the 7B native quality artifact path to the decoder contract.
+- Do not run OpenROAD/PPA for this L2 rerank.

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+  "decision": "pending",
+  "reason": "Waiting for the 7B-native quality gate and the dependent HBM rerank.",
+  "evidence_refs": [],
+  "next_action": "Dispatch after l2_decoder_attention_kv_model_native_quality_7b_v1 materializes.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/promotion_gate.md
@@ -1,0 +1,9 @@
+# Promotion Gate
+
+Promote only if the rerank records:
+
+- token latency/throughput, energy, and area trends for the conservative
+  KV16/KV8 frontier,
+- explicit reference to the 7B native quality artifact,
+- a clear decision on whether the next precision step is KV8 deployment,
+  KV4 recovery, or a KV4-inclusive rerank.

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/proposal.json
@@ -1,0 +1,68 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+  "created_utc": "2026-06-19T14:42:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_kv_physical_hbm_quality_backed_7b",
+  "title": "7B-native quality-backed Llama7B physical HBM frontier",
+  "hypothesis": "Once the 7B-class native KV quality gate has run, the physical HBM frontier should be reranked using that larger-checkpoint precision evidence instead of the older TinyLlama proxy gate.",
+  "direct_comparison": {
+    "primary_question": "Under the physical HBM model, does the conservative native-GQA KV16/KV8 frontier remain the deployable Llama7B point when the quality evidence is taken from a 7B-class checkpoint?",
+    "include": [
+      "llama7b_proxy at 32k, 64k, and 131k tokens",
+      "die areas 100, 200, and 400 mm2",
+      "native-GQA group-8 KV sharing only",
+      "packed KV16 and KV8 storage only",
+      "7B-class teacher-forced KV8/KV4 quality artifact as the precision gate"
+    ],
+    "exclude": [
+      "KV4 promotion before the 7B quality artifact is reviewed",
+      "MQA or other structural KV sharing without matching trained-checkpoint evidence",
+      "OpenROAD/PPA execution",
+      "cycle-accurate HBM or NoC simulation"
+    ]
+  },
+  "expected_benefit": [
+    "Replaces TinyLlama-only precision provenance in the quality-backed HBM frontier with a 7B-class checkpoint gate.",
+    "Keeps the deployable frontier conservative while preserving a clear follow-up path if KV4 survives the 7B gate.",
+    "Makes the later integrated Llama7B closure less abstract in the precision dimension."
+  ],
+  "risks": [
+    "The queued 7B quality gate may require evaluator-local model credentials or substantial memory.",
+    "The first rerank intentionally excludes KV4 even if the quality artifact is borderline; a KV4-inclusive rerank should be a separate reviewed job.",
+    "The HBM model remains a service/bandwidth model rather than detailed DRAM timing."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerank the conservative native-GQA KV16/KV8 physical-HBM frontier using 7B-class native KV quality evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_kv_physical_hbm_quality_backed_7b",
+      "cost_class": "low_after_quality_gate",
+      "comparison_role": "frontier_synthesis",
+      "paired_baseline_item_id": "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_kv_model_native_quality_7b_v1",
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the 7B-native quality gate to decide whether KV8 remains the conservative deployable frontier or whether a KV4 recovery/rerank track should be opened."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed__l2_decoder_attention_kv_physical_hbm_quality_backed_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_model_native_quality_7b__l2_decoder_attention_kv_model_native_quality_7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py",
+    "npu/eval/evaluate_llm_decoder_model_native_kv_quant.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/quality_gate.md
@@ -1,0 +1,5 @@
+# Quality Gate
+
+The proposal does not itself judge KV4. It consumes the 7B native quality gate
+and keeps the first physical-HBM rerank conservative at KV16/KV8. If the 7B gate
+shows KV4 is safe, open a separate KV4-inclusive rerank or recovery proposal.


### PR DESCRIPTION
## Summary

- add `decoder_attention_kv_physical_hbm_quality_backed_7b` L2 generator support
- consume the 7B native KV quality artifact path for the physical-HBM rerank
- keep the first rerank conservative at native-GQA KV16/KV8 only
- add proposal scaffold and closure-plan note for the dependent job

## Validation

- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_quality_backed control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_quality_backed_7b control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_quality_7b
- python3 -m json.tool on the new proposal JSON files
- git diff --check

No evaluation/PPA was run.
