### PR TITLE
npu: add rtl exact generation quality diagnostic

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -519,6 +519,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_report",
     ),
     (
+        "attention_mixed_int8_score32_w16_rtl_exact_generation_quality_out",
+        "attention_mixed_int8_score32_w16_rtl_exact_generation_quality_report",
+    ),
+    (
         "attention_mixed_int8_quality_backed_frontier_out",
         "attention_mixed_int8_quality_backed_frontier_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6610,6 +6610,67 @@ def _decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_e
     }
 
 
+def _decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    exact_recost = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json"
+    )
+    generation_quality_baseline = (
+        f"{base}/decoder_attention_mixed_int8_generation_quality__"
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+    )
+    q16_generation_quality = (
+        f"{base}/decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__"
+        "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1.json"
+    )
+    out = f"{base}/decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_score32_w16_exact_div_physical_recost": exact_recost,
+            "attention_mixed_int8_generation_quality_baseline": generation_quality_baseline,
+            "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality": q16_generation_quality,
+            "attention_mixed_int8_score32_w16_rtl_exact_generation_quality_out": out,
+            "attention_mixed_int8_score32_w16_rtl_exact_generation_quality_report": report,
+            "attention_mixed_int8_score32_w16_rtl_exact_generation_quality_scope": (
+                "Run a bounded native-checkpoint generation/NLL gate for score32/w16 RTL exact-divide "
+                "softmax. This isolates whether the q16 reciprocal-LUT quality failure comes from the "
+                "reciprocal approximation or from the shared RTL softmax weight/exponent model."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_MAX_PROMPTS:-8}; "
+                    "GEN_STEPS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_STEPS:-8}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--generation-steps \"$GEN_STEPS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--candidate score32_w16_rtl_exact:q8,k8,v8,s32,w16,rtl_exact "
+                    "--primary-candidate-id score32_w16_rtl_exact "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     energy_closure = (
@@ -8554,6 +8615,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_score_margin_audit",
         "decoder_attention_mixed_int8_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
+        "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
         "decoder_attention_mixed_int8_quality_backed_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
@@ -8760,6 +8822,10 @@ def _build_payload(
                 _decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_evidence(
                     item_id=item_id,
                 )
+            )
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality":
+            decoder_evidence = _decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_evidence(
+                item_id=item_id,
             )
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
             decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1403,6 +1403,162 @@ def test_consume_l2_result_frontier_attention_q16_generation_quality_uses_decode
             )
 
 
+def test_consume_l2_result_frontier_attention_rtl_exact_generation_quality_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            item_id = "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1"
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1"
+            )
+            proposal_dir.mkdir(parents=True)
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": (
+                            "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_"
+                            "generation_quality_llama7b_v1"
+                        ),
+                        "kind": "architecture",
+                        "title": "Attention score32/w16 RTL exact generation quality",
+                        "direct_comparison": {
+                            "primary_question": "Does RTL exact-divide softmax preserve generation quality?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                f"decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__{item_id}.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                f"decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__{item_id}.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "quality_gate": "mixed_int8_generation_quality",
+                        "model": {
+                            "model_id": "mistralai/Mistral-7B-v0.1",
+                            "gqa_group_size": 4.0,
+                            "dtype": "bfloat16",
+                        },
+                        "decision": {
+                            "status": "mixed_int8_generation_quality_hold",
+                            "recommended_next_step": "replace RTL exponent approximation",
+                        },
+                        "summary": {
+                            "candidate_id": "score32_w16_rtl_exact",
+                            "prompt_count": 8,
+                            "generation_steps": 8,
+                            "free_run_exact_match_rate": 0.0,
+                            "free_run_token_match_rate": 0.1,
+                            "teacher_forced_mean_nll_delta": 1.0,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# rtl exact generation quality\n")
+
+            task_request = TaskRequest(
+                request_key=f"l2_campaign:{item_id}",
+                source="test",
+                requested_by="@tester",
+                title=f"Layer2 {item_id}",
+                description="rtl exact generation quality",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": item_id,
+                    "layer": "layer2",
+                    "flow": "openroad",
+                    "developer_loop": {
+                        "proposal_id": (
+                            "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_"
+                            "generation_quality_llama7b_v1"
+                        ),
+                        "proposal_path": str(proposal_dir.relative_to(repo_root)),
+                        "evaluation": {"mode": "quality_gate"},
+                        "abstraction": {
+                            "layer": "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+                        },
+                        "comparison": {"role": "score32_w16_rtl_exact_generation_quality"},
+                    },
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key=f"l2_campaign:{item_id}",
+                task_request_id=task_request.id,
+                item_id=item_id,
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="src_verilog",
+                input_manifest={
+                    "decoder_contract": {
+                        "attention_mixed_int8_score32_w16_rtl_exact_generation_quality_out": evidence_rel,
+                        "attention_mixed_int8_score32_w16_rtl_exact_generation_quality_report": report_rel,
+                    }
+                },
+                command_manifest=[],
+                expected_outputs=[evidence_rel, report_rel],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+            session.add(
+                Run(
+                    run_key=f"{item_id}_run_1",
+                    work_item_id=work_item.id,
+                    attempt=1,
+                    executor_type=ExecutorType.INTERNAL_WORKER,
+                    status=RunStatus.SUCCEEDED,
+                    started_at=utcnow(),
+                    completed_at=utcnow(),
+                    checkout_commit="deadbeef",
+                    result_summary="2/2 commands succeeded",
+                )
+            )
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert decision_payload["proposal_assessment"]["outcome"] == "mixed_int8_generation_quality_hold"
+            assert "score32_w16_rtl_exact" in decision_payload["proposal_assessment"]["summary"]
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_out"
+                ]
+                == evidence_rel
+            )
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7762,6 +7762,76 @@ def test_generate_l2_campaign_task_adds_score32_w16_recip_lut_q16_generation_qua
             }
 
 
+def test_generate_l2_campaign_task_adds_score32_w16_rtl_exact_generation_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_"
+                        "generation_quality_llama7b_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_"
+                        "generation_quality_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+                    evaluation_mode="quality_gate",
+                    comparison_role="score32_w16_rtl_exact_generation_quality",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+                        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+                        "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py" in run
+            assert "--candidate score32_w16_rtl_exact:q8,k8,v8,s32,w16,rtl_exact" in run
+            assert "--primary-candidate-id score32_w16_rtl_exact" in run
+            assert decoder_inputs["attention_score32_w16_exact_div_physical_recost"].endswith(
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json"
+            )
+            assert decoder_inputs["attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_score32_w16_rtl_exact_generation_quality_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_score32_w16_rtl_exact_generation_quality_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+            }
+
+
 def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+  "requests": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded native-checkpoint generation/NLL quality for score32/w16 RTL exact-divide softmax after reciprocal-LUT q16 failed the same gate.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+      "comparison_role": "score32_w16_rtl_exact_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+        "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "diagnose_rtl_softmax_quality_failure",
+        "reason": "If RTL exact-divide passes, recover by improving reciprocal approximation. If it fails, recover by replacing the shared RTL softmax exponent/weight approximation."
+      }
+    }
+  ],
+  "source_commit": null
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/proposal.json
@@ -1,0 +1,86 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+  "created_utc": "2026-06-27T01:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score32/w16 RTL exact-divide generation quality",
+  "abstraction_layer": "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+  "hypothesis": "The score32/w16 floating-quantized softmax quality gate passes, while the score32/w16 reciprocal-LUT q16 RTL softmax gate fails. Running the same gate with RTL exact division isolates whether the failure is caused primarily by reciprocal approximation or by the shared RTL softmax exponent/weight approximation.",
+  "direct_comparison": {
+    "primary_question": "Does the score32/w16 RTL exact-divide softmax candidate preserve bounded greedy generation and teacher-forced reference-token likelihood on a 7B checkpoint?",
+    "baseline": "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+    "negative_control": "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+    "physical_context": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+    "candidate": "score32_w16_rtl_exact",
+    "include": [
+      "run native-checkpoint reference and score32/w16 RTL exact-divide candidate on the same bounded prompt set",
+      "measure teacher-forced reference-token NLL under reference and candidate",
+      "measure free-running greedy token match and first divergence step",
+      "classify whether exact division is enough to recover the failed reciprocal-LUT q16 quality gate"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "training or QAT",
+      "full downstream benchmark accuracy"
+    ],
+    "metrics": [
+      "decision",
+      "candidate_id",
+      "free_run_exact_match_rate",
+      "free_run_token_match_rate",
+      "diverged_prompt_count",
+      "mean_first_divergence_step",
+      "teacher_forced_mean_reference_nll",
+      "teacher_forced_mean_candidate_nll",
+      "teacher_forced_mean_nll_delta",
+      "teacher_forced_candidate_reference_token_prob_mean"
+    ]
+  },
+  "expected_benefit": [
+    "separate reciprocal approximation error from the shared RTL softmax weight/exponent approximation",
+    "avoid spending PPA effort on reciprocal variants if exact division also fails generation quality",
+    "identify whether the next precision-recovery job should target reciprocal bits or exponent/softmax modeling"
+  ],
+  "risks": [
+    "bounded greedy generation is not full task accuracy",
+    "prompt and generation-step defaults may miss longer-horizon divergence",
+    "quality outcome remains checkpoint and distribution dependent"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded native-checkpoint generation/NLL quality for score32/w16 RTL exact-divide softmax after reciprocal-LUT q16 failed the same gate.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+      "comparison_role": "score32_w16_rtl_exact_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+        "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "diagnose_rtl_softmax_quality_failure",
+        "reason": "If RTL exact-divide passes, recover by improving reciprocal approximation. If it fails, recover by replacing the shared RTL softmax exponent/weight approximation."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_generation_quality__l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py",
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1/proposal.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a score32/w16 RTL exact-divide generation-quality diagnostic route
- register the result-consumer evidence keys so the evidence-only result can publish without best_point.json
- add proposal metadata and focused generator/consumer tests

## Why
The score32 floating-quantized generation gate passes, while score32/w16 reciprocal-LUT q16 fails. This job separates reciprocal approximation error from the shared RTL softmax exponent/weight approximation.

## Tests
- PYTHONPATH=control_plane python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "rtl_exact_generation_quality or recip_lut_q16_generation_quality"
- PYTHONPATH=control_plane python -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k "rtl_exact_generation_quality or q16_generation_quality"
- python scripts/validate_runs.py --skip_eval_queue