### PR TITLE
control_plane: fix block sweep metrics artifacts

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -331,6 +331,9 @@ def _read_config_target(
     make_target: str | None,
 ) -> Layer1ConfigTarget:
     cfg = _load_json(config_path)
+    def block_metrics_path(design_name: str) -> str:
+        return f"{out_root}/{design_name}/metrics.csv"
+
     if "multiplier" in cfg:
         module_name = cfg["multiplier"]["module_name"]
         wrapper = f"{module_name}_wrapper"
@@ -471,7 +474,7 @@ def _read_config_target(
         return Layer1ConfigTarget(
             design_kind="block",
             design_name=design_name,
-            expected_metrics_path=f"{design_dir}/metrics.csv",
+            expected_metrics_path=block_metrics_path(design_name),
             commands=[
                 {
                     "name": "build_generator",
@@ -522,7 +525,7 @@ def _read_config_target(
         return Layer1ConfigTarget(
             design_kind="block",
             design_name=design_name,
-            expected_metrics_path=f"{design_dir}/metrics.csv",
+            expected_metrics_path=block_metrics_path(design_name),
             expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
             commands=[
                 {
@@ -586,7 +589,7 @@ def _read_config_target(
         return Layer1ConfigTarget(
             design_kind="block",
             design_name=design_name,
-            expected_metrics_path=f"{design_dir}/metrics.csv",
+            expected_metrics_path=block_metrics_path(design_name),
             commands=[
                 {
                     "name": "build_generator",

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -1217,7 +1217,7 @@ def test_generate_l1_sweep_task_supports_dense_gemm_tile_configs() -> None:
                     sweep_path=sweep_path,
                     config_paths=[config_path],
                     platform="nangate45",
-                    out_root="runs/designs/npu_blocks",
+                    out_root="runs/campaigns/npu/dense_gemm_tile_v1",
                     requested_by="@tester",
                     source_commit=source_commit,
                     abstraction_layer="architecture_block",
@@ -1245,8 +1245,9 @@ def test_generate_l1_sweep_task_supports_dense_gemm_tile_configs() -> None:
                 "--design-dir runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1"
             )
             assert "--top dense_gemm_tile_fp16_4x4_k1_p1" in work_item.command_manifest[3]["run"]
+            assert "--out_root runs/campaigns/npu/dense_gemm_tile_v1" in work_item.command_manifest[3]["run"]
             assert work_item.expected_outputs == [
-                "runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_4x4_k1_p1/metrics.csv"
+                "runs/campaigns/npu/dense_gemm_tile_v1/npu_dense_gemm_tile_fp16_4x4_k1_p1/metrics.csv"
             ]
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "architecture_block"

--- a/control_plane/control_plane/tests/test_run_block_sweep.py
+++ b/control_plane/control_plane/tests/test_run_block_sweep.py
@@ -1,0 +1,75 @@
+"""Coverage for the block-level OpenROAD sweep runner."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_run_block_sweep_module():
+    script_path = Path(__file__).resolve().parents[3] / "npu" / "synth" / "run_block_sweep.py"
+    spec = importlib.util.spec_from_file_location("rtlgen_run_block_sweep", script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skip_existing_reconstructs_metrics_csv(tmp_path: Path) -> None:
+    run_block_sweep = _load_run_block_sweep_module()
+    design_name = "npu_dense_gemm_tile_fp16_4x4_k1_p1"
+    design_dir = tmp_path / "runs" / "designs" / "npu_blocks" / design_name
+    verilog_dir = design_dir / "verilog"
+    verilog_dir.mkdir(parents=True)
+    (verilog_dir / f"{design_name}.v").write_text(f"module {design_name}; endmodule\n", encoding="utf-8")
+
+    out_root = tmp_path / "runs" / "campaigns" / "npu" / "dense_gemm_tile_v1"
+    sweep_params = {
+        "CLOCK_PERIOD": 2.5,
+        "CORE_UTILIZATION": 50,
+        "TAG": "npu_dense_gemm_tile_v1_cached",
+    }
+    run_id = run_block_sweep.make_run_id(sweep_params)
+    result_path = out_root / design_name / "work" / run_id / "result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "status": "ok",
+                "critical_path_ns": 2.1,
+                "die_area": 1000.0,
+                "total_power_mw": 12.5,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_block_sweep.run_single(
+        design_dir=design_dir,
+        design_name=design_name,
+        platform="nangate45",
+        top=design_name,
+        verilog_dir=verilog_dir,
+        sdc_template=None,
+        sweep_params=sweep_params,
+        out_root=out_root,
+        skip_existing=True,
+        dry_run=False,
+        force_copy=False,
+        make_target=None,
+        macro_manifest=None,
+    )
+
+    metrics_path = out_root / design_name / "metrics.csv"
+    assert metrics_path.exists()
+    rows = list(csv.DictReader(metrics_path.open(encoding="utf-8", newline="")))
+    assert len(rows) == 1
+    assert rows[0]["design"] == design_name
+    assert rows[0]["platform"] == "nangate45"
+    assert rows[0]["param_hash"] == run_id
+    assert rows[0]["tag"] == "npu_dense_gemm_tile_v1_cached"
+    assert rows[0]["work_result_json"] == str(result_path)
+    assert result["config_hash"]

--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -1581,8 +1581,25 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
     if skip_existing and result_path.exists():
         print(f"[INFO] Skipping existing run: {run_dir}")
         try:
-            return json.loads(result_path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
+            cached_payload = json.loads(result_path.read_text(encoding="utf-8"))
+            if not isinstance(cached_payload, dict):
+                raise ValueError("result.json payload is not an object")
+            if not str(cached_payload.get("design", "")).strip():
+                cached_payload["design"] = design_name
+            if not str(cached_payload.get("platform", "")).strip():
+                cached_payload["platform"] = platform
+            if not str(cached_payload.get("config_hash", "")).strip():
+                cached_payload["config_hash"] = config_hash
+            if not str(cached_payload.get("param_hash", "")).strip():
+                cached_payload["param_hash"] = run_id
+            if not str(cached_payload.get("tag", "")).strip():
+                cached_payload["tag"] = tag
+            if not str(cached_payload.get("work_result_json", "")).strip():
+                cached_payload["work_result_json"] = str(result_path)
+
+            append_metrics(circuit_root / "metrics.csv", cached_payload)
+            return cached_payload
+        except (json.JSONDecodeError, ValueError):
             return {
                 "design": design_name,
                 "platform": platform,


### PR DESCRIPTION
## Summary
- Diagnose and fix the L1 V3 dense GEMM failure where all sweep commands completed but artifact validation failed because expected metrics paths pointed at design directories while run_block_sweep writes metrics under out_root/design.
- Align block expected metrics paths with the run_block_sweep output contract for dense GEMM, dual-stream, and integrated block targets.
- Reconstruct metrics.csv from cached work/result.json on --skip_existing so reruns can recover missing CSV artifacts without rerunning OpenROAD.

## Validation
- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py control_plane/control_plane/tests/test_run_block_sweep.py -q
- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue

Fixes the artifact contract failure reported by job l1_npu_dense_gemm_tile_scaling_v3 / issue #984.