### PR TITLE
control_plane: add mixed int8 score precision recovery

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -503,6 +503,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_q12_pwl_proxy_audit_report",
     ),
     (
+        "attention_mixed_int8_score_precision_recovery_out",
+        "attention_mixed_int8_score_precision_recovery_report",
+    ),
+    (
         "attention_mixed_int8_quality_backed_frontier_out",
         "attention_mixed_int8_quality_backed_frontier_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6387,6 +6387,66 @@ def _decoder_attention_mixed_int8_q12_pwl_proxy_audit_evidence(*, item_id: str) 
     }
 
 
+def _decoder_attention_mixed_int8_score_precision_recovery_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    q12_pwl_proxy_audit = (
+        f"{base}/decoder_attention_mixed_int8_q12_pwl_proxy_audit__"
+        "l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1.json"
+    )
+    quality_backed_frontier = (
+        f"{base}/decoder_attention_mixed_int8_quality_backed_frontier__"
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+    )
+    out = f"{base}/decoder_attention_mixed_int8_score_precision_recovery__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_score_precision_recovery__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_mixed_int8_q12_pwl_proxy_audit": q12_pwl_proxy_audit,
+            "attention_mixed_int8_quality_backed_frontier": quality_backed_frontier,
+            "attention_mixed_int8_score_precision_recovery_out": out,
+            "attention_mixed_int8_score_precision_recovery_report": report,
+            "attention_mixed_int8_score_precision_recovery_scope": (
+                "Run a broad 7B attention-shadow precision recovery sweep after q12/PWL and "
+                "quality-backed frontier dependencies. This is an evidence-only job to decide "
+                "whether higher score precision or higher PWL-reciprocal precision can recover "
+                "mixed/int8 quality before recosting any new PPA."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_score_precision_recovery",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_BROAD_MAX_PROMPTS:-8}; "
+                    "GEN_STEPS=${RTLGEN_MODEL_NATIVE_7B_BROAD_GENERATION_STEPS:-8}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--generation-steps \"$GEN_STEPS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--topk 5 "
+                    "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact "
+                    "--candidate score24_float:q8,k8,v8,s24,w16,float_quantized "
+                    "--candidate score28_float:q8,k8,v8,s28,w16,float_quantized "
+                    "--candidate score32_float:q8,k8,v8,s32,w16,float_quantized "
+                    "--candidate qkv8_q16_pwl_recip_q16_bucket8:q8,k8,v8,s16,w16,pwl_recip_lut_q16_bucket8 "
+                    "--candidate qkv8_q20_pwl_recip_q20_bucket8:q8,k8,v8,s20,w20,pwl_recip_lut_q20_bucket8 "
+                    "--primary-candidate-id score32_float "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     energy_closure = (
@@ -8321,6 +8381,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_broad_native_quality",
         "decoder_attention_mixed_int8_q12_pwl_native_quality",
         "decoder_attention_mixed_int8_q12_pwl_proxy_audit",
+        "decoder_attention_mixed_int8_score_precision_recovery",
         "decoder_attention_mixed_int8_quality_backed_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
@@ -8516,6 +8577,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_q12_pwl_native_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_q12_pwl_proxy_audit":
             decoder_evidence = _decoder_attention_mixed_int8_q12_pwl_proxy_audit_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_score_precision_recovery":
+            decoder_evidence = _decoder_attention_mixed_int8_score_precision_recovery_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
             decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -170,6 +170,70 @@ def test_decoder_evidence_summary_recognizes_mixed_int8_q12_pwl_proxy_audit() ->
     assert "recommended_next_step=measure v8 composed q12/PWL datapath" in summary
 
 
+def test_decoder_evidence_summary_recognizes_mixed_int8_score_precision_recovery() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/mixed_int8_score_precision_recovery.json",
+        evidence_payload={
+            "quality_gate": "mixed_int8_attention_shadow",
+            "model": {
+                "model_id": "mistralai/Mistral-7B-v0.1",
+                "attention_heads": 32,
+                "kv_heads": 8,
+                "gqa_group_size": 4.0,
+                "dtype": "bfloat16",
+            },
+            "precision": {
+                "q_bits": 8,
+                "k_bits": 8,
+                "v_bits": 8,
+                "score_bits": 32,
+                "weight_bits": 16,
+                "softmax_mode": "float_quantized",
+            },
+            "summary": {
+                "comparison_count": 8,
+                "top1_match_rate": 0.95,
+                "topk_contains_rate": 0.98,
+                "mean_logit_cosine": 0.9951,
+                "mean_probability_kl": 0.02,
+                "max_abs_logit_delta_max": 0.31,
+            },
+            "candidate_summaries": [
+                {
+                    "candidate_id": "score32_float",
+                    "top1_match_rate": 0.95,
+                    "topk_contains_rate": 0.98,
+                    "mean_logit_cosine": 0.9951,
+                    "mean_probability_kl": 0.02,
+                },
+                {
+                    "candidate_id": "qkv8_q20_pwl_recip_q20_bucket8",
+                    "top1_match_rate": 0.93,
+                    "topk_contains_rate": 0.97,
+                    "mean_logit_cosine": 0.9920,
+                    "mean_probability_kl": 0.028,
+                },
+            ],
+            "best_candidate": {
+                "candidate_id": "score32_float",
+                "top1_match_rate": 0.95,
+                "topk_contains_rate": 0.98,
+                "mean_logit_cosine": 0.9951,
+                "mean_probability_kl": 0.02,
+            },
+            "decision": {
+                "status": "mixed_int8_native_attention_shadow_hold",
+                "next_step": "run v8 recost if score32 passes and keep mixed-int8 ranking blocked until PPA is available",
+            },
+        },
+    )
+
+    assert outcome == "mixed_int8_native_attention_shadow_hold"
+    assert "mixed/int8 native attention quality" in summary
+    assert "best_candidate_id=score32_float" in summary
+    assert "candidate_count=2" in summary
+
+
 def test_decoder_evidence_summary_recognizes_mixed_int8_native_quality() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/mixed_int8_native_quality.json",
@@ -742,6 +806,166 @@ def test_consume_l2_result_frontier_attention_mixed_int8_q12_pwl_proxy_audit_use
             assert (
                 decision_payload["source_refs"][
                     "decoder_attention_mixed_int8_q12_pwl_proxy_audit_report"
+                ]
+                == report_rel
+            )
+
+
+def test_consume_l2_result_frontier_attention_mixed_int8_score_precision_recovery_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root / "docs" / "proposals" / "prop_l2_attention_mixed_int8_score_precision_recovery_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_mixed_int8_score_precision_recovery_v1",
+                        "kind": "architecture",
+                        "title": "Attention mixed-int8 score precision recovery",
+                        "direct_comparison": {
+                            "primary_question": (
+                                "Can score 28/32 or higher-precision PWL reciprocal recover native attention shadow quality "
+                                "before final ranking?"
+                            )
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_score_precision_recovery__"
+                "l2_attention_mixed_int8_score_precision_recovery_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_score_precision_recovery__"
+                "l2_attention_mixed_int8_score_precision_recovery_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "quality_gate": "mixed_int8_attention_shadow",
+                        "model": {
+                            "model_id": "mistralai/Mistral-7B-v0.1",
+                            "attention_heads": 32,
+                            "kv_heads": 8,
+                            "gqa_group_size": 4.0,
+                            "dtype": "bfloat16",
+                        },
+                        "precision": {
+                            "q_bits": 8,
+                            "k_bits": 8,
+                            "v_bits": 8,
+                            "score_bits": 32,
+                            "weight_bits": 16,
+                            "softmax_mode": "float_quantized",
+                        },
+                        "summary": {
+                            "comparison_count": 8,
+                            "top1_match_rate": 0.97,
+                            "topk_contains_rate": 0.99,
+                            "mean_logit_cosine": 0.997,
+                            "mean_probability_kl": 0.011,
+                            "max_abs_logit_delta_max": 0.29,
+                        },
+                        "candidate_summaries": [
+                            {
+                                "candidate_id": "score32_float:q8,k8,v8,s32,w16,float_quantized",
+                                "top1_match_rate": 0.97,
+                                "topk_contains_rate": 0.99,
+                                "mean_logit_cosine": 0.997,
+                                "mean_probability_kl": 0.011,
+                            },
+                            {
+                                "candidate_id": "qkv8_q20_pwl_recip_q20_bucket8:q8,k8,v8,s20,w20,pwl_recip_lut_q20_bucket8",
+                                "top1_match_rate": 0.96,
+                                "topk_contains_rate": 0.98,
+                                "mean_logit_cosine": 0.996,
+                                "mean_probability_kl": 0.014,
+                            },
+                        ],
+                        "best_candidate": {
+                            "candidate_id": "score32_float:q8,k8,v8,s32,w16,float_quantized",
+                            "top1_match_rate": 0.97,
+                            "topk_contains_rate": 0.99,
+                            "mean_logit_cosine": 0.997,
+                            "mean_probability_kl": 0.011,
+                        },
+                        "decision": {
+                            "status": "mixed_int8_native_attention_shadow_hold",
+                            "next_step": "collect v8 composed PPA and recost only if score32 holds",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# mixed-int8 score precision recovery\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_mixed_int8_score_precision_recovery_v1",
+                campaign_dir_rel="runs/campaigns/npu/attention_mixed_int8_score_precision_recovery_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_mixed_int8_score_precision_recovery_v1",
+                comparison={"role": "precision_recovery"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "quality_gate",
+                "expected_direction": "iterate",
+                "expected_reason": "Select final recovery recipe before any PPA recosting.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_mixed_int8_score_precision_recovery",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_mixed_int8_score_precision_recovery_out": evidence_rel,
+                    "attention_mixed_int8_score_precision_recovery_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "mixed_int8_native_attention_shadow_hold"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_mixed_int8_score_precision_recovery"
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_score_precision_recovery_out"
+                ]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_score_precision_recovery_report"
                 ]
                 == report_rel
             )

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7253,6 +7253,94 @@ def test_generate_l2_campaign_task_adds_mixed_int8_q12_pwl_proxy_audit_evidence(
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_score_precision_recovery_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_score_precision_recovery",
+                    evaluation_mode="quality_gate",
+                    comparison_role="precision_recovery",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1",
+                        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_score_precision_recovery",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_attention.py" in run
+            assert "RTLGEN_MODEL_NATIVE_7B_BROAD_MAX_PROMPTS" in run
+            assert "RTLGEN_MODEL_NATIVE_7B_BROAD_GENERATION_STEPS" in run
+            assert "--generation-steps \"$GEN_STEPS\"" in run
+            assert "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact" in run
+            assert "--candidate score24_float:q8,k8,v8,s24,w16,float_quantized" in run
+            assert "--candidate score28_float:q8,k8,v8,s28,w16,float_quantized" in run
+            assert "--candidate score32_float:q8,k8,v8,s32,w16,float_quantized" in run
+            assert (
+                "--candidate qkv8_q16_pwl_recip_q16_bucket8:q8,k8,v8,s16,w16,pwl_recip_lut_q16_bucket8"
+                in run
+            )
+            assert (
+                "--candidate qkv8_q20_pwl_recip_q20_bucket8:q8,k8,v8,s20,w20,pwl_recip_lut_q20_bucket8"
+                in run
+            )
+            assert "--primary-candidate-id score32_float" in run
+            assert decoder_inputs["attention_mixed_int8_q12_pwl_proxy_audit"].endswith(
+                "decoder_attention_mixed_int8_q12_pwl_proxy_audit__"
+                "l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_mixed_int8_quality_backed_frontier"].endswith(
+                "decoder_attention_mixed_int8_quality_backed_frontier__"
+                "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_score_precision_recovery_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_score_precision_recovery_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_score_precision_recovery",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1",
+                    "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+  "requests": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a broad precision-recovery mixed/int8 native attention-shadow sweep to test score/PWL-reciprocal precision upgrades before any final mixed-int8 ranking.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score_precision_recovery",
+      "comparison_role": "precision_recovery",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "recover_quality_gate_or_hold_for_recost",
+        "reason": "Not a final ranking job: identify whether score32 or high-precision PWL-reciprocal variants recover attention-shadow quality before recosting."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/proposal.json
@@ -1,0 +1,81 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+  "created_utc": "2026-06-25T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 score precision recovery",
+  "abstraction_layer": "decoder_attention_mixed_int8_score_precision_recovery",
+  "hypothesis": "After q12/PWL and quality-backed frontier checks, higher score precision (score28/score32) or higher-precision PWL reciprocal settings may recover mixed/int8 native attention quality for a 7B checkpoint before any final PPA recosting.",
+  "direct_comparison": {
+    "primary_question": "Can score-precision recovery or higher-precision PWL-reciprocal settings recover quality while keeping the job as an evidence-only checkpoint for ranking preparation?",
+    "baseline": "l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1",
+    "candidate": "score32_float",
+    "include": [
+      "run explicit score32 and score28 float-quantized sweeps",
+      "run qkv8_q16_pwl_recip_q16_bucket8 and qkv8_q20_pwl_recip_q20_bucket8 variants",
+      "use BROAD prompt/step defaults and keep qkv8_float_exact as control/pass reference",
+      "depend on q12/PWL proxy audit and quality-backed frontier evidence",
+      "treat outcome as quality-recovery evidence only; do not rank frontier until recosted PPA exists"
+    ],
+    "exclude": [
+      "final frontier ranking or ranking-sensitive scoring",
+      "new OpenROAD/PPA runs",
+      "full-accuracy Llama7B task-perplexity study"
+    ],
+    "metrics": [
+      "decision",
+      "best_candidate_id",
+      "top1_match_rate",
+      "topk_contains_rate",
+      "mean_logit_cosine",
+      "mean_probability_kl",
+      "next_step"
+    ]
+  },
+  "expected_benefit": [
+    "decide whether score precision or PWL reciprocal precision is sufficient to recover mixed/int8 quality",
+    "avoid rerunning broad PPA before confirming the quality sweep result",
+    "produce bounded evidence for the next recost step once a valid recovery candidate is found"
+  ],
+  "risks": [
+    "quality recovery here is attention-shadow only and still below full task accuracy requirements",
+    "higher precision candidates can pass this gate but still fail broader prompt or batch-size distributions",
+    "recost is still required before final throughput/energy/area ranking"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a broad mixed-int8 score precision / PWL reciprocal precision recovery sweep; this is evidence-only and must complete before any PPA ranking.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score_precision_recovery",
+      "comparison_role": "precision_recovery",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "recover_quality_gate_or_hold_for_recost",
+        "reason": "This job is explicit evidence for whether score/softmax precision upgrades recover mixed/int8 quality; no final ranking is expected until recosted PPA is available."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_q12_pwl_proxy_audit__l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- add an evidence-only L2 job for Llama7B mixed/int8 score and softmax precision recovery
- sweep score24/28/32 float-quantized softmax plus q16/q20 PWL reciprocal variants against qkv8 float-exact control
- add proposal metadata and focused generator/consumer tests

## Why
The q12/PWL proxy audit rejected q12/PWL as quality-backed: native attention-shadow top1 was 0.96875 instead of a strict pass. Before spending PPA on another softmax datapath, we need a broad native quality recovery sweep to find whether higher score precision or higher PWL reciprocal precision can recover quality.

## Validation
- `python3 -m json.tool docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/proposal.json`
- `python3 -m json.tool docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/evaluation_requests.json`
- `python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py`
- `PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_score_precision_recovery_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_mixed_int8_score_precision_recovery control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_mixed_int8_score_precision_recovery_uses_decoder_evidence`
