### PR TITLE
control_plane: allow evidence-only L2 sync without metrics rows

### DIFF
--- a/control_plane/control_plane/services/queue_exporter.py
+++ b/control_plane/control_plane/services/queue_exporter.py
@@ -113,7 +113,11 @@ def _merge_result(run: Run, work_item: WorkItem) -> dict[str, Any]:
 
     if queue_result["status"] == "ok":
         metrics_rows = queue_result.get("metrics_rows")
-        if not isinstance(metrics_rows, list) or not metrics_rows:
+        metrics_exempt_reason = str(queue_result.get("metrics_exempt_reason", "")).strip()
+        if (
+            (not isinstance(metrics_rows, list) or not metrics_rows)
+            and metrics_exempt_reason != "evidence_only_decoder_evidence"
+        ):
             raise QueueExportError(
                 f"evaluated export for {work_item.item_id} requires non-empty queue_result.metrics_rows when status=ok"
             )
@@ -126,6 +130,7 @@ def _merge_result(run: Run, work_item: WorkItem) -> dict[str, Any]:
         "host",
         "identity_block",
         "metrics_rows",
+        "metrics_exempt_reason",
         "queue_item_id",
         "session_id",
         "status",

--- a/control_plane/control_plane/services/reconciliation_service.py
+++ b/control_plane/control_plane/services/reconciliation_service.py
@@ -404,6 +404,34 @@ def _ensure_queue_snapshot_artifact(
         artifact.sha256 = queue_sha256
 
 
+def _is_evidence_only_decision_run(*, session: Session, repo_root: Path, work_item: WorkItem, run: Run) -> bool:
+    if work_item.task_type != "l2_campaign":
+        return False
+    artifact = (
+        session.query(Artifact)
+        .filter(Artifact.run_id == run.id, Artifact.kind == "decision_proposal")
+        .one_or_none()
+    )
+    if artifact is None:
+        return False
+    path = repo_root / str(artifact.path)
+    if not path.exists():
+        return False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    recommendation = payload.get("recommendation")
+    if not isinstance(recommendation, dict):
+        return False
+    return (
+        str(recommendation.get("source", "")).strip() == "decoder_evidence"
+        and str(recommendation.get("macro_mode", "")).strip() == "evidence_only"
+    )
+
+
 def sync_run_artifacts(session: Session, request: ArtifactSyncRequest) -> ArtifactSyncResult:
     repo_root = Path(request.repo_root).resolve()
     work_item, run = _resolve_run(session, request)
@@ -444,8 +472,17 @@ def sync_run_artifacts(session: Session, request: ArtifactSyncRequest) -> Artifa
             "summary": queue_result.get("summary") or run.result_summary,
         }
     )
+    evidence_only_decision = _is_evidence_only_decision_run(
+        session=session,
+        repo_root=repo_root,
+        work_item=work_item,
+        run=run,
+    )
     if queue_result["status"] == "ok" and not queue_result["metrics_rows"]:
-        raise ArtifactSyncError(f"run {run.run_key} has no validator-compatible metrics rows to export")
+        if evidence_only_decision:
+            queue_result["metrics_exempt_reason"] = "evidence_only_decoder_evidence"
+        else:
+            raise ArtifactSyncError(f"run {run.run_key} has no validator-compatible metrics rows to export")
 
     payload = dict(run.result_payload or {})
     payload["queue_result"] = queue_result

--- a/control_plane/control_plane/tests/test_reconciliation_service.py
+++ b/control_plane/control_plane/tests/test_reconciliation_service.py
@@ -10,6 +10,7 @@ import tempfile
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from control_plane.clock import utcnow
 from control_plane.db import build_session_factory, create_all
 from control_plane.models.artifacts import Artifact
 from control_plane.models.enums import ArtifactStorageMode, ExecutorType, RunStatus, WorkItemState
@@ -181,6 +182,135 @@ def test_sync_run_artifacts_roundtrips_internal_worker_run() -> None:
             assert work_item.state == WorkItemState.ARTIFACT_SYNC
             assert run.status == RunStatus.SUCCEEDED
             assert queue_snapshot.path == "runs/eval_queue/openroad/evaluated/cp009_item.json"
+
+
+def test_sync_run_artifacts_allows_evidence_only_decision_without_metrics_rows() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        item_id = "l2_evidence_only_quality"
+        queue_path = repo_root / "runs" / "eval_queue" / "openroad" / "queued" / f"{item_id}.json"
+        queue_path.parent.mkdir(parents=True, exist_ok=True)
+        queue_path.write_text(
+            json.dumps(
+                {
+                    "version": 0.1,
+                    "item_id": item_id,
+                    "title": "evidence only quality",
+                    "layer": "layer2",
+                    "flow": "openroad",
+                    "state": "queued",
+                    "priority": 1,
+                    "requested_by": "@tester",
+                    "platform": "nangate45",
+                    "task": {
+                        "objective": "record decoder quality evidence",
+                        "source_mode": "src_verilog",
+                        "inputs": {"decoder_contract": {}},
+                        "commands": [],
+                        "expected_outputs": [
+                            "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_demo.json"
+                        ],
+                        "acceptance": [],
+                    },
+                    "handoff": {
+                        "branch": f"eval/{item_id}/<session_id>",
+                        "pr_title": "eval: evidence only quality",
+                        "identity_block_format": (
+                            "[role:evaluator][account:<evaluator_id>]"
+                            "[session:<session_id>][host:<host>][item:<queue_item_id>]"
+                        ),
+                    },
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        decision_rel = f"control_plane/shadow_exports/l2_decisions/{item_id}.json"
+        decision_path = repo_root / decision_rel
+        decision_path.parent.mkdir(parents=True, exist_ok=True)
+        decision_path.write_text(
+            json.dumps(
+                {
+                    "item_id": item_id,
+                    "recommendation": {
+                        "source": "decoder_evidence",
+                        "arch_id": "decoder_attention_kv_model_native_quality_7b",
+                        "macro_mode": "evidence_only",
+                    },
+                    "evaluation_record": {
+                        "evaluation_mode": "frontier_detail",
+                        "comparison_role": "precision_gate",
+                    },
+                    "proposal_assessment": {"outcome": "native_checkpoint_kv4_promising"},
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            import_queue_item(
+                session,
+                QueueImportRequest(
+                    repo_root=str(repo_root),
+                    queue_path=str(queue_path.relative_to(repo_root)),
+                ),
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            work_item.state = WorkItemState.ARTIFACT_SYNC
+            work_item.task_type = "l2_campaign"
+            run = Run(
+                run_key=f"{item_id}_run_1",
+                work_item_id=work_item.id,
+                attempt=1,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                result_summary="2/2 commands succeeded",
+                result_payload={"queue_result": {"status": "ok"}},
+            )
+            session.add(run)
+            session.flush()
+            session.add(
+                Artifact(
+                    run_id=run.id,
+                    kind="decision_proposal",
+                    storage_mode=ArtifactStorageMode.REPO,
+                    path=decision_rel,
+                    sha256="abc123",
+                    metadata_={"profile_count": 0},
+                )
+            )
+            session.commit()
+
+            result = sync_run_artifacts(
+                session,
+                ArtifactSyncRequest(
+                    repo_root=str(repo_root),
+                    item_id=item_id,
+                    evaluator_id="cpbot",
+                    session_id="s20260308t120000z",
+                    host="cp-host",
+                    executor="@control_plane",
+                    target_path=f"runs/eval_queue/openroad/evaluated/{item_id}.json",
+                ),
+            )
+            assert result.metrics_row_count == 0
+
+        evaluated = json.loads(
+            (repo_root / "runs" / "eval_queue" / "openroad" / "evaluated" / f"{item_id}.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert evaluated["state"] == "evaluated"
+        assert evaluated["result"]["status"] == "ok"
+        assert evaluated["result"]["metrics_rows"] == []
+        assert evaluated["result"]["metrics_exempt_reason"] == "evidence_only_decoder_evidence"
 
 
 def test_sync_run_artifacts_deduplicates_queue_snapshot_artifacts() -> None:


### PR DESCRIPTION
## Summary
- classify decoder evidence-only decision proposals as metrics-row exempt during artifact sync
- carry an explicit metrics_exempt_reason into evaluated queue exports
- add regression coverage for a successful evidence-only L2 decision with zero metrics rows

## Tests
- PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_reconciliation_service.py::test_sync_run_artifacts_allows_evidence_only_decision_without_metrics_rows control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_writes_evidence_only_decision_without_campaign_outputs
- git diff --check

Note: the full test_reconciliation_service.py file still has existing worker fixture failures where run_worker returns no_work before artifact sync; this PR's focused regression passes.