### PR TITLE
control_plane: add mixed int8 quality energy frontier audit

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1268,6 +1268,34 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 
+    if model == "llm_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            diagnosis_dict.get("decision")
+            or evidence_payload.get("decision")
+            or "mixed_int8_quality_energy_frontier_recorded"
+        )
+        parts = [
+            f"Decoder mixed/int8 quality/energy frontier evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "quality_best_candidate_id",
+            "quality_best_top1_match_rate",
+            "score32_top1_match_rate",
+            "q24_pwl_top1_match_rate",
+            "best_fp16_softmax_proxy_candidate_id",
+            "best_fp16_softmax_proxy_critical_path_ns",
+            "best_fp16_softmax_proxy_die_area_um2",
+            "best_fp16_softmax_proxy_total_power_mw",
+            "non_quality_backed_measured_recost_count",
+            "recommended_next_step",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
     if model == "llm_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1":
         decision = evidence_payload.get("decision")
         decision_dict = dict(decision) if isinstance(decision, dict) else {}

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6903,6 +6903,66 @@ def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: s
     }
 
 
+def _decoder_attention_mixed_int8_quality_energy_frontier_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    quality_backed_frontier = (
+        f"{base}/decoder_attention_mixed_int8_quality_backed_frontier__"
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+    )
+    score_precision_recovery = (
+        f"{base}/decoder_attention_mixed_int8_score_precision_recovery__"
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2.json"
+    )
+    exact_div_recost = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json"
+    )
+    exact_div_split2_recost = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1.json"
+    )
+    fp16_softmax_nm1_metrics = "runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv"
+    fp16_softmax_nm2_metrics = "runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/metrics.csv"
+    out = f"{base}/decoder_attention_mixed_int8_quality_energy_frontier__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_quality_energy_frontier__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_mixed_int8_quality_backed_frontier": quality_backed_frontier,
+            "attention_mixed_int8_score_precision_recovery": score_precision_recovery,
+            "attention_score32_w16_exact_div_physical_recost": exact_div_recost,
+            "attention_score32_w16_exact_div_split2_physical_recost": exact_div_split2_recost,
+            "attention_fp16_softmax_nm1_metrics": fp16_softmax_nm1_metrics,
+            "attention_fp16_softmax_nm2_metrics": fp16_softmax_nm2_metrics,
+            "attention_mixed_int8_quality_energy_frontier_out": out,
+            "attention_mixed_int8_quality_energy_frontier_report": report,
+            "attention_mixed_int8_quality_energy_frontier_scope": (
+                "Audit the current quality-backed mixed/int8 frontier after corrected score precision. "
+                "Keep qkv8_float_exact as the only passing quality point, retain score32/exact-div PPA "
+                "as non-quality-backed diagnostics, and use measured FP16 softmax rows to decide whether "
+                "a composed q8/k8/v8 plus floating/near-exact softmax wrapper should be measured next."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_mixed_int8_quality_energy_frontier",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py "
+                    f"--quality-backed-frontier-json {quality_backed_frontier} "
+                    f"--score-precision-recovery-json {score_precision_recovery} "
+                    f"--exact-div-recost-json {exact_div_recost} "
+                    f"--exact-div-split2-recost-json {exact_div_split2_recost} "
+                    f"--fp16-softmax-nm1-metrics {fp16_softmax_nm1_metrics} "
+                    f"--fp16-softmax-nm2-metrics {fp16_softmax_nm2_metrics} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_precision_quality_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_mixed_precision_quality__{item_id}.json"
@@ -8804,6 +8864,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
         "decoder_attention_mixed_int8_softmax_replacement_generation_quality",
         "decoder_attention_mixed_int8_quality_backed_frontier",
+        "decoder_attention_mixed_int8_quality_energy_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
         "decoder_attention_mixed_precision_quality",
         "decoder_attention_softmax_pow2sum_quality",
@@ -9028,6 +9089,8 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
             decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_energy_frontier":
+            decoder_evidence = _decoder_attention_mixed_int8_quality_energy_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_kv_dual_stream_physical_feasibility":
             decoder_evidence = _decoder_attention_kv_dual_stream_physical_feasibility_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_precision_quality":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -139,6 +139,36 @@ def test_decoder_evidence_summary_recognizes_mixed_int8_quality_backed_frontier(
     assert "old_energy_best_token_throughput_per_s=634.77" in summary
 
 
+def test_decoder_evidence_summary_recognizes_mixed_int8_quality_energy_frontier() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/mixed_int8_quality_energy_frontier.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+            "decision": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+            "diagnosis": {
+                "decision": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+                "quality_best_candidate_id": "qkv8_float_exact",
+                "quality_best_top1_match_rate": 1.0,
+                "score32_top1_match_rate": 0.984375,
+                "q24_pwl_top1_match_rate": 0.96875,
+                "best_fp16_softmax_proxy_candidate_id": "qkv8_float_exact_fp16_softmax_nm2_proxy",
+                "best_fp16_softmax_proxy_critical_path_ns": 5.47,
+                "best_fp16_softmax_proxy_die_area_um2": 2250000.0,
+                "best_fp16_softmax_proxy_total_power_mw": 0.189,
+                "non_quality_backed_measured_recost_count": 2,
+                "recommended_next_step": "measure composed q8/k8/v8 fp16 softmax wrapper",
+            },
+        },
+    )
+
+    assert outcome == "mixed_int8_quality_energy_frontier_composed_measurement_required"
+    assert "quality/energy frontier" in summary
+    assert "quality_best_candidate_id=qkv8_float_exact" in summary
+    assert "score32_top1_match_rate=0.984375" in summary
+    assert "best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy" in summary
+    assert "non_quality_backed_measured_recost_count=2" in summary
+
+
 def test_decoder_evidence_summary_recognizes_mixed_int8_q12_pwl_proxy_audit() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/mixed_int8_q12_pwl_proxy_audit.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8145,6 +8145,85 @@ def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evide
             }
 
 
+def test_generate_l2_campaign_task_adds_mixed_int8_quality_energy_frontier_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_quality_energy_frontier",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="quality_energy_frontier",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+                        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_mixed_int8_quality_energy_frontier",
+            ]
+            run = commands[0]["run"]
+            assert "audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py" in run
+            assert "--quality-backed-frontier-json" in run
+            assert "--score-precision-recovery-json" in run
+            assert "--fp16-softmax-nm1-metrics" in run
+            assert "--fp16-softmax-nm2-metrics" in run
+            assert decoder_inputs["attention_mixed_int8_quality_backed_frontier"].endswith(
+                "decoder_attention_mixed_int8_quality_backed_frontier__"
+                "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_mixed_int8_score_precision_recovery"].endswith(
+                "decoder_attention_mixed_int8_score_precision_recovery__"
+                "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2.json"
+            )
+            assert decoder_inputs["attention_fp16_softmax_nm1_metrics"].endswith(
+                "runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv"
+            )
+            assert "attention_mixed_int8_quality_energy_frontier_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_quality_energy_frontier_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_quality_energy_frontier",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+                    "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit the current quality-backed mixed/int8 energy frontier and decide the next composed softmax measurement after score32/PWL softmax failed quality.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_quality_energy_frontier",
+      "comparison_role": "quality_energy_frontier",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "select_quality_backed_softmax_measurement",
+        "reason": "qkv8_float_exact is quality-backed but not physically composed; score32/PWL rows have PPA but fail quality. This audit chooses the next measured wrapper direction."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json
@@ -1,0 +1,85 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+  "created_utc": "2026-06-29T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B mixed/int8 quality-backed energy frontier",
+  "abstraction_layer": "decoder_attention_mixed_int8_quality_energy_frontier",
+  "hypothesis": "After corrected score precision, score32 fixed-point and q24/PWL still fail the broad native attention-shadow gate, while qkv8_float_exact passes. The next frontier decision should keep qkv8_float_exact as the quality-backed precision point and use measured FP16 softmax and exact-div PPA evidence to decide whether a composed q8/k8/v8 plus floating/near-exact softmax wrapper should be measured next.",
+  "direct_comparison": {
+    "primary_question": "Which measured hardware evidence can safely support the quality-backed mixed/int8 Llama7B frontier after fixed-point/PWL softmax failed quality?",
+    "baseline": "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+    "candidate": "qkv8_float_exact with measured FP16 softmax proxy",
+    "include": [
+      "consume qkv8_float_exact quality-backed frontier evidence",
+      "consume corrected score precision recovery r2 evidence",
+      "consume measured score32 exact-div reduced-replica recost evidence as non-quality-backed diagnostic PPA",
+      "consume measured fp16 softmax nm1/nm2 physical rows as proxy data",
+      "recommend whether the next job should measure a composed q8/k8/v8 floating/near-exact softmax wrapper"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "final ranking of a not-yet-composed fp16 softmax proxy",
+      "QAT or training recovery"
+    ],
+    "metrics": [
+      "decision",
+      "quality_best_candidate_id",
+      "score32_top1_match_rate",
+      "q24_pwl_top1_match_rate",
+      "best_fp16_softmax_proxy_candidate_id",
+      "best_fp16_softmax_proxy_critical_path_ns",
+      "best_fp16_softmax_proxy_die_area_um2",
+      "best_fp16_softmax_proxy_total_power_mw",
+      "recommended_next_step"
+    ]
+  },
+  "expected_benefit": [
+    "keeps failed fixed-point/PWL softmax rows out of quality-backed frontier ranking",
+    "uses measured hardware rows to bound the exact/near-exact softmax direction",
+    "turns the next physical job into a concrete composed wrapper measurement rather than another abstract recost"
+  ],
+  "risks": [
+    "fp16 softmax metrics are measured but are not yet a composed attention wrapper",
+    "qkv8_float_exact remains attention-shadow quality evidence rather than full task accuracy",
+    "the final throughput/energy/area ranking still requires composed wrapper PPA"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit the current quality-backed mixed/int8 energy frontier and decide the next composed softmax measurement after score32/PWL softmax failed quality.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_mixed_int8_quality_energy_frontier",
+      "comparison_role": "quality_energy_frontier",
+      "cost_class": "low",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "select_quality_backed_softmax_measurement",
+        "reason": "qkv8_float_exact is quality-backed but not physically composed; score32/PWL rows have PPA but fail quality. This audit chooses the next measured wrapper direction."
+      }
+    }
+  ],
+  "source_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1.json",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/metrics.csv"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1/proposal.json"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Audit quality-backed mixed-int8 energy frontier options."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object at {path}")
+    return payload
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _read_first_ok_metrics(path: Path) -> JsonDict:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        rows = [dict(row) for row in csv.DictReader(handle)]
+    if not rows:
+        raise RuntimeError(f"metrics CSV has no rows: {path}")
+    ok_rows = [row for row in rows if str(row.get("status", "")).lower() == "ok"]
+    row = ok_rows[0] if ok_rows else rows[0]
+    return {
+        "path": str(path),
+        "design": row.get("design"),
+        "status": row.get("status"),
+        "critical_path_ns": _as_float(row.get("critical_path_ns")),
+        "die_area_um2": _as_float(row.get("die_area")),
+        "total_power_mw": _as_float(row.get("total_power_mw")),
+        "instance_area_um2": _as_float(row.get("instance_area_um2")),
+        "stdcell_area_um2": _as_float(row.get("stdcell_area_um2")),
+        "stdcell_count": _as_float(row.get("stdcell_count")),
+    }
+
+
+def _candidate_summaries(payload: JsonDict) -> list[JsonDict]:
+    rows = payload.get("candidate_summaries")
+    if not isinstance(rows, list):
+        return []
+    return [dict(row) for row in rows if isinstance(row, dict)]
+
+
+def _is_pass(row: JsonDict) -> bool:
+    status = str(row.get("decision_status") or (row.get("decision") or {}).get("status") or "")
+    return status.endswith("_pass")
+
+
+def _quality_candidate(row: JsonDict | None) -> JsonDict | None:
+    if row is None:
+        return None
+    return {
+        "candidate_id": row.get("candidate_id"),
+        "decision_status": row.get("decision_status") or (row.get("decision") or {}).get("status"),
+        "q_bits": row.get("q_bits"),
+        "k_bits": row.get("k_bits"),
+        "v_bits": row.get("v_bits"),
+        "score_bits": row.get("score_bits"),
+        "weight_bits": row.get("weight_bits"),
+        "softmax_mode": row.get("softmax_mode"),
+        "comparison_count": row.get("comparison_count"),
+        "top1_match_rate": row.get("top1_match_rate"),
+        "topk_contains_rate": row.get("topk_contains_rate"),
+        "mean_logit_cosine": row.get("mean_logit_cosine"),
+        "mean_probability_kl": row.get("mean_probability_kl"),
+        "max_abs_logit_delta_max": row.get("max_abs_logit_delta_max"),
+    }
+
+
+def _recovery_candidate(payload: JsonDict, candidate_id: str) -> JsonDict | None:
+    for row in _candidate_summaries(payload):
+        if str(row.get("candidate_id")) == candidate_id:
+            return _quality_candidate(row)
+    return None
+
+
+def _recost_summary(payload: JsonDict, *, label: str) -> JsonDict:
+    diagnosis = dict(payload.get("diagnosis") or {})
+    best = dict(payload.get("best_feasible") or payload.get("best_requested") or {})
+    return {
+        "label": label,
+        "decision": diagnosis.get("decision") or payload.get("decision"),
+        "precision_profile": best.get("precision_profile") or diagnosis.get("precision_profile"),
+        "best_feasible_latency_us": diagnosis.get("best_feasible_latency_us"),
+        "replica_recost_latency_us": best.get("replica_recost_latency_us"),
+        "replica_recost_area_fit_replica_count": best.get("replica_recost_area_fit_replica_count"),
+        "replica_recost_macs_per_cycle": best.get("replica_recost_macs_per_cycle"),
+        "replica_recost_compute_area_um2": best.get("replica_recost_compute_area_um2"),
+        "replica_recost_compute_power_mw": best.get("replica_recost_compute_power_mw"),
+        "substituted_compute_arch": (
+            best.get("substituted_compute_arch")
+            or best.get("compute_arch_name")
+            or diagnosis.get("best_requested_substituted_compute_arch")
+        ),
+        "quality_backed": False,
+        "quality_blocker": "score32 fixed-point/PWL candidates did not pass broad native attention-shadow gate",
+    }
+
+
+def build_payload(args: argparse.Namespace) -> JsonDict:
+    quality_frontier = _load_json(args.quality_backed_frontier_json)
+    score_recovery = _load_json(args.score_precision_recovery_json)
+    exact_div = _load_json(args.exact_div_recost_json)
+    exact_div_split2 = _load_json(args.exact_div_split2_recost_json)
+    fp16_nm1 = _read_first_ok_metrics(args.fp16_softmax_nm1_metrics)
+    fp16_nm2 = _read_first_ok_metrics(args.fp16_softmax_nm2_metrics)
+
+    qbf_diag = dict(quality_frontier.get("diagnosis") or {})
+    qkv8_quality_pass = "qkv8_float_exact" in {
+        str(item) for item in qbf_diag.get("quality_passing_candidate_ids", [])
+    }
+    qkv8_quality = {
+        "candidate_id": qbf_diag.get("quality_best_candidate_id"),
+        "top1_match_rate": qbf_diag.get("quality_best_top1_match_rate"),
+        "mean_probability_kl": qbf_diag.get("quality_best_mean_probability_kl"),
+        "quality_backed": qkv8_quality_pass,
+    }
+
+    score32 = _recovery_candidate(score_recovery, "score32_float")
+    q24_pwl = _recovery_candidate(score_recovery, "qkv8_q24_pwl_recip_q24_bucket8")
+    measured_non_quality_backed = [
+        _recost_summary(exact_div, label="score32_w16_exact_div"),
+        _recost_summary(exact_div_split2, label="score32_w16_exact_div_split2"),
+    ]
+
+    fp16_proxy_candidates = [
+        {
+            "candidate_id": "qkv8_float_exact_fp16_softmax_nm1_proxy",
+            "quality_source": "qkv8_float_exact",
+            "softmax_metrics": fp16_nm1,
+            "quality_backed": qkv8_quality_pass,
+            "composition_status": "measured_softmax_only_not_composed_attention_wrapper",
+        },
+        {
+            "candidate_id": "qkv8_float_exact_fp16_softmax_nm2_proxy",
+            "quality_source": "qkv8_float_exact",
+            "softmax_metrics": fp16_nm2,
+            "quality_backed": qkv8_quality_pass,
+            "composition_status": "measured_softmax_only_not_composed_attention_wrapper",
+        },
+    ]
+
+    best_proxy = min(
+        fp16_proxy_candidates,
+        key=lambda row: (
+            _as_float(row["softmax_metrics"].get("critical_path_ns"), 1e9),
+            _as_float(row["softmax_metrics"].get("die_area_um2"), 1e18),
+        ),
+    )
+
+    decision = "mixed_int8_quality_energy_frontier_composed_measurement_required"
+    recommended_next_step = (
+        "Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics "
+        "and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL "
+        "rows as quality-backed frontier points."
+    )
+
+    payload: JsonDict = {
+        "version": 1,
+        "model": "llm_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+        "decision": decision,
+        "quality_gate": {
+            "qkv8_float_exact": qkv8_quality,
+            "score32_float": score32,
+            "qkv8_q24_pwl_recip_q24_bucket8": q24_pwl,
+        },
+        "fp16_softmax_proxy_candidates": fp16_proxy_candidates,
+        "best_fp16_softmax_proxy_candidate": best_proxy,
+        "measured_non_quality_backed_recosts": measured_non_quality_backed,
+        "diagnosis": {
+            "decision": decision,
+            "quality_best_candidate_id": qkv8_quality.get("candidate_id"),
+            "quality_best_top1_match_rate": qkv8_quality.get("top1_match_rate"),
+            "score32_top1_match_rate": (score32 or {}).get("top1_match_rate"),
+            "q24_pwl_top1_match_rate": (q24_pwl or {}).get("top1_match_rate"),
+            "best_fp16_softmax_proxy_candidate_id": best_proxy.get("candidate_id"),
+            "best_fp16_softmax_proxy_critical_path_ns": best_proxy["softmax_metrics"].get("critical_path_ns"),
+            "best_fp16_softmax_proxy_die_area_um2": best_proxy["softmax_metrics"].get("die_area_um2"),
+            "best_fp16_softmax_proxy_total_power_mw": best_proxy["softmax_metrics"].get("total_power_mw"),
+            "non_quality_backed_measured_recost_count": len(measured_non_quality_backed),
+            "recommended_next_step": recommended_next_step,
+        },
+        "inputs": {
+            "quality_backed_frontier_json": str(args.quality_backed_frontier_json),
+            "score_precision_recovery_json": str(args.score_precision_recovery_json),
+            "exact_div_recost_json": str(args.exact_div_recost_json),
+            "exact_div_split2_recost_json": str(args.exact_div_split2_recost_json),
+            "fp16_softmax_nm1_metrics": str(args.fp16_softmax_nm1_metrics),
+            "fp16_softmax_nm2_metrics": str(args.fp16_softmax_nm2_metrics),
+        },
+        "assumptions": [
+            "qkv8_float_exact is the only broad native attention-shadow passing mixed/int8 candidate.",
+            "FP16 softmax metrics are measured hardware rows but not yet a composed q8/k8/v8 attention wrapper.",
+            "Score32 exact-div and PWL recosts are retained as measured diagnostic rows but are not quality-backed.",
+        ],
+    }
+    return payload
+
+
+def write_report(payload: JsonDict, path: Path) -> None:
+    diag = dict(payload.get("diagnosis") or {})
+    lines = [
+        "# Mixed-Int8 Quality/Energy Frontier Audit",
+        "",
+        f"- decision: `{payload.get('decision')}`",
+        f"- quality_best_candidate_id: `{diag.get('quality_best_candidate_id')}`",
+        f"- quality_best_top1_match_rate: `{diag.get('quality_best_top1_match_rate')}`",
+        f"- score32_top1_match_rate: `{diag.get('score32_top1_match_rate')}`",
+        f"- q24_pwl_top1_match_rate: `{diag.get('q24_pwl_top1_match_rate')}`",
+        f"- best_fp16_softmax_proxy_candidate_id: `{diag.get('best_fp16_softmax_proxy_candidate_id')}`",
+        f"- best_fp16_softmax_proxy_critical_path_ns: `{diag.get('best_fp16_softmax_proxy_critical_path_ns')}`",
+        f"- best_fp16_softmax_proxy_die_area_um2: `{diag.get('best_fp16_softmax_proxy_die_area_um2')}`",
+        f"- best_fp16_softmax_proxy_total_power_mw: `{diag.get('best_fp16_softmax_proxy_total_power_mw')}`",
+        "",
+        "## Recommendation",
+        "",
+        str(diag.get("recommended_next_step")),
+        "",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--quality-backed-frontier-json", type=Path, required=True)
+    parser.add_argument("--score-precision-recovery-json", type=Path, required=True)
+    parser.add_argument("--exact-div-recost-json", type=Path, required=True)
+    parser.add_argument("--exact-div-split2-recost-json", type=Path, required=True)
+    parser.add_argument("--fp16-softmax-nm1-metrics", type=Path, required=True)
+    parser.add_argument("--fp16-softmax-nm2-metrics", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = build_payload(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py
+++ b/tests/test_audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py
@@ -1,0 +1,136 @@
+import argparse
+import csv
+import json
+
+from npu.eval.audit_llm_decoder_attention_mixed_int8_quality_energy_frontier import build_payload
+
+
+def _write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_metrics(path, *, design, critical_path_ns, die_area, power_mw):
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "design",
+                "platform",
+                "status",
+                "critical_path_ns",
+                "die_area",
+                "total_power_mw",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "design": design,
+                "platform": "nangate45",
+                "status": "ok",
+                "critical_path_ns": critical_path_ns,
+                "die_area": die_area,
+                "total_power_mw": power_mw,
+            }
+        )
+    return path
+
+
+def test_build_payload_selects_quality_backed_fp16_softmax_proxy(tmp_path):
+    quality_frontier = _write_json(
+        tmp_path / "quality_frontier.json",
+        {
+            "diagnosis": {
+                "quality_passing_candidate_ids": ["qkv8_float_exact"],
+                "quality_best_candidate_id": "qkv8_float_exact",
+                "quality_best_top1_match_rate": 1.0,
+                "quality_best_mean_probability_kl": 0.0012,
+            }
+        },
+    )
+    score_recovery = _write_json(
+        tmp_path / "score_recovery.json",
+        {
+            "candidate_summaries": [
+                {
+                    "candidate_id": "score32_float",
+                    "decision_status": "mixed_int8_native_attention_shadow_hold",
+                    "top1_match_rate": 0.984375,
+                    "topk_contains_rate": 1.0,
+                    "mean_probability_kl": 0.0017,
+                },
+                {
+                    "candidate_id": "qkv8_q24_pwl_recip_q24_bucket8",
+                    "decision_status": "mixed_int8_native_attention_shadow_hold",
+                    "top1_match_rate": 0.96875,
+                    "topk_contains_rate": 1.0,
+                    "mean_probability_kl": 0.0132,
+                },
+            ]
+        },
+    )
+    exact_div = _write_json(
+        tmp_path / "exact_div.json",
+        {
+            "diagnosis": {
+                "decision": "score32_exact_div_feasible",
+                "best_feasible_latency_us": 12.3,
+            },
+            "best_feasible": {
+                "precision_profile": "score32_w16_exact_div",
+                "replica_recost_latency_us": 12.3,
+                "replica_recost_area_fit_replica_count": 2,
+            },
+        },
+    )
+    exact_div_split2 = _write_json(
+        tmp_path / "exact_div_split2.json",
+        {
+            "diagnosis": {
+                "decision": "score32_exact_div_split2_feasible",
+                "best_feasible_latency_us": 9.8,
+            },
+            "best_requested": {
+                "precision_profile": "score32_w16_exact_div_split2",
+                "replica_recost_latency_us": 9.8,
+                "replica_recost_area_fit_replica_count": 4,
+            },
+        },
+    )
+    nm1_metrics = _write_metrics(
+        tmp_path / "nm1.csv",
+        design="npu_fp16_cpp_nm1_softmaxcmp",
+        critical_path_ns=5.69,
+        die_area=2250000.0,
+        power_mw=0.184,
+    )
+    nm2_metrics = _write_metrics(
+        tmp_path / "nm2.csv",
+        design="npu_fp16_cpp_nm2_softmaxcmp",
+        critical_path_ns=5.47,
+        die_area=2250000.0,
+        power_mw=0.189,
+    )
+
+    payload = build_payload(
+        argparse.Namespace(
+            quality_backed_frontier_json=quality_frontier,
+            score_precision_recovery_json=score_recovery,
+            exact_div_recost_json=exact_div,
+            exact_div_split2_recost_json=exact_div_split2,
+            fp16_softmax_nm1_metrics=nm1_metrics,
+            fp16_softmax_nm2_metrics=nm2_metrics,
+        )
+    )
+
+    assert payload["decision"] == "mixed_int8_quality_energy_frontier_composed_measurement_required"
+    assert payload["quality_gate"]["qkv8_float_exact"]["quality_backed"] is True
+    assert payload["quality_gate"]["score32_float"]["top1_match_rate"] == 0.984375
+    assert payload["quality_gate"]["qkv8_q24_pwl_recip_q24_bucket8"]["top1_match_rate"] == 0.96875
+    assert (
+        payload["best_fp16_softmax_proxy_candidate"]["candidate_id"]
+        == "qkv8_float_exact_fp16_softmax_nm2_proxy"
+    )
+    assert len(payload["measured_non_quality_backed_recosts"]) == 2
+    assert payload["diagnosis"]["non_quality_backed_measured_recost_count"] == 2


### PR DESCRIPTION
## Summary
- add an evidence-only L2 audit for the mixed/int8 Llama7B quality-energy frontier
- combine qkv8_float_exact quality evidence, corrected score precision recovery, measured FP16 softmax rows, and score32 exact-div recost diagnostics
- keep score32/PWL recosts out of the quality-backed ranking and recommend a composed q8/k8/v8 near-exact softmax wrapper measurement next

## Validation
- `python3 npu/eval/audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py ...` on current merged artifacts
- `python3 -m pytest tests/test_audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py -q`
- `PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k quality_energy_frontier -q`
- `PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -k quality_energy_frontier -q`
- `PYTHONPATH=control_plane python3 scripts/validate_runs.py --skip_eval_queue`
