### PR TITLE
npu: report substituted int8 fields in energy closure

### DIFF
--- a/npu/eval/audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py
+++ b/npu/eval/audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py
@@ -175,6 +175,10 @@ def _energy_row(row: JsonDict, command_calibrated: JsonDict, sram_profile: JsonD
         key=lambda item: item[1],
     )[0].replace("_", " ")
 
+    substituted_compute_arch = row.get("substituted_compute_arch")
+    substituted_compute_replica_count = int(_as_float(row.get("substituted_compute_replica_count"), 1))
+    substituted_compute_area_um2 = _as_float(row.get("substituted_compute_area_um2"))
+
     return {
         **row,
         "candidate_id": _candidate_id(row),
@@ -183,14 +187,18 @@ def _energy_row(row: JsonDict, command_calibrated: JsonDict, sram_profile: JsonD
         "base_latency_us": _as_float(row.get("latency_us")),
         "token_throughput_per_s": _tokens_per_s(latency_us),
         "die_area_mm2": _as_float(row.get("die_area_mm2")),
+        "compute_arch": substituted_compute_arch,
+        "compute_power_mw": compute_power_mw,
+        "compute_replica_count": substituted_compute_replica_count,
+        "metrics_csv": row.get("substituted_compute_metrics_csv") or row.get("metrics_csv"),
         "compute_area_um2": _compute_area_mm2(row) * 1_000_000.0,
         "compute_area_mm2": _compute_area_mm2(row),
-        "substituted_compute_arch": row.get("substituted_compute_arch"),
-        "substituted_compute_replica_count": int(_as_float(row.get("substituted_compute_replica_count"), 1)),
+        "substituted_compute_arch": substituted_compute_arch,
+        "substituted_compute_replica_count": substituted_compute_replica_count,
         "substituted_compute_power_mw": compute_power_mw,
         "substituted_compute_power_mw_only": substituted_compute_power_mw,
         "measured_l1_overhead_power_mw_included": measured_l1_overhead_power_mw,
-        "substituted_compute_area_um2": _as_float(row.get("substituted_compute_area_um2")),
+        "substituted_compute_area_um2": substituted_compute_area_um2,
         "compute_energy_mj": compute_energy_mj,
         "hbm_energy_mj": _energy_mj_from_pj(hbm_energy_pj),
         "sram_energy_mj": _as_float(sram.get("energy_mj")),

--- a/tests/test_audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py
+++ b/tests/test_audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py
@@ -45,6 +45,7 @@ def _payload() -> dict:
             "adjusted_latency_us_if_feasible": 22.5,
             "substituted_compute_arch": "dense_gemm_int8_16x8_k1_p1",
             "substituted_compute_area_um2": 512_000.0,
+            "substituted_compute_metrics_csv": "runs/designs/npu_blocks/npu_dense_gemm_tile_int8_16x8_k1_p1/metrics.csv",
             "substituted_compute_power_mw": 2.0,
             "substituted_compute_replica_count": 128,
             "compute_area_required_um2": 1_024_000.0,
@@ -56,8 +57,12 @@ def _payload() -> dict:
                 "adjusted_latency_us_if_feasible": 22.5,
                 "substituted_compute_arch": "dense_gemm_int8_16x8_k1_p1",
                 "substituted_compute_area_um2": 512_000.0,
+                "substituted_compute_metrics_csv": "runs/designs/npu_blocks/npu_dense_gemm_tile_int8_16x8_k1_p1/metrics.csv",
                 "substituted_compute_power_mw": 2.0,
                 "substituted_compute_replica_count": 128,
+                "compute_arch": "dense_gemm_fp16_source",
+                "compute_power_mw": 1000.0,
+                "metrics_csv": "runs/designs/npu_blocks/npu_dense_gemm_tile_fp16_16x8_k1_p1/metrics.csv",
                 "die_area_mm2": 800.0,
             },
             {
@@ -94,6 +99,9 @@ def test_adjusted_latency_from_physical_feasibility_is_used(tmp_path: Path) -> N
     best = payload["best"]
     assert best["latency_us"] == 22.5
     assert best["substituted_compute_arch"] == "dense_gemm_int8_16x8_k1_p1"
+    assert best["compute_arch"] == "dense_gemm_int8_16x8_k1_p1"
+    assert best["compute_power_mw"] == 2.0
+    assert best["metrics_csv"].endswith("npu_dense_gemm_tile_int8_16x8_k1_p1/metrics.csv")
     assert payload["decision"].startswith("mixed_precision_int8_compute_energy_closure")
 
 


### PR DESCRIPTION
## Summary\n- make mixed/int8 energy-closure rows expose substituted int8 compute arch, power, replica count, and metrics path at top level\n- add regression coverage so inherited FP16 source row fields do not leak into dashboard-facing values\n\n## Validation\n- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_audit_llm_decoder_attention_mixed_precision_int8_compute_energy_closure.py\n- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue\n- smoke-run mixed/int8 closure on current Llama7B artifacts\n