### PR TITLE
control_plane: add mixed int8 broad native quality job

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -491,6 +491,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_high_score_boundary_report",
     ),
     (
+        "attention_mixed_int8_broad_native_quality_out",
+        "attention_mixed_int8_broad_native_quality_report",
+    ),
+    (
         "attention_composed_datapath_physical_feasibility_out",
         "attention_composed_datapath_physical_feasibility_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6226,6 +6226,59 @@ def _decoder_attention_mixed_int8_high_score_boundary_evidence(*, item_id: str) 
     }
 
 
+def _decoder_attention_mixed_int8_broad_native_quality_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_int8_broad_native_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_broad_native_quality__{item_id}.md"
+    high_score_boundary = (
+        f"{base}/decoder_attention_mixed_int8_high_score_boundary__"
+        "l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_mixed_int8_high_score_boundary": high_score_boundary,
+            "attention_mixed_int8_broad_native_quality_out": out,
+            "attention_mixed_int8_broad_native_quality_report": report,
+            "attention_mixed_int8_broad_native_quality_scope": (
+                "Broaden the native 7B-class attention-shadow quality gate for the only "
+                "passing mixed/int8 high-score point. Recheck score24 float-quantized "
+                "softmax against a float-exact control and nearby failing controls before "
+                "spending PPA on the mixed/int8 precision frontier."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_broad_native_quality",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_BROAD_MAX_PROMPTS:-8}; "
+                    "GEN_STEPS=${RTLGEN_MODEL_NATIVE_7B_BROAD_GENERATION_STEPS:-8}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--generation-steps \"$GEN_STEPS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--topk 5 "
+                    "--candidate score22_float:q8,k8,v8,s22,w16,float_quantized "
+                    "--candidate score24_float:q8,k8,v8,s24,w16,float_quantized "
+                    "--candidate score24_rtl_exact:q8,k8,v8,s24,w8,rtl_exact "
+                    "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact "
+                    "--primary-candidate-id score24_float "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -8115,6 +8168,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_native_quality_ablation",
         "decoder_attention_mixed_int8_score_boundary",
         "decoder_attention_mixed_int8_high_score_boundary",
+        "decoder_attention_mixed_int8_broad_native_quality",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -8303,6 +8357,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_score_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_high_score_boundary":
             decoder_evidence = _decoder_attention_mixed_int8_high_score_boundary_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_broad_native_quality":
+            decoder_evidence = _decoder_attention_mixed_int8_broad_native_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -311,6 +311,111 @@ def test_consume_l2_result_frontier_attention_mixed_int8_high_score_boundary_use
             )
 
 
+def test_consume_l2_result_frontier_attention_mixed_int8_broad_native_quality_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_mixed_int8_broad_native_quality_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_mixed_int8_broad_native_quality_v1",
+                        "kind": "architecture",
+                        "title": "Attention mixed-int8 broad native quality",
+                        "direct_comparison": {
+                            "primary_question": "Which broad generation mix offers the best frontier quality?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_broad_native_quality__l2_attention_mixed_int8_broad_native_quality_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_broad_native_quality__l2_attention_mixed_int8_broad_native_quality_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "quality_gate": "mixed_int8_attention_shadow",
+                        "model": "llm_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1",
+                        "diagnosis": {"decision": "broad_native_quality_recorded"},
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# mixed-int8 broad native quality\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_mixed_int8_broad_native_quality_v1",
+                campaign_dir_rel="runs/campaigns/npu/attention_mixed_int8_broad_native_quality_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_mixed_int8_broad_native_quality_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "iterate",
+                "expected_reason": "Use broad native evaluation to select practical precision tradeoffs.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_mixed_int8_broad_native_quality",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_mixed_int8_broad_native_quality_out": evidence_rel,
+                    "attention_mixed_int8_broad_native_quality_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "broad_native_quality_recorded"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_mixed_int8_broad_native_quality"
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_broad_native_quality_out"
+                ]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_broad_native_quality_report"
+                ]
+                == report_rel
+            )
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7028,6 +7028,78 @@ def test_generate_l2_campaign_task_adds_mixed_int8_high_score_boundary_evidence(
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_broad_native_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_broad_native_quality",
+                    evaluation_mode="quality_gate",
+                    comparison_role="precision_validation",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_broad_native_quality",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_attention.py" in run
+            assert "RTLGEN_MODEL_NATIVE_7B_BROAD_MAX_PROMPTS" in run
+            assert "RTLGEN_MODEL_NATIVE_7B_BROAD_GENERATION_STEPS" in run
+            assert "--generation-steps \"$GEN_STEPS\"" in run
+            assert "--candidate score22_float:q8,k8,v8,s22,w16,float_quantized" in run
+            assert "--candidate score24_float:q8,k8,v8,s24,w16,float_quantized" in run
+            assert "--candidate score24_rtl_exact:q8,k8,v8,s24,w8,rtl_exact" in run
+            assert "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact" in run
+            assert "--primary-candidate-id score24_float" in run
+            assert decoder_inputs["attention_mixed_int8_high_score_boundary"].endswith(
+                "decoder_attention_mixed_int8_high_score_boundary__"
+                "l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_broad_native_quality_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_broad_native_quality_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_broad_native_quality",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": ["l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1"],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1/README.md
@@ -1,0 +1,9 @@
+# Llama7B Mixed/Int8 Broad Native Quality
+
+This proposal broadens the native checkpoint attention-shadow gate for the
+only mixed/int8 score-boundary point that passed: QKV8 with score24 and
+float-quantized softmax.
+
+The result should determine whether the passing high-score point survives the
+full default prompt set before it is treated as a precision-valid architecture
+candidate for energy/PPA frontier scheduling.

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a broader 7B-class native checkpoint attention-shadow gate for the passing score24 QKV8 mixed/int8 point.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_broad_native_quality",
+      "comparison_role": "precision_validation",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "validate_score24_float_before_ppa",
+        "reason": "Score18/20/22 failed and score24_float passed on the small high-score boundary gate; the next decision needs broader native-checkpoint evidence before PPA is spent on the score24 mixed/int8 point."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1/proposal.json
@@ -1,0 +1,81 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1",
+  "created_utc": "2026-06-24T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 broad native attention quality",
+  "abstraction_layer": "decoder_attention_mixed_int8_broad_native_quality",
+  "hypothesis": "The only passing mixed/int8 high-score point, QKV8 with score24 and float-quantized softmax, remains stable when the native 7B-class checkpoint attention-shadow gate is broadened from the two-prompt boundary probe to the full default prompt set.",
+  "direct_comparison": {
+    "primary_question": "Does the score24 QKV8 attention-shadow point still preserve native 7B-class checkpoint rankings on a broader prompt set?",
+    "baseline": "l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
+    "candidate": "score24_float QKV8 attention-shadow candidate",
+    "include": [
+      "score24 float-quantized softmax as the primary candidate",
+      "qkv8 float-exact as a high-precision control",
+      "score22 float-quantized and score24 RTL-exact controls near the failing boundary",
+      "native 7B-class checkpoint teacher-forced final-logit comparisons over the default prompt set",
+      "top-1 match, top-k contains, logit cosine, probability KL, and max logit delta"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "QAT or fine-tuning recovery",
+      "full perplexity or task accuracy",
+      "additional checkpoints beyond the configured 7B-class model"
+    ],
+    "metrics": [
+      "best_candidate_id",
+      "candidate_summaries",
+      "prompt_count",
+      "generation_steps",
+      "top1_match_rate",
+      "topk_contains_rate",
+      "mean_logit_cosine",
+      "mean_probability_kl",
+      "max_abs_logit_delta_max"
+    ]
+  },
+  "expected_benefit": [
+    "reduce the prompt-sampling abstraction in the current score24 pass",
+    "decide whether score24_float is ready for a measured hardware/PPA follow-up",
+    "keep the failing score22 and RTL-exact controls in the same run for regression context"
+  ],
+  "risks": [
+    "the result is still an attention-shadow gate rather than full perplexity",
+    "the boundary may move with a different LLaMA-family checkpoint or a larger benchmark set",
+    "the passing float-quantized softmax path still needs a hardware embodiment before final frontier comparison"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a broader 7B-class native checkpoint attention-shadow gate for the passing score24 QKV8 mixed/int8 point.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_broad_native_quality",
+      "comparison_role": "precision_validation",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "validate_score24_float_before_ppa",
+        "reason": "Score18/20/22 failed and score24_float passed on the small high-score boundary gate; the next decision needs broader native-checkpoint evidence before PPA is spent on the score24 mixed/int8 point."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_high_score_boundary__l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_boundary__l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_native_quality_ablation__l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1/proposal.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the `decoder_attention_mixed_int8_broad_native_quality` L2 campaign abstraction
- broaden the score24 QKV8 native checkpoint attention-shadow gate to the full default prompt set
- include score22 and score24 RTL-exact controls next to the passing score24/qkv8 float paths

## Validation
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_broad_native_quality_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_mixed_int8_broad_native_quality_uses_decoder_evidence`
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
