### PR TITLE
[codex] attach status evidence to evaluator refresh

### DIFF
--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -174,6 +174,10 @@ def main(argv: list[str] | None = None) -> int:
     evaluator_refresh_parser.add_argument("--target-commit")
     evaluator_refresh_parser.add_argument("--reason", default="control-plane source changed")
     evaluator_refresh_parser.add_argument("--evaluator", default="remote evaluator")
+    evaluator_refresh_parser.add_argument("--database-url")
+    evaluator_refresh_parser.add_argument("--include-operator-status", action="store_true")
+    evaluator_refresh_parser.add_argument("--machine-key")
+    evaluator_refresh_parser.add_argument("--recent-limit", type=int, default=10)
     evaluator_refresh_parser.add_argument("--dry-run", action="store_true")
 
     resolver_parser = subparsers.add_parser(
@@ -1074,6 +1078,14 @@ def main(argv: list[str] | None = None) -> int:
         ]
         if args.target_commit is not None:
             argv2.extend(["--target-commit", str(args.target_commit)])
+        if args.database_url is not None:
+            argv2.extend(["--database-url", str(args.database_url)])
+        if args.machine_key is not None:
+            argv2.extend(["--machine-key", str(args.machine_key)])
+        if args.recent_limit is not None:
+            argv2.extend(["--recent-limit", str(args.recent_limit)])
+        if args.include_operator_status:
+            argv2.append("--include-operator-status")
         if args.dry_run:
             argv2.append("--dry-run")
         return request_evaluator_refresh_main(argv2)

--- a/control_plane/control_plane/cli/request_evaluator_refresh.py
+++ b/control_plane/control_plane/cli/request_evaluator_refresh.py
@@ -7,10 +7,14 @@ import json
 from pathlib import Path
 import subprocess
 
+from control_plane.db import build_engine, build_session_factory
+from control_plane.models.enums import WorkItemState
+from control_plane.models.work_items import WorkItem
 from control_plane.services.evaluator_refresh_request import (
     EvaluatorRefreshRequest,
     request_evaluator_refresh,
 )
+from control_plane.services.operator_status import OperatorStatusRequest, load_operator_status
 
 
 def _current_commit(repo_root: str) -> str:
@@ -23,6 +27,55 @@ def _current_commit(repo_root: str) -> str:
     return result.stdout.strip()
 
 
+def _operator_status_details(
+    *,
+    database_url: str,
+    repo_root: str,
+    machine_key: str | None,
+    recent_limit: int,
+) -> tuple[str, ...]:
+    engine = build_engine(database_url)
+    session_factory = build_session_factory(engine)
+    details: list[str] = []
+    with session_factory() as session:
+        status = load_operator_status(
+            session,
+            OperatorStatusRequest(recent_limit=recent_limit, repo_root=repo_root),
+        )
+        details.append(f"operator health: {status.health_summary['message']}")
+        for machine in status.evaluator_machines:
+            if machine_key and machine.get("machine_key") != machine_key:
+                continue
+            details.append(
+                "machine "
+                f"{machine.get('machine_key')}: assigned_ready={machine.get('assigned_ready')}, "
+                f"active_slots={machine.get('active_slots')}, "
+                f"heartbeat_age_seconds={machine.get('heartbeat_age_seconds')}, "
+                f"worker_attention={machine.get('worker_attention')}, "
+                f"capabilities={machine.get('capabilities')}, "
+                f"last_progress={machine.get('last_progress')}"
+            )
+        ready_query = session.query(WorkItem).filter(WorkItem.state == WorkItemState.READY)
+        if machine_key:
+            ready_query = ready_query.filter(WorkItem.assigned_machine_key == machine_key)
+        ready_items = (
+            ready_query.order_by(WorkItem.priority.desc(), WorkItem.created_at.asc(), WorkItem.item_id.asc())
+            .limit(recent_limit)
+            .all()
+        )
+        for item in ready_items:
+            details.append(
+                f"ready item {item.item_id}: assigned_machine_key={item.assigned_machine_key}, "
+                f"source_commit={item.source_commit}, task_type={item.task_type}"
+            )
+        for row in status.blocked_items[:recent_limit]:
+            details.append(
+                f"blocked item {row['item_id']}: {row.get('dependency_reason')}; "
+                f"dependencies={row.get('dependency_item_ids')}"
+            )
+    return tuple(details)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Request evaluator source refresh and daemon restart")
     parser.add_argument("--repo", required=True)
@@ -30,10 +83,24 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--target-commit")
     parser.add_argument("--reason", default="control-plane source changed")
     parser.add_argument("--evaluator", default="remote evaluator")
+    parser.add_argument("--database-url")
+    parser.add_argument("--include-operator-status", action="store_true")
+    parser.add_argument("--machine-key")
+    parser.add_argument("--recent-limit", type=int, default=10)
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
 
     target_commit = args.target_commit or _current_commit(args.repo_root)
+    details: tuple[str, ...] = ()
+    if args.include_operator_status:
+        if not args.database_url:
+            parser.error("--include-operator-status requires --database-url")
+        details = _operator_status_details(
+            database_url=args.database_url,
+            repo_root=args.repo_root,
+            machine_key=args.machine_key,
+            recent_limit=args.recent_limit,
+        )
     result = request_evaluator_refresh(
         EvaluatorRefreshRequest(
             repo=args.repo,
@@ -41,6 +108,7 @@ def main(argv: list[str] | None = None) -> int:
             reason=args.reason,
             evaluator=args.evaluator,
             dry_run=args.dry_run,
+            details=details,
         )
     )
     print(json.dumps(result.__dict__, indent=2, sort_keys=True))

--- a/control_plane/control_plane/services/evaluator_refresh_request.py
+++ b/control_plane/control_plane/services/evaluator_refresh_request.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field
 import json
 import re
 import subprocess
@@ -20,6 +21,7 @@ class EvaluatorRefreshRequest:
     reason: str = "control-plane source changed"
     evaluator: str = "remote evaluator"
     dry_run: bool = False
+    details: tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -106,6 +108,15 @@ def build_refresh_body(request: EvaluatorRefreshRequest) -> str:
             f"- evaluator: `{request.evaluator}`",
             f"- reason: {request.reason}",
             "",
+            *(
+                [
+                    "Current control-plane evidence:",
+                    *[f"- {detail}" for detail in request.details],
+                    "",
+                ]
+                if request.details
+                else []
+            ),
             "Expected evaluator procedure:",
             "1. Fetch `origin/master` and update the evaluator worktree to the target commit.",
             "2. Refresh Python dependencies if repository dependency files changed.",

--- a/control_plane/control_plane/tests/test_cli_request_evaluator_refresh.py
+++ b/control_plane/control_plane/tests/test_cli_request_evaluator_refresh.py
@@ -1,0 +1,41 @@
+"""Top-level CLI coverage for evaluator refresh requests."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from control_plane.cli.main import main
+
+
+def test_top_level_request_evaluator_refresh_forwards_operator_status_flags() -> None:
+    with patch("control_plane.cli.main.request_evaluator_refresh_main", return_value=0) as request_refresh:
+        result = main(
+            [
+                "request-evaluator-refresh",
+                "--repo",
+                "yhmtmt/RTLGen",
+                "--repo-root",
+                "/repo",
+                "--target-commit",
+                "abcdef",
+                "--database-url",
+                "postgresql+psycopg://rtlgen:rtlgen@localhost/rtlgen_control_plane",
+                "--include-operator-status",
+                "--machine-key",
+                "eval-daemon",
+                "--recent-limit",
+                "5",
+                "--dry-run",
+            ]
+        )
+
+    assert result == 0
+    forwarded = request_refresh.call_args.args[0]
+    assert forwarded[forwarded.index("--repo") + 1] == "yhmtmt/RTLGen"
+    assert forwarded[forwarded.index("--repo-root") + 1] == "/repo"
+    assert forwarded[forwarded.index("--target-commit") + 1] == "abcdef"
+    assert forwarded[forwarded.index("--database-url") + 1].startswith("postgresql+psycopg://")
+    assert forwarded[forwarded.index("--machine-key") + 1] == "eval-daemon"
+    assert forwarded[forwarded.index("--recent-limit") + 1] == "5"
+    assert "--include-operator-status" in forwarded
+    assert "--dry-run" in forwarded

--- a/control_plane/control_plane/tests/test_evaluator_refresh_request.py
+++ b/control_plane/control_plane/tests/test_evaluator_refresh_request.py
@@ -29,6 +29,23 @@ def test_build_refresh_body_includes_ack_block() -> None:
     assert "Restart evaluator-side daemons" in body
 
 
+def test_build_refresh_body_includes_operator_status_details() -> None:
+    body = build_refresh_body(
+        EvaluatorRefreshRequest(
+            repo="yhmtmt/RTLGen",
+            target_commit="abcdef1234567890",
+            details=(
+                "operator health: attention: ready=2, stalled_workers=1",
+                "machine eval-daemon: assigned_ready=2, active_slots=0",
+            ),
+        )
+    )
+
+    assert "Current control-plane evidence:" in body
+    assert "- operator health: attention: ready=2, stalled_workers=1" in body
+    assert "- machine eval-daemon: assigned_ready=2, active_slots=0" in body
+
+
 def test_request_evaluator_refresh_creates_issue_when_none_open() -> None:
     calls = []
 


### PR DESCRIPTION
## Summary
- allow evaluator refresh requests to include live operator-status evidence from the control-plane DB
- expose `--include-operator-status`, `--database-url`, `--machine-key`, and `--recent-limit` on the direct and top-level refresh CLIs
- include health, stalled machine diagnostics, assigned READY items, and blocked dependency reasons in the GitHub issue body

## Why
Remote-only Llama7B jobs can stall with fresh evaluator heartbeats but no leases. The refresh request should carry the same concrete evidence the operator sees, so evaluator restart/update instructions are reproducible and not hand-written.

## Validation
- `PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_evaluator_refresh_request.py control_plane/control_plane/tests/test_cli_request_evaluator_refresh.py control_plane/control_plane/tests/test_operator_status.py`
- dry-run and real request against the live DB posted operator-status evidence to issue #455
