### PR TITLE
control_plane: fix mixed int8 generation quality gate labeling

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -846,7 +846,11 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 
-    if isinstance(evidence_payload.get("model"), dict) and isinstance(evidence_payload.get("decision"), dict):
+    if (
+        isinstance(evidence_payload.get("model"), dict)
+        and isinstance(evidence_payload.get("decision"), dict)
+        and evidence_payload.get("quality_gate") != "mixed_int8_generation_quality"
+    ):
         decision = dict(evidence_payload["decision"])
         outcome = str(decision.get("status") or "native_checkpoint_quality_recorded")
         model_info = dict(evidence_payload["model"])
@@ -1264,7 +1268,10 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 
-    if model == "llm_decoder_attention_mixed_int8_generation_quality_llama7b_v1":
+    if (
+        model == "llm_decoder_attention_mixed_int8_generation_quality_llama7b_v1"
+        or evidence_payload.get("quality_gate") == "mixed_int8_generation_quality"
+    ):
         decision = evidence_payload.get("decision")
         decision_dict = dict(decision) if isinstance(decision, dict) else {}
         outcome = str(

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1129,7 +1129,12 @@ def test_consume_l2_result_frontier_attention_mixed_int8_generation_quality_uses
                 repo_root / evidence_rel,
                 json.dumps(
                     {
-                        "model": "llm_decoder_attention_mixed_int8_generation_quality_llama7b_v1",
+                        "quality_gate": "mixed_int8_generation_quality",
+                        "model": {
+                            "model_id": "mistralai/Mistral-7B-v0.1",
+                            "gqa_group_size": 4.0,
+                            "dtype": "bfloat16",
+                        },
                         "decision": {
                             "status": "mixed_int8_generation_quality_hold",
                             "recommended_next_step": "do not recost until generation drift is resolved",
@@ -1195,6 +1200,9 @@ def test_consume_l2_result_frontier_attention_mixed_int8_generation_quality_uses
             )
             assessment = decision_payload["proposal_assessment"]
             assert assessment["outcome"] == "mixed_int8_generation_quality_hold"
+            assert "Decoder mixed/int8 generation quality evidence" in assessment["summary"]
+            assert "KV quality evidence" not in assessment["summary"]
+            assert "free_run_exact_match_rate=0.75" in assessment["summary"]
             assert assessment["decoder_evidence_ref"] == evidence_rel
             assert (
                 decision_payload["evaluation_record"]["abstraction_layer"]

--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
@@ -429,8 +429,8 @@ def _decision(summary: JsonDict, *, expected_gqa_group_size: int, actual_gqa_gro
         "blockers": blockers,
         "next_step": next_step,
         "thresholds": {
-            "teacher_forced_nll_delta_max": 0.4,
-            "candidate_probability_assigned_to_reference_token_min": 0.1,
+            "teacher_forced_mean_nll_delta_max": 0.4,
+            "teacher_forced_candidate_reference_token_prob_mean_min": 0.1,
             "free_running_match_rate_min": 0.75,
             "expected_gqa_group_size": expected_gqa_group_size,
         },

--- a/tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
+++ b/tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
@@ -65,6 +65,7 @@ def test_generation_decision_pass_and_hold_thresholds() -> None:
     clean = {
         "teacher_forced_nll_delta_mean": 0.2,
         "candidate_probability_assigned_to_reference_token_mean": 0.35,
+        "candidate_probability_assigned_to_reference_token_min": 0.01,
         "free_running_match_rate": 0.9,
     }
     poor = {
@@ -73,7 +74,14 @@ def test_generation_decision_pass_and_hold_thresholds() -> None:
         "free_running_match_rate": 0.5,
     }
 
-    assert _decision(clean, expected_gqa_group_size=4, actual_gqa_group_size=4.0)["status"] == "mixed_int8_generation_quality_pass"
+    clean_decision = _decision(clean, expected_gqa_group_size=4, actual_gqa_group_size=4.0)
+    assert clean_decision["status"] == "mixed_int8_generation_quality_pass"
+    assert clean_decision["thresholds"] == {
+        "teacher_forced_mean_nll_delta_max": 0.4,
+        "teacher_forced_candidate_reference_token_prob_mean_min": 0.1,
+        "free_running_match_rate_min": 0.75,
+        "expected_gqa_group_size": 4,
+    }
     hold = _decision(poor, expected_gqa_group_size=4, actual_gqa_group_size=4.0)
     assert hold["status"] == "mixed_int8_generation_quality_hold"
     assert hold["blockers"]


### PR DESCRIPTION
## Summary
- make the mixed-int8 generation-quality decision thresholds name the mean metrics they actually enforce
- prevent generic native-checkpoint KV evidence classification from catching mixed-int8 generation-quality artifacts
- update focused tests to use the real evidence shape: model dict plus quality_gate=mixed_int8_generation_quality

## Diagnosis
PR #1029 produced a successful remote generation-quality run, but review found two artifact issues:

1. The gate compared mean NLL delta and mean candidate reference-token probability, while reporting threshold keys as max/min metrics.
2. The result consumer classified mixed-int8 generation-quality evidence as native-checkpoint KV evidence because the artifact uses model as a dict.

The existing run result should be treated as superseded and rerun after this fix.

## Tests
- PYTHONPATH=control_plane python3 -m pytest -q tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_frontier_attention_mixed_int8_generation_quality_uses_decoder_evidence
- python3 -m py_compile npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py control_plane/control_plane/services/l2_result_consumer.py
- git diff --check
