### PR TITLE
[codex] fix 7b hbm quality retry dependency

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3453,13 +3453,25 @@ def _decoder_attention_kv_physical_hbm_quality_backed_evidence(*, item_id: str) 
     }
 
 
-def _decoder_attention_kv_physical_hbm_quality_backed_7b_evidence(*, item_id: str) -> dict[str, Any]:
+def _decoder_attention_kv_physical_hbm_quality_backed_7b_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None = None,
+) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_kv_physical_hbm_quality_backed_7b__{item_id}.json"
     report = f"{base}/decoder_attention_kv_physical_hbm_quality_backed_7b__{item_id}.md"
+    native_quality_7b_item_id = next(
+        (
+            dep
+            for dep in (depends_on_item_ids or [])
+            if dep.startswith("l2_decoder_attention_kv_model_native_quality_7b_")
+        ),
+        "l2_decoder_attention_kv_model_native_quality_7b_v1",
+    )
     native_quality_7b = (
         f"{base}/decoder_attention_kv_model_native_quality_7b__"
-        "l2_decoder_attention_kv_model_native_quality_7b_v1.json"
+        f"{native_quality_7b_item_id}.json"
     )
     physical_frontier = (
         f"{base}/decoder_attention_kv_physical_hbm_frontier__"
@@ -7461,7 +7473,10 @@ def _build_payload(
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_quality_backed":
             decoder_evidence = _decoder_attention_kv_physical_hbm_quality_backed_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_quality_backed_7b":
-            decoder_evidence = _decoder_attention_kv_physical_hbm_quality_backed_7b_evidence(item_id=item_id)
+            decoder_evidence = _decoder_attention_kv_physical_hbm_quality_backed_7b_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+            )
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_memory_noc":
             decoder_evidence = _decoder_attention_kv_physical_hbm_memory_noc_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_physical_hbm_compute_sensitivity":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3158,6 +3158,51 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_qualit
             }
 
 
+def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_quality_backed_7b_retry_dependency() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    item_id="l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2",
+                    proposal_id="prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/proposal.json"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    abstraction_layer="decoder_attention_kv_physical_hbm_quality_backed_7b",
+                    comparison_role="frontier_synthesis",
+                    depends_on_item_ids=["l2_decoder_attention_kv_model_native_quality_7b_v1_r2"],
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["attention_kv_model_native_quality_7b"].endswith(
+                "decoder_attention_kv_model_native_quality_7b__"
+                "l2_decoder_attention_kv_model_native_quality_7b_v1_r2.json"
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": ["l2_decoder_attention_kv_model_native_quality_7b_v1_r2"],
+                "requires_merged_inputs": False,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_memory_noc() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- derive the 7B physical-HBM quality-backed native-quality evidence path from the requested native-quality dependency item
- keep the existing `v1` evidence path as the default for compatibility
- add a generator regression test for a retry dependency on `l2_decoder_attention_kv_model_native_quality_7b_v1_r2`

## Root Cause
The 7B HBM-quality-backed L2 generator accepted dependency item IDs in `developer_loop.dependencies`, but the actual decoder-contract evidence path was hard-coded to the failed `l2_decoder_attention_kv_model_native_quality_7b_v1` output. A successor item depending on the bounded `v1_r2` quality retry would still consume the stale `v1` JSON.

## Validation
- `PYTHONPATH=/tmp/rtlgen-quality-closure:/tmp/rtlgen-quality-closure/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_quality_backed_7b control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_quality_backed_7b_retry_dependency`
