### PR TITLE
[codex] Persist worker capability filters

### DIFF
--- a/control_plane/control_plane/services/lease_service.py
+++ b/control_plane/control_plane/services/lease_service.py
@@ -65,6 +65,17 @@ def _as_iso(dt) -> str:
     return dt.isoformat()
 
 
+def worker_capabilities_for_filter(
+    capabilities: dict[str, Any] | None,
+    capability_filter: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if capabilities is None and capability_filter is None:
+        return None
+    merged = dict(capabilities or {})
+    merged.update(capability_filter or {})
+    return merged
+
+
 def upsert_worker_machine(
     session: Session,
     *,
@@ -129,7 +140,7 @@ def acquire_next_lease(
             machine_key=machine_key,
             hostname=hostname,
             executor_kind=executor_kind,
-            capabilities=capabilities,
+            capabilities=worker_capabilities_for_filter(capabilities, capability_filter),
             role=machine_role,
             slot_capacity=slot_capacity,
         )

--- a/control_plane/control_plane/services/source_reconciler.py
+++ b/control_plane/control_plane/services/source_reconciler.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session
 from control_plane.models.enums import FlowName, LeaseStatus, WorkItemState
 from control_plane.models.worker_leases import WorkerLease
 from control_plane.models.work_items import WorkItem
-from control_plane.services.lease_service import upsert_worker_machine
+from control_plane.services.lease_service import upsert_worker_machine, worker_capabilities_for_filter
 
 
 class SourceReconciliationError(RuntimeError):
@@ -372,7 +372,7 @@ def next_source_required_item(
         machine_key=machine_key,
         hostname=hostname,
         executor_kind=executor_kind,
-        capabilities=capabilities,
+        capabilities=worker_capabilities_for_filter(capabilities, capability_filter),
         role=machine_role,
         slot_capacity=slot_capacity,
     )

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -18,6 +18,7 @@ from control_plane.models.runs import Run
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
 from control_plane.models.worker_leases import WorkerLease
+from control_plane.models.worker_machines import WorkerMachine
 from control_plane.services.lease_service import acquire_next_lease, expire_stale_leases, heartbeat_lease
 from control_plane.services.scheduler import assign_work_item
 
@@ -105,6 +106,27 @@ def test_acquire_next_lease_selects_matching_highest_priority_item() -> None:
         assert item_b.state == WorkItemState.LEASED
         lease = session.query(WorkerLease).filter_by(lease_token=result.lease_token).one()
         assert lease.status == LeaseStatus.ACTIVE
+
+
+def test_acquire_next_lease_persists_capability_filter() -> None:
+    with make_session() as session:
+        _, item_b = seed_ready_items(session)
+        from control_plane.services.lease_service import upsert_worker_machine
+
+        upsert_worker_machine(session, machine_key="machine-1")
+        assign_work_item(session, item_id=item_b.item_id, machine_key="machine-1")
+
+        result = acquire_next_lease(
+            session,
+            machine_key="machine-1",
+            capability_filter={"platform": "nangate45", "flow": "openroad"},
+            lease_seconds=900,
+        )
+
+        machine = session.query(WorkerMachine).filter_by(machine_key="machine-1").one()
+        assert result.item_id == item_b.item_id
+        assert machine.capabilities["platform"] == "nangate45"
+        assert machine.capabilities["flow"] == "openroad"
 
 
 def test_heartbeat_updates_expiry_and_machine_progress() -> None:

--- a/control_plane/control_plane/tests/test_source_reconciler.py
+++ b/control_plane/control_plane/tests/test_source_reconciler.py
@@ -6,10 +6,18 @@ from pathlib import Path
 import subprocess
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
+from control_plane.db import create_all
+from control_plane.models.enums import WorkItemState
+from control_plane.models.task_requests import TaskRequest
+from control_plane.models.work_items import WorkItem
+from control_plane.models.worker_machines import WorkerMachine
 from control_plane.services import source_reconciler
 from control_plane.services.source_reconciler import (
     SourceReconciliationError,
+    next_source_required_item,
     reconcile_service_repo_source,
 )
 
@@ -38,6 +46,61 @@ def _init_repo_with_stale_head(repo_root: Path) -> tuple[str, str]:
     second = _run("git", "-C", str(repo_root), "rev-parse", "HEAD")
     _run("git", "-C", str(repo_root), "checkout", "--detach", first)
     return first, second
+
+
+def test_next_source_required_item_persists_capability_filter() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    with Session(engine) as session:
+        task = TaskRequest(
+            request_key="queue:source_item",
+            source="test",
+            requested_by="tester",
+            title="source item",
+            description="requires source",
+            layer="layer2",
+            flow="openroad",
+            priority=1,
+            request_payload={"item_id": "source_item"},
+        )
+        session.add(task)
+        session.flush()
+        item = WorkItem(
+            work_item_key="queue:source_item",
+            task_request_id=task.id,
+            item_id="source_item",
+            layer="layer2",
+            flow="openroad",
+            platform="nangate45",
+            task_type="l2_campaign",
+            state=WorkItemState.READY,
+            priority=1,
+            source_commit="0" * 40,
+            assigned_machine_key="machine-1",
+            input_manifest={},
+            command_manifest=[],
+            expected_outputs=[],
+            acceptance_rules=[],
+        )
+        session.add(item)
+        session.commit()
+
+        selected = next_source_required_item(
+            session,
+            machine_key="machine-1",
+            hostname=None,
+            executor_kind="docker",
+            machine_role="evaluator",
+            slot_capacity=1,
+            capabilities=None,
+            capability_filter={"platform": "nangate45", "flow": "openroad"},
+        )
+
+        machine = session.query(WorkerMachine).filter_by(machine_key="machine-1").one()
+        assert selected is not None
+        assert selected.item_id == "source_item"
+        assert machine.capabilities["platform"] == "nangate45"
+        assert machine.capabilities["flow"] == "openroad"
 
 
 def test_reconcile_service_repo_recovers_stale_git_index_lock(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- persist worker capability filters during direct lease acquisition
- persist the same filter during pre-lease source reconciliation
- add regression coverage for both service-level paths

## Root cause
The daemon wrapper already merged `capability_filter` into reported capabilities, but lower-level lease/source service calls still upserted workers using only the raw `capabilities` payload. A worker started with only `--capability-filter-json` could therefore remain visible in the DB with `{}` capabilities until a later progress update.

## Validation
- `PYTHONPATH=/tmp/rtlgen-quality-closure/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_leases.py control_plane/control_plane/tests/test_source_reconciler.py control_plane/control_plane/tests/test_worker_daemon.py`

## Evaluation note
No PPA or evaluation jobs were run locally. Remote evaluator dispatch remains assigned to the evaluator machine.