### PR TITLE
control_plane: prepare softmax replacement quality sweep

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -527,6 +527,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_report",
     ),
     (
+        "attention_mixed_int8_softmax_replacement_generation_quality_out",
+        "attention_mixed_int8_softmax_replacement_generation_quality_report",
+    ),
+    (
         "attention_mixed_int8_quality_backed_frontier_out",
         "attention_mixed_int8_quality_backed_frontier_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6734,6 +6734,73 @@ def _decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_qua
     }
 
 
+def _decoder_attention_mixed_int8_softmax_replacement_generation_quality_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    generation_quality_baseline = (
+        f"{base}/decoder_attention_mixed_int8_generation_quality__"
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+    )
+    rtl_exact_generation_quality = (
+        f"{base}/decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__"
+        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json"
+    )
+    score_precision_recovery = (
+        f"{base}/decoder_attention_mixed_int8_score_precision_recovery__"
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1.json"
+    )
+    out = f"{base}/decoder_attention_mixed_int8_softmax_replacement_generation_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_softmax_replacement_generation_quality__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_mixed_int8_generation_quality_baseline": generation_quality_baseline,
+            "attention_mixed_int8_score32_w16_rtl_exact_generation_quality": rtl_exact_generation_quality,
+            "attention_mixed_int8_score_precision_recovery": score_precision_recovery,
+            "attention_mixed_int8_softmax_replacement_generation_quality_out": out,
+            "attention_mixed_int8_softmax_replacement_generation_quality_report": report,
+            "attention_mixed_int8_softmax_replacement_generation_quality_scope": (
+                "Run a bounded native-checkpoint generation/NLL recovery check for replacement "
+                "softmax shapes if score32/w16 RTL exact-divide quality fails. This compares the "
+                "failed RTL exact row against float baselines and q20/q24 PWL reciprocal-LUT "
+                "softmax so the next hardware embodiment can target the softmax approximation "
+                "rather than only reciprocal precision."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_softmax_replacement_generation_quality",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_MAX_PROMPTS:-8}; "
+                    "GEN_STEPS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_STEPS:-8}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--generation-steps \"$GEN_STEPS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--candidate score32_float:q8,k8,v8,s32,w16,float_quantized "
+                    "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact "
+                    "--candidate score32_w16_rtl_exact:q8,k8,v8,s32,w16,rtl_exact "
+                    "--candidate qkv8_q20_pwl_recip_q20_bucket8:q8,k8,v8,s20,w20,pwl_recip_lut_q20_bucket8 "
+                    "--candidate qkv8_q24_pwl_recip_q24_bucket8:q8,k8,v8,s24,w24,pwl_recip_lut_q24_bucket8 "
+                    "--primary-candidate-id qkv8_q24_pwl_recip_q24_bucket8 "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     energy_closure = (
@@ -8680,6 +8747,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
+        "decoder_attention_mixed_int8_softmax_replacement_generation_quality",
         "decoder_attention_mixed_int8_quality_backed_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
@@ -8896,6 +8964,10 @@ def _build_payload(
                 _decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_evidence(
                     item_id=item_id,
                 )
+            )
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_softmax_replacement_generation_quality":
+            decoder_evidence = _decoder_attention_mixed_int8_softmax_replacement_generation_quality_evidence(
+                item_id=item_id,
             )
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
             decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -1724,6 +1724,167 @@ def test_consume_l2_result_frontier_attention_rtl_recip_precision_generation_qua
             )
 
 
+def test_consume_l2_result_frontier_attention_softmax_replacement_generation_quality_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            item_id = "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1"
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1"
+            )
+            proposal_dir.mkdir(parents=True)
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": (
+                            "prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1"
+                        ),
+                        "kind": "architecture",
+                        "title": "Attention mixed-int8 softmax replacement generation quality",
+                        "direct_comparison": {
+                            "primary_question": "Which replacement softmax shape recovers generation quality?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                f"decoder_attention_mixed_int8_softmax_replacement_generation_quality__{item_id}.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                f"decoder_attention_mixed_int8_softmax_replacement_generation_quality__{item_id}.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "quality_gate": "mixed_int8_generation_quality",
+                        "model": {
+                            "model_id": "mistralai/Mistral-7B-v0.1",
+                            "gqa_group_size": 4.0,
+                            "dtype": "bfloat16",
+                        },
+                        "decision": {
+                            "status": "mixed_int8_generation_quality_pass",
+                            "recommended_next_step": "embody q24 PWL reciprocal-LUT softmax",
+                        },
+                        "summary": {
+                            "candidate_id": "qkv8_q24_pwl_recip_q24_bucket8",
+                            "prompt_count": 8,
+                            "generation_steps": 8,
+                            "free_run_exact_match_rate": 1.0,
+                            "free_run_token_match_rate": 1.0,
+                            "teacher_forced_mean_nll_delta": 0.001,
+                        },
+                        "best_candidate": {
+                            "candidate_id": "qkv8_q24_pwl_recip_q24_bucket8",
+                            "decision_status": "mixed_int8_generation_quality_pass",
+                        },
+                        "candidate_summaries": [
+                            {"candidate_id": "score32_w16_rtl_exact"},
+                            {"candidate_id": "qkv8_q20_pwl_recip_q20_bucket8"},
+                            {"candidate_id": "qkv8_q24_pwl_recip_q24_bucket8"},
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# softmax replacement generation quality\n")
+
+            task_request = TaskRequest(
+                request_key=f"l2_campaign:{item_id}",
+                source="test",
+                requested_by="@tester",
+                title=f"Layer2 {item_id}",
+                description="softmax replacement generation quality",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": item_id,
+                    "layer": "layer2",
+                    "flow": "openroad",
+                    "developer_loop": {
+                        "proposal_id": (
+                            "prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1"
+                        ),
+                        "proposal_path": str(proposal_dir.relative_to(repo_root)),
+                        "evaluation": {"mode": "quality_gate"},
+                        "abstraction": {"layer": "decoder_attention_mixed_int8_softmax_replacement_generation_quality"},
+                        "comparison": {"role": "softmax_replacement_generation_quality"},
+                    },
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key=f"l2_campaign:{item_id}",
+                task_request_id=task_request.id,
+                item_id=item_id,
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="src_verilog",
+                input_manifest={
+                    "decoder_contract": {
+                        "attention_mixed_int8_softmax_replacement_generation_quality_out": evidence_rel,
+                        "attention_mixed_int8_softmax_replacement_generation_quality_report": report_rel,
+                    }
+                },
+                command_manifest=[],
+                expected_outputs=[evidence_rel, report_rel],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+            session.add(
+                Run(
+                    run_key=f"{item_id}_run_1",
+                    work_item_id=work_item.id,
+                    attempt=1,
+                    executor_type=ExecutorType.INTERNAL_WORKER,
+                    status=RunStatus.SUCCEEDED,
+                    started_at=utcnow(),
+                    completed_at=utcnow(),
+                    checkout_commit="deadbeef",
+                    result_summary="2/2 commands succeeded",
+                )
+            )
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert decision_payload["proposal_assessment"]["outcome"] == "mixed_int8_generation_quality_pass"
+            assert "qkv8_q24_pwl_recip_q24_bucket8" in decision_payload["proposal_assessment"]["summary"]
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_softmax_replacement_generation_quality_out"
+                ]
+                == evidence_rel
+            )
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7915,6 +7915,74 @@ def test_generate_l2_campaign_task_adds_score32_w16_rtl_recip_precision_generati
             }
 
 
+def test_generate_l2_campaign_task_adds_softmax_replacement_generation_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_softmax_replacement_generation_quality",
+                    evaluation_mode="quality_gate",
+                    comparison_role="softmax_replacement_generation_quality",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+                        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+                        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_softmax_replacement_generation_quality",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py" in run
+            assert "--candidate score32_float:q8,k8,v8,s32,w16,float_quantized" in run
+            assert "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact" in run
+            assert "--candidate score32_w16_rtl_exact:q8,k8,v8,s32,w16,rtl_exact" in run
+            assert "--candidate qkv8_q20_pwl_recip_q20_bucket8:q8,k8,v8,s20,w20,pwl_recip_lut_q20_bucket8" in run
+            assert "--candidate qkv8_q24_pwl_recip_q24_bucket8:q8,k8,v8,s24,w24,pwl_recip_lut_q24_bucket8" in run
+            assert "--primary-candidate-id qkv8_q24_pwl_recip_q24_bucket8" in run
+            assert decoder_inputs["attention_mixed_int8_generation_quality_baseline"].endswith(
+                "decoder_attention_mixed_int8_generation_quality__"
+                "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+            )
+            assert decoder_inputs["attention_mixed_int8_score32_w16_rtl_exact_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_softmax_replacement_generation_quality_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_softmax_replacement_generation_quality_out"]
+                in work_item.expected_outputs
+            )
+
+
 def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary\n- Add an evidence-only L2 route for mixed-int8 replacement-softmax generation quality.\n- The route compares score32_float, qkv8_float_exact, score32_w16_rtl_exact, q20 PWL, and q24 PWL in the native Llama7B generation/NLL gate.\n- Register consumer output keys so future result PRs finalize without best_point.json.\n\nThis only prepares the exact-failure successor job; it should be dispatched if the pending RTL exact-divide diagnostic shows the shared RTL softmax approximation is the blocker.\n\n## Tests\n- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "softmax_replacement_generation_quality or rtl_recip_precision_generation_quality or rtl_exact_generation_quality"`\n- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k "softmax_replacement_generation_quality or rtl_recip_precision_generation_quality or rtl_exact_generation_quality"`\n- `/workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`