### PR TITLE
eval: run llama7b mixed/int8 quality-backed frontier audit

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json
@@ -1,0 +1,119 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-06-24T12:12:26.799585Z",
+  "item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+  "run_key": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_run_aa26060ae07e8159",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "427e92c4a71dd4a4c063ed5871876b16e956d559",
+  "review_metadata_source_commit": "427e92c4a71dd4a4c063ed5871876b16e956d559",
+  "objective": "Reconcile mixed/int8 energy closure with broad native 7B quality and mark non-matching energy rows unrankable before frontier ranking.",
+  "input_manifest": {
+    "decoder_contract": {
+      "attention_mixed_int8_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+      "attention_mixed_int8_broad_native_quality": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_broad_native_quality__l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json",
+      "attention_mixed_int8_quality_backed_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+      "attention_mixed_int8_quality_backed_frontier_scope": "Reconcile the mixed/int8 energy frontier with the broad native 7B attention-shadow quality gate. Demote score/softmax-quantized energy rows that no longer match the quality-passing qkv8_float_exact precision point, and identify the recosted PPA work needed before ranking throughput, energy, area, and precision.",
+      "attention_mixed_int8_quality_backed_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.md"
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+    "arch_id": "decoder_attention_mixed_int8_quality_backed_frontier",
+    "macro_mode": "evidence_only",
+    "outcome": "mixed_int8_quality_backed_frontier_recost_required"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+    "title": "Llama7B mixed/int8 quality-backed frontier audit",
+    "primary_question": "Which mixed/int8 energy rows remain rankable after the broad native quality gate?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "quality_backed_frontier",
+    "abstraction_layer": "decoder_attention_mixed_int8_quality_backed_frontier",
+    "expected_direction": "recost_required",
+    "expected_reason": "Broad native quality only passes qkv8_float_exact; old score/softmax-quantized mixed-int8 energy rows must not remain rankable.",
+    "summary": "Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.",
+    "outcome": "mixed_int8_quality_backed_frontier_recost_required",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+    "title": "Llama7B mixed/int8 quality-backed frontier audit",
+    "kind": "architecture",
+    "primary_question": "Which mixed/int8 energy rows remain rankable after the broad native quality gate?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "quality_backed_frontier",
+    "outcome": "mixed_int8_quality_backed_frontier_recost_required",
+    "summary": "Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+    "decoder_quality": {
+      "diagnosis": {
+        "decision": "mixed_int8_quality_backed_frontier_recost_required",
+        "invalidated_energy_candidate_count": 1,
+        "old_energy_best_candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+        "old_energy_best_energy_mj": 135.75588466251537,
+        "old_energy_best_latency_us": 1575.373891,
+        "old_energy_best_precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+        "old_energy_best_token_throughput_per_s": 634.7699461778119,
+        "quality_backed_latency_floor_us_unranked": 1575.373891,
+        "quality_backed_throughput_floor_tok_s_unranked": 634.7699461778119,
+        "quality_best_candidate_id": "qkv8_float_exact",
+        "quality_best_mean_probability_kl": 0.0012425925766148221,
+        "quality_best_top1_match_rate": 1.0,
+        "quality_candidate_count": 4,
+        "quality_passing_candidate_count": 1,
+        "quality_passing_candidate_ids": [
+          "qkv8_float_exact"
+        ],
+        "recommended_next_step": "Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row."
+      },
+      "remaining_abstractions": [
+        "The quality-passing qkv8_float_exact path has not yet been recosted with matching high-precision/exact score-softmax PPA.",
+        "The previous mixed/int8 energy closure remains useful as a latency/traffic floor only; its s8/w8 reciprocal-LUT score-softmax precision is invalid for quality-backed ranking.",
+        "This audit is an evidence reconciliation step and does not rerun OpenROAD or the native model quality gate.",
+        "HBM/SRAM/NoC abstractions from the source energy closure remain unchanged until the recosted precision path is generated."
+      ]
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+    "decoder_attention_mixed_int8_quality_backed_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+    "decoder_attention_mixed_int8_quality_backed_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {
+      "decision": "mixed_int8_quality_backed_frontier_recost_required",
+      "invalidated_energy_candidate_count": 1,
+      "old_energy_best_candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+      "old_energy_best_energy_mj": 135.75588466251537,
+      "old_energy_best_latency_us": 1575.373891,
+      "old_energy_best_precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+      "old_energy_best_token_throughput_per_s": 634.7699461778119,
+      "quality_backed_latency_floor_us_unranked": 1575.373891,
+      "quality_backed_throughput_floor_tok_s_unranked": 634.7699461778119,
+      "quality_best_candidate_id": "qkv8_float_exact",
+      "quality_best_mean_probability_kl": 0.0012425925766148221,
+      "quality_best_top1_match_rate": 1.0,
+      "quality_candidate_count": 4,
+      "quality_passing_candidate_count": 1,
+      "quality_passing_candidate_ids": [
+        "qkv8_float_exact"
+      ],
+      "recommended_next_step": "Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row."
+    },
+    "remaining_abstractions": [
+      "The quality-passing qkv8_float_exact path has not yet been recosted with matching high-precision/exact score-softmax PPA.",
+      "The previous mixed/int8 energy closure remains useful as a latency/traffic floor only; its s8/w8 reciprocal-LUT score-softmax precision is invalid for quality-backed ranking.",
+      "This audit is an evidence reconciliation step and does not rerun OpenROAD or the native model quality gate.",
+      "HBM/SRAM/NoC abstractions from the source energy closure remain unchanged until the recosted precision path is generated."
+    ]
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/evaluated.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/evaluated.json
@@ -1,0 +1,107 @@
+{
+  "flow": "openroad",
+  "task": {
+    "inputs": {
+      "decoder_contract": {
+        "attention_mixed_int8_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+        "attention_mixed_int8_broad_native_quality": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_broad_native_quality__l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json",
+        "attention_mixed_int8_quality_backed_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+        "attention_mixed_int8_quality_backed_frontier_scope": "Reconcile the mixed/int8 energy frontier with the broad native 7B attention-shadow quality gate. Demote score/softmax-quantized energy rows that no longer match the quality-passing qkv8_float_exact precision point, and identify the recosted PPA work needed before ranking throughput, energy, area, and precision.",
+        "attention_mixed_int8_quality_backed_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.md"
+      }
+    },
+    "commands": [
+      {
+        "run": "python3 npu/eval/audit_llm_decoder_attention_mixed_int8_quality_backed_frontier.py --mixed-int8-energy-closure-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json --mixed-int8-broad-native-quality-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_broad_native_quality__l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.md",
+        "name": "audit_decoder_attention_mixed_int8_quality_backed_frontier"
+      },
+      {
+        "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+        "name": "validate_runs"
+      }
+    ],
+    "objective": "Reconcile mixed/int8 energy closure with broad native 7B quality and mark non-matching energy rows unrankable before frontier ranking.",
+    "acceptance": [
+      "Write all declared decoder evidence artifacts",
+      "Keep evidence artifact paths repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "source_mode": "src_verilog",
+    "expected_outputs": [
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.md"
+    ]
+  },
+  "layer": "layer2",
+  "state": "evaluated",
+  "title": "Llama7B mixed/int8 quality-backed frontier audit",
+  "result": {
+    "branch": "eval/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/s20260624t121227z",
+    "completed_utc": "2026-06-24T12:12:25.098977Z",
+    "evaluator_id": "control_plane",
+    "executor": "@control_plane",
+    "host": "b7c2d9c80c1c",
+    "identity_block": "[role:evaluator][account:control_plane][session:s20260624t121227z][host:b7c2d9c80c1c][item:l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1]",
+    "metrics_rows": [],
+    "metrics_exempt_reason": "evidence_only_decoder_evidence",
+    "queue_item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+    "session_id": "s20260624t121227z",
+    "status": "ok",
+    "summary": "2/2 commands succeeded"
+  },
+  "handoff": {
+    "branch": "eval/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/s20260624t121227z",
+    "pr_title": "eval: run llama7b mixed/int8 quality-backed frontier audit",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "pr_body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260624t121227z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"
+    },
+    "identity_block_format": "[role:evaluator][account:<evaluator_id>][session:<session_id>][host:<host>][item:<queue_item_id>]"
+  },
+  "item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+  "version": 0.1,
+  "platform": "nangate45",
+  "priority": 2,
+  "created_utc": "2026-06-24T12:12:01.816040Z",
+  "requested_by": "developer_agent",
+  "developer_loop": {
+    "comparison": {
+      "role": "quality_backed_frontier",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "Broad native quality only passes qkv8_float_exact; old score/softmax-quantized mixed-int8 energy rows must not remain rankable.",
+      "expected_direction": "recost_required"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_mixed_int8_quality_backed_frontier"
+    },
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json"
+  },
+  "source_requirement": {
+    "repo": "",
+    "reason": "evaluator runtime must contain the queued job source commit",
+    "version": 1,
+    "required_ref": "origin/master",
+    "required_sha": "427e92c4a71dd4a4c063ed5871876b16e956d559",
+    "requires_daemon_restart": true
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/pr_body.md
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/pr_body.md
@@ -1,0 +1,40 @@
+## Summary
+- item_id: `l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1`
+- run_key: `l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_run_aa26060ae07e8159`
+- layer: `layer2`
+- task_type: `l2_campaign`
+- status: `ok`
+- summary: `2/2 commands succeeded`
+- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/evaluated.json`
+- metrics_rows_count: `0`
+- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json`
+
+## Developer Context
+- proposal_id: `prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1`
+- proposal_path: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json`
+- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
+- execution_source_commit: `427e92c4a71dd4a4c063ed5871876b16e956d559`
+- review_metadata_source_commit: `427e92c4a71dd4a4c063ed5871876b16e956d559`
+
+## Evaluation Mode
+- evaluation_mode: `frontier_detail`
+- abstraction_layer: `decoder_attention_mixed_int8_quality_backed_frontier`
+- comparison_role: `quality_backed_frontier`
+- expected_direction: `recost_required`
+- expected_reason: `Broad native quality only passes qkv8_float_exact; old score/softmax-quantized mixed-int8 energy rows must not remain rankable.`
+- expectation_status: `unspecified`
+- evaluation_summary: `Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.`
+
+## Focused Comparison
+- primary_question: `Which mixed/int8 energy rows remain rankable after the broad native quality gate?`
+- comparison_role: `quality_backed_frontier`
+- proposal_outcome: `mixed_int8_quality_backed_frontier_recost_required`
+- comparison_summary: `Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.`
+- baseline_ref: `None`
+- baseline_item_id: `None`
+
+## Checklist
+- [ ] Commit lightweight campaign artifacts only
+- [ ] Include metrics row references in result.metrics_rows
+- [ ] Keep committed result_path fields repo-portable
+- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing

--- a/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/review_package.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/review_package.json
@@ -1,0 +1,196 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-06-24T12:12:30.861408Z",
+  "control_plane_source_commit": "427e92c4a71dd4a4c063ed5871876b16e956d559",
+  "review_metadata_source_commit": "427e92c4a71dd4a4c063ed5871876b16e956d559",
+  "item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+  "run_key": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_run_aa26060ae07e8159",
+  "layer": "layer2",
+  "flow": "openroad",
+  "task_type": "l2_campaign",
+  "source_commit": "427e92c4a71dd4a4c063ed5871876b16e956d559",
+  "queue_snapshot": {
+    "path": "control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/evaluated.json",
+    "result": {
+      "branch": "eval/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/s20260624t121227z",
+      "completed_utc": "2026-06-24T12:12:25.098977Z",
+      "evaluator_id": "control_plane",
+      "executor": "@control_plane",
+      "host": "b7c2d9c80c1c",
+      "identity_block": "[role:evaluator][account:control_plane][session:s20260624t121227z][host:b7c2d9c80c1c][item:l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1]",
+      "metrics_rows": [],
+      "metrics_exempt_reason": "evidence_only_decoder_evidence",
+      "queue_item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+      "session_id": "s20260624t121227z",
+      "status": "ok",
+      "summary": "2/2 commands succeeded"
+    }
+  },
+  "review_artifact": {
+    "kind": "decision_proposal",
+    "path": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+    "storage_mode": "repo",
+    "sha256": "0c122b1a8c9613fa089ada9107e013027bde8d98e76395bba5845a0a6188335a",
+    "payload": {
+      "version": 0.1,
+      "generated_utc": "2026-06-24T12:12:26.799585Z",
+      "item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+      "run_key": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_run_aa26060ae07e8159",
+      "layer": "layer2",
+      "flow": "openroad",
+      "platform": "nangate45",
+      "task_type": "l2_campaign",
+      "source_commit": "427e92c4a71dd4a4c063ed5871876b16e956d559",
+      "review_metadata_source_commit": "427e92c4a71dd4a4c063ed5871876b16e956d559",
+      "objective": "Reconcile mixed/int8 energy closure with broad native 7B quality and mark non-matching energy rows unrankable before frontier ranking.",
+      "input_manifest": {
+        "decoder_contract": {
+          "attention_mixed_int8_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+          "attention_mixed_int8_broad_native_quality": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_broad_native_quality__l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json",
+          "attention_mixed_int8_quality_backed_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+          "attention_mixed_int8_quality_backed_frontier_scope": "Reconcile the mixed/int8 energy frontier with the broad native 7B attention-shadow quality gate. Demote score/softmax-quantized energy rows that no longer match the quality-passing qkv8_float_exact precision point, and identify the recosted PPA work needed before ranking throughput, energy, area, and precision.",
+          "attention_mixed_int8_quality_backed_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.md"
+        }
+      },
+      "recommendation": {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+        "arch_id": "decoder_attention_mixed_int8_quality_backed_frontier",
+        "macro_mode": "evidence_only",
+        "outcome": "mixed_int8_quality_backed_frontier_recost_required"
+      },
+      "objective_profiles": [],
+      "evaluation_record": {
+        "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "title": "Llama7B mixed/int8 quality-backed frontier audit",
+        "primary_question": "Which mixed/int8 energy rows remain rankable after the broad native quality gate?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "quality_backed_frontier",
+        "abstraction_layer": "decoder_attention_mixed_int8_quality_backed_frontier",
+        "expected_direction": "recost_required",
+        "expected_reason": "Broad native quality only passes qkv8_float_exact; old score/softmax-quantized mixed-int8 energy rows must not remain rankable.",
+        "summary": "Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.",
+        "outcome": "mixed_int8_quality_backed_frontier_recost_required",
+        "expectation_status": "unspecified"
+      },
+      "proposal_assessment": {
+        "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "title": "Llama7B mixed/int8 quality-backed frontier audit",
+        "kind": "architecture",
+        "primary_question": "Which mixed/int8 energy rows remain rankable after the broad native quality gate?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "quality_backed_frontier",
+        "outcome": "mixed_int8_quality_backed_frontier_recost_required",
+        "summary": "Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.",
+        "baseline_ref": null,
+        "baseline_item_id": null,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+        "decoder_quality": {
+          "diagnosis": {
+            "decision": "mixed_int8_quality_backed_frontier_recost_required",
+            "invalidated_energy_candidate_count": 1,
+            "old_energy_best_candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+            "old_energy_best_energy_mj": 135.75588466251537,
+            "old_energy_best_latency_us": 1575.373891,
+            "old_energy_best_precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+            "old_energy_best_token_throughput_per_s": 634.7699461778119,
+            "quality_backed_latency_floor_us_unranked": 1575.373891,
+            "quality_backed_throughput_floor_tok_s_unranked": 634.7699461778119,
+            "quality_best_candidate_id": "qkv8_float_exact",
+            "quality_best_mean_probability_kl": 0.0012425925766148221,
+            "quality_best_top1_match_rate": 1.0,
+            "quality_candidate_count": 4,
+            "quality_passing_candidate_count": 1,
+            "quality_passing_candidate_ids": [
+              "qkv8_float_exact"
+            ],
+            "recommended_next_step": "Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row."
+          },
+          "remaining_abstractions": [
+            "The quality-passing qkv8_float_exact path has not yet been recosted with matching high-precision/exact score-softmax PPA.",
+            "The previous mixed/int8 energy closure remains useful as a latency/traffic floor only; its s8/w8 reciprocal-LUT score-softmax precision is invalid for quality-backed ranking.",
+            "This audit is an evidence reconciliation step and does not rerun OpenROAD or the native model quality gate.",
+            "HBM/SRAM/NoC abstractions from the source energy closure remain unchanged until the recosted precision path is generated."
+          ]
+        }
+      },
+      "source_refs": {
+        "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+        "decoder_attention_mixed_int8_quality_backed_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+        "decoder_attention_mixed_int8_quality_backed_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.md"
+      },
+      "decoder_quality": {
+        "diagnosis": {
+          "decision": "mixed_int8_quality_backed_frontier_recost_required",
+          "invalidated_energy_candidate_count": 1,
+          "old_energy_best_candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+          "old_energy_best_energy_mj": 135.75588466251537,
+          "old_energy_best_latency_us": 1575.373891,
+          "old_energy_best_precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+          "old_energy_best_token_throughput_per_s": 634.7699461778119,
+          "quality_backed_latency_floor_us_unranked": 1575.373891,
+          "quality_backed_throughput_floor_tok_s_unranked": 634.7699461778119,
+          "quality_best_candidate_id": "qkv8_float_exact",
+          "quality_best_mean_probability_kl": 0.0012425925766148221,
+          "quality_best_top1_match_rate": 1.0,
+          "quality_candidate_count": 4,
+          "quality_passing_candidate_count": 1,
+          "quality_passing_candidate_ids": [
+            "qkv8_float_exact"
+          ],
+          "recommended_next_step": "Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row."
+        },
+        "remaining_abstractions": [
+          "The quality-passing qkv8_float_exact path has not yet been recosted with matching high-precision/exact score-softmax PPA.",
+          "The previous mixed/int8 energy closure remains useful as a latency/traffic floor only; its s8/w8 reciprocal-LUT score-softmax precision is invalid for quality-backed ranking.",
+          "This audit is an evidence reconciliation step and does not rerun OpenROAD or the native model quality gate.",
+          "HBM/SRAM/NoC abstractions from the source energy closure remain unchanged until the recosted precision path is generated."
+        ]
+      }
+    }
+  },
+  "developer_loop": {
+    "comparison": {
+      "role": "quality_backed_frontier",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "Broad native quality only passes qkv8_float_exact; old score/softmax-quantized mixed-int8 energy rows must not remain rankable.",
+      "expected_direction": "recost_required"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_mixed_int8_quality_backed_frontier"
+    },
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json"
+  },
+  "submission_history": null,
+  "pr_payload": {
+    "branch": "eval/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/s20260624t121227z",
+    "title": "eval: run llama7b mixed/int8 quality-backed frontier audit",
+    "body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260624t121227z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"
+    },
+    "body_md": "## Summary\n- item_id: `l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1`\n- run_key: `l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_run_aa26060ae07e8159`\n- layer: `layer2`\n- task_type: `l2_campaign`\n- status: `ok`\n- summary: `2/2 commands succeeded`\n- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/evaluated.json`\n- metrics_rows_count: `0`\n- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json`\n\n## Developer Context\n- proposal_id: `prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1`\n- proposal_path: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json`\n- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`\n- execution_source_commit: `427e92c4a71dd4a4c063ed5871876b16e956d559`\n- review_metadata_source_commit: `427e92c4a71dd4a4c063ed5871876b16e956d559`\n\n## Evaluation Mode\n- evaluation_mode: `frontier_detail`\n- abstraction_layer: `decoder_attention_mixed_int8_quality_backed_frontier`\n- comparison_role: `quality_backed_frontier`\n- expected_direction: `recost_required`\n- expected_reason: `Broad native quality only passes qkv8_float_exact; old score/softmax-quantized mixed-int8 energy rows must not remain rankable.`\n- expectation_status: `unspecified`\n- evaluation_summary: `Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.`\n\n## Focused Comparison\n- primary_question: `Which mixed/int8 energy rows remain rankable after the broad native quality gate?`\n- comparison_role: `quality_backed_frontier`\n- proposal_outcome: `mixed_int8_quality_backed_frontier_recost_required`\n- comparison_summary: `Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.`\n- baseline_ref: `None`\n- baseline_item_id: `None`\n\n## Checklist\n- [ ] Commit lightweight campaign artifacts only\n- [ ] Include metrics row references in result.metrics_rows\n- [ ] Keep committed result_path fields repo-portable\n- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing\n",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ]
+  }
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json
@@ -1,0 +1,203 @@
+{
+  "decision": "mixed_int8_quality_backed_frontier_recost_required",
+  "diagnosis": {
+    "decision": "mixed_int8_quality_backed_frontier_recost_required",
+    "invalidated_energy_candidate_count": 1,
+    "old_energy_best_candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+    "old_energy_best_energy_mj": 135.75588466251537,
+    "old_energy_best_latency_us": 1575.373891,
+    "old_energy_best_precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+    "old_energy_best_token_throughput_per_s": 634.7699461778119,
+    "quality_backed_latency_floor_us_unranked": 1575.373891,
+    "quality_backed_throughput_floor_tok_s_unranked": 634.7699461778119,
+    "quality_best_candidate_id": "qkv8_float_exact",
+    "quality_best_mean_probability_kl": 0.0012425925766148221,
+    "quality_best_top1_match_rate": 1.0,
+    "quality_candidate_count": 4,
+    "quality_passing_candidate_count": 1,
+    "quality_passing_candidate_ids": [
+      "qkv8_float_exact"
+    ],
+    "recommended_next_step": "Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row."
+  },
+  "inputs": {
+    "mixed_int8_broad_native_quality_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_broad_native_quality__l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1_r2.json",
+    "mixed_int8_energy_closure_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json"
+  },
+  "invalidated_energy_candidates": [
+    {
+      "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+      "compute_energy_mj": 1.5372362316073815,
+      "die_area_mm2": 800.0,
+      "dominant_energy_component": "hbm",
+      "energy_mj": 135.75588466251537,
+      "hbm_energy_mj": 134.14461348516411,
+      "latency_us": 1575.373891,
+      "noc_energy_mj": 0.07399145446230194,
+      "precision": {
+        "compute_arch": "dense_gemm_int8_16x8_k1_p1",
+        "compute_replica_count": 855,
+        "measured_softmax_weight_metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv",
+        "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+        "softmax_weight_generator_metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q12_wrapper/metrics.csv"
+      },
+      "quality_frontier_status": "invalid_for_quality_backed_ranking",
+      "reason": "energy row uses score/softmax quantization or reciprocal-LUT softmax evidence, while broad native quality only passed qkv8_float_exact",
+      "sram_energy_mj": 4.349128155786915e-05,
+      "token_throughput_per_s": 634.7699461778119
+    }
+  ],
+  "model": "llm_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+  "old_energy_best": {
+    "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+    "compute_energy_mj": 1.5372362316073815,
+    "die_area_mm2": 800.0,
+    "dominant_energy_component": "hbm",
+    "energy_mj": 135.75588466251537,
+    "hbm_energy_mj": 134.14461348516411,
+    "latency_us": 1575.373891,
+    "noc_energy_mj": 0.07399145446230194,
+    "precision": {
+      "compute_arch": "dense_gemm_int8_16x8_k1_p1",
+      "compute_replica_count": 855,
+      "measured_softmax_weight_metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv",
+      "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+      "softmax_weight_generator_metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q12_wrapper/metrics.csv"
+    },
+    "sram_energy_mj": 4.349128155786915e-05,
+    "token_throughput_per_s": 634.7699461778119
+  },
+  "old_latency_best": {
+    "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+    "compute_energy_mj": 1.5372362316073815,
+    "die_area_mm2": 800.0,
+    "dominant_energy_component": "hbm",
+    "energy_mj": 135.75588466251537,
+    "hbm_energy_mj": 134.14461348516411,
+    "latency_us": 1575.373891,
+    "noc_energy_mj": 0.07399145446230194,
+    "precision": {
+      "compute_arch": "dense_gemm_int8_16x8_k1_p1",
+      "compute_replica_count": 855,
+      "measured_softmax_weight_metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv",
+      "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+      "softmax_weight_generator_metrics_csv": "runs/designs/activations/attention_softmax_weight_int8_r8_acc24_recip_q12_wrapper/metrics.csv"
+    },
+    "sram_energy_mj": 4.349128155786915e-05,
+    "token_throughput_per_s": 634.7699461778119
+  },
+  "quality_backed_direction": {
+    "candidate": {
+      "candidate_id": "qkv8_float_exact",
+      "comparison_count": 64,
+      "decision_status": "mixed_int8_native_attention_shadow_pass",
+      "max_abs_logit_delta_max": 0.52734375,
+      "mean_logit_cosine": 0.9998988400355315,
+      "mean_probability_kl": 0.0012425925766148221,
+      "precision": {
+        "candidate_id": "qkv8_float_exact",
+        "k_bits": 8,
+        "q_bits": 8,
+        "score_bits": 24,
+        "softmax_mode": "float_exact",
+        "v_bits": 8,
+        "weight_bits": 16
+      },
+      "top1_match_rate": 1.0,
+      "topk_contains_rate": 1.0
+    },
+    "rankable_for_energy_frontier": false,
+    "recost_requirement": "Substitute or measure high-precision/exact score-softmax PPA for the passing qkv8_float_exact path before comparing throughput, energy, or area against FP16/dense baselines.",
+    "status": "quality_pass_requires_energy_recost"
+  },
+  "quality_candidates": {
+    "held_or_failed": [
+      {
+        "candidate_id": "score22_float",
+        "comparison_count": 64,
+        "decision_status": "mixed_int8_native_attention_shadow_hold",
+        "max_abs_logit_delta_max": 9.15625,
+        "mean_logit_cosine": 0.960946901557213,
+        "mean_probability_kl": 0.7998143431920477,
+        "precision": {
+          "candidate_id": "score22_float",
+          "k_bits": 8,
+          "q_bits": 8,
+          "score_bits": 22,
+          "softmax_mode": "float_quantized",
+          "v_bits": 8,
+          "weight_bits": 16
+        },
+        "top1_match_rate": 0.578125,
+        "topk_contains_rate": 0.90625
+      },
+      {
+        "candidate_id": "score24_float",
+        "comparison_count": 64,
+        "decision_status": "mixed_int8_native_attention_shadow_hold",
+        "max_abs_logit_delta_max": 0.53125,
+        "mean_logit_cosine": 0.9999025562684435,
+        "mean_probability_kl": 0.0014115558838723183,
+        "precision": {
+          "candidate_id": "score24_float",
+          "k_bits": 8,
+          "q_bits": 8,
+          "score_bits": 24,
+          "softmax_mode": "float_quantized",
+          "v_bits": 8,
+          "weight_bits": 16
+        },
+        "top1_match_rate": 0.96875,
+        "topk_contains_rate": 1.0
+      },
+      {
+        "candidate_id": "score24_rtl_exact",
+        "comparison_count": 64,
+        "decision_status": "mixed_int8_native_attention_shadow_hold",
+        "max_abs_logit_delta_max": 11.125,
+        "mean_logit_cosine": 0.9461727371541662,
+        "mean_probability_kl": 1.0505308035963772,
+        "precision": {
+          "candidate_id": "score24_rtl_exact",
+          "k_bits": 8,
+          "q_bits": 8,
+          "score_bits": 24,
+          "softmax_mode": "rtl_exact",
+          "v_bits": 8,
+          "weight_bits": 8
+        },
+        "top1_match_rate": 0.59375,
+        "topk_contains_rate": 0.796875
+      }
+    ],
+    "passing": [
+      {
+        "candidate_id": "qkv8_float_exact",
+        "comparison_count": 64,
+        "decision_status": "mixed_int8_native_attention_shadow_pass",
+        "max_abs_logit_delta_max": 0.52734375,
+        "mean_logit_cosine": 0.9998988400355315,
+        "mean_probability_kl": 0.0012425925766148221,
+        "precision": {
+          "candidate_id": "qkv8_float_exact",
+          "k_bits": 8,
+          "q_bits": 8,
+          "score_bits": 24,
+          "softmax_mode": "float_exact",
+          "v_bits": 8,
+          "weight_bits": 16
+        },
+        "top1_match_rate": 1.0,
+        "topk_contains_rate": 1.0
+      }
+    ]
+  },
+  "quality_gate_status": "mixed_int8_native_attention_shadow_hold",
+  "remaining_abstractions": [
+    "The quality-passing qkv8_float_exact path has not yet been recosted with matching high-precision/exact score-softmax PPA.",
+    "The previous mixed/int8 energy closure remains useful as a latency/traffic floor only; its s8/w8 reciprocal-LUT score-softmax precision is invalid for quality-backed ranking.",
+    "This audit is an evidence reconciliation step and does not rerun OpenROAD or the native model quality gate.",
+    "HBM/SRAM/NoC abstractions from the source energy closure remain unchanged until the recosted precision path is generated."
+  ],
+  "version": 1
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.md
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.md
@@ -1,0 +1,25 @@
+# Llama7B Mixed-Int8 Quality-Backed Frontier Audit
+
+- decision: `mixed_int8_quality_backed_frontier_recost_required`
+- quality passing candidates: `['qkv8_float_exact']`
+- invalidated energy candidates: `1`
+- recommended next step: `Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.`
+
+## Quality-Backed Direction
+
+| candidate | status | top1 | top-k | KL | rankable for energy frontier |
+|---|---|---:|---:|---:|---|
+| qkv8_float_exact | mixed_int8_native_attention_shadow_pass | 1.0 | 1.0 | 0.0012425925766148221 | False |
+
+## Previous Energy Best
+
+| candidate | precision profile | latency us | throughput tok/s | energy mJ | dominant | status |
+|---|---|---:|---:|---:|---|---|
+| die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024 | q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute | 1575.373891 | 634.7699461778119 | 135.75588466251537 | hbm | invalidated for quality-backed ranking |
+
+## Remaining Abstractions
+
+- The quality-passing qkv8_float_exact path has not yet been recosted with matching high-precision/exact score-softmax PPA.
+- The previous mixed/int8 energy closure remains useful as a latency/traffic floor only; its s8/w8 reciprocal-LUT score-softmax precision is invalid for quality-backed ranking.
+- This audit is an evidence reconciliation step and does not rerun OpenROAD or the native model quality gate.
+- HBM/SRAM/NoC abstractions from the source energy closure remain unchanged until the recosted precision path is generated.


### PR DESCRIPTION
## Summary
- item_id: `l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1`
- run_key: `l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_run_aa26060ae07e8159`
- layer: `layer2`
- task_type: `l2_campaign`
- status: `ok`
- summary: `2/2 commands succeeded`
- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/evaluated.json`
- metrics_rows_count: `0`
- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json`

## Developer Context
- proposal_id: `prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1`
- proposal_path: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json`
- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
- execution_source_commit: `427e92c4a71dd4a4c063ed5871876b16e956d559`
- review_metadata_source_commit: `427e92c4a71dd4a4c063ed5871876b16e956d559`

## Evaluation Mode
- evaluation_mode: `frontier_detail`
- abstraction_layer: `decoder_attention_mixed_int8_quality_backed_frontier`
- comparison_role: `quality_backed_frontier`
- expected_direction: `recost_required`
- expected_reason: `Broad native quality only passes qkv8_float_exact; old score/softmax-quantized mixed-int8 energy rows must not remain rankable.`
- expectation_status: `unspecified`
- evaluation_summary: `Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.`

## Focused Comparison
- primary_question: `Which mixed/int8 energy rows remain rankable after the broad native quality gate?`
- comparison_role: `quality_backed_frontier`
- proposal_outcome: `mixed_int8_quality_backed_frontier_recost_required`
- comparison_summary: `Decoder mixed/int8 quality-backed frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json: decision=mixed_int8_quality_backed_frontier_recost_required; quality_passing_candidate_count=1; quality_passing_candidate_ids=['qkv8_float_exact']; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; quality_best_mean_probability_kl=0.0012425925766148221; invalidated_energy_candidate_count=1; old_energy_best_candidate_id=die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024; old_energy_best_latency_us=1575.373891; old_energy_best_token_throughput_per_s=634.7699461778119; old_energy_best_energy_mj=135.75588466251537; old_energy_best_precision_profile=q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute; recommended_next_step=Recompute the Llama7B energy frontier for q8/k8/v8 projection quantization with high-precision or exact score/softmax PPA; do not rank the old s8/w8 reciprocal-LUT energy row.`
- baseline_ref: `None`
- baseline_item_id: `None`

## Checklist
- [ ] Commit lightweight campaign artifacts only
- [ ] Include metrics row references in result.metrics_rows
- [ ] Keep committed result_path fields repo-portable
- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing
