### PR TITLE
control_plane: add q24 PWL native quality job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6356,6 +6356,59 @@ def _decoder_attention_mixed_int8_q12_pwl_native_quality_evidence(*, item_id: st
     }
 
 
+def _decoder_attention_mixed_int8_q24_pwl_native_quality_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_mixed_int8_q24_pwl_native_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_q24_pwl_native_quality__{item_id}.md"
+    softmax_replacement_quality = (
+        f"{base}/decoder_attention_mixed_int8_softmax_replacement_generation_quality__"
+        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_mixed_int8_softmax_replacement_generation_quality": softmax_replacement_quality,
+            "attention_mixed_int8_q24_pwl_native_quality_out": out,
+            "attention_mixed_int8_q24_pwl_native_quality_report": report,
+            "attention_mixed_int8_q24_pwl_native_quality_scope": (
+                "Validate the q24/PWL reciprocal-LUT softmax replacement that passed bounded "
+                "generation/NLL quality on the broader native 7B attention-shadow gate. This "
+                "keeps q8/k8/v8 fixed and compares q20/q24 PWL rows against float-exact and "
+                "score24 float controls before queueing q24 PWL physical embodiment or recost."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_q24_pwl_native_quality",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_BROAD_MAX_PROMPTS:-8}; "
+                    "GEN_STEPS=${RTLGEN_MODEL_NATIVE_7B_BROAD_GENERATION_STEPS:-8}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--generation-steps \"$GEN_STEPS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--topk 5 "
+                    "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact "
+                    "--candidate qkv8_score24_float:q8,k8,v8,s24,w16,float_quantized "
+                    "--candidate qkv8_q20_pwl_recip_q20_bucket8:q8,k8,v8,s20,w20,pwl_recip_lut_q20_bucket8 "
+                    "--candidate qkv8_q24_pwl_recip_q24_bucket8:q8,k8,v8,s24,w24,pwl_recip_lut_q24_bucket8 "
+                    "--primary-candidate-id qkv8_q24_pwl_recip_q24_bucket8 "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_q12_pwl_proxy_audit_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_int8_q12_pwl_proxy_audit__{item_id}.json"
@@ -8740,6 +8793,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_high_score_boundary",
         "decoder_attention_mixed_int8_broad_native_quality",
         "decoder_attention_mixed_int8_q12_pwl_native_quality",
+        "decoder_attention_mixed_int8_q24_pwl_native_quality",
         "decoder_attention_mixed_int8_q12_pwl_proxy_audit",
         "decoder_attention_mixed_int8_score_precision_recovery",
         "decoder_attention_mixed_int8_score_margin_audit",
@@ -8941,6 +8995,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_broad_native_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_q12_pwl_native_quality":
             decoder_evidence = _decoder_attention_mixed_int8_q12_pwl_native_quality_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_q24_pwl_native_quality":
+            decoder_evidence = _decoder_attention_mixed_int8_q24_pwl_native_quality_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_q12_pwl_proxy_audit":
             decoder_evidence = _decoder_attention_mixed_int8_q12_pwl_proxy_audit_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_score_precision_recovery":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7382,6 +7382,83 @@ def test_generate_l2_campaign_task_adds_mixed_int8_q12_pwl_native_quality_eviden
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_q24_pwl_native_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_q24_pwl_native_quality",
+                    evaluation_mode="quality_gate",
+                    comparison_role="precision_validation",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_q24_pwl_native_quality",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_attention.py" in run
+            assert "--candidate qkv8_float_exact:q8,k8,v8,s24,w16,float_exact" in run
+            assert "--candidate qkv8_score24_float:q8,k8,v8,s24,w16,float_quantized" in run
+            assert (
+                "--candidate qkv8_q20_pwl_recip_q20_bucket8:q8,k8,v8,s20,w20,pwl_recip_lut_q20_bucket8"
+                in run
+            )
+            assert (
+                "--candidate qkv8_q24_pwl_recip_q24_bucket8:q8,k8,v8,s24,w24,pwl_recip_lut_q24_bucket8"
+                in run
+            )
+            assert "--primary-candidate-id qkv8_q24_pwl_recip_q24_bucket8" in run
+            assert decoder_inputs["attention_mixed_int8_softmax_replacement_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_softmax_replacement_generation_quality__"
+                "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1.json"
+            )
+            assert "attention_mixed_int8_q24_pwl_native_quality_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_q24_pwl_native_quality_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_q24_pwl_native_quality",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_mixed_int8_q12_pwl_proxy_audit_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,24 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the native 7B mixed-int8 attention-shadow quality gate for q8/k8/v8 with q24/PWL reciprocal-LUT softmax.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_q24_pwl_native_quality",
+      "comparison_role": "precision_validation",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "validate_or_reject_q24_pwl_hardware_target",
+        "reason": "q24/PWL passed bounded generation/NLL evidence; verify it on the broader native attention-shadow gate before PPA and frontier recost."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1/proposal.json
@@ -1,0 +1,81 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1",
+  "created_utc": "2026-06-29T11:15:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed-int8 q24-PWL native quality gate",
+  "abstraction_layer": "decoder_attention_mixed_int8_q24_pwl_native_quality",
+  "hypothesis": "The q24/PWL reciprocal-LUT softmax replacement that passed bounded 7B-class generation/NLL quality should be checked against the broader native attention-shadow gate before it becomes the next physical PPA and frontier-recost target.",
+  "direct_comparison": {
+    "primary_question": "Does q8/k8/v8 with q24/PWL reciprocal-LUT softmax preserve native 7B attention-shadow quality relative to float-exact and score24 float controls?",
+    "baseline": "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+    "candidate": "qkv8_q24_pwl_recip_q24_bucket8",
+    "include": [
+      "q8/k8/v8 projection quantization",
+      "q20 and q24 PWL reciprocal-LUT softmax candidates",
+      "float-exact and score24 float-quantized controls",
+      "native 7B-class checkpoint attention-shadow comparisons",
+      "top1, top-k, logit cosine, probability KL, and maximum logit-delta evidence"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "QAT or fine-tuning recovery",
+      "new HBM/SRAM/NoC modeling",
+      "claiming the q24 PWL path as rankable before physical PPA and integrated recost"
+    ],
+    "metrics": [
+      "decision",
+      "candidate_summaries",
+      "top1_match_rate",
+      "topk_contains_rate",
+      "mean_logit_cosine",
+      "mean_probability_kl",
+      "max_abs_logit_delta_max",
+      "best_candidate"
+    ]
+  },
+  "expected_benefit": [
+    "turn the bounded generation pass into the same native attention-shadow evidence stream used by the mixed-int8 frontier",
+    "avoid launching q24 PWL physical PPA if the broader native quality gate rejects it",
+    "prepare a quality-backed q24 PWL target for measured softmax/datapath PPA and Llama7B frontier recost"
+  ],
+  "risks": [
+    "attention-shadow quality is not full downstream task accuracy",
+    "the default public 7B-class checkpoint is Mistral-7B unless the evaluator overrides the model id",
+    "a passing quality gate still leaves q24 PWL softmax PPA and integrated schedule recost unmeasured"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the native 7B mixed-int8 attention-shadow gate for q8/k8/v8 with q24/PWL reciprocal-LUT softmax after q24 passed bounded generation/NLL quality.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_q24_pwl_native_quality",
+      "comparison_role": "precision_validation",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "validate_or_reject_q24_pwl_hardware_target",
+        "reason": "PR #1066 selected qkv8_q24_pwl_recip_q24_bucket8 from bounded generation/NLL evidence; this gate checks whether the same replacement is acceptable on the broader native attention-shadow path before PPA."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_softmax_replacement_generation_quality__l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1.json"
+  ],
+  "source_refs": [
+    "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1/proposal.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- add L2 generator support for the q24/PWL native 7B attention-shadow quality gate
- add proposal/evaluation request files for l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1
- add regression coverage for the generated q20/q24 PWL candidate command and dependency linkage

## Why
PR #1066 showed qkv8_q24_pwl_recip_q24_bucket8 passes bounded 7B-class generation/NLL while RTL exact softmax fails. This adds the next precision-validation gate before spending remote PPA on a q24 PWL physical embodiment and frontier recost.

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k "q24_pwl_native_quality or softmax_replacement_generation_quality"
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -k "q12_pwl_native_quality or softmax_replacement_generation_quality"
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py