### PR TITLE
control_plane: add mixed int8 score margin audit

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -507,6 +507,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_score_precision_recovery_report",
     ),
     (
+        "attention_mixed_int8_score_margin_audit_out",
+        "attention_mixed_int8_score_margin_audit_report",
+    ),
+    (
         "attention_mixed_int8_quality_backed_frontier_out",
         "attention_mixed_int8_quality_backed_frontier_report",
     ),
@@ -1215,6 +1219,44 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         ):
             if key in diagnosis_dict:
                 parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1":
+        decision = evidence_payload.get("decision")
+        decision_dict = dict(decision) if isinstance(decision, dict) else {}
+        outcome = str(
+            decision_dict.get("status")
+            or evidence_payload.get("decision")
+            or "score_margin_audit_recorded"
+        )
+        parts = [
+            f"Decoder mixed/int8 score-margin audit recorded from {evidence_ref}: decision={outcome}",
+        ]
+        candidate_audits = evidence_payload.get("candidate_audits")
+        if not isinstance(candidate_audits, list):
+            candidate_audits = evidence_payload.get("candidates")
+        if isinstance(candidate_audits, list):
+            parts.append(f"candidate_count={len(candidate_audits)}")
+            if candidate_audits:
+                primary = dict(candidate_audits[0])
+                for key in (
+                    "candidate_id",
+                    "comparison_count",
+                    "top1_miss_count",
+                    "top1_match_rate",
+                    "topk_contains_rate",
+                    "miss_topk_contains_rate",
+                    "miss_mean_reference_margin",
+                    "miss_mean_probability_kl",
+                    "miss_mean_logit_cosine",
+                    "miss_max_abs_logit_delta",
+                ):
+                    if key in primary:
+                        parts.append(f"primary_{key}={primary.get(key)}")
+        next_step = str(decision_dict.get("next_step") or decision_dict.get("recommended_next_step") or "").strip()
+        if next_step:
+            parts.append(f"next_step={next_step}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6447,6 +6447,41 @@ def _decoder_attention_mixed_int8_score_precision_recovery_evidence(*, item_id: 
     }
 
 
+def _decoder_attention_mixed_int8_score_margin_audit_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    score_precision_recovery = (
+        f"{base}/decoder_attention_mixed_int8_score_precision_recovery__"
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1.json"
+    )
+    out = f"{base}/decoder_attention_mixed_int8_score_margin_audit__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_score_margin_audit__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_mixed_int8_score_precision_recovery": score_precision_recovery,
+            "attention_mixed_int8_score_margin_audit_out": out,
+            "attention_mixed_int8_score_margin_audit_report": report,
+            "attention_mixed_int8_score_margin_audit_scope": (
+                "Audit the score precision recovery candidate rows by reference-margin buckets "
+                "and top-k containment. This is a cheap evidence-only job to separate narrow-margin "
+                "top1 drift from systematic approximation error before any new PPA recost."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_mixed_int8_score_margin",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_mixed_int8_score_margin.py "
+                    f"--score-precision-recovery-json {score_precision_recovery} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     energy_closure = (
@@ -8382,6 +8417,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_q12_pwl_native_quality",
         "decoder_attention_mixed_int8_q12_pwl_proxy_audit",
         "decoder_attention_mixed_int8_score_precision_recovery",
+        "decoder_attention_mixed_int8_score_margin_audit",
         "decoder_attention_mixed_int8_quality_backed_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
@@ -8579,6 +8615,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_q12_pwl_proxy_audit_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_score_precision_recovery":
             decoder_evidence = _decoder_attention_mixed_int8_score_precision_recovery_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_score_margin_audit":
+            decoder_evidence = _decoder_attention_mixed_int8_score_margin_audit_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
             decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -971,6 +971,124 @@ def test_consume_l2_result_frontier_attention_mixed_int8_score_precision_recover
             )
 
 
+def test_consume_l2_result_frontier_attention_mixed_int8_score_margin_audit_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_attention_mixed_int8_score_margin_audit_v1"
+            proposal_dir.mkdir(parents=True)
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_mixed_int8_score_margin_audit_v1",
+                        "kind": "architecture",
+                        "title": "Attention mixed-int8 score margin audit",
+                        "direct_comparison": {
+                            "primary_question": (
+                                "Are score32/PWL top1 misses narrow-margin top-k-stable drift or systematic errors?"
+                            )
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_score_margin_audit__"
+                "l2_attention_mixed_int8_score_margin_audit_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_score_margin_audit__"
+                "l2_attention_mixed_int8_score_margin_audit_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "model": "llm_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1",
+                        "decision": {
+                            "status": "score_margin_audit_narrow_margin_hold",
+                            "recommended_next_step": "run generation/perplexity quality before recosting score32",
+                        },
+                        "candidates": [
+                            {
+                                "candidate_id": "score32_float",
+                                "comparison_count": 64,
+                                "top1_match_rate": 0.96875,
+                                "topk_contains_rate": 1.0,
+                                "top1_miss_count": 2,
+                                "miss_topk_contains_rate": 1.0,
+                                "miss_mean_reference_margin": 0.125,
+                                "miss_mean_probability_kl": 0.0029,
+                                "miss_mean_logit_cosine": 0.9999,
+                                "miss_max_abs_logit_delta": 0.34375,
+                            }
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# mixed-int8 score margin audit\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_mixed_int8_score_margin_audit_v1",
+                campaign_dir_rel="runs/campaigns/npu/attention_mixed_int8_score_margin_audit_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_mixed_int8_score_margin_audit_v1",
+                comparison={"role": "score_margin_audit"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "quality_gate",
+                "expected_direction": "iterate",
+                "expected_reason": "Classify top1 misses before recosting.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_mixed_int8_score_margin_audit",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_mixed_int8_score_margin_audit_out": evidence_rel,
+                    "attention_mixed_int8_score_margin_audit_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "score_margin_audit_narrow_margin_hold"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_mixed_int8_score_margin_audit"
+            )
+            assert decision_payload["source_refs"]["decoder_attention_mixed_int8_score_margin_audit_out"] == evidence_rel
+            assert (
+                decision_payload["source_refs"]["decoder_attention_mixed_int8_score_margin_audit_report"]
+                == report_rel
+            )
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7341,6 +7341,70 @@ def test_generate_l2_campaign_task_adds_mixed_int8_score_precision_recovery_evid
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_score_margin_audit_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_score_margin_audit",
+                    evaluation_mode="quality_gate",
+                    comparison_role="score_margin_audit",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_mixed_int8_score_margin",
+            ]
+            run = commands[0]["run"]
+            assert "audit_llm_decoder_attention_mixed_int8_score_margin.py" in run
+            assert "--score-precision-recovery-json" in run
+            assert decoder_inputs["attention_mixed_int8_score_precision_recovery"].endswith(
+                "decoder_attention_mixed_int8_score_precision_recovery__"
+                "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_score_margin_audit_out" in decoder_inputs
+            assert decoder_inputs["attention_mixed_int8_score_margin_audit_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_score_margin_audit",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1/README.md
@@ -1,0 +1,5 @@
+# Llama7B Mixed/Int8 Score Margin Audit
+
+This proposal adds a cheap evidence-only audit after the score precision recovery sweep. It consumes the merged recovery JSON, buckets top1 misses by reference margin, and decides whether the remaining drift is narrow-margin/top-k-stable or systematic.
+
+No new PPA or model inference is requested by this job.

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1",
+  "requests": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit score precision recovery rows by reference-margin bucket and classify the remaining top1 failures before recosting.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score_margin_audit",
+      "comparison_role": "score_margin_audit",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "classify_precision_recovery_failure_mode",
+        "reason": "Not a final ranking job: determine whether the observed top1 drift is narrow-margin/top-k-stable or systematic before PPA recosting."
+      }
+    }
+  ],
+  "source_commit": "571ee45629c1d2bc62795c8b7a7aecdd812f49a7"
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1/proposal.json
@@ -1,0 +1,82 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1",
+  "created_utc": "2026-06-25T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 score margin audit",
+  "abstraction_layer": "decoder_attention_mixed_int8_score_margin_audit",
+  "hypothesis": "The score32/PWL precision recovery failures are likely concentrated in narrow reference-margin rows with top-k containment preserved; confirming this separates recoverable decoding-policy sensitivity from systematic approximation error before any recosted PPA run.",
+  "direct_comparison": {
+    "primary_question": "Are the remaining mixed/int8 score precision top1 failures narrow-margin, top-k-stable drift or systematic quality failures?",
+    "baseline": "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+    "candidate": "score32_float and high-precision PWL reciprocal rows from the score recovery artifact",
+    "include": [
+      "consume the merged score precision recovery JSON artifact",
+      "bucket top1 misses by reference margin",
+      "report top-k containment, KL, cosine, and max logit delta for misses and all rows",
+      "classify whether failures are narrow-margin/top-k-stable or systematic",
+      "produce an evidence-only result for the next generation/perplexity or exact-softmax decision"
+    ],
+    "exclude": [
+      "new Hugging Face model inference",
+      "new OpenROAD/PPA runs",
+      "final throughput/energy/area ranking"
+    ],
+    "metrics": [
+      "decision",
+      "candidate_id",
+      "comparison_count",
+      "miss_count",
+      "miss_rate",
+      "miss_topk_contains_rate",
+      "miss_mean_reference_margin",
+      "miss_mean_probability_kl",
+      "miss_mean_logit_cosine",
+      "max_abs_logit_delta_max"
+    ]
+  },
+  "expected_benefit": [
+    "avoid recosting candidates whose quality failure is systematic",
+    "identify whether exact/high-precision softmax should be embodied next",
+    "provide concrete row-level evidence for a later model-level generation/perplexity audit"
+  ],
+  "risks": [
+    "this remains attention-shadow evidence and does not prove generated-text quality",
+    "margin buckets are only as broad as the current prompt/step corpus",
+    "top-k-stable drift can still affect sampling when temperature or decoding policy changes"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit score precision recovery rows by reference-margin bucket and classify the remaining top1 failures before recosting.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score_margin_audit",
+      "comparison_role": "score_margin_audit",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "classify_precision_recovery_failure_mode",
+        "reason": "This job should decide whether to pursue generation/perplexity quality validation for narrow-margin drift or switch to exact/high-precision softmax embodiment."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "npu/eval/audit_llm_decoder_attention_mixed_int8_score_margin.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/proposal.json"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_mixed_int8_score_margin.py
+++ b/npu/eval/audit_llm_decoder_attention_mixed_int8_score_margin.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Audit mixed-int8 score precision recovery artifacts by reference-margin miss buckets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+DECISION_PASS = "score_margin_audit_pass"
+DECISION_NARROW_HOLD = "score_margin_audit_narrow_margin_hold"
+DECISION_SYSTEMATIC_HOLD = "score_margin_audit_systematic_hold"
+DECISION_UNKNOWN = "score_margin_audit_unknown"
+
+REFERENCE_MARGIN_BUCKETS: tuple[tuple[float, str], ...] = (
+    (0.5, "0_0.5"),
+    (1.0, "0_5_1.0"),
+    (2.0, "1.0_2.0"),
+    (4.0, "2.0_4.0"),
+)
+NARROW_MARGIN_LABELS = {"0_0.5", "0_5_1.0"}
+
+
+DecisionStatus = str
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None or value == "":
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_str(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def _load_json(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object at {path}")
+    return payload
+
+
+def _row_like(value: Any) -> bool:
+    return isinstance(value, dict) and ("candidate_id" in value) and (
+        "reference_margin" in value
+        or "reference_top1" in value
+        or "candidate_top1" in value
+        or "top1_match" in value
+        or "topk_contains" in value
+    )
+
+
+def _summary_like(value: Any) -> bool:
+    return isinstance(value, dict) and "candidate_id" in value and (
+        "top1_match_rate" in value
+        or "topk_contains_rate" in value
+        or "top1_match" in value
+    )
+
+
+def _get_candidate_rows(payload: JsonDict) -> list[JsonDict]:
+    candidates: list[JsonDict] = []
+    for key in ("candidate_rows", "rows", "rows_by_candidate"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            candidates.extend([dict(row) for row in value if _row_like(row)])
+    if not candidates:
+        def walk(node: Any) -> None:
+            if isinstance(node, list):
+                for item in node:
+                    walk(item)
+            elif isinstance(node, dict):
+                if _row_like(node):
+                    candidates.append(dict(node))
+                    return
+                for value in node.values():
+                    walk(value)
+
+        walk(payload)
+    return candidates
+
+
+def _get_candidate_summaries(payload: JsonDict) -> list[JsonDict]:
+    summaries: list[JsonDict] = []
+    for key in ("candidate_summaries", "candidate_summary", "best_candidate", "summary"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            summaries.extend([dict(row) for row in value if _summary_like(row)])
+        elif isinstance(value, dict) and _summary_like(value):
+            summaries.append(dict(value))
+
+    if not summaries:
+        def walk(node: Any) -> None:
+            if isinstance(node, list):
+                for item in node:
+                    walk(item)
+            elif isinstance(node, dict):
+                if _summary_like(node):
+                    summaries.append(dict(node))
+                    return
+                for value in node.values():
+                    walk(value)
+
+        walk(payload)
+    return summaries
+
+
+def _precision_fields(row: JsonDict) -> dict[str, Any]:
+    return {
+        key: row.get(key)
+        for key in (
+            "candidate_id",
+            "q_bits",
+            "k_bits",
+            "v_bits",
+            "score_bits",
+            "weight_bits",
+            "softmax_mode",
+            "precision_profile",
+        )
+        if key in row
+    }
+
+
+def _bucket_label(reference_margin: float) -> str:
+    if reference_margin < 0.0:
+        return "negative"
+    for edge, label in REFERENCE_MARGIN_BUCKETS:
+        if reference_margin < edge:
+            return label
+    return ">=4.0"
+
+
+def _summarize_rows(rows: list[JsonDict]) -> dict[str, Any]:
+    if not rows:
+        return {
+            "comparison_count": 0,
+            "top1_match_rate": 0.0,
+            "topk_contains_rate": 0.0,
+            "mean_logit_cosine": 0.0,
+            "mean_probability_kl": 0.0,
+            "top1_miss_count": 0,
+            "miss_topk_contains_rate": 0.0,
+            "miss_mean_reference_margin": 0.0,
+            "miss_mean_logit_cosine": 0.0,
+            "miss_mean_probability_kl": 0.0,
+            "miss_max_abs_logit_delta": 0.0,
+            "top1_miss_by_reference_margin": {
+                "0_0.5": 0,
+                "0_5_1.0": 0,
+                "1.0_2.0": 0,
+                "2.0_4.0": 0,
+                ">=4.0": 0,
+                "negative": 0,
+            },
+            "max_abs_logit_delta": 0.0,
+        }
+
+    comparison_count = len(rows)
+    top1_matches = [_as_float(row.get("top1_match"), 0.0) for row in rows]
+    topk_contains = [_as_float(row.get("topk_contains"), 0.0) for row in rows]
+    logit_cosine = [_as_float(row.get("logit_cosine"), 0.0) for row in rows]
+    kl = [_as_float(row.get("probability_kl"), 0.0) for row in rows]
+    delta = [_as_float(row.get("max_abs_logit_delta"), 0.0) for row in rows]
+
+    misses_by_bucket = {
+        "0_0.5": 0,
+        "0_5_1.0": 0,
+        "1.0_2.0": 0,
+        "2.0_4.0": 0,
+        ">=4.0": 0,
+        "negative": 0,
+    }
+
+    miss_rows: list[JsonDict] = []
+    for row in rows:
+        if _as_float(row.get("top1_match"), 0.0) < 1.0:
+            miss_rows.append(row)
+            margin = _as_float(row.get("reference_margin"), 0.0)
+            misses_by_bucket[_bucket_label(margin)] += 1
+
+    miss_topk = [_as_float(row.get("topk_contains"), 0.0) for row in miss_rows]
+    miss_margins = [_as_float(row.get("reference_margin"), 0.0) for row in miss_rows]
+    miss_cosines = [_as_float(row.get("logit_cosine"), 0.0) for row in miss_rows]
+    miss_kl = [_as_float(row.get("probability_kl"), 0.0) for row in miss_rows]
+    miss_deltas = [_as_float(row.get("max_abs_logit_delta"), 0.0) for row in miss_rows]
+
+    return {
+        "comparison_count": comparison_count,
+        "top1_match_rate": mean(top1_matches) if comparison_count else 0.0,
+        "topk_contains_rate": mean(topk_contains) if comparison_count else 0.0,
+        "mean_logit_cosine": mean(logit_cosine) if comparison_count else 0.0,
+        "mean_probability_kl": mean(kl) if comparison_count else 0.0,
+        "top1_miss_count": sum(1 for value in top1_matches if value < 1.0),
+        "miss_topk_contains_rate": mean(miss_topk) if miss_topk else 0.0,
+        "miss_mean_reference_margin": mean(miss_margins) if miss_margins else 0.0,
+        "miss_mean_logit_cosine": mean(miss_cosines) if miss_cosines else 0.0,
+        "miss_mean_probability_kl": mean(miss_kl) if miss_kl else 0.0,
+        "miss_max_abs_logit_delta": max(miss_deltas) if miss_deltas else 0.0,
+        "top1_miss_by_reference_margin": misses_by_bucket,
+        "max_abs_logit_delta": max(delta) if delta else 0.0,
+    }
+
+
+def _coalesce_summary(
+    candidate_id: str,
+    row_summary: dict[str, Any],
+    candidate_summary: JsonDict | None,
+    *,
+    row_count: int,
+) -> JsonDict:
+    candidate_summary = candidate_summary or {}
+    out: JsonDict = {"candidate_id": candidate_id}
+    precision = _precision_fields(candidate_summary)
+    if precision:
+        out.update(precision)
+
+    prefer_rows = row_count > 0
+    out["comparison_count"] = _as_int(
+        row_summary.get("comparison_count") if prefer_rows else candidate_summary.get("comparison_count"),
+        0,
+    )
+    out["top1_match_rate"] = _as_float(
+        row_summary.get("top1_match_rate") if prefer_rows else candidate_summary.get("top1_match_rate"),
+        0.0,
+    )
+    out["topk_contains_rate"] = _as_float(
+        row_summary.get("topk_contains_rate") if prefer_rows else candidate_summary.get("topk_contains_rate"),
+        0.0,
+    )
+    out["mean_logit_cosine"] = _as_float(
+        row_summary.get("mean_logit_cosine") if prefer_rows else candidate_summary.get("mean_logit_cosine"),
+        0.0,
+    )
+    out["mean_probability_kl"] = _as_float(
+        row_summary.get("mean_probability_kl") if prefer_rows else candidate_summary.get("mean_probability_kl"),
+        0.0,
+    )
+    out["max_abs_logit_delta"] = _as_float(
+        row_summary.get("max_abs_logit_delta") if prefer_rows else (
+            candidate_summary.get("max_abs_logit_delta_max") or candidate_summary.get("max_abs_logit_delta")
+        ),
+        0.0,
+    )
+    for key in (
+        "miss_topk_contains_rate",
+        "miss_mean_reference_margin",
+        "miss_mean_logit_cosine",
+        "miss_mean_probability_kl",
+        "miss_max_abs_logit_delta",
+    ):
+        out[key] = _as_float(row_summary.get(key), 0.0) if prefer_rows else _as_float(candidate_summary.get(key), 0.0)
+
+    if "max_abs_logit_delta_max" in candidate_summary:
+        out["max_abs_logit_delta"] = _as_float(candidate_summary.get("max_abs_logit_delta_max"), out["max_abs_logit_delta"])
+
+    if candidate_summary:
+        decision_status = candidate_summary.get("decision_status")
+        if isinstance(decision_status, str) and decision_status:
+            out["decision_status"] = decision_status
+
+    miss_buckets = row_summary.get("top1_miss_by_reference_margin", {}) if row_summary else {}
+    if isinstance(miss_buckets, dict):
+        out["top1_miss_by_reference_margin"] = {
+            key: _as_int(value, 0)
+            for key, value in miss_buckets.items()
+        }
+    else:
+        out["top1_miss_by_reference_margin"] = {
+            "0_0.5": 0,
+            "0_5_1.0": 0,
+            "1.0_2.0": 0,
+            "2.0_4.0": 0,
+            ">=4.0": 0,
+            "negative": 0,
+        }
+
+    if row_count > 0 and "top1_miss_count" in row_summary and row_summary["top1_miss_count"] is not None:
+        out["top1_miss_count"] = _as_int(row_summary["top1_miss_count"], 0)
+    elif out["comparison_count"]:
+        out["top1_miss_count"] = out["comparison_count"] - _as_int(round(out["top1_match_rate"] * out["comparison_count"]))
+    else:
+        out["top1_miss_count"] = 0
+
+    return out
+
+
+def _classify_candidate(candidate: JsonDict) -> DecisionStatus:
+    comparison_count = _as_int(candidate.get("comparison_count"), 0)
+    if comparison_count <= 0:
+        return DECISION_UNKNOWN
+
+    top1_match_rate = _as_float(candidate.get("top1_match_rate"), 0.0)
+    topk_contains_rate = _as_float(candidate.get("topk_contains_rate"), 0.0)
+    if top1_match_rate >= 1.0 and topk_contains_rate >= 1.0:
+        return DECISION_PASS
+
+    if topk_contains_rate < 1.0:
+        return DECISION_SYSTEMATIC_HOLD
+
+    top1_miss_by_reference_margin = candidate.get("top1_miss_by_reference_margin")
+    top1_miss_count = _as_int(candidate.get("top1_miss_count"), 0)
+    if top1_miss_count <= 0:
+        return DECISION_PASS
+
+    if not isinstance(top1_miss_by_reference_margin, dict):
+        return DECISION_SYSTEMATIC_HOLD
+
+    narrow_miss_count = sum(
+        _as_int(top1_miss_by_reference_margin.get(label), 0)
+        for label in NARROW_MARGIN_LABELS
+    )
+
+    if narrow_miss_count == top1_miss_count:
+        return DECISION_NARROW_HOLD
+    return DECISION_SYSTEMATIC_HOLD
+
+
+def _status_rank(status: DecisionStatus) -> int:
+    order = {
+        DECISION_PASS: 0,
+        DECISION_NARROW_HOLD: 1,
+        DECISION_SYSTEMATIC_HOLD: 2,
+        DECISION_UNKNOWN: 3,
+    }
+    return order.get(status, 3)
+
+
+def build_payload(args: argparse.Namespace) -> JsonDict:
+    source = _load_json(args.score_precision_recovery_json)
+    rows = _get_candidate_rows(source)
+    summaries = _get_candidate_summaries(source)
+
+    rows_by_candidate: dict[str, list[JsonDict]] = {}
+    for row in rows:
+        candidate_id = _as_str(row.get("candidate_id"))
+        if not candidate_id:
+            continue
+        rows_by_candidate.setdefault(candidate_id, []).append(row)
+
+    summary_by_candidate: dict[str, JsonDict] = {}
+    for row in summaries:
+        candidate_id = _as_str(row.get("candidate_id"))
+        if not candidate_id:
+            continue
+        if candidate_id not in summary_by_candidate:
+            summary_by_candidate[candidate_id] = dict(row)
+
+    if not rows_by_candidate and not summary_by_candidate:
+        raise RuntimeError("no candidate rows or candidate summaries in score-precision artifact")
+
+    candidate_ids = sorted(set(rows_by_candidate) | set(summary_by_candidate))
+    candidates: list[JsonDict] = []
+    for candidate_id in candidate_ids:
+        candidate_rows = rows_by_candidate.get(candidate_id, [])
+        summary = summary_by_candidate.get(candidate_id)
+        row_summary = _summarize_rows(candidate_rows)
+        candidate = _coalesce_summary(
+            candidate_id,
+            row_summary,
+            summary,
+            row_count=len(candidate_rows),
+        )
+        candidate["candidate_rows_used"] = len(candidate_rows)
+        candidate["top1_miss_by_reference_margin"] = row_summary.get("top1_miss_by_reference_margin", candidate.get("top1_miss_by_reference_margin", {}))
+        candidate["top1_miss_count"] = _as_int(
+            candidate.get("top1_miss_count"),
+            _as_int(row_summary.get("top1_miss_count"), 0),
+        )
+        if "decision_status" in candidate:
+            candidate["source_decision_status"] = candidate["decision_status"]
+        candidate["audit_status"] = _classify_candidate(candidate)
+        candidate["narrow_margin_miss_count"] = sum(
+            _as_int(candidate["top1_miss_by_reference_margin"].get(label), 0)
+            for label in NARROW_MARGIN_LABELS
+        )
+        candidates.append(candidate)
+
+    candidates.sort(key=lambda item: (_status_rank(item.get("audit_status", "")), -_as_float(item.get("top1_match_rate")), -_as_int(item.get("comparison_count")), _as_str(item.get("candidate_id"))))
+
+    audit_status_counts = {
+        DECISION_PASS: 0,
+        DECISION_NARROW_HOLD: 0,
+        DECISION_SYSTEMATIC_HOLD: 0,
+        DECISION_UNKNOWN: 0,
+    }
+    for candidate in candidates:
+        audit_status_counts[candidate["audit_status"]] = audit_status_counts.get(candidate["audit_status"], 0) + 1
+
+    if audit_status_counts[DECISION_SYSTEMATIC_HOLD]:
+        decision = DECISION_SYSTEMATIC_HOLD
+        recommended_next_step = (
+            "Review wide-margin top-1 mismatches before rank-sensitive hardware spend."
+        )
+    elif audit_status_counts[DECISION_NARROW_HOLD]:
+        decision = DECISION_NARROW_HOLD
+        recommended_next_step = (
+            "The misses are concentrated in narrow-margin regions; keep this recovery path blocked until "
+            "bounded top-k and follow-up scoring checks show stable high-margin behavior."
+        )
+    elif audit_status_counts[DECISION_PASS]:
+        decision = DECISION_PASS
+        recommended_next_step = (
+            "No top-1 misses found under current sample set; keep candidate-level margin buckets for cross-set confirmation."
+        )
+    else:
+        decision = DECISION_UNKNOWN
+        recommended_next_step = (
+            "No margin-complete per-comparison rows were present; rerun with candidate_rows for precise miss-bucket audit."
+        )
+
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1",
+        "decision": {
+            "status": decision,
+            "audit_status_counts": audit_status_counts,
+            "recommended_next_step": recommended_next_step,
+        },
+        "inputs": {
+            "score_precision_recovery_json": str(args.score_precision_recovery_json),
+        },
+        "candidates": candidates,
+        "candidate_count": len(candidates),
+    }
+
+
+def _write_markdown(payload: JsonDict, path: Path) -> None:
+    lines = [
+        f"# {payload['model']}",
+        "",
+        f"- decision: `{payload['decision']['status']}`",
+        f"- decision_counts: `{payload['decision']['audit_status_counts']}`",
+        f"- candidate_count: `{payload['candidate_count']}`",
+        f"- recommended_next_step: `{payload['decision']['recommended_next_step']}`",
+        "",
+        "## Candidates",
+        "",
+        "| candidate_id | audit_status | top1_match | topk_contains | mean_cosine | mean_kl | max_delta | miss_count | miss_topk | miss_margin | miss_kl | miss_cosine | narrow_miss | bucketed_misses |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+
+    for candidate in payload["candidates"]:
+        bucket_text = ", ".join(
+            f"{bucket}:{candidate['top1_miss_by_reference_margin'].get(bucket, 0)}"
+            for bucket in ["0_0.5", "0_5_1.0", "1.0_2.0", "2.0_4.0", ">=4.0", "negative"]
+        )
+        lines.append(
+            "| {candidate_id} | {audit_status} | {top1_match_rate:.6f} | {topk_contains_rate:.6f} | "
+            "{mean_logit_cosine:.6f} | {mean_probability_kl:.6f} | {max_abs_logit_delta:.6f} | {top1_miss_count} | "
+            "{miss_topk_contains_rate:.6f} | {miss_mean_reference_margin:.6f} | {miss_mean_probability_kl:.6f} | "
+            "{miss_mean_logit_cosine:.6f} | {narrow_margin_miss_count} | {bucket_text} |".format(
+                candidate_id=candidate.get("candidate_id"),
+                audit_status=candidate.get("audit_status"),
+                top1_match_rate=_as_float(candidate.get("top1_match_rate")),
+                topk_contains_rate=_as_float(candidate.get("topk_contains_rate")),
+                mean_logit_cosine=_as_float(candidate.get("mean_logit_cosine")),
+                mean_probability_kl=_as_float(candidate.get("mean_probability_kl")),
+                max_abs_logit_delta=_as_float(candidate.get("max_abs_logit_delta")),
+                top1_miss_count=_as_int(candidate.get("top1_miss_count")),
+                miss_topk_contains_rate=_as_float(candidate.get("miss_topk_contains_rate")),
+                miss_mean_reference_margin=_as_float(candidate.get("miss_mean_reference_margin")),
+                miss_mean_probability_kl=_as_float(candidate.get("miss_mean_probability_kl")),
+                miss_mean_logit_cosine=_as_float(candidate.get("miss_mean_logit_cosine")),
+                narrow_margin_miss_count=_as_int(candidate.get("narrow_margin_miss_count")),
+                bucket_text=bucket_text,
+            )
+        )
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--score-precision-recovery-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = build_payload(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(payload, args.out_md)
+    print(json.dumps({"ok": True, "status": payload["decision"]["status"], "candidate_count": payload["candidate_count"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_llm_decoder_attention_mixed_int8_score_margin.py
+++ b/tests/test_audit_llm_decoder_attention_mixed_int8_score_margin.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_mixed_int8_score_margin import (  # noqa: E402
+    DECISION_NARROW_HOLD,
+    DECISION_PASS,
+    DECISION_SYSTEMATIC_HOLD,
+    build_payload,
+)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _args(tmp_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        score_precision_recovery_json=tmp_path / "score_precision_recovery.json",
+        out=tmp_path / "out.json",
+        out_md=tmp_path / "out.md",
+    )
+
+
+def test_audit_classifies_narrow_and_systematic_by_margin_bucket(tmp_path: Path) -> None:
+    payload = {
+        "candidate_summaries": [
+            {
+                "candidate_id": "candidate_narrow",
+                "q_bits": 8,
+                "k_bits": 8,
+                "v_bits": 8,
+                "score_bits": 8,
+                "weight_bits": 8,
+                "softmax_mode": "float_quantized",
+                "top1_match_rate": 0.5,
+                "topk_contains_rate": 1.0,
+                "mean_logit_cosine": 0.999,
+                "mean_probability_kl": 0.01,
+                "max_abs_logit_delta": 0.2,
+            },
+            {
+                "candidate_id": "candidate_systematic",
+                "q_bits": 8,
+                "k_bits": 8,
+                "v_bits": 8,
+                "score_bits": 16,
+                "weight_bits": 12,
+                "softmax_mode": "pwl_recip_lut_q16_bucket8",
+                "top1_match_rate": 0.0,
+                "topk_contains_rate": 1.0,
+                "mean_logit_cosine": 0.99,
+                "mean_probability_kl": 0.09,
+                "max_abs_logit_delta": 1.7,
+            },
+            {
+                "candidate_id": "candidate_pass",
+                "q_bits": 8,
+                "k_bits": 8,
+                "v_bits": 8,
+                "score_bits": 32,
+                "weight_bits": 16,
+                "softmax_mode": "float_quantized",
+                "top1_match_rate": 1.0,
+                "topk_contains_rate": 1.0,
+                "mean_logit_cosine": 0.9999,
+                "mean_probability_kl": 0.001,
+                "max_abs_logit_delta": 0.1,
+            },
+        ],
+        "candidate_rows": [
+            {"candidate_id": "candidate_narrow", "top1_match": 1.0, "topk_contains": 1.0, "reference_margin": 0.2, "logit_cosine": 0.999, "probability_kl": 0.001, "max_abs_logit_delta": 0.2},
+            {"candidate_id": "candidate_narrow", "top1_match": 0.0, "topk_contains": 1.0, "reference_margin": 0.2, "logit_cosine": 0.998, "probability_kl": 0.002, "max_abs_logit_delta": 0.3},
+            {"candidate_id": "candidate_narrow", "top1_match": 0.0, "topk_contains": 1.0, "reference_margin": 0.9, "logit_cosine": 0.998, "probability_kl": 0.003, "max_abs_logit_delta": 0.25},
+            {"candidate_id": "candidate_narrow", "top1_match": 1.0, "topk_contains": 1.0, "reference_margin": 1.8, "logit_cosine": 0.999, "probability_kl": 0.001, "max_abs_logit_delta": 0.22},
+            {"candidate_id": "candidate_systematic", "top1_match": 1.0, "topk_contains": 1.0, "reference_margin": 0.3, "logit_cosine": 0.996, "probability_kl": 0.002, "max_abs_logit_delta": 0.21},
+            {"candidate_id": "candidate_systematic", "top1_match": 0.0, "topk_contains": 1.0, "reference_margin": 5.2, "logit_cosine": 0.992, "probability_kl": 0.019, "max_abs_logit_delta": 1.9},
+            {"candidate_id": "candidate_pass", "top1_match": 1.0, "topk_contains": 1.0, "reference_margin": 0.1, "logit_cosine": 0.9997, "probability_kl": 0.001, "max_abs_logit_delta": 0.08},
+            {"candidate_id": "candidate_pass", "top1_match": 1.0, "topk_contains": 1.0, "reference_margin": 0.4, "logit_cosine": 0.9996, "probability_kl": 0.0008, "max_abs_logit_delta": 0.06},
+        ],
+    }
+    args = _args(tmp_path)
+    _write_json(args.score_precision_recovery_json, payload)
+
+    output = build_payload(args)
+    by_id = {row["candidate_id"]: row for row in output["candidates"]}
+
+    assert output["decision"]["status"] == DECISION_SYSTEMATIC_HOLD
+    assert by_id["candidate_narrow"]["audit_status"] == DECISION_NARROW_HOLD
+    assert by_id["candidate_narrow"]["top1_miss_by_reference_margin"]["0_0.5"] == 1
+    assert by_id["candidate_narrow"]["top1_miss_by_reference_margin"]["0_5_1.0"] == 1
+    assert by_id["candidate_narrow"]["top1_miss_count"] == 2
+    assert by_id["candidate_narrow"]["miss_topk_contains_rate"] == 1.0
+    assert by_id["candidate_narrow"]["miss_mean_reference_margin"] == 0.55
+    assert by_id["candidate_narrow"]["miss_mean_probability_kl"] == 0.0025
+    assert by_id["candidate_systematic"]["audit_status"] == DECISION_SYSTEMATIC_HOLD
+    assert by_id["candidate_systematic"]["top1_miss_by_reference_margin"][">=4.0"] == 1
+    assert by_id["candidate_systematic"]["miss_max_abs_logit_delta"] == 1.9
+    assert by_id["candidate_pass"]["audit_status"] == DECISION_PASS
+
+
+def test_audit_falls_back_to_candidate_summaries_when_rows_missing(tmp_path: Path) -> None:
+    payload = {
+        "candidate_summaries": [
+            {
+                "candidate_id": "score32_float",
+                "top1_match_rate": 1.0,
+                "topk_contains_rate": 1.0,
+                "mean_logit_cosine": 0.9999,
+                "mean_probability_kl": 0.0001,
+                "max_abs_logit_delta": 0.2,
+                "comparison_count": 12,
+            },
+            {
+                "candidate_id": "score16_float",
+                "top1_match_rate": 0.5,
+                "topk_contains_rate": 1.0,
+                "mean_logit_cosine": 0.997,
+                "mean_probability_kl": 0.2,
+                "max_abs_logit_delta": 0.9,
+                "comparison_count": 12,
+            },
+        ],
+    }
+    args = _args(tmp_path)
+    _write_json(args.score_precision_recovery_json, payload)
+
+    output = build_payload(args)
+    by_id = {row["candidate_id"]: row for row in output["candidates"]}
+
+    assert by_id["score32_float"]["audit_status"] == DECISION_PASS
+    assert by_id["score16_float"]["audit_status"] == DECISION_SYSTEMATIC_HOLD
+    assert by_id["score16_float"]["top1_miss_count"] == 6
+    assert output["decision"]["status"] == DECISION_SYSTEMATIC_HOLD


### PR DESCRIPTION
## Summary

Adds a low-cost L2 score-margin audit after the mixed/int8 score precision recovery sweep.

The new evaluator script consumes the merged score precision recovery JSON and classifies each candidate by whether top1 misses are narrow-margin/top-k-stable or systematic. The control plane can now generate and consume `decoder_attention_mixed_int8_score_margin_audit` jobs and preserve the JSON/Markdown artifacts through result finalization.

## Why

The latest score precision recovery result showed `score32_float` still at top1 0.96875 while top-k stayed 1.0. Before spending PPA on exact/high-precision softmax or recosting a frontier, we need evidence whether the misses are narrow-margin decoding sensitivity or a systematic approximation failure.

## Validation

- `python3 -m py_compile npu/eval/audit_llm_decoder_attention_mixed_int8_score_margin.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py`
- `PYTHONPATH=control_plane python3 -m pytest -q tests/test_audit_llm_decoder_attention_mixed_int8_score_margin.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_mixed_int8_score_margin_audit_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_mixed_int8_score_margin_audit_uses_decoder_evidence`
- real-artifact smoke on `decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1.json` produced `score_margin_audit_narrow_margin_hold`
