### PR TITLE
[codex] control_plane: tolerate worker db telemetry disconnects

### DIFF
--- a/control_plane/control_plane/tests/test_command_runner.py
+++ b/control_plane/control_plane/tests/test_command_runner.py
@@ -1,0 +1,75 @@
+"""Command runner callback robustness coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+from control_plane.workers.command_runner import run_command_manifest
+
+
+def test_command_runner_continues_when_cancel_callback_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        work_dir = Path(td) / "work"
+        log_dir = Path(td) / "logs"
+        work_dir.mkdir()
+        calls = {"cancel": 0}
+
+        def flaky_cancel() -> bool:
+            calls["cancel"] += 1
+            if calls["cancel"] == 1:
+                raise RuntimeError("control-plane db temporarily unavailable")
+            return False
+
+        results = run_command_manifest(
+            command_manifest=[
+                {
+                    "name": "write_output",
+                    "run": "python3 -c \"from pathlib import Path; Path('done.txt').write_text('ok\\n')\"",
+                }
+            ],
+            work_dir=str(work_dir),
+            log_dir=str(log_dir),
+            progress_interval_seconds=1,
+            cancel_requested=flaky_cancel,
+        )
+
+        assert len(results) == 1
+        assert results[0].returncode == 0
+        assert (work_dir / "done.txt").read_text(encoding="utf-8") == "ok\n"
+        assert calls["cancel"] >= 1
+
+
+def test_command_runner_continues_when_progress_callback_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        work_dir = Path(td) / "work"
+        log_dir = Path(td) / "logs"
+        work_dir.mkdir()
+        calls = {"progress": 0}
+
+        def flaky_progress(_payload: dict) -> None:
+            calls["progress"] += 1
+            if calls["progress"] == 1:
+                raise RuntimeError("control-plane db temporarily unavailable")
+
+        results = run_command_manifest(
+            command_manifest=[
+                {
+                    "name": "slow_output",
+                    "run": (
+                        "python3 -c \"import time; "
+                        "print('start', flush=True); "
+                        "time.sleep(1.5); "
+                        "print('done', flush=True)\""
+                    ),
+                }
+            ],
+            work_dir=str(work_dir),
+            log_dir=str(log_dir),
+            progress_interval_seconds=1,
+            on_command_progress=flaky_progress,
+        )
+
+        assert len(results) == 1
+        assert results[0].returncode == 0
+        assert calls["progress"] >= 1

--- a/control_plane/control_plane/tests/test_worker_executor.py
+++ b/control_plane/control_plane/tests/test_worker_executor.py
@@ -10,6 +10,7 @@ import time
 from unittest import mock
 
 from sqlalchemy import create_engine
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from control_plane.db import build_session_factory, create_all
@@ -887,6 +888,188 @@ def test_worker_honors_cancel_requested_during_command() -> None:
             assert work_item.state == WorkItemState.FAILED
             assert run.status == RunStatus.CANCELED
             assert run.result_payload["failure_classification"]["category"] == "command_canceled"
+
+
+def test_worker_continues_when_cancel_check_db_disconnect_occurs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            seeded = seed_timeout_work_item(session, item_id="item_cancel_db_retry")
+            seeded.assigned_machine_key = "worker-1"
+            session.commit()
+
+        session_factory = build_session_factory(engine)
+        import control_plane.workers.executor as executor
+
+        original_is_run_cancel_requested = executor.is_run_cancel_requested
+        calls = {"count": 0}
+
+        def _flaky_cancel_requested(_session, *, run_key: str) -> bool:
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise OperationalError("select 1", {}, Exception("db connection lost"))
+            return original_is_run_cancel_requested(_session, run_key=run_key)
+
+        with mock.patch.object(executor, "is_run_cancel_requested", side_effect=_flaky_cancel_requested):
+            results = run_worker(
+                session_factory,
+                config=WorkerConfig(
+                    repo_root=str(repo_root),
+                    machine_key="worker-1",
+                    capabilities={"platform": "nangate45", "flow": "openroad"},
+                    capability_filter={"platform": "nangate45", "flow": "openroad"},
+                    lease_seconds=60,
+                    heartbeat_seconds=1,
+                    command_progress_seconds=1,
+                ),
+                max_items=1,
+            )
+
+        assert len(results) == 1
+        assert results[0].status == "succeeded"
+
+        with Session(engine) as session:
+            run = session.query(Run).filter_by(run_key=results[0].run_key).one()
+            assert run.status == RunStatus.SUCCEEDED
+            assert run.result_payload["failure_classification"]["category"] == "none"
+            assert run.result_payload["retry_decision"]["requeue"] is False
+            assert calls["count"] >= 1
+
+
+def test_worker_continues_when_command_progress_event_db_disconnect_is_retryable() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            seeded = seed_timeout_work_item(session, item_id="item_progress_db_retry")
+            seeded.assigned_machine_key = "worker-1"
+            session.commit()
+
+        session_factory = build_session_factory(engine)
+        import control_plane.workers.executor as executor
+
+        original_append_run_event = executor.append_run_event
+        calls = {"progress": 0, "failed_calls": 0}
+
+        def _flaky_append_run_event(
+            session,
+            *,
+            run_key: str,
+            event_type: str,
+            event_payload: dict | None = None,
+        ) -> None:
+            if event_type == "command_progress":
+                calls["progress"] += 1
+                if calls["failed_calls"] == 0:
+                    calls["failed_calls"] += 1
+                    raise OperationalError("insert into run_events", {}, Exception("db connection lost"))
+            return original_append_run_event(
+                session,
+                run_key=run_key,
+                event_type=event_type,
+                event_payload=event_payload,
+            )
+
+        with mock.patch.object(executor, "append_run_event", side_effect=_flaky_append_run_event):
+            results = run_worker(
+                session_factory,
+                config=WorkerConfig(
+                    repo_root=str(repo_root),
+                    machine_key="worker-1",
+                    capabilities={"platform": "nangate45", "flow": "openroad"},
+                    capability_filter={"platform": "nangate45", "flow": "openroad"},
+                    lease_seconds=60,
+                    heartbeat_seconds=1,
+                    command_progress_seconds=1,
+                    command_timeout_seconds=5,
+                ),
+                max_items=1,
+            )
+
+        assert len(results) == 1
+        assert results[0].status == "succeeded"
+
+        with Session(engine) as session:
+            run = session.query(Run).filter_by(run_key=results[0].run_key).one()
+            assert run.status == RunStatus.SUCCEEDED
+            assert run.result_payload["failure_classification"]["category"] == "none"
+            event_types = {row.event_type for row in session.query(RunEvent).filter_by(run_id=run.id).all()}
+            assert "command_progress" in event_types
+            assert "command_finished" in event_types
+            assert calls["failed_calls"] == 1
+            assert calls["progress"] >= 1
+
+
+def test_worker_completes_when_complete_run_db_disconnect_is_retryable() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            seeded = seed_ready_work_item(session, item_id="item_complete_db_retry", repo_root=repo_root, failing=False)
+            seeded.assigned_machine_key = "worker-1"
+            session.commit()
+
+        session_factory = build_session_factory(engine)
+        import control_plane.workers.executor as executor
+        original_complete_run = executor.complete_run
+        calls = {"count": 0}
+
+        def _flaky_complete_run(
+            session,
+            *,
+            run_key: str,
+            status: str,
+            result_summary: str,
+            result_payload: dict | None = None,
+            artifacts: list[dict] | None = None,
+        ):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise OperationalError("update runs", {}, Exception("db connection lost"))
+            return original_complete_run(
+                session,
+                run_key=run_key,
+                status=status,
+                result_summary=result_summary,
+                result_payload=result_payload,
+                artifacts=artifacts,
+            )
+
+        with mock.patch.object(executor, "complete_run", side_effect=_flaky_complete_run):
+            results = run_worker(
+                session_factory,
+                config=WorkerConfig(
+                    repo_root=str(repo_root),
+                    machine_key="worker-1",
+                    capabilities={"platform": "nangate45", "flow": "openroad"},
+                    capability_filter={"platform": "nangate45", "flow": "openroad"},
+                    lease_seconds=60,
+                    heartbeat_seconds=1,
+                ),
+                max_items=1,
+            )
+
+        assert len(results) == 1
+        assert results[0].status == "succeeded"
+        assert calls["count"] == 2
+
+        with Session(engine) as session:
+            run = session.query(Run).filter_by(run_key=results[0].run_key).one()
+            assert run.status == RunStatus.SUCCEEDED
+            assert run.result_payload["retry_decision"]["requeue"] is False
 
 
 def test_worker_marks_stalled_command_as_timed_out() -> None:

--- a/control_plane/control_plane/workers/command_runner.py
+++ b/control_plane/control_plane/workers/command_runner.py
@@ -187,14 +187,19 @@ def _monitor_command(
         if returncode is not None:
             return returncode
 
-        if cancel_requested is not None and cancel_requested():
-            _terminate_process_group(process)
+        if cancel_requested is not None:
             try:
-                process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                _terminate_process_group(process, force=True)
-                process.wait(timeout=5)
-            return 130
+                canceled = cancel_requested()
+            except Exception:
+                canceled = False
+            if canceled:
+                _terminate_process_group(process)
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    _terminate_process_group(process, force=True)
+                    process.wait(timeout=5)
+                return 130
 
         if timeout_seconds is not None and now - started >= timeout_seconds:
             _terminate_process_group(process)
@@ -216,17 +221,20 @@ def _monitor_command(
             return 125
 
         if on_command_progress is not None and now >= next_progress:
-            on_command_progress(
-                {
-                    "command_name": command_name,
-                    "elapsed_seconds": now - started,
-                    "stdout_log": str(stdout_path),
-                    "stderr_log": str(stderr_path),
-                    "stdout_bytes": stdout_path.stat().st_size if stdout_path.exists() else 0,
-                    "stderr_bytes": stderr_path.stat().st_size if stderr_path.exists() else 0,
-                    "last_output_age_seconds": last_output_age,
-                }
-            )
+            try:
+                on_command_progress(
+                    {
+                        "command_name": command_name,
+                        "elapsed_seconds": now - started,
+                        "stdout_log": str(stdout_path),
+                        "stderr_log": str(stderr_path),
+                        "stdout_bytes": stdout_path.stat().st_size if stdout_path.exists() else 0,
+                        "stderr_bytes": stderr_path.stat().st_size if stderr_path.exists() else 0,
+                        "last_output_age_seconds": last_output_age,
+                    }
+                )
+            except Exception:
+                pass
             next_progress = now + max(1, progress_interval_seconds)
 
         time.sleep(1)

--- a/control_plane/control_plane/workers/executor.py
+++ b/control_plane/control_plane/workers/executor.py
@@ -7,8 +7,10 @@ from dataclasses import dataclass
 import json
 from pathlib import Path
 import shutil
+import time
 from typing import Any
 
+from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.orm import Session, sessionmaker
 
 from control_plane.ids import make_id
@@ -81,6 +83,46 @@ class WorkerLoopResult:
     run_key: str | None = None
     command_count: int = 0
     summary: str | None = None
+
+
+_RUN_EVENT_RETRY_ATTEMPTS = 3
+_RUN_EVENT_RETRY_DELAY_SECONDS = 0.25
+
+
+def _is_retryable_db_error(exc: Exception) -> bool:
+    return isinstance(exc, (OperationalError, DBAPIError))
+
+
+def _dispose_session_engine(session_factory: sessionmaker) -> None:
+    engine = getattr(session_factory, "kw", {}).get("bind")
+    if engine is None:
+        return
+    try:
+        engine.dispose()
+    except Exception:
+        return
+
+
+def _with_db_retry(
+    session_factory: sessionmaker,
+    op,
+    *,
+    swallow: bool,
+):
+    for attempt in range(1, _RUN_EVENT_RETRY_ATTEMPTS + 1):
+        try:
+            with session_factory() as session:
+                return op(session)
+        except Exception as exc:  # pragma: no cover - defensive retry path
+            if not _is_retryable_db_error(exc):
+                raise
+            if attempt >= _RUN_EVENT_RETRY_ATTEMPTS:
+                if swallow:
+                    return None
+                raise
+            _dispose_session_engine(session_factory)
+            if attempt < _RUN_EVENT_RETRY_ATTEMPTS:
+                time.sleep(_RUN_EVENT_RETRY_DELAY_SECONDS)
 
 
 def _classify_failure(
@@ -380,6 +422,54 @@ def _active_command_manifest(work_item: WorkItem, trial_index: int) -> list[dict
     return commands
 
 
+def _safe_append_run_event(
+    session_factory: sessionmaker,
+    *,
+    run_key: str,
+    event_type: str,
+    event_payload: dict[str, Any] | None = None,
+) -> None:
+    def _op(session: Session) -> None:
+        append_run_event(session, run_key=run_key, event_type=event_type, event_payload=event_payload)
+
+    _with_db_retry(session_factory, _op, swallow=True)
+
+
+def _complete_run_with_retry(
+    session_factory: sessionmaker,
+    *,
+    run_key: str,
+    status: str,
+    result_summary: str,
+    result_payload: dict[str, Any] | None,
+    artifacts: list[dict[str, Any]] | None,
+    failure_requeue: bool,
+    failure_classification: dict[str, Any] | None,
+) -> Any:
+    def _op(session: Session):
+        if failure_requeue:
+            _safe_append_run_event(
+                session_factory=session_factory,
+                run_key=run_key,
+                event_type="run_requeued",
+                event_payload={"failure_classification": failure_classification},
+            )
+        return complete_run(
+            session,
+            run_key=run_key,
+            status=status,
+            result_summary=result_summary,
+            result_payload=result_payload,
+            artifacts=artifacts,
+        )
+
+    return _with_db_retry(
+        session_factory,
+        _op,
+        swallow=False,
+    )
+
+
 def _should_continue_trials(session: Session, work_item: WorkItem) -> bool:
     policy = _trial_policy(work_item)
     completed = _completed_trial_runs(session, work_item.id)
@@ -404,8 +494,8 @@ def _promote_post_run_state(*, session_factory: sessionmaker, work_item_id: str,
             next_trial_index = len(completed) + 1
             next_seed = _trial_policy(work_item)["seed_start"] + next_trial_index - 1
             session.commit()
-            append_run_event(
-                session,
+            _safe_append_run_event(
+                session_factory,
                 run_key=run_key,
                 event_type="trial_scheduled",
                 event_payload={"next_trial_index": next_trial_index, "next_seed": next_seed},
@@ -415,8 +505,8 @@ def _promote_post_run_state(*, session_factory: sessionmaker, work_item_id: str,
             if work_item.state != WorkItemState.ARTIFACT_SYNC:
                 work_item.state = WorkItemState.ARTIFACT_SYNC
                 session.commit()
-            append_run_event(
-                session,
+            _safe_append_run_event(
+                session_factory,
                 run_key=run_key,
                 event_type="trial_set_completed",
                 event_payload={"success_count": success_count, "completed_trials": len(completed)},
@@ -545,13 +635,12 @@ def _record_completion_result(
     event_type: str,
     payload: dict[str, Any],
 ) -> None:
-    with session_factory() as session:
-        append_run_event(
-            session,
-            run_key=run_key,
-            event_type=event_type,
-            event_payload=payload,
-        )
+    _safe_append_run_event(
+        session_factory,
+        run_key=run_key,
+        event_type=event_type,
+        event_payload=payload,
+    )
 
 
 def _process_requested_submission_retry(
@@ -791,36 +880,37 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
             attempt=attempt,
             max_retry_attempts=config.max_retry_attempts,
         )
-        with session_factory() as session:
-            append_run_event(
-                session,
+        _safe_append_run_event(
+            session_factory,
+            run_key=run_key,
+            event_type="checkout_failed",
+            event_payload={"error": checkout_error},
+        )
+        if failure["requeue"]:
+            _safe_append_run_event(
+                session_factory,
                 run_key=run_key,
-                event_type="checkout_failed",
-                event_payload={"error": checkout_error},
+                event_type="run_requeued",
+                event_payload={"failure_classification": failure},
             )
-            if failure["requeue"]:
-                append_run_event(
-                    session,
-                    run_key=run_key,
-                    event_type="run_requeued",
-                    event_payload={"failure_classification": failure},
-                )
-            complete_run(
-                session,
-                run_key=run_key,
-                status="failed",
-                result_summary=f"checkout failed: {checkout_error}",
-                result_payload={
-                    "checkout_error": checkout_error,
-                    "failure_classification": failure,
-                    "retry_decision": {
-                        "requeue": failure["requeue"],
-                        "attempt": failure["attempt"],
-                        "max_retry_attempts": failure["max_retry_attempts"],
-                    },
+        _complete_run_with_retry(
+            session_factory,
+            run_key=run_key,
+            status="failed",
+            result_summary=f"checkout failed: {checkout_error}",
+            result_payload={
+                "checkout_error": checkout_error,
+                "failure_classification": failure,
+                "retry_decision": {
+                    "requeue": failure["requeue"],
+                    "attempt": failure["attempt"],
+                    "max_retry_attempts": failure["max_retry_attempts"],
                 },
-                artifacts=[],
-            )
+            },
+            artifacts=[],
+            failure_requeue=failure["requeue"],
+            failure_classification=failure,
+        )
         return WorkerLoopResult(
             status="failed",
             item_id=work_item.item_id,
@@ -828,21 +918,20 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
             summary=f"checkout failed: {checkout_error}",
         )
 
-    with session_factory() as session:
-        append_run_event(
-            session,
-            run_key=run_key,
-            event_type="checkout_prepared",
-            event_payload={
-                "repo_root": checkout_info.repo_root,
-                "head_sha": checkout_info.head_sha,
-                "git_dirty": checkout_info.git_dirty,
-                "source_commit": checkout_info.source_commit,
-                "source_commit_matches": checkout_info.source_commit_matches,
-                "source_commit_relation": checkout_info.source_commit_relation,
-                "materialized_submodules": list(checkout_info.materialized_submodules),
-            },
-        )
+    _safe_append_run_event(
+        session_factory,
+        run_key=run_key,
+        event_type="checkout_prepared",
+        event_payload={
+            "repo_root": checkout_info.repo_root,
+            "head_sha": checkout_info.head_sha,
+            "git_dirty": checkout_info.git_dirty,
+            "source_commit": checkout_info.source_commit,
+            "source_commit_matches": checkout_info.source_commit_matches,
+            "source_commit_relation": checkout_info.source_commit_relation,
+            "materialized_submodules": list(checkout_info.materialized_submodules),
+        },
+    )
 
     _materialize_generated_inputs(
         checkout_root=checkout_info.work_dir,
@@ -918,25 +1007,23 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
         acceptance_warnings = acceptance.warnings
         if acceptance_errors:
             success = False
-            with session_factory() as session:
-                append_run_event(
-                    session,
-                    run_key=run_key,
-                    event_type="acceptance_failed",
-                    event_payload={"errors": acceptance_errors},
-                )
+            _safe_append_run_event(
+                session_factory,
+                run_key=run_key,
+                event_type="acceptance_failed",
+                event_payload={"errors": acceptance_errors},
+            )
         elif acceptance_warnings:
-            with session_factory() as session:
-                append_run_event(
-                    session,
-                    run_key=run_key,
-                    event_type="acceptance_warnings",
-                    event_payload={
-                        "warnings": acceptance_warnings,
-                        "ok_file_count": acceptance.ok_file_count,
-                        "non_ok_file_count": acceptance.non_ok_file_count,
-                    },
-                )
+            _safe_append_run_event(
+                session_factory,
+                run_key=run_key,
+                event_type="acceptance_warnings",
+                event_payload={
+                    "warnings": acceptance_warnings,
+                    "ok_file_count": acceptance.ok_file_count,
+                    "non_ok_file_count": acceptance.non_ok_file_count,
+                },
+            )
 
     artifacts = collect_expected_output_artifacts(
         repo_root=checkout_info.work_dir,
@@ -1042,31 +1129,25 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
             *acceptance_warnings,
         ]
 
-    with session_factory() as session:
-        if failure["requeue"]:
-            append_run_event(
-                session,
-                run_key=run_key,
-                event_type="run_requeued",
-                event_payload={"failure_classification": failure},
-            )
-        completed = complete_run(
-            session,
-            run_key=run_key,
-            status=_terminal_run_status(success=success, failure_category=failure["category"]),
-            result_summary=worker_error or summarize_command_results(command_results),
-            result_payload=result_payload,
-            artifacts=[
-                {
-                    "kind": artifact.kind,
-                    "storage_mode": artifact.storage_mode,
-                    "path": artifact.path,
-                    "sha256": artifact.sha256,
-                    "metadata": artifact.metadata,
-                }
-                for artifact in artifacts
-            ],
-        )
+    completed = _complete_run_with_retry(
+        session_factory,
+        run_key=run_key,
+        status=_terminal_run_status(success=success, failure_category=failure["category"]),
+        result_summary=worker_error or summarize_command_results(command_results),
+        result_payload=result_payload,
+        artifacts=[
+            {
+                "kind": artifact.kind,
+                "storage_mode": artifact.storage_mode,
+                "path": artifact.path,
+                "sha256": artifact.sha256,
+                "metadata": artifact.metadata,
+            }
+            for artifact in artifacts
+        ],
+        failure_requeue=failure["requeue"],
+        failure_classification=failure,
+    )
 
     if completed.status == "succeeded":
         _sync_expected_outputs_to_repo(
@@ -1122,23 +1203,22 @@ def _record_command_result(
             "returncode": result.returncode,
         }
     )
-    with session_factory() as session:
-        append_run_event(
-            session,
-            run_key=run_key,
-            event_type="command_finished",
-            event_payload={
-                "command_name": result.name,
-                "command": result.command,
-                "returncode": result.returncode,
-                "duration_seconds": result.duration_seconds,
-                "stdout_log": result.stdout_log,
-                "stderr_log": result.stderr_log,
-                "timed_out": result.timed_out,
-                "stalled": result.stalled,
-                "canceled": result.canceled,
-            },
-        )
+    _safe_append_run_event(
+        session_factory=session_factory,
+        run_key=run_key,
+        event_type="command_finished",
+        event_payload={
+            "command_name": result.name,
+            "command": result.command,
+            "returncode": result.returncode,
+            "duration_seconds": result.duration_seconds,
+            "stdout_log": result.stdout_log,
+            "stderr_log": result.stderr_log,
+            "timed_out": result.timed_out,
+            "stalled": result.stalled,
+            "canceled": result.canceled,
+        },
+    )
 
 
 def _record_command_started(
@@ -1157,13 +1237,12 @@ def _record_command_started(
         "stderr_log": payload["stderr_log"],
     }
     heartbeat.update_progress(progress)
-    with session_factory() as session:
-        append_run_event(
-            session,
-            run_key=run_key,
-            event_type="command_started",
-            event_payload=payload,
-        )
+    _safe_append_run_event(
+        session_factory=session_factory,
+        run_key=run_key,
+        event_type="command_started",
+        event_payload=payload,
+    )
 
 
 def _record_command_progress(
@@ -1180,18 +1259,20 @@ def _record_command_progress(
         **payload,
     }
     heartbeat.update_progress(progress)
-    with session_factory() as session:
-        append_run_event(
-            session,
-            run_key=run_key,
-            event_type="command_progress",
-            event_payload=progress,
-        )
+    _safe_append_run_event(
+        session_factory=session_factory,
+        run_key=run_key,
+        event_type="command_progress",
+        event_payload=progress,
+    )
 
 
 def _is_cancel_requested(*, session_factory: sessionmaker, run_key: str) -> bool:
-    with session_factory() as session:
+    def _op(session: Session) -> bool:
         return is_run_cancel_requested(session, run_key=run_key)
+
+    result = _with_db_retry(session_factory, _op, swallow=True)
+    return bool(result)
 
 
 def _terminal_run_status(*, success: bool, failure_category: str) -> str:


### PR DESCRIPTION
## Summary

This hardens the control-plane worker against transient DB disconnects during long-running evaluator commands.

The score32 L1 PPA run lost about 80 minutes because a PostgreSQL connection closed while the worker was polling run state / writing telemetry. The OpenROAD child process itself was not the failing component, so telemetry/cancel DB failures should not terminate the job.

## Changes

- Retry retryable SQLAlchemy DB errors for run events, cancel checks, and final run completion.
- Dispose the session engine between retry attempts so stale pooled connections are not reused.
- Treat command-runner callback failures as non-fatal for `cancel_requested` and `on_command_progress`.
- Add regression tests for cancel polling, progress event writes, completion retry, and command-runner callback failures.

## Validation

```bash
PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q \
  control_plane/control_plane/tests/test_command_runner.py \
  control_plane/control_plane/tests/test_worker_executor.py::test_worker_continues_when_cancel_check_db_disconnect_occurs \
  control_plane/control_plane/tests/test_worker_executor.py::test_worker_continues_when_command_progress_event_db_disconnect_is_retryable \
  control_plane/control_plane/tests/test_worker_executor.py::test_worker_completes_when_complete_run_db_disconnect_is_retryable
```

Result: `5 passed, 1 warning`.
