### PR TITLE
npu: preserve primary score margin audit candidate

### DIFF
--- a/npu/eval/audit_llm_decoder_attention_mixed_int8_score_margin.py
+++ b/npu/eval/audit_llm_decoder_attention_mixed_int8_score_margin.py
@@ -349,6 +349,13 @@ def build_payload(args: argparse.Namespace) -> JsonDict:
     source = _load_json(args.score_precision_recovery_json)
     rows = _get_candidate_rows(source)
     summaries = _get_candidate_summaries(source)
+    primary_candidate_id = ""
+    primary_summary = source.get("candidate_summary")
+    if isinstance(primary_summary, dict):
+        primary_candidate_id = _as_str(primary_summary.get("candidate_id"))
+    if not primary_candidate_id:
+        primary = source.get("primary_candidate_id")
+        primary_candidate_id = _as_str(primary)
 
     rows_by_candidate: dict[str, list[JsonDict]] = {}
     for row in rows:
@@ -395,7 +402,15 @@ def build_payload(args: argparse.Namespace) -> JsonDict:
         )
         candidates.append(candidate)
 
-    candidates.sort(key=lambda item: (_status_rank(item.get("audit_status", "")), -_as_float(item.get("top1_match_rate")), -_as_int(item.get("comparison_count")), _as_str(item.get("candidate_id"))))
+    candidates.sort(
+        key=lambda item: (
+            0 if primary_candidate_id and _as_str(item.get("candidate_id")) == primary_candidate_id else 1,
+            _status_rank(item.get("audit_status", "")),
+            -_as_float(item.get("top1_match_rate")),
+            -_as_int(item.get("comparison_count")),
+            _as_str(item.get("candidate_id")),
+        )
+    )
 
     audit_status_counts = {
         DECISION_PASS: 0,
@@ -439,6 +454,7 @@ def build_payload(args: argparse.Namespace) -> JsonDict:
         "inputs": {
             "score_precision_recovery_json": str(args.score_precision_recovery_json),
         },
+        "primary_candidate_id": primary_candidate_id,
         "candidates": candidates,
         "candidate_count": len(candidates),
     }
@@ -450,6 +466,7 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
         "",
         f"- decision: `{payload['decision']['status']}`",
         f"- decision_counts: `{payload['decision']['audit_status_counts']}`",
+        f"- primary_candidate_id: `{payload.get('primary_candidate_id', '')}`",
         f"- candidate_count: `{payload['candidate_count']}`",
         f"- recommended_next_step: `{payload['decision']['recommended_next_step']}`",
         "",

--- a/tests/test_audit_llm_decoder_attention_mixed_int8_score_margin.py
+++ b/tests/test_audit_llm_decoder_attention_mixed_int8_score_margin.py
@@ -78,6 +78,9 @@ def test_audit_classifies_narrow_and_systematic_by_margin_bucket(tmp_path: Path)
                 "max_abs_logit_delta": 0.1,
             },
         ],
+        "candidate_summary": {
+            "candidate_id": "candidate_narrow",
+        },
         "candidate_rows": [
             {"candidate_id": "candidate_narrow", "top1_match": 1.0, "topk_contains": 1.0, "reference_margin": 0.2, "logit_cosine": 0.999, "probability_kl": 0.001, "max_abs_logit_delta": 0.2},
             {"candidate_id": "candidate_narrow", "top1_match": 0.0, "topk_contains": 1.0, "reference_margin": 0.2, "logit_cosine": 0.998, "probability_kl": 0.002, "max_abs_logit_delta": 0.3},
@@ -96,6 +99,8 @@ def test_audit_classifies_narrow_and_systematic_by_margin_bucket(tmp_path: Path)
     by_id = {row["candidate_id"]: row for row in output["candidates"]}
 
     assert output["decision"]["status"] == DECISION_SYSTEMATIC_HOLD
+    assert output["primary_candidate_id"] == "candidate_narrow"
+    assert output["candidates"][0]["candidate_id"] == "candidate_narrow"
     assert by_id["candidate_narrow"]["audit_status"] == DECISION_NARROW_HOLD
     assert by_id["candidate_narrow"]["top1_miss_by_reference_margin"]["0_0.5"] == 1
     assert by_id["candidate_narrow"]["top1_miss_by_reference_margin"]["0_5_1.0"] == 1


### PR DESCRIPTION
## Summary

Keeps the source score-recovery primary candidate first in the score-margin audit output.

The initial audit sorted passing controls before held candidates, which made generated review summaries call `qkv8_float_exact` the primary row even though the audit question is about `score32_float`. This preserves `candidate_summary.candidate_id` from the source artifact as `primary_candidate_id` and sorts it first.

## Validation

- `python3 -m py_compile npu/eval/audit_llm_decoder_attention_mixed_int8_score_margin.py`
- `PYTHONPATH=control_plane python3 -m pytest -q tests/test_audit_llm_decoder_attention_mixed_int8_score_margin.py`
- real-artifact smoke now reports `primary score32_float` and first candidate `score32_float`
