### PR TITLE
control_plane: add mixed int8 high score boundary job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -487,6 +487,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_score_boundary_report",
     ),
     (
+        "attention_mixed_int8_high_score_boundary_out",
+        "attention_mixed_int8_high_score_boundary_report",
+    ),
+    (
         "attention_composed_datapath_physical_feasibility_out",
         "attention_composed_datapath_physical_feasibility_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6171,6 +6171,61 @@ def _decoder_attention_mixed_int8_score_boundary_evidence(*, item_id: str) -> di
     }
 
 
+def _decoder_attention_mixed_int8_high_score_boundary_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_int8_high_score_boundary__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_high_score_boundary__{item_id}.md"
+    score_boundary = (
+        f"{base}/decoder_attention_mixed_int8_score_boundary__"
+        "l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_mixed_int8_score_boundary": score_boundary,
+            "attention_mixed_int8_high_score_boundary_out": out,
+            "attention_mixed_int8_high_score_boundary_report": report,
+            "attention_mixed_int8_high_score_boundary_scope": (
+                "Run a 7B-class native checkpoint high-score sweep after score10/12/14/16 "
+                "failed. This narrows whether score18/20/22/24 can preserve QKV8 attention "
+                "rankings or whether the practical frontier needs high-precision scores/softmax."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_high_score_boundary",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_MAX_PROMPTS:-2}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--topk 5 "
+                    "--candidate score18_float:q8,k8,v8,s18,w16,float_quantized "
+                    "--candidate score20_float:q8,k8,v8,s20,w16,float_quantized "
+                    "--candidate score22_float:q8,k8,v8,s22,w16,float_quantized "
+                    "--candidate score24_float:q8,k8,v8,s24,w16,float_quantized "
+                    "--candidate score18_rtl_exact:q8,k8,v8,s18,w8,rtl_exact "
+                    "--candidate score20_rtl_exact:q8,k8,v8,s20,w8,rtl_exact "
+                    "--candidate score22_rtl_exact:q8,k8,v8,s22,w8,rtl_exact "
+                    "--candidate score24_rtl_exact:q8,k8,v8,s24,w8,rtl_exact "
+                    "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact "
+                    "--primary-candidate-id score24_float "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -8059,6 +8114,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_native_quality",
         "decoder_attention_mixed_int8_native_quality_ablation",
         "decoder_attention_mixed_int8_score_boundary",
+        "decoder_attention_mixed_int8_high_score_boundary",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -8245,6 +8301,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_native_quality_ablation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_score_boundary":
             decoder_evidence = _decoder_attention_mixed_int8_score_boundary_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_high_score_boundary":
+            decoder_evidence = _decoder_attention_mixed_int8_high_score_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -206,6 +206,111 @@ def test_decoder_evidence_summary_recognizes_mixed_int8_native_quality_ablation(
     assert "best_top1_match_rate=0.9" in summary
 
 
+def test_consume_l2_result_frontier_attention_mixed_int8_high_score_boundary_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_mixed_int8_high_score_boundary_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_mixed_int8_high_score_boundary_v1",
+                        "kind": "architecture",
+                        "title": "Attention mixed-int8 high score boundary",
+                        "direct_comparison": {
+                            "primary_question": "Which high-score boundary candidate meets the quality target?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_high_score_boundary__l2_attention_mixed_int8_high_score_boundary_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_high_score_boundary__l2_attention_mixed_int8_high_score_boundary_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
+                        "diagnosis": {"decision": "high_score_boundary_recorded"},
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# mixed-int8 high score boundary\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_mixed_int8_high_score_boundary_v1",
+                campaign_dir_rel="runs/campaigns/npu/attention_mixed_int8_high_score_boundary_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_mixed_int8_high_score_boundary_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use score-boundary refinement to guide precision selection.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_mixed_int8_high_score_boundary",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_mixed_int8_high_score_boundary_out": evidence_rel,
+                    "attention_mixed_int8_high_score_boundary_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "high_score_boundary_recorded"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_mixed_int8_high_score_boundary"
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_high_score_boundary_out"
+                ]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_high_score_boundary_report"
+                ]
+                == report_rel
+            )
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6960,6 +6960,74 @@ def test_generate_l2_campaign_task_adds_mixed_int8_score_boundary_evidence() -> 
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_high_score_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_high_score_boundary",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="precision_boundary",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_high_score_boundary",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_attention.py" in run
+            assert "--candidate score18_float:q8,k8,v8,s18,w16,float_quantized" in run
+            assert "--candidate score24_rtl_exact:q8,k8,v8,s24,w8,rtl_exact" in run
+            assert "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact" in run
+            assert "--primary-candidate-id score24_float" in run
+            assert decoder_inputs["attention_mixed_int8_score_boundary"].endswith(
+                "decoder_attention_mixed_int8_score_boundary__"
+                "l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_high_score_boundary_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_high_score_boundary_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_high_score_boundary",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": ["l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1"],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1/README.md
@@ -1,0 +1,8 @@
+# Llama7B Mixed/Int8 High Score Precision Boundary
+
+This proposal extends the native checkpoint score precision boundary after the
+score10/12/14/16 sweep did not recover the mixed/int8 attention quality gate.
+
+The output should determine whether QKV8 can pass with score18/20/22/24
+quantized attention scores, or whether the practical frontier must keep
+attention scores and softmax at near-full precision.

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a 7B-class native checkpoint high-score boundary sweep for QKV8 attention after score16 failed.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_high_score_boundary",
+      "comparison_role": "precision_boundary",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "find_high_score_precision_boundary",
+        "reason": "Score10-16 all failed while the earlier high-resolution QKV8 path passed; this job narrows whether score18/20/22 can preserve rankings or whether only near-full score precision is viable."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1/proposal.json
@@ -1,0 +1,79 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
+  "created_utc": "2026-06-24T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 attention high-score precision boundary",
+  "abstraction_layer": "decoder_attention_mixed_int8_high_score_boundary",
+  "hypothesis": "QKV8 attention may remain viable if score precision is raised above the failing score16 boundary. A native 7B-class sweep over score18/20/22/24 should decide whether any practical score quantization remains, or whether the frontier must keep high-precision attention scores and softmax.",
+  "direct_comparison": {
+    "primary_question": "What is the lowest high-score precision that preserves native 7B-class checkpoint rankings for QKV8 attention?",
+    "baseline": "l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1",
+    "candidate": "score18/20/22/24 QKV8 attention-shadow candidates",
+    "include": [
+      "score18, score20, score22, and score24 float-quantized softmax candidates",
+      "score18, score20, score22, and score24 RTL exact int8 softmax candidates",
+      "a qkv8_float_exact reference-style candidate",
+      "native 7B-class checkpoint prompt-level final-logit comparisons",
+      "top-1 match, top-k contains, logit cosine, probability KL, and max logit delta"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "QAT or fine-tuning recovery",
+      "full perplexity or task accuracy",
+      "reciprocal-LUT variants beyond the existing score8 failure"
+    ],
+    "metrics": [
+      "best_candidate_id",
+      "lowest_passing_score_bits",
+      "candidate_summaries",
+      "top1_match_rate",
+      "topk_contains_rate",
+      "mean_logit_cosine",
+      "mean_probability_kl"
+    ]
+  },
+  "expected_benefit": [
+    "narrow the precision boundary between failing score16 and the previously passing high-resolution QKV8 path",
+    "avoid PPA on score-quantized hardware points that fail native checkpoint evidence",
+    "decide whether the next practical hardware point should keep high-precision scores/softmax while preserving QKV8 projections"
+  ],
+  "risks": [
+    "the result is still a prompt-level attention-shadow gate rather than full perplexity",
+    "the boundary may move with a larger prompt set or a different LLaMA-family checkpoint",
+    "RTL exact softmax still abstracts reciprocal implementation cost"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a 7B-class native checkpoint high-score boundary sweep for QKV8 attention after score16 failed.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_high_score_boundary",
+      "comparison_role": "precision_boundary",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "find_high_score_precision_boundary",
+        "reason": "Score10-16 all failed while the earlier high-resolution QKV8 path passed; this job narrows whether score18/20/22 can preserve rankings or whether only near-full score precision is viable."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_boundary__l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_native_quality_ablation__l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1/proposal.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the `decoder_attention_mixed_int8_high_score_boundary` L2 campaign abstraction
- wire evaluator command/result consumption for score18/20/22/24 plus qkv8 float-exact reference
- add proposal docs for the follow-on Llama7B high-score precision boundary job

## Validation
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_high_score_boundary_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_mixed_int8_high_score_boundary_uses_decoder_evidence`
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
