### PR TITLE
[codex] forward no proposal update flag

### DIFF
--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -88,6 +88,7 @@ def main(argv: list[str] | None = None) -> int:
     generate_l1_parser.add_argument("--no-auto-dispatch", action="store_true")
     generate_l1_parser.add_argument("--dispatch-machine-key")
     generate_l1_parser.add_argument("--dispatch-freshness-seconds", type=int, default=120)
+    generate_l1_parser.add_argument("--no-update-proposal-files", action="store_true")
 
     consume_l1_parser = subparsers.add_parser(
         "consume-l1-result",
@@ -149,6 +150,7 @@ def main(argv: list[str] | None = None) -> int:
     generate_l2_parser.add_argument("--no-auto-dispatch", action="store_true")
     generate_l2_parser.add_argument("--dispatch-machine-key")
     generate_l2_parser.add_argument("--dispatch-freshness-seconds", type=int, default=120)
+    generate_l2_parser.add_argument("--no-update-proposal-files", action="store_true")
 
     github_poll_parser = subparsers.add_parser("poll-github", help="Poll GitHub review PR state and reconcile merged PRs")
     github_poll_parser.add_argument("--database-url", required=True)
@@ -540,6 +542,8 @@ def main(argv: list[str] | None = None) -> int:
                 argv2.extend([key, str(value)])
         if args.no_auto_dispatch:
             argv2.append("--no-auto-dispatch")
+        if args.no_update_proposal_files:
+            argv2.append("--no-update-proposal-files")
         if args.dispatch_freshness_seconds is not None:
             argv2.extend(["--dispatch-freshness-seconds", str(args.dispatch_freshness_seconds)])
         return generate_l1_sweep_main(argv2)
@@ -624,6 +628,8 @@ def main(argv: list[str] | None = None) -> int:
             argv2.append("--no-run-physical")
         if args.no_auto_dispatch:
             argv2.append("--no-auto-dispatch")
+        if args.no_update_proposal_files:
+            argv2.append("--no-update-proposal-files")
         for item_id in args.depends_on_item_id or []:
             argv2.extend(["--depends-on-item-id", str(item_id)])
         if args.requires_merged_inputs:

--- a/control_plane/control_plane/tests/test_cli_generate_l1.py
+++ b/control_plane/control_plane/tests/test_cli_generate_l1.py
@@ -37,6 +37,7 @@ def test_top_level_generate_l1_forwards_extended_generation_flags() -> None:
                 "100",
                 "--stop-after-failures",
                 "2",
+                "--no-update-proposal-files",
             ]
         )
 
@@ -50,6 +51,35 @@ def test_top_level_generate_l1_forwards_extended_generation_flags() -> None:
     assert forwarded[forwarded.index("--trial-count") + 1] == "3"
     assert forwarded[forwarded.index("--seed-start") + 1] == "100"
     assert forwarded[forwarded.index("--stop-after-failures") + 1] == "2"
+    assert "--no-update-proposal-files" in forwarded
+
+
+def test_top_level_generate_l2_forwards_no_update_proposal_files() -> None:
+    with patch("control_plane.cli.main.generate_l2_campaign_main", return_value=0) as generate:
+        result = main(
+            [
+                "generate-l2-campaign",
+                "--database-url",
+                "sqlite+pysqlite:///:memory:",
+                "--repo-root",
+                "/repo",
+                "--campaign-path",
+                "campaign.json",
+                "--item-id",
+                "l2_item",
+                "--no-run-physical",
+                "--requires-materialized-refs",
+                "--no-update-proposal-files",
+            ]
+        )
+
+    assert result == 0
+    forwarded = generate.call_args.args[0]
+    assert forwarded[forwarded.index("--campaign-path") + 1] == "campaign.json"
+    assert forwarded[forwarded.index("--item-id") + 1] == "l2_item"
+    assert "--no-run-physical" in forwarded
+    assert "--requires-materialized-refs" in forwarded
+    assert "--no-update-proposal-files" in forwarded
 
 
 def test_top_level_run_worker_forwards_only_worker_flags() -> None:


### PR DESCRIPTION
## Summary
- add `--no-update-proposal-files` to the top-level `generate-l1-sweep` and `generate-l2-campaign` commands
- forward the flag to the direct generator CLIs
- cover both forwarding paths with top-level CLI tests

## Why
The direct generator modules support source/DB refreshes without rewriting proposal files, but the top-level wrapper rejected the same flag. That made routine evaluator-source refreshes brittle and forced bypassing the main CLI.

## Validation
- `PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_cli_generate_l1.py control_plane/control_plane/tests/test_worker_daemon_cli.py control_plane/control_plane/tests/test_worker_daemon.py control_plane/control_plane/tests/test_operator_status.py`
