### PR TITLE
control_plane: release repo-materialized dependencies after DB rebuild

### DIFF
--- a/control_plane/control_plane/services/dependency_gate.py
+++ b/control_plane/control_plane/services/dependency_gate.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 from pathlib import Path
+import subprocess
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -55,6 +57,36 @@ def _path_exists(repo_root: Path, path_text: str) -> bool:
     return path.exists()
 
 
+def _repo_head(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return None
+    return result.stdout.strip() or None
+
+
+def _refresh_released_source_requirement(work_item: WorkItem, *, repo_root: Path) -> None:
+    head = _repo_head(repo_root)
+    if not head:
+        return
+    work_item.source_commit = head
+    if work_item.task_request is None:
+        return
+    payload = dict(work_item.task_request.request_payload or {})
+    source_requirement = dict(payload.get("source_requirement") or {})
+    if source_requirement:
+        source_requirement["required_sha"] = head
+        source_requirement.setdefault("required_ref", "origin/master")
+        source_requirement.setdefault("requires_daemon_restart", True)
+        payload["source_requirement"] = source_requirement
+        work_item.task_request.request_payload = payload
+
+
 def _materialized_artifacts_exist(session: Session, *, repo_root: Path, work_item: WorkItem) -> DependencyGateResult:
     run = _latest_successful_run(work_item)
     if run is None:
@@ -77,6 +109,41 @@ def _materialized_artifacts_exist(session: Session, *, repo_root: Path, work_ite
     return DependencyGateResult(True)
 
 
+def _repo_materialized_dependency_exists(*, repo_root: Path, item_id: str, requires_materialized_refs: bool) -> DependencyGateResult:
+    decision_path = repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json"
+    review_package = repo_root / "control_plane" / "shadow_exports" / "review" / item_id / "review_package.json"
+    queue_snapshot = repo_root / "control_plane" / "shadow_exports" / "review" / item_id / "evaluated.json"
+    if not decision_path.exists():
+        return DependencyGateResult(False, f"dependency {item_id} not found")
+    if not requires_materialized_refs:
+        return DependencyGateResult(True)
+    for path in (review_package, queue_snapshot):
+        if not path.exists():
+            return DependencyGateResult(False, f"dependency {item_id} missing materialized artifact: {path}")
+    try:
+        decision_payload = json.loads(decision_path.read_text(encoding="utf-8"))
+    except Exception:
+        return DependencyGateResult(False, f"dependency {item_id} decision artifact is unreadable")
+    source_refs = decision_payload.get("source_refs")
+    if isinstance(source_refs, dict):
+        for rel_path in source_refs.values():
+            if isinstance(rel_path, list):
+                continue
+            if not isinstance(rel_path, str) or not rel_path.strip():
+                continue
+            path = Path(rel_path)
+            if path.is_absolute():
+                candidate = path
+            else:
+                candidate = repo_root / path
+            if not candidate.exists():
+                return DependencyGateResult(
+                    False,
+                    f"dependency {item_id} missing materialized artifact: {rel_path}",
+                )
+    return DependencyGateResult(True)
+
+
 def evaluate_work_item_dependencies(
     session: Session,
     *,
@@ -91,7 +158,14 @@ def evaluate_work_item_dependencies(
     for item_id in config.item_ids:
         dependency = session.query(WorkItem).filter(WorkItem.item_id == item_id).one_or_none()
         if dependency is None:
-            return DependencyGateResult(False, f"dependency {item_id} not found")
+            repo_dependency = _repo_materialized_dependency_exists(
+                repo_root=root,
+                item_id=item_id,
+                requires_materialized_refs=config.requires_materialized_refs,
+            )
+            if not repo_dependency.satisfied:
+                return repo_dependency
+            continue
         if config.requires_merged_inputs:
             if dependency.state != WorkItemState.MERGED:
                 return DependencyGateResult(False, f"dependency {item_id} is not merged")
@@ -117,6 +191,7 @@ def refresh_blocked_dependents(session: Session, *, repo_root: str | Path, depen
         if gate.satisfied:
             work_item.state = WorkItemState.DISPATCH_PENDING
             work_item.queue_snapshot_path = None
+            _refresh_released_source_requirement(work_item, repo_root=root)
             released.append(work_item.item_id)
     return released
 
@@ -130,5 +205,6 @@ def refresh_all_blocked_items(session: Session, *, repo_root: str | Path) -> lis
         if gate.satisfied:
             work_item.state = WorkItemState.DISPATCH_PENDING
             work_item.queue_snapshot_path = None
+            _refresh_released_source_requirement(work_item, repo_root=root)
             released.append(work_item.item_id)
     return released

--- a/control_plane/control_plane/tests/test_dependency_gate.py
+++ b/control_plane/control_plane/tests/test_dependency_gate.py
@@ -1,5 +1,7 @@
 import tempfile
+import json
 from pathlib import Path
+import subprocess
 
 from control_plane.models.artifacts import Artifact
 from control_plane.models.enums import RunStatus, WorkItemState
@@ -125,4 +127,108 @@ def test_refresh_all_blocked_items_releases_satisfied_dependent() -> None:
             session.refresh(blocked)
 
         assert released == ["blocked_item"]
-        assert blocked.state == WorkItemState.READY
+        assert blocked.state == WorkItemState.DISPATCH_PENDING
+
+
+def test_refresh_all_blocked_items_releases_repo_materialized_missing_dependency() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        (repo_root / "README.md").write_text("demo\n", encoding="utf-8")
+        subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
+        subprocess.run(["git", "add", "README.md"], cwd=repo_root, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "init"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+        )
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        item_id = "missing_db_dependency"
+        decision_rel = f"control_plane/shadow_exports/l2_decisions/{item_id}.json"
+        review_rel = f"control_plane/shadow_exports/review/{item_id}/review_package.json"
+        queue_rel = f"control_plane/shadow_exports/review/{item_id}/evaluated.json"
+        evidence_rel = "runs/datasets/demo/evidence.json"
+        for rel, text in (
+            (
+                decision_rel,
+                json.dumps(
+                    {
+                        "item_id": item_id,
+                        "source_refs": {
+                            "decoder_evidence_json": evidence_rel,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            ),
+            (review_rel, "{}\n"),
+            (queue_rel, "{}\n"),
+            (evidence_rel, "{}\n"),
+        ):
+            path = repo_root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+
+        with make_session() as session:
+            blocked_task = TaskRequest(
+                request_key="queue:blocked",
+                source="test",
+                requested_by="tester",
+                title="blocked",
+                description="blocked",
+                layer="layer2",
+                flow="openroad",
+                priority=1,
+                request_payload={
+                    "source_requirement": {
+                        "version": 1,
+                        "required_ref": "origin/master",
+                        "required_sha": "oldsha",
+                        "requires_daemon_restart": True,
+                    },
+                    "developer_loop": {
+                        "dependencies": {
+                            "item_ids": [item_id],
+                            "requires_merged_inputs": True,
+                            "requires_materialized_refs": True,
+                        }
+                    }
+                },
+            )
+            session.add(blocked_task)
+            session.flush()
+            blocked = WorkItem(
+                work_item_key="queue:blocked",
+                task_request_id=blocked_task.id,
+                item_id="blocked_item",
+                layer="layer2",
+                flow="openroad",
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.BLOCKED,
+                priority=1,
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[],
+                acceptance_rules=[],
+            )
+            session.add(blocked)
+            session.commit()
+
+            released = refresh_all_blocked_items(session, repo_root=repo_root)
+            session.commit()
+            session.refresh(blocked)
+            refreshed_required_sha = blocked.task_request.request_payload["source_requirement"]["required_sha"]
+
+        assert released == ["blocked_item"]
+        assert blocked.state == WorkItemState.DISPATCH_PENDING
+        assert blocked.source_commit == head
+        assert refreshed_required_sha == head


### PR DESCRIPTION
## Summary
- let dependency gates accept repo-materialized merged dependency artifacts when the dependency row is missing from a rebuilt DB
- refresh released items' source_commit and source_requirement.required_sha to current repo HEAD so delayed releases do not check out pre-dependency source trees
- update dependency gate regression coverage for dispatch_pending release state and rebuilt-DB fallback

## Tests
- PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_dependency_gate.py control_plane/control_plane/tests/test_reconciliation_service.py::test_sync_run_artifacts_allows_evidence_only_decision_without_metrics_rows control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_writes_evidence_only_decision_without_campaign_outputs
- git diff --check