### PR TITLE
[codex] expose blocked work item dependencies

### DIFF
--- a/control_plane/control_plane/api/routes_operator_status.py
+++ b/control_plane/control_plane/api/routes_operator_status.py
@@ -272,6 +272,10 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
           <div class="table-wrap"><table id="dispatch-pending-table"></table></div>
         </div>
         <div class="panel">
+          <h2>Blocked Items</h2>
+          <div class="table-wrap"><table id="blocked-items-table"></table></div>
+        </div>
+        <div class="panel">
           <h2>Resolver Cases</h2>
           <div class="table-wrap"><table id="resolver-cases-table"></table></div>
         </div>
@@ -370,6 +374,7 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
       machines: document.getElementById("machines-table"),
       pendingSubmissions: document.getElementById("pending-submissions-table"),
       dispatchPending: document.getElementById("dispatch-pending-table"),
+      blockedItems: document.getElementById("blocked-items-table"),
       resolverCases: document.getElementById("resolver-cases-table"),
       states: document.getElementById("states-table"),
       runIndexSummary: document.getElementById("run-index-summary-table"),
@@ -705,6 +710,13 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
             <button data-action="supersede" data-item-id="${escapeHtml(row.item_id)}">Supersede</button>
           ` },
       ], payload.dispatch_pending_items || []);
+      renderTable(tables.blockedItems, [
+        { key: "item_id", label: "Item", render: (value) => `<span class='mono'>${escapeHtml(value)}</span>` },
+        { key: "task_type", label: "Task" },
+        { key: "dependency_reason", label: "Blocker", render: (value) => escapeHtml(value || "dependencies pending") },
+        { key: "dependency_item_ids", label: "Dependencies", render: (value) => `<span class='mono'>${escapeHtml((value || []).join(", "))}</span>` },
+        { key: "updated_at", label: "Updated", render: (value) => escapeHtml(formatTime(value)) },
+      ], payload.blocked_items || []);
       renderTable(tables.resolverCases, [
         { key: "item_id", label: "Item", render: (value) => `<span class='mono'>${escapeHtml(value || "")}</span>` },
         { key: "failure_class", label: "Class" },
@@ -901,6 +913,7 @@ def _status_payload(database_url: str, recent_limit: int) -> dict[str, object]:
         "evaluator_machines": status.evaluator_machines,
         "pending_submission_items": status.pending_submission_items,
         "dispatch_pending_items": status.dispatch_pending_items,
+        "blocked_items": status.blocked_items,
         "recent_failures": status.recent_failures,
         "recent_submissions": status.recent_submissions,
         "recent_resolver_cases": status.recent_resolver_cases,

--- a/control_plane/control_plane/services/operator_status.py
+++ b/control_plane/control_plane/services/operator_status.py
@@ -20,6 +20,7 @@ from control_plane.models.worker_leases import WorkerLease
 from control_plane.models.worker_machines import WorkerMachine
 from control_plane.models.work_items import WorkItem
 from control_plane.services.completion_retry_service import submission_retry_status
+from control_plane.services.dependency_gate import dependency_gate_config_from_payload, evaluate_work_item_dependencies
 from control_plane.services.operator_submission import assess_submission_eligibility
 from control_plane.services.run_index_query import comparative_run_index
 from control_plane.services.trial_variance import load_seed_trial_variance
@@ -77,6 +78,7 @@ class OperatorStatusResult:
     stale_leases: list[dict[str, object]]
     pending_submission_items: list[dict[str, object]]
     dispatch_pending_items: list[dict[str, object]]
+    blocked_items: list[dict[str, object]]
     recent_failures: list[dict[str, object]]
     recent_submissions: list[dict[str, object]]
     recent_resolver_cases: list[dict[str, object]]
@@ -266,6 +268,42 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
             }
         )
 
+    blocked_items = []
+    for work_item in (
+        session.query(WorkItem)
+        .filter(WorkItem.state == WorkItemState.BLOCKED)
+        .order_by(WorkItem.updated_at.desc(), WorkItem.created_at.desc())
+        .limit(request.recent_limit)
+        .all()
+    ):
+        latest_run = None
+        if work_item.runs:
+            latest_run = sorted(work_item.runs, key=lambda row: (row.attempt, row.created_at or utcnow()))[-1]
+        gate = evaluate_work_item_dependencies(
+            session,
+            repo_root=Path(request.repo_root).resolve(),
+            work_item=work_item,
+        )
+        dependency_config = dependency_gate_config_from_payload(work_item.task_request.request_payload or {})
+        blocked_items.append(
+            {
+                "item_id": work_item.item_id,
+                "task_type": work_item.task_type,
+                "platform": work_item.platform,
+                "assigned_machine_key": work_item.assigned_machine_key,
+                "source_commit": work_item.source_commit,
+                "dependency_item_ids": list(dependency_config.item_ids),
+                "requires_merged_inputs": dependency_config.requires_merged_inputs,
+                "requires_materialized_refs": dependency_config.requires_materialized_refs,
+                "dependency_satisfied": gate.satisfied,
+                "dependency_reason": gate.reason,
+                "created_at": work_item.created_at.isoformat() if work_item.created_at else None,
+                "updated_at": work_item.updated_at.isoformat() if work_item.updated_at else None,
+                "run_key": latest_run.run_key if latest_run is not None else None,
+                "run_status": latest_run.status.value if latest_run is not None else None,
+            }
+        )
+
     recent_failures = []
     for run in (
         session.query(Run)
@@ -367,6 +405,9 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
     dispatch_pending_count = state_counts.get(WorkItemState.DISPATCH_PENDING.value, 0)
     if dispatch_pending_count:
         attention_flags.append(f"dispatch_pending={dispatch_pending_count}")
+    blocked_count = state_counts.get(WorkItemState.BLOCKED.value, 0)
+    if blocked_count:
+        attention_flags.append(f"blocked={blocked_count}")
     ready_items = state_counts.get(WorkItemState.READY.value, 0)
     if ready_items:
         attention_flags.append(f"ready={ready_items}")
@@ -397,6 +438,7 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
         stale_leases=stale_leases,
         pending_submission_items=pending_submission_items,
         dispatch_pending_items=dispatch_pending_items,
+        blocked_items=blocked_items,
         recent_failures=recent_failures,
         recent_submissions=recent_submissions,
         recent_resolver_cases=recent_resolver_cases,

--- a/control_plane/control_plane/tests/test_operator_status.py
+++ b/control_plane/control_plane/tests/test_operator_status.py
@@ -423,6 +423,65 @@ def test_operator_status_does_not_flag_assigned_ready_worker_with_progress() -> 
         assert "stalled_workers=" not in status.health_summary["message"]
 
 
+def test_operator_status_reports_blocked_dependency_reason() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    with Session(engine) as session:
+        dependency = _seed_item(session, item_id="quality_gate", state=WorkItemState.READY)
+        blocked_task = TaskRequest(
+            request_key="queue:blocked_followup",
+            source="test",
+            requested_by="tester",
+            title="blocked followup",
+            description="blocked followup",
+            layer=LayerName.LAYER2,
+            flow=FlowName.OPENROAD,
+            priority=1,
+            request_payload={
+                "item_id": "blocked_followup",
+                "developer_loop": {
+                    "dependencies": {
+                        "item_ids": [dependency.item_id],
+                        "requires_merged_inputs": True,
+                        "requires_materialized_refs": True,
+                    }
+                },
+            },
+        )
+        session.add(blocked_task)
+        session.flush()
+        session.add(
+            WorkItem(
+                work_item_key="queue:blocked_followup",
+                task_request_id=blocked_task.id,
+                item_id="blocked_followup",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.BLOCKED,
+                priority=1,
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[],
+                acceptance_rules=[],
+            )
+        )
+        session.commit()
+
+        status = load_operator_status(session, OperatorStatusRequest(recent_limit=5))
+
+    assert len(status.blocked_items) == 1
+    row = status.blocked_items[0]
+    assert row["item_id"] == "blocked_followup"
+    assert row["dependency_item_ids"] == ["quality_gate"]
+    assert row["requires_merged_inputs"] is True
+    assert row["requires_materialized_refs"] is True
+    assert row["dependency_satisfied"] is False
+    assert row["dependency_reason"] == "dependency quality_gate is not merged"
+    assert "blocked=1" in status.health_summary["message"]
+
+
 def test_operator_status_marks_resumable_pending_submission(monkeypatch) -> None:
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
     create_all(engine)


### PR DESCRIPTION
## Summary
- expose blocked work items in the operator status API and dashboard
- show dependency item IDs and the concrete dependency gate reason for blocked items
- include blocked item count in the operator health summary

## Why
Blocked downstream architecture jobs currently look idle unless the operator manually inspects payload dependencies. This makes pending closure jobs easier to distinguish from remote worker stalls.

## Validation
- `PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_operator_status.py`
