### PR TITLE
docs: fix mixed int8 native quality request schema

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_llama7b_v1/evaluation_requests.json
@@ -1,21 +1,25 @@
-[
-  {
-    "item_id": "l2_decoder_attention_mixed_int8_native_quality_llama7b_v1",
-    "task_type": "l2_campaign",
-    "objective": "Run a 7B-class native checkpoint quality gate for the q8/k8/v8 mixed/int8 softmax-recip attention path used by the current latency frontier.",
-    "evaluation_mode": "frontier_detail",
-    "abstraction_layer": "decoder_attention_mixed_int8_native_quality",
-    "comparison_role": "precision_gate",
-    "cost_class": "medium",
-    "depends_on_item_ids": [
-      "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2"
-    ],
-    "requires_merged_inputs": true,
-    "requires_materialized_refs": true,
-    "expected_result": {
-      "direction": "validate_or_reject_mixed_int8_latency_frontier_precision",
-      "reason": "The mixed/int8 point has much higher token throughput but higher energy and only proxy quality; native checkpoint evidence is required before it can remain a precision-valid latency frontier."
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_native_quality_llama7b_v1",
+  "source_commit": "b38572fa9f94a409fe3030aa39687c42c7018358",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_native_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a 7B-class native checkpoint quality gate for the q8/k8/v8 mixed/int8 softmax-recip attention path used by the current latency frontier.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_native_quality",
+      "comparison_role": "precision_gate",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "validate_or_reject_mixed_int8_latency_frontier_precision",
+        "reason": "The mixed/int8 point has much higher token throughput but higher energy and only proxy quality; native checkpoint evidence is required before it can remain a precision-valid latency frontier."
+      },
+      "status": "pending"
     }
-  }
-]
+  ]
+}
 


### PR DESCRIPTION
## Summary
- fix the mixed/int8 native quality proposal evaluation_requests.json to use the control-plane object schema with requested_items

## Validation
- attempted generate-l2-campaign exposed the raw-list schema error before dispatch