### PR TITLE
control_plane: detect assigned ready source mismatches

### DIFF
--- a/control_plane/control_plane/services/resolver_detection.py
+++ b/control_plane/control_plane/services/resolver_detection.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 from pathlib import Path
 import re
+import subprocess
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -131,9 +132,39 @@ def _event_payload_dict(event: RunEvent) -> dict[str, Any]:
     return event.event_payload if isinstance(event.event_payload, dict) else {}
 
 
+def _source_head_satisfies_requirement(*, repo_root: str | None, worker_head: str, required_sha: str) -> bool:
+    worker = str(worker_head or "").strip()
+    required = str(required_sha or "").strip()
+    if not required:
+        return True
+    if not worker:
+        return False
+    if worker == required:
+        return True
+    if not repo_root:
+        return False
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(Path(repo_root).resolve()), "merge-base", "--is-ancestor", required, worker],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, RuntimeError):
+        return False
+    return result.returncode == 0
+
+
 def _payload_has_submission_error(payload: dict[str, Any]) -> bool:
     error = str(payload.get("submission_error") or payload.get("error") or "").strip()
     return bool(error and error.lower() != "none")
+
+
+def _submission_error_reason(payload: dict[str, Any]) -> str | None:
+    error = str(payload.get("submission_error") or payload.get("error") or "").strip()
+    if error and error.lower() != "none":
+        return error
+    return None
 
 
 def _event_is_stable_submission_success(event: RunEvent) -> bool:
@@ -253,6 +284,72 @@ def detect_orphaned_running_items(
     return detections
 
 
+def detect_assigned_ready_source_mismatches(
+    session: Session,
+    *,
+    repo_root: str | None = None,
+) -> list[ResolverDetection]:
+    rows = (
+        session.query(WorkItem, WorkerMachine)
+        .join(WorkerMachine, WorkerMachine.machine_key == WorkItem.assigned_machine_key)
+        .filter(WorkItem.state == WorkItemState.READY)
+        .filter(WorkItem.source_commit.isnot(None))
+        .filter(~WorkItem.leases.any(WorkerLease.status == LeaseStatus.ACTIVE))
+        .order_by(WorkItem.priority.desc(), WorkItem.created_at.asc(), WorkItem.item_id.asc())
+        .all()
+    )
+    detections: list[ResolverDetection] = []
+    for work_item, machine in rows:
+        required_sha = str(work_item.source_commit or "").strip()
+        if not required_sha:
+            continue
+        capabilities = dict(machine.capabilities or {})
+        worker_source = capabilities.get("worker_source")
+        if not isinstance(worker_source, dict):
+            worker_source = {}
+        worker_head = str(worker_source.get("head") or "").strip()
+        if _source_head_satisfies_requirement(
+            repo_root=repo_root,
+            worker_head=worker_head,
+            required_sha=required_sha,
+        ):
+            continue
+        evidence = {
+            "item_id": work_item.item_id,
+            "work_item_state": work_item.state.value,
+            "machine_key": machine.machine_key,
+            "assigned_machine_key": work_item.assigned_machine_key,
+            "required_sha": required_sha,
+            "worker_head": worker_head or None,
+            "worker_source": worker_source,
+            "last_seen_at": machine.last_seen_at.isoformat() if machine.last_seen_at is not None else None,
+            "repo_root": repo_root,
+            "task_type": work_item.task_type,
+            "platform": work_item.platform,
+            "flow": work_item.flow.value if work_item.flow is not None else None,
+            "source_commit": work_item.source_commit,
+        }
+        detections.append(
+            ResolverDetection(
+                fingerprint="assigned_ready_source_mismatch:source_commit_unsatisfied",
+                failure_class="assigned_ready_source_mismatch",
+                owner="eval",
+                severity="high",
+                summary=(
+                    f"ready work item {work_item.item_id} requires source {required_sha}, "
+                    f"but assigned worker {machine.machine_key} reports {worker_head or 'no worker_source head'}"
+                ),
+                item_id=work_item.item_id,
+                run_key="no_run",
+                machine_key=machine.machine_key,
+                source_commit=work_item.source_commit,
+                repo_root=repo_root,
+                evidence=evidence,
+            )
+        )
+    return detections
+
+
 def detect_blocked_submission_items(
     session: Session,
     *,
@@ -275,6 +372,8 @@ def detect_blocked_submission_items(
         submission_failure_reason = None
         latest_event = _latest_event(session, run.id)
         latest_event_time = latest_event.event_time if latest_event is not None else None
+        if latest_event is not None and latest_event.event_type in _SUBMISSION_FAILURE_EVENT_TYPES:
+            submission_failure_reason = _submission_error_reason(_event_payload_dict(latest_event))
         if latest_event_time is not None and latest_event_time.tzinfo is None:
             latest_event_time = latest_event_time.replace(tzinfo=now.tzinfo)
         if _has_submission_progress_after_latest_failure(
@@ -285,12 +384,13 @@ def detect_blocked_submission_items(
         ):
             continue
         if latest_event_time is not None and (now - latest_event_time).total_seconds() < stale_grace_seconds:
-            submission_failure_reason = assess_submission_eligibility(
-                session,
-                work_item=work_item,
-                run=run,
-                repo_root=None,
-            ).reason
+            if not submission_failure_reason:
+                submission_failure_reason = assess_submission_eligibility(
+                    session,
+                    work_item=work_item,
+                    run=run,
+                    repo_root=None,
+                ).reason
             if not (submission_failure_reason and str(submission_failure_reason).strip().lower().startswith("gh pr create failed")):
                 continue
         eligibility = assess_submission_eligibility(
@@ -299,15 +399,19 @@ def detect_blocked_submission_items(
             run=run,
             repo_root=repo_path,
         )
-        if eligibility.eligible or not eligibility.reason:
+        reason = submission_failure_reason if (
+            submission_failure_reason
+            and str(submission_failure_reason).strip().lower().startswith("gh pr create failed")
+        ) else eligibility.reason
+        if eligibility.eligible or not reason:
             continue
-        reason_key, owner, severity = _artifact_sync_reason_classification(eligibility.reason)
+        reason_key, owner, severity = _artifact_sync_reason_classification(reason)
         evidence = {
             "item_id": work_item.item_id,
             "run_key": run.run_key,
             "run_status": run.status.value,
             "machine_key": work_item.assigned_machine_key,
-            "eligibility_reason": eligibility.reason,
+            "eligibility_reason": reason,
             "task_type": work_item.task_type,
             "work_item_state": work_item.state.value,
             "repo_root": repo_root,
@@ -319,7 +423,7 @@ def detect_blocked_submission_items(
                 failure_class="artifact_sync_blocked_submission",
                 owner=owner,
                 severity=severity,
-                summary=f"work item {work_item.item_id} is blocked in ARTIFACT_SYNC: {eligibility.reason}",
+                summary=f"work item {work_item.item_id} is blocked in ARTIFACT_SYNC: {reason}",
                 item_id=work_item.item_id,
                 run_key=run.run_key,
                 machine_key=work_item.assigned_machine_key,

--- a/control_plane/control_plane/services/resolver_dev_daemon.py
+++ b/control_plane/control_plane/services/resolver_dev_daemon.py
@@ -26,6 +26,7 @@ from control_plane.services.resolver_case_service import (
 )
 from control_plane.services.resolver_detection import (
     ResolverDetection,
+    detect_assigned_ready_source_mismatches,
     detect_blocked_submission_items,
     detect_orphaned_running_items,
 )
@@ -493,6 +494,12 @@ def _collect_detections(
             session,
             repo_root=repo_root,
             stale_grace_seconds=blocked_submission_stale_grace_seconds,
+        )
+    )
+    detections.extend(
+        detect_assigned_ready_source_mismatches(
+            session,
+            repo_root=repo_root,
         )
     )
     return sorted(detections, key=lambda row: (row.failure_class, row.item_id, row.run_key))

--- a/control_plane/control_plane/tests/test_resolver_detection.py
+++ b/control_plane/control_plane/tests/test_resolver_detection.py
@@ -18,7 +18,11 @@ from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
 from control_plane.models.worker_leases import WorkerLease
 from control_plane.models.worker_machines import WorkerMachine
-from control_plane.services.resolver_detection import detect_blocked_submission_items, detect_orphaned_running_items
+from control_plane.services.resolver_detection import (
+    detect_assigned_ready_source_mismatches,
+    detect_blocked_submission_items,
+    detect_orphaned_running_items,
+)
 
 
 def make_session() -> Session:
@@ -351,6 +355,126 @@ def test_skip_orphan_detector_for_terminal_latest_event() -> None:
         session.commit()
 
         detections = detect_orphaned_running_items(session, repo_root="/repo")
+
+    assert detections == []
+
+
+def test_detect_assigned_ready_source_mismatch() -> None:
+    now = utcnow()
+    with make_session() as session, tempfile.TemporaryDirectory() as repo_root:
+        task = TaskRequest(
+            request_key="queue:needs-source",
+            source="test",
+            requested_by="tester",
+            title="needs source",
+            description="detect stale worker source",
+            layer=LayerName.LAYER2,
+            flow=FlowName.OPENROAD,
+            priority=1,
+            request_payload={"item_id": "needs-source"},
+        )
+        session.add(task)
+        session.flush()
+        work_item = WorkItem(
+            work_item_key="queue:needs-source",
+            task_request_id=task.id,
+            item_id="needs-source",
+            layer=LayerName.LAYER2,
+            flow=FlowName.OPENROAD,
+            platform="nangate45",
+            task_type="l2_campaign",
+            state=WorkItemState.READY,
+            priority=1,
+            source_commit="b" * 40,
+            assigned_machine_key="eval-source",
+            input_manifest={},
+            command_manifest=[],
+            expected_outputs=[],
+            acceptance_rules=[],
+        )
+        session.add(work_item)
+        session.add(
+            WorkerMachine(
+                machine_key="eval-source",
+                hostname="eval-source",
+                executor_kind="local_process",
+                role="evaluator",
+                slot_capacity=4,
+                capabilities={
+                    "flow": "openroad",
+                    "platform": "nangate45",
+                    "worker_source": {
+                        "head": "a" * 40,
+                        "repo_root": "/workspaces/rtlgen-eval-clean",
+                    },
+                },
+                last_seen_at=now - timedelta(minutes=30),
+            )
+        )
+        session.commit()
+
+        detections = detect_assigned_ready_source_mismatches(session, repo_root=repo_root)
+
+    assert len(detections) == 1
+    detection = detections[0]
+    assert detection.failure_class == "assigned_ready_source_mismatch"
+    assert detection.fingerprint == "assigned_ready_source_mismatch:source_commit_unsatisfied"
+    assert detection.owner == "eval"
+    assert detection.severity == "high"
+    assert detection.item_id == "needs-source"
+    assert detection.run_key == "no_run"
+    assert detection.machine_key == "eval-source"
+    assert detection.evidence["required_sha"] == "b" * 40
+    assert detection.evidence["worker_head"] == "a" * 40
+
+
+def test_detect_assigned_ready_source_mismatch_skips_matching_head() -> None:
+    with make_session() as session, tempfile.TemporaryDirectory() as repo_root:
+        task = TaskRequest(
+            request_key="queue:source-ok",
+            source="test",
+            requested_by="tester",
+            title="source ok",
+            description="matching worker source",
+            layer=LayerName.LAYER2,
+            flow=FlowName.OPENROAD,
+            priority=1,
+            request_payload={"item_id": "source-ok"},
+        )
+        session.add(task)
+        session.flush()
+        session.add(
+            WorkItem(
+                work_item_key="queue:source-ok",
+                task_request_id=task.id,
+                item_id="source-ok",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.READY,
+                priority=1,
+                source_commit="c" * 40,
+                assigned_machine_key="eval-source",
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[],
+                acceptance_rules=[],
+            )
+        )
+        session.add(
+            WorkerMachine(
+                machine_key="eval-source",
+                hostname="eval-source",
+                executor_kind="local_process",
+                role="evaluator",
+                slot_capacity=4,
+                capabilities={"worker_source": {"head": "c" * 40}},
+            )
+        )
+        session.commit()
+
+        detections = detect_assigned_ready_source_mismatches(session, repo_root=repo_root)
 
     assert detections == []
 

--- a/control_plane/control_plane/tests/test_resolver_dev_daemon.py
+++ b/control_plane/control_plane/tests/test_resolver_dev_daemon.py
@@ -168,6 +168,62 @@ def _seed_blocked_submission_item(engine, *, submission_failed_reason: str | Non
         session.commit()
 
 
+def _seed_assigned_ready_source_mismatch(engine) -> None:
+    now = utcnow()
+    with Session(engine) as session:
+        task = TaskRequest(
+            request_key="queue:needs-source",
+            source="test",
+            requested_by="tester",
+            title="needs source",
+            description="detect stale worker source",
+            layer=LayerName.LAYER2,
+            flow=FlowName.OPENROAD,
+            priority=1,
+            request_payload={"item_id": "needs-source"},
+        )
+        session.add(task)
+        session.flush()
+        session.add(
+            WorkItem(
+                work_item_key="queue:needs-source",
+                task_request_id=task.id,
+                item_id="needs-source",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.READY,
+                priority=1,
+                source_commit="b" * 40,
+                assigned_machine_key="eval-source",
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[],
+                acceptance_rules=[],
+            )
+        )
+        session.add(
+            WorkerMachine(
+                machine_key="eval-source",
+                hostname="eval-source",
+                executor_kind="local_process",
+                role="evaluator",
+                slot_capacity=4,
+                capabilities={
+                    "flow": "openroad",
+                    "platform": "nangate45",
+                    "worker_source": {
+                        "head": "a" * 40,
+                        "repo_root": "/workspaces/rtlgen-eval-clean",
+                    },
+                },
+                last_seen_at=now - timedelta(minutes=30),
+            )
+        )
+        session.commit()
+
+
 def test_dev_resolver_opens_issue_once_for_same_evidence() -> None:
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
     create_all(engine)
@@ -351,6 +407,47 @@ def test_dev_resolver_opens_issue_for_blocked_submission() -> None:
     assert case.owner == "dev"
     assert case.fingerprint == "artifact_sync_blocked_submission:proposal_linkage_unresolved"
     assert case.issue_number == 176
+    assert case.status == "awaiting_remote"
+
+
+def test_dev_resolver_opens_issue_for_assigned_ready_source_mismatch() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    _seed_assigned_ready_source_mismatch(engine)
+
+    session_factory = build_session_factory(engine)
+    with patch(
+        "control_plane.services.resolver_dev_daemon.open_issue_for_case",
+        return_value=ResolverIssueCreateResult(issue_number=177, issue_url="https://github.com/yhmtmt/RTLGen/issues/177"),
+    ) as open_issue_mock, patch(
+        "control_plane.services.resolver_dev_daemon.comment_issue_for_case"
+    ) as comment_mock, patch(
+        "control_plane.services.resolver_dev_daemon.time.sleep"
+    ):
+        result = run_dev_resolver(
+            session_factory,
+            ResolverDevDaemonConfig(
+                repo="yhmtmt/RTLGen",
+                repo_root="/repo",
+                poll_seconds=0,
+                max_polls=1,
+            ),
+        )
+
+    with Session(engine) as session:
+        case = session.query(ResolverCase).one()
+
+    assert result.detection_count == 1
+    assert result.opened_issue_count == 1
+    assert result.updated_issue_count == 0
+    assert open_issue_mock.call_count == 1
+    assert comment_mock.call_count == 0
+    assert case.failure_class == "assigned_ready_source_mismatch"
+    assert case.owner == "eval"
+    assert case.fingerprint == "assigned_ready_source_mismatch:source_commit_unsatisfied"
+    assert case.issue_number == 177
+    assert case.latest_item_id == "needs-source"
+    assert case.latest_run_key == "no_run"
     assert case.status == "awaiting_remote"
 
 


### PR DESCRIPTION
## Summary
- add resolver detection for READY items assigned to workers whose reported worker_source head does not satisfy source_commit
- wire the detector into the dev resolver daemon so stale evaluator-source cases become first-class resolver issues
- preserve explicit gh-pr-create submission failures over secondary artifact eligibility reasons

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_resolver_detection.py control_plane/control_plane/tests/test_resolver_dev_daemon.py control_plane/control_plane/tests/test_operator_status.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue
- git diff --check

## Live evidence
- detector reports l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1 requires cd87b369 while eval-daemon-b7c2d9c80c1c reports ae02ff76
