### PR TITLE
control_plane: add llama7b integrated abstraction closure job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -474,6 +474,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_composed_datapath_physical_feasibility_out",
         "attention_composed_datapath_physical_feasibility_report",
     ),
+    (
+        "attention_integrated_abstraction_closure_out",
+        "attention_integrated_abstraction_closure_report",
+    ),
 )
 
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5530,6 +5530,68 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     }
 
 
+def _decoder_attention_integrated_abstraction_closure_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_integrated_abstraction_closure__{item_id}.json"
+    report = f"{base}/decoder_attention_integrated_abstraction_closure__{item_id}.md"
+    composed_datapath = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1.json"
+    )
+    hbm_quality_backed = (
+        f"{base}/decoder_attention_kv_physical_hbm_quality_backed_7b__"
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json"
+    )
+    native_quality = (
+        f"{base}/decoder_attention_kv_model_native_quality_7b__"
+        "l2_decoder_attention_kv_model_native_quality_7b_v1_r2.json"
+    )
+    q12_frontier_best = (
+        "runs/campaigns/npu/e2e_eval_llm_attention_tail_stress_v1__"
+        "l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1/"
+        "best_point.json"
+    )
+    hbm_campaign_best = (
+        "runs/campaigns/npu/e2e_eval_mlp_smoke_v1_reuse__"
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2/"
+        "best_point.json"
+    )
+    return {
+        "inputs": {
+            "attention_composed_datapath_physical_feasibility": composed_datapath,
+            "attention_kv_physical_hbm_quality_backed_7b": hbm_quality_backed,
+            "attention_kv_model_native_quality_7b": native_quality,
+            "attention_composed_datapath_q12_pwl_best": q12_frontier_best,
+            "attention_kv_physical_hbm_quality_backed_7b_best": hbm_campaign_best,
+            "attention_integrated_abstraction_closure_out": out,
+            "attention_integrated_abstraction_closure_report": report,
+            "attention_integrated_abstraction_closure_scope": (
+                "Integrate the merged q12/PWL composed datapath feasibility result, "
+                "the merged 7B quality-backed HBM frontier, and native 7B KV quality "
+                "evidence into one Llama7B frontier closure artifact. Report the "
+                "selected token-throughput/area/precision point and name any remaining "
+                "energy, HBM, SRAM, NoC, or datapath abstractions explicitly."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_integrated_abstraction_closure",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_integrated_abstraction_closure.py "
+                    f"--composed-datapath-json {composed_datapath} "
+                    f"--hbm-quality-backed-json {hbm_quality_backed} "
+                    f"--native-quality-json {native_quality} "
+                    f"--q12-frontier-best-json {q12_frontier_best} "
+                    f"--hbm-campaign-best-json {hbm_campaign_best} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -7406,6 +7468,7 @@ def _build_payload(
         "decoder_attention_kv_hbm_closed_onchip_schedule",
         "decoder_attention_kv_subtile_pipeline_schedule",
         "decoder_attention_composed_datapath_physical_feasibility",
+        "decoder_attention_integrated_abstraction_closure",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -7568,6 +7631,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_kv_subtile_pipeline_schedule_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_composed_datapath_physical_feasibility":
             decoder_evidence = _decoder_attention_composed_datapath_physical_feasibility_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_integrated_abstraction_closure":
+            decoder_evidence = _decoder_attention_integrated_abstraction_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1688,6 +1688,129 @@ def test_consume_l2_result_frontier_endpoint_router_sram_composition_uses_decode
             ] == report_rel
 
 
+def test_consume_l2_result_integrated_abstraction_closure_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+                        "kind": "architecture",
+                        "title": "Integrated abstraction closure",
+                        "direct_comparison": {
+                            "primary_question": "Which Llama7B point remains after integrated closure?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_integrated_abstraction_closure__"
+                "l2_decoder_attention_integrated_abstraction_closure_llama7b_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_integrated_abstraction_closure__"
+                "l2_decoder_attention_integrated_abstraction_closure_llama7b_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "model": "llm_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+                        "decision": "integrated_closure_recorded_q12_blocked_hbm_service_frontier",
+                        "diagnosis": {
+                            "decision": "integrated_closure_recorded_q12_blocked_hbm_service_frontier",
+                            "recommended_next_step": "close integrated energy and service details",
+                        },
+                        "best": {
+                            "arch_id": "physical_hbm_gqa8_kv8_service_frontier",
+                            "latency_us": 30.944,
+                            "token_throughput_per_s": 32316.443,
+                            "die_area_mm2": 100.0,
+                            "energy_status": "full_integrated_energy_missing",
+                        },
+                        "closure_flags": {
+                            "q12_pwl_composed_datapath_measured": True,
+                            "integrated_energy_model_available": False,
+                        },
+                        "remaining_abstractions": [
+                            "Full Llama7B integrated energy is not yet composed.",
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# integrated closure\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+                campaign_dir_rel="runs/campaigns/npu/integrated_closure_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path=(
+                    "docs/proposals/"
+                    "prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1"
+                ),
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "record_integrated_abstraction_closure_frontier",
+                "expected_reason": "Use integrated closure evidence for the next targeted abstraction job.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_integrated_abstraction_closure",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_integrated_abstraction_closure_out": evidence_rel,
+                    "attention_integrated_abstraction_closure_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            result = consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert result.recommended_arch_id == "physical_hbm_gqa8_kv8_service_frontier"
+            assert decision_payload["proposal_assessment"]["outcome"] == (
+                "integrated_closure_recorded_q12_blocked_hbm_service_frontier"
+            )
+            assert decision_payload["recommendation"]["source"] == "decoder_evidence"
+            assert decision_payload["source_refs"]["decoder_attention_integrated_abstraction_closure_out"] == evidence_rel
+            assert (
+                decision_payload["source_refs"]["decoder_attention_integrated_abstraction_closure_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_frontier_attention_local_sram_capacity_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6141,6 +6141,81 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_q12_pwl_fron
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_integrated_abstraction_closure_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_integrated_abstraction_closure",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="frontier_closure",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1",
+                        "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_integrated_abstraction_closure",
+            ]
+            assert "audit_llm_decoder_attention_integrated_abstraction_closure.py" in run
+            assert (
+                "--composed-datapath-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1.json"
+            ) in run
+            assert (
+                "--hbm-quality-backed-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_physical_hbm_quality_backed_7b__"
+                "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json"
+            ) in run
+            assert decoder_inputs["attention_integrated_abstraction_closure_out"].endswith(
+                "decoder_attention_integrated_abstraction_closure__"
+                "l2_decoder_attention_integrated_abstraction_closure_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_integrated_abstraction_closure_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_integrated_abstraction_closure",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1",
+                    "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+  "source_commit_note": "Dispatch should go to the remote evaluator only, and should use a merged proposal/metadata commit that includes this proposal artifact.",
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed_7b__l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json"
+  ],
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Consume merged q12/PWL composed datapath and merged 7B quality-backed HBM results in one integrated abstraction-closure pass for Llama7B attention.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_integrated_abstraction_closure",
+      "comparison_role": "frontier_closure",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1",
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_integrated_abstraction_closure_frontier",
+        "reason": "Report a reranked Llama7B 131k attention frontier with remaining abstraction sensitivities from both merged inputs."
+      },
+      "cost_class": "low"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+  "created_utc": "2026-06-22T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_integrated_abstraction_closure",
+  "title": "Integrated Llama7B attention abstraction-closure rerank with merged q12/PWL and 7B quality-backed HBM inputs",
+  "hypothesis": "A single L2 rerun that consumes the merged q12/PWL composed datapath frontier and merged 7B quality-backed HBM frontier should produce the next best Llama7B attention candidate and expose the remaining abstractions that still need RTL-level closure.",
+  "direct_comparison": {
+    "primary_question": "After integrating both merged artifacts, which Llama7B attention frontier point remains dominant and what specific abstraction dimensions (e.g., SRAM timing, NoC arbitration, queueing policy, and cost model margins) remain explicit?",
+    "include": [
+      "Llama7B attention abstraction-closure rerank using 131k context.",
+      "substitute the merged L2 q12/PWL composed softmax frontier artifact.",
+      "substitute the merged L2 7B quality-backed physical HBM artifact for quality provenance.",
+      "report remaining abstractions as a named table with one-line sensitivity notes per term."
+    ],
+    "exclude": [
+      "new L1/RTL/PPA or quality-control-plane jobs",
+      "OpenROAD synthesis / PPA generation",
+      "new model-quality gate jobs beyond the already-merged 7B KV artifact",
+      "new memory-controller micro-architecture simulation"
+    ],
+    "follow_on_broad_sweep": [
+      "Target one remaining abstraction from the report with a dedicated follow-on RTL or service-accurate estimator job."
+    ]
+  },
+  "expected_benefit": [
+    "Produces a cleaner Llama7B frontier candidate by consuming both merged abstractions in one rerank.",
+    "Separates remaining uncertainty from already-validated datapath quality/compute assumptions.",
+    "Creates an explicit handoff artifact for the next targeted closure job instead of carrying two stacked abstractions implicitly."
+  ],
+  "risks": [
+    "The integrated rerank still uses non-routed global NoC/HBM contention assumptions outside the merged inputs.",
+    "The result can narrow, but not remove, SRAM queue-depth and locality abstractions without additional RTL or measured-service evidence.",
+    "If either merged baseline artifact is revoked or regenerated, the rerank must be repeated."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Integrate merged q12/PWL composed datapath and merged 7B quality-backed HBM artifacts to rerank the Llama7B attention frontier and publish remaining abstractions.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_integrated_abstraction_closure",
+      "comparison_role": "frontier_closure",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1",
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_integrated_abstraction_closure_frontier",
+        "reason": "Identify the reranked 131k Llama7B attention frontier with a compact remaining-abstraction report."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed_7b__l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed_7b__l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "docs/proposals/prop_l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/proposal.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_integrated_abstraction_closure.py
+++ b/npu/eval/audit_llm_decoder_attention_integrated_abstraction_closure.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Audit the current Llama7B attention frontier after recent abstraction closures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _maybe_load_json(path: Path | None) -> JsonDict | None:
+    if path is None or not path.exists():
+        return None
+    return _load_json(path)
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _latency_to_tokens_per_s(latency_us: float) -> float | None:
+    if latency_us <= 0.0:
+        return None
+    return 1_000_000.0 / latency_us
+
+
+def _kv4_quality(native_quality: JsonDict) -> JsonDict | None:
+    best = native_quality.get("best_kv4_candidate")
+    if isinstance(best, dict):
+        return best
+    candidates = native_quality.get("candidate_summary")
+    if not isinstance(candidates, list):
+        return None
+    kv4 = [row for row in candidates if isinstance(row, dict) and _as_int(row.get("kv_bits"), -1) == 4]
+    if not kv4:
+        return None
+    return max(
+        kv4,
+        key=lambda row: (
+            _as_float(row.get("top1_match_rate")),
+            _as_float(row.get("topk_contains_rate")),
+            _as_float(row.get("mean_logit_cosine")),
+            -_as_float(row.get("mean_probability_kl")),
+        ),
+    )
+
+
+def _kv8_quality(native_quality: JsonDict) -> JsonDict | None:
+    candidates = native_quality.get("candidate_summary")
+    if isinstance(candidates, dict):
+        kv8_rows = candidates.get("kv8")
+        if isinstance(kv8_rows, list) and kv8_rows:
+            return kv8_rows[0] if isinstance(kv8_rows[0], dict) else None
+    if not isinstance(candidates, list):
+        return None
+    kv8 = [row for row in candidates if isinstance(row, dict) and _as_int(row.get("kv_bits"), -1) == 8]
+    return kv8[0] if kv8 else None
+
+
+def _precision_summary(native_quality: JsonDict, hbm_best: JsonDict) -> JsonDict:
+    decision = native_quality.get("decision")
+    decision = decision if isinstance(decision, dict) else {}
+    kv4 = _kv4_quality(native_quality)
+    kv8 = _kv8_quality(native_quality)
+    kv4_cosine = _as_float((kv4 or {}).get("mean_logit_cosine"))
+    kv4_kl = _as_float((kv4 or {}).get("mean_probability_kl"))
+    kv4_top1 = _as_float((kv4 or {}).get("top1_match_rate"))
+    kv4_topk = _as_float((kv4 or {}).get("topk_contains_rate"))
+    return {
+        "selected_frontier_kv_bits": _as_int(hbm_best.get("kv_bits")),
+        "selected_frontier_kv_sharing": str(hbm_best.get("kv_sharing", "")),
+        "native_quality_status": str(decision.get("status", "")),
+        "native_quality_cautions": list(decision.get("cautions") or []),
+        "kv8_candidate": kv8,
+        "kv4_candidate": kv4,
+        "kv4_promotable_without_recovery": bool(
+            kv4
+            and kv4_top1 >= 0.98
+            and kv4_topk >= 0.995
+            and kv4_cosine >= 0.999
+            and kv4_kl <= 0.01
+        ),
+    }
+
+
+def _subcampaign_summary(best_point: JsonDict | None) -> JsonDict | None:
+    if not best_point:
+        return None
+    best = best_point.get("best")
+    if not isinstance(best, dict):
+        return None
+    return {
+        "arch_id": best.get("arch_id"),
+        "macro_mode": best.get("macro_mode"),
+        "latency_ms_mean": best.get("latency_ms_mean"),
+        "throughput_infer_per_s_mean": best.get("throughput_infer_per_s_mean"),
+        "energy_mj_mean": best.get("energy_mj_mean"),
+        "die_area_um2_mean": best.get("die_area_um2_mean"),
+        "total_power_mw_mean": best.get("total_power_mw_mean"),
+        "critical_path_ns_mean": best.get("critical_path_ns_mean"),
+        "scope": "subcampaign_not_full_llama7b_integrated_energy",
+    }
+
+
+def _build_payload(
+    *,
+    composed_datapath: JsonDict,
+    hbm_quality_backed: JsonDict,
+    native_quality: JsonDict,
+    q12_frontier_best: JsonDict | None,
+    hbm_campaign_best: JsonDict | None,
+) -> JsonDict:
+    hbm_best = hbm_quality_backed.get("best")
+    if not isinstance(hbm_best, dict):
+        raise SystemExit("hbm-quality-backed-json is missing object field 'best'")
+    composed_diagnosis = composed_datapath.get("diagnosis")
+    composed_diagnosis = composed_diagnosis if isinstance(composed_diagnosis, dict) else {}
+    best_requested = composed_datapath.get("best_requested")
+    best_requested = best_requested if isinstance(best_requested, dict) else {}
+
+    hbm_latency_us = _as_float(hbm_best.get("latency_us"))
+    precision = _precision_summary(native_quality, hbm_best)
+    q12_promotable = str(composed_diagnosis.get("decision")) not in {
+        "",
+        "dual_stream_area_blocked",
+    } and bool(composed_datapath.get("best_feasible"))
+    q12_clock_ok = bool(composed_diagnosis.get("best_requested_compute_clock_ok"))
+    q12_area_fit = bool(composed_diagnosis.get("best_requested_area_fit"))
+    full_energy_available = False
+
+    remaining_abstractions = [
+        "HBM/DRAM service is still an aggregate bandwidth/efficiency model, not cycle-accurate DRAM timing.",
+        "NoC/SRAM contention in the selected HBM frontier is still a compact service model.",
+        "Full Llama7B integrated energy is not yet composed from measured compute, SRAM, NoC, and HBM energy.",
+    ]
+    if not q12_promotable:
+        remaining_abstractions.append(
+            "Measured q12/PWL dual-stream composed datapath is available, but the current dual-stream frontier is blocked by area or clock and cannot be promoted."
+        )
+    if not precision["kv4_promotable_without_recovery"]:
+        remaining_abstractions.append(
+            "KV4 remains precision-risky without QAT, scale-granularity recovery, or a larger 7B-class confirmation."
+        )
+
+    best = {
+        "arch_id": "physical_hbm_gqa8_kv8_service_frontier",
+        "latency_us": hbm_latency_us,
+        "token_throughput_per_s": _latency_to_tokens_per_s(hbm_latency_us),
+        "die_area_mm2": hbm_best.get("die_area_mm2"),
+        "kv_bits": hbm_best.get("kv_bits"),
+        "kv_sharing": hbm_best.get("kv_sharing"),
+        "macs_per_cycle": hbm_best.get("macs_per_cycle"),
+        "vector_ops_per_cycle": hbm_best.get("vector_ops_per_cycle"),
+        "dominant_resource": hbm_best.get("dominant_tile_resource"),
+        "energy_mj": None,
+        "energy_status": "full_integrated_energy_missing",
+        "precision_status": precision["native_quality_status"],
+    }
+
+    decision = "integrated_closure_recorded_q12_blocked_hbm_service_frontier"
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_integrated_abstraction_closure_llama7b_v1",
+        "decision": decision,
+        "diagnosis": {
+            "decision": decision,
+            "recommended_next_step": "close integrated energy and HBM/NoC/SRAM service details before promoting a final Llama7B point",
+            "selected_frontier": "physical_hbm_gqa8_kv8_service_frontier",
+            "q12_pwl_datapath": str(composed_diagnosis.get("decision", "")),
+            "precision_status": precision["native_quality_status"],
+        },
+        "best": best,
+        "ranked_candidates": [
+            {
+                "name": "quality_backed_hbm_gqa8_kv8",
+                "status": "current_selected_service_frontier",
+                "token_throughput_per_s": best["token_throughput_per_s"],
+                "latency_us": best["latency_us"],
+                "area_mm2": best["die_area_mm2"],
+                "energy_mj": None,
+                "precision": {
+                    "kv_bits": best["kv_bits"],
+                    "kv_sharing": best["kv_sharing"],
+                    "status": precision["native_quality_status"],
+                },
+                "dominant_resource": best["dominant_resource"],
+            },
+            {
+                "name": "q12_pwl_dual_stream_composed_datapath",
+                "status": "blocked_not_promotable" if not q12_promotable else "promotable",
+                "latency_us_if_feasible": composed_diagnosis.get("best_requested_latency_us"),
+                "area_fit": q12_area_fit,
+                "clock_ok": q12_clock_ok,
+                "logic_slack_um2": composed_diagnosis.get("best_requested_logic_slack_um2"),
+                "required_compute_density_gain": composed_diagnosis.get(
+                    "best_requested_required_compute_density_gain"
+                ),
+                "compute_mode": best_requested.get("compute_mode"),
+            },
+        ],
+        "precision": precision,
+        "subcampaign_energy_refs": {
+            "q12_pwl_tail_stress": _subcampaign_summary(q12_frontier_best),
+            "hbm_quality_backed_mlp_smoke": _subcampaign_summary(hbm_campaign_best),
+        },
+        "closure_flags": {
+            "q12_pwl_composed_datapath_measured": True,
+            "q12_pwl_dual_stream_promotable": q12_promotable,
+            "native_7b_quality_available": bool(native_quality),
+            "conservative_kv8_quality_backed": _as_int(hbm_best.get("kv_bits")) == 8,
+            "kv4_promotable_without_recovery": precision["kv4_promotable_without_recovery"],
+            "hbm_model_cycle_accurate": False,
+            "integrated_energy_model_available": full_energy_available,
+        },
+        "closure_diagnosis": {
+            "selected_frontier": "Use conservative GQA8/KV8 physical-HBM service frontier until the remaining service and energy abstractions are closed.",
+            "q12_pwl_datapath": str(composed_diagnosis.get("decision", "")),
+            "q12_pwl_next_step": str(composed_diagnosis.get("recommended_next_step", "")),
+            "precision_next_step": str((native_quality.get("decision") or {}).get("next_step", "")),
+        },
+        "recommended_next_l1_points": [
+            {
+                "primitive": "denser_or_lower_replica_q12_pwl_dual_stream_datapath",
+                "reason": "The measured q12/PWL wrapper blocks the dual-stream frontier on area/clock before it can improve throughput.",
+            },
+        ],
+        "recommended_next_l2_jobs": [
+            {
+                "job": "integrated_energy_closure",
+                "reason": "Token throughput and area are bounded, but full Llama7B energy is still not comparable across candidates.",
+            },
+            {
+                "job": "hbm_noc_sram_service_detail",
+                "reason": "The selected frontier is still HBM-service dominated and uses aggregate NoC/SRAM service assumptions.",
+            },
+            {
+                "job": "kv4_recovery_or_larger_quality_confirmation",
+                "reason": "KV4 has top-k stability but misses the cosine/KL caution line.",
+            },
+        ],
+        "remaining_abstractions": remaining_abstractions,
+        "source_artifacts": {
+            "composed_datapath_model": composed_datapath.get("model"),
+            "hbm_quality_backed_model": hbm_quality_backed.get("model"),
+            "native_quality_model": (native_quality.get("model") or {}).get("model_id"),
+        },
+    }
+
+
+def _write_report(payload: JsonDict, report: Path) -> None:
+    best = payload["best"]
+    lines = [
+        "# Llama7B Integrated Abstraction Closure",
+        "",
+        "## Selected Frontier",
+        f"- arch_id: `{best['arch_id']}`",
+        f"- latency_us: `{best['latency_us']}`",
+        f"- token_throughput_per_s: `{best['token_throughput_per_s']}`",
+        f"- die_area_mm2: `{best['die_area_mm2']}`",
+        f"- kv: `{best['kv_sharing']} / {best['kv_bits']}b`",
+        f"- dominant_resource: `{best['dominant_resource']}`",
+        f"- energy_status: `{best['energy_status']}`",
+        "",
+        "## Closure Flags",
+    ]
+    for key, value in payload["closure_flags"].items():
+        lines.append(f"- {key}: `{value}`")
+    lines.extend(["", "## Ranked Candidates"])
+    for row in payload["ranked_candidates"]:
+        lines.append(f"- `{row['name']}`: `{row['status']}`")
+    lines.extend(["", "## Remaining Abstractions"])
+    for item in payload["remaining_abstractions"]:
+        lines.append(f"- {item}")
+    lines.extend(["", "## Recommended Next Jobs"])
+    for item in payload["recommended_next_l2_jobs"]:
+        lines.append(f"- `{item['job']}`: {item['reason']}")
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--composed-datapath-json", type=Path, required=True)
+    parser.add_argument("--hbm-quality-backed-json", type=Path, required=True)
+    parser.add_argument("--native-quality-json", type=Path, required=True)
+    parser.add_argument("--q12-frontier-best-json", type=Path)
+    parser.add_argument("--hbm-campaign-best-json", type=Path)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = _build_payload(
+        composed_datapath=_load_json(args.composed_datapath_json),
+        hbm_quality_backed=_load_json(args.hbm_quality_backed_json),
+        native_quality=_load_json(args.native_quality_json),
+        q12_frontier_best=_maybe_load_json(args.q12_frontier_best_json),
+        hbm_campaign_best=_maybe_load_json(args.hbm_campaign_best_json),
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_report(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a low-cost L2 integrated closure job for the Llama7B attention frontier. The job consumes the merged q12/PWL composed datapath result, the merged 7B quality-backed HBM result, and native 7B KV quality evidence, then emits a remaining-abstractions report for the next targeted closure step.\n\nValidation:\n- PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_integrated_abstraction_closure_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_integrated_abstraction_closure_uses_decoder_evidence\n- python3 scripts/validate_runs.py --skip_eval_queue\n- python3 npu/eval/audit_llm_decoder_attention_integrated_abstraction_closure.py ... smoke over existing merged artifacts