### PR TITLE
control_plane: consume q16 quality evidence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -515,6 +515,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_generation_quality_report",
     ),
     (
+        "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_out",
+        "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_report",
+    ),
+    (
         "attention_mixed_int8_quality_backed_frontier_out",
         "attention_mixed_int8_quality_backed_frontier_report",
     ),

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1222,6 +1222,187 @@ def test_consume_l2_result_frontier_attention_mixed_int8_generation_quality_uses
             )
 
 
+def test_consume_l2_result_frontier_attention_q16_generation_quality_uses_decoder_evidence_without_best_point() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            item_id = "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1"
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1"
+            )
+            proposal_dir.mkdir(parents=True)
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": (
+                            "prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_"
+                            "generation_quality_llama7b_v1"
+                        ),
+                        "kind": "architecture",
+                        "title": "Attention score32/w16 q16 generation quality",
+                        "direct_comparison": {
+                            "primary_question": (
+                                "Does the q16 reciprocal-LUT physical frontier preserve generation quality?"
+                            )
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__"
+                f"{item_id}.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__"
+                f"{item_id}.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "quality_gate": "mixed_int8_generation_quality",
+                        "model": {
+                            "model_id": "mistralai/Mistral-7B-v0.1",
+                            "gqa_group_size": 4.0,
+                            "dtype": "bfloat16",
+                        },
+                        "decision": {
+                            "status": "mixed_int8_generation_quality_pass",
+                            "recommended_next_step": "promote q16 recip-lut to quality-backed frontier",
+                        },
+                        "summary": {
+                            "candidate_id": "score32_w16_rtl_recip_q16",
+                            "prompt_count": 8,
+                            "generation_steps": 8,
+                            "free_run_exact_match_rate": 1.0,
+                            "free_run_token_match_rate": 1.0,
+                            "diverged_prompt_count": 0,
+                            "teacher_forced_mean_reference_nll": 0.25,
+                            "teacher_forced_mean_candidate_nll": 0.2501,
+                            "teacher_forced_mean_nll_delta": 0.0001,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# q16 mixed-int8 generation quality\n")
+
+            task_request = TaskRequest(
+                request_key=f"l2_campaign:{item_id}",
+                source="test",
+                requested_by="@tester",
+                title=f"Layer2 {item_id}",
+                description="q16 generation quality",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": item_id,
+                    "layer": "layer2",
+                    "flow": "openroad",
+                    "developer_loop": {
+                        "proposal_id": (
+                            "prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_"
+                            "generation_quality_llama7b_v1"
+                        ),
+                        "proposal_path": str(proposal_dir.relative_to(repo_root)),
+                        "evaluation": {
+                            "mode": "quality_gate",
+                            "expected_direction": "accept_or_hold_q16_recip_lut_frontier",
+                        },
+                        "abstraction": {
+                            "layer": (
+                                "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality"
+                            ),
+                        },
+                        "comparison": {
+                            "role": "score32_w16_recip_lut_q16_generation_quality",
+                        },
+                    },
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key=f"l2_campaign:{item_id}",
+                task_request_id=task_request.id,
+                item_id=item_id,
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="src_verilog",
+                input_manifest={
+                    "decoder_contract": {
+                        "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_out": evidence_rel,
+                        "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_report": report_rel,
+                    }
+                },
+                command_manifest=[],
+                expected_outputs=[evidence_rel, report_rel],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+            session.add(
+                Run(
+                    run_key=f"{item_id}_run_1",
+                    work_item_id=work_item.id,
+                    attempt=1,
+                    executor_type=ExecutorType.INTERNAL_WORKER,
+                    status=RunStatus.SUCCEEDED,
+                    started_at=utcnow(),
+                    completed_at=utcnow(),
+                    checkout_commit="deadbeef",
+                    result_summary="2/2 commands succeeded",
+                )
+            )
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "mixed_int8_generation_quality_pass"
+            assert "score32_w16_rtl_recip_q16" in assessment["summary"]
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality"
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_out"
+                ]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_report"
+                ]
+                == report_rel
+            )
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",


### PR DESCRIPTION
## Summary
- register the score32/w16 reciprocal-LUT q16 generation-quality output keys with the L2 decoder evidence consumer
- add a regression test for evidence-only q16 quality jobs that do not emit best_point.json
- fixes the live ARTIFACT_SYNC failure after the q16 quality job succeeded

## Tests
- PYTHONPATH=control_plane python -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k "q16_generation_quality or mixed_int8_generation_quality"
- python scripts/validate_runs.py --skip_eval_queue