### PR TITLE
npu: add q16 reciprocal quality gate

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6554,6 +6554,62 @@ def _decoder_attention_mixed_int8_generation_quality_evidence(*, item_id: str) -
     }
 
 
+def _decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    physical_recost = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1.json"
+    )
+    generation_quality_baseline = (
+        f"{base}/decoder_attention_mixed_int8_generation_quality__"
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+    )
+    out = f"{base}/decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_score32_w16_recip_lut_q16_physical_recost": physical_recost,
+            "attention_mixed_int8_generation_quality_baseline": generation_quality_baseline,
+            "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_out": out,
+            "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_report": report,
+            "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_scope": (
+                "Run a bounded native-checkpoint generation/NLL gate for the physically measured "
+                "score32/w16 RTL reciprocal-LUT q16 candidate. This confirms the precision side of "
+                "the current fastest reduced-replica frontier before treating it as quality-backed."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_MAX_PROMPTS:-8}; "
+                    "GEN_STEPS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_STEPS:-8}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--generation-steps \"$GEN_STEPS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--candidate score32_w16_rtl_recip_q16:q8,k8,v8,s32,w16,rtl_recip_lut_q16 "
+                    "--primary-candidate-id score32_w16_rtl_recip_q16 "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     energy_closure = (
@@ -8497,6 +8553,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_score_precision_recovery",
         "decoder_attention_mixed_int8_score_margin_audit",
         "decoder_attention_mixed_int8_generation_quality",
+        "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
         "decoder_attention_mixed_int8_quality_backed_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
@@ -8698,6 +8755,12 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_score_margin_audit_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_generation_quality":
             decoder_evidence = _decoder_attention_mixed_int8_generation_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality":
+            decoder_evidence = (
+                _decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_evidence(
+                    item_id=item_id,
+                )
+            )
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
             decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7680,6 +7680,88 @@ def test_generate_l2_campaign_task_adds_mixed_int8_generation_quality_evidence()
             }
 
 
+def test_generate_l2_campaign_task_adds_score32_w16_recip_lut_q16_generation_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_"
+                        "generation_quality_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_"
+                        "generation_quality_llama7b_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_"
+                        "generation_quality_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer=(
+                        "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality"
+                    ),
+                    evaluation_mode="quality_gate",
+                    comparison_role="score32_w16_recip_lut_q16_generation_quality",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+                        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py" in run
+            assert "--candidate score32_w16_rtl_recip_q16:q8,k8,v8,s32,w16,rtl_recip_lut_q16" in run
+            assert "--primary-candidate-id score32_w16_rtl_recip_q16" in run
+            assert decoder_inputs["attention_score32_w16_recip_lut_q16_physical_recost"].endswith(
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_mixed_int8_generation_quality_baseline"].endswith(
+                "decoder_attention_mixed_int8_generation_quality__"
+                "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+            )
+            assert "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+                    "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+  "requests": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded native-checkpoint generation/NLL quality for the score32/w16 RTL reciprocal-LUT q16 candidate that currently has the best physical recost.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
+      "comparison_role": "score32_w16_recip_lut_q16_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "accept_or_hold_q16_recip_lut_frontier",
+        "reason": "The result should decide whether the fastest q16 reciprocal-LUT physical recost can be treated as a quality-backed frontier candidate."
+      }
+    }
+  ],
+  "source_commit": null
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1/proposal.json
@@ -1,0 +1,83 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+  "created_utc": "2026-06-27T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score32/w16 reciprocal-LUT q16 generation quality",
+  "abstraction_layer": "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
+  "hypothesis": "The score32/w16 RTL reciprocal-LUT q16 softmax candidate is the current fastest physically recosted reduced-replica point, but it is approximate. A bounded native-checkpoint generation/NLL quality gate can determine whether it is acceptable enough to treat as the quality-backed frontier.",
+  "direct_comparison": {
+    "primary_question": "Does the physically measured score32/w16 reciprocal-LUT q16 attention candidate preserve bounded greedy generation and teacher-forced reference-token likelihood on a 7B checkpoint?",
+    "baseline": "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+    "candidate": "score32_w16_rtl_recip_q16",
+    "physical_context": "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+    "include": [
+      "run native-checkpoint reference and score32/w16 reciprocal-LUT q16 candidate on the same bounded prompt set",
+      "measure teacher-forced reference-token NLL under reference and candidate",
+      "measure free-running greedy token match and first divergence step",
+      "record whether the physically best q16 recost remains quality admissible"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "training or QAT",
+      "full downstream benchmark accuracy"
+    ],
+    "metrics": [
+      "decision",
+      "candidate_id",
+      "free_run_exact_match_rate",
+      "free_run_token_match_rate",
+      "diverged_prompt_count",
+      "mean_first_divergence_step",
+      "teacher_forced_mean_reference_nll",
+      "teacher_forced_mean_candidate_nll",
+      "teacher_forced_mean_nll_delta",
+      "teacher_forced_candidate_reference_token_prob_mean"
+    ]
+  },
+  "expected_benefit": [
+    "confirm whether the q16 reciprocal-LUT physical frontier is also precision-backed",
+    "separate physical speedup from quality risk before ranking it above exact-div alternatives",
+    "avoid relying on PPA-only evidence for an approximate softmax datapath"
+  ],
+  "risks": [
+    "bounded greedy generation is not full task accuracy",
+    "prompt and generation-step defaults may miss longer-horizon divergence",
+    "quality outcome remains checkpoint and distribution dependent"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded native-checkpoint generation/NLL quality for the score32/w16 RTL reciprocal-LUT q16 candidate that currently has the best physical recost.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
+      "comparison_role": "score32_w16_recip_lut_q16_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "accept_or_hold_q16_recip_lut_frontier",
+        "reason": "The result should decide whether the fastest q16 reciprocal-LUT physical recost can be treated as a quality-backed frontier candidate."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_generation_quality__l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py",
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_v1/proposal.json"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py
+++ b/npu/eval/estimate_llm_decoder_attention_mixed_precision_quality.py
@@ -134,8 +134,8 @@ def _rtl_quantized_softmax(logits: Vector, *, score_bits: int, weight_bits: int,
     reciprocal_bits = _rtl_reciprocal_bits(mode)
     if mode not in {"rtl_exact", "rtl_pow2sum"} and reciprocal_bits is None:
         raise ValueError(f"unsupported RTL softmax mode: {mode}")
-    if weight_bits > 8:
-        raise ValueError("RTL softmax modes model the int8 softmax weight block; weight_bits must be <= 8")
+    if weight_bits < 2 or weight_bits > 24:
+        raise ValueError("RTL softmax modes expect integer output weights in [2, 24]")
     qlogits, _scale = _quantize_symmetric(logits, score_bits)
     if not qlogits:
         return []

--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
@@ -234,8 +234,8 @@ def _rtl_quantized_softmax(
     else:
         reciprocal_bits = 0
 
-    if weight_bits > 8:
-        raise ValueError("RTL softmax mode expects integer output weights (weight_bits <= 8)")
+    if weight_bits < 2 or weight_bits > 24:
+        raise ValueError("RTL softmax mode expects integer output weights in [2, 24]")
 
     q_logits, _ = _quantize_symmetric_list(logits, score_bits)
     if not q_logits:

--- a/tests/test_llm_decoder_model_native_mixed_int8_attention.py
+++ b/tests/test_llm_decoder_model_native_mixed_int8_attention.py
@@ -74,16 +74,25 @@ def test_quantized_softmax_variants_and_ranges() -> None:
     exact = _rtl_quantized_softmax(logits, score_bits=8, weight_bits=8, softmax_mode="rtl_exact")
     pow2sum = _rtl_quantized_softmax(logits, score_bits=8, weight_bits=8, softmax_mode="rtl_pow2sum")
     lut = _rtl_quantized_softmax(logits, score_bits=8, weight_bits=8, softmax_mode="rtl_recip_lut_q10")
+    lut_q16_w16 = _rtl_quantized_softmax(
+        logits,
+        score_bits=32,
+        weight_bits=16,
+        softmax_mode="rtl_recip_lut_q16",
+    )
 
     assert len(exact) == len(logits)
     assert len(pow2sum) == len(logits)
     assert len(lut) == len(logits)
+    assert len(lut_q16_w16) == len(logits)
     assert max(range(len(exact)), key=exact.__getitem__) == 1
     assert max(range(len(pow2sum)), key=pow2sum.__getitem__) == 1
     assert max(range(len(lut)), key=lut.__getitem__) == 1
+    assert max(range(len(lut_q16_w16)), key=lut_q16_w16.__getitem__) == 1
     assert all(0.0 <= value <= 1.0 for value in exact)
     assert all(0.0 <= value <= 1.0 for value in pow2sum)
     assert all(0.0 <= value <= 1.0 for value in lut)
+    assert all(0.0 <= value <= 1.0 for value in lut_q16_w16)
 
 
 def test_quantize_symmetric_list() -> None:
@@ -222,6 +231,12 @@ def test_parse_candidate_spec_and_list_compatibility() -> None:
     assert q12_pwl.score_bits == 12
     assert q12_pwl.weight_bits == 12
     assert q12_pwl.softmax_mode == "pwl_recip_lut_q12_bucket8"
+
+    q16_rtl = _parse_candidate_spec("score32_w16_rtl_recip_q16:q8,k8,v8,s32,w16,rtl_recip_lut_q16")
+    assert q16_rtl.candidate_id == "score32_w16_rtl_recip_q16"
+    assert q16_rtl.score_bits == 32
+    assert q16_rtl.weight_bits == 16
+    assert q16_rtl.softmax_mode == "rtl_recip_lut_q16"
 
     with pytest.raises(ValueError):
         _parse_candidate_spec("qkv8_score8:r8")


### PR DESCRIPTION
## Summary
- add an L2 quality-gate proposal for the physically best score32/w16 RTL reciprocal-LUT q16 candidate
- wire the control-plane generator route for the q16 generation-quality job
- allow RTL softmax quality evaluators to model integer output weights up to 24 bits and cover w16 q16 parsing/range tests

## Tests
- python -m pytest -q tests/test_llm_decoder_model_native_mixed_int8_attention.py
- PYTHONPATH=control_plane python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "recip_lut_q16_generation_quality or mixed_int8_generation_quality"
- python scripts/validate_runs.py --skip_eval_queue