### PR TITLE
Wire native 7B quality gate into HBM frontier

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -3528,6 +3528,7 @@ def _decoder_attention_kv_physical_hbm_quality_backed_7b_evidence(
                     "--macs-per-cycle 524288 "
                     "--vector-ops-per-cycle 65536 "
                     "--clock-ns 1.0 "
+                    f"--quality-gate-json {native_quality_7b} "
                     f"--out {out} "
                     f"--out-md {report}"
                 ),

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3134,6 +3134,12 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_qualit
             assert "--kv-sharing-list gqa8" in run
             assert "--kv-bits-list 16,8" in run
             assert "--kv-bits-list 16,8,4" not in run
+            assert (
+                "--quality-gate-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_model_native_quality_7b__"
+                "l2_decoder_attention_kv_model_native_quality_7b_v1.json"
+            ) in run
             assert decoder_inputs["attention_kv_memory_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_kv_physical_hbm_quality_backed_7b__"
@@ -3192,6 +3198,14 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_qualit
 
             work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
             decoder_inputs = work_item.input_manifest["decoder_contract"]
+            run = work_item.command_manifest[0]["run"]
+            assert "estimate_llm_decoder_attention_kv_physical_hbm_frontier.py" in run
+            assert (
+                "--quality-gate-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_model_native_quality_7b__"
+                "l2_decoder_attention_kv_model_native_quality_7b_v1_r2.json"
+            ) in run
             assert decoder_inputs["attention_kv_model_native_quality_7b"].endswith(
                 "decoder_attention_kv_model_native_quality_7b__"
                 "l2_decoder_attention_kv_model_native_quality_7b_v1_r2.json"

--- a/npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
@@ -35,6 +35,109 @@ def _str_list(value: str) -> list[str]:
     return items
 
 
+def _as_str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _as_int(value: Any, *, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_float(value: Any, *, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_text_list(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    items: list[str] = []
+    for value in values:
+        text = _as_str(value)
+        if text:
+            items.append(text)
+    return items
+
+
+def _compact_quality_candidate(row: Any) -> JsonDict | None:
+    if not isinstance(row, dict):
+        return None
+    kv_bits = _as_int(row.get("kv_bits"), default=-1)
+    if kv_bits < 0:
+        return None
+    return {
+        "kv_bits": kv_bits,
+        "kv_granularity": _as_str(row.get("kv_granularity")),
+        "comparison_count": _as_int(row.get("comparison_count")),
+        "top1_match_rate": _as_float(row.get("top1_match_rate")),
+        "topk_contains_rate": _as_float(row.get("topk_contains_rate")),
+        "mean_logit_cosine": _as_float(row.get("mean_logit_cosine")),
+        "mean_probability_kl": _as_float(row.get("mean_probability_kl")),
+        "min_reference_margin": _as_float(row.get("min_reference_margin")),
+        "max_abs_logit_delta_max": _as_float(row.get("max_abs_logit_delta_max")),
+    }
+
+
+def _load_quality_gate_json(path_text: str) -> JsonDict:
+    path = Path(path_text)
+    if not path.exists():
+        raise SystemExit(f"quality-gate-json does not exist: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid quality-gate-json {path}: {exc}") from exc
+    except OSError as exc:
+        raise SystemExit(f"failed to read quality-gate-json {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        payload = {}
+
+    model_payload = payload.get("model", {})
+    if not isinstance(model_payload, dict):
+        model_payload = {}
+    decision_payload = payload.get("decision", {})
+    if not isinstance(decision_payload, dict):
+        decision_payload = {}
+    candidate_summary = payload.get("candidate_summary", [])
+    if not isinstance(candidate_summary, list):
+        candidate_summary = []
+    best_kv4_candidate = payload.get("best_kv4_candidate")
+    compact_candidates = [
+        candidate
+        for candidate in (_compact_quality_candidate(row) for row in candidate_summary)
+        if candidate is not None
+    ]
+    return {
+        "quality_gate_json": str(path),
+        "model": {
+            "model_id": _as_str(model_payload.get("model_id")),
+            "attention_heads": _as_int(model_payload.get("attention_heads")),
+            "kv_heads": _as_int(model_payload.get("kv_heads")),
+            "gqa_group_size": _as_float(model_payload.get("gqa_group_size")),
+            "device": _as_str(model_payload.get("device")),
+            "dtype": _as_str(model_payload.get("dtype")),
+            "requested_dtype": _as_str(model_payload.get("requested_dtype")),
+        },
+        "decision": {
+            "status": _as_str(decision_payload.get("status")),
+            "blockers": _normalize_text_list(decision_payload.get("blockers")),
+            "cautions": _normalize_text_list(decision_payload.get("cautions")),
+            "next_step": _as_str(decision_payload.get("next_step")),
+        },
+        "candidate_summary": {
+            "kv4": [row for row in compact_candidates if row["kv_bits"] == 4],
+            "kv8": [row for row in compact_candidates if row["kv_bits"] == 8],
+        },
+        "best_kv4_candidate": _compact_quality_candidate(best_kv4_candidate),
+    }
+
+
 def _ceil_div(a: int | float, b: int | float) -> int:
     return int(math.ceil(a / b)) if a else 0
 
@@ -370,6 +473,7 @@ def build_report(
     macs_per_cycle_list: list[int],
     vector_ops_per_cycle_list: list[int],
     clock_ns: float,
+    quality_gate: JsonDict | None = None,
 ) -> JsonDict:
     shapes = {
         "llama7b_proxy": {"layers": 32, "hidden_size": 4096, "attention_heads": 32},
@@ -560,6 +664,7 @@ def build_report(
         ),
         "best_by_memory_noc": retained_memory_noc,
         "best_by_compute": best_by_compute,
+        "quality_gate": quality_gate,
         "assumptions": [
             "This is a planning model for single-token decode attention/KV, not a JEDEC HBM timing model.",
             "HBM bandwidth is derived from stack count, pseudo-channel count, interface width, MT/s, and the core clock period.",
@@ -658,6 +763,69 @@ def _write_markdown(path: Path, payload: JsonDict) -> None:
         )
     lines.extend(["", "## Assumptions", ""])
     lines.extend(f"- {item}" for item in payload["assumptions"])
+    quality_gate = payload.get("quality_gate")
+    if isinstance(quality_gate, dict):
+        model = quality_gate.get("model", {})
+        decision = quality_gate.get("decision", {})
+        candidates = quality_gate.get("candidate_summary", {})
+        lines.extend(
+            [
+                "",
+                "## Native KV Quality Gate Summary",
+                "",
+                f"- status: `{_as_str(decision.get('status'))}`",
+                f"- model: `{_as_str(model.get('model_id'))}`",
+                f"- gqa_group_size: `{_as_float(model.get('gqa_group_size'))}`",
+                "",
+            ]
+        )
+        if isinstance(decision.get("blockers"), list) and decision["blockers"]:
+            lines.extend(["## Blockers", ""])
+            lines.extend(f"- {item}" for item in decision["blockers"])
+            lines.append("")
+        if isinstance(decision.get("cautions"), list) and decision["cautions"]:
+            lines.extend(["## Cautions", ""])
+            lines.extend(f"- {item}" for item in decision["cautions"])
+            lines.append("")
+        for tag in ("kv8", "kv4"):
+            rows = candidates.get(tag)
+            if not isinstance(rows, list) or not rows:
+                continue
+            lines.extend(
+                [
+                    f"### {tag.upper()} summary",
+                    "",
+                    "| bits | granularity | top1 | top-k | cosine | kl | comparisons | margin | delta |",
+                    "|---:|---|---:|---:|---:|---:|---:|---:|---:|",
+                ]
+            )
+            for row in rows:
+                lines.append(
+                    "| {bits} | {gran} | {top1} | {topk} | {cos} | {kl} | {count} | {margin} | {delta} |".format(
+                        bits=row["kv_bits"],
+                        gran=row.get("kv_granularity") or "tensor",
+                        top1=row.get("top1_match_rate"),
+                        topk=row.get("topk_contains_rate"),
+                        cos=row.get("mean_logit_cosine"),
+                        kl=row.get("mean_probability_kl"),
+                        count=row.get("comparison_count"),
+                        margin=row.get("min_reference_margin"),
+                        delta=row.get("max_abs_logit_delta_max"),
+                    )
+                )
+            lines.append("")
+        best_kv4 = quality_gate.get("best_kv4_candidate")
+        if isinstance(best_kv4, dict):
+            lines.extend(
+                [
+                    "### best KV4 candidate",
+                    "",
+                    f"- granularity: `{_as_str(best_kv4.get('kv_granularity'))}`",
+                    f"- top1_match_rate: `{_as_float(best_kv4.get('top1_match_rate'))}`",
+                    f"- topk_contains_rate: `{_as_float(best_kv4.get('topk_contains_rate'))}`",
+                    f"- mean_logit_cosine: `{_as_float(best_kv4.get('mean_logit_cosine'))}`",
+                ]
+            )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -694,10 +862,14 @@ def main() -> int:
     ap.add_argument("--macs-per-cycle", type=_int_list, default=[524288])
     ap.add_argument("--vector-ops-per-cycle", type=_int_list, default=[65536])
     ap.add_argument("--clock-ns", type=float, default=1.0)
+    ap.add_argument("--quality-gate-json")
     ap.add_argument("--out", required=True)
     ap.add_argument("--out-md", required=True)
     args = ap.parse_args()
 
+    quality_gate = None
+    if args.quality_gate_json:
+        quality_gate = _load_quality_gate_json(args.quality_gate_json)
     payload = build_report(
         label=args.label,
         sequence_length_list=args.sequence_length_list,
@@ -729,6 +901,7 @@ def main() -> int:
         macs_per_cycle_list=args.macs_per_cycle,
         vector_ops_per_cycle_list=args.vector_ops_per_cycle,
         clock_ns=args.clock_ns,
+        quality_gate=quality_gate,
     )
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
+++ b/tests/test_estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Tests for quality-gate wiring in the physical HBM frontier estimator."""
+
+import json
+from pathlib import Path
+
+import npu.eval.estimate_llm_decoder_attention_kv_physical_hbm_frontier as estimator
+
+
+def _write_quality_payload(path: Path) -> None:
+    payload = {
+        "version": 0.2,
+        "model": {
+            "model_id": "mock/7b",
+            "attention_heads": 32,
+            "kv_heads": 4,
+            "gqa_group_size": 8.0,
+            "device": "cpu",
+            "dtype": "float16",
+            "requested_dtype": "auto",
+        },
+        "decision": {
+            "status": "native_checkpoint_kv4_promising",
+            "blockers": ["minor concern"],
+            "cautions": ["check top-k sensitivity"],
+            "next_step": "validate at larger scale",
+        },
+        "candidate_summary": [
+            {
+                "kv_bits": 4,
+                "kv_granularity": "tensor",
+                "comparison_count": 128,
+                "top1_match_rate": 0.992,
+                "topk_contains_rate": 0.999,
+                "mean_logit_cosine": 0.9992,
+                "mean_probability_kl": 0.0015,
+                "min_reference_margin": 0.11,
+                "max_abs_logit_delta_max": 0.009,
+            },
+            {
+                "kv_bits": 8,
+                "kv_granularity": "token_vector",
+                "comparison_count": 128,
+                "top1_match_rate": 0.999,
+                "topk_contains_rate": 1.0,
+                "mean_logit_cosine": 0.9999,
+                "mean_probability_kl": 0.0005,
+                "min_reference_margin": 0.21,
+                "max_abs_logit_delta_max": 0.003,
+            },
+        ],
+        "best_kv4_candidate": {
+            "kv_bits": 4,
+            "kv_granularity": "tensor",
+            "comparison_count": 128,
+            "top1_match_rate": 0.992,
+            "topk_contains_rate": 0.999,
+            "mean_logit_cosine": 0.9992,
+            "mean_probability_kl": 0.0015,
+            "min_reference_margin": 0.11,
+            "max_abs_logit_delta_max": 0.009,
+        },
+    }
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _build_payload_with_quality(quality_path: Path) -> estimator.JsonDict:
+    quality_gate = estimator._load_quality_gate_json(str(quality_path))
+    return estimator.build_report(
+        label="llama7b_proxy",
+        sequence_length_list=[4096],
+        die_area_mm2_list=[100.0],
+        kv_sharing_list=["gqa8"],
+        kv_bits_list=[8],
+        stack_count_list=[1],
+        pseudo_channels_per_stack_list=[8],
+        pseudo_channel_width_bits_list=[64],
+        data_rate_mtps_list=[3200],
+        hbm_efficiency_list=[0.6],
+        tile_tokens_list=[512],
+        prefetch_distance_tiles_list=[4],
+        hbm_outstanding_list=[8],
+        arbitration_efficiency_list=[0.9],
+        virtual_channel_list=[4],
+        prefetch_start_list=["during_qkv"],
+        sram_area_fraction_list=[0.6],
+        usable_sram_fraction_list=[0.7],
+        bitcell_area_um2_per_bit_list=[0.02],
+        local_sram_fraction_list=[0.25],
+        bank_count_list=[16],
+        bank_bandwidth_bytes_per_cycle_list=[1024.0],
+        bank_interleave_tokens_list=[16],
+        bank_conflict_efficiency_list=[0.75],
+        noc_bandwidth_bytes_per_cycle_list=[16384.0],
+        noc_hops_list=[1],
+        router_latency_cycles_per_hop_list=[2],
+        macs_per_cycle_list=[524288],
+        vector_ops_per_cycle_list=[65536],
+        clock_ns=1.0,
+        quality_gate=quality_gate,
+    )
+
+
+def test_load_quality_gate_json_returns_compact_summary(tmp_path: Path) -> None:
+    quality_path = tmp_path / "quality.json"
+    _write_quality_payload(quality_path)
+
+    summary = estimator._load_quality_gate_json(str(quality_path))
+
+    assert summary["model"]["model_id"] == "mock/7b"
+    assert summary["decision"]["status"] == "native_checkpoint_kv4_promising"
+    assert summary["candidate_summary"]["kv4"][0]["kv_bits"] == 4
+    assert summary["candidate_summary"]["kv8"][0]["kv_bits"] == 8
+    assert summary["best_kv4_candidate"]["kv_bits"] == 4
+
+
+def test_build_report_and_markdown_include_quality_gate_summary(tmp_path: Path) -> None:
+    quality_path = tmp_path / "quality.json"
+    _write_quality_payload(quality_path)
+    out_md = tmp_path / "out.md"
+
+    payload = _build_payload_with_quality(quality_path)
+    assert payload["quality_gate"]["decision"]["status"] == "native_checkpoint_kv4_promising"
+    assert payload["quality_gate"]["candidate_summary"]["kv4"][0]["kv_bits"] == 4
+
+    estimator._write_markdown(out_md, payload)
+    markdown = out_md.read_text(encoding="utf-8")
+    assert "## Native KV Quality Gate Summary" in markdown
+    assert "- status: `native_checkpoint_kv4_promising`" in markdown
+    assert "### KV4 summary" in markdown
+    assert "### best KV4 candidate" in markdown


### PR DESCRIPTION
## Summary
- add optional --quality-gate-json support to the physical HBM frontier estimator
- embed compact native KV quality evidence in JSON/Markdown output
- make the 7B quality-backed HBM task pass the dependency artifact path, including retry-specific item ids

## Tests
- PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k decoder_attention_kv_physical_hbm_quality_backed_7b tests/test_estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
- PYTHONPATH=.:control_plane python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_physical_hbm_frontier.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py tests/test_estimate_llm_decoder_attention_kv_physical_hbm_frontier.py
- git diff --check
- one-row estimator CLI smoke with and without --quality-gate-json

No local PPA/evaluation was launched; this is code/test wiring only.