### PR TITLE
control_plane: add mixed int8 quality-backed frontier audit

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -495,6 +495,14 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_broad_native_quality_report",
     ),
     (
+        "attention_mixed_int8_quality_backed_frontier_out",
+        "attention_mixed_int8_quality_backed_frontier_report",
+    ),
+    (
+        "attention_mixed_int8_quality_energy_frontier_out",
+        "attention_mixed_int8_quality_energy_frontier_report",
+    ),
+    (
         "attention_composed_datapath_physical_feasibility_out",
         "attention_composed_datapath_physical_feasibility_report",
     ),
@@ -1165,6 +1173,36 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         recommended_next = str(diagnosis_dict.get("recommended_next_step", "")).strip()
         if recommended_next:
             parts.append(f"recommended_next_step={recommended_next}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            diagnosis_dict.get("decision")
+            or evidence_payload.get("decision")
+            or "mixed_int8_quality_backed_frontier_recorded"
+        )
+        parts = [
+            f"Decoder mixed/int8 quality-backed frontier evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "quality_passing_candidate_count",
+            "quality_passing_candidate_ids",
+            "quality_best_candidate_id",
+            "quality_best_top1_match_rate",
+            "quality_best_mean_probability_kl",
+            "invalidated_energy_candidate_count",
+            "old_energy_best_candidate_id",
+            "old_energy_best_latency_us",
+            "old_energy_best_token_throughput_per_s",
+            "old_energy_best_energy_mj",
+            "old_energy_best_precision_profile",
+            "recommended_next_step",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6279,6 +6279,48 @@ def _decoder_attention_mixed_int8_broad_native_quality_evidence(*, item_id: str)
     }
 
 
+def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    energy_closure = (
+        f"{base}/decoder_attention_mixed_int8_energy_closure__"
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json"
+    )
+    broad_native_quality = (
+        f"{base}/decoder_attention_mixed_int8_broad_native_quality__"
+        "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json"
+    )
+    out = f"{base}/decoder_attention_mixed_int8_quality_backed_frontier__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_quality_backed_frontier__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_mixed_int8_energy_closure": energy_closure,
+            "attention_mixed_int8_broad_native_quality": broad_native_quality,
+            "attention_mixed_int8_quality_backed_frontier_out": out,
+            "attention_mixed_int8_quality_backed_frontier_report": report,
+            "attention_mixed_int8_quality_backed_frontier_scope": (
+                "Reconcile the mixed/int8 energy frontier with the broad native 7B attention-shadow "
+                "quality gate. Demote score/softmax-quantized energy rows that no longer match the "
+                "quality-passing qkv8_float_exact precision point, and identify the recosted PPA "
+                "work needed before ranking throughput, energy, area, and precision."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_mixed_int8_quality_backed_frontier",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_mixed_int8_quality_backed_frontier.py "
+                    f"--mixed-int8-energy-closure-json {energy_closure} "
+                    f"--mixed-int8-broad-native-quality-json {broad_native_quality} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -8169,6 +8211,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_score_boundary",
         "decoder_attention_mixed_int8_high_score_boundary",
         "decoder_attention_mixed_int8_broad_native_quality",
+        "decoder_attention_mixed_int8_quality_backed_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -8359,6 +8402,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_high_score_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_broad_native_quality":
             decoder_evidence = _decoder_attention_mixed_int8_broad_native_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
+            decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -101,6 +101,37 @@ def test_decoder_evidence_summary_recognizes_mixed_precision_int8_compute_energy
     assert "best_dominant_energy_component=hbm" in summary
 
 
+def test_decoder_evidence_summary_recognizes_mixed_int8_quality_backed_frontier() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/mixed_int8_quality_backed_frontier.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+            "decision": "mixed_int8_quality_backed_frontier_recost_required",
+            "diagnosis": {
+                "decision": "mixed_int8_quality_backed_frontier_recost_required",
+                "quality_passing_candidate_count": 1,
+                "quality_passing_candidate_ids": ["qkv8_float_exact"],
+                "quality_best_candidate_id": "qkv8_float_exact",
+                "quality_best_top1_match_rate": 1.0,
+                "quality_best_mean_probability_kl": 0.0012,
+                "invalidated_energy_candidate_count": 1,
+                "old_energy_best_candidate_id": "die800_dense_gemm_int8_16x8_k1_p1",
+                "old_energy_best_latency_us": 1575.37,
+                "old_energy_best_token_throughput_per_s": 634.77,
+                "old_energy_best_energy_mj": 135.75,
+                "old_energy_best_precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+                "recommended_next_step": "recompute with high-precision score-softmax",
+            },
+        },
+    )
+
+    assert outcome == "mixed_int8_quality_backed_frontier_recost_required"
+    assert "quality-backed frontier" in summary
+    assert "quality_best_candidate_id=qkv8_float_exact" in summary
+    assert "invalidated_energy_candidate_count=1" in summary
+    assert "old_energy_best_token_throughput_per_s=634.77" in summary
+
+
 def test_decoder_evidence_summary_recognizes_mixed_int8_native_quality() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/mixed_int8_native_quality.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7100,6 +7100,80 @@ def test_generate_l2_campaign_task_adds_mixed_int8_broad_native_quality_evidence
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_quality_backed_frontier",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="quality_backed_frontier",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+                        "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_mixed_int8_quality_backed_frontier",
+            ]
+            run = commands[0]["run"]
+            assert "audit_llm_decoder_attention_mixed_int8_quality_backed_frontier.py" in run
+            assert "--mixed-int8-energy-closure-json" in run
+            assert "--mixed-int8-broad-native-quality-json" in run
+            assert decoder_inputs["attention_mixed_int8_energy_closure"].endswith(
+                "decoder_attention_mixed_int8_energy_closure__"
+                "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json"
+            )
+            assert decoder_inputs["attention_mixed_int8_broad_native_quality"].endswith(
+                "decoder_attention_mixed_int8_broad_native_quality__"
+                "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json"
+            )
+            assert "attention_mixed_int8_quality_backed_frontier_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_quality_backed_frontier_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_quality_backed_frontier",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+                    "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json
@@ -1,0 +1,83 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+  "created_utc": "2026-06-24T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 quality-backed frontier audit",
+  "abstraction_layer": "decoder_attention_mixed_int8_quality_backed_frontier",
+  "hypothesis": "The mixed/int8 energy frontier must be revised after broad native 7B attention-shadow quality rejected score/softmax quantization. Only the qkv8_float_exact direction should remain as a quality-backed candidate until it is recosted with matching high-precision score-softmax PPA.",
+  "direct_comparison": {
+    "primary_question": "Which mixed/int8 energy rows remain rankable after the broad native quality gate?",
+    "baseline": "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+    "candidate": "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2",
+    "include": [
+      "consume merged mixed/int8 energy closure r2",
+      "consume merged broad native 7B attention-shadow quality r2",
+      "identify quality-passing candidate IDs and precision profile",
+      "invalidate score/softmax-quantized energy rows that do not match the passing precision point",
+      "record the recost requirement before throughput, energy, and area ranking"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "new native checkpoint inference",
+      "QAT or fine-tuning recovery",
+      "new HBM/SRAM/NoC modeling"
+    ],
+    "metrics": [
+      "decision",
+      "quality_passing_candidate_ids",
+      "quality_best_candidate_id",
+      "quality_best_top1_match_rate",
+      "quality_best_mean_probability_kl",
+      "invalidated_energy_candidate_count",
+      "old_energy_best_latency_us",
+      "old_energy_best_token_throughput_per_s",
+      "old_energy_best_energy_mj",
+      "remaining_abstractions"
+    ]
+  },
+  "expected_benefit": [
+    "prevent stale score/softmax-quantized PPA rows from being ranked as the mixed/int8 frontier",
+    "preserve the old energy row as an unranked latency/traffic floor while identifying the required recost",
+    "define the next PPA job around q8/k8/v8 projections with high-precision or exact score-softmax"
+  ],
+  "risks": [
+    "this audit does not produce the recosted PPA numbers",
+    "the quality gate remains attention-shadow evidence rather than full perplexity or task accuracy",
+    "the passing qkv8_float_exact direction may still need a hardware score-softmax embodiment before final comparison"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Reconcile mixed/int8 energy closure against broad native 7B quality evidence and mark non-matching energy rows unrankable.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_quality_backed_frontier",
+      "comparison_role": "quality_backed_frontier",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "retract_invalid_mixed_int8_energy_ranking",
+        "reason": "The broad native quality result only passes qkv8_float_exact; the old energy-best row uses score/softmax quantization and must not remain a quality-backed frontier point."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_broad_native_quality__l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_mixed_int8_quality_backed_frontier.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1/proposal.json"
+  ]
+}

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -442,6 +442,25 @@ primitive envelope. Under that envelope, the physical primitive metrics do not
 make q10 cheaper than q12/q14/q16; q10 remains a quality/minimum-precision
 choice until an integrated datapath measurement says otherwise.
 
+## Mixed-Int8 Quality-Backed Frontier
+After running native 7B-class attention-shadow quality gates, do not rank a
+mixed/int8 energy row by PPA alone. Reconcile the latest energy closure with the
+latest broad native quality artifact first:
+```sh
+python3 npu/eval/audit_llm_decoder_attention_mixed_int8_quality_backed_frontier.py \
+  --mixed-int8-energy-closure-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json \
+  --mixed-int8-broad-native-quality-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_broad_native_quality__l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json \
+  --out /tmp/decoder_attention_mixed_int8_quality_backed_frontier.json \
+  --out-md /tmp/decoder_attention_mixed_int8_quality_backed_frontier.md
+```
+
+If the broad quality gate only passes `qkv8_float_exact`, prior score/softmax
+quantized energy rows such as `s8/w8/recip_lut` are unranked latency/traffic
+floors, not quality-backed frontier points. The next PPA job must recost the
+q8/k8/v8 projection path with matching high-precision or exact score-softmax
+hardware before comparing token throughput, energy, and area against the FP16
+baseline.
+
 Optionally verify path-like fields exist:
 ```sh
 python3 npu/eval/validate.py --campaign <campaign.json> --check_paths

--- a/npu/eval/audit_llm_decoder_attention_mixed_int8_quality_backed_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_mixed_int8_quality_backed_frontier.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Reconcile mixed-int8 energy closure with broad native attention quality."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object at {path}")
+    return payload
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _candidate_summaries(quality: JsonDict) -> list[JsonDict]:
+    rows = quality.get("candidate_summaries")
+    if not isinstance(rows, list):
+        return []
+    return [dict(row) for row in rows if isinstance(row, dict)]
+
+
+def _is_pass(row: JsonDict) -> bool:
+    status = str(row.get("decision_status") or (row.get("decision") or {}).get("status") or "")
+    return status.endswith("_pass")
+
+
+def _quality_precision(row: JsonDict) -> JsonDict:
+    return {
+        "candidate_id": row.get("candidate_id"),
+        "q_bits": row.get("q_bits"),
+        "k_bits": row.get("k_bits"),
+        "v_bits": row.get("v_bits"),
+        "score_bits": row.get("score_bits"),
+        "weight_bits": row.get("weight_bits"),
+        "softmax_mode": row.get("softmax_mode"),
+    }
+
+
+def _energy_precision(row: JsonDict) -> JsonDict:
+    return {
+        "precision_profile": row.get("precision_profile"),
+        "measured_softmax_weight_metrics_csv": row.get("measured_softmax_weight_metrics_csv"),
+        "softmax_weight_generator_metrics_csv": row.get("softmax_weight_generator_metrics_csv"),
+        "compute_arch": row.get("compute_arch") or row.get("substituted_compute_arch"),
+        "compute_replica_count": row.get("compute_replica_count") or row.get("substituted_compute_replica_count"),
+    }
+
+
+def _energy_summary(row: JsonDict | None) -> JsonDict | None:
+    if not isinstance(row, dict):
+        return None
+    return {
+        "candidate_id": row.get("candidate_id"),
+        "precision": _energy_precision(row),
+        "latency_us": row.get("latency_us"),
+        "token_throughput_per_s": row.get("token_throughput_per_s"),
+        "energy_mj": row.get("energy_mj"),
+        "die_area_mm2": row.get("die_area_mm2"),
+        "compute_energy_mj": row.get("compute_energy_mj"),
+        "hbm_energy_mj": row.get("hbm_energy_mj"),
+        "sram_energy_mj": row.get("sram_energy_mj"),
+        "noc_energy_mj": row.get("noc_energy_mj"),
+        "dominant_energy_component": row.get("dominant_energy_component"),
+    }
+
+
+def _quality_summary(row: JsonDict) -> JsonDict:
+    return {
+        "candidate_id": row.get("candidate_id"),
+        "decision_status": row.get("decision_status") or (row.get("decision") or {}).get("status"),
+        "precision": _quality_precision(row),
+        "comparison_count": row.get("comparison_count"),
+        "top1_match_rate": row.get("top1_match_rate"),
+        "topk_contains_rate": row.get("topk_contains_rate"),
+        "mean_logit_cosine": row.get("mean_logit_cosine"),
+        "mean_probability_kl": row.get("mean_probability_kl"),
+        "max_abs_logit_delta_max": row.get("max_abs_logit_delta_max"),
+    }
+
+
+def _score_softmax_quantized(row: JsonDict) -> bool:
+    precision = str(row.get("precision_profile") or "")
+    softmax_paths = " ".join(
+        str(row.get(key) or "")
+        for key in ("measured_softmax_weight_metrics_csv", "softmax_weight_generator_metrics_csv")
+    )
+    return (
+        "_s8_" in precision
+        or "_w8_" in precision
+        or "recip_lut" in precision
+        or "int8" in softmax_paths
+        or "recip_q" in softmax_paths
+    )
+
+
+def build_payload(args: argparse.Namespace) -> JsonDict:
+    energy = _load_json(args.mixed_int8_energy_closure_json)
+    quality = _load_json(args.mixed_int8_broad_native_quality_json)
+    quality_rows = _candidate_summaries(quality)
+    if not quality_rows:
+        raise RuntimeError("broad native quality artifact contains no candidate_summaries")
+
+    passing = [_quality_summary(row) for row in quality_rows if _is_pass(row)]
+    held = [_quality_summary(row) for row in quality_rows if not _is_pass(row)]
+    qkv8_float_exact = next(
+        (row for row in quality_rows if str(row.get("candidate_id")) == "qkv8_float_exact"),
+        None,
+    )
+    qkv8_pass = qkv8_float_exact is not None and _is_pass(qkv8_float_exact)
+
+    energy_best = energy.get("best") if isinstance(energy.get("best"), dict) else {}
+    latency_best = energy.get("latency_best") if isinstance(energy.get("latency_best"), dict) else {}
+    energy_rows = [row for row in [energy_best, latency_best, *energy.get("pareto_rows", [])] if isinstance(row, dict)]
+    invalidated_rows: list[JsonDict] = []
+    seen: set[str] = set()
+    for row in energy_rows:
+        candidate_id = str(row.get("candidate_id") or "")
+        if candidate_id in seen:
+            continue
+        seen.add(candidate_id)
+        if _score_softmax_quantized(row):
+            invalidated_rows.append(
+                {
+                    **(_energy_summary(row) or {}),
+                    "quality_frontier_status": "invalid_for_quality_backed_ranking",
+                    "reason": (
+                        "energy row uses score/softmax quantization or reciprocal-LUT softmax evidence, "
+                        "while broad native quality only passed qkv8_float_exact"
+                    ),
+                }
+            )
+
+    decision = "mixed_int8_quality_backed_frontier_recost_required"
+    recommended_next_step = (
+        "Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with "
+        "high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row."
+    )
+    if not qkv8_pass:
+        decision = "mixed_int8_quality_backed_frontier_no_passing_candidate"
+        recommended_next_step = "No mixed-int8 attention candidate passed the broad native quality gate; return to precision search."
+    elif not invalidated_rows:
+        decision = "mixed_int8_quality_backed_frontier_recorded"
+        recommended_next_step = "Inspect whether the energy closure already matches the passing qkv8_float_exact precision path."
+
+    best_quality = _quality_summary(qkv8_float_exact) if isinstance(qkv8_float_exact, dict) else None
+    old_best = _energy_summary(energy_best)
+    latency_floor = _as_float((old_best or {}).get("latency_us"))
+    old_throughput = _as_float((old_best or {}).get("token_throughput_per_s"))
+
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "decision": decision,
+        "quality_gate_status": (quality.get("decision") or {}).get("status") if isinstance(quality.get("decision"), dict) else None,
+        "inputs": {
+            "mixed_int8_energy_closure_json": str(args.mixed_int8_energy_closure_json),
+            "mixed_int8_broad_native_quality_json": str(args.mixed_int8_broad_native_quality_json),
+        },
+        "diagnosis": {
+            "decision": decision,
+            "quality_candidate_count": len(quality_rows),
+            "quality_passing_candidate_count": len(passing),
+            "quality_passing_candidate_ids": [row.get("candidate_id") for row in passing],
+            "quality_best_candidate_id": (best_quality or {}).get("candidate_id"),
+            "quality_best_top1_match_rate": (best_quality or {}).get("top1_match_rate"),
+            "quality_best_mean_probability_kl": (best_quality or {}).get("mean_probability_kl"),
+            "invalidated_energy_candidate_count": len(invalidated_rows),
+            "old_energy_best_candidate_id": (old_best or {}).get("candidate_id"),
+            "old_energy_best_latency_us": (old_best or {}).get("latency_us"),
+            "old_energy_best_token_throughput_per_s": (old_best or {}).get("token_throughput_per_s"),
+            "old_energy_best_energy_mj": (old_best or {}).get("energy_mj"),
+            "old_energy_best_precision_profile": ((old_best or {}).get("precision") or {}).get("precision_profile"),
+            "quality_backed_latency_floor_us_unranked": latency_floor if invalidated_rows else None,
+            "quality_backed_throughput_floor_tok_s_unranked": old_throughput if invalidated_rows else None,
+            "recommended_next_step": recommended_next_step,
+        },
+        "quality_backed_direction": {
+            "status": "quality_pass_requires_energy_recost" if qkv8_pass else "no_quality_pass",
+            "candidate": best_quality,
+            "rankable_for_energy_frontier": False if invalidated_rows else qkv8_pass,
+            "recost_requirement": (
+                "Substitute or measure high-precision/exact score-softmax PPA for the passing qkv8_float_exact path "
+                "before comparing throughput, energy, or area against FP16/dense baselines."
+            ),
+        },
+        "invalidated_energy_candidates": invalidated_rows,
+        "quality_candidates": {
+            "passing": passing,
+            "held_or_failed": held,
+        },
+        "old_energy_best": old_best,
+        "old_latency_best": _energy_summary(latency_best),
+        "remaining_abstractions": [
+            "The quality-passing qkv8_float_exact path has not yet been recosted with matching high-precision/exact score-softmax PPA.",
+            "The previous mixed/int8 energy closure remains useful as a latency/traffic floor only; its s8/w8 reciprocal-LUT score-softmax precision is invalid for quality-backed ranking.",
+            "This audit is an evidence reconciliation step and does not rerun OpenROAD or the native model quality gate.",
+            "HBM/SRAM/NoC abstractions from the source energy closure remain unchanged until the recosted precision path is generated.",
+        ],
+    }
+
+
+def write_markdown(payload: JsonDict, report: Path) -> None:
+    diag = payload["diagnosis"]
+    direction = payload["quality_backed_direction"]
+    best = direction.get("candidate") or {}
+    old_best = payload.get("old_energy_best") or {}
+    lines = [
+        "# Llama7B Mixed-Int8 Quality-Backed Frontier Audit",
+        "",
+        f"- decision: `{diag['decision']}`",
+        f"- quality passing candidates: `{diag['quality_passing_candidate_ids']}`",
+        f"- invalidated energy candidates: `{diag['invalidated_energy_candidate_count']}`",
+        f"- recommended next step: `{diag['recommended_next_step']}`",
+        "",
+        "## Quality-Backed Direction",
+        "",
+        "| candidate | status | top1 | top-k | KL | rankable for energy frontier |",
+        "|---|---|---:|---:|---:|---|",
+        "| {candidate_id} | {decision_status} | {top1_match_rate} | {topk_contains_rate} | {mean_probability_kl} | {rankable} |".format(
+            candidate_id=best.get("candidate_id"),
+            decision_status=best.get("decision_status"),
+            top1_match_rate=best.get("top1_match_rate"),
+            topk_contains_rate=best.get("topk_contains_rate"),
+            mean_probability_kl=best.get("mean_probability_kl"),
+            rankable=direction.get("rankable_for_energy_frontier"),
+        ),
+        "",
+        "## Previous Energy Best",
+        "",
+        "| candidate | precision profile | latency us | throughput tok/s | energy mJ | dominant | status |",
+        "|---|---|---:|---:|---:|---|---|",
+        "| {candidate_id} | {precision_profile} | {latency_us} | {token_throughput_per_s} | {energy_mj} | {dominant_energy_component} | invalidated for quality-backed ranking |".format(
+            candidate_id=old_best.get("candidate_id"),
+            precision_profile=(old_best.get("precision") or {}).get("precision_profile"),
+            latency_us=old_best.get("latency_us"),
+            token_throughput_per_s=old_best.get("token_throughput_per_s"),
+            energy_mj=old_best.get("energy_mj"),
+            dominant_energy_component=old_best.get("dominant_energy_component"),
+        ),
+        "",
+        "## Remaining Abstractions",
+        "",
+    ]
+    for item in payload["remaining_abstractions"]:
+        lines.append(f"- {item}")
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mixed-int8-energy-closure-json", type=Path, required=True)
+    parser.add_argument("--mixed-int8-broad-native-quality-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = build_payload(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a quality-backed mixed/int8 frontier audit that reconciles the energy closure with broad native 7B attention quality
- mark the old s8/w8 reciprocal-LUT energy candidate unrankable when only qkv8_float_exact passes quality
- wire the new L2 abstraction, result summary, proposal document, and README guidance

## Validation
- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_mixed_int8_quality_backed_frontier control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence
- python3 -m py_compile npu/eval/audit_llm_decoder_attention_mixed_int8_quality_backed_frontier.py
- python3 npu/eval/audit_llm_decoder_attention_mixed_int8_quality_backed_frontier.py --mixed-int8-energy-closure-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json --mixed-int8-broad-native-quality-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_broad_native_quality__l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json --out /tmp/mixed_int8_quality_frontier.json --out-md /tmp/mixed_int8_quality_frontier.md

Smoke decision: mixed_int8_quality_backed_frontier_recost_required, best quality candidate qkv8_float_exact, invalidated energy candidates 1.