### PR TITLE
[codex] add score32/w16 recip-lut q16 composed point

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1124,6 +1124,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1",
+        "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
     }:
         diagnosis = evidence_payload.get("diagnosis")
         diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
@@ -1144,6 +1145,8 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             if model == "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1"
             else "Decoder composed dual-stream physical feasibility evidence (score32/w16 exact-div split2 reduced-replica recost)"
             if model == "llm_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1"
+            else "Decoder composed dual-stream physical feasibility evidence (score32/w16 recip-lut q16 reduced-replica recost)"
+            if model == "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1"
             else "Decoder dual-stream physical feasibility evidence"
         )
         parts = [

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5453,6 +5453,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     q12_pwl_frontier = "q12_pwl_softmax_frontier" in item_id
     score32_split2_reduced_replica = "score32_w16_exact_div_split2_reduced_replica" in item_id
     score32_reduced_replica = "score32_w16_exact_div_reduced_replica" in item_id
+    score32_recip_lut_q16_reduced_replica = "score32_w16_recip_lut_q16_reduced_replica" in item_id
     score32_frontier = "score32_w16_exact_div_frontier" in item_id
     variant_frontier = "variant_frontier" in item_id
     composed_dual_stream_metrics = (
@@ -5463,6 +5464,11 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         composed_dual_stream_metrics = (
             "runs/designs/npu_blocks/"
             "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/metrics.csv"
+        )
+    elif score32_recip_lut_q16_reduced_replica:
+        composed_dual_stream_metrics = (
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/metrics.csv"
         )
     elif score32_frontier or score32_reduced_replica:
         composed_dual_stream_metrics = (
@@ -5490,6 +5496,9 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     if score32_split2_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a32_s32_w16_exact_div_int8_compute"
+    elif score32_recip_lut_q16_reduced_replica:
+        model_name = "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1"
+        precision_profile = "q8_k8_v8_a32_s32_w16_recip_lut_q16_int8_compute"
     elif score32_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a32_s32_w16_exact_div_int8_compute"
@@ -5532,7 +5541,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
                     f"--quality-gate-json {quality_gate} "
                     f"--precision-profile {precision_profile} "
                     f"--model-name {model_name} "
-                    f"{'--recompute-area-fit-replicas ' if score32_reduced_replica or score32_split2_reduced_replica else ''}"
+                    f"{'--recompute-area-fit-replicas ' if score32_reduced_replica or score32_split2_reduced_replica or score32_recip_lut_q16_reduced_replica else ''}"
                     "--frontier-row-limit 8 "
                     "--buffer-area-um2-per-byte 0.0 "
                     f"--out {out} "

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1333,6 +1333,30 @@ def test_decoder_evidence_summary_recognizes_composed_datapath_score32_split2_re
     assert "best_requested_replica_recost_latency_us=8200.0" in summary
 
 
+def test_decoder_evidence_summary_recognizes_composed_datapath_score32_recip_lut_q16_reduced_replica_model() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/composed_datapath_score32_recip_lut_q16_reduced_replica.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+            "diagnosis": {
+                "decision": "dual_stream_feasible",
+                "precision_profile": "q8_k8_v8_a32_s32_w16_recip_lut_q16_int8_compute",
+                "best_requested_mode": "dual_mac",
+                "best_requested_replica_recost_enabled": True,
+                "best_requested_replica_recost_area_fit_replica_count": 768,
+                "best_requested_replica_recost_macs_per_cycle": 98112,
+                "best_requested_replica_recost_latency_us": 9900.0,
+                "best_feasible_latency_us": 9900.0,
+            },
+        },
+    )
+
+    assert outcome == "dual_stream_feasible"
+    assert "score32/w16 recip-lut q16 reduced-replica recost" in summary
+    assert "precision_profile=q8_k8_v8_a32_s32_w16_recip_lut_q16_int8_compute" in summary
+    assert "best_requested_replica_recost_latency_us=9900.0" in summary
+
+
 def _seed_succeeded_l2_campaign(session: Session, repo_root: Path) -> tuple[str, str]:
     campaign_dir = repo_root / "runs" / "campaigns" / "npu" / "demo_campaign"
     schedule_rel = "runs/campaigns/npu/demo_campaign/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6242,6 +6242,61 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_redu
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_recip_lut_q16_reduced_replica_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1"
+                in run
+            )
+            assert "--recompute-area-fit-replicas" in run
+            assert (
+                "--precision-profile q8_k8_v8_a32_s32_w16_recip_lut_q16_int8_compute" in run
+            )
+            assert decoder_inputs["attention_kv_composed_dual_stream_metrics"] == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/metrics.csv"
+            )
+            assert (
+                "--composed-dual-stream-metrics runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/metrics.csv "
+                in run
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_split2_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds score32/w16 reciprocal-LUT q16 composed datapath generation, config, and sweep files.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for q8/k8/v8/a32/s32/w16 composed dual-stream attention with q16 reciprocal-LUT normalization.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_recip_lut_q16_quality_recost",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_recip_lut_q16.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_score32_w16_recip_lut_q16_datapath",
+        "reason": "This tests the nearest bounded hardware substitute for the exact divider bottleneck while keeping score32/w16/v8 widths."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_v1/proposal.json
@@ -1,0 +1,76 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_v1",
+  "created_utc": "2026-06-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Composed dual-stream attention score32/w16 reciprocal-LUT q16 datapath",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The score32/w16 exact-divider composed datapath is physically dominated by synthesized division. Replacing only the final normalization divide with a q16 reciprocal LUT should preserve the score32/w16 precision family while measuring a bounded hardware normalization structure.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 PPA cost and timing are achieved by score32/w16 reciprocal-LUT q16 normalization compared with the score32/w16 exact-divider datapath?",
+    "baselines": [
+      "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_split2_ppa_v1"
+    ],
+    "candidate": "l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_ppa_v1",
+    "include": [
+      "generate RTL with mac_accum_bits=32",
+      "generate softmax_score_bits=32 and softmax_weight_bits=16",
+      "replace exact divide with a fixed q16 reciprocal LUT over the bounded shift-exp denominator range",
+      "generate value_bits=8",
+      "run the composed datapath guard before OpenROAD",
+      "measure Nangate45 area, power, timing, and timing debug paths"
+    ],
+    "exclude": [
+      "native model-quality retraining",
+      "full floating-point exp softmax hardware",
+      "system-level Llama7B recost; that is a dependent Layer 2 item"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "The reciprocal LUT is a fixed-point approximation to the exact divider, so precision must remain classified separately from exact-div evidence.",
+    "The job measures the local composed datapath only; Llama7B system-level ranking is a dependent Layer 2 substitution job."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for q8/k8/v8/a32/s32/w16 composed dual-stream attention with q16 reciprocal-LUT normalization.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_recip_lut_q16_quality_recost",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_recip_lut_q16.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_score32_w16_recip_lut_q16_datapath",
+        "reason": "This tests the nearest bounded hardware substitute for the exact divider bottleneck while keeping score32/w16/v8 widths."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_recip_lut_q16.json"
+  ],
+  "knowledge_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/metrics.csv"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds score32/w16 recip-lut q16 reduced-replica L1 metrics and Llama7B route wiring.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the measured score32/w16 recip-lut q16 composed dual-stream attention wrapper at the area-fit replica count and measured wrapper clock.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_recip_lut_q16_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_recip_lut_q16_area_fit_recost",
+        "reason": "The q16 recip-lut composed wrapper is a conservative path update of the prior score32 frontier."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_v1/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_v1",
+  "created_utc": "2026-06-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score32/w16 recip-lut q16 composed datapath reduced-replica recost",
+  "hypothesis": "The existing exact-div reduced-replica Llama7B route is blocked by area; a score32/w16 recip-lut q16 composed datapath variant can produce a conservative area-fit point with updated measured wrapper characteristics and explicitly classified approximation.",
+  "direct_comparison": {
+    "primary_question": "What is the feasibility and latency after re-costing the score32/w16 recip-lut q16 composed datapath at the measured area-fit replica count?",
+    "baseline": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+    "include": [
+      "Use the measured score32/w16 recip-lut q16 composed dual-stream wrapper metrics.",
+      "Scale the Llama7B subtile schedule by the measured wrapper and area-fit replicate geometry.",
+      "Recompute feasible and adjusted latency fields at the measured wrapper clock."
+    ],
+    "exclude": [
+      "new KV service model generation",
+      "new L1 datapath PPA generation",
+      "new quality proxy reruns"
+    ],
+    "metrics": [
+      "decision",
+      "precision_profile",
+      "best_requested_replica_recost_area_fit_replica_count",
+      "best_requested_replica_recost_macs_per_cycle",
+      "best_requested_replica_recost_latency_us",
+      "best_feasible_latency_us"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the measured score32/w16 recip-lut q16 composed dual-stream attention wrapper at the measured area-fit replica count.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_recip_lut_q16_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_recip_lut_q16_area_fit_recost",
+        "reason": "This records the conservative area-fit datapath point for the q16 recip-lut score32/w16 composed wrapper before any new end-to-end quality work."
+      }
+    }
+  ],
+  "source_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json",
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py"
+  ],
+  "remaining_abstractions": [
+    "This is an L2-only scaled feasibility recost using pre-measured composed wrapper metrics.",
+    "Subtile schedule selection and HBM/NoC/SRAM assumptions stay inherited from upstream merged dependencies."
+  ]
+}

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -806,9 +806,13 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
         "attention_softmax_weight_q12_pwl_recip_like"
         if softmax_impl == "pwl_recip_lut"
         else (
+            f"attention_softmax_weight_score32_w16_recip_lut_q{reciprocal_bits}_like"
+            if softmax_score_bits == 32 and softmax_weight_bits == 16 and softmax_impl == "recip_lut"
+            else (
             "attention_softmax_weight_score32_w16_exact_div_like"
             if softmax_score_bits == 32 and softmax_weight_bits == 16 and softmax_impl == "exact_div"
             else "attention_softmax_weight_int8_r8_acc24_recip_q10_like"
+            )
         )
     )
     value_name = f"attention_full_value_stream_q8v{value_bits}_p8_ppc2"
@@ -1104,7 +1108,11 @@ endmodule
             "softmax_weight": (
                 "one shared q12 PWL reciprocal-normalized generator"
                 if softmax_impl == "pwl_recip_lut"
-                else "one shared rowwise int8 shift-exp reciprocal-normalized generator"
+                else (
+                    "one shared score32/w16 shift-exp reciprocal-LUT-normalized generator"
+                    if softmax_score_bits == 32 and softmax_weight_bits == 16 and softmax_impl == "recip_lut"
+                    else "one shared rowwise int8 shift-exp reciprocal-normalized generator"
+                )
             ),
             "full_value": "two q8/v6 weighted-value streams",
             "control": "start/done, seed LFSR, per-stream buffer registers",

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_recip_lut_q16.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_recip_lut_q16.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_score32_w16_recip_lut_q16"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_score32_w16_recip_lut_q16"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc32 attention_softmax_weight_score32_w16_recip_lut_q16_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_score32_w16_recip_lut_q16"
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/config.json
@@ -1,0 +1,24 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "mac_accum_bits": 32,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 32,
+    "softmax_weight_bits": 16,
+    "softmax_accum_bits": 40,
+    "reciprocal_bits": 16,
+    "value_bits": 8,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_internal_pipeline_stages": 0,
+    "softmax_impl": "recip_lut"
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -15,6 +15,7 @@ def _write_config(
     softmax_accum_bits: int | None = None,
     softmax_score_bits: int | None = None,
     softmax_weight_bits: int | None = None,
+    reciprocal_bits: int | None = None,
     softmax_input_frac_bits: int | None = None,
     softmax_reciprocal_lut_bucket_shift: int | None = None,
 ) -> None:
@@ -48,6 +49,8 @@ def _write_config(
         comp["softmax_score_bits"] = softmax_score_bits
     if softmax_weight_bits is not None:
         comp["softmax_weight_bits"] = softmax_weight_bits
+    if reciprocal_bits is not None:
+        comp["reciprocal_bits"] = reciprocal_bits
     if softmax_input_frac_bits is not None:
         comp["softmax_input_frac_bits"] = softmax_input_frac_bits
     if softmax_reciprocal_lut_bucket_shift is not None:
@@ -381,6 +384,47 @@ def test_attention_dual_stream_composed_generator_score32_v8_exact_softmax(tmp_p
     assert manifest["value_bits"] == 8
     assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
     assert "wire signed [7:0] value_00" in top_text
+
+
+def test_attention_dual_stream_composed_generator_score32_v8_recip_lut_q16_softmax(
+    tmp_path: Path,
+) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_score32_v8_recip_lut_q16"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="recip_lut",
+        mac_accum_bits=32,
+        softmax_accum_bits=40,
+        softmax_score_bits=32,
+        softmax_weight_bits=16,
+        reciprocal_bits=16,
+    )
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    cfg["attention_dual_stream_composed"]["value_bits"] = 8
+    config_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["mac_module"] == "int8_mac_s8s8_acc32"
+    assert manifest["softmax_impl"] == "recip_lut"
+    assert manifest["softmax_score_bits"] == 32
+    assert manifest["softmax_weight_bits"] == 16
+    assert manifest["reciprocal_bits"] == 16
+    assert manifest["value_bits"] == 8
+    assert manifest["softmax_latency_stages"] == 1
+    assert manifest["value_alignment_delay_stages"] == 2
+    assert "module attention_softmax_weight_score32_w16_recip_lut_q16_like" in top_text
+    assert "localparam integer RECIPROCAL_BITS = 16" in top_text
+    assert "localparam integer RECIPROCAL_WIDTH = 32" in top_text
+    assert "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut" in top_text
+    assert "reciprocal_q = reciprocal_lut(sum_weight)" in top_text
+    assert "/ sum_weight" not in top_text
+    assert "/ sum_weight_q" not in top_text
+    assert "wire [63:0] softmax_weights" in top_text
+    assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
 
 
 def test_attention_dual_stream_composed_generator_score32_v8_exact_softmax_divider_operand_pipeline(


### PR DESCRIPTION
## Summary
- add score32/w16/v8 composed dual-stream datapath config using q16 reciprocal-LUT normalization instead of exact division
- give the score32/w16 reciprocal-LUT softmax module a distinct generated name for OpenROAD keep-module sweeps
- add L1 PPA proposal and L2 reduced-replica recost proposal/routing for the new metrics path

## Validation
- python3 -m pytest -q tests/test_attention_dual_stream_composed_generator.py
- PYTHONPATH=control_plane python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "score32_recip_lut_q16_reduced_replica or score32_reduced_replica"
- PYTHONPATH=control_plane python3 -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k "recip_lut_q16_reduced_replica"
- python3 scripts/validate_runs.py --skip_eval_queue
- generated score32/w16 recip-lut q16 RTL, ran composed guard, and compiled with iverilog
