### PR TITLE
control_plane: add mixed int8 energy closure job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -471,6 +471,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_precision_int8_compute_physical_feasibility_report",
     ),
     (
+        "attention_mixed_int8_energy_closure_out",
+        "attention_mixed_int8_energy_closure_report",
+    ),
+    (
         "attention_composed_datapath_physical_feasibility_out",
         "attention_composed_datapath_physical_feasibility_report",
     ),
@@ -1057,6 +1061,42 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         ):
             if key in diagnosis_dict:
                 parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_mixed_precision_int8_compute_energy_closure_llama7b_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        best = evidence_payload.get("best")
+        best_dict = dict(best) if isinstance(best, dict) else {}
+        outcome = str(diagnosis_dict.get("decision") or evidence_payload.get("decision") or "mixed_int8_energy_closure_recorded")
+        parts = [
+            f"Decoder mixed/int8 energy closure evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "source_rows_used",
+            "physical_feasible_rows",
+            "best_requested_mode",
+            "best_requested_adjusted_latency_us_if_feasible",
+            "best_requested_substituted_compute_arch",
+            "best_requested_substituted_compute_area_um2",
+            "best_requested_substituted_compute_power_mw",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        for key in (
+            "candidate_id",
+            "latency_us",
+            "token_throughput_per_s",
+            "energy_mj",
+            "die_area_mm2",
+            "dominant_energy_component",
+        ):
+            if key in best_dict:
+                parts.append(f"best_{key}={best_dict.get(key)}")
+        recommended_next = str(diagnosis_dict.get("recommended_next_step", "")).strip()
+        if recommended_next:
+            parts.append(f"recommended_next_step={recommended_next}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5968,6 +5968,55 @@ def _decoder_attention_dense_gemm_v3_measured_compute_closure_evidence(*, item_i
     }
 
 
+def _decoder_attention_mixed_int8_energy_closure_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    mixed_int8_physical = (
+        f"{base}/decoder_attention_mixed_precision_int8_compute_physical_feasibility__"
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1.json"
+    )
+    hbm_command_calibrated = (
+        f"{base}/decoder_attention_hbm_command_calibrated_service__"
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json"
+    )
+    sram_profile = f"{base}/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+    baseline_closure = (
+        f"{base}/decoder_attention_dense_gemm_v3_measured_compute_closure__"
+        "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1.json"
+    )
+    out = f"{base}/decoder_attention_mixed_int8_energy_closure__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_energy_closure__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_mixed_precision_int8_compute_physical_feasibility": mixed_int8_physical,
+            "attention_hbm_command_calibrated_service": hbm_command_calibrated,
+            "attention_sram_profile": sram_profile,
+            "attention_dense_gemm_v3_measured_compute_closure": baseline_closure,
+            "attention_mixed_int8_energy_closure_out": out,
+            "attention_mixed_int8_energy_closure_report": report,
+            "attention_mixed_int8_energy_closure_scope": (
+                "Convert the quality-gated mixed/int8 softmax-recip physical-feasibility rows into "
+                "source-backed HBM/SRAM energy rows using substituted int8 compute PPA, then compare "
+                "throughput, energy, area, and precision against the exact-FP16 dense-GEMM V3 closure."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_mixed_int8_energy_closure",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py "
+                    f"--mixed-precision-int8-compute-physical-feasibility-json {mixed_int8_physical} "
+                    f"--hbm-command-calibrated-service-json {hbm_command_calibrated} "
+                    f"--sram-profile-json {sram_profile} "
+                    f"--baseline-closure-json {baseline_closure} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -7852,6 +7901,7 @@ def _build_payload(
         "decoder_attention_hbm_command_calibrated_service",
         "decoder_attention_measured_compute_energy_closure",
         "decoder_attention_dense_gemm_v3_measured_compute_closure",
+        "decoder_attention_mixed_int8_energy_closure",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -8030,6 +8080,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_measured_compute_energy_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_dense_gemm_v3_measured_compute_closure":
             decoder_evidence = _decoder_attention_dense_gemm_v3_measured_compute_closure_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_energy_closure":
+            decoder_evidence = _decoder_attention_mixed_int8_energy_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -69,6 +69,38 @@ def test_decoder_evidence_summary_recognizes_softmax_recip_lut_mixed_precision_i
     assert "best_requested_substituted_compute_arch=dense_gemm_int8_16x8_k1_p1" in summary
 
 
+def test_decoder_evidence_summary_recognizes_mixed_precision_int8_compute_energy_closure() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/int8_energy.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_mixed_precision_int8_compute_energy_closure_llama7b_v1",
+            "diagnosis": {
+                "decision": "mixed_precision_int8_compute_improves_latency_not_energy",
+                "source_rows_used": 3,
+                "physical_feasible_rows": 3,
+                "best_requested_mode": "dual_mac",
+                "best_requested_adjusted_latency_us_if_feasible": 1575.373891,
+                "best_requested_substituted_compute_arch": "dense_gemm_int8_16x8_k1_p1",
+                "best_requested_substituted_compute_area_um2": 89549280.0,
+                "best_requested_substituted_compute_power_mw": 974.7,
+            },
+            "best": {
+                "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1",
+                "latency_us": 1575.373891,
+                "token_throughput_per_s": 634.77,
+                "energy_mj": 135.75,
+                "die_area_mm2": 800.0,
+                "dominant_energy_component": "hbm",
+            },
+        },
+    )
+
+    assert outcome == "mixed_precision_int8_compute_improves_latency_not_energy"
+    assert "mixed/int8 energy closure" in summary
+    assert "best_token_throughput_per_s=634.77" in summary
+    assert "best_dominant_energy_component=hbm" in summary
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6713,6 +6713,62 @@ def test_generate_l2_campaign_task_adds_dense_gemm_v3_measured_compute_closure_e
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_energy_closure_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_energy_closure",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="frontier_closure",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+                        "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_mixed_int8_energy_closure",
+            ]
+            run = commands[0]["run"]
+            assert "audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py" in run
+            assert "--mixed-precision-int8-compute-physical-feasibility-json" in run
+            assert "--baseline-closure-json" in run
+            assert "attention_mixed_precision_int8_compute_physical_feasibility" in decoder_inputs
+            assert "attention_mixed_int8_energy_closure_out" in decoder_inputs
+            assert decoder_inputs["attention_mixed_int8_energy_closure_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_energy_closure",
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1/README.md
@@ -1,0 +1,10 @@
+# Llama7B Mixed/Int8 Energy Closure
+
+This proposal records the missing comparison between the quality-gated mixed/int8
+softmax-recip physical-feasibility point and the exact-FP16 dense-GEMM V3
+measured-compute closure.
+
+The job is a low-cost audit. It consumes existing artifacts, uses the
+`substituted_compute_*` int8 PPA fields from the physical-feasibility row, adds
+measured local L1 overhead power when present, and emits a comparable
+throughput/energy/area/precision closure report. It does not run OpenROAD.

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,47 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1",
+  "requests": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_energy_closure",
+      "comparison_role": "frontier_closure",
+      "expected_direction": "compare_mixed_int8_against_fp16_v3",
+      "expected_reason": "Record whether the mixed/int8 softmax-recip point is the energy, latency, or precision-risk frontier when compared against exact-FP16 dense-GEMM V3 closure.",
+      "dispatch_machine_key": "eval-daemon-b7c2d9c80c1c",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1",
+        "l2_decoder_attention_sram_profile_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Convert mixed/int8 physical-feasibility rows into comparable source-backed energy rows and compare them against exact-FP16 dense-GEMM V3 Llama7B closure.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_energy_closure",
+      "comparison_role": "frontier_closure",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1",
+        "l2_decoder_attention_sram_profile_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "compare_mixed_int8_against_fp16_v3",
+        "reason": "Record the mixed/int8 throughput-energy-area-precision tradeoff against the current exact-FP16 measured baseline."
+      },
+      "status": "proposed",
+      "notes": "Run on the remote evaluator. This is a low-cost audit job; it should not launch OpenROAD."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1/proposal.json
@@ -1,0 +1,84 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1",
+  "created_utc": "2026-06-24T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 energy closure against exact-FP16 V3 baseline",
+  "abstraction_layer": "decoder_attention_mixed_int8_energy_closure",
+  "hypothesis": "The quality-gated mixed/int8 softmax-recip dual-stream point should be compared against the exact-FP16 dense-GEMM V3 closure with the same source-backed HBM/SRAM energy accounting. This determines whether the lower-precision point is an energy, latency, area, or precision frontier rather than only a physical-feasibility result.",
+  "direct_comparison": {
+    "primary_question": "Does the mixed/int8 softmax-recip point replace the exact-FP16 dense-GEMM V3 Llama7B frontier when token throughput, energy, area, and precision are considered together?",
+    "baseline": "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+    "candidate": "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1",
+    "include": [
+      "consume merged mixed/int8 softmax-recip physical-feasibility artifact",
+      "use substituted int8 compute PPA fields instead of source FP16 row power",
+      "add measured local L1 overhead power carried by the physical-feasibility row",
+      "consume source-backed HBM command energy and merged SRAM profile",
+      "compare against exact-FP16 dense-GEMM V3 measured-compute closure"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "new Llama7B checkpoint perplexity measurement",
+      "new HBM vendor signoff model",
+      "new routed NoC or SRAM compiler signoff"
+    ],
+    "metrics": [
+      "decision",
+      "token_throughput_per_s",
+      "energy_mj",
+      "die_area_mm2",
+      "precision_profile",
+      "dominant_energy_component",
+      "remaining_abstractions"
+    ]
+  },
+  "expected_benefit": [
+    "turn the mixed/int8 physical-feasibility result into a directly comparable frontier record",
+    "separate the latency frontier from the energy frontier if HBM traffic dominates",
+    "record the remaining precision-quality gap before any lower-precision promotion"
+  ],
+  "risks": [
+    "mixed/int8 quality is still proxy-backed and may not survive real-checkpoint validation",
+    "energy uses replicated measured blocks rather than a full integrated macro",
+    "NoC/SRAM and HBM energy are still model/profile based"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Convert the mixed/int8 softmax-recip physical-feasibility rows into source-backed energy rows and compare them against the exact-FP16 dense-GEMM V3 Llama7B closure.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_energy_closure",
+      "comparison_role": "frontier_closure",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1",
+        "l2_decoder_attention_sram_profile_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "compare_mixed_int8_against_fp16_v3",
+        "reason": "Record whether mixed/int8 is energy-best, latency-best, or only a precision-risk candidate under the current Llama7B energy model."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_dense_gemm_v3_measured_compute_closure__l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_int8_compute_physical_feasibility__l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_hbm_command_calibrated_service__l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_sram_profile__l2_decoder_attention_sram_profile_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py
+++ b/npu/eval/audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Compose bounded Llama7B energy closure from mixed-int8 compute feasibility rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+import sys
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_integrated_energy_closure import (  # noqa: E402
+    _as_float,
+    _energy_mj_from_pj,
+    _energy_mj_from_power,
+    _load_json,
+    _sram_energy_terms,
+    _tokens_per_s,
+    _traffic,
+)
+
+JsonDict = dict[str, Any]
+
+
+def _candidate_id(row: JsonDict) -> str:
+    die_area_mm2 = _as_float(row.get("die_area_mm2"))
+    compute_arch = row.get("substituted_compute_arch", row.get("substituted_compute_variant_label", "compute"))
+    replicas = int(_as_float(row.get("substituted_compute_replica_count"), 1))
+    return (
+        f"die{die_area_mm2:g}_"
+        f"{compute_arch}_"
+        f"rep{replicas}_"
+        f"lat{_effective_latency_us(row):g}_"
+        f"hbm{_as_float(row.get('hbm_byte_share')):.6f}_"
+        f"tt{int(_as_float(row.get('tile_tokens'), 0.0))}"
+    )
+
+
+def _effective_latency_us(row: JsonDict) -> float:
+    adjusted = row.get("adjusted_latency_us_if_feasible")
+    if adjusted is not None:
+        adjusted_us = _as_float(adjusted)
+        if adjusted_us > 0.0:
+            return adjusted_us
+    return _as_float(row.get("latency_us"))
+
+
+def _hbm_energy_pj_per_byte(command_calibrated: JsonDict) -> float:
+    calibration = command_calibrated.get("command_energy_calibration")
+    if isinstance(calibration, dict):
+        value = _as_float(calibration.get("source_hbm_energy_pj_per_byte"))
+        if value > 0.0:
+            return value
+    best = command_calibrated.get("best") if isinstance(command_calibrated.get("best"), dict) else {}
+    hbm = best.get("hbm_command_calibrated_energy") if isinstance(best.get("hbm_command_calibrated_energy"), dict) else {}
+    read_bytes = _as_float(hbm.get("read_bytes")) + _as_float(hbm.get("write_bytes"))
+    if read_bytes > 0.0:
+        return _as_float(hbm.get("energy_pj")) / read_bytes
+    return 31.76
+
+
+def _compute_candidate_rows(payload: JsonDict, *, limit: int) -> list[JsonDict]:
+    rows: list[JsonDict] = []
+    if isinstance(payload.get("rows"), list):
+        rows.extend(row for row in payload["rows"] if isinstance(row, dict))
+    for key in ("best_requested", "best_feasible", "best_area_fit"):
+        candidate = payload.get(key)
+        if isinstance(candidate, dict):
+            rows.append(candidate)
+
+    filtered: list[JsonDict] = []
+    seen: set[str] = set()
+    for row in rows:
+        latency = _effective_latency_us(row)
+        if latency <= 0.0:
+            continue
+        if _as_float(row.get("substituted_compute_power_mw")) <= 0.0:
+            continue
+        if not row.get("substituted_compute_arch"):
+            continue
+        row = dict(row)
+        row["candidate_id"] = _candidate_id(row)
+        if row["candidate_id"] in seen:
+            continue
+        seen.add(row["candidate_id"])
+        filtered.append(row)
+
+    filtered.sort(
+        key=lambda row: (
+            _effective_latency_us(row),
+            _as_float(row.get("die_area_mm2")),
+            _as_float(row.get("substituted_compute_power_mw")),
+            str(row.get("substituted_compute_arch")),
+        )
+    )
+    return filtered[:limit]
+
+
+def _compute_area_mm2(row: JsonDict) -> float:
+    required_um2 = _as_float(row.get("compute_area_required_um2"))
+    if required_um2 > 0.0:
+        return required_um2 / 1_000_000.0
+    block_area_um2 = _as_float(row.get("substituted_compute_area_um2"))
+    replicas = _as_float(row.get("substituted_compute_replica_count"), 1.0)
+    if block_area_um2 <= 0.0:
+        return 0.0
+    if replicas > 1.0:
+        return block_area_um2 * replicas / 1_000_000.0
+    return block_area_um2 / 1_000_000.0
+
+
+def _energy_row(row: JsonDict, command_calibrated: JsonDict, sram_profile: JsonDict) -> JsonDict:
+    latency_us = _effective_latency_us(row)
+    traffic = _traffic(row)
+
+    hbm_pj_per_byte = _hbm_energy_pj_per_byte(command_calibrated)
+    hbm_read_bytes = _as_float(traffic.get("hbm_read_bytes"))
+    kv_write_bytes = _as_float(traffic.get("kv_write_bytes"))
+    hbm_energy_pj = (hbm_read_bytes + kv_write_bytes) * hbm_pj_per_byte
+
+    sram = _sram_energy_terms(sram_profile, traffic)
+    noc_hops = _as_float(row.get("noc_hops"), 1.0)
+    noc_payload_bytes = _as_float(traffic.get("estimated_noc_payload_bytes"))
+    noc_energy_pj = noc_payload_bytes * noc_hops * 0.02
+
+    substituted_compute_power_mw = _as_float(row.get("substituted_compute_power_mw"))
+    measured_l1_overhead_power_mw = _as_float(row.get("measured_l1_overhead_power_mw"))
+    compute_power_mw = substituted_compute_power_mw + measured_l1_overhead_power_mw
+    if compute_power_mw <= 0.0:
+        compute_power_mw = substituted_compute_power_mw
+    compute_energy_mj = _energy_mj_from_power(compute_power_mw, latency_us)
+
+    components = {
+        "compute": {
+            "status": "substituted_int8_compute_power_from_physical_feasibility",
+            "energy_mj": compute_energy_mj,
+            "power_mw": compute_power_mw,
+            "substituted_compute_power_mw": substituted_compute_power_mw,
+            "measured_l1_overhead_power_mw_included": measured_l1_overhead_power_mw,
+            "power_area_mm2": _compute_area_mm2(row),
+            "replica_count": int(_as_float(row.get("substituted_compute_replica_count"), 1)),
+            "latency_us": latency_us,
+            "compute_arch": row.get("substituted_compute_arch"),
+            "block_area_um2": _as_float(row.get("substituted_compute_area_um2")),
+        },
+        "hbm": {
+            "status": "source_backed_aggregate_hbm_energy",
+            "energy_mj": _energy_mj_from_pj(hbm_energy_pj),
+            "energy_pj": hbm_energy_pj,
+            "energy_pj_per_byte": hbm_pj_per_byte,
+            "read_bytes": hbm_read_bytes,
+            "write_bytes": kv_write_bytes,
+        },
+        "sram": sram,
+        "noc": {
+            "status": "profile_payload_byte_hop",
+            "energy_mj": _energy_mj_from_pj(noc_energy_pj),
+            "energy_pj": noc_energy_pj,
+            "payload_bytes": noc_payload_bytes,
+            "hops": noc_hops,
+            "energy_pj_per_byte_hop": 0.02,
+        },
+    }
+    total_energy_mj = sum(_as_float(component.get("energy_mj")) for component in components.values() if component.get("energy_mj") is not None)
+    dominant = max(
+        (
+            (name, _as_float(component.get("energy_mj")))
+            for name, component in components.items()
+            if isinstance(component, dict)
+        ),
+        key=lambda item: item[1],
+    )[0].replace("_", " ")
+
+    return {
+        **row,
+        "candidate_id": _candidate_id(row),
+        "arch_id": "mixed_precision_int8_compute_energy_closure_frontier",
+        "latency_us": latency_us,
+        "base_latency_us": _as_float(row.get("latency_us")),
+        "token_throughput_per_s": _tokens_per_s(latency_us),
+        "die_area_mm2": _as_float(row.get("die_area_mm2")),
+        "compute_area_um2": _compute_area_mm2(row) * 1_000_000.0,
+        "compute_area_mm2": _compute_area_mm2(row),
+        "substituted_compute_arch": row.get("substituted_compute_arch"),
+        "substituted_compute_replica_count": int(_as_float(row.get("substituted_compute_replica_count"), 1)),
+        "substituted_compute_power_mw": compute_power_mw,
+        "substituted_compute_power_mw_only": substituted_compute_power_mw,
+        "measured_l1_overhead_power_mw_included": measured_l1_overhead_power_mw,
+        "substituted_compute_area_um2": _as_float(row.get("substituted_compute_area_um2")),
+        "compute_energy_mj": compute_energy_mj,
+        "hbm_energy_mj": _energy_mj_from_pj(hbm_energy_pj),
+        "sram_energy_mj": _as_float(sram.get("energy_mj")),
+        "noc_energy_mj": _energy_mj_from_pj(noc_energy_pj),
+        "energy_mj": total_energy_mj,
+        "energy_status": "mixed_precision_int8_compute_power_and_measured_hbm_sram_service",
+        "dominant_energy_component": dominant,
+        "energy_components": components,
+    }
+
+
+def _baseline_summary(path: Path | None) -> JsonDict | None:
+    if path is None:
+        return None
+    payload = _load_json(path)
+    best = payload.get("best") if isinstance(payload.get("best"), dict) else {}
+    latency_best = payload.get("latency_best") if isinstance(payload.get("latency_best"), dict) else {}
+    return {
+        "model": payload.get("model"),
+        "decision": payload.get("decision"),
+        "energy_best_candidate_id": best.get("candidate_id"),
+        "energy_best_latency_us": best.get("latency_us"),
+        "energy_best_throughput_tok_s": best.get("token_throughput_per_s"),
+        "energy_best_energy_mj": best.get("energy_mj"),
+        "energy_best_area_mm2": best.get("die_area_mm2"),
+        "latency_best_candidate_id": latency_best.get("candidate_id"),
+        "latency_best_latency_us": latency_best.get("latency_us"),
+        "latency_best_energy_mj": latency_best.get("energy_mj"),
+        "latency_best_area_mm2": latency_best.get("die_area_mm2"),
+    }
+
+
+def _pareto(rows: list[JsonDict]) -> list[JsonDict]:
+    frontier: list[JsonDict] = []
+    for row in rows:
+        dominated = False
+        for other in rows:
+            if other is row:
+                continue
+            no_worse = (
+                _as_float(other.get("latency_us")) <= _as_float(row.get("latency_us"))
+                and _as_float(other.get("energy_mj")) <= _as_float(row.get("energy_mj"))
+                and _as_float(other.get("die_area_mm2")) <= _as_float(row.get("die_area_mm2"))
+            )
+            better = (
+                _as_float(other.get("latency_us")) < _as_float(row.get("latency_us"))
+                or _as_float(other.get("energy_mj")) < _as_float(row.get("energy_mj"))
+                or _as_float(other.get("die_area_mm2")) < _as_float(row.get("die_area_mm2"))
+            )
+            if no_worse and better:
+                dominated = True
+                break
+        if not dominated:
+            frontier.append(row)
+    return sorted(frontier, key=lambda item: (_as_float(item.get("latency_us")), _as_float(item.get("energy_mj"))))
+
+
+def build_payload(args: argparse.Namespace) -> JsonDict:
+    command_calibrated = _load_json(args.hbm_command_calibrated_service_json)
+    feasibility = _load_json(args.mixed_precision_int8_compute_physical_feasibility_json)
+    sram_profile = _load_json(args.sram_profile_json)
+
+    source_rows = _compute_candidate_rows(feasibility, limit=args.row_limit)
+    if not source_rows:
+        raise RuntimeError("no substituted-compute feasibility rows found")
+
+    modeled_rows = [_energy_row(row, command_calibrated, sram_profile) for row in source_rows]
+    latency_best = min(modeled_rows, key=lambda row: (_as_float(row["latency_us"]), _as_float(row["energy_mj"])))
+    energy_best = min(modeled_rows, key=lambda row: (_as_float(row["energy_mj"]), _as_float(row["latency_us"])))
+    pareto_rows = _pareto(modeled_rows)
+    baseline_closure_json = getattr(args, "baseline_closure_json", None)
+    baseline = _baseline_summary(baseline_closure_json)
+
+    best_requested = feasibility.get("best_requested")
+    best_requested = best_requested if isinstance(best_requested, dict) else {}
+    feasibility_diag = feasibility.get("diagnosis") if isinstance(feasibility.get("diagnosis"), dict) else {}
+    decision = "mixed_precision_int8_compute_energy_closure_recorded"
+    recommended_next_step = "promote mixed-precision dual-stream candidate into measured RTL/PPA wrapper"
+    if not bool(feasibility_diag.get("physical_feasible_rows")):
+        decision = "mixed_precision_int8_compute_energy_closure_recorded_source_latency_fallback"
+        recommended_next_step = "inspect feasibility inputs; next run should include adjusted latency from measured dual-stream feasibility"
+    baseline_energy = _as_float((baseline or {}).get("energy_best_energy_mj"))
+    baseline_latency = _as_float((baseline or {}).get("energy_best_latency_us"))
+    if baseline_energy > 0.0 and _as_float(energy_best.get("energy_mj")) < baseline_energy:
+        decision = "mixed_precision_int8_compute_replaces_fp16_v3_energy_frontier"
+        recommended_next_step = "prioritize checkpoint-quality validation for the mixed/int8 frontier before promotion"
+    elif baseline_latency > 0.0 and _as_float(latency_best.get("latency_us")) < baseline_latency:
+        decision = "mixed_precision_int8_compute_improves_latency_not_energy"
+        recommended_next_step = (
+            "keep exact-FP16 V3 as the energy baseline and use mixed/int8 as the latency frontier "
+            "pending real-checkpoint quality validation"
+        )
+
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_mixed_precision_int8_compute_energy_closure_llama7b_v1",
+        "decision": decision,
+        "source_model": feasibility.get("source_model"),
+        "inputs": {
+            "hbm_command_calibrated_service_json": str(args.hbm_command_calibrated_service_json),
+            "mixed_precision_int8_compute_physical_feasibility_json": str(args.mixed_precision_int8_compute_physical_feasibility_json),
+            "sram_profile_json": str(args.sram_profile_json),
+        },
+        "diagnosis": {
+            "decision": decision,
+            "source_rows_used": len(source_rows),
+            "feasibility_rows": feasibility_diag.get("source_rows_used"),
+            "physical_feasible_rows": feasibility_diag.get("physical_feasible_rows", 0),
+            "best_requested_mode": best_requested.get("compute_mode"),
+            "best_requested_latency_us": best_requested.get("latency_us"),
+            "best_requested_adjusted_latency_us_if_feasible": best_requested.get("adjusted_latency_us_if_feasible"),
+            "best_requested_substituted_compute_arch": best_requested.get("substituted_compute_arch"),
+            "best_requested_substituted_compute_replica_count": best_requested.get("substituted_compute_replica_count"),
+            "best_requested_substituted_compute_area_um2": best_requested.get("substituted_compute_area_um2"),
+            "best_requested_substituted_compute_power_mw": best_requested.get("substituted_compute_power_mw"),
+            "baseline_fp16_v3": baseline,
+            "recommended_next_step": recommended_next_step,
+        },
+        "input_row_count": len(source_rows),
+        "best": {
+            **energy_best,
+            "arch_id": "mixed_precision_int8_compute_energy_closure_best",
+        },
+        "latency_best": latency_best,
+        "pareto_rows": pareto_rows[: args.pareto_row_limit],
+        "source_artifacts": {
+            "hbm_command_calibrated_service_model": command_calibrated.get("model"),
+            "sram_profile_model": sram_profile.get("model"),
+            "baseline_closure_json": str(baseline_closure_json) if baseline_closure_json else None,
+        },
+        "remaining_abstractions": [
+            "HBM and SRAM energy are sourced from existing aggregate campaign helpers; NoC still uses the payload-byte-hop model.",
+            "Compute energy is from substituted_compute_power_mw plus measured local L1 overhead power carried by mixed-precision feasibility rows, not from a fresh end-to-end measured compute rerun.",
+            "adjusted_latency_us_if_feasible is used when present and source latency is used as a fallback.",
+            "Mixed/int8 quality remains proxy-backed, not real Llama7B checkpoint perplexity or task accuracy.",
+        ],
+    }
+
+
+def write_markdown(payload: JsonDict, report: Path) -> None:
+    best = payload["best"]
+    diag = payload["diagnosis"]
+    lines = [
+        "# Llama7B Mixed-Precision Int8 Compute Energy Closure",
+        "",
+        f"- decision: `{diag['decision']}`",
+        f"- source rows used: `{diag['source_rows_used']}`",
+        f"- physical feasible rows: `{diag['physical_feasible_rows']}`",
+        f"- best requested mode: `{diag['best_requested_mode']}`",
+        f"- best requested adjusted latency us: `{diag['best_requested_adjusted_latency_us_if_feasible']}`",
+        f"- best requested substituted compute arch: `{diag['best_requested_substituted_compute_arch']}`",
+        f"- best requested substituted compute area um2: `{diag['best_requested_substituted_compute_area_um2']}`",
+        f"- best requested substituted compute power mw: `{diag['best_requested_substituted_compute_power_mw']}`",
+        f"- baseline fp16 v3 energy mJ: `{(diag.get('baseline_fp16_v3') or {}).get('energy_best_energy_mj')}`",
+        f"- baseline fp16 v3 latency us: `{(diag.get('baseline_fp16_v3') or {}).get('energy_best_latency_us')}`",
+        f"- recommended next step: `{diag['recommended_next_step']}`",
+        "",
+        "## Best Measured Point",
+        "",
+        "| candidate | latency us | throughput tok/s | energy mJ | area mm2 | compute mJ | HBM mJ | sram mJ | dominant |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|",
+        "| {candidate_id} | {latency_us} | {token_throughput_per_s} | {energy_mj} | {die_area_mm2} | {compute_energy_mj} | {hbm_energy_mj} | {sram_energy_mj} | {dominant_energy_component} |".format(
+            **best
+        ),
+        "",
+        "## Pareto Rows",
+        "",
+        "| candidate | latency us | energy mJ | area mm2 | compute arch | compute replicas | dominant |",
+        "|---|---:|---:|---:|---|---:|---|",
+    ]
+    for row in payload["pareto_rows"]:
+        lines.append(
+            "| {candidate_id} | {latency_us} | {energy_mj} | {die_area_mm2} | {substituted_compute_arch} | {substituted_compute_replica_count} | {dominant_energy_component} |".format(
+                **row
+            )
+        )
+
+    lines.extend(["", "## Remaining Abstractions", ""])
+    for item in payload["remaining_abstractions"]:
+        lines.append(f"- {item}")
+
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hbm-command-calibrated-service-json", type=Path, required=True)
+    parser.add_argument("--mixed-precision-int8-compute-physical-feasibility-json", type=Path, required=True)
+    parser.add_argument("--sram-profile-json", type=Path, required=True)
+    parser.add_argument("--baseline-closure-json", type=Path)
+    parser.add_argument("--row-limit", type=int, default=256)
+    parser.add_argument("--pareto-row-limit", type=int, default=24)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+
+    args = parser.parse_args()
+    payload = build_payload(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py
+++ b/tests/test_audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure import (  # noqa: E402
+    build_payload,
+)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _args(tmp_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        hbm_command_calibrated_service_json=tmp_path / "hbm.json",
+        mixed_precision_int8_compute_physical_feasibility_json=tmp_path / "feasibility.json",
+        sram_profile_json=tmp_path / "sram.json",
+        row_limit=16,
+        pareto_row_limit=8,
+        out=tmp_path / "out.json",
+        out_md=tmp_path / "out.md",
+    )
+
+
+def _payload() -> dict:
+    return {
+        "diagnosis": {
+            "physical_feasible_rows": 1,
+            "source_rows_used": 2,
+        },
+        "best_requested": {
+            "compute_mode": "dual_mac",
+            "latency_us": 100.0,
+            "adjusted_latency_us_if_feasible": 22.5,
+            "substituted_compute_arch": "dense_gemm_int8_16x8_k1_p1",
+            "substituted_compute_area_um2": 512_000.0,
+            "substituted_compute_power_mw": 2.0,
+            "substituted_compute_replica_count": 128,
+            "compute_area_required_um2": 1_024_000.0,
+        },
+        "rows": [
+            {
+                "compute_mode": "dual_mac",
+                "latency_us": 100.0,
+                "adjusted_latency_us_if_feasible": 22.5,
+                "substituted_compute_arch": "dense_gemm_int8_16x8_k1_p1",
+                "substituted_compute_area_um2": 512_000.0,
+                "substituted_compute_power_mw": 2.0,
+                "substituted_compute_replica_count": 128,
+                "die_area_mm2": 800.0,
+            },
+            {
+                "compute_mode": "split_mac",
+                "latency_us": 30.0,
+                "adjusted_latency_us_if_feasible": 0.0,
+                "substituted_compute_arch": "dense_gemm_fp16_16x16_k1_p1",
+                "substituted_compute_area_um2": 800_000.0,
+                "substituted_compute_power_mw": 1000.0,
+                "substituted_compute_replica_count": 16,
+                "die_area_mm2": 700.0,
+            },
+        ],
+    }
+
+
+def test_adjusted_latency_from_physical_feasibility_is_used(tmp_path: Path) -> None:
+    args = _args(tmp_path)
+    _write_json(args.hbm_command_calibrated_service_json, {
+        "command_energy_calibration": {
+            "source_hbm_energy_pj_per_byte": 1.0,
+        }
+    })
+    _write_json(args.mixed_precision_int8_compute_physical_feasibility_json, _payload())
+    _write_json(
+        args.sram_profile_json,
+        {
+            "totals": {"allocated_sram_bytes": 4096},
+            "sram_metrics_summary": {"total_read_energy_pj": 1024.0, "total_write_energy_pj": 512.0},
+        },
+    )
+
+    payload = build_payload(args)
+    best = payload["best"]
+    assert best["latency_us"] == 22.5
+    assert best["substituted_compute_arch"] == "dense_gemm_int8_16x8_k1_p1"
+    assert payload["decision"].startswith("mixed_precision_int8_compute_energy_closure")
+
+
+def test_substituted_compute_fields_are_preserved_in_energy_components(tmp_path: Path) -> None:
+    args = _args(tmp_path)
+    _write_json(args.hbm_command_calibrated_service_json, {
+        "command_energy_calibration": {
+            "source_hbm_energy_pj_per_byte": 2.5,
+        }
+    })
+    _write_json(args.mixed_precision_int8_compute_physical_feasibility_json, _payload())
+    _write_json(
+        args.sram_profile_json,
+        {
+            "totals": {"allocated_sram_bytes": 4096},
+            "sram_metrics_summary": {"total_read_energy_pj": 1024.0, "total_write_energy_pj": 512.0},
+        },
+    )
+
+    payload = build_payload(args)
+    best = payload["best"]
+    assert best["substituted_compute_arch"] == "dense_gemm_int8_16x8_k1_p1"
+    assert best["substituted_compute_power_mw"] == 2.0
+    assert best["substituted_compute_replica_count"] == 128
+    compute_component = best["energy_components"]["compute"]
+    assert compute_component["compute_arch"] == "dense_gemm_int8_16x8_k1_p1"
+    assert compute_component["replica_count"] == 128


### PR DESCRIPTION
## Summary\n- add a mixed/int8 energy-closure audit that consumes the softmax-recip int8 physical-feasibility artifact\n- use substituted int8 compute power/area fields plus measured local L1 overhead power instead of source FP16 row power\n- wire the new L2 abstraction/proposal and result summary handling\n\n## Validation\n- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_energy_closure_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_mixed_precision_int8_compute_energy_closure\n- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue\n- smoke-run audit on current Llama7B artifacts with FP16 V3 baseline\n