### PR TITLE
control_plane: add hbm energy sensitivity job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -482,6 +482,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_integrated_energy_closure_out",
         "attention_integrated_energy_closure_report",
     ),
+    (
+        "attention_hbm_energy_sensitivity_out",
+        "attention_hbm_energy_sensitivity_report",
+    ),
 )
 
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5647,6 +5647,58 @@ def _decoder_attention_integrated_energy_closure_evidence(*, item_id: str) -> di
     }
 
 
+def _decoder_attention_hbm_energy_sensitivity_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_hbm_energy_sensitivity__{item_id}.json"
+    report = f"{base}/decoder_attention_hbm_energy_sensitivity__{item_id}.md"
+    integrated_energy = (
+        f"{base}/decoder_attention_integrated_energy_closure__"
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
+    )
+    hbm_quality_backed = (
+        f"{base}/decoder_attention_kv_physical_hbm_quality_backed_7b__"
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json"
+    )
+    measured_compute = (
+        f"{base}/decoder_attention_kv_dense_tile_measured_compute__"
+        "l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1.json"
+    )
+    sram_profile = f"{base}/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    return {
+        "inputs": {
+            "attention_integrated_energy_closure": integrated_energy,
+            "attention_kv_physical_hbm_quality_backed_7b": hbm_quality_backed,
+            "attention_kv_dense_tile_measured_compute": measured_compute,
+            "attention_sram_profile": sram_profile,
+            "attention_hbm_energy_sensitivity_out": out,
+            "attention_hbm_energy_sensitivity_report": report,
+            "attention_hbm_energy_sensitivity_scope": (
+                "Sweep HBM pJ/byte across retained quality-backed Llama7B attention "
+                "frontier rows. Report whether the lowest-latency 100 mm2 point remains "
+                "energy-optimal or whether larger SRAM/die points become better once HBM "
+                "energy is accounted for."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_hbm_energy_sensitivity",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_hbm_energy_sensitivity.py "
+                    f"--integrated-energy-json {integrated_energy} "
+                    f"--hbm-quality-backed-json {hbm_quality_backed} "
+                    f"--measured-compute-json {measured_compute} "
+                    f"--sram-profile-json {sram_profile} "
+                    "--hbm-energy-pj-per-byte-list 1,2,4,8,16,32 "
+                    "--noc-energy-pj-per-byte-hop 0.02 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -7525,6 +7577,7 @@ def _build_payload(
         "decoder_attention_composed_datapath_physical_feasibility",
         "decoder_attention_integrated_abstraction_closure",
         "decoder_attention_integrated_energy_closure",
+        "decoder_attention_hbm_energy_sensitivity",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -7691,6 +7744,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_integrated_abstraction_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_integrated_energy_closure":
             decoder_evidence = _decoder_attention_integrated_energy_closure_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_hbm_energy_sensitivity":
+            decoder_evidence = _decoder_attention_hbm_energy_sensitivity_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1939,6 +1939,127 @@ def test_consume_l2_result_integrated_energy_closure_uses_decoder_evidence() -> 
             )
 
 
+def test_consume_l2_result_hbm_energy_sensitivity_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+                        "kind": "architecture",
+                        "title": "HBM energy sensitivity",
+                        "direct_comparison": {
+                            "primary_question": "Does HBM energy change the best Llama7B point?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_hbm_energy_sensitivity__"
+                "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_hbm_energy_sensitivity__"
+                "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "model": "llm_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+                        "decision": "hbm_energy_sensitivity_changes_energy_optimum",
+                        "diagnosis": {
+                            "decision": "hbm_energy_sensitivity_changes_energy_optimum",
+                            "recommended_next_step": "close HBM/DRAM energy and service modeling",
+                        },
+                        "best": {
+                            "arch_id": "hbm_energy_sensitivity_energy_best",
+                            "latency_us": 34.4,
+                            "token_throughput_per_s": 29069.77,
+                            "die_area_mm2": 200.0,
+                            "energy_mj": 6.7,
+                            "energy_status": "hbm_energy_parameter_swept_not_dram_signoff",
+                        },
+                        "remaining_abstractions": [
+                            "HBM energy remains a pJ/byte sensitivity sweep.",
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# hbm energy sensitivity\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+                campaign_dir_rel="runs/campaigns/npu/hbm_energy_sensitivity_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path=(
+                    "docs/proposals/"
+                    "prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1"
+                ),
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "record_hbm_energy_sensitivity_frontier",
+                "expected_reason": "Use HBM energy sensitivity evidence for the next closure job.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_hbm_energy_sensitivity",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_hbm_energy_sensitivity_out": evidence_rel,
+                    "attention_hbm_energy_sensitivity_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            result = consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert result.recommended_arch_id == "hbm_energy_sensitivity_energy_best"
+            assert decision_payload["proposal_assessment"]["outcome"] == (
+                "hbm_energy_sensitivity_changes_energy_optimum"
+            )
+            assert decision_payload["recommendation"]["source"] == "decoder_evidence"
+            assert decision_payload["recommendation"]["energy_mj"] == 6.7
+            assert decision_payload["source_refs"]["decoder_attention_hbm_energy_sensitivity_out"] == evidence_rel
+            assert (
+                decision_payload["source_refs"]["decoder_attention_hbm_energy_sensitivity_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_frontier_attention_local_sram_capacity_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6284,6 +6284,74 @@ def test_generate_l2_campaign_task_adds_attention_integrated_energy_closure_evid
             }
 
 
+def test_generate_l2_campaign_task_adds_attention_hbm_energy_sensitivity_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_hbm_energy_sensitivity",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="frontier_closure",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_hbm_energy_sensitivity",
+            ]
+            assert "audit_llm_decoder_attention_hbm_energy_sensitivity.py" in run
+            assert (
+                "--integrated-energy-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_integrated_energy_closure__"
+                "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
+            ) in run
+            assert "--hbm-energy-pj-per-byte-list 1,2,4,8,16,32" in run
+            assert decoder_inputs["attention_hbm_energy_sensitivity_out"].endswith(
+                "decoder_attention_hbm_energy_sensitivity__"
+                "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_hbm_energy_sensitivity_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_hbm_energy_sensitivity",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -27,6 +27,18 @@ than free or heuristic assumptions.
   - die area point: `100.0 mm2`
   - precision: native-GQA `gqa8`, `kv8`
   - dominant resource: `hbm`
+- The integrated energy-accounting closure
+  `l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2` is merged by
+  PR #969. It reports:
+  - total energy: `8.14357724928343 mJ/token`
+  - energy status: `parameterized_integrated_energy_not_full_measurement`
+  - dominant energy component: `hbm`
+  - compute energy: `1.12424255488 mJ/token`, scaled from the nearest measured
+    dense compute reference
+  - HBM energy: `7.014935724818432 mJ/token`, using `8 pJ/byte`
+  - NoC energy: `0.00427893972795392 mJ/token`, using byte-hop accounting
+  - SRAM energy: `0.00012002985704362652 mJ/token`, scaled from CACTI macro
+    profile evidence
 - There is no active queue item for this closure stage. New evaluations should
   continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`.
@@ -36,10 +48,12 @@ than free or heuristic assumptions.
 1. Full integrated energy closure
    - Scope: compose measured compute, local SRAM, NoC/router/FIFO, HBM service,
      q12/PWL datapath, and precision choices into one Llama7B energy metric.
-   - Status: not closed. The integrated closure explicitly reports
-     `energy_status=full_integrated_energy_missing`.
-   - Next result: make token throughput, energy, area, and precision directly
-     comparable for the selected Llama7B frontier and plausible challengers.
+   - Status: partially closed by PR #969. Token throughput, area, precision, and
+     a measured-plus-parameterized energy account are now present, but the energy
+     account explicitly reports
+     `energy_status=parameterized_integrated_energy_not_full_measurement`.
+   - Next result: remove or bound the dominant HBM pJ/byte sensitivity and the
+     scaled compute-energy term before claiming an energy-optimal point.
 
 2. HBM/DRAM and on-chip service detail
    - Scope: replace aggregate HBM efficiency and compact NoC/SRAM service caps
@@ -93,8 +107,11 @@ than free or heuristic assumptions.
 
 ## Ordering
 
-The next evaluation should close the highest-impact missing comparison term:
-full integrated energy for the selected `physical_hbm_gqa8_kv8_service_frontier`
-and its plausible challengers. In parallel or immediately after, refine the
-HBM/NoC/SRAM service model because the selected point is HBM-dominant. All new
-evaluation jobs should run on the remote evaluator, not the devcontainer.
+The next evaluation should close the highest-impact remaining comparison term:
+HBM energy sensitivity. The merged integrated-energy result is HBM-energy
+dominated, so the next job should sweep HBM pJ/byte over the retained
+quality-backed HBM frontier rows and report whether the lowest-latency 100 mm2
+point remains energy-robust or whether a larger SRAM/die point becomes
+energy-optimal. After that, refine HBM/NoC/SRAM service detail and directly
+measure or bound the selected compute service point. All new evaluation jobs
+should run on the remote evaluator, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,30 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+  "source_commit_note": "Dispatch should go to remote evaluator eval-daemon-b7c2d9c80c1c after this proposal and generator support are merged.",
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed_7b__l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json"
+  ],
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Sweep HBM pJ/byte over retained quality-backed Llama7B attention frontier rows and report whether throughput-best, energy-best, and balanced points differ.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_hbm_energy_sensitivity",
+      "comparison_role": "frontier_closure",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_hbm_energy_sensitivity_frontier",
+        "reason": "Expose sensitivity to the dominant HBM pJ/byte energy term before claiming an energy-optimal Llama7B attention point."
+      },
+      "cost_class": "low",
+      "notes": "This request must run on remote evaluator eval-daemon-b7c2d9c80c1c."
+    }
+  ],
+  "source_commit": "d9f42e55"
+}

--- a/docs/proposals/prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+  "created_utc": "2026-06-22T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_hbm_energy_sensitivity",
+  "title": "Llama7B attention HBM energy sensitivity over retained quality-backed frontier rows",
+  "hypothesis": "Because the merged integrated-energy closure is dominated by parameterized HBM pJ/byte, sweeping that parameter across retained quality-backed frontier rows should show whether the fastest 100 mm2 point is also energy-robust or whether larger SRAM/die points become energy-optimal.",
+  "direct_comparison": {
+    "primary_question": "Does the selected Llama7B 131k attention frontier remain best when HBM energy per byte is swept, or does the energy optimum move to a larger-memory point?",
+    "include": [
+      "consume the merged integrated energy closure result",
+      "consume the merged 7B quality-backed HBM frontier rows",
+      "sweep HBM pJ/byte over an explicit range",
+      "report latency-best, energy-best, balanced, and Pareto candidates for each HBM energy point"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "cycle-accurate DRAM command/current modeling",
+      "new model-quality or QAT jobs",
+      "new HBM controller RTL"
+    ],
+    "follow_on_broad_sweep": [
+      "If the energy optimum changes, close HBM/DRAM service and energy modeling before promoting an energy-optimal architecture point."
+    ]
+  },
+  "expected_benefit": [
+    "Turns the dominant energy parameter from a hidden constant into an explicit sensitivity table.",
+    "Shows whether throughput-best and energy-best are the same or different architecture points.",
+    "Preserves precision status by using the quality-backed HBM frontier rows."
+  ],
+  "risks": [
+    "The sweep bounds energy sensitivity but does not replace HBM with a physical DRAM power model.",
+    "Compute, NoC, and SRAM energy terms inherit the measured-plus-parameterized accounting from the prior integrated-energy closure.",
+    "A broader die/memory frontier may still be needed if the retained HBM rows are too narrow."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Sweep HBM pJ/byte over retained quality-backed Llama7B attention frontier rows and report throughput/energy/area/precision tradeoffs.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_hbm_energy_sensitivity",
+      "comparison_role": "frontier_closure",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_hbm_energy_sensitivity_frontier",
+        "reason": "Determine whether the Llama7B selected frontier is stable when the dominant HBM energy parameter is swept."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed_7b__l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "docs/proposals/prop_l2_decoder_attention_integrated_energy_closure_llama7b_v1/proposal.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_hbm_energy_sensitivity.py
+++ b/npu/eval/audit_llm_decoder_attention_hbm_energy_sensitivity.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Sweep HBM pJ/byte energy for retained Llama7B attention frontier rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_integrated_energy_closure import (  # noqa: E402
+    _as_float,
+    _compute_energy_terms,
+    _energy_mj_from_pj,
+    _load_json,
+    _sram_energy_terms,
+    _tokens_per_s,
+    _traffic,
+)
+
+
+JsonDict = dict[str, Any]
+
+
+def _float_list(text: str) -> list[float]:
+    values = [float(part.strip()) for part in text.split(",") if part.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("list must contain at least one value")
+    if any(value < 0.0 for value in values):
+        raise argparse.ArgumentTypeError("energy values must be non-negative")
+    return values
+
+
+def _candidate_id(row: JsonDict) -> str:
+    return (
+        f"die{_as_float(row.get('die_area_mm2')):g}_kv{int(_as_float(row.get('kv_bits')))}_"
+        f"{row.get('kv_sharing', 'kv')}_lat{_as_float(row.get('latency_us')):g}_"
+        f"hbm{_as_float(row.get('hbm_byte_share')):.6f}_"
+        f"dt{int(_as_float(row.get('data_rate_mtps')))}_eff{_as_float(row.get('hbm_efficiency')):g}_"
+        f"tt{int(_as_float(row.get('tile_tokens')))}"
+    )
+
+
+def _precision_status(row: JsonDict, integrated_energy: JsonDict) -> str:
+    kv_bits = _as_float(row.get("kv_bits"))
+    if kv_bits >= 8.0:
+        return "quality_backed_conservative"
+    precision = integrated_energy.get("precision")
+    if isinstance(precision, dict) and precision.get("kv4_promotable_without_recovery"):
+        return "kv4_promotable_with_existing_evidence"
+    return "precision_risky_requires_recovery"
+
+
+def _frontier_rows(hbm_quality_backed: JsonDict, limit: int) -> list[JsonDict]:
+    rows: list[JsonDict] = []
+    for key in ("best", "top_rows", "best_by_memory_noc", "best_by_hbm_physical"):
+        value = hbm_quality_backed.get(key)
+        if isinstance(value, dict):
+            rows.append(value)
+        elif isinstance(value, list):
+            rows.extend(row for row in value if isinstance(row, dict))
+    seen: set[str] = set()
+    deduped: list[JsonDict] = []
+    for row in rows:
+        if _as_float(row.get("latency_us")) <= 0.0 or _as_float(row.get("die_area_mm2")) <= 0.0:
+            continue
+        candidate_id = _candidate_id(row)
+        if candidate_id in seen:
+            continue
+        seen.add(candidate_id)
+        deduped.append(row)
+    deduped.sort(
+        key=lambda row: (
+            _as_float(row.get("latency_us")),
+            _as_float(row.get("die_area_mm2")),
+            _as_float(row.get("hbm_byte_share")),
+        )
+    )
+    return deduped[:limit]
+
+
+def _energy_row(
+    *,
+    row: JsonDict,
+    integrated_energy: JsonDict,
+    measured_compute: JsonDict,
+    sram_profile: JsonDict,
+    hbm_energy_pj_per_byte: float,
+    noc_energy_pj_per_byte_hop: float,
+) -> JsonDict:
+    latency_us = _as_float(row.get("latency_us"))
+    macs_per_cycle = _as_float(row.get("macs_per_cycle"))
+    traffic = _traffic(row)
+    compute = _compute_energy_terms(
+        selected=row,
+        measured_compute=measured_compute,
+        latency_us=latency_us,
+        target_macs_per_cycle=macs_per_cycle,
+    )
+    sram = _sram_energy_terms(sram_profile, traffic)
+    hbm_energy_pj = _as_float(traffic["hbm_read_bytes"]) * hbm_energy_pj_per_byte
+    noc_hops = _as_float(row.get("noc_hops"), 1.0)
+    noc_bytes = _as_float(traffic["estimated_noc_payload_bytes"])
+    noc_energy_pj = noc_bytes * noc_hops * noc_energy_pj_per_byte_hop
+    components = {
+        "compute_mj": _as_float(compute.get("energy_mj")),
+        "hbm_mj": _energy_mj_from_pj(hbm_energy_pj),
+        "sram_mj": _as_float(sram.get("energy_mj")),
+        "noc_mj": _energy_mj_from_pj(noc_energy_pj),
+    }
+    total_energy_mj = sum(components.values())
+    dominant_energy_component = max(components.items(), key=lambda item: item[1])[0].replace("_mj", "")
+    return {
+        "candidate_id": _candidate_id(row),
+        "arch_id": "physical_hbm_gqa8_kv8_service_frontier",
+        "latency_us": latency_us,
+        "token_throughput_per_s": _tokens_per_s(latency_us),
+        "die_area_mm2": _as_float(row.get("die_area_mm2")),
+        "kv_bits": row.get("kv_bits"),
+        "kv_sharing": row.get("kv_sharing"),
+        "precision_status": _precision_status(row, integrated_energy),
+        "macs_per_cycle": macs_per_cycle,
+        "vector_ops_per_cycle": row.get("vector_ops_per_cycle"),
+        "hbm_energy_pj_per_byte": hbm_energy_pj_per_byte,
+        "hbm_byte_share": row.get("hbm_byte_share"),
+        "hbm_read_bytes": traffic["hbm_read_bytes"],
+        "total_tile_kv_read_bytes": traffic["total_tile_kv_read_bytes"],
+        "energy_mj": total_energy_mj,
+        "dominant_energy_component": dominant_energy_component,
+        "energy_components": components,
+        "source_latency_resource": row.get("dominant_tile_resource"),
+        "data_rate_mtps": row.get("data_rate_mtps"),
+        "hbm_efficiency": row.get("hbm_efficiency"),
+        "tile_tokens": row.get("tile_tokens"),
+        "total_sram_mib": row.get("total_sram_mib"),
+        "remaining_energy_abstractions": [
+            "HBM energy is swept by pJ/byte rather than modeled with cycle-accurate DRAM command power.",
+            "Compute energy is still scaled from the nearest measured dense compute reference.",
+            "NoC/SRAM energy uses the same profile-scaled accounting as the integrated energy closure.",
+        ],
+    }
+
+
+def _pareto(rows: list[JsonDict]) -> list[JsonDict]:
+    frontier: list[JsonDict] = []
+    for row in rows:
+        dominated = False
+        for other in rows:
+            if other is row:
+                continue
+            no_worse = (
+                _as_float(other.get("latency_us")) <= _as_float(row.get("latency_us"))
+                and _as_float(other.get("energy_mj")) <= _as_float(row.get("energy_mj"))
+                and _as_float(other.get("die_area_mm2")) <= _as_float(row.get("die_area_mm2"))
+            )
+            better = (
+                _as_float(other.get("latency_us")) < _as_float(row.get("latency_us"))
+                or _as_float(other.get("energy_mj")) < _as_float(row.get("energy_mj"))
+                or _as_float(other.get("die_area_mm2")) < _as_float(row.get("die_area_mm2"))
+            )
+            if no_worse and better:
+                dominated = True
+                break
+        if not dominated:
+            frontier.append(row)
+    return sorted(frontier, key=lambda item: (_as_float(item.get("latency_us")), _as_float(item.get("energy_mj"))))
+
+
+def _with_score(rows: list[JsonDict], baseline: JsonDict) -> list[JsonDict]:
+    baseline_latency = max(1e-12, _as_float(baseline.get("latency_us")))
+    baseline_energy = max(1e-12, _as_float(baseline.get("energy_mj")))
+    baseline_area = max(1e-12, _as_float(baseline.get("die_area_mm2")))
+    scored: list[JsonDict] = []
+    for row in rows:
+        out = dict(row)
+        out["unit_weight_latency_energy_area_score"] = (
+            _as_float(row.get("latency_us")) / baseline_latency
+            + _as_float(row.get("energy_mj")) / baseline_energy
+            + _as_float(row.get("die_area_mm2")) / baseline_area
+        )
+        scored.append(out)
+    return scored
+
+
+def build_payload(args: argparse.Namespace) -> JsonDict:
+    integrated_energy = _load_json(args.integrated_energy_json)
+    hbm_quality_backed = _load_json(args.hbm_quality_backed_json)
+    measured_compute = _load_json(args.measured_compute_json)
+    sram_profile = _load_json(args.sram_profile_json)
+    rows = _frontier_rows(hbm_quality_backed, args.frontier_row_limit)
+    if not rows:
+        raise RuntimeError("no retained HBM frontier rows found")
+
+    nominal_hbm = _as_float((integrated_energy.get("energy_parameters") or {}).get("hbm_energy_pj_per_byte"), 8.0)
+    sweeps: list[JsonDict] = []
+    nominal_selected: JsonDict | None = None
+    for hbm_energy in args.hbm_energy_pj_per_byte_list:
+        energy_rows = [
+            _energy_row(
+                row=row,
+                integrated_energy=integrated_energy,
+                measured_compute=measured_compute,
+                sram_profile=sram_profile,
+                hbm_energy_pj_per_byte=hbm_energy,
+                noc_energy_pj_per_byte_hop=args.noc_energy_pj_per_byte_hop,
+            )
+            for row in rows
+        ]
+        latency_best = min(energy_rows, key=lambda item: (_as_float(item["latency_us"]), _as_float(item["energy_mj"])))
+        energy_best = min(energy_rows, key=lambda item: (_as_float(item["energy_mj"]), _as_float(item["latency_us"])))
+        scored_rows = _with_score(energy_rows, latency_best)
+        balanced_best = min(
+            scored_rows,
+            key=lambda item: (
+                _as_float(item["unit_weight_latency_energy_area_score"]),
+                _as_float(item["latency_us"]),
+            ),
+        )
+        pareto_rows = _pareto(energy_rows)
+        if abs(hbm_energy - nominal_hbm) < 1e-9:
+            nominal_selected = {
+                "hbm_energy_pj_per_byte": hbm_energy,
+                "latency_best": latency_best,
+                "energy_best": energy_best,
+                "balanced_best": balanced_best,
+                "pareto_rows": pareto_rows[: args.pareto_row_limit],
+            }
+        sweeps.append(
+            {
+                "hbm_energy_pj_per_byte": hbm_energy,
+                "latency_best": latency_best,
+                "energy_best": energy_best,
+                "balanced_best": balanced_best,
+                "pareto_row_count": len(pareto_rows),
+                "pareto_rows": pareto_rows[: args.pareto_row_limit],
+            }
+        )
+
+    if nominal_selected is None:
+        nominal_selected = min(sweeps, key=lambda sweep: abs(sweep["hbm_energy_pj_per_byte"] - nominal_hbm))
+
+    latency_candidate = nominal_selected["latency_best"]
+    energy_candidate = nominal_selected["energy_best"]
+    energy_changes_frontier = latency_candidate["candidate_id"] != energy_candidate["candidate_id"]
+    decision = (
+        "hbm_energy_sensitivity_changes_energy_optimum"
+        if energy_changes_frontier
+        else "hbm_energy_sensitivity_keeps_latency_energy_optimum"
+    )
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+        "decision": decision,
+        "diagnosis": {
+            "decision": decision,
+            "nominal_hbm_energy_pj_per_byte": nominal_selected["hbm_energy_pj_per_byte"],
+            "latency_best_candidate_id": latency_candidate["candidate_id"],
+            "energy_best_candidate_id": energy_candidate["candidate_id"],
+            "energy_changes_frontier": energy_changes_frontier,
+            "recommended_next_step": (
+                "close HBM/DRAM energy and service modeling before claiming an energy-optimal Llama7B point"
+                if energy_changes_frontier
+                else "directly measure the selected compute service point and refine HBM service timing"
+            ),
+        },
+        "best": {
+            **energy_candidate,
+            "arch_id": "hbm_energy_sensitivity_energy_best",
+            "energy_status": "hbm_energy_parameter_swept_not_dram_signoff",
+        },
+        "latency_best_at_nominal": latency_candidate,
+        "balanced_best_at_nominal": nominal_selected["balanced_best"],
+        "nominal_pareto_rows": nominal_selected["pareto_rows"],
+        "sweeps": sweeps,
+        "input_row_count": len(rows),
+        "energy_parameters": {
+            "hbm_energy_pj_per_byte_list": args.hbm_energy_pj_per_byte_list,
+            "nominal_hbm_energy_pj_per_byte": nominal_hbm,
+            "noc_energy_pj_per_byte_hop": args.noc_energy_pj_per_byte_hop,
+        },
+        "remaining_abstractions": [
+            "HBM energy remains a pJ/byte sensitivity sweep rather than a DRAM command/current model.",
+            "HBM timing still comes from the merged physical-HBM service frontier, not a cycle-accurate memory controller.",
+            "Compute energy remains scaled from the nearest measured dense compute reference until the selected MAC/cycle point is measured.",
+            "NoC and SRAM energy remain profile-scaled as in the integrated energy closure.",
+        ],
+        "source_artifacts": {
+            "integrated_energy_model": integrated_energy.get("model"),
+            "hbm_quality_backed_model": hbm_quality_backed.get("model"),
+            "measured_compute_model": measured_compute.get("model"),
+            "sram_profile_model": sram_profile.get("model"),
+        },
+    }
+
+
+def write_markdown(payload: JsonDict, report: Path) -> None:
+    best = payload["best"]
+    latency_best = payload["latency_best_at_nominal"]
+    lines = [
+        "# Llama7B HBM Energy Sensitivity",
+        "",
+        "## Decision",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- nominal_hbm_energy_pj_per_byte: `{payload['diagnosis']['nominal_hbm_energy_pj_per_byte']}`",
+        f"- energy_changes_frontier: `{payload['diagnosis']['energy_changes_frontier']}`",
+        "",
+        "## Nominal Bests",
+        "",
+        "| role | candidate | latency us | throughput tok/s | energy mJ | area mm2 | hbm share | dominant energy |",
+        "|---|---|---:|---:|---:|---:|---:|---|",
+        "| latency | {candidate_id} | {latency_us} | {token_throughput_per_s} | {energy_mj} | {die_area_mm2} | {hbm_byte_share} | {dominant_energy_component} |".format(
+            **latency_best
+        ),
+        "| energy | {candidate_id} | {latency_us} | {token_throughput_per_s} | {energy_mj} | {die_area_mm2} | {hbm_byte_share} | {dominant_energy_component} |".format(
+            **best
+        ),
+        "",
+        "## Sweep Summary",
+        "",
+        "| hbm pJ/B | latency best | energy best | energy best mJ | energy best area | pareto rows |",
+        "|---:|---|---|---:|---:|---:|",
+    ]
+    for sweep in payload["sweeps"]:
+        energy_best = sweep["energy_best"]
+        lines.append(
+            "| {hbm} | {lat} | {eng} | {energy} | {area} | {pareto} |".format(
+                hbm=sweep["hbm_energy_pj_per_byte"],
+                lat=sweep["latency_best"]["candidate_id"],
+                eng=energy_best["candidate_id"],
+                energy=energy_best["energy_mj"],
+                area=energy_best["die_area_mm2"],
+                pareto=sweep["pareto_row_count"],
+            )
+        )
+    lines.extend(["", "## Remaining Abstractions"])
+    for item in payload["remaining_abstractions"]:
+        lines.append(f"- {item}")
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--integrated-energy-json", type=Path, required=True)
+    parser.add_argument("--hbm-quality-backed-json", type=Path, required=True)
+    parser.add_argument("--measured-compute-json", type=Path, required=True)
+    parser.add_argument("--sram-profile-json", type=Path, required=True)
+    parser.add_argument("--hbm-energy-pj-per-byte-list", type=_float_list, default=[1.0, 2.0, 4.0, 8.0, 16.0, 32.0])
+    parser.add_argument("--noc-energy-pj-per-byte-hop", type=float, default=0.02)
+    parser.add_argument("--frontier-row-limit", type=int, default=96)
+    parser.add_argument("--pareto-row-limit", type=int, default=16)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = build_payload(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an evidence-only Llama7B HBM energy sensitivity audit over retained quality-backed HBM frontier rows
- wire decoder_attention_hbm_energy_sensitivity into L2 generation/result consumption
- add proposal sidecar and focused generator/consumer tests
- update the Llama7B closure plan with merged integrated-energy r2 evidence

## Validation
- PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_hbm_energy_sensitivity_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_hbm_energy_sensitivity_uses_decoder_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_integrated_energy_closure_uses_decoder_evidence
- python3 -m py_compile npu/eval/audit_llm_decoder_attention_hbm_energy_sensitivity.py
- python3 scripts/validate_runs.py --skip_eval_queue

## Dispatch note
After merge, dispatch l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1 to remote evaluator eval-daemon-b7c2d9c80c1c.