### PR TITLE
control_plane: add q12 PWL mixed-int8 quality gate

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -495,6 +495,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_broad_native_quality_report",
     ),
     (
+        "attention_mixed_int8_q12_pwl_native_quality_out",
+        "attention_mixed_int8_q12_pwl_native_quality_report",
+    ),
+    (
         "attention_mixed_int8_quality_backed_frontier_out",
         "attention_mixed_int8_quality_backed_frontier_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6279,6 +6279,60 @@ def _decoder_attention_mixed_int8_broad_native_quality_evidence(*, item_id: str)
     }
 
 
+def _decoder_attention_mixed_int8_q12_pwl_native_quality_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_int8_q12_pwl_native_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_q12_pwl_native_quality__{item_id}.md"
+    quality_backed_frontier = (
+        f"{base}/decoder_attention_mixed_int8_quality_backed_frontier__"
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_mixed_int8_quality_backed_frontier": quality_backed_frontier,
+            "attention_mixed_int8_q12_pwl_native_quality_out": out,
+            "attention_mixed_int8_q12_pwl_native_quality_report": report,
+            "attention_mixed_int8_q12_pwl_native_quality_scope": (
+                "Validate whether the measured q12/PWL reciprocal-LUT softmax datapath can "
+                "serve as a quality-backed hardware proxy for the q8/k8/v8 float-exact "
+                "mixed/int8 frontier. The PWL mode mirrors the measured block's "
+                "score_bits=12, weight_bits=12, input_frac_bits=8, reciprocal_bits=12, "
+                "and reciprocal_lut_bucket_shift=8 contract."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_q12_pwl_native_quality",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_BROAD_MAX_PROMPTS:-8}; "
+                    "GEN_STEPS=${RTLGEN_MODEL_NATIVE_7B_BROAD_GENERATION_STEPS:-8}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--generation-steps \"$GEN_STEPS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--topk 5 "
+                    "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact "
+                    "--candidate qkv8_score24_float:q8,k8,v8,s24,w16,float_quantized "
+                    "--candidate qkv8_score24_rtl_exact:q8,k8,v8,s24,w8,rtl_exact "
+                    "--candidate qkv8_q12_pwl_recip_q12_bucket8:q8,k8,v8,s12,w12,pwl_recip_lut_q12_bucket8 "
+                    "--primary-candidate-id qkv8_q12_pwl_recip_q12_bucket8 "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     energy_closure = (
@@ -8211,6 +8265,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_score_boundary",
         "decoder_attention_mixed_int8_high_score_boundary",
         "decoder_attention_mixed_int8_broad_native_quality",
+        "decoder_attention_mixed_int8_q12_pwl_native_quality",
         "decoder_attention_mixed_int8_quality_backed_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
@@ -8402,6 +8457,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_high_score_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_broad_native_quality":
             decoder_evidence = _decoder_attention_mixed_int8_broad_native_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_q12_pwl_native_quality":
+            decoder_evidence = _decoder_attention_mixed_int8_q12_pwl_native_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
             decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -447,6 +447,143 @@ def test_consume_l2_result_frontier_attention_mixed_int8_broad_native_quality_us
             )
 
 
+def test_consume_l2_result_frontier_attention_mixed_int8_q12_pwl_native_quality_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_attention_mixed_int8_q12_pwl_native_quality_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_mixed_int8_q12_pwl_native_quality_v1",
+                        "kind": "architecture",
+                        "title": "Attention mixed-int8 q12 PWL native quality",
+                        "direct_comparison": {
+                            "primary_question": "Can the measured q12/PWL softmax proxy keep quality?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_q12_pwl_native_quality__"
+                "l2_attention_mixed_int8_q12_pwl_native_quality_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_q12_pwl_native_quality__"
+                "l2_attention_mixed_int8_q12_pwl_native_quality_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "quality_gate": "mixed_int8_attention_shadow",
+                        "model": {
+                            "model_id": "mistralai/Mistral-7B-v0.1",
+                            "attention_heads": 32,
+                            "kv_heads": 8,
+                            "gqa_group_size": 4.0,
+                            "dtype": "bfloat16",
+                        },
+                        "precision": {
+                            "q_bits": 8,
+                            "k_bits": 8,
+                            "v_bits": 8,
+                            "score_bits": 12,
+                            "weight_bits": 12,
+                            "softmax_mode": "pwl_recip_lut_q12_bucket8",
+                        },
+                        "summary": {
+                            "comparison_count": 64,
+                            "top1_match_rate": 1.0,
+                            "topk_contains_rate": 1.0,
+                            "mean_logit_cosine": 0.9999,
+                            "mean_probability_kl": 0.001,
+                            "max_abs_logit_delta_max": 0.5,
+                        },
+                        "decision": {
+                            "status": "mixed_int8_native_attention_shadow_pass",
+                            "next_step": "Use the q12/PWL row as a measured-hardware proxy.",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# mixed-int8 q12 PWL native quality\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_mixed_int8_q12_pwl_native_quality_v1",
+                campaign_dir_rel="runs/campaigns/npu/attention_mixed_int8_q12_pwl_native_quality_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_mixed_int8_q12_pwl_native_quality_v1",
+                comparison={"role": "precision_validation"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "quality_gate",
+                "expected_direction": "iterate",
+                "expected_reason": "Check q12/PWL softmax proxy quality before recosting.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_mixed_int8_q12_pwl_native_quality",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_mixed_int8_q12_pwl_native_quality_out": evidence_rel,
+                    "attention_mixed_int8_q12_pwl_native_quality_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "mixed_int8_native_attention_shadow_pass"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_mixed_int8_q12_pwl_native_quality"
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_q12_pwl_native_quality_out"
+                ]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_q12_pwl_native_quality_report"
+                ]
+                == report_rel
+            )
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7100,6 +7100,79 @@ def test_generate_l2_campaign_task_adds_mixed_int8_broad_native_quality_evidence
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_q12_pwl_native_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_q12_pwl_native_quality",
+                    evaluation_mode="quality_gate",
+                    comparison_role="precision_validation",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_q12_pwl_native_quality",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_attention.py" in run
+            assert "pwl_recip_lut_q12_bucket8" in run
+            assert "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact" in run
+            assert "--candidate qkv8_score24_float:q8,k8,v8,s24,w16,float_quantized" in run
+            assert "--candidate qkv8_score24_rtl_exact:q8,k8,v8,s24,w8,rtl_exact" in run
+            assert (
+                "--candidate qkv8_q12_pwl_recip_q12_bucket8:q8,k8,v8,s12,w12,pwl_recip_lut_q12_bucket8"
+                in run
+            )
+            assert "--primary-candidate-id qkv8_q12_pwl_recip_q12_bucket8" in run
+            assert decoder_inputs["attention_mixed_int8_quality_backed_frontier"].endswith(
+                "decoder_attention_mixed_int8_quality_backed_frontier__"
+                "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_q12_pwl_native_quality_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_q12_pwl_native_quality_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_q12_pwl_native_quality",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": ["l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,24 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1",
+  "requests": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the native 7B mixed/int8 attention-shadow quality gate for q8/k8/v8 with q12/PWL reciprocal-LUT softmax.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_q12_pwl_native_quality",
+      "comparison_role": "precision_validation",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "validate_or_reject_q12_pwl_hardware_proxy",
+        "reason": "Measured q12/PWL PPA should only be used for the mixed/int8 frontier if its arithmetic passes the native quality gate."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1/proposal.json
@@ -1,0 +1,81 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1",
+  "created_utc": "2026-06-25T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 q12-PWL native quality gate",
+  "abstraction_layer": "decoder_attention_mixed_int8_q12_pwl_native_quality",
+  "hypothesis": "The measured q12/PWL reciprocal-LUT softmax datapath may be a cheaper hardware proxy for the only broad-quality-passing q8/k8/v8 float-exact mixed/int8 attention direction, but it must pass the native 7B attention-shadow quality gate before it can be used for throughput, energy, and area ranking.",
+  "direct_comparison": {
+    "primary_question": "Does q8/k8/v8 with the measured q12/PWL reciprocal-LUT softmax arithmetic preserve the Llama7B native attention-shadow quality of the qkv8_float_exact control?",
+    "baseline": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+    "candidate": "qkv8_q12_pwl_recip_q12_bucket8",
+    "include": [
+      "q8/k8/v8 projection quantization",
+      "q12 score quantization with fixed input_frac_bits=8",
+      "q12 PWL exp anchors at 0, 2, 4, and 8",
+      "q12 reciprocal normalization with reciprocal_lut_bucket_shift=8",
+      "float-exact, score24 float-quantized, and score24 RTL-exact controls"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "QAT or fine-tuning recovery",
+      "new HBM/SRAM/NoC modeling",
+      "using q12/PWL PPA as rankable unless this quality gate passes"
+    ],
+    "metrics": [
+      "decision",
+      "candidate_summaries",
+      "top1_match_rate",
+      "topk_contains_rate",
+      "mean_logit_cosine",
+      "mean_probability_kl",
+      "max_abs_logit_delta_max",
+      "best_candidate"
+    ]
+  },
+  "expected_benefit": [
+    "separate precision validity from PPA availability for the measured q12/PWL softmax block",
+    "decide whether existing q12/PWL dual-stream PPA can be used as a bounded hardware proxy",
+    "avoid recosting the mixed/int8 frontier with a softmax approximation that the native model rejects"
+  ],
+  "risks": [
+    "the quality gate is still attention-shadow evidence rather than full task accuracy",
+    "the existing measured composed q12/PWL datapath uses v6 values, so a passing result still requires a v8 PPA recost or explicit substitution caveat",
+    "PWL score scaling is fixed to the measured input_frac_bits=8 contract and may need later range adaptation"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the native 7B mixed/int8 attention-shadow gate for q8/k8/v8 with q12/PWL reciprocal-LUT softmax and controls.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_q12_pwl_native_quality",
+      "comparison_role": "precision_validation",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "validate_or_reject_q12_pwl_hardware_proxy",
+        "reason": "The current mixed/int8 frontier only has qkv8_float_exact quality backing; measured q12/PWL PPA cannot be ranked unless its arithmetic passes the native quality gate."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/metrics.csv"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json"
+  ]
+}

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -461,6 +461,15 @@ q8/k8/v8 projection path with matching high-precision or exact score-softmax
 hardware before comparing token throughput, energy, and area against the FP16
 baseline.
 
+The measured q12/PWL reciprocal-LUT softmax path is a candidate proxy for that
+recost, but only after a native quality gate validates the same arithmetic. In
+the mixed/int8 native evaluator, use softmax mode
+`pwl_recip_lut_q12_bucket8` for the measured contract:
+`score_bits=12`, `weight_bits=12`, fixed `input_frac_bits=8`, PWL exp anchors
+at 0/2/4/8, `reciprocal_bits=12`, and `reciprocal_lut_bucket_shift=8`.
+Do not substitute the q12/PWL PPA row for `qkv8_float_exact` unless this gate
+passes or the report explicitly marks the substitution as not quality-backed.
+
 Optionally verify path-like fields exist:
 ```sh
 python3 npu/eval/validate.py --campaign <campaign.json> --check_paths

--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
@@ -113,6 +113,22 @@ def _rtl_reciprocal_bits(mode: str) -> int:
     return bits
 
 
+def _pwl_reciprocal_mode(mode: str) -> tuple[int, int]:
+    prefix = "pwl_recip_lut_q"
+    bucket_token = "_bucket"
+    if not mode.startswith(prefix) or bucket_token not in mode:
+        return 0, 0
+    bits_text, bucket_text = mode[len(prefix) :].split(bucket_token, 1)
+    try:
+        reciprocal_bits = int(bits_text)
+        bucket_shift = int(bucket_text)
+    except ValueError as exc:
+        raise ValueError(f"unsupported softmax mode: {mode}") from exc
+    if reciprocal_bits <= 0 or reciprocal_bits > 24 or bucket_shift < 0 or bucket_shift > 12:
+        raise ValueError(f"unsupported softmax mode: {mode}")
+    return reciprocal_bits, bucket_shift
+
+
 def _quantize_symmetric_list(values: list[float], bits: int) -> tuple[list[int], float]:
     if bits >= 24:
         return [int(round(value * 1024.0)) for value in values], 1.0 / 1024.0
@@ -122,6 +138,86 @@ def _quantize_symmetric_list(values: list[float], bits: int) -> tuple[list[int],
         return [0 for _ in values], 1.0
     scale = max_abs / levels
     return [max(-levels, min(levels, int(round(value / scale)))) for value in values], scale
+
+
+def _pwl_recip_lut_softmax(
+    logits: list[float],
+    *,
+    score_bits: int,
+    weight_bits: int,
+    reciprocal_bits: int,
+    bucket_shift: int,
+    input_frac_bits: int = 8,
+) -> list[float]:
+    if score_bits < 2 or score_bits > 24:
+        raise ValueError("PWL reciprocal softmax expects score_bits in [2, 24]")
+    if weight_bits < 2 or weight_bits > 24:
+        raise ValueError("PWL reciprocal softmax expects weight_bits in [2, 24]")
+    if not logits:
+        return []
+
+    input_scale = 1 << input_frac_bits
+    output_scale = (1 << weight_bits) - 1
+    min_score = -(1 << (score_bits - 1))
+    max_score = (1 << (score_bits - 1)) - 1
+    q_logits = [
+        max(min_score, min(max_score, int(round(value * input_scale))))
+        for value in logits
+    ]
+    row_max = max(q_logits)
+
+    x2 = 2 * input_scale
+    x4 = 4 * input_scale
+    x8 = 8 * input_scale
+    y0 = output_scale
+    y2 = int(math.exp(-2.0) * output_scale + 0.5)
+    y4 = int(math.exp(-4.0) * output_scale + 0.5)
+    y8 = int(math.exp(-8.0) * output_scale + 0.5)
+
+    def pwl_weight(delta_in: int) -> int:
+        clamped_delta = max(0, delta_in)
+        if clamped_delta > x8:
+            return 0
+        if clamped_delta == x8:
+            return y8
+        if clamped_delta <= x2:
+            seg_x0 = 0
+            seg_width = x2
+            y0_seg = y0
+            y1_seg = y2
+        elif clamped_delta <= x4:
+            seg_x0 = x2
+            seg_width = x4 - x2
+            y0_seg = y2
+            y1_seg = y4
+        else:
+            seg_x0 = x4
+            seg_width = x8 - x4
+            y0_seg = y4
+            y1_seg = y8
+        ydiff = y0_seg - y1_seg
+        interp_num = ((clamped_delta - seg_x0) * ydiff) + (seg_width >> 1)
+        return y0_seg - (interp_num // seg_width)
+
+    exp_weights = [pwl_weight(row_max - value) for value in q_logits]
+    sum_weight = sum(exp_weights)
+    if sum_weight <= 0:
+        return _safe_exp_softmax(logits)
+
+    bucket_step = 1 << bucket_shift
+    reciprocal_bucket = (sum_weight + bucket_step - 1) >> bucket_shift
+    if reciprocal_bucket <= 0:
+        reciprocal_q = 0
+    else:
+        bucket_denom = reciprocal_bucket << bucket_shift
+        reciprocal_q = ((output_scale << reciprocal_bits) + (bucket_denom >> 1)) // bucket_denom
+
+    lanes: list[int] = []
+    for weight in exp_weights:
+        lane_scaled = (weight * reciprocal_q) + (1 << (reciprocal_bits - 1))
+        lane_scaled >>= reciprocal_bits
+        lanes.append(min(output_scale, lane_scaled))
+    return [lane / float(output_scale) for lane in lanes]
 
 
 def _rtl_quantized_softmax(
@@ -329,6 +425,11 @@ def _parse_candidate_list(value: str) -> list[CandidateConfig]:
 
 def _parse_softmax_mode(value: str) -> str:
     supported = {"float_quantized", "float_exact", "rtl_exact", "rtl_pow2sum", "rtl_recip_lut_q8"}
+    if value.startswith("pwl_recip_lut_q"):
+        reciprocal_bits, _ = _pwl_reciprocal_mode(value)
+        if reciprocal_bits <= 0:
+            raise argparse.ArgumentTypeError(f"unsupported softmax mode: {value}")
+        return value
     if value.startswith("rtl_recip_lut_q"):
         bits = _rtl_reciprocal_bits(value)
         if bits <= 0:
@@ -614,6 +715,16 @@ def _softmax_patch(score_bits: int, weight_bits: int, softmax_mode: str):
         if softmax_mode == "float_exact":
             out = _safe_exp_softmax(values)
             return torch.tensor(out, dtype=torch.float32, device=row.device).reshape(row.shape)
+        if softmax_mode.startswith("pwl_recip_lut_q"):
+            reciprocal_bits, bucket_shift = _pwl_reciprocal_mode(softmax_mode)
+            out = _pwl_recip_lut_softmax(
+                values,
+                score_bits=score_bits,
+                weight_bits=weight_bits,
+                reciprocal_bits=reciprocal_bits,
+                bucket_shift=bucket_shift,
+            )
+            return torch.tensor(out, dtype=row.dtype if row.dtype.is_floating_point else torch.float32, device=row.device).reshape(row.shape)
         out = _rtl_quantized_softmax(values, score_bits=score_bits, weight_bits=weight_bits, softmax_mode=softmax_mode)
         return torch.tensor(out, dtype=row.dtype if row.dtype.is_floating_point else torch.float32, device=row.device).reshape(row.shape)
 


### PR DESCRIPTION
Adds a native mixed/int8 quality gate for the measured q12/PWL reciprocal-LUT softmax path so we can decide whether existing q12/PWL PPA is a valid proxy for the qkv8_float_exact frontier.\n\nChanges:\n- adds evaluator softmax mode `pwl_recip_lut_q12_bucket8`, mirroring the measured q12 PWL block: score_bits=12, weight_bits=12, input_frac_bits=8, reciprocal_bits=12, reciprocal_lut_bucket_shift=8\n- adds L2 abstraction `decoder_attention_mixed_int8_q12_pwl_native_quality` and proposal metadata\n- wires result-consumer source refs for the new evidence artifact\n- documents the q12/PWL proxy caveat in `npu/eval/README.md`\n\nValidation:\n- `python3 -m py_compile npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py`\n- parser/arithmetic smoke for `pwl_recip_lut_q12_bucket8`\n- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_broad_native_quality_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_q12_pwl_native_quality_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_mixed_int8_native_quality control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_mixed_int8_quality_backed_frontier control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_mixed_int8_q12_pwl_native_quality_uses_decoder_evidence`