### PR TITLE
npu: add score32 reduced-replica recost

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1122,6 +1122,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
         "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+        "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
     }:
         diagnosis = evidence_payload.get("diagnosis")
         diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
@@ -1138,6 +1139,8 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             if model == "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
             else "Decoder composed dual-stream physical feasibility evidence (score32/w16 exact-div frontier)"
             if model == "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1"
+            else "Decoder composed dual-stream physical feasibility evidence (score32/w16 exact-div reduced-replica recost)"
+            if model == "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1"
             else "Decoder dual-stream physical feasibility evidence"
         )
         parts = [
@@ -1158,6 +1161,10 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "best_requested_substituted_compute_area_um2",
             "best_requested_substituted_compute_variant_label",
             "best_requested_compute_clock_ok",
+            "best_requested_replica_recost_enabled",
+            "best_requested_replica_recost_area_fit_replica_count",
+            "best_requested_replica_recost_macs_per_cycle",
+            "best_requested_replica_recost_latency_us",
             "best_feasible_mode",
             "best_feasible_latency_us",
             "recommended_next_step",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5451,13 +5451,14 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
     )
     q12_pwl_frontier = "q12_pwl_softmax_frontier" in item_id
+    score32_reduced_replica = "score32_w16_exact_div_reduced_replica" in item_id
     score32_frontier = "score32_w16_exact_div_frontier" in item_id
     variant_frontier = "variant_frontier" in item_id
     composed_dual_stream_metrics = (
         "runs/designs/npu_blocks/"
         "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv"
     )
-    if score32_frontier:
+    if score32_frontier or score32_reduced_replica:
         composed_dual_stream_metrics = (
             "runs/designs/npu_blocks/"
             "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv"
@@ -5480,7 +5481,10 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         f"--composed-dual-stream-metrics {path}"
         for path in composed_dual_stream_metrics.split(",")
     )
-    if score32_frontier:
+    if score32_reduced_replica:
+        model_name = "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1"
+        precision_profile = "q8_k8_v8_a32_s32_w16_exact_div_int8_compute"
+    elif score32_frontier:
         model_name = "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1"
         precision_profile = "q8_k8_v8_a32_s32_w16_exact_div_int8_compute"
     elif q12_pwl_frontier:
@@ -5519,6 +5523,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
                     f"--quality-gate-json {quality_gate} "
                     f"--precision-profile {precision_profile} "
                     f"--model-name {model_name} "
+                    f"{'--recompute-area-fit-replicas ' if score32_reduced_replica else ''}"
                     "--frontier-row-limit 8 "
                     "--buffer-area-um2-per-byte 0.0 "
                     f"--out {out} "

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1285,6 +1285,30 @@ def test_decoder_evidence_summary_recognizes_composed_datapath_score32_frontier_
     assert "precision_profile=q8_k8_v8_a32_s32_w16_exact_div_int8_compute" in summary
 
 
+def test_decoder_evidence_summary_recognizes_composed_datapath_score32_reduced_replica_model() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/composed_datapath_score32_reduced_replica.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
+            "diagnosis": {
+                "decision": "dual_stream_feasible",
+                "precision_profile": "q8_k8_v8_a32_s32_w16_exact_div_int8_compute",
+                "best_requested_mode": "dual_mac",
+                "best_requested_replica_recost_enabled": True,
+                "best_requested_replica_recost_area_fit_replica_count": 801,
+                "best_requested_replica_recost_macs_per_cycle": 102528,
+                "best_requested_replica_recost_latency_us": 10100.0,
+                "best_feasible_latency_us": 10100.0,
+            },
+        },
+    )
+
+    assert outcome == "dual_stream_feasible"
+    assert "score32/w16 exact-div reduced-replica recost" in summary
+    assert "best_requested_replica_recost_area_fit_replica_count=801" in summary
+    assert "best_requested_replica_recost_latency_us=10100.0" in summary
+
+
 def _seed_succeeded_l2_campaign(session: Session, repo_root: Path) -> tuple[str, str]:
     campaign_dir = repo_root / "runs" / "campaigns" / "npu" / "demo_campaign"
     schedule_rel = "runs/campaigns/npu/demo_campaign/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6194,6 +6194,54 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_fron
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_reduced_replica_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1"
+                in run
+            )
+            assert "--recompute-area-fit-replicas" in run
+            assert "--precision-profile q8_k8_v8_a32_s32_w16_exact_div_int8_compute" in run
+            assert decoder_inputs["attention_kv_composed_dual_stream_metrics"] == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_integrated_abstraction_closure_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds score32/w16 exact-div reduced-replica recost support.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the measured score32/v8/w16 exact-div composed dual-stream attention wrapper at the area-fit replica count and measured wrapper clock.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_quality_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_quality_area_fit_recost",
+        "reason": "This is the dependent reduced-replica Llama7B recost after the score32/w16 frontier substitution was area-blocked."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_v1",
+  "created_utc": "2026-06-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score32/w16 exact-div composed datapath reduced-replica recost",
+  "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+  "hypothesis": "The measured score32/v8/w16 composed datapath may still define a useful quality-backed Llama7B point if the compute replica count is reduced to the area-fit bound and latency is recomputed at the measured wrapper clock.",
+  "direct_comparison": {
+    "primary_question": "What Llama7B latency/area/energy direction remains when the measured score32/w16 exact-div composed datapath is constrained to the area-fit replica count?",
+    "baseline": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+    "candidate": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
+    "include": [
+      "consume measured score32/w16 exact-div composed datapath metrics",
+      "use the existing Llama7B sub-tile schedule structure",
+      "reduce compute replicas to the measured-area budgeted count",
+      "recompute QKV, QK, value, tile service, layer, and total latency at the measured wrapper clock"
+    ],
+    "exclude": [
+      "new native checkpoint quality run",
+      "new HBM/DRAM service model",
+      "new L1 datapath synthesis"
+    ],
+    "metrics": [
+      "decision",
+      "precision_profile",
+      "best_requested_replica_recost_area_fit_replica_count",
+      "best_requested_replica_recost_macs_per_cycle",
+      "best_requested_replica_recost_latency_us",
+      "best_feasible_latency_us"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the measured score32/v8/w16 exact-div composed dual-stream attention wrapper at the area-fit replica count and measured wrapper clock.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_quality_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_quality_area_fit_recost",
+        "reason": "The prior score32/w16 frontier was dual_stream_area_blocked; this records the conservative area-fit latency point before spending another L1 PPA run."
+      }
+    }
+  ],
+  "source_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1.json",
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py"
+  ],
+  "remaining_abstractions": [
+    "This recosts the existing analytic schedule rather than running a new end-to-end simulator.",
+    "HBM/SRAM/NoC service models are inherited unchanged from the upstream sub-tile schedule.",
+    "The measured exact-divider softmax structure is still a fixed-point approximation profile, not a full floating exp datapath."
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -22,6 +22,8 @@ JsonDict = dict[str, Any]
 def _effective_latency_us(row: JsonDict) -> float:
     value = row.get("adjusted_latency_us_if_feasible")
     if value is None:
+        value = row.get("replica_recost_latency_us")
+    if value is None:
         value = row.get("latency_us")
     return float(value)
 
@@ -170,6 +172,7 @@ def _row_with_budget(
     compute_arch_name: str | None,
     buffer_area_um2_per_byte: float,
     precision_profile: str,
+    recompute_area_fit_replicas: bool,
 ) -> JsonDict:
     clusters = int(source_row["cluster_count"])
     compute_multiplier = float(source_row.get("compute_area_multiplier", 1.0))
@@ -223,8 +226,8 @@ def _row_with_budget(
     compute_substitution_enabled = use_composed_dual_stream or (compute_block is not None)
     if use_composed_dual_stream:
         target_block_area = composed_area
-        target_block_macs = int(source_row["macs_per_cycle"])
         target_replica_count = composed_replica_count
+        target_block_macs = source_block_macs_per_cycle
         base_compute_area = target_replica_count * target_block_area
         base_compute_power = target_replica_count * composed_power
         target_block_clock = composed_clock_ns
@@ -361,9 +364,217 @@ def _row_with_budget(
             "adjusted_latency_us_if_feasible": adjusted_latency_us,
             "adjusted_tile_service_cycles_if_feasible": adjusted_tile_service_cycles,
             "adjusted_speedup_if_feasible": adjusted_speedup,
+            "replica_recost_enabled": False,
+            "replica_recost_source_replica_count": None,
+            "replica_recost_area_fit_replica_count": None,
+            "replica_recost_macs_per_cycle": None,
+            "replica_recost_latency_us": None,
+            "replica_recost_tile_service_cycles": None,
+            "replica_recost_layer_cycles": None,
+            "replica_recost_total_cycles": None,
         }
     )
+    if recompute_area_fit_replicas and compute_substitution_enabled and replica_count_budgeted > 0:
+        recost = _area_fit_replica_recost(
+            source_row,
+            target_replica_count=target_replica_count,
+            area_fit_replica_count=min(target_replica_count, replica_count_budgeted),
+            block_macs_per_cycle=target_block_macs,
+            block_clock_ns=target_block_clock,
+            block_power_mw=target_block_power,
+            target_block_area_um2=target_block_area,
+            source_block_macs_per_cycle=int(source_row["measured_block_macs_per_cycle"]),
+            source_clock_ns=float(source_row["clock_ns"]),
+            current_compute_area_um2=current_compute_area,
+            compute_budget_um2=compute_budget,
+            logic_area_used_um2=current_logic_used,
+            selected_l1_overhead_area_um2=selected_l1_overhead,
+            current_l1_overhead_area_um2=current_l1_overhead,
+            buffer_fit=buffer_fit,
+        )
+        out.update(recost)
     return out
+
+
+def _ceil_scaled_cycles(value: Any, *, old_macs: int, new_macs: int) -> int:
+    return int(math.ceil(float(value) * max(1, old_macs) / max(1, new_macs)))
+
+
+def _area_fit_replica_recost(
+    source_row: JsonDict,
+    *,
+    target_replica_count: int,
+    area_fit_replica_count: int,
+    block_macs_per_cycle: int,
+    block_clock_ns: float,
+    block_power_mw: float,
+    target_block_area_um2: float,
+    source_block_macs_per_cycle: int,
+    source_clock_ns: float,
+    current_compute_area_um2: float,
+    compute_budget_um2: float,
+    logic_area_used_um2: float,
+    selected_l1_overhead_area_um2: float,
+    current_l1_overhead_area_um2: float,
+    buffer_fit: bool,
+) -> JsonDict:
+    new_macs = max(1, int(area_fit_replica_count) * max(1, int(block_macs_per_cycle)))
+    old_macs = max(1, int(source_row.get("macs_per_cycle", target_replica_count * source_block_macs_per_cycle)))
+    qkv_cycles = _ceil_scaled_cycles(source_row["qkv_cycles"], old_macs=old_macs, new_macs=new_macs)
+    tile_qk_cycles = _ceil_scaled_cycles(source_row["tile_qk_cycles"], old_macs=old_macs, new_macs=new_macs)
+    tile_value_cycles = _ceil_scaled_cycles(source_row["tile_value_cycles"], old_macs=old_macs, new_macs=new_macs)
+    source_scaled = dict(source_row)
+    source_scaled.update(
+        {
+            "qkv_cycles": qkv_cycles,
+            "tile_qk_cycles": tile_qk_cycles,
+            "tile_value_cycles": tile_value_cycles,
+            "clock_ns": block_clock_ns,
+        }
+    )
+    scheduled = _scheduled_subtile_pipeline(source_scaled)
+    compute_area = int(area_fit_replica_count) * target_block_area_um2
+    compute_power = int(area_fit_replica_count) * block_power_mw
+    logic_required = logic_area_used_um2 + (compute_area - current_compute_area_um2) + (
+        selected_l1_overhead_area_um2 - current_l1_overhead_area_um2
+    )
+    area_fit = logic_required <= compute_budget_um2
+    recost_feasible = area_fit and buffer_fit
+    source_latency_us = float(source_row["latency_us"])
+    latency_us = float(scheduled["latency_us"])
+    return {
+        "replica_recost_enabled": True,
+        "replica_recost_source_replica_count": target_replica_count,
+        "replica_recost_area_fit_replica_count": int(area_fit_replica_count),
+        "replica_recost_macs_per_cycle": new_macs,
+        "replica_recost_clock_ns": round(block_clock_ns, 6),
+        "replica_recost_qkv_cycles": qkv_cycles,
+        "replica_recost_tile_qk_cycles": tile_qk_cycles,
+        "replica_recost_tile_value_cycles": tile_value_cycles,
+        "replica_recost_tile_service_cycles": scheduled["tile_service_cycles"],
+        "replica_recost_layer_cycles": scheduled["layer_cycles"],
+        "replica_recost_total_cycles": scheduled["total_cycles"],
+        "replica_recost_latency_us": latency_us,
+        "replica_recost_latency_slowdown_vs_source": round(latency_us / max(1e-9, source_latency_us), 6),
+        "replica_recost_compute_area_um2": round(compute_area, 6),
+        "replica_recost_compute_power_mw": round(compute_power, 6),
+        "replica_recost_logic_area_required_um2": round(logic_required, 6),
+        "replica_recost_logic_area_slack_um2": round(compute_budget_um2 - logic_required, 6),
+        "replica_recost_area_fit": area_fit,
+        "replica_recost_buffer_fit": buffer_fit,
+        "replica_recost_physical_feasible": recost_feasible,
+        "replica_recost_compute_clock_ok": True,
+        "compute_clock_ok": True if recost_feasible else block_clock_ns <= source_clock_ns,
+        "area_fit": True if recost_feasible else area_fit,
+        "physical_feasible": recost_feasible,
+        "adjusted_latency_us_if_feasible": latency_us if recost_feasible else None,
+        "adjusted_tile_service_cycles_if_feasible": scheduled["tile_service_cycles"] if recost_feasible else None,
+        "adjusted_speedup_if_feasible": (
+            float(source_row["source_latency_us"]) / latency_us
+            if recost_feasible and source_row.get("source_latency_us") is not None
+            else None
+        ),
+    }
+
+
+def _scheduled_subtile_pipeline(row: JsonDict) -> JsonDict:
+    subtiles = int(row.get("subtile_count", 1))
+    prefetch_distance = int(row.get("prefetch_distance", 0))
+    normalize_strategy = str(row.get("normalize_strategy", "online_correction"))
+    compute_mode = str(row.get("compute_mode", "dual_mac"))
+    qk_sub, value_sub = _compute_stage_cycles(row, subtiles=subtiles, compute_mode=compute_mode)
+    stats_sub = int(row.get("subtile_stats_cycles", math.ceil(int(row["tile_stats_cycles"]) / subtiles)))
+    hbm_sub = int(row.get("subtile_hbm_cycles", math.ceil(int(row["tile_hbm_cycles"]) / subtiles)))
+    memory_aux_sub = int(
+        row.get(
+            "subtile_aux_memory_cycles",
+            max(
+                math.ceil(int(row.get("tile_local_sram_cycles", 0)) / subtiles),
+                math.ceil(int(row.get("tile_shared_path_cycles", 0)) / subtiles),
+            ),
+        )
+    )
+    hbm_end = [max(0, index + 1 - prefetch_distance) * hbm_sub for index in range(subtiles)]
+    stats_end: list[int] = []
+    value_end: list[int] = []
+    shared_gemm_free = 0
+    qk_free = 0
+    value_free = 0
+    stats_free = 0
+
+    for index in range(subtiles):
+        qk_start = max(qk_free, hbm_end[index], index * memory_aux_sub)
+        if compute_mode == "shared_mac":
+            qk_start = max(qk_start, shared_gemm_free)
+        qk_done = qk_start + qk_sub
+        qk_free = qk_done
+        if compute_mode == "shared_mac":
+            shared_gemm_free = qk_done
+
+        stats_start = max(stats_free, qk_done)
+        stats_done = stats_start + stats_sub
+        stats_end.append(stats_done)
+        stats_free = stats_done
+
+        if normalize_strategy == "full_tile_normalize":
+            continue
+        value_start = max(value_free, stats_done + int(row.get("online_rescale_penalty_cycles", 0)), hbm_end[index])
+        if compute_mode == "shared_mac":
+            value_start = max(value_start, shared_gemm_free)
+        value_done = value_start + value_sub
+        value_end.append(value_done)
+        value_free = value_done
+        if compute_mode == "shared_mac":
+            shared_gemm_free = value_done
+
+    if normalize_strategy == "full_tile_normalize":
+        all_stats_done = stats_end[-1]
+        for index in range(subtiles):
+            value_start = max(value_free, all_stats_done, hbm_end[index])
+            if compute_mode == "shared_mac":
+                value_start = max(value_start, shared_gemm_free)
+            value_done = value_start + value_sub
+            value_end.append(value_done)
+            value_free = value_done
+            if compute_mode == "shared_mac":
+                shared_gemm_free = value_done
+    elif normalize_strategy != "online_correction":
+        raise ValueError(f"unknown normalize strategy: {normalize_strategy}")
+
+    hbm_exposed_cycles = hbm_end[-1]
+    pipeline_cycles = max(value_end[-1], hbm_exposed_cycles, subtiles * memory_aux_sub)
+    residual_memory_cycles = max(int(row.get("tile_local_sram_cycles", 0)), int(row.get("tile_shared_path_cycles", 0)))
+    tile_service_cycles = max(pipeline_cycles, residual_memory_cycles)
+    layer_cycles = (
+        int(row["qkv_cycles"])
+        + int(row["tile_waves"]) * tile_service_cycles
+        + int(row.get("command_dispatch_cycles", 0))
+        + int(row["cross_tile_reduction_cycles"])
+        + int(row["kv_write_cycles"])
+    )
+    total_cycles = layer_cycles * int(row["layers"])
+    return {
+        "subtile_qk_cycles": qk_sub,
+        "subtile_value_cycles": value_sub,
+        "tile_service_cycles": tile_service_cycles,
+        "layer_cycles": layer_cycles,
+        "total_cycles": total_cycles,
+        "latency_us": round(total_cycles * float(row["clock_ns"]) / 1000.0, 6),
+    }
+
+
+def _compute_stage_cycles(row: JsonDict, *, subtiles: int, compute_mode: str) -> tuple[int, int]:
+    qk_base = int(row["tile_qk_cycles"])
+    value_base = int(row["tile_value_cycles"])
+    if compute_mode == "shared_mac":
+        scale = 1.0
+    elif compute_mode == "split_mac":
+        scale = 2.0
+    elif compute_mode == "dual_mac":
+        scale = 1.0
+    else:
+        raise ValueError(f"unknown compute mode: {compute_mode}")
+    return int(math.ceil(qk_base * scale / subtiles)), int(math.ceil(value_base * scale / subtiles))
 
 
 def _effective_selection_key(row: JsonDict) -> tuple[float, float, float, str]:
@@ -407,6 +618,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                         compute_arch_name=args.compute_arch_name,
                         buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
                         precision_profile=args.precision_profile,
+                        recompute_area_fit_replicas=args.recompute_area_fit_replicas,
                     )
                 )
         else:
@@ -421,6 +633,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                     compute_arch_name=args.compute_arch_name,
                     buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
                     precision_profile=args.precision_profile,
+                    recompute_area_fit_replicas=args.recompute_area_fit_replicas,
                 )
             )
     feasible_rows = [row for row in rows if row["physical_feasible"]]
@@ -466,6 +679,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "quality_gate_json": str(args.quality_gate_json) if args.quality_gate_json else None,
             "precision_profile": args.precision_profile,
             "buffer_area_um2_per_byte": args.buffer_area_um2_per_byte,
+            "recompute_area_fit_replicas": args.recompute_area_fit_replicas,
         },
         "quality_gate": {
             "decision": (quality_gate or {}).get("diagnosis", {}).get("decision"),
@@ -496,6 +710,12 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "best_requested_substituted_compute_variant_label": best_requested.get("substituted_compute_variant_label"),
             "best_requested_substituted_compute_area_um2": best_requested.get("substituted_compute_area_um2"),
             "best_requested_compute_clock_ok": best_requested.get("compute_clock_ok"),
+            "best_requested_replica_recost_enabled": best_requested.get("replica_recost_enabled"),
+            "best_requested_replica_recost_area_fit_replica_count": best_requested.get(
+                "replica_recost_area_fit_replica_count"
+            ),
+            "best_requested_replica_recost_macs_per_cycle": best_requested.get("replica_recost_macs_per_cycle"),
+            "best_requested_replica_recost_latency_us": best_requested.get("replica_recost_latency_us"),
             "best_feasible_mode": best_feasible.get("compute_mode") if best_feasible else None,
             "best_feasible_latency_us": _effective_latency_us(best_feasible) if best_feasible else None,
             "best_feasible_source_latency_us": best_feasible.get("latency_us") if best_feasible else None,
@@ -583,6 +803,14 @@ def main() -> int:
     )
     parser.add_argument("--frontier-row-limit", type=int, default=8)
     parser.add_argument("--buffer-area-um2-per-byte", type=float, default=0.0)
+    parser.add_argument(
+        "--recompute-area-fit-replicas",
+        action="store_true",
+        help=(
+            "When measured compute substitution exceeds area budget, recost a conservative point "
+            "using the budgeted replica count and measured substituted clock."
+        ),
+    )
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
     args = parser.parse_args()

--- a/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -36,6 +36,7 @@ def _args(
     source: Path,
     compute_metrics: Path | None = None,
     composed_metrics: list[str] | None = None,
+    recompute_area_fit_replicas: bool = False,
 ) -> argparse.Namespace:
     full_value = tmp_path / "full_value.csv"
     softmax = tmp_path / "softmax.csv"
@@ -54,6 +55,7 @@ def _args(
         model_name="unit",
         frontier_row_limit=8,
         buffer_area_um2_per_byte=0.0,
+        recompute_area_fit_replicas=recompute_area_fit_replicas,
     )
 
 
@@ -250,3 +252,97 @@ def test_composed_q12_pwl_wrapper_variant_label_is_concise(tmp_path: Path) -> No
 
     assert result["diagnosis"]["best_requested_substituted_compute_variant_label"] == "q12_pwl"
     assert result["best_requested"]["substituted_compute_variant_label"] == "q12_pwl"
+
+
+def test_composed_wrapper_can_recost_area_fit_replica_count(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    _write_json(
+        source,
+        {
+            "model": "unit_source",
+            "best_by_compute_mode": [
+                {
+                    "compute_mode": "dual_mac",
+                    "latency_us": 1.6,
+                    "source_latency_us": 3.2,
+                    "latency_speedup_vs_hbm_closed_source": 2.0,
+                    "cluster_count": 1,
+                    "compute_area_multiplier": 1.0,
+                    "compute_area_um2": 90.0,
+                    "compute_budget_um2": 170.0,
+                    "measured_l1_overhead_area_um2": 10.0,
+                    "local_datapath_area_um2": 4.0,
+                    "softmax_weight_generator_area_um2": 2.0,
+                    "logic_area_used_um2": 160.0,
+                    "required_stream_buffer_bytes": 16,
+                    "available_local_capacity_bytes": 32,
+                    "measured_block_area_um2": 45.0,
+                    "measured_block_clock_ns": 1.0,
+                    "measured_block_macs_per_cycle": 128,
+                    "measured_block_power_mw": 1.0,
+                    "compute_replica_count": 2,
+                    "compute_arch": "dense_gemm_16x8_k1_p1",
+                    "macs_per_cycle": 256,
+                    "clock_ns": 1.0,
+                    "layers": 1,
+                    "qkv_cycles": 10,
+                    "tile_qk_cycles": 80,
+                    "tile_stats_cycles": 8,
+                    "tile_value_cycles": 80,
+                    "tile_hbm_cycles": 10,
+                    "tile_local_sram_cycles": 1,
+                    "tile_shared_path_cycles": 1,
+                    "tile_waves": 1,
+                    "command_dispatch_cycles": 0,
+                    "cross_tile_reduction_cycles": 0,
+                    "kv_write_cycles": 0,
+                    "subtile_count": 1,
+                    "subtile_buffer_count": 1,
+                    "prefetch_distance": 0,
+                    "normalize_strategy": "online_correction",
+                    "online_rescale_penalty_cycles": 0,
+                    "subtile_stats_cycles": 8,
+                    "subtile_hbm_cycles": 10,
+                    "subtile_aux_memory_cycles": 1,
+                    "tile_service_cycles": 88,
+                }
+            ],
+        },
+    )
+    metrics = tmp_path / "score32" / "metrics.csv"
+    metrics.parent.mkdir(parents=True, exist_ok=True)
+    metrics.write_text(
+        "\n".join(
+            [
+                "status,critical_path_ns,die_area,instance_area_um2,total_power_mw,param_hash,tag,result_path",
+                "ok,2.0,100.0,100.0,4.0,abc,score32,results/score32",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    blocked = build_report(_args(tmp_path, source=source, composed_metrics=[str(metrics)]))
+    recost = build_report(
+        _args(
+            tmp_path,
+            source=source,
+            composed_metrics=[str(metrics)],
+            recompute_area_fit_replicas=True,
+        )
+    )
+
+    assert blocked["diagnosis"]["decision"] == "dual_stream_area_blocked"
+    assert blocked["diagnosis"]["best_feasible_mode"] is None
+    assert blocked["best_requested"]["replica_recost_enabled"] is False
+
+    assert recost["diagnosis"]["decision"] == "dual_stream_feasible"
+    assert recost["best_requested"]["replica_recost_enabled"] is True
+    assert recost["best_requested"]["replica_recost_source_replica_count"] == 2
+    assert recost["best_requested"]["replica_recost_area_fit_replica_count"] == 1
+    assert recost["best_requested"]["replica_recost_macs_per_cycle"] == 128
+    assert recost["best_requested"]["replica_recost_latency_us"] == 716.0 / 1000.0
+    assert recost["best_requested"]["area_fit"] is True
+    assert recost["best_requested"]["physical_feasible"] is True
+    assert recost["best_requested"]["compute_clock_ok"] is True
+    assert recost["diagnosis"]["best_feasible_latency_us"] == 716.0 / 1000.0


### PR DESCRIPTION
## Summary
- add an area-fit reduced-replica recost mode to the composed dual-stream physical-feasibility estimator
- wire a score32/w16 exact-div reduced-replica L2 item and proposal
- include reduced-replica fields in L2 review summaries

## Local checks
- python -m pytest -q tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_reduced_replica_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_composed_datapath_score32_reduced_replica_model
- python scripts/validate_runs.py --skip_eval_queue

## Sanity result
Real merged score32 inputs recost to 801 area-fit replicas, 102528 MAC/cycle, and 9635.596032 us latency.