### PR TITLE
[codex] add dense gemm depth scaling v3 job

### DIFF
--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -93,6 +93,25 @@ than free or heuristic assumptions.
   - dominant energy component: `hbm`
   - next result: replace the abstract `524288 MAC/cycle` target with measured
     dense-tile compute capacity and recompute throughput/energy/area
+- The measured compute energy closure result
+  `l2_decoder_attention_measured_compute_energy_closure_llama7b_v1` is merged
+  by PR #981. It reports:
+  - the abstract `400.0 mm2` / `524288 MAC/cycle` frontier is not physically
+    plausible at measured exact-FP16 dense-tile density
+  - the abstract selected point would require `4096` copies of the best
+    measured 128-MAC/cycle dense tile, or `1888.64512 mm2` of compute area
+    before SRAM, HBM, NoC, and reserved area
+  - the corrected measured-compute-constrained energy best is
+    `die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512`
+  - corrected latency: `72544.06213406654 us/token`
+  - corrected token throughput: `13.784725731954872 token/s`
+  - corrected energy: `81.66413005453946 mJ/token`
+  - compute energy: `18.095420734855 mJ/token`
+  - HBM energy: `63.520046663430314 mJ/token`
+  - dominant energy component remains `hbm`, but throughput and area are now
+    dominated by measured compute density
+  - next result: measure denser exact-FP16 dense GEMM tiles before accepting the
+    measured-compute frontier as the best possible exact-FP16 architecture
 - There is no active queue item for this closure stage. New evaluations should
   continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`.
@@ -112,14 +131,13 @@ than free or heuristic assumptions.
 1a. Measured compute capacity and energy closure
    - Scope: replace abstract selected-point `macs_per_cycle` and nearest-row
      compute-energy scaling with measured dense-tile replicated capacity rows.
-   - Status: the current HBM-calibrated best assumes `524288 MAC/cycle` on a
-     `400.0 mm2` die. The merged dense-tile measured-compute artifact reaches
-     about `132k MAC/cycle` only at the `1200.0 mm2` planning point, so the
-     abstract `400.0 mm2` frontier must be checked before reuse.
-   - Next result: run
-     `l2_decoder_attention_measured_compute_energy_closure_llama7b_v1` to
-     determine whether the current selected family survives measured compute
-     capacity/energy constraints.
+   - Status: closed for the current measured dense-tile set by PR #981. The
+     current exact-FP16 measured-compute frontier reaches about `132k
+     MAC/cycle` only at the `1200.0 mm2` planning point, and the abstract
+     `524288 MAC/cycle` selected point is infeasible.
+   - Next result: run `l1_npu_dense_gemm_tile_scaling_v3` to measure whether
+     16x16 exact-FP16 `k_unroll` depth scaling improves MAC/cycle/mm2 enough to
+     rerank the Llama7B frontier.
 
 2. HBM/DRAM and on-chip service detail
    - Scope: replace aggregate HBM efficiency and compact NoC/SRAM service caps
@@ -179,9 +197,11 @@ than free or heuristic assumptions.
 
 ## Ordering
 
-The next evaluation should close the selected compute target. HBM calibration is
-stable across source-backed pJ/bit and row-hit sensitivity, but the selected
-point still assumes an abstract `524288 MAC/cycle` compute service point on a
-`400.0 mm2` die. The next job should replace that assumption with measured
-dense-tile replicated capacity rows and recompute throughput/energy/area. All
-new evaluation jobs should run on the remote evaluator, not the devcontainer.
+The next evaluation should test whether exact-FP16 dense compute can become
+denser before moving to lower precision or a wider generator. PR #981 already
+closed the abstract selected compute target and showed that the current
+measured dense-tile set makes the old `524288 MAC/cycle` point infeasible. The
+next job is `l1_npu_dense_gemm_tile_scaling_v3`: remeasure the 16x16 k1
+baseline and measure a 16x16 k2 depth point in the same larger macro floorplan.
+All new evaluation jobs should run on the remote evaluator, not the
+devcontainer.

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/README.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/README.md
@@ -1,0 +1,14 @@
+# Dense FP16 GEMM Tile Scaling V3
+
+This proposal measures whether the current best exact-FP16 dense GEMM tile can
+gain useful MAC density by increasing `k_unroll` inside the existing 16x16
+generator limit.
+
+PR #981 showed that the abstract `524288 MAC/cycle` Llama7B frontier is not
+physically plausible when replaced by measured dense-tile compute capacity. The
+next question is whether a denser measured tile can improve the corrected
+frontier before changing precision or inventing a wider generator.
+
+The immediate evaluator job reruns the 16x16 baseline in the same larger macro
+floorplan as the new depth point, then measures `16x16 k2 p2`. A `16x16 k4 p2`
+config is prepared as a later boundary item after the k2 result is reviewed.

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/design_brief.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/design_brief.md
@@ -1,0 +1,29 @@
+# Design Brief
+
+## Proposal
+
+- `proposal_id`: `prop_l1_npu_dense_gemm_tile_scaling_v3`
+- `title`: `Dense FP16 GEMM tile depth scaling V3`
+
+## Problem
+
+PR #981 replaced the abstract Llama7B compute target with measured dense-tile
+capacity and showed that the old `524288 MAC/cycle` point would require about
+`1888.64512 mm2` of compute area. The corrected frontier is therefore limited
+by exact-FP16 measured MAC density.
+
+## Architecture
+
+- exact RTLGen FP16 MAC primitive reused from dense tile V2.
+- `16x16 k1 p2` baseline remeasured under the V3 floorplan.
+- `16x16 k1 p1` pipeline comparison.
+- `16x16 k2 p2` depth scaling point.
+- `16x16 k4 p2` config is present but reserved for a later boundary dispatch.
+- narrow self-stimulating wrapper with all MAC outputs folded into
+  `result_hash`.
+- no memory, NoC, producer, vector tail, softmax, normalization, or reducer.
+
+## Direction Gate
+
+- status: approved_after_source_merge
+- dispatch: remote evaluator `eval-daemon-b7c2d9c80c1c`

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/evaluation_gate.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/evaluation_gate.md
@@ -1,0 +1,12 @@
+# Evaluation Gate
+
+- status: approved_after_source_merge
+- approved_by: developer_agent
+- approved_utc: 2026-06-22T00:00:00Z
+- allowed_evaluations:
+  - Run `l1_npu_dense_gemm_tile_scaling_v3` as a hierarchy-preserving Layer 1
+    PPA sweep on the remote evaluator only.
+- required_machine: `eval-daemon-b7c2d9c80c1c`
+- note: The queued payload must include `source_requirement.required_sha` for
+  the merged commit containing this proposal, the V3 sweep, and the new dense
+  tile configs.

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/evaluation_requests.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/evaluation_requests.json
@@ -1,0 +1,33 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_scaling_v3",
+  "requests": [
+    {
+      "item_id": "l1_npu_dense_gemm_tile_scaling_v3",
+      "task_type": "l1_sweep",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "measurement",
+      "expected_direction": "measure_dense_tile_depth_scaling",
+      "expected_reason": "Measure whether exact-FP16 16x16 k_unroll depth improves MAC density enough to revise the PR #981 measured-compute-constrained Llama7B frontier.",
+      "dispatch_machine_key": "eval-daemon-b7c2d9c80c1c",
+      "configs": [
+        "runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p2/config.json",
+        "runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p1/config.json",
+        "runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k2_p2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/dense_gemm_tile_v3/sweeps/nangate45_dense_tile_depth_hier.json",
+      "out_root": "runs/campaigns/npu/dense_gemm_tile_v3"
+    }
+  ],
+  "requested_items": [
+    {
+      "item_id": "l1_npu_dense_gemm_tile_scaling_v3",
+      "task_type": "l1_sweep",
+      "objective": "Measure 16x16 exact-FP16 dense GEMM k1/k2 pipeline and depth scaling under one larger hierarchy-preserving Nangate45 floorplan.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "architecture_block",
+      "status": "blocked_until_source_merged",
+      "notes": "Dispatch only after this proposal, the V3 sweep, and the new dense tile configs are merged to master; queue with source_requirement.required_sha set to that merge commit and dispatch_machine_key eval-daemon-b7c2d9c80c1c."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/implementation_summary.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/implementation_summary.md
@@ -1,0 +1,25 @@
+# Implementation Summary
+
+## Scope
+
+- Add exact-FP16 dense GEMM tile configs:
+  - `16x16 k1 p1`
+  - `16x16 k2 p2`
+  - `16x16 k4 p2` as a prepared boundary point, not part of the first
+    dispatch.
+- Add a V3 hierarchy-preserving Nangate45 sweep with a larger macro floorplan.
+- Reuse the existing dense GEMM tile generator and structural guard.
+
+## Local Validation
+
+- `cmake -S . -B build && cmake --build build --target rtlgen`
+- temporary RTL generation and `check_dense_gemm_tile_guard.py` passed for:
+  - `16x16 k1 p1` with 256 MAC/cycle
+  - `16x16 k2 p2` with 512 MAC/cycle
+  - `16x16 k4 p2` with 1024 MAC/cycle
+
+## Evaluation Request
+
+- requested task: `l1_npu_dense_gemm_tile_scaling_v3`
+- dispatch machine: `eval-daemon-b7c2d9c80c1c`
+- cost class: medium

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/proposal.json
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l1_npu_dense_gemm_tile_scaling_v3",
+  "created_utc": "2026-06-22T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "title": "Dense FP16 GEMM tile depth scaling V3",
+  "abstraction_layer": "architecture_block",
+  "hypothesis": "The measured-compute Llama7B frontier is limited by exact-FP16 dense tile MAC density. Increasing k_unroll within the existing 16x16 generator limit may improve MAC/cycle/mm2 or expose the next physical boundary without changing precision or generator semantics.",
+  "direct_comparison": {
+    "primary_question": "Does a 16x16 exact-FP16 dense GEMM tile with k_unroll=2 improve measured MAC density and energy per MAC versus the 16x16 k1 baseline under the same macro floorplan?",
+    "include": [
+      "16x16 k1 p2 exact-FP16 dense tile baseline remeasured in the V3 floorplan",
+      "16x16 k1 p1 exact-FP16 dense tile pipeline comparison",
+      "16x16 k2 p2 exact-FP16 dense tile depth scaling point",
+      "hierarchy-preserving Nangate45 PPA sweep",
+      "structural guard that all MAC outputs fold into the visible result hash",
+      "failure rows preserved as boundary evidence if timing, area, or flow fails"
+    ],
+    "exclude": [
+      "32-wide dense tiles, because the current generator validates array_m and array_n only up to 16",
+      "the prepared 16x16 k4 p2 boundary point in the first dispatch",
+      "softmax, normalization, reducer, CQ, DMA, SRAM, NoC, or producer integration",
+      "quality-changing precision approximation"
+    ],
+    "follow_on_broad_sweep": [
+      "If k2 improves density, run the prepared k4 boundary item or add a larger integrated macro measurement.",
+      "If k2 does not improve density, use the PR #981 measured-compute-constrained frontier and pivot to precision recovery or integrated compute hierarchy.",
+      "If the flow fails, record the failed point as the current exact-FP16 dense-tile scaling boundary before trying a different circuit algorithm."
+    ]
+  },
+  "expected_benefit": [
+    "Reduces the dominant measured-compute abstraction exposed by PR #981.",
+    "Tests exact-FP16 compute density before introducing lower precision.",
+    "Separates depth-scaling effects from unsupported wider-array generator changes.",
+    "Provides source-linked metrics for recomputing the Llama7B throughput, energy, and area frontier."
+  ],
+  "risks": [
+    "The k2 point may run longer or fail if area/timing pressure grows faster than MAC count.",
+    "The larger floorplan makes absolute delay less directly comparable to earlier V2 rows, so the V3 job remeasures the k1 baseline in the same floorplan.",
+    "The wrapper remains a macro-style PPA harness rather than a complete NPU block.",
+    "Pipeline stage 2 registers MAC outputs but does not retime inside the exact FP16 MAC primitive."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l1_npu_dense_gemm_tile_scaling_v3",
+      "task_type": "l1_sweep",
+      "objective": "Measure 16x16 exact-FP16 dense GEMM k1/k2 pipeline and depth scaling under one larger hierarchy-preserving Nangate45 floorplan.",
+      "evaluation_mode": "measurement_only",
+      "abstraction_layer": "architecture_block",
+      "cost_class": "medium",
+      "expected_result": {
+        "direction": "measure_dense_tile_depth_scaling",
+        "reason": "Determine whether exact-FP16 k_unroll depth improves measured MAC density enough to change the PR #981 measured-compute-constrained Llama7B frontier."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p2/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "pr:981",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "npu/rtlgen/gen_dense_gemm_tile.py",
+    "npu/eval/check_dense_gemm_tile_guard.py",
+    "runs/campaigns/npu/dense_gemm_tile_v3/sweeps/nangate45_dense_tile_depth_hier.json"
+  ]
+}

--- a/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/quality_gate.md
+++ b/docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/quality_gate.md
@@ -1,0 +1,19 @@
+# Quality Gate
+
+## Checks
+
+- metric: structural MAC count
+  - threshold: generated manifests report 256 MAC/cycle for `16x16 k1` and
+    512 MAC/cycle for `16x16 k2`.
+- metric: datapath connectivity
+  - threshold: every generated MAC instance output folds into `result_hash`.
+- metric: PPA output
+  - threshold: each design records `metrics.csv` rows; failed rows are kept as
+    boundary evidence rather than discarded.
+- metric: comparison readiness
+  - threshold: result rows are sufficient to compute MAC/cycle/mm2 and
+    mW/(MAC/cycle), then feed the measured-compute Llama7B frontier rerank.
+
+## Result
+
+- status: pending

--- a/runs/campaigns/npu/dense_gemm_tile_v3/sweeps/nangate45_dense_tile_depth_hier.json
+++ b/runs/campaigns/npu/dense_gemm_tile_v3/sweeps/nangate45_dense_tile_depth_hier.json
@@ -1,0 +1,30 @@
+{
+  "flow_params": {
+    "TAG": [
+      "npu_dense_gemm_tile_v3_depth_hier"
+    ],
+    "FLOW_VARIANT": [
+      "dense_gemm_tile_v3_depth_hier"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2600 2600"
+    ],
+    "CORE_AREA": [
+      "50 50 2550 2550"
+    ],
+    "PLACE_DENSITY": [
+      0.35,
+      0.45
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "gemm_mac_fp16_ieee"
+    ]
+  },
+  "tag_prefix": "npu_dense_gemm_tile_v3_depth"
+}

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p1/config.json
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k1_p1/config.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1",
+  "top_name": "dense_gemm_tile_fp16_16x16_k1_p1",
+  "dense_gemm_tile": {
+    "module_name": "dense_gemm_tile_fp16_16x16_k1_p1",
+    "precision": "fp16",
+    "array_m": 16,
+    "array_n": 16,
+    "k_unroll": 1,
+    "pipeline_stages": 1,
+    "rtlgen_cpp": {
+      "binary_path": "build/rtlgen",
+      "module_name": "gemm_mac_fp16_ieee",
+      "total_width": 16,
+      "mantissa_width": 10
+    }
+  }
+}

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k2_p2/config.json
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k2_p2/config.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1",
+  "top_name": "dense_gemm_tile_fp16_16x16_k2_p2",
+  "dense_gemm_tile": {
+    "module_name": "dense_gemm_tile_fp16_16x16_k2_p2",
+    "precision": "fp16",
+    "array_m": 16,
+    "array_n": 16,
+    "k_unroll": 2,
+    "pipeline_stages": 2,
+    "rtlgen_cpp": {
+      "binary_path": "build/rtlgen",
+      "module_name": "gemm_mac_fp16_ieee",
+      "total_width": 16,
+      "mantissa_width": 10
+    }
+  }
+}

--- a/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k4_p2/config.json
+++ b/runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x16_k4_p2/config.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1",
+  "top_name": "dense_gemm_tile_fp16_16x16_k4_p2",
+  "dense_gemm_tile": {
+    "module_name": "dense_gemm_tile_fp16_16x16_k4_p2",
+    "precision": "fp16",
+    "array_m": 16,
+    "array_n": 16,
+    "k_unroll": 4,
+    "pipeline_stages": 2,
+    "rtlgen_cpp": {
+      "binary_path": "build/rtlgen",
+      "module_name": "gemm_mac_fp16_ieee",
+      "total_width": 16,
+      "mantissa_width": 10
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the Layer 1 dense FP16 GEMM tile scaling V3 proposal
- add 16x16 k1 p1, k2 p2, and prepared k4 p2 dense tile configs
- add a larger hierarchy-preserving Nangate45 V3 sweep
- update the Llama7B closure plan with the merged PR #981 measured-compute correction

## Why
PR #981 showed the abstract 524288 MAC/cycle Llama7B point is infeasible at current measured dense-tile density. This support change prepares the next remote evaluator job to test whether exact-FP16 16x16 depth scaling improves MAC/cycle/mm2 before we move to lower precision or a wider generator.

## Validation
- `cmake -S . -B build && cmake --build build --target rtlgen`
- temporary RTL generation plus `check_dense_gemm_tile_guard.py` for 16x16 k1 p1, k2 p2, and k4 p2
- scratch `generate-l1-sweep` into SQLite for `l1_npu_dense_gemm_tile_scaling_v3`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
