### PR TITLE
npu: load dense gemm tile campaign metrics

### DIFF
--- a/npu/eval/estimate_llm_decoder_attention_kv_measured_compute.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_measured_compute.py
@@ -109,8 +109,11 @@ def _load_dense_tile_shape(config_path: Path) -> tuple[str, int, int, int, int]:
 
 def _load_dense_gemm_tile_candidates(*, repo_root: Path, tag_substring: str) -> list[JsonDict]:
     candidates: list[JsonDict] = []
-    for metrics_path in sorted((repo_root / "runs/designs/npu_blocks").glob("npu_dense_gemm_tile_*/metrics.csv")):
-        config_path = metrics_path.parent / "config.json"
+    design_metric_paths = sorted((repo_root / "runs/designs/npu_blocks").glob("npu_dense_gemm_tile_*/metrics.csv"))
+    campaign_metric_paths = sorted((repo_root / "runs/campaigns" / "npu").glob("dense_gemm_tile_*/*/metrics.csv"))
+    for metrics_path in design_metric_paths + campaign_metric_paths:
+        design_name = metrics_path.parent.name
+        config_path = repo_root / "runs" / "designs" / "npu_blocks" / design_name / "config.json"
         if not config_path.exists():
             continue
         precision, array_m, array_n, k_unroll, pipeline_stages = _load_dense_tile_shape(config_path)

--- a/tests/test_estimate_llm_decoder_attention_kv_measured_compute.py
+++ b/tests/test_estimate_llm_decoder_attention_kv_measured_compute.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for candidate-loading helpers in the measured compute estimator."""
+
+import csv
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import npu.eval.estimate_llm_decoder_attention_kv_measured_compute as measured_compute
+
+
+def _write_dense_gemm_design_config(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "dense_gemm_tile": {
+            "precision": "fp16",
+            "array_m": 16,
+            "array_n": 16,
+            "k_unroll": 1,
+            "pipeline_stages": 1,
+        }
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_metrics_csv(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "tag": "npu_dense_gemm_tile_v3_depth_hier",
+            "status": "ok",
+            "critical_path_ns": "1.23",
+            "instance_area_um2": "4567.0",
+            "total_power_mw": "12.5",
+            "param_hash": "hash-a",
+        }
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["tag", "status", "critical_path_ns", "instance_area_um2", "total_power_mw", "param_hash"]
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_load_dense_gemm_tile_candidates_reads_campaign_metrics(tmp_path: Path) -> None:
+    design_name = "npu_dense_gemm_tile_fp16_16x16_k1_p1"
+    design_config = tmp_path / "runs" / "designs" / "npu_blocks" / design_name / "config.json"
+    _write_dense_gemm_design_config(design_config)
+
+    campaign_metrics = tmp_path / "runs" / "campaigns" / "npu" / "dense_gemm_tile_v3" / design_name / "metrics.csv"
+    _write_metrics_csv(campaign_metrics)
+
+    candidates = measured_compute._load_dense_gemm_tile_candidates(
+        repo_root=tmp_path,
+        tag_substring="npu_dense_gemm_tile_v3_depth_hier",
+    )
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert (
+        candidate["metrics_csv"]
+        == "runs/campaigns/npu/dense_gemm_tile_v3/npu_dense_gemm_tile_fp16_16x16_k1_p1/metrics.csv"
+    )
+    assert candidate["metrics_tag"] == "npu_dense_gemm_tile_v3_depth_hier"
+    assert candidate["dense_array_m"] == 16
+    assert candidate["dense_array_n"] == 16
+    assert candidate["compute_arch"] == "dense_gemm_16x16_k1_p1"


### PR DESCRIPTION
## Summary
- Fix the V3 measured-compute estimator so `dense_gemm_tile` candidates are loaded from campaign metrics paths such as `runs/campaigns/npu/dense_gemm_tile_v3/<design>/metrics.csv`.
- Keep dense tile config resolution anchored at `runs/designs/npu_blocks/<design>/config.json`, which is where the generator config lives.
- Add a focused regression for V3 campaign metrics candidate loading.

## Failure Diagnosed
The queued L2 item `l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1` failed immediately in `estimate_decoder_attention_kv_dense_tile_v3_measured_compute` because no candidates were found for `compute_source=dense_gemm_tile` and tag `npu_dense_gemm_tile_v3_depth_hier`. The V3 metrics are valid and merged, but they now live under the campaign out-root after the block artifact path fix.

## Validation
- `PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_estimate_llm_decoder_attention_kv_measured_compute.py`
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
- Local reproduction of the failed estimator command now finds 4 V3 candidates and the downstream measured-compute closure audit completes with a best point.
