### PR TITLE
control_plane: consume evidence-only L2 results

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -445,6 +445,8 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
     ("attention_local_sram_capacity_out", "attention_local_sram_capacity_report"),
     ("attention_kv_measured_sram_rebalance_out", "attention_kv_measured_sram_rebalance_report"),
     ("attention_kv_measured_hbm_service_out", "attention_kv_measured_hbm_service_report"),
+    ("attention_kv_model_native_quality_out", "attention_kv_model_native_quality_report"),
+    ("attention_kv_model_native_quality_7b_out", "attention_kv_model_native_quality_7b_report"),
     ("attention_kv_onchip_service_schedule_out", "attention_kv_onchip_service_schedule_report"),
     (
         "attention_kv_endpoint_full_onchip_service_schedule_out",
@@ -712,6 +714,35 @@ def _decoder_recommendation_override(
 
 def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, Any]) -> tuple[str, str]:
     model = str(evidence_payload.get("model", "")).strip()
+    if isinstance(evidence_payload.get("model"), dict) and isinstance(evidence_payload.get("decision"), dict):
+        decision = dict(evidence_payload["decision"])
+        outcome = str(decision.get("status") or "native_checkpoint_quality_recorded")
+        model_info = dict(evidence_payload["model"])
+        parts = [
+            f"Decoder native-checkpoint KV quality evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in ("model_id", "attention_heads", "kv_heads", "gqa_group_size", "dtype"):
+            if key in model_info:
+                parts.append(f"{key}={model_info.get(key)}")
+        best_kv4 = evidence_payload.get("best_kv4_candidate")
+        if isinstance(best_kv4, dict):
+            for key in (
+                "kv_bits",
+                "kv_granularity",
+                "top1_match_rate",
+                "topk_contains_rate",
+                "mean_logit_cosine",
+                "mean_probability_kl",
+                "max_abs_logit_delta_max",
+            ):
+                if key in best_kv4:
+                    parts.append(f"kv4_{key}={best_kv4.get(key)}")
+        next_step = str(decision.get("next_step", "")).strip()
+        if next_step:
+            parts.append(f"next_step={next_step}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
     if model == "llm_decoder_attention_kv_measured_sram_rebalance_llama7b_v1":
         best = evidence_payload.get("best")
         best_dict = dict(best) if isinstance(best, dict) else {}
@@ -1643,6 +1674,62 @@ def _build_payload(
     }
 
 
+def _decoder_evidence_recommendation(
+    *,
+    repo_root: Path,
+    work_item: WorkItem,
+    evidence_ref: str,
+    outcome: str,
+) -> dict[str, Any]:
+    abstraction_layer = _developer_loop_abstraction_layer(repo_root, work_item)
+    return {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": evidence_ref,
+        "arch_id": abstraction_layer or work_item.item_id,
+        "macro_mode": "evidence_only",
+        "outcome": outcome,
+    }
+
+
+def _build_decoder_evidence_payload(
+    *,
+    repo_root: Path,
+    work_item: WorkItem,
+    run: Run,
+    evidence_ref: str,
+    evidence_payload: dict[str, Any],
+    source_refs: dict[str, str],
+    evaluation_record: dict[str, Any] | None,
+    proposal_assessment: dict[str, Any] | None,
+) -> dict[str, Any]:
+    outcome = str((proposal_assessment or {}).get("outcome") or "decoder_evidence_recorded")
+    return {
+        "version": 0.1,
+        "generated_utc": utcnow().astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "item_id": work_item.item_id,
+        "run_key": run.run_key,
+        "layer": work_item.layer.value,
+        "flow": work_item.flow.value,
+        "platform": work_item.platform,
+        "task_type": work_item.task_type,
+        "source_commit": run.checkout_commit or work_item.source_commit,
+        "review_metadata_source_commit": _repo_head(repo_root) or run.checkout_commit or work_item.source_commit,
+        "objective": work_item.task_request.description,
+        "input_manifest": work_item.input_manifest,
+        "recommendation": _decoder_evidence_recommendation(
+            repo_root=repo_root,
+            work_item=work_item,
+            evidence_ref=evidence_ref,
+            outcome=outcome,
+        ),
+        "objective_profiles": [],
+        "evaluation_record": evaluation_record,
+        "proposal_assessment": proposal_assessment,
+        "source_refs": source_refs,
+        "decoder_quality": _decoder_quality_brief(evidence_payload),
+    }
+
+
 def _upsert_artifact(session: Session, *, run: Run, target_path: str, payload: dict[str, Any]) -> None:
     artifact = (
         session.query(Artifact)
@@ -1675,6 +1762,69 @@ def consume_l2_result(session: Session, request: Layer2ConsumeRequest) -> Layer2
     if run.status != RunStatus.SUCCEEDED:
         raise Layer2ResultConsumerError(f"run is not succeeded: {run.run_key} status={run.status.value}")
 
+    proposal = _load_proposal(repo_root, work_item)
+    evidence_ref, evidence_source_refs = _decoder_evidence_paths(repo_root=repo_root, work_item=work_item)
+    if evidence_ref and _find_output_path_optional(work_item, "/best_point.json") is None:
+        evidence_path = _resolve_path(repo_root=repo_root, path_text=evidence_ref)
+        evidence_payload = _load_json(evidence_path)
+        evaluation_mode = _effective_evaluation_mode(repo_root, work_item)
+        comparison_role = _effective_comparison_role(repo_root, work_item)
+        proposal_assessment, evaluation_record, proposal_source_refs = _build_decoder_evidence_assessment(
+            work_item=work_item,
+            proposal=proposal,
+            repo_root=repo_root,
+            evaluation_mode=evaluation_mode,
+            comparison_role=comparison_role,
+        )
+        payload = _build_decoder_evidence_payload(
+            repo_root=repo_root,
+            work_item=work_item,
+            run=run,
+            evidence_ref=evidence_ref,
+            evidence_payload=evidence_payload,
+            evaluation_record=evaluation_record,
+            proposal_assessment=proposal_assessment,
+            source_refs={
+                "decoder_evidence_json": evidence_ref,
+                **evidence_source_refs,
+                **proposal_source_refs,
+            },
+        )
+        recommended_arch_id = str(payload["recommendation"].get("arch_id", "")).strip()
+        recommended_macro_mode = str(payload["recommendation"].get("macro_mode", "")).strip()
+        if not recommended_arch_id or not recommended_macro_mode:
+            raise Layer2ResultConsumerError(f"could not derive recommended point for work item: {work_item.item_id}")
+        target_rel = request.target_path or _default_target_path(item_id=work_item.item_id)
+        target_path = _resolve_path(repo_root=repo_root, path_text=target_rel)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+        _upsert_artifact(session, run=run, target_path=str(target_path.relative_to(repo_root)), payload=payload)
+        work_item.state = WorkItemState.ARTIFACT_SYNC
+        session.add(
+            RunEvent(
+                run_id=run.id,
+                event_time=utcnow(),
+                event_type="l2_decision_proposed",
+                event_payload={
+                    "target_path": str(target_path.relative_to(repo_root)),
+                    "recommended_arch_id": recommended_arch_id,
+                    "recommended_macro_mode": recommended_macro_mode,
+                    "profile_count": 0,
+                },
+            )
+        )
+        session.commit()
+        return Layer2ConsumeResult(
+            item_id=work_item.item_id,
+            run_key=run.run_key,
+            target_path=str(target_path),
+            recommended_arch_id=recommended_arch_id,
+            recommended_macro_mode=recommended_macro_mode,
+            profile_count=0,
+            work_item_state=work_item.state.value,
+        )
+
     best_point_rel = _find_output_path(work_item, "/best_point.json")
     summary_rel = _find_output_path(work_item, "/summary.csv")
     results_rel = _find_output_path(work_item, "/results.csv")
@@ -1685,7 +1835,6 @@ def consume_l2_result(session: Session, request: Layer2ConsumeRequest) -> Layer2
     summary_rows = _load_csv(_resolve_path(repo_root=repo_root, path_text=summary_rel))
     results_rows = _load_csv(_resolve_path(repo_root=repo_root, path_text=results_rel))
     summary_best = _summary_best_row(summary_rows)
-    proposal = _load_proposal(repo_root, work_item)
     evaluation_mode = _effective_evaluation_mode(repo_root, work_item)
     comparison_role = _effective_comparison_role(repo_root, work_item)
     explicit_comparison_role = _explicit_comparison_role(repo_root, work_item)

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5981,8 +5981,8 @@ def _decoder_attention_kv_model_native_quality_evidence(*, item_id: str) -> dict
     trace_calibration = f"{base}/decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json"
     return {
         "inputs": {
-            "attention_kv_memory_out": out,
-            "attention_kv_memory_report": report,
+            "attention_kv_model_native_quality_out": out,
+            "attention_kv_model_native_quality_report": report,
             "attention_kv_trace_calibration": trace_calibration,
             "attention_kv_model_native_quality_scope": (
                 "Run a trained native-GQA checkpoint through teacher-forced decode while feeding back "
@@ -6017,8 +6017,8 @@ def _decoder_attention_kv_model_native_quality_7b_evidence(*, item_id: str) -> d
     trace_calibration = f"{base}/decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json"
     return {
         "inputs": {
-            "attention_kv_memory_out": out,
-            "attention_kv_memory_report": report,
+            "attention_kv_model_native_quality_7b_out": out,
+            "attention_kv_model_native_quality_7b_report": report,
             "attention_kv_trace_calibration": trace_calibration,
             "attention_kv_model_native_quality_7b_scope": (
                 "Run a 7B-class trained checkpoint through teacher-forced decode while feeding back "

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -588,6 +588,132 @@ def test_consume_l2_result_writes_decision_proposal() -> None:
             assert artifact.path == f"control_plane/shadow_exports/l2_decisions/{item_id}.json"
 
 
+def test_consume_l2_result_writes_evidence_only_decision_without_campaign_outputs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        item_id = "l2_decoder_attention_kv_model_native_quality_7b_v1_r2"
+        evidence_rel = (
+            "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+            f"decoder_attention_kv_model_native_quality_7b__{item_id}.json"
+        )
+        report_rel = (
+            "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+            f"decoder_attention_kv_model_native_quality_7b__{item_id}.md"
+        )
+        _write(
+            repo_root / evidence_rel,
+            json.dumps(
+                {
+                    "model": {
+                        "model_id": "mistralai/Mistral-7B-v0.1",
+                        "attention_heads": 32,
+                        "kv_heads": 8,
+                        "gqa_group_size": 4.0,
+                        "dtype": "bfloat16",
+                    },
+                    "decision": {
+                        "status": "native_checkpoint_kv4_promising",
+                        "next_step": "Use this checkpoint evidence with the PPA model.",
+                    },
+                    "best_kv4_candidate": {
+                        "kv_bits": 4,
+                        "kv_granularity": "tensor",
+                        "top1_match_rate": 1.0,
+                        "topk_contains_rate": 1.0,
+                        "mean_logit_cosine": 0.9978,
+                        "mean_probability_kl": 0.0168,
+                    },
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+        _write(repo_root / report_rel, "# quality report\n")
+
+        with Session(engine) as session:
+            task_request = TaskRequest(
+                request_key=f"l2_campaign:{item_id}",
+                source="test",
+                requested_by="@tester",
+                title="Layer2 native quality",
+                description="native checkpoint quality gate",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": item_id,
+                    "layer": "layer2",
+                    "flow": "openroad",
+                    "developer_loop": {
+                        "proposal_id": "prop_l2_decoder_attention_kv_model_native_quality_7b_v1",
+                        "evaluation": {
+                            "mode": "frontier_detail",
+                            "expected_direction": "iterate",
+                        },
+                        "comparison": {"role": "precision_gate"},
+                        "abstraction": {"layer": "decoder_attention_kv_model_native_quality_7b"},
+                    },
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key=f"l2_campaign:{item_id}",
+                task_request_id=task_request.id,
+                item_id=item_id,
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="src_verilog",
+                input_manifest={
+                    "decoder_contract": {
+                        "attention_kv_memory_out": evidence_rel,
+                        "attention_kv_memory_report": report_rel,
+                    }
+                },
+                command_manifest=[],
+                expected_outputs=[evidence_rel, report_rel],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+            run = Run(
+                run_key=f"{item_id}_run_1",
+                work_item_id=work_item.id,
+                attempt=1,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                result_summary="2/2 commands succeeded",
+                result_payload={"queue_result": {"status": "ok"}},
+            )
+            session.add(run)
+            session.commit()
+
+            result = consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+            assert result.recommended_arch_id == "decoder_attention_kv_model_native_quality_7b"
+            assert result.recommended_macro_mode == "evidence_only"
+            assert result.profile_count == 0
+
+            proposal_path = repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json"
+            payload = json.loads(proposal_path.read_text(encoding="utf-8"))
+            assert payload["recommendation"]["source"] == "decoder_evidence"
+            assert payload["proposal_assessment"]["outcome"] == "native_checkpoint_kv4_promising"
+            assert payload["source_refs"]["decoder_evidence_json"] == evidence_rel
+            assert payload["source_refs"]["decoder_attention_kv_memory_report"] == report_rel
+
+
 def test_consume_l2_result_allows_explicit_target_path() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -3765,7 +3765,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
             assert "run_hf_eval_python.sh" in run
             assert "evaluate_llm_decoder_model_native_kv_quant.py" in run
             assert "--kv-bits-list 8,4" in run
-            assert decoder_inputs["attention_kv_memory_out"] == (
+            assert decoder_inputs["attention_kv_model_native_quality_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_kv_model_native_quality__"
                 "l2_decoder_attention_kv_model_native_quality_tinyllama_v1.json"
@@ -3774,7 +3774,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
                 "decoder_attention_kv_trace_calibration__l2_decoder_attention_kv_trace_calibration_v1.json"
             )
             assert "teacher-forced decode" in decoder_inputs["attention_kv_model_native_quality_scope"]
-            assert decoder_inputs["attention_kv_memory_out"] in work_item.expected_outputs
+            assert decoder_inputs["attention_kv_model_native_quality_out"] in work_item.expected_outputs
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "decoder_attention_kv_model_native_quality",
             }
@@ -3834,7 +3834,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
             assert "--max-prompts \"$MAX_PROMPTS\"" in run
             assert "--generation-steps \"$GENERATION_STEPS\"" in run
             assert "--dtype \"$DTYPE\"" in run
-            assert decoder_inputs["attention_kv_memory_out"] == (
+            assert decoder_inputs["attention_kv_model_native_quality_7b_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_kv_model_native_quality_7b__"
                 "l2_decoder_attention_kv_model_native_quality_7b_v1.json"


### PR DESCRIPTION
## Summary
- allow L2 completion processing to emit decision proposals from decoder evidence-only JSON/MD outputs when no campaign best_point.json exists
- add native KV quality evidence contract keys for future generated jobs
- add regression coverage for the completed native 7B quality gate shape

## Tests
- PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_quality control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_quality_7b
- git diff --check