### PR TITLE
eval: run llama7b mixed/int8 quality energy frontier

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json
@@ -1,0 +1,107 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-06-29T12:05:52.214261Z",
+  "item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+  "run_key": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1_run_f98c514043c1cafa",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2",
+  "review_metadata_source_commit": "aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2",
+  "objective": "Audit the current quality-backed mixed/int8 energy frontier and decide the next composed softmax measurement after score32/PWL softmax failed quality.",
+  "input_manifest": {
+    "decoder_contract": {
+      "attention_fp16_softmax_nm1_metrics": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv",
+      "attention_fp16_softmax_nm2_metrics": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/metrics.csv",
+      "attention_mixed_int8_quality_backed_frontier": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+      "attention_mixed_int8_score_precision_recovery": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2.json",
+      "attention_score32_w16_exact_div_physical_recost": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json",
+      "attention_mixed_int8_quality_energy_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+      "attention_mixed_int8_quality_energy_frontier_scope": "Audit the current quality-backed mixed/int8 frontier after corrected score precision. Keep qkv8_float_exact as the only passing quality point, retain score32/exact-div PPA as non-quality-backed diagnostics, and use measured FP16 softmax rows to decide whether a composed q8/k8/v8 plus floating/near-exact softmax wrapper should be measured next.",
+      "attention_mixed_int8_quality_energy_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.md",
+      "attention_score32_w16_exact_div_split2_physical_recost": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1.json"
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+    "arch_id": "decoder_attention_mixed_int8_quality_energy_frontier",
+    "macro_mode": "evidence_only",
+    "outcome": "mixed_int8_quality_energy_frontier_composed_measurement_required"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+    "title": "Llama7B mixed/int8 quality-backed energy frontier",
+    "primary_question": "Which measured hardware evidence can safely support the quality-backed mixed/int8 Llama7B frontier after fixed-point/PWL softmax failed quality?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "quality_energy_frontier",
+    "abstraction_layer": "decoder_attention_mixed_int8_quality_energy_frontier",
+    "expected_direction": "select_quality_backed_softmax_measurement",
+    "expected_reason": "qkv8_float_exact is quality-backed but not physically composed; score32/PWL rows have PPA but fail quality. This audit chooses the next measured wrapper direction.",
+    "summary": "Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.",
+    "outcome": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+    "title": "Llama7B mixed/int8 quality-backed energy frontier",
+    "kind": "architecture",
+    "primary_question": "Which measured hardware evidence can safely support the quality-backed mixed/int8 Llama7B frontier after fixed-point/PWL softmax failed quality?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "quality_energy_frontier",
+    "outcome": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+    "summary": "Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+    "decoder_quality": {
+      "diagnosis": {
+        "best_fp16_softmax_proxy_candidate_id": "qkv8_float_exact_fp16_softmax_nm2_proxy",
+        "best_fp16_softmax_proxy_critical_path_ns": 5.476841177082706,
+        "best_fp16_softmax_proxy_die_area_um2": 2250000.0,
+        "best_fp16_softmax_proxy_total_power_mw": 0.189074,
+        "decision": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+        "non_quality_backed_measured_recost_count": 2,
+        "q24_pwl_top1_match_rate": 0.96875,
+        "quality_best_candidate_id": "qkv8_float_exact",
+        "quality_best_top1_match_rate": 1.0,
+        "recommended_next_step": "Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.",
+        "score32_top1_match_rate": 0.984375
+      },
+      "assumptions": [
+        "qkv8_float_exact is the only broad native attention-shadow passing mixed/int8 candidate.",
+        "FP16 softmax metrics are measured hardware rows but not yet a composed q8/k8/v8 attention wrapper.",
+        "Score32 exact-div and PWL recosts are retained as measured diagnostic rows but are not quality-backed."
+      ]
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+    "decoder_attention_mixed_int8_quality_energy_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+    "decoder_attention_mixed_int8_quality_energy_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {
+      "best_fp16_softmax_proxy_candidate_id": "qkv8_float_exact_fp16_softmax_nm2_proxy",
+      "best_fp16_softmax_proxy_critical_path_ns": 5.476841177082706,
+      "best_fp16_softmax_proxy_die_area_um2": 2250000.0,
+      "best_fp16_softmax_proxy_total_power_mw": 0.189074,
+      "decision": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+      "non_quality_backed_measured_recost_count": 2,
+      "q24_pwl_top1_match_rate": 0.96875,
+      "quality_best_candidate_id": "qkv8_float_exact",
+      "quality_best_top1_match_rate": 1.0,
+      "recommended_next_step": "Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.",
+      "score32_top1_match_rate": 0.984375
+    },
+    "assumptions": [
+      "qkv8_float_exact is the only broad native attention-shadow passing mixed/int8 candidate.",
+      "FP16 softmax metrics are measured hardware rows but not yet a composed q8/k8/v8 attention wrapper.",
+      "Score32 exact-div and PWL recosts are retained as measured diagnostic rows but are not quality-backed."
+    ]
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/evaluated.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/evaluated.json
@@ -1,0 +1,113 @@
+{
+  "flow": "openroad",
+  "task": {
+    "inputs": {
+      "decoder_contract": {
+        "attention_fp16_softmax_nm1_metrics": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv",
+        "attention_fp16_softmax_nm2_metrics": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/metrics.csv",
+        "attention_mixed_int8_quality_backed_frontier": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+        "attention_mixed_int8_score_precision_recovery": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2.json",
+        "attention_score32_w16_exact_div_physical_recost": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json",
+        "attention_mixed_int8_quality_energy_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+        "attention_mixed_int8_quality_energy_frontier_scope": "Audit the current quality-backed mixed/int8 frontier after corrected score precision. Keep qkv8_float_exact as the only passing quality point, retain score32/exact-div PPA as non-quality-backed diagnostics, and use measured FP16 softmax rows to decide whether a composed q8/k8/v8 plus floating/near-exact softmax wrapper should be measured next.",
+        "attention_mixed_int8_quality_energy_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.md",
+        "attention_score32_w16_exact_div_split2_physical_recost": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1.json"
+      }
+    },
+    "commands": [
+      {
+        "run": "python3 npu/eval/audit_llm_decoder_attention_mixed_int8_quality_energy_frontier.py --quality-backed-frontier-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json --score-precision-recovery-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2.json --exact-div-recost-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json --exact-div-split2-recost-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1.json --fp16-softmax-nm1-metrics runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv --fp16-softmax-nm2-metrics runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/metrics.csv --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.md",
+        "name": "audit_decoder_attention_mixed_int8_quality_energy_frontier"
+      },
+      {
+        "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+        "name": "validate_runs"
+      }
+    ],
+    "objective": "Audit the current quality-backed mixed/int8 energy frontier and decide the next composed softmax measurement after score32/PWL softmax failed quality.",
+    "acceptance": [
+      "Write all declared decoder evidence artifacts",
+      "Keep evidence artifact paths repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "source_mode": "src_verilog",
+    "expected_outputs": [
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.md"
+    ]
+  },
+  "layer": "layer2",
+  "state": "evaluated",
+  "title": "Llama7B mixed/int8 quality energy frontier",
+  "result": {
+    "branch": "eval/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/s20260629t120552z",
+    "completed_utc": "2026-06-29T12:05:51.625568Z",
+    "evaluator_id": "control_plane",
+    "executor": "@control_plane",
+    "host": "b7c2d9c80c1c",
+    "identity_block": "[role:evaluator][account:control_plane][session:s20260629t120552z][host:b7c2d9c80c1c][item:l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1]",
+    "metrics_rows": [],
+    "metrics_exempt_reason": "evidence_only_decoder_evidence",
+    "queue_item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+    "session_id": "s20260629t120552z",
+    "status": "ok",
+    "summary": "2/2 commands succeeded"
+  },
+  "handoff": {
+    "branch": "eval/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/s20260629t120552z",
+    "pr_title": "eval: run llama7b mixed/int8 quality energy frontier",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "pr_body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260629t120552z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1"
+    },
+    "identity_block_format": "[role:evaluator][account:<evaluator_id>][session:<session_id>][host:<host>][item:<queue_item_id>]"
+  },
+  "item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+  "version": 0.1,
+  "platform": "nangate45",
+  "priority": 1,
+  "created_utc": "2026-06-29T12:05:33.214107Z",
+  "requested_by": "@codex",
+  "developer_loop": {
+    "comparison": {
+      "role": "quality_energy_frontier",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "qkv8_float_exact is quality-backed but not physically composed; score32/PWL rows have PPA but fail quality. This audit chooses the next measured wrapper direction.",
+      "expected_direction": "select_quality_backed_softmax_measurement"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_mixed_int8_quality_energy_frontier"
+    },
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json"
+  },
+  "source_requirement": {
+    "repo": "",
+    "reason": "evaluator runtime must contain the queued job source commit",
+    "version": 1,
+    "required_ref": "origin/master",
+    "required_sha": "aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2",
+    "requires_daemon_restart": true
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/pr_body.md
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/pr_body.md
@@ -1,0 +1,40 @@
+## Summary
+- item_id: `l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1`
+- run_key: `l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1_run_f98c514043c1cafa`
+- layer: `layer2`
+- task_type: `l2_campaign`
+- status: `ok`
+- summary: `2/2 commands succeeded`
+- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/evaluated.json`
+- metrics_rows_count: `0`
+- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json`
+
+## Developer Context
+- proposal_id: `prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1`
+- proposal_path: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json`
+- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
+- execution_source_commit: `aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2`
+- review_metadata_source_commit: `aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2`
+
+## Evaluation Mode
+- evaluation_mode: `frontier_detail`
+- abstraction_layer: `decoder_attention_mixed_int8_quality_energy_frontier`
+- comparison_role: `quality_energy_frontier`
+- expected_direction: `select_quality_backed_softmax_measurement`
+- expected_reason: `qkv8_float_exact is quality-backed but not physically composed; score32/PWL rows have PPA but fail quality. This audit chooses the next measured wrapper direction.`
+- expectation_status: `unspecified`
+- evaluation_summary: `Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.`
+
+## Focused Comparison
+- primary_question: `Which measured hardware evidence can safely support the quality-backed mixed/int8 Llama7B frontier after fixed-point/PWL softmax failed quality?`
+- comparison_role: `quality_energy_frontier`
+- proposal_outcome: `mixed_int8_quality_energy_frontier_composed_measurement_required`
+- comparison_summary: `Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.`
+- baseline_ref: `None`
+- baseline_item_id: `None`
+
+## Checklist
+- [ ] Commit lightweight campaign artifacts only
+- [ ] Include metrics row references in result.metrics_rows
+- [ ] Keep committed result_path fields repo-portable
+- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing

--- a/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/review_package.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/review_package.json
@@ -1,0 +1,186 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-06-29T12:05:54.126278Z",
+  "control_plane_source_commit": "aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2",
+  "review_metadata_source_commit": "aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2",
+  "item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+  "run_key": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1_run_f98c514043c1cafa",
+  "layer": "layer2",
+  "flow": "openroad",
+  "task_type": "l2_campaign",
+  "source_commit": "aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2",
+  "queue_snapshot": {
+    "path": "control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/evaluated.json",
+    "result": {
+      "branch": "eval/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/s20260629t120552z",
+      "completed_utc": "2026-06-29T12:05:51.625568Z",
+      "evaluator_id": "control_plane",
+      "executor": "@control_plane",
+      "host": "b7c2d9c80c1c",
+      "identity_block": "[role:evaluator][account:control_plane][session:s20260629t120552z][host:b7c2d9c80c1c][item:l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1]",
+      "metrics_rows": [],
+      "metrics_exempt_reason": "evidence_only_decoder_evidence",
+      "queue_item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+      "session_id": "s20260629t120552z",
+      "status": "ok",
+      "summary": "2/2 commands succeeded"
+    }
+  },
+  "review_artifact": {
+    "kind": "decision_proposal",
+    "path": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+    "storage_mode": "repo",
+    "sha256": "54ac5057f8a8f177530b91cbf31d4892a4cd744bcb491dfca9c03592ed30c9ec",
+    "payload": {
+      "version": 0.1,
+      "generated_utc": "2026-06-29T12:05:52.214261Z",
+      "item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+      "run_key": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1_run_f98c514043c1cafa",
+      "layer": "layer2",
+      "flow": "openroad",
+      "platform": "nangate45",
+      "task_type": "l2_campaign",
+      "source_commit": "aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2",
+      "review_metadata_source_commit": "aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2",
+      "objective": "Audit the current quality-backed mixed/int8 energy frontier and decide the next composed softmax measurement after score32/PWL softmax failed quality.",
+      "input_manifest": {
+        "decoder_contract": {
+          "attention_fp16_softmax_nm1_metrics": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv",
+          "attention_fp16_softmax_nm2_metrics": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/metrics.csv",
+          "attention_mixed_int8_quality_backed_frontier": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+          "attention_mixed_int8_score_precision_recovery": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2.json",
+          "attention_score32_w16_exact_div_physical_recost": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json",
+          "attention_mixed_int8_quality_energy_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+          "attention_mixed_int8_quality_energy_frontier_scope": "Audit the current quality-backed mixed/int8 frontier after corrected score precision. Keep qkv8_float_exact as the only passing quality point, retain score32/exact-div PPA as non-quality-backed diagnostics, and use measured FP16 softmax rows to decide whether a composed q8/k8/v8 plus floating/near-exact softmax wrapper should be measured next.",
+          "attention_mixed_int8_quality_energy_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.md",
+          "attention_score32_w16_exact_div_split2_physical_recost": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1.json"
+        }
+      },
+      "recommendation": {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+        "arch_id": "decoder_attention_mixed_int8_quality_energy_frontier",
+        "macro_mode": "evidence_only",
+        "outcome": "mixed_int8_quality_energy_frontier_composed_measurement_required"
+      },
+      "objective_profiles": [],
+      "evaluation_record": {
+        "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+        "title": "Llama7B mixed/int8 quality-backed energy frontier",
+        "primary_question": "Which measured hardware evidence can safely support the quality-backed mixed/int8 Llama7B frontier after fixed-point/PWL softmax failed quality?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "quality_energy_frontier",
+        "abstraction_layer": "decoder_attention_mixed_int8_quality_energy_frontier",
+        "expected_direction": "select_quality_backed_softmax_measurement",
+        "expected_reason": "qkv8_float_exact is quality-backed but not physically composed; score32/PWL rows have PPA but fail quality. This audit chooses the next measured wrapper direction.",
+        "summary": "Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.",
+        "outcome": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+        "expectation_status": "unspecified"
+      },
+      "proposal_assessment": {
+        "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+        "title": "Llama7B mixed/int8 quality-backed energy frontier",
+        "kind": "architecture",
+        "primary_question": "Which measured hardware evidence can safely support the quality-backed mixed/int8 Llama7B frontier after fixed-point/PWL softmax failed quality?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "quality_energy_frontier",
+        "outcome": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+        "summary": "Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.",
+        "baseline_ref": null,
+        "baseline_item_id": null,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+        "decoder_quality": {
+          "diagnosis": {
+            "best_fp16_softmax_proxy_candidate_id": "qkv8_float_exact_fp16_softmax_nm2_proxy",
+            "best_fp16_softmax_proxy_critical_path_ns": 5.476841177082706,
+            "best_fp16_softmax_proxy_die_area_um2": 2250000.0,
+            "best_fp16_softmax_proxy_total_power_mw": 0.189074,
+            "decision": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+            "non_quality_backed_measured_recost_count": 2,
+            "q24_pwl_top1_match_rate": 0.96875,
+            "quality_best_candidate_id": "qkv8_float_exact",
+            "quality_best_top1_match_rate": 1.0,
+            "recommended_next_step": "Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.",
+            "score32_top1_match_rate": 0.984375
+          },
+          "assumptions": [
+            "qkv8_float_exact is the only broad native attention-shadow passing mixed/int8 candidate.",
+            "FP16 softmax metrics are measured hardware rows but not yet a composed q8/k8/v8 attention wrapper.",
+            "Score32 exact-div and PWL recosts are retained as measured diagnostic rows but are not quality-backed."
+          ]
+        }
+      },
+      "source_refs": {
+        "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+        "decoder_attention_mixed_int8_quality_energy_frontier_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+        "decoder_attention_mixed_int8_quality_energy_frontier_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.md"
+      },
+      "decoder_quality": {
+        "diagnosis": {
+          "best_fp16_softmax_proxy_candidate_id": "qkv8_float_exact_fp16_softmax_nm2_proxy",
+          "best_fp16_softmax_proxy_critical_path_ns": 5.476841177082706,
+          "best_fp16_softmax_proxy_die_area_um2": 2250000.0,
+          "best_fp16_softmax_proxy_total_power_mw": 0.189074,
+          "decision": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+          "non_quality_backed_measured_recost_count": 2,
+          "q24_pwl_top1_match_rate": 0.96875,
+          "quality_best_candidate_id": "qkv8_float_exact",
+          "quality_best_top1_match_rate": 1.0,
+          "recommended_next_step": "Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.",
+          "score32_top1_match_rate": 0.984375
+        },
+        "assumptions": [
+          "qkv8_float_exact is the only broad native attention-shadow passing mixed/int8 candidate.",
+          "FP16 softmax metrics are measured hardware rows but not yet a composed q8/k8/v8 attention wrapper.",
+          "Score32 exact-div and PWL recosts are retained as measured diagnostic rows but are not quality-backed."
+        ]
+      }
+    }
+  },
+  "developer_loop": {
+    "comparison": {
+      "role": "quality_energy_frontier",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "qkv8_float_exact is quality-backed but not physically composed; score32/PWL rows have PPA but fail quality. This audit chooses the next measured wrapper direction.",
+      "expected_direction": "select_quality_backed_softmax_measurement"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_mixed_int8_quality_energy_frontier"
+    },
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json"
+  },
+  "submission_history": null,
+  "pr_payload": {
+    "branch": "eval/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/s20260629t120552z",
+    "title": "eval: run llama7b mixed/int8 quality energy frontier",
+    "body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260629t120552z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1"
+    },
+    "body_md": "## Summary\n- item_id: `l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1`\n- run_key: `l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1_run_f98c514043c1cafa`\n- layer: `layer2`\n- task_type: `l2_campaign`\n- status: `ok`\n- summary: `2/2 commands succeeded`\n- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/evaluated.json`\n- metrics_rows_count: `0`\n- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json`\n\n## Developer Context\n- proposal_id: `prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1`\n- proposal_path: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json`\n- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`\n- execution_source_commit: `aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2`\n- review_metadata_source_commit: `aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2`\n\n## Evaluation Mode\n- evaluation_mode: `frontier_detail`\n- abstraction_layer: `decoder_attention_mixed_int8_quality_energy_frontier`\n- comparison_role: `quality_energy_frontier`\n- expected_direction: `select_quality_backed_softmax_measurement`\n- expected_reason: `qkv8_float_exact is quality-backed but not physically composed; score32/PWL rows have PPA but fail quality. This audit chooses the next measured wrapper direction.`\n- expectation_status: `unspecified`\n- evaluation_summary: `Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.`\n\n## Focused Comparison\n- primary_question: `Which measured hardware evidence can safely support the quality-backed mixed/int8 Llama7B frontier after fixed-point/PWL softmax failed quality?`\n- comparison_role: `quality_energy_frontier`\n- proposal_outcome: `mixed_int8_quality_energy_frontier_composed_measurement_required`\n- comparison_summary: `Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.`\n- baseline_ref: `None`\n- baseline_item_id: `None`\n\n## Checklist\n- [ ] Commit lightweight campaign artifacts only\n- [ ] Include metrics row references in result.metrics_rows\n- [ ] Keep committed result_path fields repo-portable\n- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing\n",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ]
+  }
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json
@@ -1,0 +1,154 @@
+{
+  "assumptions": [
+    "qkv8_float_exact is the only broad native attention-shadow passing mixed/int8 candidate.",
+    "FP16 softmax metrics are measured hardware rows but not yet a composed q8/k8/v8 attention wrapper.",
+    "Score32 exact-div and PWL recosts are retained as measured diagnostic rows but are not quality-backed."
+  ],
+  "best_fp16_softmax_proxy_candidate": {
+    "candidate_id": "qkv8_float_exact_fp16_softmax_nm2_proxy",
+    "composition_status": "measured_softmax_only_not_composed_attention_wrapper",
+    "quality_backed": true,
+    "quality_source": "qkv8_float_exact",
+    "softmax_metrics": {
+      "critical_path_ns": 5.476841177082706,
+      "design": "npu_fp16_cpp_nm2_softmaxcmp",
+      "die_area_um2": 2250000.0,
+      "instance_area_um2": 0.0,
+      "path": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/metrics.csv",
+      "status": "ok",
+      "stdcell_area_um2": 0.0,
+      "stdcell_count": 0.0,
+      "total_power_mw": 0.189074
+    }
+  },
+  "decision": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+  "diagnosis": {
+    "best_fp16_softmax_proxy_candidate_id": "qkv8_float_exact_fp16_softmax_nm2_proxy",
+    "best_fp16_softmax_proxy_critical_path_ns": 5.476841177082706,
+    "best_fp16_softmax_proxy_die_area_um2": 2250000.0,
+    "best_fp16_softmax_proxy_total_power_mw": 0.189074,
+    "decision": "mixed_int8_quality_energy_frontier_composed_measurement_required",
+    "non_quality_backed_measured_recost_count": 2,
+    "q24_pwl_top1_match_rate": 0.96875,
+    "quality_best_candidate_id": "qkv8_float_exact",
+    "quality_best_top1_match_rate": 1.0,
+    "recommended_next_step": "Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.",
+    "score32_top1_match_rate": 0.984375
+  },
+  "fp16_softmax_proxy_candidates": [
+    {
+      "candidate_id": "qkv8_float_exact_fp16_softmax_nm1_proxy",
+      "composition_status": "measured_softmax_only_not_composed_attention_wrapper",
+      "quality_backed": true,
+      "quality_source": "qkv8_float_exact",
+      "softmax_metrics": {
+        "critical_path_ns": 5.690256573668907,
+        "design": "npu_fp16_cpp_nm1_softmaxcmp",
+        "die_area_um2": 2250000.0,
+        "instance_area_um2": 0.0,
+        "path": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv",
+        "status": "ok",
+        "stdcell_area_um2": 0.0,
+        "stdcell_count": 0.0,
+        "total_power_mw": 0.184588
+      }
+    },
+    {
+      "candidate_id": "qkv8_float_exact_fp16_softmax_nm2_proxy",
+      "composition_status": "measured_softmax_only_not_composed_attention_wrapper",
+      "quality_backed": true,
+      "quality_source": "qkv8_float_exact",
+      "softmax_metrics": {
+        "critical_path_ns": 5.476841177082706,
+        "design": "npu_fp16_cpp_nm2_softmaxcmp",
+        "die_area_um2": 2250000.0,
+        "instance_area_um2": 0.0,
+        "path": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/metrics.csv",
+        "status": "ok",
+        "stdcell_area_um2": 0.0,
+        "stdcell_count": 0.0,
+        "total_power_mw": 0.189074
+      }
+    }
+  ],
+  "inputs": {
+    "exact_div_recost_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json",
+    "exact_div_split2_recost_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1.json",
+    "fp16_softmax_nm1_metrics": "runs/designs/npu_blocks/npu_fp16_cpp_nm1_softmaxcmp/metrics.csv",
+    "fp16_softmax_nm2_metrics": "runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/metrics.csv",
+    "quality_backed_frontier_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+    "score_precision_recovery_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score_precision_recovery__l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1_r2.json"
+  },
+  "measured_non_quality_backed_recosts": [
+    {
+      "best_feasible_latency_us": 9636.7536,
+      "decision": "dual_stream_feasible",
+      "label": "score32_w16_exact_div",
+      "precision_profile": "q8_k8_v8_a32_s32_w16_exact_div_int8_compute",
+      "quality_backed": false,
+      "quality_blocker": "score32 fixed-point/PWL candidates did not pass broad native attention-shadow gate",
+      "replica_recost_area_fit_replica_count": 801,
+      "replica_recost_compute_area_um2": 399091842.0,
+      "replica_recost_compute_power_mw": 9051.3,
+      "replica_recost_latency_us": 9636.7536,
+      "replica_recost_macs_per_cycle": 102528,
+      "substituted_compute_arch": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div"
+    },
+    {
+      "best_feasible_latency_us": 13187.938061,
+      "decision": "dual_stream_feasible",
+      "label": "score32_w16_exact_div_split2",
+      "precision_profile": "q8_k8_v8_a32_s32_w16_exact_div_int8_compute",
+      "quality_backed": false,
+      "quality_blocker": "score32 fixed-point/PWL candidates did not pass broad native attention-shadow gate",
+      "replica_recost_area_fit_replica_count": 745,
+      "replica_recost_compute_area_um2": 399282750.0,
+      "replica_recost_compute_power_mw": 12814.0,
+      "replica_recost_latency_us": 13187.938061,
+      "replica_recost_macs_per_cycle": 95360,
+      "substituted_compute_arch": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2"
+    }
+  ],
+  "model": "llm_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
+  "quality_gate": {
+    "qkv8_float_exact": {
+      "candidate_id": "qkv8_float_exact",
+      "mean_probability_kl": 0.0012425925766148221,
+      "quality_backed": true,
+      "top1_match_rate": 1.0
+    },
+    "qkv8_q24_pwl_recip_q24_bucket8": {
+      "candidate_id": "qkv8_q24_pwl_recip_q24_bucket8",
+      "comparison_count": 64,
+      "decision_status": "mixed_int8_native_attention_shadow_hold",
+      "k_bits": 8,
+      "max_abs_logit_delta_max": 3.625,
+      "mean_logit_cosine": 0.9989974107757253,
+      "mean_probability_kl": 0.013176719152554741,
+      "q_bits": 8,
+      "score_bits": 24,
+      "softmax_mode": "pwl_recip_lut_q24_bucket8",
+      "top1_match_rate": 0.96875,
+      "topk_contains_rate": 1.0,
+      "v_bits": 8,
+      "weight_bits": 24
+    },
+    "score32_float": {
+      "candidate_id": "score32_float",
+      "comparison_count": 64,
+      "decision_status": "mixed_int8_native_attention_shadow_hold",
+      "k_bits": 8,
+      "max_abs_logit_delta_max": 0.6875,
+      "mean_logit_cosine": 0.9998751206989908,
+      "mean_probability_kl": 0.0017210117614710435,
+      "q_bits": 8,
+      "score_bits": 32,
+      "softmax_mode": "float_quantized",
+      "top1_match_rate": 0.984375,
+      "topk_contains_rate": 1.0,
+      "v_bits": 8,
+      "weight_bits": 16
+    }
+  },
+  "version": 1
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.md
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.md
@@ -1,0 +1,15 @@
+# Mixed-Int8 Quality/Energy Frontier Audit
+
+- decision: `mixed_int8_quality_energy_frontier_composed_measurement_required`
+- quality_best_candidate_id: `qkv8_float_exact`
+- quality_best_top1_match_rate: `1.0`
+- score32_top1_match_rate: `0.984375`
+- q24_pwl_top1_match_rate: `0.96875`
+- best_fp16_softmax_proxy_candidate_id: `qkv8_float_exact_fp16_softmax_nm2_proxy`
+- best_fp16_softmax_proxy_critical_path_ns: `5.476841177082706`
+- best_fp16_softmax_proxy_die_area_um2: `2250000.0`
+- best_fp16_softmax_proxy_total_power_mw: `0.189074`
+
+## Recommendation
+
+Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.


### PR DESCRIPTION
## Summary
- item_id: `l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1`
- run_key: `l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1_run_f98c514043c1cafa`
- layer: `layer2`
- task_type: `l2_campaign`
- status: `ok`
- summary: `2/2 commands succeeded`
- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/evaluated.json`
- metrics_rows_count: `0`
- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json`

## Developer Context
- proposal_id: `prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1`
- proposal_path: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json`
- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
- execution_source_commit: `aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2`
- review_metadata_source_commit: `aee481ec8ebcf4cb07ee75b731ffdb48994c9aa2`

## Evaluation Mode
- evaluation_mode: `frontier_detail`
- abstraction_layer: `decoder_attention_mixed_int8_quality_energy_frontier`
- comparison_role: `quality_energy_frontier`
- expected_direction: `select_quality_backed_softmax_measurement`
- expected_reason: `qkv8_float_exact is quality-backed but not physically composed; score32/PWL rows have PPA but fail quality. This audit chooses the next measured wrapper direction.`
- expectation_status: `unspecified`
- evaluation_summary: `Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.`

## Focused Comparison
- primary_question: `Which measured hardware evidence can safely support the quality-backed mixed/int8 Llama7B frontier after fixed-point/PWL softmax failed quality?`
- comparison_role: `quality_energy_frontier`
- proposal_outcome: `mixed_int8_quality_energy_frontier_composed_measurement_required`
- comparison_summary: `Decoder mixed/int8 quality/energy frontier evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json: decision=mixed_int8_quality_energy_frontier_composed_measurement_required; quality_best_candidate_id=qkv8_float_exact; quality_best_top1_match_rate=1.0; score32_top1_match_rate=0.984375; q24_pwl_top1_match_rate=0.96875; best_fp16_softmax_proxy_candidate_id=qkv8_float_exact_fp16_softmax_nm2_proxy; best_fp16_softmax_proxy_critical_path_ns=5.476841177082706; best_fp16_softmax_proxy_die_area_um2=2250000.0; best_fp16_softmax_proxy_total_power_mw=0.189074; non_quality_backed_measured_recost_count=2; recommended_next_step=Measure a composed q8/k8/v8 attention wrapper that keeps qkv8_float_exact quality semantics and substitutes a floating/near-exact softmax datapath; do not rank score32 exact-div or PWL rows as quality-backed frontier points.`
- baseline_ref: `None`
- baseline_item_id: `None`

## Checklist
- [ ] Commit lightweight campaign artifacts only
- [ ] Include metrics row references in result.metrics_rows
- [ ] Keep committed result_path fields repo-portable
- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing
