### PR TITLE
control_plane: add hbm dram service energy job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -486,6 +486,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_hbm_energy_sensitivity_out",
         "attention_hbm_energy_sensitivity_report",
     ),
+    (
+        "attention_hbm_dram_service_energy_out",
+        "attention_hbm_dram_service_energy_report",
+    ),
 )
 
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5699,6 +5699,76 @@ def _decoder_attention_hbm_energy_sensitivity_evidence(*, item_id: str) -> dict[
     }
 
 
+def _decoder_attention_hbm_dram_service_energy_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_hbm_dram_service_energy__{item_id}.json"
+    report = f"{base}/decoder_attention_hbm_dram_service_energy__{item_id}.md"
+    integrated_energy = (
+        f"{base}/decoder_attention_integrated_energy_closure__"
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
+    )
+    hbm_sensitivity = (
+        f"{base}/decoder_attention_hbm_energy_sensitivity__"
+        "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1.json"
+    )
+    hbm_quality_backed = (
+        f"{base}/decoder_attention_kv_physical_hbm_quality_backed_7b__"
+        "l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json"
+    )
+    hbm_controller = (
+        f"{base}/decoder_attention_kv_hbm_controller__"
+        "l2_decoder_attention_kv_hbm_controller_llama7b_v1_r3.json"
+    )
+    measured_compute = (
+        f"{base}/decoder_attention_kv_dense_tile_measured_compute__"
+        "l2_decoder_attention_kv_dense_tile_measured_compute_llama7b_v1.json"
+    )
+    sram_profile = f"{base}/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    return {
+        "inputs": {
+            "attention_integrated_energy_closure": integrated_energy,
+            "attention_hbm_energy_sensitivity": hbm_sensitivity,
+            "attention_kv_physical_hbm_quality_backed_7b": hbm_quality_backed,
+            "attention_kv_hbm_controller": hbm_controller,
+            "attention_kv_dense_tile_measured_compute": measured_compute,
+            "attention_sram_profile": sram_profile,
+            "attention_hbm_dram_service_energy_out": out,
+            "attention_hbm_dram_service_energy_report": report,
+            "attention_hbm_dram_service_energy_scope": (
+                "Replace the HBM pJ/byte-only frontier comparison with an explicit "
+                "HBM/DRAM command-class service-energy model. Consume the merged HBM "
+                "sensitivity result, retained quality-backed frontier rows, and HBM "
+                "controller evidence; report whether latency-best, energy-best, and "
+                "balanced points move under row-hit, burst, outstanding-request, and "
+                "activate/precharge accounting."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_hbm_dram_service_energy",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_hbm_dram_service_energy.py "
+                    f"--integrated-energy-json {integrated_energy} "
+                    f"--hbm-energy-sensitivity-json {hbm_sensitivity} "
+                    f"--hbm-quality-backed-json {hbm_quality_backed} "
+                    f"--hbm-controller-json {hbm_controller} "
+                    f"--measured-compute-json {measured_compute} "
+                    f"--sram-profile-json {sram_profile} "
+                    "--read-hit-pj-per-byte 4.0 "
+                    "--read-miss-pj-per-byte 10.0 "
+                    "--write-pj-per-byte 6.0 "
+                    "--activate-precharge-pj-per-row 3000.0 "
+                    "--command-pj-per-burst 5.0 "
+                    "--noc-energy-pj-per-byte-hop 0.02 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -7578,6 +7648,7 @@ def _build_payload(
         "decoder_attention_integrated_abstraction_closure",
         "decoder_attention_integrated_energy_closure",
         "decoder_attention_hbm_energy_sensitivity",
+        "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -7746,6 +7817,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_integrated_energy_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_sensitivity":
             decoder_evidence = _decoder_attention_hbm_energy_sensitivity_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
+            decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -2060,6 +2060,129 @@ def test_consume_l2_result_hbm_energy_sensitivity_uses_decoder_evidence() -> Non
             )
 
 
+def test_consume_l2_result_hbm_dram_service_energy_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+                        "kind": "architecture",
+                        "title": "HBM DRAM service energy",
+                        "direct_comparison": {
+                            "primary_question": "Does DRAM command-service energy change the Llama7B frontier?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_hbm_dram_service_energy__"
+                "l2_decoder_attention_hbm_dram_service_energy_llama7b_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_hbm_dram_service_energy__"
+                "l2_decoder_attention_hbm_dram_service_energy_llama7b_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "model": "llm_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+                        "decision": "hbm_dram_service_energy_preserves_energy_frontier",
+                        "diagnosis": {
+                            "decision": "hbm_dram_service_energy_preserves_energy_frontier",
+                            "recommended_next_step": "calibrate HBM stack currents",
+                        },
+                        "best": {
+                            "arch_id": "hbm_dram_service_energy_best",
+                            "latency_us": 70.0,
+                            "token_throughput_per_s": 14285.71,
+                            "die_area_mm2": 400.0,
+                            "energy_mj": 5.4,
+                            "energy_status": "hbm_dram_command_service_energy_model_not_signoff",
+                            "dominant_energy_component": "compute",
+                        },
+                        "remaining_abstractions": [
+                            "HBM/DRAM service is command-class and row-hit aware but not signoff.",
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# hbm dram service energy\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+                campaign_dir_rel="runs/campaigns/npu/hbm_dram_service_energy_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path=(
+                    "docs/proposals/"
+                    "prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1"
+                ),
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "record_hbm_dram_service_energy_frontier",
+                "expected_reason": "Use DRAM service-energy evidence for the next closure job.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_hbm_dram_service_energy",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_hbm_dram_service_energy_out": evidence_rel,
+                    "attention_hbm_dram_service_energy_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            result = consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert result.recommended_arch_id == "hbm_dram_service_energy_best"
+            assert decision_payload["proposal_assessment"]["outcome"] == (
+                "hbm_dram_service_energy_preserves_energy_frontier"
+            )
+            assert decision_payload["recommendation"]["source"] == "decoder_evidence"
+            assert decision_payload["recommendation"]["energy_mj"] == 5.4
+            assert decision_payload["recommendation"]["token_throughput_per_s"] == 14285.71
+            assert decision_payload["source_refs"]["decoder_attention_hbm_dram_service_energy_out"] == evidence_rel
+            assert (
+                decision_payload["source_refs"]["decoder_attention_hbm_dram_service_energy_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_frontier_attention_local_sram_capacity_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6352,6 +6352,79 @@ def test_generate_l2_campaign_task_adds_attention_hbm_energy_sensitivity_evidenc
             }
 
 
+def test_generate_l2_campaign_task_adds_attention_hbm_dram_service_energy_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_hbm_dram_service_energy",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="frontier_closure",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_hbm_dram_service_energy",
+            ]
+            assert "audit_llm_decoder_attention_hbm_dram_service_energy.py" in run
+            assert (
+                "--hbm-energy-sensitivity-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_hbm_energy_sensitivity__"
+                "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1.json"
+            ) in run
+            assert (
+                "--hbm-controller-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_hbm_controller__"
+                "l2_decoder_attention_kv_hbm_controller_llama7b_v1_r3.json"
+            ) in run
+            assert decoder_inputs["attention_hbm_dram_service_energy_out"].endswith(
+                "decoder_attention_hbm_dram_service_energy__"
+                "l2_decoder_attention_hbm_dram_service_energy_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_hbm_dram_service_energy_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_hbm_dram_service_energy",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -39,6 +39,17 @@ than free or heuristic assumptions.
   - NoC energy: `0.00427893972795392 mJ/token`, using byte-hop accounting
   - SRAM energy: `0.00012002985704362652 mJ/token`, scaled from CACTI macro
     profile evidence
+- The HBM energy sensitivity result
+  `l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1` is merged by
+  PR #973. It reports:
+  - latency/throughput best remains the `100.0 mm2` `gqa8/kv8` point at
+    `30.944 us/token` and `32316.442606 token/s`
+  - at the nominal `8 pJ/byte` HBM setting, energy best moves to the
+    `400.0 mm2` `gqa8/kv8` point at `66.432 us/token`, `15052.986513 token/s`,
+    and `4.719907157640776 mJ/token`
+  - the frontier is therefore sensitive to the dominant HBM energy term and
+    still needs HBM/DRAM service-energy closure before claiming an
+    energy-optimal point
 - There is no active queue item for this closure stage. New evaluations should
   continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`.
@@ -58,10 +69,15 @@ than free or heuristic assumptions.
 2. HBM/DRAM and on-chip service detail
    - Scope: replace aggregate HBM efficiency and compact NoC/SRAM service caps
      with a more explicit controller, arbitration, and contention model.
-   - Status: not cycle-accurate. The current selected frontier is HBM-dominant
-     and still uses an aggregate bandwidth/efficiency model.
-   - Next result: bound whether HBM service, NoC/SRAM contention, or compute
-     service changes the selected `gqa8/kv8` frontier.
+   - Status: partially bounded by the HBM energy sensitivity result, but not
+     cycle-accurate. The current selected frontier is HBM-sensitive and still
+     needs a controller-derived service and command-class energy model.
+   - Next result: run
+     `l2_decoder_attention_hbm_dram_service_energy_llama7b_v1`, consuming the
+     merged HBM sensitivity result and HBM controller artifact, to determine
+     whether row-hit, burst, outstanding-request, activate/precharge, and
+     command accounting changes the latency-best, energy-best, balanced, or
+     Pareto frontier.
 
 3. Composed q12/PWL softmax datapath density recovery
    - Scope: score max, exponent approximation, sum accumulation, reciprocal
@@ -108,10 +124,10 @@ than free or heuristic assumptions.
 ## Ordering
 
 The next evaluation should close the highest-impact remaining comparison term:
-HBM energy sensitivity. The merged integrated-energy result is HBM-energy
-dominated, so the next job should sweep HBM pJ/byte over the retained
-quality-backed HBM frontier rows and report whether the lowest-latency 100 mm2
-point remains energy-robust or whether a larger SRAM/die point becomes
-energy-optimal. After that, refine HBM/NoC/SRAM service detail and directly
+HBM/DRAM service-energy detail. The merged HBM energy sensitivity result shows
+that the energy optimum moves under the HBM pJ/byte assumption, so the next job
+should replace the scalar HBM energy term with explicit row-hit, burst,
+outstanding-request, activate/precharge, and command accounting. After that,
+calibrate the HBM pJ parameters from source-backed HBM stack data and directly
 measure or bound the selected compute service point. All new evaluation jobs
 should run on the remote evaluator, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,32 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+  "source_commit_note": "Dispatch should go to remote evaluator eval-daemon-b7c2d9c80c1c after this proposal and generator support are merged.",
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_hbm_energy_sensitivity__l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed_7b__l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_hbm_controller__l2_decoder_attention_kv_hbm_controller_llama7b_v1_r3.json"
+  ],
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Apply a lightweight HBM/DRAM command-service energy model to retained quality-backed Llama7B attention frontier rows and report throughput/energy/area/precision tradeoffs.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_hbm_dram_service_energy",
+      "comparison_role": "frontier_closure",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_hbm_dram_service_energy_frontier",
+        "reason": "Determine whether the HBM-energy-sensitive frontier remains stable under explicit DRAM command/service accounting."
+      },
+      "cost_class": "low",
+      "notes": "This request must run on remote evaluator eval-daemon-b7c2d9c80c1c.",
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1/proposal.json
@@ -1,0 +1,76 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+  "created_utc": "2026-06-22T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_hbm_dram_service_energy",
+  "title": "Llama7B attention HBM/DRAM service-energy closure",
+  "hypothesis": "The merged HBM energy sensitivity result shows the energy optimum depends on HBM energy. Replacing the scalar pJ/byte term with explicit row-hit, burst, outstanding-request, activate/precharge, and command energy accounting should give a tighter frontier decision before promoting an energy-optimal Llama7B point.",
+  "direct_comparison": {
+    "primary_question": "Does a lightweight HBM/DRAM command-service energy model preserve or move the Llama7B latency-best, energy-best, and balanced frontier points?",
+    "include": [
+      "consume the merged integrated energy closure",
+      "consume the merged HBM energy sensitivity result",
+      "consume retained quality-backed HBM frontier rows",
+      "consume the HBM controller service artifact",
+      "split HBM energy into row-hit reads, row-miss reads, writes, activate/precharge, and command overhead",
+      "report latency-best, energy-best, balanced, and Pareto candidates under the DRAM service-energy model"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "vendor HBM current-table signoff",
+      "cycle-accurate DRAM controller RTL",
+      "new model-quality or QAT jobs"
+    ],
+    "follow_on_broad_sweep": [
+      "If the selected point remains stable, calibrate the DRAM pJ parameters from source-backed HBM stack data and close the scaled compute-energy term.",
+      "If the selected point moves, rerun the Llama7B frontier ranking under the moved point and update the architecture recommendation."
+    ]
+  },
+  "expected_benefit": [
+    "Reduces the dominant HBM-energy abstraction from a single pJ/byte scalar to explicit command and service terms.",
+    "Exposes any throughput penalty from controller-derived service efficiency rather than only energy sensitivity.",
+    "Keeps precision status tied to the existing quality-backed gqa8/kv8 frontier rows."
+  ],
+  "risks": [
+    "The DRAM model is still parameterized; pJ values need calibration against source-backed HBM stack current data before final energy claims.",
+    "Compute energy remains scaled from the nearest measured dense compute reference.",
+    "NoC and SRAM energy inherit the profile-scaled accounting from the integrated energy closure."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Apply a lightweight HBM/DRAM command-service energy model to retained quality-backed Llama7B attention frontier rows and report throughput/energy/area/precision tradeoffs.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_hbm_dram_service_energy",
+      "comparison_role": "frontier_closure",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_hbm_dram_service_energy_frontier",
+        "reason": "Determine whether the HBM-energy-sensitive frontier remains stable under explicit DRAM command/service accounting."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_hbm_energy_sensitivity__l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_hbm_energy_sensitivity__l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_physical_hbm_quality_backed_7b__l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_hbm_controller__l2_decoder_attention_kv_hbm_controller_llama7b_v1_r3.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "docs/proposals/prop_l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1/proposal.json",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_hbm_dram_service_energy.py
+++ b/npu/eval/audit_llm_decoder_attention_hbm_dram_service_energy.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Apply a lightweight HBM/DRAM command-service energy model to Llama7B attention rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_hbm_energy_sensitivity import (  # noqa: E402
+    _candidate_id,
+    _energy_row,
+    _frontier_rows,
+    _pareto,
+    _with_score,
+)
+from npu.eval.audit_llm_decoder_attention_integrated_energy_closure import (  # noqa: E402
+    _as_float,
+    _energy_mj_from_pj,
+    _load_json,
+    _tokens_per_s,
+    _traffic,
+)
+
+
+JsonDict = dict[str, Any]
+
+
+def _best(payload: JsonDict) -> JsonDict:
+    best = payload.get("best")
+    return best if isinstance(best, dict) else {}
+
+
+def _frontier_family_key(row: JsonDict) -> str:
+    return (
+        f"die{_as_float(row.get('die_area_mm2')):g}:"
+        f"kv{int(_as_float(row.get('kv_bits')))}:"
+        f"{row.get('kv_sharing', 'kv')}:"
+        f"tt{int(_as_float(row.get('tile_tokens')))}"
+    )
+
+
+def _controller_defaults(controller_payload: JsonDict) -> JsonDict:
+    best = _best(controller_payload)
+    return {
+        "row_hit_rate": _as_float(best.get("row_hit_rate"), 0.9),
+        "request_overhead_cycles": _as_float(best.get("request_overhead_cycles"), 4.0),
+        "row_miss_penalty_cycles": _as_float(best.get("row_miss_penalty_cycles"), 16.0),
+        "scheduler_efficiency": _as_float(best.get("scheduler_efficiency"), 0.9),
+        "arbitration_efficiency": _as_float(best.get("arbitration_efficiency"), 0.85),
+        "burst_bytes": _as_float(best.get("burst_bytes"), 1024.0),
+        "hbm_outstanding": _as_float(best.get("hbm_outstanding"), 8.0),
+    }
+
+
+def _row_raw_hbm_bytes_per_cycle(row: JsonDict) -> float:
+    raw = _as_float(row.get("raw_hbm_bytes_per_cycle"))
+    if raw > 0.0:
+        return raw
+    effective = _as_float(row.get("effective_hbm_bytes_per_cycle"), _as_float(row.get("hbm_effective_bytes_per_cycle")))
+    efficiency = _as_float(row.get("hbm_efficiency"))
+    if effective > 0.0 and efficiency > 0.0:
+        return effective / efficiency
+    stack_count = max(1.0, _as_float(row.get("stack_count"), 8.0))
+    pseudo_channels = max(1.0, _as_float(row.get("pseudo_channels_per_stack"), 16.0))
+    pseudo_width_bits = max(1.0, _as_float(row.get("pseudo_channel_width_bits"), 64.0))
+    data_rate_mtps = max(1.0, _as_float(row.get("data_rate_mtps"), 6400.0))
+    clock_mhz = 1000.0 / max(1e-12, _as_float(row.get("clock_ns"), 1.0))
+    return stack_count * pseudo_channels * (pseudo_width_bits / 8.0) * data_rate_mtps / clock_mhz
+
+
+def _modeled_hbm_service(row: JsonDict, controller: JsonDict) -> JsonDict:
+    row_hit_rate = min(1.0, max(0.0, _as_float(row.get("row_hit_rate"), controller["row_hit_rate"])))
+    scheduler_efficiency = min(1.0, max(0.0, _as_float(row.get("scheduler_efficiency"), controller["scheduler_efficiency"])))
+    arbitration_efficiency = min(1.0, max(0.0, _as_float(row.get("arbitration_efficiency"), controller["arbitration_efficiency"])))
+    burst_bytes = max(1.0, _as_float(row.get("burst_bytes"), controller["burst_bytes"]))
+    outstanding = max(1.0, _as_float(row.get("hbm_outstanding"), controller["hbm_outstanding"]))
+    request_overhead_cycles = max(0.0, _as_float(row.get("request_overhead_cycles"), controller["request_overhead_cycles"]))
+    row_miss_penalty_cycles = max(0.0, _as_float(row.get("row_miss_penalty_cycles"), controller["row_miss_penalty_cycles"]))
+    raw_bytes_per_cycle = max(1e-12, _row_raw_hbm_bytes_per_cycle(row))
+    sustained_bytes_per_cycle = raw_bytes_per_cycle * scheduler_efficiency * arbitration_efficiency
+    payload_cycles = burst_bytes / max(1e-12, sustained_bytes_per_cycle)
+    hidden_command_cycles = (request_overhead_cycles + (1.0 - row_hit_rate) * row_miss_penalty_cycles) / math.sqrt(outstanding)
+    service_cycles_per_burst = payload_cycles + hidden_command_cycles
+    modeled_effective_bytes_per_cycle = burst_bytes / max(1e-12, service_cycles_per_burst)
+    modeled_hbm_efficiency = modeled_effective_bytes_per_cycle / raw_bytes_per_cycle
+    original_effective = _as_float(row.get("effective_hbm_bytes_per_cycle"), _as_float(row.get("hbm_effective_bytes_per_cycle")))
+    if original_effective <= 0.0:
+        original_effective = raw_bytes_per_cycle * max(1e-12, _as_float(row.get("hbm_efficiency"), 1.0))
+    return {
+        "raw_hbm_bytes_per_cycle": raw_bytes_per_cycle,
+        "modeled_effective_hbm_bytes_per_cycle": modeled_effective_bytes_per_cycle,
+        "original_effective_hbm_bytes_per_cycle": original_effective,
+        "modeled_hbm_efficiency": modeled_hbm_efficiency,
+        "original_hbm_efficiency": _as_float(row.get("hbm_efficiency")),
+        "row_hit_rate": row_hit_rate,
+        "scheduler_efficiency": scheduler_efficiency,
+        "arbitration_efficiency": arbitration_efficiency,
+        "burst_bytes": burst_bytes,
+        "hbm_outstanding": outstanding,
+        "request_overhead_cycles": request_overhead_cycles,
+        "row_miss_penalty_cycles": row_miss_penalty_cycles,
+        "payload_cycles_per_burst": payload_cycles,
+        "hidden_command_cycles_per_burst": hidden_command_cycles,
+        "service_cycles_per_burst": service_cycles_per_burst,
+    }
+
+
+def _dram_energy_terms(
+    *,
+    row: JsonDict,
+    service: JsonDict,
+    read_hit_pj_per_byte: float,
+    read_miss_pj_per_byte: float,
+    write_pj_per_byte: float,
+    activate_precharge_pj_per_row: float,
+    command_pj_per_burst: float,
+) -> JsonDict:
+    traffic = _traffic(row)
+    read_bytes = _as_float(traffic["hbm_read_bytes"])
+    write_bytes = _as_float(traffic["kv_write_bytes"])
+    row_hit_rate = _as_float(service["row_hit_rate"])
+    hit_read_bytes = read_bytes * row_hit_rate
+    miss_read_bytes = read_bytes - hit_read_bytes
+    burst_bytes = max(1.0, _as_float(service["burst_bytes"]))
+    row_bytes = burst_bytes
+    burst_count = math.ceil((read_bytes + write_bytes) / burst_bytes)
+    miss_row_count = math.ceil(miss_read_bytes / row_bytes)
+    read_hit_pj = hit_read_bytes * read_hit_pj_per_byte
+    read_miss_pj = miss_read_bytes * read_miss_pj_per_byte
+    write_pj = write_bytes * write_pj_per_byte
+    activate_precharge_pj = miss_row_count * activate_precharge_pj_per_row
+    command_pj = burst_count * command_pj_per_burst
+    total_pj = read_hit_pj + read_miss_pj + write_pj + activate_precharge_pj + command_pj
+    return {
+        "status": "hbm_dram_command_class_energy_model_not_signoff",
+        "energy_mj": _energy_mj_from_pj(total_pj),
+        "energy_pj": total_pj,
+        "read_bytes": read_bytes,
+        "write_bytes": write_bytes,
+        "row_hit_read_bytes": hit_read_bytes,
+        "row_miss_read_bytes": miss_read_bytes,
+        "burst_count": burst_count,
+        "miss_row_count": miss_row_count,
+        "read_hit_pj": read_hit_pj,
+        "read_miss_pj": read_miss_pj,
+        "write_pj": write_pj,
+        "activate_precharge_pj": activate_precharge_pj,
+        "command_pj": command_pj,
+        "read_hit_pj_per_byte": read_hit_pj_per_byte,
+        "read_miss_pj_per_byte": read_miss_pj_per_byte,
+        "write_pj_per_byte": write_pj_per_byte,
+        "activate_precharge_pj_per_row": activate_precharge_pj_per_row,
+        "command_pj_per_burst": command_pj_per_burst,
+    }
+
+
+def _service_adjusted_latency(row: JsonDict, service: JsonDict) -> JsonDict:
+    latency_us = _as_float(row.get("latency_us"))
+    if latency_us <= 0.0:
+        return {"latency_us": latency_us, "service_latency_scale": 1.0, "hbm_latency_weight": 0.0}
+    original = max(1e-12, _as_float(service["original_effective_hbm_bytes_per_cycle"]))
+    modeled = max(1e-12, _as_float(service["modeled_effective_hbm_bytes_per_cycle"]))
+    service_scale = original / modeled
+    if str(row.get("dominant_tile_resource", "")) == "hbm":
+        hbm_latency_weight = min(0.95, max(0.35, _as_float(row.get("hbm_byte_share"), 0.5)))
+    else:
+        hbm_latency_weight = min(0.65, max(0.1, _as_float(row.get("hbm_byte_share"), 0.25)))
+    adjusted_latency_us = latency_us * ((1.0 - hbm_latency_weight) + hbm_latency_weight * service_scale)
+    return {
+        "latency_us": adjusted_latency_us,
+        "base_latency_us": latency_us,
+        "service_latency_scale": service_scale,
+        "hbm_latency_weight": hbm_latency_weight,
+    }
+
+
+def _dram_modeled_row(
+    *,
+    row: JsonDict,
+    integrated_energy: JsonDict,
+    measured_compute: JsonDict,
+    sram_profile: JsonDict,
+    controller: JsonDict,
+    args: argparse.Namespace,
+) -> JsonDict:
+    base = _energy_row(
+        row=row,
+        integrated_energy=integrated_energy,
+        measured_compute=measured_compute,
+        sram_profile=sram_profile,
+        hbm_energy_pj_per_byte=0.0,
+        noc_energy_pj_per_byte_hop=args.noc_energy_pj_per_byte_hop,
+    )
+    service = _modeled_hbm_service(row, controller)
+    dram = _dram_energy_terms(
+        row=row,
+        service=service,
+        read_hit_pj_per_byte=args.read_hit_pj_per_byte,
+        read_miss_pj_per_byte=args.read_miss_pj_per_byte,
+        write_pj_per_byte=args.write_pj_per_byte,
+        activate_precharge_pj_per_row=args.activate_precharge_pj_per_row,
+        command_pj_per_burst=args.command_pj_per_burst,
+    )
+    latency = _service_adjusted_latency(row, service)
+    components = dict(base["energy_components"])
+    components["hbm_mj"] = _as_float(dram["energy_mj"])
+    total_energy_mj = sum(_as_float(value) for value in components.values())
+    dominant_energy_component = max(components.items(), key=lambda item: _as_float(item[1]))[0].replace("_mj", "")
+    out = {
+        **base,
+        "arch_id": "hbm_dram_service_energy_frontier",
+        "latency_us": latency["latency_us"],
+        "token_throughput_per_s": _tokens_per_s(latency["latency_us"]),
+        "base_latency_us": latency["base_latency_us"],
+        "service_latency_scale": latency["service_latency_scale"],
+        "hbm_latency_weight": latency["hbm_latency_weight"],
+        "energy_mj": total_energy_mj,
+        "energy_status": "hbm_dram_command_service_energy_model_not_signoff",
+        "dominant_energy_component": dominant_energy_component,
+        "energy_components": components,
+        "hbm_dram_service": service,
+        "hbm_dram_energy": dram,
+        "remaining_energy_abstractions": [
+            "HBM service uses burst/row-hit/outstanding-request accounting, not a cycle-accurate DRAM controller RTL simulation.",
+            "HBM energy is split by command class, but pJ values are explicit model parameters rather than vendor signoff currents.",
+            "Compute energy is still scaled from the nearest measured dense compute reference.",
+            "NoC/SRAM energy uses profile-scaled accounting from the integrated energy closure.",
+        ],
+    }
+    return out
+
+
+def build_payload(args: argparse.Namespace) -> JsonDict:
+    integrated_energy = _load_json(args.integrated_energy_json)
+    hbm_sensitivity = _load_json(args.hbm_energy_sensitivity_json)
+    hbm_quality_backed = _load_json(args.hbm_quality_backed_json)
+    measured_compute = _load_json(args.measured_compute_json)
+    sram_profile = _load_json(args.sram_profile_json)
+    hbm_controller = _load_json(args.hbm_controller_json)
+    rows = _frontier_rows(hbm_quality_backed, args.frontier_row_limit)
+    if not rows:
+        raise RuntimeError("no retained HBM frontier rows found")
+    controller = _controller_defaults(hbm_controller)
+    modeled_rows = [
+        _dram_modeled_row(
+            row=row,
+            integrated_energy=integrated_energy,
+            measured_compute=measured_compute,
+            sram_profile=sram_profile,
+            controller=controller,
+            args=args,
+        )
+        for row in rows
+    ]
+    latency_best = min(modeled_rows, key=lambda item: (_as_float(item["latency_us"]), _as_float(item["energy_mj"])))
+    energy_best = min(modeled_rows, key=lambda item: (_as_float(item["energy_mj"]), _as_float(item["latency_us"])))
+    balanced_best = min(
+        _with_score(modeled_rows, latency_best),
+        key=lambda item: (
+            _as_float(item["unit_weight_latency_energy_area_score"]),
+            _as_float(item["latency_us"]),
+        ),
+    )
+    pareto_rows = _pareto(modeled_rows)[: args.pareto_row_limit]
+    previous_best = _best(hbm_sensitivity)
+    previous_candidate_id = str(previous_best.get("candidate_id", ""))
+    energy_candidate_id = str(energy_best.get("candidate_id", ""))
+    previous_family = _frontier_family_key(previous_best)
+    energy_family = _frontier_family_key(energy_best)
+    energy_frontier_changed = previous_family != energy_family
+    energy_variant_changed = bool(previous_candidate_id and previous_candidate_id != energy_candidate_id)
+    service_slowdown_vs_sensitivity = _as_float(latency_best["latency_us"]) / max(
+        1e-12,
+        _as_float((hbm_sensitivity.get("latency_best_at_nominal") or {}).get("latency_us")),
+    )
+    decision = (
+        "hbm_dram_service_energy_changes_energy_frontier"
+        if energy_frontier_changed
+        else "hbm_dram_service_energy_preserves_energy_frontier"
+    )
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_hbm_dram_service_energy_llama7b_v1",
+        "decision": decision,
+        "diagnosis": {
+            "decision": decision,
+            "previous_hbm_sensitivity_energy_best": previous_candidate_id,
+            "hbm_dram_energy_best": energy_candidate_id,
+            "previous_hbm_sensitivity_energy_family": previous_family,
+            "hbm_dram_energy_family": energy_family,
+            "energy_frontier_changed_vs_hbm_sensitivity": energy_frontier_changed,
+            "energy_variant_changed_vs_hbm_sensitivity": energy_variant_changed,
+            "service_slowdown_vs_hbm_sensitivity_latency_best": service_slowdown_vs_sensitivity,
+            "recommended_next_step": (
+                "directly measure the selected compute service point and replace DRAM pJ parameters with sourced HBM stack currents"
+            ),
+        },
+        "best": {
+            **energy_best,
+            "arch_id": "hbm_dram_service_energy_best",
+        },
+        "latency_best_under_dram_model": latency_best,
+        "balanced_best_under_dram_model": balanced_best,
+        "pareto_rows": pareto_rows,
+        "input_row_count": len(rows),
+        "dram_model_parameters": {
+            "read_hit_pj_per_byte": args.read_hit_pj_per_byte,
+            "read_miss_pj_per_byte": args.read_miss_pj_per_byte,
+            "write_pj_per_byte": args.write_pj_per_byte,
+            "activate_precharge_pj_per_row": args.activate_precharge_pj_per_row,
+            "command_pj_per_burst": args.command_pj_per_burst,
+            "noc_energy_pj_per_byte_hop": args.noc_energy_pj_per_byte_hop,
+            "controller_defaults": controller,
+        },
+        "remaining_abstractions": [
+            "HBM/DRAM service is now command-class and row-hit aware, but still not a cycle-accurate controller simulation.",
+            "HBM/DRAM energy parameters are explicit pJ values; they need source-backed stack-current calibration before final energy claims.",
+            "Compute energy remains scaled from the nearest measured dense compute reference until the selected MAC/cycle point is measured.",
+            "NoC/SRAM energy remains profile-scaled rather than routed switching or SRAM compiler signoff.",
+        ],
+        "source_artifacts": {
+            "integrated_energy_model": integrated_energy.get("model"),
+            "hbm_energy_sensitivity_model": hbm_sensitivity.get("model"),
+            "hbm_quality_backed_model": hbm_quality_backed.get("model"),
+            "hbm_controller_model": hbm_controller.get("model"),
+            "measured_compute_model": measured_compute.get("model"),
+            "sram_profile_model": sram_profile.get("model"),
+        },
+    }
+
+
+def write_markdown(payload: JsonDict, report: Path) -> None:
+    best = payload["best"]
+    latency_best = payload["latency_best_under_dram_model"]
+    balanced_best = payload["balanced_best_under_dram_model"]
+    lines = [
+        "# Llama7B HBM/DRAM Service Energy",
+        "",
+        "## Decision",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- previous_hbm_sensitivity_energy_best: `{payload['diagnosis']['previous_hbm_sensitivity_energy_best']}`",
+        f"- hbm_dram_energy_best: `{payload['diagnosis']['hbm_dram_energy_best']}`",
+        f"- service_slowdown_vs_hbm_sensitivity_latency_best: `{payload['diagnosis']['service_slowdown_vs_hbm_sensitivity_latency_best']}`",
+        "",
+        "## Best Points",
+        "",
+        "| role | candidate | latency us | throughput tok/s | energy mJ | area mm2 | dominant energy |",
+        "|---|---|---:|---:|---:|---:|---|",
+    ]
+    for role, row in (("latency", latency_best), ("energy", best), ("balanced", balanced_best)):
+        lines.append(
+            "| {role} | {candidate_id} | {latency_us} | {token_throughput_per_s} | {energy_mj} | {die_area_mm2} | {dominant_energy_component} |".format(
+                role=role,
+                **row,
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## DRAM Model Parameters",
+            "",
+            "| parameter | value |",
+            "|---|---:|",
+        ]
+    )
+    for key, value in payload["dram_model_parameters"].items():
+        if isinstance(value, dict):
+            continue
+        lines.append(f"| {key} | {value} |")
+    lines.extend(["", "## Pareto Rows", "", "| candidate | latency us | energy mJ | area mm2 | service scale |", "|---|---:|---:|---:|---:|"])
+    for row in payload["pareto_rows"]:
+        lines.append(
+            "| {candidate_id} | {latency_us} | {energy_mj} | {die_area_mm2} | {service_latency_scale} |".format(
+                **row
+            )
+        )
+    lines.extend(["", "## Remaining Abstractions"])
+    for item in payload["remaining_abstractions"]:
+        lines.append(f"- {item}")
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--integrated-energy-json", type=Path, required=True)
+    parser.add_argument("--hbm-energy-sensitivity-json", type=Path, required=True)
+    parser.add_argument("--hbm-quality-backed-json", type=Path, required=True)
+    parser.add_argument("--hbm-controller-json", type=Path, required=True)
+    parser.add_argument("--measured-compute-json", type=Path, required=True)
+    parser.add_argument("--sram-profile-json", type=Path, required=True)
+    parser.add_argument("--read-hit-pj-per-byte", type=float, default=4.0)
+    parser.add_argument("--read-miss-pj-per-byte", type=float, default=10.0)
+    parser.add_argument("--write-pj-per-byte", type=float, default=6.0)
+    parser.add_argument("--activate-precharge-pj-per-row", type=float, default=3000.0)
+    parser.add_argument("--command-pj-per-burst", type=float, default=5.0)
+    parser.add_argument("--noc-energy-pj-per-byte-hop", type=float, default=0.02)
+    parser.add_argument("--frontier-row-limit", type=int, default=96)
+    parser.add_argument("--pareto-row-limit", type=int, default=16)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_payload(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a focused Llama7B HBM/DRAM service-energy audit script
- wire the new decoder_attention_hbm_dram_service_energy abstraction into L2 generation and result consumption
- add proposal metadata and update the Llama7B closure plan

## Validation
- python3 -m py_compile npu/eval/audit_llm_decoder_attention_hbm_dram_service_energy.py
- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_hbm_dram_service_energy_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_hbm_energy_sensitivity_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_hbm_dram_service_energy_uses_decoder_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_hbm_energy_sensitivity_uses_decoder_evidence
- python3 scripts/validate_runs.py --skip_eval_queue

Next evaluation dispatch must target remote evaluator eval-daemon-b7c2d9c80c1c.