### PR TITLE
[codex] Clarify stalled worker empty capabilities

### DIFF
--- a/control_plane/control_plane/services/operator_status.py
+++ b/control_plane/control_plane/services/operator_status.py
@@ -140,7 +140,10 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
         worker_attention = None
         if active_slots == 0 and assigned_ready > 0 and last_seen_at is not None and last_seen_at >= fresh_machine_cutoff:
             if last_progress is None:
-                worker_attention = "fresh_heartbeat_assigned_ready_without_progress"
+                if capabilities:
+                    worker_attention = "fresh_heartbeat_assigned_ready_without_progress"
+                else:
+                    worker_attention = "fresh_heartbeat_assigned_ready_empty_capabilities"
         heartbeat_age_seconds = None
         if last_seen_at is not None:
             heartbeat_age_seconds = max(0.0, (now - last_seen_at).total_seconds())

--- a/control_plane/control_plane/tests/test_operator_status.py
+++ b/control_plane/control_plane/tests/test_operator_status.py
@@ -382,6 +382,62 @@ def test_operator_status_reports_evaluator_machine_capacity() -> None:
         assert "stalled_workers=1" in status.health_summary["message"]
 
 
+def test_operator_status_reports_empty_capability_stalled_worker() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    with Session(engine) as session:
+        from control_plane.services.lease_service import upsert_worker_machine
+        machine = upsert_worker_machine(
+            session,
+            machine_key="worker-empty-caps",
+            hostname="worker-empty-caps",
+            role="evaluator",
+            slot_capacity=4,
+            capabilities={},
+        )
+        task = TaskRequest(
+            request_key="queue:empty_caps_ready",
+            source="test",
+            requested_by="tester",
+            title="empty caps ready",
+            description="empty caps ready",
+            layer="layer2",
+            flow="openroad",
+            priority=1,
+            request_payload={"item_id": "empty_caps_ready"},
+        )
+        session.add(task)
+        session.flush()
+        session.add(
+            WorkItem(
+                work_item_key="queue:empty_caps_ready",
+                task_request_id=task.id,
+                item_id="empty_caps_ready",
+                layer="layer2",
+                flow="openroad",
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.READY,
+                priority=1,
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[],
+                acceptance_rules=[],
+                assigned_machine_key=machine.machine_key,
+            )
+        )
+        session.commit()
+
+        status = load_operator_status(session, OperatorStatusRequest(recent_limit=5))
+        row = next(r for r in status.evaluator_machines if r["machine_key"] == "worker-empty-caps")
+        assert row["assigned_ready"] == 1
+        assert row["active_slots"] == 0
+        assert row["capabilities"] == {}
+        assert row["last_progress"] is None
+        assert row["worker_attention"] == "fresh_heartbeat_assigned_ready_empty_capabilities"
+        assert "stalled_workers=1" in status.health_summary["message"]
+
+
 def test_operator_status_does_not_flag_assigned_ready_worker_with_progress() -> None:
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
     create_all(engine)

--- a/control_plane/operator_runbook.md
+++ b/control_plane/operator_runbook.md
@@ -167,6 +167,77 @@ Healthy busy state:
 - `ARTIFACT_SYNC` items drain to `AWAITING_REVIEW`
 - eligible items open draft PRs automatically when submit is enabled
 
+## Stalled Evaluator Heartbeat
+
+`operator_status` reports a stalled evaluator when a machine has fresh
+heartbeats, assigned `READY` work, no active lease, and no worker progress.
+
+Important `worker_attention` values:
+- `fresh_heartbeat_assigned_ready_without_progress`: the worker has persisted
+  capabilities, but has not reported source reconciliation, no-work, worker
+  error, or command progress for its assigned work.
+- `fresh_heartbeat_assigned_ready_empty_capabilities`: the worker heartbeat is
+  fresh but `worker_machines.capabilities` is `{}`. A current worker launched
+  through `run_worker_daemon_service.sh` should persist `platform`, `flow`, and
+  `worker_source.head` before leasing. This usually means an old process is
+  still writing the heartbeat, the evaluator was not restarted onto current
+  `origin/master`, or a non-worker/duplicate process is using the same
+  `RTLCP_MACHINE_KEY`.
+
+First confirm the item is actually eligible before changing assignments:
+```sh
+source /workspaces/RTLGen/control_plane/.venv/bin/activate
+PYTHONPATH=/workspaces/RTLGen/control_plane \
+python3 - <<'PY'
+import os
+
+from control_plane.db import build_engine, build_session_factory
+from control_plane.services.scheduler import select_next_work_item
+
+db = os.environ["RTLCP_DATABASE_URL"]
+machine_key = "<machine_key>"
+engine = build_engine(db)
+Session = build_session_factory(engine)
+with Session() as session:
+    item = select_next_work_item(
+        session,
+        machine_key=machine_key,
+        machine_capabilities={},
+        capability_filter={"platform": "nangate45", "flow": "openroad"},
+    )
+    print(item.item_id, item.state.value, item.source_commit)
+    session.rollback()
+PY
+```
+
+If the selector finds the assigned item, do not move the work to another
+machine just to clear the dashboard. Fix the evaluator process:
+```sh
+sudo systemctl stop rtlgen-evaluator-worker.service || true
+pkill -f 'run-worker-daemon.*<machine_key>' || true
+
+cd /workspaces/rtlgen-eval-clean
+git fetch origin
+git reset --hard origin/master
+
+export RTLCP_MACHINE_KEY='<machine_key>'
+export RTLCP_CAPABILITY_FILTER_JSON='{"platform":"nangate45","flow":"openroad"}'
+export RTLCP_AUTO_UPDATE_SOURCE=1
+sudo systemctl start rtlgen-evaluator-worker.service
+```
+
+Then verify the machine row changes:
+```sh
+/workspaces/RTLGen/control_plane/scripts/operator_status.sh --format table
+```
+
+A corrected worker should show non-empty capabilities, including
+`worker_source.head`, and then transition to `source_reconcile`,
+`worker_poll/no_work`, or an active lease/run. If PostgreSQL shows lingering
+connections from the evaluator host, check for duplicate worker processes before
+terminating database backends; idle DB sessions are a symptom, not proof of the
+root cause.
+
 ## Recovery
 
 Restart evaluator worker after pulling latest `master`:


### PR DESCRIPTION
## Summary
- distinguish assigned-ready evaluator heartbeats with empty capabilities from the existing no-progress stalled-worker state
- add operator-status regression coverage for the empty-capabilities stalled remote worker symptom
- document the runbook for confirming queue eligibility and restarting the intended evaluator worker process

## Why
The active Llama7B closure jobs are assigned to the remote evaluator, but the remote machine row is heartbeating with `{}` capabilities and no progress. The dashboard should make that distinct from a worker that has capabilities but is not reporting progress.

## Validation
- `PYTHONPATH=/tmp/rtlgen-quality-closure/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_operator_status.py`

## Evaluation note
No local/devcontainer evaluation or PPA was run. Active queue items remain remote-assigned.