### PR TITLE
[codex] add dense gemm v3 measured-compute rerank

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5897,6 +5897,77 @@ def _decoder_attention_measured_compute_energy_closure_evidence(*, item_id: str)
     }
 
 
+def _decoder_attention_dense_gemm_v3_measured_compute_closure_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    measured_compute = f"{base}/decoder_attention_kv_dense_tile_v3_measured_compute__{item_id}.json"
+    measured_compute_report = f"{base}/decoder_attention_kv_dense_tile_v3_measured_compute__{item_id}.md"
+    out = f"{base}/decoder_attention_dense_gemm_v3_measured_compute_closure__{item_id}.json"
+    report = f"{base}/decoder_attention_dense_gemm_v3_measured_compute_closure__{item_id}.md"
+    hbm_command_calibrated = (
+        f"{base}/decoder_attention_hbm_command_calibrated_service__"
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json"
+    )
+    previous_closure = (
+        f"{base}/decoder_attention_measured_compute_energy_closure__"
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json"
+    )
+    sram_profile = f"{base}/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    dense_v3_promotion = "docs/proposals/prop_l1_npu_dense_gemm_tile_scaling_v3/promotion_result.json"
+    return {
+        "inputs": {
+            "dense_gemm_tile_scaling_v3": dense_v3_promotion,
+            "attention_hbm_command_calibrated_service": hbm_command_calibrated,
+            "attention_measured_compute_energy_closure_previous": previous_closure,
+            "attention_sram_profile": sram_profile,
+            "attention_kv_dense_tile_v3_measured_compute_out": measured_compute,
+            "attention_kv_dense_tile_v3_measured_compute_report": measured_compute_report,
+            "attention_dense_gemm_v3_measured_compute_closure_out": out,
+            "attention_dense_gemm_v3_measured_compute_closure_report": report,
+            "attention_dense_gemm_v3_measured_compute_closure_scope": (
+                "Regenerate the Llama7B native-GQA KV8 measured-compute rows using the "
+                "Layer 1 dense GEMM tile V3 exact-FP16 depth-scaling metrics, then rerun "
+                "the source-backed HBM command-calibrated measured-compute energy closure "
+                "against that V3 compute set and compare with the PR #981 corrected frontier."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_decoder_attention_kv_dense_tile_v3_measured_compute",
+                "run": (
+                    "python3 npu/eval/estimate_llm_decoder_attention_kv_measured_compute.py "
+                    "--repo-root . "
+                    "--compute-source dense_gemm_tile "
+                    "--tag-substring npu_dense_gemm_tile_v3_depth_hier "
+                    "--sequence-length-list 131072 "
+                    "--die-area-mm2-list 100,200,400,800,1200 "
+                    "--sram-area-fraction 0.4,0.6,0.75 "
+                    "--logic-area-fraction 0.05,0.1,0.2,0.4,0.6 "
+                    "--reserved-area-fraction 0.1 "
+                    "--usable-sram-fraction 0.7,0.85 "
+                    "--local-sram-fraction 0.1,0.25,0.5 "
+                    "--tile-tokens-list 512,1024 "
+                    "--bank-count 16,64 "
+                    "--vector-ops-per-mac 0.125 "
+                    f"--out {measured_compute} "
+                    f"--out-md {measured_compute_report}"
+                ),
+            },
+            {
+                "name": "audit_decoder_attention_dense_gemm_v3_measured_compute_closure",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_measured_compute_energy_closure.py "
+                    f"--hbm-command-calibrated-service-json {hbm_command_calibrated} "
+                    f"--measured-compute-json {measured_compute} "
+                    f"--sram-profile-json {sram_profile} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [measured_compute, measured_compute_report, out, report],
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -7780,6 +7851,7 @@ def _build_payload(
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
         "decoder_attention_measured_compute_energy_closure",
+        "decoder_attention_dense_gemm_v3_measured_compute_closure",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -7956,6 +8028,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_hbm_command_calibrated_service_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_measured_compute_energy_closure":
             decoder_evidence = _decoder_attention_measured_compute_energy_closure_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_dense_gemm_v3_measured_compute_closure":
+            decoder_evidence = _decoder_attention_dense_gemm_v3_measured_compute_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6640,6 +6640,79 @@ def test_generate_l2_campaign_task_adds_attention_measured_compute_energy_closur
             }
 
 
+def test_generate_l2_campaign_task_adds_dense_gemm_v3_measured_compute_closure_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_dense_gemm_v3_measured_compute_closure",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="frontier_closure",
+                    depends_on_item_ids=[
+                        "l1_npu_dense_gemm_tile_scaling_v3",
+                        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1",
+                        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:2]] == [
+                "estimate_decoder_attention_kv_dense_tile_v3_measured_compute",
+                "audit_decoder_attention_dense_gemm_v3_measured_compute_closure",
+            ]
+            assert "--tag-substring npu_dense_gemm_tile_v3_depth_hier" in commands[0]["run"]
+            assert "audit_llm_decoder_attention_measured_compute_energy_closure.py" in commands[1]["run"]
+            assert (
+                "--measured-compute-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_kv_dense_tile_v3_measured_compute__"
+                "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1.json"
+            ) in commands[1]["run"]
+            assert decoder_inputs["attention_kv_dense_tile_v3_measured_compute_out"] in work_item.expected_outputs
+            assert (
+                decoder_inputs["attention_dense_gemm_v3_measured_compute_closure_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_dense_gemm_v3_measured_compute_closure",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l1_npu_dense_gemm_tile_scaling_v3",
+                    "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1",
+                    "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/README.md
@@ -1,0 +1,14 @@
+# Llama7B Measured Compute Closure with V3 Dense GEMM Metrics
+
+This proposal stages an L2 rerank job that uses the merged `l1_npu_dense_gemm_tile_scaling_v3`
+compute metrics to rebuild the Llama7B attention measured-compute frontier.
+
+The rerank combines:
+
+- source-backed HBM command-calibrated service,
+- merged SRAM profile,
+- corrected compute anchor from `l1_npu_dense_gemm_tile_scaling_v3`,
+- and the PR #981 measured-compute frontier as the explicit comparison baseline.
+
+The job is blocked until the L1 V3 merge is available and dispatches only on
+`eval-daemon-b7c2d9c80c1c`.

--- a/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/design_brief.md
@@ -1,0 +1,48 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1`
+- `title`: `Llama7B measured compute closure with dense GEMM V3 metrics`
+
+## Problem
+PR #981 showed that abstract compute assumptions can invalidate the Llama7B frontier.
+The V3 dense-GEMM tile merge now adds a larger, higher-confidence measured dense-tile
+anchor, so the L2 frontier must be reranked before the next architecture step.
+
+## Hypothesis
+Replacing the PR #981 measured-compute source rows with merged V3 dense-GEMM replica data will either
+reconfirm the current family or force a new selection if 524288 MAC/cycle remains
+infeasible under the measured macro density and area budget.
+
+## Evaluation Scope
+- direct comparison set:
+  - PR #981 measured-compute frontier vs. the reranked V3-dense-GEMM rerank
+  - source-backed HBM command-calibrated service terms
+  - SRAM profile terms
+- evaluation mode:
+  - `frontier_detail` rerank only
+- dependency order:
+  - `l1_npu_dense_gemm_tile_scaling_v3` must be merged before rerank
+  - then `l2_decoder_attention_measured_compute_energy_closure_llama7b_v1` and
+    `l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1` are required inputs
+- excluded first-stage comparisons:
+  - no new PPA/OpenROAD sweeps, no quality/QAT exploration
+  - no new HBM, SRAM, or NoC physical model changes
+- follow-on broad sweep:
+  - if the dense-V3 rerank changes family, keep it as baseline for integrated compute or SRAM/NoC closure jobs
+  - if unchanged, proceed with residual-service sensitivity jobs
+
+## Knowledge Inputs
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json`
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_hbm_command_calibrated_service__l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json`
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json`
+- `item:l1_npu_dense_gemm_tile_scaling_v3`
+
+## Candidate Direction
+Adopt the V3-dense-compute frontier if it is feasible under the current HBM/SRAM accounting,
+otherwise keep the PR #981 corrected baseline and continue to residual-service closure work.
+
+## Direction Gate
+- status: blocked_until_l1_v3_merged
+- note: Wait for `l1_npu_dense_gemm_tile_scaling_v3` merge and dispatch to
+  `eval-daemon-b7c2d9c80c1c`.

--- a/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+- status: blocked_until_l1_v3_merged
+- approved_by:
+- approved_utc:
+- allowed_evaluations:
+  - `l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1`
+- required_machine: `eval-daemon-b7c2d9c80c1c`
+- note: Dispatch is blocked until `l1_npu_dense_gemm_tile_scaling_v3` is merged because
+  this rerank depends on the V3 dense-GEMM compute rows.

--- a/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,45 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+  "requests": [
+    {
+      "item_id": "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_dense_gemm_v3_measured_compute_closure",
+      "comparison_role": "frontier_closure",
+      "expected_direction": "rerank_measured_compute_closure",
+      "expected_reason": "Recompute the measured-compute Llama7B frontier with merged V3 dense-GEMM compute density versus the PR #981 baseline closure.",
+      "dispatch_machine_key": "eval-daemon-b7c2d9c80c1c",
+      "depends_on_item_ids": [
+        "l1_npu_dense_gemm_tile_scaling_v3",
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerank PR #981 Llama7B measured-compute frontier against source-backed HBM command service using merged V3 dense-GEMM compute rows.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_dense_gemm_v3_measured_compute_closure",
+      "comparison_role": "frontier_closure",
+      "depends_on_item_ids": [
+        "l1_npu_dense_gemm_tile_scaling_v3",
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rerank_measured_compute_closure",
+        "reason": "Record whether V3 dense-GEMM rows preserve or replace the PR #981 corrected measured-compute frontier."
+      },
+      "status": "blocked_until_l1_v3_merged",
+      "notes": "Hold dispatch until `l1_npu_dense_gemm_tile_scaling_v3` artifacts are merged into the campaign source set; run only on eval-daemon-b7c2d9c80c1c."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/implementation_summary.md
@@ -1,0 +1,23 @@
+# Implementation Summary
+
+## Scope
+- Add the proposal scaffold for the L2 rerank job that replaces the PR #981
+  corrected measured-compute frontier with merged V3 dense-GEMM compute rows.
+- Add a distinct control-plane L2 abstraction layer that first regenerates
+  measured-compute rows with `npu_dense_gemm_tile_v3_depth_hier`, then runs the
+  measured-compute energy closure audit on that V3 artifact.
+
+## Files Added
+- `docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/README.md`
+- `docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/proposal.json`
+- `docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/evaluation_requests.json`
+- `docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/evaluation_gate.md`
+- `docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/quality_gate.md`
+- `docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/design_brief.md`
+- `control_plane/control_plane/services/l2_task_generator.py`
+- `control_plane/control_plane/tests/test_l2_task_generator.py`
+
+## Local Validation
+- `python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py`
+- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'dense_gemm_v3_measured_compute_closure or measured_compute_energy_closure'`
+- Status remains blocked until L1 V3 merge artifacts are available.

--- a/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/proposal.json
@@ -1,0 +1,76 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+  "created_utc": "2026-06-22T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B measured compute closure with dense GEMM V3 metrics",
+  "abstraction_layer": "decoder_attention_dense_gemm_v3_measured_compute_closure",
+  "hypothesis": "The PR #981 measured-compute closure used the latest merged compute frontier available then, but PR #982 has now merged a deeper 16x16 exact-FP16 dense GEMM tile point under a larger floorplan. Substituting that merged V3 dense compute source and reranking Llama7B should yield a corrected measured-compute frontier and expose whether the abstract 524288 MAC/cycle point remains physically plausible.",
+  "direct_comparison": {
+    "primary_question": "Does the V3 dense GEMM tile compute source change the corrected PR #981 measured-compute frontier for Llama7B when compared against source-backed HBM command service and SRAM profile?",
+    "include": [
+      "consume merged l1 dense-GEMM V3 metrics from `l1_npu_dense_gemm_tile_scaling_v3`",
+      "consume merged source-backed HBM command-calibrated service results",
+      "consume merged SRAM profile",
+      "recompute PR #981 measured-compute frontier rows under the V3 dense tile source",
+      "compare measured frontiers, latency-best, energy-best, and Pareto points against the PR #981 corrected frontier"
+    ],
+    "exclude": [
+      "new RTL generation or OpenROAD/PPA sweeps",
+      "changes to HBM/DRAM command-model internals",
+      "new NoC or SRAM physical model jobs",
+      "quality/QAT architecture changes"
+    ],
+    "follow_on_broad_sweep": [
+      "If V3 dense compute shifts the family, keep this frontier as the next architecture baseline and add integrated compute verification.",
+      "If V3 dense compute does not shift the family, proceed to NoC/SRAM/command-service residual closure depth."
+    ]
+  },
+  "expected_benefit": [
+    "replace the PR #981 abstract compute anchor with merged V3 dense-GEMM measured compute density",
+    "rebuild Llama7B throughput/energy/area with source-backed HBM command service and SRAM profile",
+    "provide a single controlled rerank artifact that can be promoted without changing software quality assumptions"
+  ],
+  "risks": [
+    "V3 dense compute rows may still be replica-scaled and not full integrated compute macro measurements.",
+    "the rerank remains sensitive to SRAM and NoC profile scaling assumptions.",
+    "the new rerank is blocked from running until source-merged V3 compute artifacts are available."
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "rerank PR #981 measured-compute Llama7B frontier against merged V3 dense-GEMM compute rows using source-backed HBM command-calibrated service and SRAM profile.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_dense_gemm_v3_measured_compute_closure",
+      "comparison_role": "frontier_closure",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l1_npu_dense_gemm_tile_scaling_v3",
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rerank_measured_compute_closure",
+        "reason": "Determine whether the PR #981 corrected frontier holds under merged V3 dense-GEMM measured compute density and select updated best rows if needed."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json",
+    "item:l1_npu_dense_gemm_tile_scaling_v3"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_hbm_command_calibrated_service__l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+  ],
+  "knowledge_refs": [
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "npu/eval/audit_llm_decoder_attention_measured_compute_energy_closure.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/quality_gate.md
@@ -1,0 +1,29 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1`
+- `title`: `Llama7B measured compute closure with dense GEMM V3 metrics`
+
+## Why This Gate Is Required
+PR #981 introduced a corrected measured-compute closure for Llama7B but the compute anchor
+was not yet reranked against merged V3 dense-GEMM metrics. The rerank determines whether
+the selected family remains feasible under measured `macs_per_cycle` density rather than the 524288 abstract target.
+
+## Reference
+- baseline_ref: `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json`
+- reference_ref: `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_hbm_command_calibrated_service__l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json`
+
+## Checks
+- metric: compare frontier family
+  - threshold: PR #981 corrected frontier family must be explicitly represented and the reranked PR #981-v3 family must be logged for decision.
+- metric: measured compute source
+  - threshold: selected rerank rows must identify the merged V3 dense-GEMM source rows and report required compute replicas/compute area per die.
+- metric: source-backed consistency
+  - threshold: HBM command-calibrated service and SRAM profile terms remain present in the reranked evidence.
+
+## Local Commands
+- command: `python3 npu/eval/audit_llm_decoder_attention_measured_compute_energy_closure.py --hbm-command-calibrated-service-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_hbm_command_calibrated_service__l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json --measured-compute-json <merged-l1-v3-dense-compute-artifact.json> --sram-profile-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json --out /tmp/decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1.json --out-md /tmp/decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1.md`
+
+## Result
+- status: blocked_until_l1_v3_merged
+- note: Blocked until the V3 dense-GEMM source rows are merged and materialized in the remote evaluator queue.


### PR DESCRIPTION
## Summary
- add a distinct L2 abstraction layer for dense GEMM V3 measured-compute reranking
- regenerate measured-compute rows using `npu_dense_gemm_tile_v3_depth_hier`
- feed the V3 measured-compute artifact into the existing HBM-calibrated measured-compute energy closure audit
- add proposal docs for the follow-on Llama7B frontier rerank after `l1_npu_dense_gemm_tile_scaling_v3` merges

## Why
PR #981 corrected the Llama7B frontier by replacing the abstract 524288 MAC/cycle target with measured dense-tile compute. PR #982 launched V3 exact-FP16 dense tile depth scaling. This support PR makes the next L2 rerank dispatchable as soon as the V3 L1 metrics are merged.

## Validation
- `python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py`
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'dense_gemm_v3_measured_compute_closure or measured_compute_energy_closure'`
- scratch `generate-l2-campaign` into SQLite for `l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
