### PR TITLE
control_plane: add mixed int8 score boundary job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -483,6 +483,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_native_quality_ablation_report",
     ),
     (
+        "attention_mixed_int8_score_boundary_out",
+        "attention_mixed_int8_score_boundary_report",
+    ),
+    (
         "attention_composed_datapath_physical_feasibility_out",
         "attention_composed_datapath_physical_feasibility_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6117,6 +6117,60 @@ def _decoder_attention_mixed_int8_native_quality_ablation_evidence(*, item_id: s
     }
 
 
+def _decoder_attention_mixed_int8_score_boundary_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_int8_score_boundary__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_score_boundary__{item_id}.md"
+    ablation = (
+        f"{base}/decoder_attention_mixed_int8_native_quality_ablation__"
+        "l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_mixed_int8_native_quality_ablation": ablation,
+            "attention_mixed_int8_score_boundary_out": out,
+            "attention_mixed_int8_score_boundary_report": report,
+            "attention_mixed_int8_score_boundary_scope": (
+                "Run a 7B-class native checkpoint score-bit boundary sweep after the mixed/int8 "
+                "ablation showed QKV8 is acceptable but score8 fails. This identifies the lowest "
+                "score precision that preserves rankings before mapping the candidate back to PPA."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_score_boundary",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_MAX_PROMPTS:-2}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--topk 5 "
+                    "--candidate score10_float:q8,k8,v8,s10,w16,float_quantized "
+                    "--candidate score12_float:q8,k8,v8,s12,w16,float_quantized "
+                    "--candidate score14_float:q8,k8,v8,s14,w16,float_quantized "
+                    "--candidate score16_float:q8,k8,v8,s16,w16,float_quantized "
+                    "--candidate score10_rtl_exact:q8,k8,v8,s10,w8,rtl_exact "
+                    "--candidate score12_rtl_exact:q8,k8,v8,s12,w8,rtl_exact "
+                    "--candidate score14_rtl_exact:q8,k8,v8,s14,w8,rtl_exact "
+                    "--candidate score16_rtl_exact:q8,k8,v8,s16,w8,rtl_exact "
+                    "--primary-candidate-id score12_rtl_exact "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -8004,6 +8058,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_energy_closure",
         "decoder_attention_mixed_int8_native_quality",
         "decoder_attention_mixed_int8_native_quality_ablation",
+        "decoder_attention_mixed_int8_score_boundary",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -8188,6 +8243,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_native_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_native_quality_ablation":
             decoder_evidence = _decoder_attention_mixed_int8_native_quality_ablation_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_score_boundary":
+            decoder_evidence = _decoder_attention_mixed_int8_score_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6897,6 +6897,69 @@ def test_generate_l2_campaign_task_adds_mixed_int8_native_quality_ablation_evide
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_score_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_score_boundary",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="precision_boundary",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_score_boundary",
+            ]
+            run = commands[0]["run"]
+            assert "--candidate score10_float:q8,k8,v8,s10,w16,float_quantized" in run
+            assert "--candidate score16_rtl_exact:q8,k8,v8,s16,w8,rtl_exact" in run
+            assert "--primary-candidate-id score12_rtl_exact" in run
+            assert decoder_inputs["attention_mixed_int8_native_quality_ablation"].endswith(
+                "decoder_attention_mixed_int8_native_quality_ablation__"
+                "l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_score_boundary_out" in decoder_inputs
+            assert decoder_inputs["attention_mixed_int8_score_boundary_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_score_boundary",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": ["l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1"],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1/README.md
@@ -1,0 +1,9 @@
+# Llama7B Mixed/Int8 Score Precision Boundary
+
+This proposal sweeps attention score precision after the native checkpoint
+ablation showed QKV8 is acceptable while score8 is not.
+
+The output should identify the lowest score precision that preserves the
+7B-class checkpoint attention-shadow ranking gate before a hardware/PPA mapping
+job is scheduled.
+

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,24 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a 7B-class native checkpoint score-bit boundary sweep for QKV8 attention after score8 failed.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_score_boundary",
+      "comparison_role": "precision_boundary",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "find_lowest_passing_score_precision",
+        "reason": "The previous ablation showed QKV8 itself passes but score8 fails; the next frontier needs the lowest score precision that still preserves rankings."
+      },
+      "status": "pending"
+    }
+  ]
+}
+

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1/proposal.json
@@ -1,0 +1,79 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1",
+  "created_utc": "2026-06-24T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 attention score precision boundary",
+  "abstraction_layer": "decoder_attention_mixed_int8_score_boundary",
+  "hypothesis": "QKV8 can remain in the latency frontier if attention score precision is raised above the failing score8 point. A native 7B-class score-bit boundary sweep should identify the lowest passing score precision before PPA is spent on a new hardware candidate.",
+  "direct_comparison": {
+    "primary_question": "What is the lowest attention score precision that preserves native 7B-class checkpoint rankings for QKV8 attention?",
+    "baseline": "l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1",
+    "candidate": "score10/12/14/16 QKV8 attention-shadow candidates",
+    "include": [
+      "score10, score12, score14, and score16 float-quantized softmax candidates",
+      "score10, score12, score14, and score16 RTL exact int8 softmax candidates",
+      "native 7B-class checkpoint prompt-level final-logit comparisons",
+      "top-1 match, top-k contains, logit cosine, probability KL, and max logit delta"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "QAT or fine-tuning recovery",
+      "full perplexity or task accuracy",
+      "reciprocal-LUT variants beyond the current score8 failure"
+    ],
+    "metrics": [
+      "best_candidate_id",
+      "lowest_passing_score_bits",
+      "candidate_summaries",
+      "top1_match_rate",
+      "topk_contains_rate",
+      "mean_logit_cosine",
+      "mean_probability_kl"
+    ]
+  },
+  "expected_benefit": [
+    "replace the vague precision failure with a concrete score-bit boundary",
+    "identify whether the next hardware point should target score10, score12, score14, score16, or abandon score quantization",
+    "avoid PPA on precision points that fail native checkpoint evidence"
+  ],
+  "risks": [
+    "the result is still a prompt-level attention-shadow gate rather than full perplexity",
+    "the boundary may move with a larger prompt set or a different LLaMA-family checkpoint",
+    "RTL exact softmax still abstracts reciprocal implementation cost"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a 7B-class native checkpoint score-bit boundary sweep for QKV8 attention after score8 failed.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_score_boundary",
+      "comparison_role": "precision_boundary",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "find_lowest_passing_score_precision",
+        "reason": "The previous ablation showed QKV8 itself passes but score8 fails; the next frontier needs the lowest score precision that still preserves rankings."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_native_quality_ablation__l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_native_quality__l2_decoder_attention_mixed_int8_native_quality_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1/proposal.json"
+  ]
+}
+


### PR DESCRIPTION
## Summary
- add decoder_attention_mixed_int8_score_boundary L2 evidence generation
- add proposal to sweep score10/12/14/16 after score8 failed native checkpoint quality
- register score-boundary artifacts with the result consumer

## Tests
- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_score_boundary_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_mixed_int8_native_quality_ablation
- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue