### PR TITLE
control_plane: fix rtl exact evaluation request metadata

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
-  "requests": [
+  "requested_items": [
     {
       "item_id": "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
       "task_type": "l2_campaign",


### PR DESCRIPTION
## Summary\n- Rename the RTL-exact diagnostic proposal request list from `requests` to `requested_items` so control-plane generators/finalizers consume it.\n\n## Tests\n- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "rtl_exact_generation_quality or recip_lut_q16_generation_quality"`\n- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k "rtl_exact_generation_quality or q16_generation_quality"`\n- `/workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`