### PR TITLE
npu: fix high score precision semantics

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6512,6 +6512,7 @@ def _decoder_attention_mixed_int8_score_precision_recovery_evidence(*, item_id: 
                     "--candidate score32_float:q8,k8,v8,s32,w16,float_quantized "
                     "--candidate qkv8_q16_pwl_recip_q16_bucket8:q8,k8,v8,s16,w16,pwl_recip_lut_q16_bucket8 "
                     "--candidate qkv8_q20_pwl_recip_q20_bucket8:q8,k8,v8,s20,w20,pwl_recip_lut_q20_bucket8 "
+                    "--candidate qkv8_q24_pwl_recip_q24_bucket8:q8,k8,v8,s24,w24,pwl_recip_lut_q24_bucket8 "
                     "--primary-candidate-id score32_float "
                     f"--out {out} "
                     f"--out-md {report}'"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7600,6 +7600,10 @@ def test_generate_l2_campaign_task_adds_mixed_int8_score_precision_recovery_evid
                 "--candidate qkv8_q20_pwl_recip_q20_bucket8:q8,k8,v8,s20,w20,pwl_recip_lut_q20_bucket8"
                 in run
             )
+            assert (
+                "--candidate qkv8_q24_pwl_recip_q24_bucket8:q8,k8,v8,s24,w24,pwl_recip_lut_q24_bucket8"
+                in run
+            )
             assert "--primary-candidate-id score32_float" in run
             assert decoder_inputs["attention_mixed_int8_q12_pwl_proxy_audit"].endswith(
                 "decoder_attention_mixed_int8_q12_pwl_proxy_audit__"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/evaluation_requests.json
@@ -25,6 +25,27 @@
   "source_commit": "68d78c106c9d3b4891657cc2aa259171397aa4ab",
   "requested_items": [
     {
+      "item_id": "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the broad precision-recovery mixed/int8 native attention-shadow sweep after fixing high-score quantization so s24/s28/s32 and q20/q24 PWL no longer alias.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score_precision_recovery",
+      "comparison_role": "precision_recovery",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "recover_quality_gate_or_hold_for_recost",
+        "reason": "The merged v1 recovery run did not actually increase score fractional precision for s24/s28/s32; rerun with corrected score quantization before making PPA or frontier decisions."
+      },
+      "status": "pending"
+    },
+    {
       "item_id": "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
       "task_type": "l2_campaign",
       "objective": "Run a broad precision-recovery mixed/int8 native attention-shadow sweep to test score/PWL-reciprocal precision upgrades before any final mixed-int8 ranking.",

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1/proposal.json
@@ -6,14 +6,14 @@
   "kind": "architecture",
   "title": "Llama7B mixed/int8 score precision recovery",
   "abstraction_layer": "decoder_attention_mixed_int8_score_precision_recovery",
-  "hypothesis": "After q12/PWL and quality-backed frontier checks, higher score precision (score28/score32) or higher-precision PWL reciprocal settings may recover mixed/int8 native attention quality for a 7B checkpoint before any final PPA recosting.",
+  "hypothesis": "After q12/PWL and quality-backed frontier checks, higher score precision (score28/score32) or higher-precision PWL reciprocal settings may recover mixed/int8 native attention quality for a 7B checkpoint before any final PPA recosting. The corrected r2 run must use score-bit-dependent input fractional precision because the merged v1 evidence aliased score24/28/32 under a fixed 1/1024 score step.",
   "direct_comparison": {
     "primary_question": "Can score-precision recovery or higher-precision PWL-reciprocal settings recover quality while keeping the job as an evidence-only checkpoint for ranking preparation?",
     "baseline": "l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1",
     "candidate": "score32_float",
     "include": [
       "run explicit score32 and score28 float-quantized sweeps",
-      "run qkv8_q16_pwl_recip_q16_bucket8 and qkv8_q20_pwl_recip_q20_bucket8 variants",
+      "run qkv8_q16_pwl_recip_q16_bucket8, qkv8_q20_pwl_recip_q20_bucket8, and qkv8_q24_pwl_recip_q24_bucket8 variants",
       "use BROAD prompt/step defaults and keep qkv8_float_exact as control/pass reference",
       "depend on q12/PWL proxy audit and quality-backed frontier evidence",
       "treat outcome as quality-recovery evidence only; do not rank frontier until recosted PPA exists"
@@ -63,6 +63,26 @@
       "expected_result": {
         "direction": "recover_quality_gate_or_hold_for_recost",
         "reason": "This job is explicit evidence for whether score/softmax precision upgrades recover mixed/int8 quality; no final ranking is expected until recosted PPA is available."
+      }
+    },
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the broad mixed-int8 score precision / PWL reciprocal precision recovery sweep after fixing high-score quantization semantics.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score_precision_recovery",
+      "comparison_role": "precision_recovery",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "recover_quality_gate_or_hold_for_recost",
+        "reason": "The merged v1 recovery run did not increase score fractional precision for s24/s28/s32; r2 is the corrected evidence before recosting any high-score or q24/PWL point."
       }
     }
   ],

--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
@@ -140,6 +140,26 @@ def _quantize_symmetric_list(values: list[float], bits: int) -> tuple[list[int],
     return [max(-levels, min(levels, int(round(value / scale)))) for value in values], scale
 
 
+def _score_input_frac_bits(score_bits: int) -> int:
+    if score_bits < 5:
+        raise ValueError("score_bits must leave room for sign and integer score range")
+    return min(28, score_bits - 4)
+
+
+def _quantize_score_fixed_list(values: list[float], score_bits: int) -> tuple[list[int], float]:
+    frac_bits = _score_input_frac_bits(score_bits)
+    input_scale = 1 << frac_bits
+    min_score = -(1 << (score_bits - 1))
+    max_score = (1 << (score_bits - 1)) - 1
+    return (
+        [
+            max(min_score, min(max_score, int(round(value * input_scale))))
+            for value in values
+        ],
+        1.0 / float(input_scale),
+    )
+
+
 def _pwl_recip_lut_softmax(
     logits: list[float],
     *,
@@ -147,15 +167,17 @@ def _pwl_recip_lut_softmax(
     weight_bits: int,
     reciprocal_bits: int,
     bucket_shift: int,
-    input_frac_bits: int = 8,
+    input_frac_bits: int | None = None,
 ) -> list[float]:
-    if score_bits < 2 or score_bits > 24:
-        raise ValueError("PWL reciprocal softmax expects score_bits in [2, 24]")
+    if score_bits < 5 or score_bits > 24:
+        raise ValueError("PWL reciprocal softmax expects score_bits in [5, 24]")
     if weight_bits < 2 or weight_bits > 24:
         raise ValueError("PWL reciprocal softmax expects weight_bits in [2, 24]")
     if not logits:
         return []
 
+    if input_frac_bits is None:
+        input_frac_bits = _score_input_frac_bits(score_bits)
     input_scale = 1 << input_frac_bits
     output_scale = (1 << weight_bits) - 1
     min_score = -(1 << (score_bits - 1))
@@ -712,7 +734,7 @@ def _softmax_patch(score_bits: int, weight_bits: int, softmax_mode: str):
             row = row.float()
         values = row.reshape(-1).tolist()
         if softmax_mode == "float_quantized":
-            q_values, scale = _quantize_symmetric_list(values, score_bits)
+            q_values, scale = _quantize_score_fixed_list(values, score_bits)
             out = [value * scale for value in q_values]
             out = _safe_exp_softmax(out)
             return torch.tensor(out, dtype=torch.float32, device=row.device).reshape(row.shape)

--- a/tests/test_llm_decoder_model_native_mixed_int8_attention.py
+++ b/tests/test_llm_decoder_model_native_mixed_int8_attention.py
@@ -14,9 +14,12 @@ from npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention import (
     _load_prompts,
     _parse_candidate_list,
     _parse_candidate_spec,
+    _pwl_recip_lut_softmax,
+    _quantize_score_fixed_list,
     _run_model_eval,
     _quantize_symmetric_list,
     _rtl_quantized_softmax,
+    _score_input_frac_bits,
     _summarize_rows,
     _install_attention_wrappers,
     _restore_attention_wrappers,
@@ -102,6 +105,40 @@ def test_quantize_symmetric_list() -> None:
     assert q[1] < 0
     assert q[2] > 0
     assert scale > 0.0
+
+
+def test_score_quantization_precision_scales_above_24_bits() -> None:
+    values = [0.0, 0.123456, -0.123456]
+
+    q24, scale24 = _quantize_score_fixed_list(values, score_bits=24)
+    q32, scale32 = _quantize_score_fixed_list(values, score_bits=32)
+
+    assert _score_input_frac_bits(12) == 8
+    assert _score_input_frac_bits(24) > _score_input_frac_bits(12)
+    assert _score_input_frac_bits(32) > _score_input_frac_bits(24)
+    assert scale32 < scale24
+    assert q32 != q24
+
+
+def test_pwl_softmax_uses_score_precision_for_input_fraction() -> None:
+    logits = [0.0, -0.001]
+
+    q12 = _pwl_recip_lut_softmax(
+        logits,
+        score_bits=12,
+        weight_bits=12,
+        reciprocal_bits=12,
+        bucket_shift=8,
+    )
+    q24 = _pwl_recip_lut_softmax(
+        logits,
+        score_bits=24,
+        weight_bits=24,
+        reciprocal_bits=24,
+        bucket_shift=8,
+    )
+
+    assert q12 != q24
 
 
 def test_fake_attention_patch_quantizes_qkv_once_and_restores() -> None:


### PR DESCRIPTION
## Summary\n- make native mixed-int8 float-quantized softmax use score-bit-dependent fixed-point precision instead of aliasing score24/28/32 to a fixed 1/1024 step\n- make PWL softmax derive input fractional precision from score_bits, preserving q12 at 8 frac bits while making q20/q24 materially different\n- add q24 PWL to the score precision recovery sweep and add an explicit r2 request documenting why the previous recovery evidence must be rerun\n\n## Tests\n- python3 -m pytest tests/test_llm_decoder_model_native_mixed_int8_attention.py -q\n- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k score_precision_recovery -q\n- PYTHONPATH=control_plane python3 scripts/validate_runs.py --skip_eval_queue