### PR TITLE
npu: reject held q12 pwl proxy audit

### DIFF
--- a/npu/eval/audit_llm_decoder_attention_mixed_int8_q12_pwl_proxy.py
+++ b/npu/eval/audit_llm_decoder_attention_mixed_int8_q12_pwl_proxy.py
@@ -412,11 +412,12 @@ def _build_payload(args: argparse.Namespace) -> JsonDict:
         }
 
     quality_status = _quality_status_category(q12_quality.get("decision_status", ""))
-    q12_quality["proxy_pass"] = (
+    quality_pass = (
         quality_status == "pass"
         and _is_one(q12_quality.get("top1_match_rate"))
         and _is_one(q12_quality.get("topk_contains_rate"))
     )
+    q12_quality["proxy_pass"] = quality_pass
     q12_quality["quality_passed"] = q12_quality["proxy_pass"]
 
     frontier_payload = _load_json(args.quality_backed_frontier_json)
@@ -436,27 +437,17 @@ def _build_payload(args: argparse.Namespace) -> JsonDict:
             "Align quality-backed frontier inputs to explicitly identify qkv8_float_exact as the active quality-backed direction "
             "before promoting this proxy check."
         )
-    elif not q12_quality["decision_status"] and not q12_quality["proxy_pass"]:
+    elif not q12_quality["decision_status"] and not quality_pass:
         decision_status = "q12_pwl_proxy_missing_evidence"
         next_step = (
             "Collect per-candidate quality evidence for qkv8_q12_pwl_recip_q12_bucket8 from the same mixed-int8 artifact generation "
             "that produced the frontier."
         )
-    elif q12_quality["decision_status"] and quality_status == "fail":
+    elif not quality_pass:
         decision_status = "q12_pwl_proxy_quality_rejected"
         next_step = (
-            "Do not use q12/PWL composed proxy evidence yet; improve the qkv8_q12_pwl_recip_q12_bucket8 quality gate "
-            "before re-running this audit."
-        )
-    elif q12_quality["decision_status"] and quality_status == "caution":
-        decision_status = "q12_pwl_proxy_quality_caution"
-        next_step = (
-            "Treat q12/PWL softmax as a provisional proxy only; resolve quality caution before closing as quality-backed."
-        )
-    elif not q12_quality["proxy_pass"]:
-        decision_status = "q12_pwl_proxy_quality_caution"
-        next_step = (
-            "The candidate is not a strict pass for top-1/top-k at 1.0, so keep this path as quality-risk only."
+            "Do not use q12/PWL composed proxy as quality-backed for frontier decisions; improve the qkv8_q12_pwl_recip_q12_bucket8 "
+            "quality gate and top-1/top-k equality before re-running this audit."
         )
     else:
         if not composed:

--- a/tests/test_audit_llm_decoder_attention_mixed_int8_q12_pwl_proxy.py
+++ b/tests/test_audit_llm_decoder_attention_mixed_int8_q12_pwl_proxy.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_mixed_int8_q12_pwl_proxy import (  # noqa: E402
+    _build_payload,
+)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _args(tmp_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        q12_pwl_native_quality_json=tmp_path / "q12_quality.json",
+        quality_backed_frontier_json=tmp_path / "frontier.json",
+        composed_q12_pwl_metrics=tmp_path / "composed.csv",
+        full_value_v8_metrics=tmp_path / "fullv8.csv",
+        out=tmp_path / "out.json",
+        out_md=tmp_path / "out.md",
+    )
+
+
+def test_hold_native_quality_status_no_longer_allows_quality_backed_proxy(tmp_path: Path) -> None:
+    args = _args(tmp_path)
+    _write_json(
+        args.q12_pwl_native_quality_json,
+        {
+            "candidate_summaries": [
+                {
+                    "candidate_id": "qkv8_q12_pwl_recip_q12_bucket8",
+                    "decision_status": "mixed_int8_native_attention_shadow_hold",
+                    "top1_match_rate": 1.0,
+                    "topk_contains_rate": 1.0,
+                }
+            ]
+        },
+    )
+    _write_json(
+        args.quality_backed_frontier_json,
+        {
+            "quality_backed_direction": {
+                "candidate_id": "qkv8_float_exact",
+                "decision_status": "mixed_int8_native_attention_shadow_pass",
+            }
+        },
+    )
+
+    payload = _build_payload(args)
+
+    assert payload["decision"]["status"] == "q12_pwl_proxy_quality_rejected"
+    assert payload["q12_pwl_quality"]["proxy_pass"] is False
+    assert payload["q12_pwl_quality"]["quality_passed"] is False


### PR DESCRIPTION
## Summary
- make the q12/PWL proxy audit reject any native quality result that is not a strict pass
- keep `proxy_pass` / `quality_passed` false for hold results
- add a focused regression for `mixed_int8_native_attention_shadow_hold`

## Why
The Llama7B q12/PWL native quality run produced `mixed_int8_native_attention_shadow_hold` with top1 match below the strict gate. The audit previously reported this as `q12_pwl_proxy_quality_caution`, which was too soft for frontier ranking. A held quality gate must not be treated as quality-backed proxy evidence.

## Validation
- `python3 -m py_compile npu/eval/audit_llm_decoder_attention_mixed_int8_q12_pwl_proxy.py tests/test_audit_llm_decoder_attention_mixed_int8_q12_pwl_proxy.py`
- `PYTHONPATH=. python3 -m pytest -q tests/test_audit_llm_decoder_attention_mixed_int8_q12_pwl_proxy.py`
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_mixed_int8_q12_pwl_proxy_audit control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_mixed_int8_q12_pwl_proxy_audit_uses_decoder_evidence`
