### PR TITLE
npu: parse pwl recip native attention candidates

### DIFF
--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
@@ -355,7 +355,11 @@ def _parse_candidate_spec(spec: Any) -> CandidateConfig:
             for part in parts:
                 if len(part) == 0:
                     continue
-                if part in {"float_quantized", "float_exact", "rtl_exact", "rtl_pow2sum"} or part.startswith("rtl_recip_lut_q"):
+                if (
+                    part in {"float_quantized", "float_exact", "rtl_exact", "rtl_pow2sum"}
+                    or part.startswith("rtl_recip_lut_q")
+                    or part.startswith("pwl_recip_lut_q")
+                ):
                     if softmax_mode:
                         raise ValueError(f"candidate spec {spec!r} has duplicate softmax mode tokens")
                     softmax_mode = part

--- a/tests/test_llm_decoder_model_native_mixed_int8_attention.py
+++ b/tests/test_llm_decoder_model_native_mixed_int8_attention.py
@@ -215,6 +215,14 @@ def test_parse_candidate_spec_and_list_compatibility() -> None:
     generated = _parse_candidate_spec("q8,k8,v8,s8,w8,rtl_recip_lut_q10")
     assert generated.candidate_id == "q8_k8_v8_s8_w8_rtl_recip_lut_q10"
 
+    q12_pwl = _parse_candidate_spec(
+        "qkv8_q12_pwl_recip_q12_bucket8:q8,k8,v8,s12,w12,pwl_recip_lut_q12_bucket8"
+    )
+    assert q12_pwl.candidate_id == "qkv8_q12_pwl_recip_q12_bucket8"
+    assert q12_pwl.score_bits == 12
+    assert q12_pwl.weight_bits == 12
+    assert q12_pwl.softmax_mode == "pwl_recip_lut_q12_bucket8"
+
     with pytest.raises(ValueError):
         _parse_candidate_spec("qkv8_score8:r8")
 


### PR DESCRIPTION
## Summary
- fix native mixed-int8 attention candidate parsing for `pwl_recip_lut_q*` softmax modes
- add a regression for the exact q12/PWL candidate used by `l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1`

## Root Cause
The native evaluator already implemented `_parse_softmax_mode()` and `_softmax_patch()` support for `pwl_recip_lut_q12_bucket8`, but comma candidate parsing classified only float/RTL modes before trying token-pair parsing. As a result, `pwl_recip_lut_q12_bucket8` was parsed as a malformed `p...` numeric token and the remote job failed immediately with `exit_code=2`.

## Validation
- `PYTHONPATH=. python3 -m pytest tests/test_llm_decoder_model_native_mixed_int8_attention.py::test_parse_candidate_spec_and_list_compatibility tests/test_llm_decoder_model_native_mixed_int8_attention.py::test_parse_candidate_list_from_semicolon_values`
- `python3 -m py_compile npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py`
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_q12_pwl_native_quality_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_q12_pwl_proxy_audit_evidence`
