### PR TITLE
npu: add mixed int8 native quality ablation

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -479,6 +479,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_native_quality_report",
     ),
     (
+        "attention_mixed_int8_native_quality_ablation_out",
+        "attention_mixed_int8_native_quality_ablation_report",
+    ),
+    (
         "attention_composed_datapath_physical_feasibility_out",
         "attention_composed_datapath_physical_feasibility_report",
     ),
@@ -785,6 +789,20 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         next_step = str(decision.get("next_step", "")).strip()
         if next_step:
             parts.append(f"next_step={next_step}")
+        candidate_summaries = evidence_payload.get("candidate_summaries")
+        if isinstance(candidate_summaries, list) and candidate_summaries:
+            best_candidate = dict(evidence_payload.get("best_candidate") or {})
+            if best_candidate:
+                parts.append(f"best_candidate_id={best_candidate.get('candidate_id')}")
+                for key in (
+                    "top1_match_rate",
+                    "topk_contains_rate",
+                    "mean_logit_cosine",
+                    "mean_probability_kl",
+                ):
+                    if key in best_candidate:
+                        parts.append(f"best_{key}={best_candidate.get(key)}")
+            parts.append(f"candidate_count={len(candidate_summaries)}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6066,6 +6066,57 @@ def _decoder_attention_mixed_int8_native_quality_evidence(*, item_id: str) -> di
     }
 
 
+def _decoder_attention_mixed_int8_native_quality_ablation_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_int8_native_quality_ablation__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_native_quality_ablation__{item_id}.md"
+    native_quality = (
+        f"{base}/decoder_attention_mixed_int8_native_quality__"
+        "l2_decoder_attention_mixed_int8_native_quality_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_mixed_int8_native_quality": native_quality,
+            "attention_mixed_int8_native_quality_ablation_out": out,
+            "attention_mixed_int8_native_quality_ablation_report": report,
+            "attention_mixed_int8_native_quality_ablation_scope": (
+                "Run the same 7B-class trained checkpoint with a small ablation ladder for the "
+                "mixed/int8 attention-shadow quality failure. Compare QKV-only quantization, "
+                "score quantization, float-quantized softmax, RTL exact int8 softmax, and RTL "
+                "reciprocal-softmax to identify which approximation blocks promotion."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_native_quality_ablation",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_MAX_PROMPTS:-2}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--topk 5 "
+                    "--candidate qkv8_float_softmax:q8,k8,v8,s24,w16,float_quantized "
+                    "--candidate qkv8_score8_float_softmax:q8,k8,v8,s8,w16,float_quantized "
+                    "--candidate qkv8_score8_rtl_exact:q8,k8,v8,s8,w8,rtl_exact "
+                    "--candidate qkv8_score8_rtl_recip_q8:q8,k8,v8,s8,w8,rtl_recip_lut_q8 "
+                    "--primary-candidate-id qkv8_score8_rtl_recip_q8 "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -7952,6 +8003,7 @@ def _build_payload(
         "decoder_attention_dense_gemm_v3_measured_compute_closure",
         "decoder_attention_mixed_int8_energy_closure",
         "decoder_attention_mixed_int8_native_quality",
+        "decoder_attention_mixed_int8_native_quality_ablation",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -8134,6 +8186,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_energy_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_native_quality":
             decoder_evidence = _decoder_attention_mixed_int8_native_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_native_quality_ablation":
+            decoder_evidence = _decoder_attention_mixed_int8_native_quality_ablation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -142,6 +142,70 @@ def test_decoder_evidence_summary_recognizes_mixed_int8_native_quality() -> None
     assert "top1_match_rate=1.0" in summary
 
 
+def test_decoder_evidence_summary_recognizes_mixed_int8_native_quality_ablation() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/mixed_int8_native_quality_ablation.json",
+        evidence_payload={
+            "quality_gate": "mixed_int8_attention_shadow",
+            "model": {
+                "model_id": "mistralai/Mistral-7B-v0.1",
+                "attention_heads": 32,
+                "kv_heads": 8,
+                "gqa_group_size": 4.0,
+                "dtype": "bfloat16",
+            },
+            "precision": {
+                "q_bits": 8,
+                "k_bits": 8,
+                "v_bits": 8,
+                "score_bits": 8,
+                "weight_bits": 8,
+                "softmax_mode": "rtl_recip_lut_q8",
+            },
+            "summary": {
+                "comparison_count": 16,
+                "top1_match_rate": 0.625,
+                "topk_contains_rate": 0.75,
+                "mean_logit_cosine": 0.94,
+                "mean_probability_kl": 1.0,
+                "max_abs_logit_delta_max": 10.125,
+            },
+            "candidate_summaries": [
+                {
+                    "candidate_id": "qkv8_float_softmax",
+                    "top1_match_rate": 0.9,
+                    "topk_contains_rate": 1.0,
+                    "mean_logit_cosine": 0.99,
+                    "mean_probability_kl": 0.01,
+                },
+                {
+                    "candidate_id": "qkv8_score8_rtl_recip_q8",
+                    "top1_match_rate": 0.625,
+                    "topk_contains_rate": 0.75,
+                    "mean_logit_cosine": 0.94,
+                    "mean_probability_kl": 1.0,
+                },
+            ],
+            "best_candidate": {
+                "candidate_id": "qkv8_float_softmax",
+                "top1_match_rate": 0.9,
+                "topk_contains_rate": 1.0,
+                "mean_logit_cosine": 0.99,
+                "mean_probability_kl": 0.01,
+            },
+            "decision": {
+                "status": "mixed_int8_native_attention_shadow_hold",
+                "next_step": "Hold current hardware candidate; inspect ablation best.",
+            },
+        },
+    )
+
+    assert outcome == "mixed_int8_native_attention_shadow_hold"
+    assert "candidate_count=2" in summary
+    assert "best_candidate_id=qkv8_float_softmax" in summary
+    assert "best_top1_match_rate=0.9" in summary
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6833,6 +6833,70 @@ def test_generate_l2_campaign_task_adds_mixed_int8_native_quality_evidence() -> 
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_native_quality_ablation_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_native_quality_ablation",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="precision_failure_diagnosis",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_native_quality_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_native_quality_ablation",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_attention.py" in run
+            assert "--candidate qkv8_float_softmax:q8,k8,v8,s24,w16,float_quantized" in run
+            assert "--candidate qkv8_score8_rtl_recip_q8:q8,k8,v8,s8,w8,rtl_recip_lut_q8" in run
+            assert "--primary-candidate-id qkv8_score8_rtl_recip_q8" in run
+            assert decoder_inputs["attention_mixed_int8_native_quality"].endswith(
+                "decoder_attention_mixed_int8_native_quality__"
+                "l2_decoder_attention_mixed_int8_native_quality_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_native_quality_ablation_out" in decoder_inputs
+            assert decoder_inputs["attention_mixed_int8_native_quality_ablation_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_native_quality_ablation",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": ["l2_decoder_attention_mixed_int8_native_quality_llama7b_v1"],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1/README.md
@@ -1,0 +1,10 @@
+# Llama7B Mixed/Int8 Native Quality Ablation
+
+This proposal diagnoses the native-checkpoint quality failure observed for the
+mixed/int8 latency frontier by running a small precision ladder on the same
+7B-class checkpoint and prompt gate.
+
+The goal is to identify whether the promotion blocker is mainly QKV
+quantization, score quantization, or the RTL int8 reciprocal-softmax
+approximation.
+

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,24 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a 7B-class native checkpoint ablation ladder to isolate the precision loss source in the mixed/int8 softmax-recip attention path.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_native_quality_ablation",
+      "comparison_role": "precision_failure_diagnosis",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_native_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "identify_precision_blocker",
+        "reason": "The prior native quality gate held the mixed/int8 latency frontier; this ablation determines which approximation should be redesigned or relaxed next."
+      },
+      "status": "pending"
+    }
+  ]
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1/proposal.json
@@ -1,0 +1,81 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1",
+  "created_utc": "2026-06-24T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 native attention quality ablation",
+  "abstraction_layer": "decoder_attention_mixed_int8_native_quality_ablation",
+  "hypothesis": "The current mixed/int8 latency frontier failed a real 7B-class attention-shadow quality gate. A small native-checkpoint ablation ladder can identify whether the dominant precision loss is from QKV quantization, score quantization, int8 softmax normalization, or the reciprocal-LUT approximation.",
+  "direct_comparison": {
+    "primary_question": "Which approximation in the mixed/int8 attention path causes the native 7B-class checkpoint ranking drift?",
+    "baseline": "l2_decoder_attention_mixed_int8_native_quality_llama7b_v1",
+    "candidate": "multi-candidate q8/k8/v8 attention-shadow ablation ladder",
+    "include": [
+      "q8/k8/v8 with float-quantized softmax",
+      "q8/k8/v8 with score8 plus float-quantized softmax",
+      "q8/k8/v8 with score8 plus RTL exact int8 softmax",
+      "q8/k8/v8 with score8 plus RTL reciprocal-LUT q8 softmax",
+      "top-1 match, top-k contains, logit cosine, probability KL, and max logit delta per candidate"
+    ],
+    "exclude": [
+      "QAT or fine-tuning recovery",
+      "full perplexity or task accuracy",
+      "new OpenROAD/PPA runs",
+      "new HBM/NoC/SRAM modeling"
+    ],
+    "metrics": [
+      "decision",
+      "best_candidate_id",
+      "candidate_summaries",
+      "primary_candidate_summary",
+      "top1_match_rate",
+      "topk_contains_rate",
+      "mean_logit_cosine",
+      "mean_probability_kl"
+    ]
+  },
+  "expected_benefit": [
+    "pinpoint which approximation should be relaxed or redesigned before another PPA/energy closure",
+    "avoid pursuing a high-throughput mixed/int8 point that cannot survive native checkpoint precision",
+    "define the next practical precision frontier candidate with less abstraction"
+  ],
+  "risks": [
+    "the ablation still uses prompt-level attention shadowing rather than QAT or full perplexity",
+    "candidate quality may be model-specific to the configured 7B-class checkpoint",
+    "the evaluator runtime must expose enough memory for repeated 7B checkpoint passes"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a 7B-class native checkpoint ablation ladder to isolate the precision loss source in the mixed/int8 softmax-recip attention path.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_native_quality_ablation",
+      "comparison_role": "precision_failure_diagnosis",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_native_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "identify_precision_blocker",
+        "reason": "The prior native quality gate held the mixed/int8 latency frontier; this ablation determines which approximation should be redesigned or relaxed next."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_native_quality__l2_decoder_attention_mixed_int8_native_quality_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_precision_quality__l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_llama7b_v1/proposal.json"
+  ]
+}
+

--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import importlib
 import json
 import math
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -22,6 +24,17 @@ DEFAULT_PROMPTS = [
     "The color of the clear daytime sky is",
     "When comparing approximate inference results, the safest metric is",
 ]
+
+
+@dataclass(frozen=True)
+class CandidateConfig:
+    candidate_id: str
+    q_bits: int
+    k_bits: int
+    v_bits: int
+    score_bits: int
+    weight_bits: int
+    softmax_mode: str
 
 
 def _float(value: Any, default: float = 0.0) -> float:
@@ -195,8 +208,127 @@ def _parse_positive_int(value: str) -> int:
     return value
 
 
+def _candidate_id_from_bits(*, q_bits: int, k_bits: int, v_bits: int, score_bits: int, weight_bits: int, softmax_mode: str) -> str:
+    return f"q{q_bits}_k{k_bits}_v{v_bits}_s{score_bits}_w{weight_bits}_{softmax_mode}"
+
+
+def _parse_candidate_token_pair(token: str) -> tuple[str, int]:
+    token = token.strip()
+    if len(token) < 2:
+        raise ValueError(f"invalid candidate token: {token!r}")
+    key = token[0].lower()
+    return key, int(token[1:])
+
+
+def _parse_candidate_spec(spec: Any) -> CandidateConfig:
+    if isinstance(spec, dict):
+        candidate_id = str(spec.get("candidate_id", "")).strip()
+        q_bits = int(spec["q_bits"])
+        k_bits = int(spec["k_bits"])
+        v_bits = int(spec["v_bits"])
+        score_bits = int(spec["score_bits"])
+        weight_bits = int(spec["weight_bits"])
+        softmax_mode = str(spec["softmax_mode"])
+    else:
+        spec = str(spec).strip()
+        if not spec:
+            raise ValueError("empty candidate spec")
+
+        candidate_id = ""
+        spec_body = spec
+        if "{" in spec_body and spec_body.rstrip().endswith("}"):
+            data = json.loads(spec_body)
+            if not isinstance(data, dict):
+                raise ValueError("candidate spec JSON object must be an object")
+            candidate_id = str(data.get("candidate_id", "")).strip()
+            q_bits = int(data["q_bits"])
+            k_bits = int(data["k_bits"])
+            v_bits = int(data["v_bits"])
+            score_bits = int(data["score_bits"])
+            weight_bits = int(data["weight_bits"])
+            softmax_mode = str(data["softmax_mode"])
+        else:
+            if ":" in spec_body:
+                candidate_id, spec_body = spec_body.split(":", 1)
+                candidate_id = candidate_id.strip()
+            parts = [item.strip() for item in spec_body.split(",") if item.strip()]
+            if len(parts) != 6:
+                raise ValueError(f"candidate spec {spec!r} must contain q,k,v,s,w and softmax mode")
+            values: dict[str, int] = {}
+            softmax_mode = ""
+            for part in parts:
+                if len(part) == 0:
+                    continue
+                if part in {"float_quantized", "float_exact", "rtl_exact", "rtl_pow2sum"} or part.startswith("rtl_recip_lut_q"):
+                    if softmax_mode:
+                        raise ValueError(f"candidate spec {spec!r} has duplicate softmax mode tokens")
+                    softmax_mode = part
+                    continue
+                key, value = _parse_candidate_token_pair(part)
+                if key in values:
+                    raise ValueError(f"duplicate candidate token key {key!r} in {spec!r}")
+                if key == "s":
+                    score_bits = value
+                    values[key] = value
+                elif key in {"q", "k", "v", "w"}:
+                    values[key] = value
+                else:
+                    if softmax_mode:
+                        raise ValueError(f"candidate spec {spec!r} has an unknown token {part!r}")
+                    softmax_mode = part
+            if "q" not in values or "k" not in values or "v" not in values or "s" not in values or "w" not in values:
+                raise ValueError(f"candidate spec {spec!r} must include q,k,v,s,w,mode")
+            q_bits = values["q"]
+            k_bits = values["k"]
+            v_bits = values["v"]
+            weight_bits = values["w"]
+            if not softmax_mode:
+                raise ValueError(f"candidate spec {spec!r} missing softmax mode token")
+
+    q_bits = _parse_positive_int(str(q_bits))
+    k_bits = _parse_positive_int(str(k_bits))
+    v_bits = _parse_positive_int(str(v_bits))
+    score_bits = _parse_positive_int(str(score_bits))
+    weight_bits = _parse_positive_int(str(weight_bits))
+    if not candidate_id:
+        candidate_id = _candidate_id_from_bits(
+            q_bits=q_bits,
+            k_bits=k_bits,
+            v_bits=v_bits,
+            score_bits=score_bits,
+            weight_bits=weight_bits,
+            softmax_mode=softmax_mode,
+        )
+
+    return CandidateConfig(
+        candidate_id=candidate_id,
+        q_bits=q_bits,
+        k_bits=k_bits,
+        v_bits=v_bits,
+        score_bits=score_bits,
+        weight_bits=weight_bits,
+        softmax_mode=_parse_softmax_mode(softmax_mode),
+    )
+
+
+def _parse_candidate_list(value: str) -> list[CandidateConfig]:
+    raw = value.strip()
+    if not raw:
+        return []
+    if raw.startswith("["):
+        payload = json.loads(raw)
+        if not isinstance(payload, list):
+            raise argparse.ArgumentTypeError("candidate-list expects a JSON array or semicolon-separated spec values")
+        return [_parse_candidate_spec(item) for item in payload]
+    # preserve support for old shell-style repeated lists that contain commas in each spec
+    items = [item.strip() for item in raw.replace("\n", ";").split(";") if item.strip()]
+    if len(items) == 1:
+        return [_parse_candidate_spec(items[0])]
+    return [_parse_candidate_spec(item) for item in items]
+
+
 def _parse_softmax_mode(value: str) -> str:
-    supported = {"float_quantized", "rtl_exact", "rtl_pow2sum", "rtl_recip_lut_q8"}
+    supported = {"float_quantized", "float_exact", "rtl_exact", "rtl_pow2sum", "rtl_recip_lut_q8"}
     if value.startswith("rtl_recip_lut_q"):
         bits = _rtl_reciprocal_bits(value)
         if bits <= 0:
@@ -222,6 +354,114 @@ def _resolve_torch_dtype(torch_module: Any, *, device: str, dtype_name: str) -> 
 def _dtype_label(dtype: Any) -> str:
     text = str(dtype)
     return text.split(".", 1)[-1] if "." in text else text
+
+
+def _load_runtime_modules() -> tuple[Any, Any, Any]:
+    try:
+        torch_module = importlib.import_module("torch")
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            "missing runtime dependency for mixed/int8 attention quality: install torch and transformers"
+        ) from exc
+
+    try:
+        transformers = importlib.import_module("transformers")
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            "missing runtime dependency for mixed/int8 attention quality: install torch and transformers"
+        ) from exc
+
+    auto_model_cls = getattr(transformers, "AutoModelForCausalLM", None)
+    auto_tokenizer_cls = getattr(transformers, "AutoTokenizer", None)
+    if auto_model_cls is None or auto_tokenizer_cls is None:
+        raise SystemExit(
+            "transformers package does not expose AutoModelForCausalLM/AutoTokenizer for mixed/int8 attention quality"
+        )
+
+    return torch_module, auto_model_cls, auto_tokenizer_cls
+
+
+def _candidate_precision(candidate: CandidateConfig) -> JsonDict:
+    return {
+        "candidate_id": candidate.candidate_id,
+        "q_bits": candidate.q_bits,
+        "k_bits": candidate.k_bits,
+        "v_bits": candidate.v_bits,
+        "score_bits": candidate.score_bits,
+        "weight_bits": candidate.weight_bits,
+        "softmax_mode": candidate.softmax_mode,
+    }
+
+
+def _resolve_candidates(args: argparse.Namespace) -> list[CandidateConfig]:
+    candidates: list[CandidateConfig] = []
+    if args.candidate:
+        candidates.extend(args.candidate)
+    for chunk in args.candidate_list:
+        if chunk:
+            candidates.extend(chunk)
+
+    if not candidates:
+        candidates.append(
+            CandidateConfig(
+                candidate_id=_candidate_id_from_bits(
+                    q_bits=args.q_bits,
+                    k_bits=args.k_bits,
+                    v_bits=args.v_bits,
+                    score_bits=args.score_bits,
+                    weight_bits=args.weight_bits,
+                    softmax_mode=args.softmax_mode,
+                ),
+                q_bits=args.q_bits,
+                k_bits=args.k_bits,
+                v_bits=args.v_bits,
+                score_bits=args.score_bits,
+                weight_bits=args.weight_bits,
+                softmax_mode=args.softmax_mode,
+            )
+        )
+    return candidates
+
+
+def _candidate_quality_rank(candidate_summary: JsonDict) -> tuple[int, float, float, float, float, float, float]:
+    status = str(candidate_summary.get("decision_status", ""))
+    if status == "mixed_int8_native_attention_shadow_pass":
+        status_score = 3
+    elif status == "mixed_int8_native_attention_shadow_caution":
+        status_score = 2
+    else:
+        status_score = 1
+    return (
+        status_score,
+        _float(candidate_summary.get("top1_match_rate"), 0.0),
+        _float(candidate_summary.get("topk_contains_rate"), 0.0),
+        _float(candidate_summary.get("mean_logit_cosine"), 0.0),
+        -_float(candidate_summary.get("mean_probability_kl"), 0.0),
+        -_float(candidate_summary.get("max_abs_logit_delta_mean"), 0.0),
+        -_float(candidate_summary.get("comparison_count"), 0.0),
+    )
+
+
+def _pick_primary_summary(candidate_summaries: list[JsonDict], *, primary_candidate_id: str) -> JsonDict:
+    if primary_candidate_id:
+        for summary in candidate_summaries:
+            if summary.get("candidate_id") == primary_candidate_id:
+                return summary
+        raise SystemExit(f"primary candidate id not found: {primary_candidate_id}")
+    return candidate_summaries[0]
+
+
+def _summarize_candidate_rows(*, candidate: CandidateConfig, rows: list[JsonDict], decision: JsonDict) -> JsonDict:
+    summary = _summarize_rows(rows)
+    summary.update(
+        {
+            "candidate_id": candidate.candidate_id,
+            **_candidate_precision(candidate),
+            "decision_status": decision["status"],
+            "decision": decision,
+        }
+    )
+    return summary
 
 
 def _decision(summary: JsonDict, *, expected_gqa_group_size: int, actual_gqa_group_size: float) -> JsonDict:
@@ -371,6 +611,9 @@ def _softmax_patch(score_bits: int, weight_bits: int, softmax_mode: str):
             out = [value * scale for value in q_values]
             out = _safe_exp_softmax(out)
             return torch.tensor(out, dtype=torch.float32, device=row.device).reshape(row.shape)
+        if softmax_mode == "float_exact":
+            out = _safe_exp_softmax(values)
+            return torch.tensor(out, dtype=torch.float32, device=row.device).reshape(row.shape)
         out = _rtl_quantized_softmax(values, score_bits=score_bits, weight_bits=weight_bits, softmax_mode=softmax_mode)
         return torch.tensor(out, dtype=row.dtype if row.dtype.is_floating_point else torch.float32, device=row.device).reshape(row.shape)
 
@@ -418,12 +661,151 @@ def _run_single_inference(
     return out.past_key_values, logits, probs, order
 
 
-def _run_model_eval(args: argparse.Namespace) -> JsonDict:
+def _collect_reference_rows(
+    reference_model: Any,
+    tokenizer: Any,
+    prompts: list[str],
+    *,
+    generation_steps: int,
+    topk: int,
+    device: str,
+    torch_module: Any,
+) -> tuple[list[JsonDict], list[JsonDict]]:
+    rows: list[JsonDict] = []
+    prompt_records: list[JsonDict] = []
+
+    for prompt_index, prompt in enumerate(prompts):
+        encoded = tokenizer(prompt, return_tensors="pt")
+        prompt_input_ids = encoded["input_ids"].to(device)
+
+        with torch_module.no_grad():
+            ref_past, ref_logits, ref_probs, _ = _run_single_inference(
+                reference_model,
+                input_ids=prompt_input_ids,
+                past_key_values=None,
+                topk=max(2, topk),
+            )
+
+        ref_order = _topk(ref_logits, max(2, topk))
+        ref_top1 = ref_order[0]
+        ref_margin = ref_logits[ref_order[0]] - ref_logits[ref_order[1]] if len(ref_order) > 1 else 0.0
+        prompt_records.append(
+            {
+                "prompt_index": prompt_index,
+                "prompt": prompt,
+                "prefill_reference_top1": ref_top1,
+                "prefill_reference_margin": ref_margin,
+            }
+        )
+        rows.append(
+            {
+                "prompt_index": prompt_index,
+                "step": 0,
+                "input_ids": prompt_input_ids[0].tolist(),
+                "reference_top1": ref_top1,
+                "reference_margin": ref_margin,
+                "reference_logits": ref_logits,
+                "reference_probs": ref_probs,
+            }
+        )
+
+        for step in range(1, generation_steps):
+            input_token = ref_top1
+            next_input = torch_module.tensor([[input_token]], dtype=torch_module.long, device=device)
+            with torch_module.no_grad():
+                ref_past, ref_logits, ref_probs, ref_order = _run_single_inference(
+                    reference_model,
+                    input_ids=next_input,
+                    past_key_values=ref_past,
+                    topk=max(2, topk),
+                )
+            ref_margin = ref_logits[ref_order[0]] - ref_logits[ref_order[1]] if len(ref_order) > 1 else 0.0
+            ref_top1 = ref_order[0]
+            rows.append(
+                {
+                    "prompt_index": prompt_index,
+                    "step": step,
+                    "input_ids": [input_token],
+                    "reference_top1": ref_top1,
+                    "reference_margin": ref_margin,
+                    "reference_logits": ref_logits,
+                    "reference_probs": ref_probs,
+                }
+            )
+
+    return rows, prompt_records
+
+
+def _evaluate_candidate_rows(
+    reference_rows: list[JsonDict],
+    candidate_model: Any,
+    candidate: CandidateConfig,
+    *,
+    tokenizer: Any,
+    device: str,
+    torch_module: Any,
+    topk: int,
+) -> list[JsonDict]:
+    del tokenizer
+    softmax_ctx = _softmax_patch(
+        score_bits=candidate.score_bits,
+        weight_bits=candidate.weight_bits,
+        softmax_mode=candidate.softmax_mode,
+    )
+    candidate_rows: list[JsonDict] = []
+    past_by_prompt: dict[int, Any] = {}
+    patches = _install_attention_wrappers(
+        candidate_model,
+        q_bits=candidate.q_bits,
+        k_bits=candidate.k_bits,
+        v_bits=candidate.v_bits,
+    )
+
     try:
-        import torch  # type: ignore
-        from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore
-    except ModuleNotFoundError as exc:
-        raise SystemExit("missing runtime dependency for mixed/int8 attention quality: install torch and transformers") from exc
+        for row in reference_rows:
+            prompt_index = int(row["prompt_index"])
+            step = int(row["step"])
+            input_ids = row["input_ids"]
+            past = None if step == 0 else past_by_prompt[prompt_index]
+
+            with torch_module.no_grad():
+                with softmax_ctx():
+                    cand_past, cand_logits, cand_probs, cand_order = _run_single_inference(
+                        candidate_model,
+                        input_ids=torch_module.tensor([input_ids], dtype=torch_module.long, device=device),
+                        past_key_values=past,
+                        topk=topk,
+                    )
+
+            past_by_prompt[prompt_index] = cand_past
+            ref_top1 = int(row["reference_top1"])
+            cand_top1 = int(cand_order[0])
+            reference_logits = [float(value) for value in row["reference_logits"]]
+            reference_probs = [float(value) for value in row["reference_probs"]]
+            candidate_rows.append(
+                {
+                    "candidate_id": candidate.candidate_id,
+                    "prompt_index": prompt_index,
+                    "step": step,
+                    "reference_top1": ref_top1,
+                    "candidate_top1": cand_top1,
+                    "top1_match": 1.0 if cand_top1 == ref_top1 else 0.0,
+                    "topk_contains": 1.0 if ref_top1 in cand_order else 0.0,
+                    "reference_margin": float(row["reference_margin"]),
+                    "logit_cosine": _cosine(reference_logits, cand_logits),
+                    "probability_kl": _kl_divergence(reference_probs, cand_probs),
+                    "max_abs_logit_delta": max(abs(a - b) for a, b in zip(reference_logits, cand_logits)),
+                }
+            )
+
+    finally:
+        _restore_attention_wrappers(patches)
+
+    return candidate_rows
+
+
+def _run_model_eval(args: argparse.Namespace) -> JsonDict:
+    torch, AutoModelForCausalLM, AutoTokenizer = _load_runtime_modules()
 
     model_id = args.model_id or "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
     device = args.device
@@ -463,127 +845,47 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
     if not prompts:
         raise SystemExit("no prompts to evaluate")
 
-    patches = _install_attention_wrappers(
-        candidate_model,
-        q_bits=args.q_bits,
-        k_bits=args.k_bits,
-        v_bits=args.v_bits,
+    candidates = _resolve_candidates(args)
+    candidate_ids = [candidate.candidate_id for candidate in candidates]
+    if len(set(candidate_ids)) != len(candidate_ids):
+        raise SystemExit(f"candidate ids must be unique: {candidate_ids}")
+
+    reference_rows, prompt_records = _collect_reference_rows(
+        reference_model,
+        tokenizer,
+        prompts,
+        generation_steps=args.generation_steps,
+        topk=args.topk,
+        device=device,
+        torch_module=torch,
     )
 
     candidate_rows: list[JsonDict] = []
-    prompt_records: list[JsonDict] = []
-    try:
-        softmax_ctx = _softmax_patch(
-            score_bits=args.score_bits,
-            weight_bits=args.weight_bits,
-            softmax_mode=args.softmax_mode,
+    candidate_summaries: list[JsonDict] = []
+    for candidate in candidates:
+        rows = _evaluate_candidate_rows(
+            reference_rows,
+            candidate_model,
+            candidate,
+            tokenizer=tokenizer,
+            device=device,
+            torch_module=torch,
+            topk=args.topk,
         )
+        decision = _decision(
+            _summarize_rows(rows),
+            expected_gqa_group_size=args.expected_gqa_group_size,
+            actual_gqa_group_size=gqa_group_size,
+        )
+        candidate_summary = _summarize_candidate_rows(candidate=candidate, rows=rows, decision=decision)
+        candidate_rows.extend(rows)
+        candidate_summaries.append(candidate_summary)
 
-        for prompt_index, prompt in enumerate(prompts):
-            encoded = tokenizer(prompt, return_tensors="pt")
-            input_ids = encoded["input_ids"].to(device)
+    if not candidate_summaries:
+        raise SystemExit("no candidates were configured")
 
-            with torch.no_grad():
-                ref_past, ref_logits, ref_probs, _ = _run_single_inference(
-                    reference_model,
-                    input_ids=input_ids,
-                    past_key_values=None,
-                    topk=max(2, args.topk),
-                )
-            ref_order = _topk(ref_logits, max(2, args.topk))
-            ref_top1 = ref_order[0]
-            ref_margin = ref_logits[ref_order[0]] - ref_logits[ref_order[1]] if len(ref_order) > 1 else 0.0
-            prompt_records.append(
-                {
-                    "prompt_index": prompt_index,
-                    "prompt": prompt,
-                    "prefill_reference_top1": ref_top1,
-                    "prefill_reference_margin": ref_margin,
-                }
-            )
-
-            with torch.no_grad():
-                with softmax_ctx():
-                    cand_past, cand_logits, cand_probs, cand_order = _run_single_inference(
-                        candidate_model,
-                        input_ids=input_ids,
-                        past_key_values=None,
-                        topk=args.topk,
-                    )
-                next_id = ref_order[0]
-                cand_top1 = cand_order[0]
-                candidate_rows.append(
-                    {
-                        "prompt_index": prompt_index,
-                        "step": 0,
-                        "reference_top1": ref_top1,
-                        "candidate_top1": cand_top1,
-                        "top1_match": 1.0 if cand_top1 == ref_top1 else 0.0,
-                        "topk_contains": 1.0 if ref_top1 in cand_order else 0.0,
-                        "reference_margin": ref_margin,
-                        "logit_cosine": _cosine(ref_logits, cand_logits),
-                        "probability_kl": _kl_divergence(ref_probs, cand_probs),
-                        "max_abs_logit_delta": max(abs(a - b) for a, b in zip(ref_logits, cand_logits)),
-                    }
-                )
-
-            for step in range(1, args.generation_steps):
-                next_input = torch.tensor([[next_id]], dtype=torch.long, device=device)
-                with torch.no_grad():
-                    ref_past, ref_logits, ref_probs, ref_order = _run_single_inference(
-                        reference_model,
-                        input_ids=next_input,
-                        past_key_values=ref_past,
-                        topk=max(2, args.topk),
-                    )
-                ref_margin = ref_logits[ref_order[0]] - ref_logits[ref_order[1]] if len(ref_order) > 1 else 0.0
-
-                with torch.no_grad():
-                    with softmax_ctx():
-                        cand_past, cand_logits, cand_probs, cand_order = _run_single_inference(
-                            candidate_model,
-                            input_ids=next_input,
-                            past_key_values=cand_past,
-                            topk=args.topk,
-                        )
-
-                next_id = ref_order[0]
-                candidate_rows.append(
-                    {
-                        "prompt_index": prompt_index,
-                        "step": step,
-                        "reference_top1": next_id,
-                        "candidate_top1": cand_order[0],
-                        "top1_match": 1.0 if cand_order[0] == next_id else 0.0,
-                        "topk_contains": 1.0 if next_id in cand_order else 0.0,
-                        "reference_margin": ref_margin,
-                        "logit_cosine": _cosine(ref_logits, cand_logits),
-                        "probability_kl": _kl_divergence(ref_probs, cand_probs),
-                        "max_abs_logit_delta": max(abs(a - b) for a, b in zip(ref_logits, cand_logits)),
-                    }
-                )
-
-    finally:
-        _restore_attention_wrappers(patches)
-
-    candidate_summary = _summarize_rows(candidate_rows)
-    candidate_summary.update(
-        {
-            "q_bits": args.q_bits,
-            "k_bits": args.k_bits,
-            "v_bits": args.v_bits,
-            "score_bits": args.score_bits,
-            "weight_bits": args.weight_bits,
-            "softmax_mode": args.softmax_mode,
-            "comparison_count": len(candidate_rows),
-        }
-    )
-
-    decision = _decision(
-        candidate_summary,
-        expected_gqa_group_size=args.expected_gqa_group_size,
-        actual_gqa_group_size=gqa_group_size,
-    )
+    best_candidate = max(candidate_summaries, key=_candidate_quality_rank)
+    primary_summary = _pick_primary_summary(candidate_summaries, primary_candidate_id=args.primary_candidate_id)
 
     return {
         "version": 0.1,
@@ -603,17 +905,19 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
         "expected_gqa_group_size": args.expected_gqa_group_size,
         "candidate_rows": candidate_rows,
         "prompt_records": prompt_records,
-        "candidate_summary": candidate_summary,
-        "summary": candidate_summary,
-        "precision": {
-            "q_bits": args.q_bits,
-            "k_bits": args.k_bits,
-            "v_bits": args.v_bits,
-            "score_bits": args.score_bits,
-            "weight_bits": args.weight_bits,
-            "softmax_mode": args.softmax_mode,
+        "candidate_summaries": candidate_summaries,
+        "candidate_summary": primary_summary,
+        "best_candidate": {
+            "candidate_id": best_candidate["candidate_id"],
+            "decision_status": best_candidate["decision_status"],
+            "top1_match_rate": best_candidate["top1_match_rate"],
+            "topk_contains_rate": best_candidate["topk_contains_rate"],
+            "mean_logit_cosine": best_candidate["mean_logit_cosine"],
+            "mean_probability_kl": best_candidate["mean_probability_kl"],
         },
-        "decision": decision,
+        "summary": primary_summary,
+        "precision": _candidate_precision(next(candidate for candidate in candidates if candidate.candidate_id == primary_summary["candidate_id"])),
+        "decision": primary_summary["decision"],
         "assumptions": [
             "This is a native-checkpoint attention-shadow gate, not a full QAT or perplexity study.",
             "Teacher-forced next-token inputs isolate attention-path ranking drift from decoding-policy variance.",
@@ -629,31 +933,39 @@ def _write_report_md(payload: JsonDict) -> str:
         "",
         f"- model_id: `{payload['model']['model_id']}`",
         f"- decision: `{payload['decision']['status']}`",
+        f"- best_candidate: `{payload['best_candidate']['candidate_id']}` ({payload['best_candidate']['decision_status']})",
         f"- attention_head_count: `{payload['model']['attention_heads']}`",
         f"- kv_head_count: `{payload['model']['kv_heads']}`",
         f"- gqa_group_size: `{payload['model']['gqa_group_size']}`",
         f"- expected_gqa_group_size: `{payload['expected_gqa_group_size']}`",
         "",
-        "## Candidate",
+        "## Candidates",
         "",
-        f"- q_bits: `{payload['candidate_summary']['q_bits']}`",
-        f"- k_bits: `{payload['candidate_summary']['k_bits']}`",
-        f"- v_bits: `{payload['candidate_summary']['v_bits']}`",
-        f"- score_bits: `{payload['candidate_summary']['score_bits']}`",
-        f"- weight_bits: `{payload['candidate_summary']['weight_bits']}`",
-        f"- softmax_mode: `{payload['candidate_summary']['softmax_mode']}`",
-        "",
-        "## Candidate Metrics",
-        "",
-        "| comparisons | top1_match | topk_contains | mean_cosine | mean_kl | min_margin | max_delta |",
-        "|---:|---:|---:|---:|---:|---:|---:|",
-        "| {comparison_count} | {top1_match_rate:.6f} | {topk_contains_rate:.6f} | {mean_logit_cosine:.6f} | {mean_probability_kl:.6f} | {min_reference_margin:.6f} | {max_abs_logit_delta_max:.6f} |".format(
-            **payload["candidate_summary"]
-        ),
-        "",
-        f"- decision: `{payload['decision']['status']}`",
-        f"- next_step: {payload['decision']['next_step']}",
+        "| candidate_id | q_bits | k_bits | v_bits | score_bits | weight_bits | softmax_mode | top1_match | topk_contains | mean_cosine | mean_kl | decision |",
+        "|---|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|---|",
     ]
+    for row in payload['candidate_summaries']:
+        lines.append(
+            "| {candidate_id} | {q_bits} | {k_bits} | {v_bits} | {score_bits} | {weight_bits} | {softmax_mode} | "
+            "{top1_match_rate:.6f} | {topk_contains_rate:.6f} | {mean_logit_cosine:.6f} | {mean_probability_kl:.6f} | "
+            "{decision_status} |".format(**row)
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Primary Candidate Metrics",
+            "",
+            "| comparisons | top1_match | topk_contains | mean_cosine | mean_kl | min_margin | max_delta |",
+            "|---:|---:|---:|---:|---:|---:|---:|",
+            "| {comparison_count} | {top1_match_rate:.6f} | {topk_contains_rate:.6f} | {mean_logit_cosine:.6f} | {mean_probability_kl:.6f} | {min_reference_margin:.6f} | {max_abs_logit_delta_max:.6f} |".format(
+                **payload["candidate_summary"]
+            ),
+            "",
+            f"- decision: `{payload['decision']['status']}`",
+            f"- next_step: {payload['decision']['next_step']}",
+        ]
+    )
 
     if payload["decision"].get("blockers"):
         lines.extend(["", "## Blockers", ""])
@@ -682,6 +994,9 @@ def main() -> int:
     parser.add_argument("--score-bits", type=_parse_positive_int, default=8)
     parser.add_argument("--weight-bits", type=_parse_positive_int, default=8)
     parser.add_argument("--softmax-mode", type=_parse_softmax_mode, default="rtl_recip_lut_q8")
+    parser.add_argument("--candidate", action="append", type=_parse_candidate_spec, default=[])
+    parser.add_argument("--candidate-list", action="append", type=_parse_candidate_list, default=[])
+    parser.add_argument("--primary-candidate-id", default="")
     parser.add_argument("--device", default="auto", choices=["auto", "cpu", "cuda"])
     parser.add_argument("--dtype", default="auto", choices=["auto", "float32", "float16", "bfloat16"])
     parser.add_argument("--out", required=True)

--- a/tests/test_llm_decoder_model_native_mixed_int8_attention.py
+++ b/tests/test_llm_decoder_model_native_mixed_int8_attention.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import argparse
+import types
 from pathlib import Path
 
 import pytest
 
 from npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention import (
+    _collect_reference_rows,
     _decision,
     _iter_llama_attention_modules,
+    _load_runtime_modules,
     _load_prompts,
+    _parse_candidate_list,
+    _parse_candidate_spec,
+    _run_model_eval,
     _quantize_symmetric_list,
     _rtl_quantized_softmax,
     _summarize_rows,
@@ -130,3 +137,279 @@ def test_fake_attention_patch_quantizes_qkv_once_and_restores() -> None:
     assert model.model.layer.q_proj.__class__.__name__ == "_Linear"
     assert model.model.layer.k_proj.__class__.__name__ == "_Linear"
     assert model.model.layer.v_proj.__class__.__name__ == "_Linear"
+
+
+def test_collect_reference_rows_preserves_teacher_forced_input_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    import npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention as evaluator
+
+    class _NoGrad:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    class _FakeTensor:
+        def __init__(self, value: list[list[int]] | list[int]) -> None:
+            self.value = value
+
+        def to(self, _device: str) -> "_FakeTensor":
+            return self
+
+        def __getitem__(self, index: int) -> "_FakeTensor":
+            value = self.value[index]  # type: ignore[index]
+            return _FakeTensor(value)
+
+        def tolist(self) -> list[int] | list[list[int]]:
+            return self.value
+
+    class _FakeTorch:
+        long = int
+
+        @staticmethod
+        def tensor(value: list[list[int]], dtype=None, device=None) -> _FakeTensor:
+            return _FakeTensor(value)
+
+        @staticmethod
+        def no_grad() -> _NoGrad:
+            return _NoGrad()
+
+    class _FakeTokenizer:
+        def __call__(self, _prompt: str, return_tensors: str) -> dict[str, _FakeTensor]:
+            assert return_tensors == "pt"
+            return {"input_ids": _FakeTensor([[10, 20]])}
+
+    calls: list[list[int] | list[list[int]]] = []
+
+    def _fake_single_inference(_model: object, *, input_ids: _FakeTensor, **_kwargs: object):
+        calls.append(input_ids.tolist())
+        if len(calls) == 1:
+            return "past0", [0.0, 1.0, 0.5], [0.2, 0.5, 0.3], [1, 2]
+        return "past1", [0.1, 0.2, 1.2], [0.2, 0.2, 0.6], [2, 1]
+
+    monkeypatch.setattr(evaluator, "_run_single_inference", _fake_single_inference)
+
+    rows, _prompt_records = _collect_reference_rows(
+        object(),
+        _FakeTokenizer(),
+        ["prompt"],
+        generation_steps=2,
+        topk=2,
+        device="cpu",
+        torch_module=_FakeTorch(),
+    )
+
+    assert calls == [[[10, 20]], [[1]]]
+    assert rows[0]["input_ids"] == [10, 20]
+    assert rows[0]["reference_top1"] == 1
+    assert rows[1]["input_ids"] == [1]
+    assert rows[1]["reference_top1"] == 2
+
+
+def test_parse_candidate_spec_and_list_compatibility() -> None:
+    candidate = _parse_candidate_spec("qkv8_float_softmax:q8,k8,v8,s24,w16,float_quantized")
+    assert candidate.candidate_id == "qkv8_float_softmax"
+    assert candidate.q_bits == 8
+    assert candidate.score_bits == 24
+
+    generated = _parse_candidate_spec("q8,k8,v8,s8,w8,rtl_recip_lut_q10")
+    assert generated.candidate_id == "q8_k8_v8_s8_w8_rtl_recip_lut_q10"
+
+    with pytest.raises(ValueError):
+        _parse_candidate_spec("qkv8_score8:r8")
+
+
+def test_parse_candidate_list_from_semicolon_values() -> None:
+    candidates = _parse_candidate_list(
+        "qkv8_reference:q8,k8,v8,s24,w16,float_exact;qkv8_approx:q8,k8,v8,s8,w8,rtl_recip_lut_q8"
+    )
+
+    assert len(candidates) == 2
+    assert candidates[0].candidate_id == "qkv8_reference"
+    assert candidates[1].candidate_id == "qkv8_approx"
+    assert candidates[1].softmax_mode == "rtl_recip_lut_q8"
+
+
+def test_run_model_eval_multiple_candidates_and_primary_summary_compatibility(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeTorch:
+        float16 = "float16"
+        float32 = "float32"
+        bfloat16 = "bfloat16"
+
+        class cuda:
+            @staticmethod
+            def is_available() -> bool:
+                return False
+
+        @staticmethod
+        def no_grad() -> types.SimpleNamespace:
+            return types.SimpleNamespace(__enter__=lambda self: None, __exit__=lambda self, *args: None)
+
+        @staticmethod
+        def tensor(value: list[int], dtype=None, device=None):
+            return value
+
+        long = int
+
+    class _FakeConfig:
+        num_attention_heads = 8
+        num_key_value_heads = 4
+
+    class _FakeModel:
+        def __init__(self) -> None:
+            self.config = _FakeConfig()
+
+        def to(self, device: str) -> "_FakeModel":
+            return self
+
+        def eval(self) -> "_FakeModel":
+            return self
+
+    class _FakeAutoModel:
+        @staticmethod
+        def from_pretrained(*args, **kwargs) -> _FakeModel:
+            return _FakeModel()
+
+    class _FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            return object()
+
+    candidate_rows_by_id = {
+        "baseline": [
+            {
+                "candidate_id": "baseline",
+                "top1_match": 1.0,
+                "topk_contains": 1.0,
+                "logit_cosine": 0.9999,
+                "probability_kl": 0.001,
+                "reference_margin": 0.2,
+                "max_abs_logit_delta": 0.01,
+                "prompt_index": 0,
+                "step": 0,
+            },
+            {
+                "candidate_id": "baseline",
+                "top1_match": 1.0,
+                "topk_contains": 1.0,
+                "logit_cosine": 0.9997,
+                "probability_kl": 0.0012,
+                "reference_margin": 0.2,
+                "max_abs_logit_delta": 0.02,
+                "prompt_index": 0,
+                "step": 1,
+            },
+        ],
+        "ablated": [
+            {
+                "candidate_id": "ablated",
+                "top1_match": 0.2,
+                "topk_contains": 0.2,
+                "logit_cosine": 0.95,
+                "probability_kl": 0.02,
+                "reference_margin": 0.2,
+                "max_abs_logit_delta": 0.1,
+                "prompt_index": 0,
+                "step": 0,
+            },
+            {
+                "candidate_id": "ablated",
+                "top1_match": 0.0,
+                "topk_contains": 0.0,
+                "logit_cosine": 0.94,
+                "probability_kl": 0.04,
+                "reference_margin": 0.2,
+                "max_abs_logit_delta": 0.2,
+                "prompt_index": 0,
+                "step": 1,
+            },
+        ],
+    }
+
+    def _fake_collect_reference_rows(*args, **kwargs):
+        return [
+            {"prompt_index": 0, "step": 0},
+            {"prompt_index": 0, "step": 1},
+        ], [
+            {
+                "prompt_index": 0,
+                "prompt": "sample",
+                "prefill_reference_top1": 1,
+                "prefill_reference_margin": 0.2,
+            }
+        ]
+
+    def _fake_evaluate_candidate_rows(_reference_rows, _candidate_model, candidate, **_kwargs):
+        return [row.copy() for row in candidate_rows_by_id[candidate.candidate_id]]
+
+    def _fake_supports_attention_quantization(model: object) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        "npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention._load_runtime_modules",
+        lambda: (_FakeTorch(), _FakeAutoModel, _FakeAutoTokenizer),
+    )
+    monkeypatch.setattr(
+        "npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention._collect_reference_rows",
+        _fake_collect_reference_rows,
+    )
+    monkeypatch.setattr(
+        "npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention._evaluate_candidate_rows",
+        _fake_evaluate_candidate_rows,
+    )
+    monkeypatch.setattr(
+        "npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention._supports_attention_quantization",
+        _fake_supports_attention_quantization,
+    )
+
+    args = argparse.Namespace(
+        model_id="",
+        prompt_file="",
+        max_prompts=1,
+        generation_steps=2,
+        topk=5,
+        expected_gqa_group_size=2,
+        q_bits=8,
+        k_bits=8,
+        v_bits=8,
+        score_bits=8,
+        weight_bits=8,
+        softmax_mode="rtl_recip_lut_q8",
+        candidate=[
+            _parse_candidate_spec("baseline:q8,k8,v8,s24,w16,float_quantized"),
+            _parse_candidate_spec("ablated:q8,k8,v8,s8,w8,float_quantized"),
+        ],
+        candidate_list=[],
+        primary_candidate_id="baseline",
+        device="cpu",
+        dtype="auto",
+        out="out.json",
+        out_md="out.md",
+    )
+
+    payload = _run_model_eval(args)
+
+    assert len(payload["candidate_summaries"]) == 2
+    assert payload["best_candidate"]["candidate_id"] == "baseline"
+    assert payload["candidate_summary"]["candidate_id"] == "baseline"
+    assert payload["summary"]["candidate_id"] == "baseline"
+    assert payload["precision"]["candidate_id"] == "baseline"
+    assert payload["candidate_summary"]["decision_status"] == payload["decision"]["status"]
+    assert payload["candidate_rows"]
+    assert all(row["candidate_id"] in {"baseline", "ablated"} for row in payload["candidate_rows"])
+
+
+def test_load_runtime_modules_without_transformers_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention as evaluator
+
+    real_import_module = evaluator.importlib.import_module
+
+    def _fake_import_module(name: str):
+        if name == "transformers":
+            raise ModuleNotFoundError("No module named 'transformers'")
+        return real_import_module(name)
+
+    monkeypatch.setattr(evaluator.importlib, "import_module", _fake_import_module)
+
+    with pytest.raises(SystemExit):
+        _load_runtime_modules()


### PR DESCRIPTION
## Summary
- add multi-candidate ablation support to the native mixed/int8 attention quality evaluator
- wire decoder_attention_mixed_int8_native_quality_ablation into L2 generation and result consumption
- add proposal for isolating whether QKV, score, or RTL reciprocal softmax causes the native quality hold

## Tests
- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_llm_decoder_model_native_mixed_int8_attention.py tests/test_llm_decoder_model_native_kv_quant.py tests/test_llm_decoder_attention_mixed_precision_quality.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_native_quality_ablation_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_mixed_int8_native_quality_ablation
- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue