### PR TITLE
control_plane: include source requirements in refresh evidence

### DIFF
--- a/control_plane/control_plane/cli/request_evaluator_refresh.py
+++ b/control_plane/control_plane/cli/request_evaluator_refresh.py
@@ -52,6 +52,7 @@ def _operator_status_details(
                 f"active_slots={machine.get('active_slots')}, "
                 f"heartbeat_age_seconds={machine.get('heartbeat_age_seconds')}, "
                 f"worker_attention={machine.get('worker_attention')}, "
+                f"source_requirements={machine.get('source_requirements')}, "
                 f"capabilities={machine.get('capabilities')}, "
                 f"last_progress={machine.get('last_progress')}"
             )

--- a/control_plane/control_plane/tests/test_cli_request_evaluator_refresh.py
+++ b/control_plane/control_plane/tests/test_cli_request_evaluator_refresh.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import tempfile
 from unittest.mock import patch
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from control_plane.cli.request_evaluator_refresh import _operator_status_details
 from control_plane.cli.main import main
+from control_plane.clock import utcnow
+from control_plane.db import create_all
+from control_plane.models.enums import FlowName, LayerName, WorkItemState
+from control_plane.models.task_requests import TaskRequest
+from control_plane.models.worker_machines import WorkerMachine
+from control_plane.models.work_items import WorkItem
 
 
 def test_top_level_request_evaluator_refresh_forwards_operator_status_flags() -> None:
@@ -39,3 +51,75 @@ def test_top_level_request_evaluator_refresh_forwards_operator_status_flags() ->
     assert forwarded[forwarded.index("--recent-limit") + 1] == "5"
     assert "--include-operator-status" in forwarded
     assert "--dry-run" in forwarded
+
+
+def test_operator_status_details_include_source_requirements() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            machine = WorkerMachine(
+                machine_key="eval-daemon",
+                hostname="eval-daemon",
+                executor_kind="local_process",
+                role="evaluator",
+                slot_capacity=4,
+                capabilities={
+                    "flow": "openroad",
+                    "platform": "nangate45",
+                    "worker_source": {
+                        "head": "a" * 40,
+                        "repo_root": "/workspaces/rtlgen-eval-clean",
+                    },
+                },
+                last_seen_at=utcnow(),
+            )
+            session.add(machine)
+            task = TaskRequest(
+                request_key="queue:needs_source",
+                source="test",
+                requested_by="tester",
+                title="needs source",
+                description="needs source",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={"item_id": "needs_source"},
+            )
+            session.add(task)
+            session.flush()
+            session.add(
+                WorkItem(
+                    work_item_key="queue:needs_source",
+                    task_request_id=task.id,
+                    item_id="needs_source",
+                    layer=LayerName.LAYER2,
+                    flow=FlowName.OPENROAD,
+                    platform="nangate45",
+                    task_type="l2_campaign",
+                    state=WorkItemState.READY,
+                    priority=1,
+                    source_commit="b" * 40,
+                    assigned_machine_key=machine.machine_key,
+                    input_manifest={},
+                    command_manifest=[],
+                    expected_outputs=[],
+                    acceptance_rules=[],
+                )
+            )
+            session.commit()
+
+        details = _operator_status_details(
+            database_url=f"sqlite+pysqlite:///{db_path}",
+            repo_root=td,
+            machine_key="eval-daemon",
+            recent_limit=5,
+        )
+
+    machine_detail = next(row for row in details if row.startswith("machine eval-daemon:"))
+    assert "worker_attention=assigned_ready_requires_newer_source" in machine_detail
+    assert "source_requirements=[" in machine_detail
+    assert "needs_source" in machine_detail
+    assert "'required_sha': '" + ("b" * 40) + "'" in machine_detail
+    assert "'worker_head': '" + ("a" * 40) + "'" in machine_detail


### PR DESCRIPTION
## Summary
- include per-machine source_requirements in evaluator refresh request evidence
- make stale worker-source refresh comments show required_sha, worker_head, and satisfied=false
- add SQLite-backed CLI coverage for the evidence formatter

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_cli_request_evaluator_refresh.py control_plane/control_plane/tests/test_operator_status.py control_plane/control_plane/tests/test_evaluator_refresh_request.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue
- git diff --check
