### PR TITLE
control_plane: transport mixed int8 decoder evidence

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -25,6 +25,7 @@ _ALLOWED_RUNS_SUFFIXES = {
 
 _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_",
+    "decoder_attention_mixed_int8_",
     "decoder_attention_noc_profile__",
     "decoder_attention_sram_profile__",
 }

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -94,6 +94,16 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
     )
     assert is_transportable_expected_output(
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_mixed_int8_broad_native_quality__"
+        "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1.json"
+    )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_mixed_int8_high_score_boundary__"
+        "l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1.md"
+    )
+    assert is_transportable_expected_output(
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule__"
         "l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_llama7b_v1.json"
     )


### PR DESCRIPTION
## Summary
- allow `decoder_attention_mixed_int8_*` dataset artifacts through the remote expected-output transport policy
- add regression coverage for mixed/int8 JSON and Markdown evidence artifacts

## Why
The broad native quality run completed, but only logs were transported; completion could not consume the evidence JSON/MD and fell back to `/best_point.json`.

## Validation
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_broad_native_quality_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_mixed_int8_broad_native_quality_uses_decoder_evidence`
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
