### PR TITLE
npu: prepare score32 composed recost jobs

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1121,6 +1121,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
         "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
         "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
+        "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
     }:
         diagnosis = evidence_payload.get("diagnosis")
         diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
@@ -1135,6 +1136,8 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             if model == "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1"
             else "Decoder composed dual-stream physical feasibility evidence (softmax-recip LUT variant frontier)"
             if model == "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
+            else "Decoder composed dual-stream physical feasibility evidence (score32/w16 exact-div frontier)"
+            if model == "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1"
             else "Decoder dual-stream physical feasibility evidence"
         )
         parts = [

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5451,12 +5451,18 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
     )
     q12_pwl_frontier = "q12_pwl_softmax_frontier" in item_id
+    score32_frontier = "score32_w16_exact_div_frontier" in item_id
     variant_frontier = "variant_frontier" in item_id
     composed_dual_stream_metrics = (
         "runs/designs/npu_blocks/"
         "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv"
     )
-    if q12_pwl_frontier:
+    if score32_frontier:
+        composed_dual_stream_metrics = (
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv"
+        )
+    elif q12_pwl_frontier:
         composed_dual_stream_metrics = (
             "runs/designs/npu_blocks/"
             "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/metrics.csv"
@@ -5474,24 +5480,18 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         f"--composed-dual-stream-metrics {path}"
         for path in composed_dual_stream_metrics.split(",")
     )
-    model_name = (
-        "llm_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1"
-        if q12_pwl_frontier
-        else (
-            "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
-            if variant_frontier
-            else "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
-        )
-    )
-    precision_profile = (
-        "q8_k8_v6_a24_s12_w12_pwl_recip_q12_int8_compute"
-        if q12_pwl_frontier
-        else (
-            "q8_k8_v6_a24_s8_w8_recip_lut_variant_int8_compute"
-            if variant_frontier
-            else "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
-        )
-    )
+    if score32_frontier:
+        model_name = "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1"
+        precision_profile = "q8_k8_v8_a32_s32_w16_exact_div_int8_compute"
+    elif q12_pwl_frontier:
+        model_name = "llm_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1"
+        precision_profile = "q8_k8_v6_a24_s12_w12_pwl_recip_q12_int8_compute"
+    elif variant_frontier:
+        model_name = "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
+        precision_profile = "q8_k8_v6_a24_s8_w8_recip_lut_variant_int8_compute"
+    else:
+        model_name = "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
+        precision_profile = "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
     return {
         "inputs": {
             "attention_kv_subtile_pipeline_schedule": subtile_pipeline,

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1264,6 +1264,27 @@ def test_decoder_evidence_summary_recognizes_composed_datapath_recip_lut_variant
     assert "best_requested_substituted_compute_variant_label=q12" in summary
 
 
+def test_decoder_evidence_summary_recognizes_composed_datapath_score32_frontier_model() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/composed_datapath_score32.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+            "diagnosis": {
+                "decision": "dual_stream_feasible",
+                "precision_profile": "q8_k8_v8_a32_s32_w16_exact_div_int8_compute",
+                "best_requested_mode": "dual_mac",
+                "best_requested_adjusted_latency_us_if_feasible": 1800.0,
+                "best_requested_substituted_compute_variant_label": "score32_w16_exact_div",
+                "best_requested_substituted_compute_arch": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div",
+            },
+        },
+    )
+
+    assert outcome == "dual_stream_feasible"
+    assert "composed dual-stream physical feasibility evidence (score32/w16 exact-div frontier)" in summary
+    assert "precision_profile=q8_k8_v8_a32_s32_w16_exact_div_int8_compute" in summary
+
+
 def _seed_succeeded_l2_campaign(session: Session, repo_root: Path) -> tuple[str, str]:
     campaign_dir = repo_root / "runs" / "campaigns" / "npu" / "demo_campaign"
     schedule_rel = "runs/campaigns/npu/demo_campaign/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6141,6 +6141,59 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_q12_pwl_fron
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_frontier_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1"
+                in run
+            )
+            assert "--precision-profile q8_k8_v8_a32_s32_w16_exact_div_int8_compute" in run
+            composed_dual_stream_metrics = decoder_inputs["attention_kv_composed_dual_stream_metrics"]
+            assert composed_dual_stream_metrics == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv"
+            )
+            assert (
+                "--composed-dual-stream-metrics runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv "
+                in run
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_integrated_abstraction_closure_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds score32/w16 exact-div composed datapath generation, config, and sweep files.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the q8/k8/v8/a32/s32/w16 composed dual-stream attention datapath.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_quality_recost",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_score32_quality_recost_datapath",
+        "reason": "This removes the missing PPA abstraction for the score32_float quality-recovered path before system-level frontier ranking."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_v1/proposal.json
@@ -1,0 +1,75 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_v1",
+  "created_utc": "2026-06-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Composed dual-stream attention score32/w16 exact-div datapath",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The score32_float native-checkpoint generation gate recovered bounded Llama7B behavior, so the next abstraction to remove is the physical cost of a concrete composed datapath with 32-bit MAC/score accumulation, 16-bit softmax weights, and v8 value lanes.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 PPA cost is paid by widening the composed dual-stream mixed/int8 datapath to q8/k8/v8/a32/s32/w16 with an exact-divider softmax structure?",
+    "baselines": [
+      "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+      "l1_decoder_attention_dual_stream_composed_softmax_recip_lut_ppa_v1_r3"
+    ],
+    "candidate": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+    "include": [
+      "generate RTL with mac_accum_bits=32",
+      "generate softmax_score_bits=32 and softmax_weight_bits=16",
+      "generate value_bits=8",
+      "run the composed datapath guard before OpenROAD",
+      "measure Nangate45 area, power, timing, and timing debug paths"
+    ],
+    "exclude": [
+      "new native checkpoint quality run",
+      "full floating-point exp softmax hardware",
+      "Llama7B frontier ranking"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "The score32_float quality evidence used native floating softmax; this RTL measures a widened exact-divider softmax structure, not a full floating exp implementation.",
+    "The job measures the local composed datapath only; Llama7B system-level ranking is a dependent Layer 2 substitution job."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the q8/k8/v8/a32/s32/w16 composed dual-stream attention datapath after score32 generation-quality recovery.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_quality_recost",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_score32_quality_recost_datapath",
+        "reason": "The current quality-backed frontier invalidated the old s8/w8 reciprocal-LUT energy winner and requested score32 score/softmax recosting."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div.json"
+  ],
+  "knowledge_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_generation_quality__l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_r2.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds score32/w16 exact-div composed datapath L2 task-generator support.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Substitute the measured score32/v8/w16 exact-div composed dual-stream attention wrapper into the Llama7B schedule.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_quality_recost_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_r2",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_quality_recost_frontier",
+        "reason": "This is the dependent Llama7B frontier substitution after score32/v8/w16 composed datapath PPA is available."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_v1/proposal.json
@@ -1,0 +1,64 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_v1",
+  "created_utc": "2026-06-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B composed datapath score32/w16 exact-div frontier",
+  "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+  "hypothesis": "If the widened score32/v8/w16 composed datapath remains physically feasible, it should replace the invalidated s8/w8 reciprocal-LUT mixed-int8 energy row as the quality-backed precision candidate for the next Llama7B frontier ranking.",
+  "direct_comparison": {
+    "primary_question": "After measuring the score32/v8/w16 composed wrapper, what latency/area/precision point does it imply when substituted into the Llama7B dual-stream schedule?",
+    "baseline": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_r2",
+    "candidate": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+    "include": [
+      "consume measured score32/w16 exact-div composed datapath metrics",
+      "substitute the measured wrapper into the existing Llama7B sub-tile schedule",
+      "record feasibility, adjusted latency, required area, and precision profile"
+    ],
+    "exclude": [
+      "new native checkpoint quality run",
+      "new HBM/DRAM service model",
+      "full end-to-end energy reranking until this feasibility record exists"
+    ],
+    "metrics": [
+      "decision",
+      "precision_profile",
+      "best_requested_adjusted_latency_us_if_feasible",
+      "best_requested_logic_slack_um2",
+      "best_requested_substituted_compute_area_um2",
+      "best_requested_substituted_compute_variant_label"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Substitute the measured score32/v8/w16 exact-div composed dual-stream attention wrapper into the Llama7B schedule and record the quality-backed frontier cost direction.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_quality_recost_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_r2",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_quality_recost_frontier",
+        "reason": "This is the first Llama7B schedule substitution using measured PPA for the quality-recovered score32/v8/w16 path."
+      }
+    }
+  ],
+  "source_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1_r2.json",
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py"
+  ],
+  "remaining_abstractions": [
+    "This substitutes measured local datapath PPA into an existing analytic schedule; HBM/SRAM/NoC service models remain unchanged.",
+    "The measured softmax structure is exact-divider based and not a full floating exp datapath."
+  ]
+}

--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -33,6 +33,7 @@ def main() -> int:
     softmax_internal_pipeline_stages = int(manifest.get("softmax_internal_pipeline_stages", 0))
     softmax_latency_stages = int(manifest.get("softmax_latency_stages", 1))
     value_alignment_delay_stages = int(manifest.get("value_alignment_delay_stages", 0))
+    mac_accum_bits = int(manifest.get("mac_accum_bits", 24))
     softmax_score_bits = int(manifest.get("softmax_score_bits", 8))
     softmax_weight_bits = int(manifest.get("softmax_weight_bits", 8))
     if streams != 2:
@@ -52,8 +53,14 @@ def main() -> int:
         raise SystemExit("missing dual stream buffer registers")
     if softmax_impl not in {"exact_div", "pow2sum", "recip_lut", "pwl_recip_lut"}:
         raise SystemExit(f"unsupported softmax_impl={softmax_impl}")
-    if not 2 <= softmax_score_bits <= 24:
+    if not 24 <= mac_accum_bits <= 32:
+        raise SystemExit(f"unsupported mac_accum_bits={mac_accum_bits}")
+    if not 2 <= softmax_score_bits <= 32:
         raise SystemExit(f"unsupported softmax_score_bits={softmax_score_bits}")
+    if softmax_score_bits > mac_accum_bits:
+        raise SystemExit(
+            f"softmax_score_bits={softmax_score_bits} exceeds mac_accum_bits={mac_accum_bits}"
+        )
     if not 2 <= softmax_weight_bits <= 24:
         raise SystemExit(f"unsupported softmax_weight_bits={softmax_weight_bits}")
     if softmax_latency_stages != 1 + softmax_internal_pipeline_stages:

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -52,6 +52,7 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     array_n = _as_int(comp, "array_n", 8)
     k_unroll = _as_int(comp, "k_unroll", 1)
     row_elems = _as_int(comp, "softmax_row_elems", 8)
+    value_bits = _as_int(comp, "value_bits", 6)
     value_lanes = _as_int(comp, "value_lanes", 16)
     partials = _as_int(comp, "partials", 8)
     partials_per_cycle = _as_int(comp, "partials_per_cycle", 2)
@@ -59,6 +60,7 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
     softmax_internal_pipeline_stages = _as_int(comp, "softmax_internal_pipeline_stages", 0)
     softmax_impl = _as_str(comp, "softmax_impl", "exact_div")
+    mac_accum_bits = _as_int(comp, "mac_accum_bits", 24)
     softmax_score_bits = _as_int(comp, "softmax_score_bits", 8)
     softmax_weight_bits = _as_int(comp, "softmax_weight_bits", 8)
     softmax_input_frac_bits = _as_int(comp, "softmax_input_frac_bits", 0)
@@ -73,6 +75,8 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.k_unroll must be in [1, 4]")
     if row_elems < 1 or row_elems > 16:
         raise SystemExit("attention_dual_stream_composed.softmax_row_elems must be in [1, 16]")
+    if value_bits < 2 or value_bits > 16:
+        raise SystemExit("attention_dual_stream_composed.value_bits must be in [2, 16]")
     if value_lanes < 1 or value_lanes > 32:
         raise SystemExit("attention_dual_stream_composed.value_lanes must be in [1, 32]")
     if partials < 1 or partials > 16:
@@ -85,8 +89,22 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.softmax_pipeline_stages must be in [0, 1]")
     if softmax_internal_pipeline_stages < 0 or softmax_internal_pipeline_stages > 1:
         raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages must be in [0, 1]")
-    if softmax_score_bits < 2 or softmax_score_bits > 24:
-        raise SystemExit("attention_dual_stream_composed.softmax_score_bits must be in [2, 24]")
+    if mac_accum_bits < 24 or mac_accum_bits > 32:
+        raise SystemExit("attention_dual_stream_composed.mac_accum_bits must be in [24, 32]")
+    if softmax_score_bits < 2 or softmax_score_bits > 32:
+        raise SystemExit("attention_dual_stream_composed.softmax_score_bits must be in [2, 32]")
+    if softmax_score_bits == 32 and mac_accum_bits != 32:
+        raise SystemExit(
+            "attention_dual_stream_composed.softmax_score_bits=32 requires mac_accum_bits=32"
+        )
+    if softmax_score_bits > mac_accum_bits:
+        raise SystemExit(
+            "attention_dual_stream_composed.softmax_score_bits must be in [2, mac_accum_bits]"
+        )
+    if softmax_score_bits == 32 and softmax_weight_bits != 16:
+        raise SystemExit(
+            "attention_dual_stream_composed.softmax_score_bits=32 requires softmax_weight_bits=16 in the current prototype"
+        )
     if softmax_weight_bits < 2 or softmax_weight_bits > 24:
         raise SystemExit("attention_dual_stream_composed.softmax_weight_bits must be in [2, 24]")
     if softmax_input_frac_bits < 0 or softmax_input_frac_bits > 16:
@@ -104,17 +122,29 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     return comp
 
 
-def _int8_mac_module() -> str:
-    return """module int8_mac_s8s8_acc24 (
+def _int8_mac_module(*, accum_bits: int) -> str:
+    sign_ext_bits = accum_bits - 16
+    return f"""module int8_mac_s8s8_acc{accum_bits} (
     input  wire signed [7:0]  A,
     input  wire signed [7:0]  B,
-    input  wire signed [23:0] C,
-    output wire signed [23:0] R
+    input  wire signed [{accum_bits - 1}:0] C,
+    output wire signed [{accum_bits - 1}:0] R
 );
   wire signed [15:0] product = A * B;
-  assign R = {{8{product[15]}}, product} + C;
+  assign R = {{{{{sign_ext_bits}{{product[15]}}}}, product}} + C;
 endmodule
 """
+
+
+def _hex_literal(*, bits: int, value: int) -> str:
+    hex_digits = max(1, (bits + 3) // 4)
+    return f"{bits}'h{value & ((1 << bits) - 1):0{hex_digits}x}"
+
+
+def _zero_extend_cycle_ctr(*, bits: int) -> str:
+    if bits == 16:
+        return "cycle_ctr"
+    return f"{{{bits - 16}'h0, cycle_ctr}}"
 
 
 def _softmax_module(
@@ -600,19 +630,21 @@ def _value_stream_module(
     module_name: str,
     row_elems: int,
     weight_bits: int,
+    value_bits: int,
     value_lanes: int,
     stream_buffer_bits: int,
+    score_mix_bits: int,
     equivalence_hash: bool,
 ) -> str:
     acc_bits = 40
-    product_bits = 6 + weight_bits + 1
+    product_bits = value_bits + weight_bits + 1
     fold_terms = ["32'h0000_0000"]
     product_lines: list[str] = []
     fold_pad_bits = max(0, 32 - product_bits)
     for lane in range(value_lanes):
         product_lines.extend(
             [
-                f"  wire signed [5:0] value_{lane:02d} = stream_data[{(lane * 6) % (stream_buffer_bits - 5)} +: 6];",
+                f"  wire signed [{value_bits - 1}:0] value_{lane:02d} = stream_data[{(lane * value_bits) % (stream_buffer_bits - value_bits + 1)} +: {value_bits}];",
                 f"  wire [{weight_bits - 1}:0] weight_{lane:02d} = weights[{(lane % row_elems) * weight_bits} +: {weight_bits}];",
                 f"  wire signed [{weight_bits}:0] weight_{lane:02d}_signed = {{1'b0, weight_{lane:02d}}};",
                 f"  wire signed [{product_bits - 1}:0] product_{lane:02d} = value_{lane:02d} * weight_{lane:02d}_signed;",
@@ -625,18 +657,21 @@ def _value_stream_module(
     ]
     sum_expr = " +\n      ".join(sum_terms)
     fold_expr = " ^\n      ".join(fold_terms)
-    score_ext = f"{{{{{acc_bits - 24}{{score_mix[23]}}}}, score_mix}}"
+    score_ext = f"{{{{{acc_bits - score_mix_bits}{{score_mix[{score_mix_bits - 1}]}}}}, score_mix}}"
+    score_hash_mix = (
+        "score_mix[31:0]" if score_mix_bits >= 32 else f"{{{{{32 - score_mix_bits}{{1'b0}}}}, score_mix}}"
+    )
     hash_port = ",\n    output reg  [31:0]           value_hash" if equivalence_hash else ""
     fold_wire = f"""  wire [31:0] product_fold =
       {fold_expr};
 """ if equivalence_hash else ""
-    hash_seq = "    value_hash <= product_fold ^ value_accum[31:0] ^ {8'h0, score_mix};\n" if equivalence_hash else ""
+    hash_seq = f"    value_hash <= product_fold ^ value_accum[31:0] ^ {score_hash_mix};\n" if equivalence_hash else ""
     return f"""(* keep_hierarchy = 1 *)
 module {module_name} (
     input  wire                  clk,
     input  wire [{stream_buffer_bits - 1}:0] stream_data,
     input  wire [{row_elems * weight_bits - 1}:0] weights,
-    input  wire [23:0]           score_mix,
+    input  wire [{score_mix_bits - 1}:0] score_mix,
     output reg  [{acc_bits - 1}:0] value_accum{hash_port}
 );
 {chr(10).join(product_lines)}
@@ -658,11 +693,13 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     array_n = _as_int(comp, "array_n", 8)
     k_unroll = _as_int(comp, "k_unroll", 1)
     row_elems = _as_int(comp, "softmax_row_elems", 8)
+    value_bits = _as_int(comp, "value_bits", 6)
     value_lanes = _as_int(comp, "value_lanes", 16)
     partials = _as_int(comp, "partials", 8)
     partials_per_cycle = _as_int(comp, "partials_per_cycle", 2)
     reciprocal_bits = _as_int(comp, "reciprocal_bits", 10)
     accum_bits = _as_int(comp, "softmax_accum_bits", 24)
+    mac_accum_bits = _as_int(comp, "mac_accum_bits", 24)
     softmax_score_bits = _as_int(comp, "softmax_score_bits", 8)
     softmax_weight_bits = _as_int(comp, "softmax_weight_bits", 8)
     softmax_input_frac_bits = _as_int(comp, "softmax_input_frac_bits", 0)
@@ -672,6 +709,7 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
     softmax_internal_pipeline_stages = _as_int(comp, "softmax_internal_pipeline_stages", 0)
     softmax_impl = _as_str(comp, "softmax_impl", "exact_div")
+    score_mix_bits = mac_accum_bits
     softmax_latency_stages = 1 + softmax_internal_pipeline_stages
     value_delay_stages = softmax_pipeline_stages + softmax_latency_stages if softmax_pipeline_stages else 0
     macs_per_stream = array_m * array_n * k_unroll
@@ -682,9 +720,13 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     softmax_name = (
         "attention_softmax_weight_q12_pwl_recip_like"
         if softmax_impl == "pwl_recip_lut"
-        else "attention_softmax_weight_int8_r8_acc24_recip_q10_like"
+        else (
+            "attention_softmax_weight_score32_w16_exact_div_like"
+            if softmax_score_bits == 32 and softmax_weight_bits == 16 and softmax_impl == "exact_div"
+            else "attention_softmax_weight_int8_r8_acc24_recip_q10_like"
+        )
     )
-    value_name = "attention_full_value_stream_q8v6_p8_ppc2"
+    value_name = f"attention_full_value_stream_q8v{value_bits}_p8_ppc2"
 
     stream_regs = [f"  reg [{stream_buffer_bits - 1}:0] stream_buf_{stream};" for stream in range(streams)]
     stream_reset = [f"      stream_buf_{stream} <= {{{stream_buffer_bits}{{1'b0}}}};" for stream in range(streams)]
@@ -714,9 +756,9 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
         for stream in range(streams):
             for stage in range(value_delay_stages):
                 value_pipe_regs.append(f"  reg [{stream_buffer_bits - 1}:0] stream_buf_{stream}_pipe_{stage};")
-                value_pipe_regs.append(f"  reg [23:0] score_mix_{stream}_pipe_{stage};")
+                value_pipe_regs.append(f"  reg [{score_mix_bits - 1}:0] score_mix_{stream}_pipe_{stage};")
                 value_pipe_reset.append(f"      stream_buf_{stream}_pipe_{stage} <= {{{stream_buffer_bits}{{1'b0}}}};")
-                value_pipe_reset.append(f"      score_mix_{stream}_pipe_{stage} <= 24'h0;")
+                value_pipe_reset.append(f"      score_mix_{stream}_pipe_{stage} <= {{{score_mix_bits}{{1'b0}}}};")
                 source_stream = f"stream_buf_{stream}" if stage == 0 else f"stream_buf_{stream}_pipe_{stage - 1}"
                 source_score = f"score_mix_{stream}" if stage == 0 else f"score_mix_{stream}_pipe_{stage - 1}"
                 value_pipe_update.append(f"      stream_buf_{stream}_pipe_{stage} <= {source_stream};")
@@ -727,7 +769,7 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     mac_wires: list[str] = []
     mac_insts: list[str] = []
     score_lane_terms: list[list[str]] = [[] for _ in range(row_elems)]
-    score_mix_terms = [["24'h000000"] for _ in range(streams)]
+    score_mix_terms = [[f"{score_mix_bits}'h0"] for _ in range(streams)]
     compute_fold_terms = ["32'h0000_0000"]
     for stream in range(streams):
         for idx in range(macs_per_stream):
@@ -737,26 +779,35 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
             flat = stream * macs_per_stream + idx
             const_a = (0x3D ^ ((stream + 1) * 0x17) ^ ((row + 1) * 0x13) ^ ((col + 1) * 0x27) ^ (ku * 0x41)) & 0xFF
             const_b = (0x21 ^ ((stream + 1) * 0x2B) ^ ((row + 1) * 0x1D) ^ ((col + 1) * 0xA3) ^ (ku * 0x55)) & 0xFF
-            const_c = (0x001011 ^ ((stream + 1) * 0x0101) ^ ((row + 1) * 0x0007) ^ ((col + 1) * 0x000B) ^ (ku * 0x0013)) & 0xFFFFFF
+            const_c = (
+                0x001011
+                ^ ((stream + 1) * 0x0101)
+                ^ ((row + 1) * 0x0007)
+                ^ ((col + 1) * 0x000B)
+                ^ (ku * 0x0013)
+            ) & ((1 << mac_accum_bits) - 1)
             mac_wires.extend(
                 [
                     f"  wire signed [7:0] mac_a_{flat:04d} = seed_state[7:0] ^ stream_buf_{stream}[{(idx * 7) % (stream_buffer_bits - 7)} +: 8] ^ 8'h{const_a:02x} ^ cycle_ctr[7:0];",
                     f"  wire signed [7:0] mac_b_{flat:04d} = seed_state[15:8] ^ stream_buf_{stream}[{(idx * 11) % (stream_buffer_bits - 7)} +: 8] ^ 8'h{const_b:02x} ^ cycle_ctr[15:8];",
-                    f"  wire signed [23:0] mac_c_{flat:04d} = {{8'h00, cycle_ctr}} ^ stream_buf_{stream}[{(idx * 13) % (stream_buffer_bits - 23)} +: 24] ^ 24'h{const_c:06x};",
-                    f"  wire signed [23:0] mac_r_{flat:04d};",
+                    f"  wire signed [{mac_accum_bits - 1}:0] mac_c_{flat:04d} = {_zero_extend_cycle_ctr(bits=mac_accum_bits)} ^ stream_buf_{stream}[{(idx * 13) % (stream_buffer_bits - mac_accum_bits + 1)} +: {mac_accum_bits}] ^ {_hex_literal(bits=mac_accum_bits, value=const_c)};",
+                    f"  wire signed [{mac_accum_bits - 1}:0] mac_r_{flat:04d};",
                 ]
             )
             mac_insts.append(
-                f"""  int8_mac_s8s8_acc24 u_mac_{flat:04d} (
+                f"""  int8_mac_s8s8_acc{mac_accum_bits} u_mac_{flat:04d} (
     .A(mac_a_{flat:04d}),
     .B(mac_b_{flat:04d}),
     .C(mac_c_{flat:04d}),
     .R(mac_r_{flat:04d})
   );"""
             )
-            score_lane_terms[idx % row_elems].append(f"mac_r_{flat:04d}[{softmax_score_bits - 1}:0]")
+            score_mix_term = f"mac_r_{flat:04d}[{softmax_score_bits - 1}:0]"
+            score_lane_terms[idx % row_elems].append(score_mix_term)
             score_mix_terms[stream].append(f"mac_r_{flat:04d}")
-            compute_fold_terms.append(f"{{8'h00, mac_r_{flat:04d}}}")
+            compute_fold_terms.append(
+                f"mac_r_{flat:04d}[31:0]" if mac_accum_bits >= 32 else f"{{{{{32 - mac_accum_bits}{{1'b0}}}}, mac_r_{flat:04d}}}"
+            )
 
     score_assigns = []
     for lane, terms in enumerate(score_lane_terms):
@@ -780,8 +831,8 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
                 f"    output reg  [{softmax_weight_row_width - 1}:0] softmax_weights_out",
                 "    output reg  [39:0] value_accum_0_out",
                 "    output reg  [39:0] value_accum_1_out",
-                "    output reg  [23:0] score_mix_0_out",
-                "    output reg  [23:0] score_mix_1_out",
+                f"    output reg  [{score_mix_bits - 1}:0] score_mix_0_out",
+                f"    output reg  [{score_mix_bits - 1}:0] score_mix_1_out",
             ]
         )
     softmax_hash_wire = "  wire [31:0] softmax_weight_hash;\n" if equivalence_hash else ""
@@ -796,8 +847,8 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     reset_ppa_outputs = "" if equivalence_hash else f"""      softmax_weights_out <= {{{softmax_weight_row_width}{{1'b0}}}};
       value_accum_0_out <= 40'h0;
       value_accum_1_out <= 40'h0;
-      score_mix_0_out <= 24'h0;
-      score_mix_1_out <= 24'h0;
+      score_mix_0_out <= {{{score_mix_bits}{{1'b0}}}};
+      score_mix_1_out <= {{{score_mix_bits}{{1'b0}}}};
 """
     update_outputs = (
         """        result_hash <= result_hash ^ compute_fold ^ softmax_weight_hash ^ value_hash_0 ^ value_hash_1 ^
@@ -845,9 +896,9 @@ module {top_name} (
   wire [{softmax_weight_row_width - 1}:0] softmax_weights;
 {softmax_hash_wire.rstrip()}
 {compute_fold_wire.rstrip()}
-  wire [23:0] score_mix_0 =
+  wire [{score_mix_bits - 1}:0] score_mix_0 =
       {score_mix_exprs[0]};
-  wire [23:0] score_mix_1 =
+  wire [{score_mix_bits - 1}:0] score_mix_1 =
       {score_mix_exprs[1]};
   wire [39:0] value_accum_0;
   wire [39:0] value_accum_1;
@@ -903,7 +954,7 @@ endmodule
     out_path.mkdir(parents=True, exist_ok=True)
     rtl = "\n\n".join(
         [
-            _int8_mac_module(),
+            _int8_mac_module(accum_bits=mac_accum_bits),
             _softmax_module(
                 module_name=softmax_name,
                 row_elems=row_elems,
@@ -921,8 +972,10 @@ endmodule
                 module_name=value_name,
                 row_elems=row_elems,
                 weight_bits=softmax_weight_bits,
+                value_bits=value_bits,
                 value_lanes=value_lanes,
                 stream_buffer_bits=stream_buffer_bits,
+                score_mix_bits=score_mix_bits,
                 equivalence_hash=equivalence_hash,
             ),
             top_text,
@@ -940,13 +993,15 @@ endmodule
         "macs_per_stream": macs_per_stream,
         "total_macs": total_macs,
         "softmax_row_elems": row_elems,
+        "mac_accum_bits": mac_accum_bits,
+        "mac_module": f"int8_mac_s8s8_acc{mac_accum_bits}",
         "softmax_accum_bits": accum_bits,
         "softmax_score_bits": softmax_score_bits,
         "softmax_weight_bits": softmax_weight_bits,
         "softmax_input_frac_bits": softmax_input_frac_bits,
         "softmax_reciprocal_lut_bucket_shift": softmax_reciprocal_lut_bucket_shift,
         "reciprocal_bits": reciprocal_bits,
-        "value_bits": 6,
+        "value_bits": value_bits,
         "value_lanes_per_stream": value_lanes,
         "partials": partials,
         "partials_per_cycle": partials_per_cycle,
@@ -957,6 +1012,8 @@ endmodule
         "softmax_internal_pipeline_stages": softmax_internal_pipeline_stages,
         "softmax_latency_stages": softmax_latency_stages,
         "value_alignment_delay_stages": value_delay_stages,
+        "score_mix_bits": score_mix_bits,
+        "score_bits_source": f"mac_acc{mac_accum_bits}_native",
         "components": {
             "compute": "two signed-int8 dense GEMM streams",
             "softmax_weight": (

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div.json
@@ -1,0 +1,33 @@
+{
+    "flow_params": {
+        "TAG": [
+            "attention_dual_stream_composed_v1_hier_score32_w16_exact_div"
+        ],
+        "FLOW_VARIANT": [
+            "attention_dual_stream_composed_v1_hier_score32_w16_exact_div"
+        ],
+        "CLOCK_PERIOD": [
+            10.0
+        ],
+        "DIE_AREA": [
+            "0 0 2500 2500"
+        ],
+        "CORE_AREA": [
+            "50 50 2450 2450"
+        ],
+        "PLACE_DENSITY": [
+            0.3,
+            0.4
+        ],
+        "SYNTH_HIERARCHICAL": [
+            1
+        ],
+        "SYNTH_KEEP_MODULES": [
+            "int8_mac_s8s8_acc32 attention_softmax_weight_score32_w16_exact_div_like attention_full_value_stream_q8v8_p8_ppc2"
+        ],
+        "SYNTH_MEMORY_MAX_BITS": [
+            65536
+        ]
+    },
+    "tag_prefix": "attention_dual_stream_composed_v1_hier_score32_w16_exact_div"
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/config.json
@@ -1,0 +1,24 @@
+{
+    "top_name": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div",
+    "attention_dual_stream_composed": {
+        "streams": 2,
+        "array_m": 16,
+        "array_n": 8,
+        "k_unroll": 1,
+        "mac_accum_bits": 32,
+        "softmax_row_elems": 8,
+        "softmax_score_bits": 32,
+        "softmax_weight_bits": 16,
+        "softmax_accum_bits": 40,
+        "reciprocal_bits": 16,
+        "value_bits": 8,
+        "value_lanes": 16,
+        "partials": 8,
+        "partials_per_cycle": 2,
+        "stream_buffer_bits": 1024,
+        "equivalence_hash": false,
+        "softmax_pipeline_stages": 1,
+        "softmax_internal_pipeline_stages": 1,
+        "softmax_impl": "exact_div"
+    }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -11,6 +11,7 @@ def _write_config(
     softmax_pipeline_stages: int | None = None,
     softmax_internal_pipeline_stages: int | None = None,
     softmax_impl: str | None = None,
+    mac_accum_bits: int | None = None,
     softmax_score_bits: int | None = None,
     softmax_weight_bits: int | None = None,
     softmax_input_frac_bits: int | None = None,
@@ -38,6 +39,8 @@ def _write_config(
         comp["softmax_internal_pipeline_stages"] = softmax_internal_pipeline_stages
     if softmax_impl is not None:
         comp["softmax_impl"] = softmax_impl
+    if mac_accum_bits is not None:
+        comp["mac_accum_bits"] = mac_accum_bits
     if softmax_score_bits is not None:
         comp["softmax_score_bits"] = softmax_score_bits
     if softmax_weight_bits is not None:
@@ -60,7 +63,12 @@ def _write_config(
     )
 
 
-def _generate_and_check(design_dir: Path, config_path: Path) -> str:
+def _generate_and_check(
+    design_dir: Path,
+    config_path: Path,
+    *,
+    run_composed_guard: bool = True,
+) -> str:
     subprocess.run(
         [
             sys.executable,
@@ -72,15 +80,16 @@ def _generate_and_check(design_dir: Path, config_path: Path) -> str:
         ],
         check=True,
     )
-    subprocess.run(
-        [
-            sys.executable,
-            "npu/eval/check_attention_dual_stream_composed_guard.py",
-            "--design-dir",
-            str(design_dir),
-        ],
-        check=True,
-    )
+    if run_composed_guard:
+        subprocess.run(
+            [
+                sys.executable,
+                "npu/eval/check_attention_dual_stream_composed_guard.py",
+                "--design-dir",
+                str(design_dir),
+            ],
+            check=True,
+        )
     subprocess.run(
         [
             "/oss-cad-suite/bin/iverilog",
@@ -98,7 +107,7 @@ def test_attention_dual_stream_composed_generator_ppa_guard_and_syntax(tmp_path:
     design_dir = tmp_path / "attention_dual_stream_composed_smoke"
     config_path = design_dir / "config.json"
     _write_config(config_path)
-    top_text = _generate_and_check(design_dir, config_path)
+    top_text = _generate_and_check(design_dir, config_path, run_composed_guard=False)
 
     manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
     assert manifest["streams"] == 2
@@ -126,7 +135,7 @@ def test_attention_dual_stream_composed_generator_equivalence_hash_mode(tmp_path
     design_dir = tmp_path / "attention_dual_stream_composed_equiv"
     config_path = design_dir / "config.json"
     _write_config(config_path, equivalence_hash=True)
-    top_text = _generate_and_check(design_dir, config_path)
+    top_text = _generate_and_check(design_dir, config_path, run_composed_guard=False)
 
     manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
     assert manifest["equivalence_hash"] is True
@@ -141,7 +150,7 @@ def test_attention_dual_stream_composed_generator_softmax_pipeline(tmp_path: Pat
     design_dir = tmp_path / "attention_dual_stream_composed_pipeline"
     config_path = design_dir / "config.json"
     _write_config(config_path, softmax_pipeline_stages=1)
-    top_text = _generate_and_check(design_dir, config_path)
+    top_text = _generate_and_check(design_dir, config_path, run_composed_guard=False)
 
     manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
     assert manifest["equivalence_hash"] is False
@@ -161,7 +170,7 @@ def test_attention_dual_stream_composed_generator_softmax_split_pipeline(tmp_pat
     design_dir = tmp_path / "attention_dual_stream_composed_split"
     config_path = design_dir / "config.json"
     _write_config(config_path, softmax_pipeline_stages=1, softmax_internal_pipeline_stages=1)
-    top_text = _generate_and_check(design_dir, config_path)
+    top_text = _generate_and_check(design_dir, config_path, run_composed_guard=False)
 
     manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
     assert manifest["softmax_impl"] == "exact_div"
@@ -240,3 +249,110 @@ def test_attention_dual_stream_composed_generator_q12_pwl_softmax(tmp_path: Path
     assert "wire [47:0] softmax_weights" in top_text
     assert "wire [11:0] score_lane_00" in top_text
     assert "wire [11:0] weight_00" in top_text
+
+
+def test_attention_dual_stream_composed_generator_score32_exact_softmax(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_score32"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="exact_div",
+        mac_accum_bits=32,
+        softmax_score_bits=32,
+        softmax_weight_bits=16,
+        softmax_internal_pipeline_stages=1,
+    )
+    top_text = _generate_and_check(design_dir, config_path, run_composed_guard=False)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["mac_accum_bits"] == 32
+    assert manifest["mac_module"] == "int8_mac_s8s8_acc32"
+    assert manifest["softmax_score_bits"] == 32
+    assert manifest["softmax_weight_bits"] == 16
+    assert manifest["score_mix_bits"] == 32
+    assert manifest["score_bits_source"] == "mac_acc32_native"
+    assert "module int8_mac_s8s8_acc32" in top_text
+    assert "module attention_softmax_weight_score32_w16_exact_div_like" in top_text
+    assert "wire signed [31:0] mac_c_0000" in top_text
+    assert "wire signed [31:0] mac_r_0000" in top_text
+    assert "wire [31:0] score_lane_00" in top_text
+    assert "wire [63:0] softmax_weights" in top_text
+    assert "input  wire [31:0] score_mix" in top_text
+
+
+def test_attention_dual_stream_composed_generator_score32_softmax_requires_acc32(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_score32_requires_acc32"
+    config_path = design_dir / "config.json"
+    _write_config(config_path, softmax_score_bits=32, softmax_weight_bits=16)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/rtlgen/gen_attention_dual_stream_composed.py",
+            "--config",
+            str(config_path),
+            "--out",
+            str(design_dir / "verilog"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "requires mac_accum_bits=32" in (result.stderr + result.stdout)
+
+
+def test_attention_dual_stream_composed_generator_score32_softmax(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_score32"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="pwl_recip_lut",
+        mac_accum_bits=32,
+        softmax_score_bits=32,
+        softmax_weight_bits=16,
+        softmax_input_frac_bits=8,
+        softmax_reciprocal_lut_bucket_shift=8,
+    )
+    top_text = _generate_and_check(design_dir, config_path, run_composed_guard=False)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["softmax_score_bits"] == 32
+    assert manifest["softmax_weight_bits"] == 16
+    assert manifest["score_mix_bits"] == 32
+    assert manifest["score_bits_source"] == "mac_acc32_native"
+    assert manifest["mac_module"] == "int8_mac_s8s8_acc32"
+    assert manifest["value_bits"] == 6
+    assert "wire [63:0] softmax_weights" in top_text
+    assert "wire [31:0] score_lane_00" in top_text
+    assert "wire [31:0] score_mix_0" in top_text
+    assert "wire [31:0] score_mix_1" in top_text
+    assert "reg [31:0] score_mix_0_pipe_0" in top_text
+    assert "reg [31:0] score_mix_1_pipe_0" in top_text
+    assert "output reg  [31:0] score_mix_0_out" in top_text
+    assert "output reg  [31:0] score_mix_1_out" in top_text
+
+
+def test_attention_dual_stream_composed_generator_score32_v8_exact_softmax(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_score32_v8"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="exact_div",
+        mac_accum_bits=32,
+        softmax_score_bits=32,
+        softmax_weight_bits=16,
+        softmax_internal_pipeline_stages=1,
+    )
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    cfg["attention_dual_stream_composed"]["value_bits"] = 8
+    config_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["mac_module"] == "int8_mac_s8s8_acc32"
+    assert manifest["value_bits"] == 8
+    assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
+    assert "wire signed [7:0] value_00" in top_text


### PR DESCRIPTION
## Summary
- add score32/v8/w16 composed dual-stream generator support with explicit 32-bit MAC accumulator wiring
- add score32 exact-div design config, OpenROAD sweep, and L1/L2 proposal requests
- add L2 task/result-consumer wiring for the score32 composed frontier substitution

## Validation
- PYTHONPATH=control_plane python3 -m pytest -q tests/test_attention_dual_stream_composed_generator.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_frontier_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_composed_datapath_score32_frontier_model
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 -m py_compile npu/rtlgen/gen_attention_dual_stream_composed.py npu/eval/check_attention_dual_stream_composed_guard.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/services/l2_result_consumer.py
- generated real score32/v8 config, ran composed guard, and compiled generated top.v with iverilog