### PR TITLE
control_plane: prepare rtl reciprocal precision quality sweep

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -523,6 +523,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_score32_w16_rtl_exact_generation_quality_report",
     ),
     (
+        "attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_out",
+        "attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_report",
+    ),
+    (
         "attention_mixed_int8_quality_backed_frontier_out",
         "attention_mixed_int8_quality_backed_frontier_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6671,6 +6671,69 @@ def _decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_evide
     }
 
 
+def _decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    q16_generation_quality = (
+        f"{base}/decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__"
+        "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1.json"
+    )
+    rtl_exact_generation_quality = (
+        f"{base}/decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__"
+        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json"
+    )
+    out = f"{base}/decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality__{item_id}.md"
+    candidate_args = " ".join(
+        [
+            f"--candidate score32_w16_rtl_recip_q{bits}:q8,k8,v8,s32,w16,rtl_recip_lut_q{bits}"
+            for bits in (16, 18, 20, 22, 24)
+        ]
+    )
+    return {
+        "inputs": {
+            "attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality": q16_generation_quality,
+            "attention_mixed_int8_score32_w16_rtl_exact_generation_quality": rtl_exact_generation_quality,
+            "attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_out": out,
+            "attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_report": report,
+            "attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_scope": (
+                "Run a bounded native-checkpoint generation/NLL quality boundary for score32/w16 RTL "
+                "reciprocal-LUT precision q16 through q24. Queue this only after RTL exact-divide "
+                "quality passes, so the result identifies the minimum reciprocal precision worth "
+                "embodying physically instead of masking a shared RTL softmax exponent/weight issue."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_MAX_PROMPTS:-8}; "
+                    "GEN_STEPS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_STEPS:-8}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--generation-steps \"$GEN_STEPS\" "
+                    "--dtype \"$DTYPE\" "
+                    f"{candidate_args} "
+                    "--primary-candidate-id score32_w16_rtl_recip_q24 "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     energy_closure = (
@@ -8616,6 +8679,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+        "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
         "decoder_attention_mixed_int8_quality_backed_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
@@ -8826,6 +8890,12 @@ def _build_payload(
         elif abstraction_layer_name == "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality":
             decoder_evidence = _decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_evidence(
                 item_id=item_id,
+            )
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality":
+            decoder_evidence = (
+                _decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_evidence(
+                    item_id=item_id,
+                )
             )
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
             decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1559,6 +1559,171 @@ def test_consume_l2_result_frontier_attention_rtl_exact_generation_quality_uses_
             )
 
 
+def test_consume_l2_result_frontier_attention_rtl_recip_precision_generation_quality_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            item_id = (
+                "l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_"
+                "generation_quality_llama7b_v1"
+            )
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1"
+            )
+            proposal_dir.mkdir(parents=True)
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": (
+                            "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_"
+                            "generation_quality_llama7b_v1"
+                        ),
+                        "kind": "architecture",
+                        "title": "Attention score32/w16 RTL reciprocal precision generation quality",
+                        "direct_comparison": {
+                            "primary_question": "What reciprocal precision recovers RTL softmax generation quality?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                f"decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality__{item_id}.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                f"decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality__{item_id}.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "quality_gate": "mixed_int8_generation_quality",
+                        "model": {
+                            "model_id": "mistralai/Mistral-7B-v0.1",
+                            "gqa_group_size": 4.0,
+                            "dtype": "bfloat16",
+                        },
+                        "decision": {
+                            "status": "mixed_int8_generation_quality_pass",
+                            "recommended_next_step": "measure q24 reciprocal-LUT datapath PPA",
+                        },
+                        "summary": {
+                            "candidate_id": "score32_w16_rtl_recip_q24",
+                            "prompt_count": 8,
+                            "generation_steps": 8,
+                            "free_run_exact_match_rate": 1.0,
+                            "free_run_token_match_rate": 1.0,
+                            "teacher_forced_mean_nll_delta": 0.001,
+                        },
+                        "candidate_summaries": [
+                            {"candidate_id": "score32_w16_rtl_recip_q16"},
+                            {"candidate_id": "score32_w16_rtl_recip_q24"},
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# rtl reciprocal precision generation quality\n")
+
+            task_request = TaskRequest(
+                request_key=f"l2_campaign:{item_id}",
+                source="test",
+                requested_by="@tester",
+                title=f"Layer2 {item_id}",
+                description="rtl reciprocal precision generation quality",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": item_id,
+                    "layer": "layer2",
+                    "flow": "openroad",
+                    "developer_loop": {
+                        "proposal_id": (
+                            "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_"
+                            "generation_quality_llama7b_v1"
+                        ),
+                        "proposal_path": str(proposal_dir.relative_to(repo_root)),
+                        "evaluation": {"mode": "quality_gate"},
+                        "abstraction": {
+                            "layer": (
+                                "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality"
+                            ),
+                        },
+                        "comparison": {"role": "score32_w16_rtl_recip_precision_generation_quality"},
+                    },
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key=f"l2_campaign:{item_id}",
+                task_request_id=task_request.id,
+                item_id=item_id,
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="src_verilog",
+                input_manifest={
+                    "decoder_contract": {
+                        "attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_out": evidence_rel,
+                        "attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_report": report_rel,
+                    }
+                },
+                command_manifest=[],
+                expected_outputs=[evidence_rel, report_rel],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+            session.add(
+                Run(
+                    run_key=f"{item_id}_run_1",
+                    work_item_id=work_item.id,
+                    attempt=1,
+                    executor_type=ExecutorType.INTERNAL_WORKER,
+                    status=RunStatus.SUCCEEDED,
+                    started_at=utcnow(),
+                    completed_at=utcnow(),
+                    checkout_commit="deadbeef",
+                    result_summary="2/2 commands succeeded",
+                )
+            )
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert decision_payload["proposal_assessment"]["outcome"] == "mixed_int8_generation_quality_pass"
+            assert "score32_w16_rtl_recip_q24" in decision_payload["proposal_assessment"]["summary"]
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_out"
+                ]
+                == evidence_rel
+            )
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7832,6 +7832,89 @@ def test_generate_l2_campaign_task_adds_score32_w16_rtl_exact_generation_quality
             }
 
 
+def test_generate_l2_campaign_task_adds_score32_w16_rtl_recip_precision_generation_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_"
+                        "generation_quality_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_"
+                        "generation_quality_llama7b_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_"
+                        "generation_quality_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer=(
+                        "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality"
+                    ),
+                    evaluation_mode="quality_gate",
+                    comparison_role="score32_w16_rtl_recip_precision_generation_quality",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+                        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py" in run
+            for bits in (16, 18, 20, 22, 24):
+                assert (
+                    f"--candidate score32_w16_rtl_recip_q{bits}:q8,k8,v8,s32,w16,rtl_recip_lut_q{bits}"
+                    in run
+                )
+            assert "--primary-candidate-id score32_w16_rtl_recip_q24" in run
+            assert decoder_inputs["attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_mixed_int8_score32_w16_rtl_exact_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+                    "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary\n- Add an evidence-only L2 route for score32/w16 RTL reciprocal precision generation-quality sweeps.\n- The route compares q16/q18/q20/q22/q24 reciprocal-LUT softmax candidates in the existing native Llama7B generation/NLL gate.\n- Register consumer output keys so future result PRs do not require best_point.json.\n\nThis only prepares the follow-up job; it should be dispatched after the pending RTL exact-divide diagnostic shows reciprocal precision is the remaining blocker.\n\n## Tests\n- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "rtl_recip_precision_generation_quality or rtl_exact_generation_quality or recip_lut_q16_generation_quality"`\n- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k "rtl_recip_precision_generation_quality or rtl_exact_generation_quality or q16_generation_quality"`\n- `/workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`