### PR TITLE
npu: expose repo root to HF eval scripts

### DIFF
--- a/npu/eval/run_hf_eval_python.sh
+++ b/npu/eval/run_hf_eval_python.sh
@@ -76,4 +76,5 @@ printf 'rtlgen hf eval: using %s (Python %s)\n' "${selected_python}" "${version}
 script="$1"
 shift
 cd "${repo_root}"
+export PYTHONPATH="${repo_root}${PYTHONPATH:+:${PYTHONPATH}}"
 exec "${selected_python}" "${script}" "$@"

--- a/tests/test_run_hf_eval_python.py
+++ b/tests/test_run_hf_eval_python.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Tests for the Hugging Face eval launcher."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_run_hf_eval_python_adds_repo_root_to_pythonpath(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    fake_python = tmp_path / "fake_python"
+    marker = tmp_path / "marker.json"
+    probe_script = tmp_path / "probe.py"
+
+    fake_python.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            if [[ "${1:-}" == "-" ]]; then
+              cat >/dev/null
+              exit 0
+            fi
+            if [[ "${1:-}" == "-c" ]]; then
+              printf '3.11.0\\n'
+              exit 0
+            fi
+            exec python3 "$@"
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    probe_script.write_text(
+        textwrap.dedent(
+            """\
+            import json
+            import os
+            import sys
+            import npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention
+
+            with open(sys.argv[1], "w", encoding="utf-8") as f:
+                json.dump({"pythonpath": os.environ.get("PYTHONPATH", "")}, f)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["RTLGEN_HF_MATERIALIZER_PYTHON"] = str(fake_python)
+    env.pop("PYTHONPATH", None)
+
+    subprocess.run(
+        ["bash", "npu/eval/run_hf_eval_python.sh", str(probe_script), str(marker)],
+        cwd=repo_root,
+        env=env,
+        check=True,
+    )
+
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    assert data["pythonpath"].split(os.pathsep)[0] == str(repo_root)


### PR DESCRIPTION
## Summary
- export the repo root on PYTHONPATH in run_hf_eval_python.sh before executing eval scripts
- add a wrapper regression test using a fake HF Python so package imports are validated without torch/transformers

## Diagnosis
The remote generation-quality job checked out the requested commit but failed in 1.4s during startup. Reproducing the launcher shape locally showed the new script failed with:

```
ModuleNotFoundError: No module named 'npu'
```

The wrapper already cd'd to the repo root but path-executed scripts only had the script directory on sys.path. Exporting the repo root fixes package imports for this and future HF eval scripts.

## Tests
- python3 -m pytest -q tests/test_run_hf_eval_python.py tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
- git diff --check
- RTLGEN_HF_MATERIALIZER_PYTHON=<fake> bash npu/eval/run_hf_eval_python.sh npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py --help
