### PR TITLE
[codex] add score32 exact softmax split2 timing point

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_v1/evaluation_requests.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds softmax_internal_pipeline_stages=2 support and the score32/w16 exact-div split2 design config.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the q8/k8/v8/a32/s32/w16 composed dual-stream attention datapath with exact softmax divider operands registered before the final divide.",
+      "evaluation_mode": "frontier_timing_closure",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_exact_divider_operand_pipeline",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div_split2.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1"
+      ],
+      "expected_result": {
+        "direction": "reduce_exact_softmax_timing_path",
+        "reason": "This keeps exact integer softmax arithmetic while testing whether one extra divider operand register recovers score32/w16 clock rate enough to improve Llama7B frontier recost."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_v1/proposal.json
@@ -1,0 +1,77 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_v1",
+  "created_utc": "2026-06-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Composed score32/w16 exact-div datapath with divider operand pipeline",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The current measured score32/w16 exact-divider composed datapath is timing-limited by the exact softmax path from registered exp weights into registered output weights. Registering the rounded numerator and denominator before the final divide should reduce critical path while preserving exact integer softmax values and perf/RTL equivalence with one extra cycle of aligned value-stream latency.",
+  "direct_comparison": {
+    "primary_question": "How much timing, area, and power change when the score32/w16 exact-divider composed datapath adds a second internal exact-softmax pipeline boundary?",
+    "baseline": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+    "candidate": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_ppa_v1",
+    "include": [
+      "generate RTL with mac_accum_bits=32",
+      "generate softmax_score_bits=32 and softmax_weight_bits=16",
+      "keep exact_div softmax arithmetic",
+      "register numerator and denominator operands before the final divider",
+      "increase value-stream alignment delay to match the added softmax latency",
+      "run the composed datapath guard before OpenROAD",
+      "measure Nangate45 area, power, timing, and timing debug paths"
+    ],
+    "exclude": [
+      "new precision approximation",
+      "new native checkpoint quality run",
+      "Llama7B frontier recost before L1 PPA evidence exists"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "The local composed datapath still models the tile-level compute wrapper rather than a full integrated NPU floorplan.",
+    "System-level Llama7B ranking must be rerun after the new L1 PPA is available."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the q8/k8/v8/a32/s32/w16 composed dual-stream attention datapath with a second exact-divider softmax pipeline boundary.",
+      "evaluation_mode": "frontier_timing_closure",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_exact_divider_operand_pipeline",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div_split2.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/timing_debug_report.md"
+      ],
+      "depends_on": [
+        "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1"
+      ],
+      "expected_result": {
+        "direction": "reduce_exact_softmax_timing_path",
+        "reason": "The prior score32/w16 exact-div run reports a 36.174 ns critical path from u_softmax/exp_weight_q into u_softmax/weights."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div_split2.json"
+  ],
+  "knowledge_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/timing_debug_report.md",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json"
+  ]
+}

--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -99,6 +99,10 @@ def main() -> int:
         for token in ("exp_weight_q", "sum_weight_q"):
             if token not in top_text:
                 raise SystemExit(f"missing split softmax pipeline token: {token}")
+    if softmax_internal_pipeline_stages >= 2:
+        for token in ("numer_q", "sum_weight_qq"):
+            if token not in top_text:
+                raise SystemExit(f"missing divider operand pipeline token: {token}")
     if softmax_impl == "pow2sum":
         for token in ("denom_shift", "lane_scaled"):
             if token not in top_text:

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -87,8 +87,8 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.stream_buffer_bits must be in [128, 4096]")
     if softmax_pipeline_stages < 0 or softmax_pipeline_stages > 1:
         raise SystemExit("attention_dual_stream_composed.softmax_pipeline_stages must be in [0, 1]")
-    if softmax_internal_pipeline_stages < 0 or softmax_internal_pipeline_stages > 1:
-        raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages must be in [0, 1]")
+    if softmax_internal_pipeline_stages < 0 or softmax_internal_pipeline_stages > 2:
+        raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages must be in [0, 2]")
     if mac_accum_bits < 24 or mac_accum_bits > 32:
         raise SystemExit("attention_dual_stream_composed.mac_accum_bits must be in [24, 32]")
     if softmax_score_bits < 2 or softmax_score_bits > 32:
@@ -327,7 +327,7 @@ module {module_name} (
   end
 endmodule
 """
-    if internal_pipeline_stages:
+    if internal_pipeline_stages == 1:
         return f"""(* keep_hierarchy = 1 *)
 module {module_name} (
     input  wire                  clk,
@@ -398,6 +398,91 @@ module {module_name} (
       exp_weight_q[i] <= exp_weight[i];
     end
     sum_weight_q <= sum_weight;
+    weights <= next_weights;
+{hash_seq.rstrip()}
+  end
+endmodule
+"""
+    if internal_pipeline_stages == 2:
+        return f"""(* keep_hierarchy = 1 *)
+module {module_name} (
+    input  wire                  clk,
+    input  wire [{score_row_width - 1}:0] scores,
+    output reg  [{weight_row_width - 1}:0] weights{hash_port}
+);
+  localparam integer ROW_ELEMS = {row_elems};
+  localparam integer SCORE_BITS = {score_bits};
+  localparam integer WEIGHT_BITS = {weight_bits};
+  localparam integer ACCUM_BITS = {accum_bits};
+  localparam integer PRODUCT_BITS = {product_bits};
+  localparam integer MAX_SHIFT = 7;
+  localparam integer OUTPUT_SCALE = {output_scale};
+  localparam integer RECIPROCAL_BITS = {reciprocal_bits};
+
+  integer i;
+  integer signed lane_val;
+  integer signed row_max;
+  integer delta;
+  reg [ACCUM_BITS-1:0] exp_weight [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight;
+  reg [ACCUM_BITS-1:0] exp_weight_q [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight_q;
+  reg [PRODUCT_BITS-1:0] numer [0:ROW_ELEMS-1];
+  reg [PRODUCT_BITS-1:0] numer_q [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight_qq;
+  reg [WEIGHT_BITS-1:0] lane_out;
+  reg [{weight_row_width - 1}:0] next_weights;
+{hash_reg.rstrip()}
+
+  always @(*) begin
+    row_max = -(1 << (SCORE_BITS - 1));
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
+      if (lane_val > row_max)
+        row_max = lane_val;
+    end
+
+    sum_weight = {{ACCUM_BITS{{1'b0}}}};
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
+      delta = row_max - lane_val;
+      if (delta < 0)
+        delta = 0;
+      if (delta > MAX_SHIFT)
+        delta = MAX_SHIFT;
+      exp_weight[i] = ({{{{(ACCUM_BITS-1){{1'b0}}}}, 1'b1}} << (MAX_SHIFT - delta));
+      sum_weight = sum_weight + exp_weight[i];
+    end
+  end
+
+  always @(*) begin
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      numer[i] = (exp_weight_q[i] * OUTPUT_SCALE) + (sum_weight_q >> 1);
+    end
+  end
+
+  always @(*) begin
+    next_weights = {{{weight_row_width}{{1'b0}}}};
+{hash_init.rstrip()}
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      if (sum_weight_qq != 0)
+        lane_out = numer_q[i] / sum_weight_qq;
+      else
+        lane_out = {{WEIGHT_BITS{{1'b0}}}};
+      if (lane_out > OUTPUT_SCALE)
+        lane_out = OUTPUT_SCALE;
+      next_weights[(i*WEIGHT_BITS) +: WEIGHT_BITS] = lane_out;
+{hash_update.rstrip()}
+    end
+  end
+
+  always @(posedge clk) begin
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      exp_weight_q[i] <= exp_weight[i];
+      numer_q[i] <= numer[i];
+    end
+    sum_weight_q <= sum_weight;
+    sum_weight_qq <= sum_weight_q;
     weights <= next_weights;
 {hash_seq.rstrip()}
   end

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div_split2.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exact_div_split2.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_score32_w16_exact_div_split2"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_score32_w16_exact_div_split2"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc32 attention_softmax_weight_score32_w16_exact_div_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_score32_w16_exact_div_split2"
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/config.json
@@ -1,0 +1,24 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "mac_accum_bits": 32,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 32,
+    "softmax_weight_bits": 16,
+    "softmax_accum_bits": 40,
+    "reciprocal_bits": 16,
+    "value_bits": 8,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_internal_pipeline_stages": 2,
+    "softmax_impl": "exact_div"
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -12,6 +12,7 @@ def _write_config(
     softmax_internal_pipeline_stages: int | None = None,
     softmax_impl: str | None = None,
     mac_accum_bits: int | None = None,
+    softmax_accum_bits: int | None = None,
     softmax_score_bits: int | None = None,
     softmax_weight_bits: int | None = None,
     softmax_input_frac_bits: int | None = None,
@@ -41,6 +42,8 @@ def _write_config(
         comp["softmax_impl"] = softmax_impl
     if mac_accum_bits is not None:
         comp["mac_accum_bits"] = mac_accum_bits
+    if softmax_accum_bits is not None:
+        comp["softmax_accum_bits"] = softmax_accum_bits
     if softmax_score_bits is not None:
         comp["softmax_score_bits"] = softmax_score_bits
     if softmax_weight_bits is not None:
@@ -185,6 +188,25 @@ def test_attention_dual_stream_composed_generator_softmax_split_pipeline(tmp_pat
     assert "lane_out = numer / sum_weight_q" in top_text
 
 
+def test_attention_dual_stream_composed_generator_softmax_divider_operand_pipeline(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_split2"
+    config_path = design_dir / "config.json"
+    _write_config(config_path, softmax_pipeline_stages=1, softmax_internal_pipeline_stages=2)
+    top_text = _generate_and_check(design_dir, config_path, run_composed_guard=False)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["softmax_impl"] == "exact_div"
+    assert manifest["softmax_pipeline_stages"] == 1
+    assert manifest["softmax_internal_pipeline_stages"] == 2
+    assert manifest["softmax_latency_stages"] == 3
+    assert manifest["value_alignment_delay_stages"] == 4
+    assert "numer_q" in top_text
+    assert "sum_weight_qq" in top_text
+    assert "lane_out = numer_q[i] / sum_weight_qq" in top_text
+    assert ".stream_data(stream_buf_0_pipe_3)" in top_text
+    assert ".score_mix(score_mix_1_pipe_3)" in top_text
+
+
 def test_attention_dual_stream_composed_generator_softmax_pow2sum_replacement(tmp_path: Path) -> None:
     design_dir = tmp_path / "attention_dual_stream_composed_pow2sum"
     config_path = design_dir / "config.json"
@@ -259,6 +281,7 @@ def test_attention_dual_stream_composed_generator_score32_exact_softmax(tmp_path
         softmax_pipeline_stages=1,
         softmax_impl="exact_div",
         mac_accum_bits=32,
+        softmax_accum_bits=40,
         softmax_score_bits=32,
         softmax_weight_bits=16,
         softmax_internal_pipeline_stages=1,
@@ -309,6 +332,7 @@ def test_attention_dual_stream_composed_generator_score32_softmax(tmp_path: Path
         softmax_pipeline_stages=1,
         softmax_impl="pwl_recip_lut",
         mac_accum_bits=32,
+        softmax_accum_bits=40,
         softmax_score_bits=32,
         softmax_weight_bits=16,
         softmax_input_frac_bits=8,
@@ -341,6 +365,7 @@ def test_attention_dual_stream_composed_generator_score32_v8_exact_softmax(tmp_p
         softmax_pipeline_stages=1,
         softmax_impl="exact_div",
         mac_accum_bits=32,
+        softmax_accum_bits=40,
         softmax_score_bits=32,
         softmax_weight_bits=16,
         softmax_internal_pipeline_stages=1,
@@ -356,3 +381,40 @@ def test_attention_dual_stream_composed_generator_score32_v8_exact_softmax(tmp_p
     assert manifest["value_bits"] == 8
     assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
     assert "wire signed [7:0] value_00" in top_text
+
+
+def test_attention_dual_stream_composed_generator_score32_v8_exact_softmax_divider_operand_pipeline(
+    tmp_path: Path,
+) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_score32_v8_split2"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="exact_div",
+        mac_accum_bits=32,
+        softmax_accum_bits=40,
+        softmax_score_bits=32,
+        softmax_weight_bits=16,
+        softmax_internal_pipeline_stages=2,
+    )
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    cfg["attention_dual_stream_composed"]["value_bits"] = 8
+    config_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["mac_module"] == "int8_mac_s8s8_acc32"
+    assert manifest["softmax_score_bits"] == 32
+    assert manifest["softmax_weight_bits"] == 16
+    assert manifest["value_bits"] == 8
+    assert manifest["softmax_internal_pipeline_stages"] == 2
+    assert manifest["softmax_latency_stages"] == 3
+    assert manifest["value_alignment_delay_stages"] == 4
+    assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
+    assert "localparam integer PRODUCT_BITS = 56" in top_text
+    assert "reg [PRODUCT_BITS-1:0] numer_q [0:ROW_ELEMS-1]" in top_text
+    assert "reg [ACCUM_BITS-1:0] sum_weight_qq" in top_text
+    assert "lane_out = numer_q[i] / sum_weight_qq" in top_text
+    assert ".stream_data(stream_buf_0_pipe_3)" in top_text


### PR DESCRIPTION
## Summary

Adds a score32/w16 exact-div composed datapath timing experiment that preserves exact integer softmax arithmetic while inserting one more internal pipeline boundary before the final divider output.

Changes:
- allow `softmax_internal_pipeline_stages=2` in `gen_attention_dual_stream_composed.py`
- register `numer_q` and `sum_weight_qq` before the final exact divide
- extend the composed guard to require those divider operand registers when stage count is 2
- add the score32/v8 split2 design config, sweep, and L1 proposal/evaluation request

## Why

The current measured score32/w16 exact-div composed wrapper has a 36.174 ns critical path from `u_softmax/exp_weight_q` into `u_softmax/weights`. This PR creates the next L1 PPA job to test whether an exact extra divider operand pipeline stage improves the measured clock enough to change the Llama7B frontier recost.

## Validation

- `pytest -q tests/test_attention_dual_stream_composed_generator.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l1_task_generator.py control_plane/control_plane/tests/test_cli_generate_l1.py`
- generated the new score32 split2 config and ran `check_attention_dual_stream_composed_guard.py`
- compiled generated RTL with `/oss-cad-suite/bin/iverilog -g2012`