### PR TITLE
control_plane: recognize q24 PWL native evidence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -499,6 +499,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_q12_pwl_native_quality_report",
     ),
     (
+        "attention_mixed_int8_q24_pwl_native_quality_out",
+        "attention_mixed_int8_q24_pwl_native_quality_report",
+    ),
+    (
         "attention_mixed_int8_q12_pwl_proxy_audit_out",
         "attention_mixed_int8_q12_pwl_proxy_audit_report",
     ),

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -693,6 +693,148 @@ def test_consume_l2_result_frontier_attention_mixed_int8_q12_pwl_native_quality_
             )
 
 
+def test_consume_l2_result_frontier_attention_mixed_int8_q24_pwl_native_quality_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_attention_mixed_int8_q24_pwl_native_quality_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_attention_mixed_int8_q24_pwl_native_quality_v1",
+                        "kind": "architecture",
+                        "title": "Attention mixed-int8 q24 PWL native quality",
+                        "direct_comparison": {
+                            "primary_question": "Can the q24/PWL softmax replacement keep quality?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_q24_pwl_native_quality__"
+                "l2_attention_mixed_int8_q24_pwl_native_quality_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_q24_pwl_native_quality__"
+                "l2_attention_mixed_int8_q24_pwl_native_quality_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "quality_gate": "mixed_int8_attention_shadow",
+                        "model": {
+                            "model_id": "mistralai/Mistral-7B-v0.1",
+                            "attention_heads": 32,
+                            "kv_heads": 8,
+                            "gqa_group_size": 4.0,
+                            "dtype": "bfloat16",
+                        },
+                        "precision": {
+                            "candidate_id": "qkv8_q24_pwl_recip_q24_bucket8",
+                            "q_bits": 8,
+                            "k_bits": 8,
+                            "v_bits": 8,
+                            "score_bits": 24,
+                            "weight_bits": 24,
+                            "softmax_mode": "pwl_recip_lut_q24_bucket8",
+                        },
+                        "summary": {
+                            "candidate_id": "qkv8_q24_pwl_recip_q24_bucket8",
+                            "comparison_count": 64,
+                            "top1_match_rate": 0.96875,
+                            "topk_contains_rate": 1.0,
+                            "mean_logit_cosine": 0.99909,
+                            "mean_probability_kl": 0.013,
+                            "max_abs_logit_delta_max": 2.25,
+                            "decision_status": "mixed_int8_native_attention_shadow_hold",
+                        },
+                        "decision": {
+                            "status": "mixed_int8_native_attention_shadow_hold",
+                            "next_step": "Hold q24/PWL until safer quantization is proven.",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# mixed-int8 q24 PWL native quality\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_attention_mixed_int8_q24_pwl_native_quality_v1",
+                campaign_dir_rel="runs/campaigns/npu/attention_mixed_int8_q24_pwl_native_quality_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,"
+                    "critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,"
+                    "throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_attention_mixed_int8_q24_pwl_native_quality_v1",
+                comparison={"role": "precision_validation"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "quality_gate",
+                "expected_direction": "iterate",
+                "expected_reason": "Check q24/PWL softmax replacement quality before PPA.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_mixed_int8_q24_pwl_native_quality",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_mixed_int8_q24_pwl_native_quality_out": evidence_rel,
+                    "attention_mixed_int8_q24_pwl_native_quality_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "mixed_int8_native_attention_shadow_hold"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_mixed_int8_q24_pwl_native_quality"
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_q24_pwl_native_quality_out"
+                ]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"][
+                    "decoder_attention_mixed_int8_q24_pwl_native_quality_report"
+                ]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_frontier_attention_mixed_int8_q12_pwl_proxy_audit_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- add q24 PWL native-quality output/report keys to the L2 decoder evidence consumer
- add a regression test that consumes q24 PWL evidence without requiring campaign best_point.json

## Why
The remote q24 PWL native-quality run succeeded, but completion processing failed in ARTIFACT_SYNC because consume_l2_result did not recognize attention_mixed_int8_q24_pwl_native_quality_out and fell back to campaign best_point.json.

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -k q24_pwl_native_quality
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k q24_pwl_native_quality
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_reconciliation_service.py -k evidence_only_decision_without_metrics_rows
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue
