### PR TITLE
docs: add successor quality proposal scaffolds

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded native-checkpoint generation/NLL quality for score32/w16 RTL reciprocal-LUT q16/q18/q20/q22/q24 after exact-divide softmax recovers the q16 failure.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
+      "comparison_role": "score32_w16_rtl_recip_precision_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "find_minimum_quality_safe_reciprocal_precision",
+        "reason": "If exact division passes, this job should identify the lowest reciprocal-LUT precision that is quality-safe enough to justify physical PPA measurement."
+      }
+    }
+  ],
+  "source_commit": null
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1/proposal.json
@@ -1,0 +1,91 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1",
+  "created_utc": "2026-06-27T02:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score32/w16 RTL reciprocal precision generation quality",
+  "abstraction_layer": "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
+  "hypothesis": "If score32/w16 RTL exact-divide softmax passes generation quality after q16 reciprocal-LUT fails, the remaining recovery axis is reciprocal precision. Sweeping q16 through q24 in the same native-checkpoint generation/NLL gate can identify the minimum reciprocal precision worth embodying before launching physical PPA work.",
+  "direct_comparison": {
+    "primary_question": "What RTL reciprocal-LUT precision is sufficient to recover bounded greedy generation and teacher-forced reference-token likelihood on a 7B checkpoint?",
+    "baseline": "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+    "negative_control": "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+    "gate_precondition": "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1 must pass or otherwise show exact division recovers the q16 failure.",
+    "candidates": [
+      "score32_w16_rtl_recip_q16",
+      "score32_w16_rtl_recip_q18",
+      "score32_w16_rtl_recip_q20",
+      "score32_w16_rtl_recip_q22",
+      "score32_w16_rtl_recip_q24"
+    ],
+    "include": [
+      "run native-checkpoint reference and all reciprocal precision candidates on the same bounded prompt set",
+      "measure teacher-forced reference-token NLL under reference and each candidate",
+      "measure free-running greedy token match and first divergence step",
+      "select the lowest reciprocal precision that satisfies the generation-quality gate"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "training or QAT",
+      "full downstream benchmark accuracy"
+    ],
+    "metrics": [
+      "decision",
+      "best_candidate",
+      "candidate_summaries",
+      "free_run_exact_match_rate",
+      "free_run_token_match_rate",
+      "diverged_prompt_count",
+      "mean_first_divergence_step",
+      "teacher_forced_mean_nll_delta",
+      "teacher_forced_candidate_reference_token_prob_mean"
+    ]
+  },
+  "expected_benefit": [
+    "avoid physical implementation of unnecessarily wide reciprocal precision",
+    "turn the q16 failure into a bounded quality frontier instead of a single failed point",
+    "make the next PPA job target a quality-supported reciprocal precision"
+  ],
+  "risks": [
+    "bounded greedy generation is not full task accuracy",
+    "prompt and generation-step defaults may miss longer-horizon divergence",
+    "quality outcome remains checkpoint and distribution dependent",
+    "candidate precision that passes quality still requires a physical PPA embodiment"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded native-checkpoint generation/NLL quality for score32/w16 RTL reciprocal-LUT q16/q18/q20/q22/q24 after exact-divide softmax recovers the q16 failure.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
+      "comparison_role": "score32_w16_rtl_recip_precision_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "find_minimum_quality_safe_reciprocal_precision",
+        "reason": "If exact division passes, this job should identify the lowest reciprocal-LUT precision that is quality-safe enough to justify physical PPA measurement."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_generation_quality__l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality__l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py",
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/proposal.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded native-checkpoint generation/NLL quality for replacement softmax shapes if score32/w16 RTL exact-divide softmax also fails.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_softmax_replacement_generation_quality",
+      "comparison_role": "softmax_replacement_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "choose_softmax_replacement_after_rtl_exact_failure",
+        "reason": "If RTL exact-divide fails, this job should identify whether float-exact, float-quantized, or high-precision PWL reciprocal-LUT softmax is the next quality-backed embodiment target."
+      }
+    }
+  ],
+  "source_commit": null
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1/proposal.json
@@ -1,0 +1,93 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+  "created_utc": "2026-06-27T02:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed-int8 softmax replacement generation quality",
+  "abstraction_layer": "decoder_attention_mixed_int8_softmax_replacement_generation_quality",
+  "hypothesis": "If score32/w16 RTL exact-divide softmax still fails the generation-quality gate, the reciprocal is not the primary blocker. The next recovery step should compare replacement softmax shapes under the same native-checkpoint gate before investing in another physical datapath.",
+  "direct_comparison": {
+    "primary_question": "Which replacement score/softmax shape recovers bounded greedy generation and teacher-forced reference-token likelihood when score32/w16 RTL exact-divide softmax fails?",
+    "baseline": "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+    "negative_control": "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+    "recovery_reference": "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+    "candidates": [
+      "score32_float",
+      "qkv8_float_exact",
+      "score32_w16_rtl_exact",
+      "qkv8_q20_pwl_recip_q20_bucket8",
+      "qkv8_q24_pwl_recip_q24_bucket8"
+    ],
+    "include": [
+      "run native-checkpoint reference and replacement softmax candidates on the same bounded prompt set",
+      "measure teacher-forced reference-token NLL under reference and each candidate",
+      "measure free-running greedy token match and first divergence step",
+      "identify whether a PWL reciprocal-LUT or float-exact replacement should become the next hardware target"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "training or QAT",
+      "full downstream benchmark accuracy"
+    ],
+    "metrics": [
+      "decision",
+      "best_candidate",
+      "candidate_summaries",
+      "free_run_exact_match_rate",
+      "free_run_token_match_rate",
+      "diverged_prompt_count",
+      "mean_first_divergence_step",
+      "teacher_forced_mean_nll_delta",
+      "teacher_forced_candidate_reference_token_prob_mean"
+    ]
+  },
+  "expected_benefit": [
+    "avoid overfitting reciprocal precision when exact division is not enough",
+    "choose the next softmax approximation family from model-level generation evidence",
+    "connect prior broad quality evidence to a concrete successor datapath target"
+  ],
+  "risks": [
+    "bounded greedy generation is not full task accuracy",
+    "prompt and generation-step defaults may miss longer-horizon divergence",
+    "quality outcome remains checkpoint and distribution dependent",
+    "replacement softmax candidates that pass quality still require matching physical PPA measurement"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded native-checkpoint generation/NLL quality for replacement softmax shapes if score32/w16 RTL exact-divide softmax also fails.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_softmax_replacement_generation_quality",
+      "comparison_role": "softmax_replacement_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "choose_softmax_replacement_after_rtl_exact_failure",
+        "reason": "If RTL exact-divide fails, this job should identify whether float-exact, float-quantized, or high-precision PWL reciprocal-LUT softmax is the next quality-backed embodiment target."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_generation_quality__l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py",
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/proposal.json"
+  ]
+}


### PR DESCRIPTION
## Summary\n- Add proposal/evaluation-request scaffolds for the RTL reciprocal precision generation-quality successor.\n- Add proposal/evaluation-request scaffolds for the softmax replacement generation-quality successor.\n- These are not dispatched; they document the two branches after the pending RTL exact-divide diagnostic.\n\n## Tests\n- `python -m json.tool` on all added JSON files\n- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python - <<'PY' ... _load_requested_item_entry ... PY`\n- `/workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`