### PR TITLE
npu: add score24 w16 exact-div composed attention point

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_v1/evaluation_requests.json
@@ -1,0 +1,32 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_v1",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the q8/k8/v8/a24/s24/w16 exact-divider composed dual-stream attention datapath as the closest local wrapper to the qkv8_float_exact quality-backed frontier.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score24_near_exact_quality_recost",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score24_w16_exact_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/timing_debug_report.md"
+      ],
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+        "l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1"
+      ],
+      "expected_result": {
+        "direction": "measure_score24_near_exact_quality_recost_datapath",
+        "reason": "The merged quality/energy frontier audit selected qkv8_float_exact as the only passing mixed/int8 point and requested a composed q8/k8/v8 near-exact softmax wrapper measurement."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_v1",
+  "created_utc": "2026-06-29T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Composed dual-stream attention score24/w16 exact-div datapath",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The current quality-backed mixed/int8 frontier only passes qkv8_float_exact, whose native attention quality control uses q8/k8/v8 with 24-bit scores and 16-bit softmax weights. Measuring a concrete q8/k8/v8 score24/w16 exact-divider composed wrapper removes the nearest local datapath PPA abstraction before a full Llama7B system recost.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 PPA cost is paid by a q8/k8/v8/a24/s24/w16 exact-divider composed dual-stream attention wrapper, and how does it compare to the prior score32/w16 exact-divider wrapper?",
+    "baseline": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+    "candidate": "l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_ppa_v1",
+    "include": [
+      "generate RTL with mac_accum_bits=24",
+      "generate softmax_score_bits=24 and softmax_weight_bits=16",
+      "generate value_bits=8",
+      "run the composed datapath guard before OpenROAD",
+      "measure Nangate45 area, power, timing, and timing debug paths"
+    ],
+    "exclude": [
+      "new native checkpoint quality run",
+      "full floating-point exp softmax hardware",
+      "Llama7B system-level frontier recost"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This RTL is an exact-divider integer softmax wrapper, not full floating exp/div softmax.",
+    "The job measures the local composed datapath only; a dependent Layer 2 job must substitute measured PPA into the Llama7B schedule.",
+    "Quality backing comes from qkv8_float_exact native attention-shadow evidence; score24 exact-divider RTL quality remains a later equivalence/quality check if this PPA point is promising."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the q8/k8/v8/a24/s24/w16 exact-divider composed dual-stream attention datapath as the closest local wrapper to the qkv8_float_exact quality-backed frontier.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score24_near_exact_quality_recost",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score24_w16_exact_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_score24_near_exact_quality_recost_datapath",
+        "reason": "The merged quality/energy frontier audit selected qkv8_float_exact as the only passing mixed/int8 point and requested a composed q8/k8/v8 near-exact softmax wrapper measurement."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score24_w16_exact_div.json"
+  ],
+  "knowledge_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_v1/proposal.json"
+  ]
+}

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -802,19 +802,14 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     total_macs = streams * macs_per_stream
     softmax_score_row_width = row_elems * softmax_score_bits
     softmax_weight_row_width = row_elems * softmax_weight_bits
-    softmax_name = (
-        "attention_softmax_weight_q12_pwl_recip_like"
-        if softmax_impl == "pwl_recip_lut"
-        else (
-            f"attention_softmax_weight_score32_w16_recip_lut_q{reciprocal_bits}_like"
-            if softmax_score_bits == 32 and softmax_weight_bits == 16 and softmax_impl == "recip_lut"
-            else (
-            "attention_softmax_weight_score32_w16_exact_div_like"
-            if softmax_score_bits == 32 and softmax_weight_bits == 16 and softmax_impl == "exact_div"
-            else "attention_softmax_weight_int8_r8_acc24_recip_q10_like"
-            )
-        )
-    )
+    if softmax_impl == "pwl_recip_lut":
+        softmax_name = "attention_softmax_weight_q12_pwl_recip_like"
+    elif softmax_impl == "exact_div" and (softmax_score_bits, softmax_weight_bits) != (8, 8):
+        softmax_name = f"attention_softmax_weight_score{softmax_score_bits}_w{softmax_weight_bits}_exact_div_like"
+    elif softmax_impl == "recip_lut" and (softmax_score_bits, softmax_weight_bits) == (32, 16):
+        softmax_name = f"attention_softmax_weight_score32_w16_recip_lut_q{reciprocal_bits}_like"
+    else:
+        softmax_name = "attention_softmax_weight_int8_r8_acc24_recip_q10_like"
     value_name = f"attention_full_value_stream_q8v{value_bits}_p8_ppc2"
 
     stream_regs = [f"  reg [{stream_buffer_bits - 1}:0] stream_buf_{stream};" for stream in range(streams)]

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score24_w16_exact_div.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score24_w16_exact_div.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_score24_w16_exact_div"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_score24_w16_exact_div"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_score24_w16_exact_div_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_score24_w16_exact_div"
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/config.json
@@ -1,0 +1,24 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "mac_accum_bits": 24,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 24,
+    "softmax_weight_bits": 16,
+    "softmax_accum_bits": 32,
+    "reciprocal_bits": 16,
+    "value_bits": 8,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_internal_pipeline_stages": 1,
+    "softmax_impl": "exact_div"
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -16,6 +16,7 @@ def _write_config(
     softmax_score_bits: int | None = None,
     softmax_weight_bits: int | None = None,
     reciprocal_bits: int | None = None,
+    value_bits: int | None = None,
     softmax_input_frac_bits: int | None = None,
     softmax_reciprocal_lut_bucket_shift: int | None = None,
 ) -> None:
@@ -51,6 +52,8 @@ def _write_config(
         comp["softmax_weight_bits"] = softmax_weight_bits
     if reciprocal_bits is not None:
         comp["reciprocal_bits"] = reciprocal_bits
+    if value_bits is not None:
+        comp["value_bits"] = value_bits
     if softmax_input_frac_bits is not None:
         comp["softmax_input_frac_bits"] = softmax_input_frac_bits
     if softmax_reciprocal_lut_bucket_shift is not None:
@@ -305,6 +308,39 @@ def test_attention_dual_stream_composed_generator_score32_exact_softmax(tmp_path
     assert "wire [31:0] score_lane_00" in top_text
     assert "wire [63:0] softmax_weights" in top_text
     assert "input  wire [31:0] score_mix" in top_text
+
+
+def test_attention_dual_stream_composed_generator_score24_w16_exact_softmax(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_score24_w16"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="exact_div",
+        mac_accum_bits=24,
+        softmax_accum_bits=32,
+        softmax_score_bits=24,
+        softmax_weight_bits=16,
+        value_bits=8,
+        softmax_internal_pipeline_stages=1,
+    )
+    top_text = _generate_and_check(design_dir, config_path, run_composed_guard=False)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["mac_accum_bits"] == 24
+    assert manifest["mac_module"] == "int8_mac_s8s8_acc24"
+    assert manifest["softmax_score_bits"] == 24
+    assert manifest["softmax_weight_bits"] == 16
+    assert manifest["value_bits"] == 8
+    assert manifest["score_mix_bits"] == 24
+    assert manifest["score_bits_source"] == "mac_acc24_native"
+    assert "module int8_mac_s8s8_acc24" in top_text
+    assert "module attention_softmax_weight_score24_w16_exact_div_like" in top_text
+    assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
+    assert "wire signed [23:0] mac_c_0000" in top_text
+    assert "wire [23:0] score_lane_00" in top_text
+    assert "wire [63:0] softmax_weights" in top_text
+    assert "input  wire [23:0] score_mix" in top_text
 
 
 def test_attention_dual_stream_composed_generator_score32_softmax_requires_acc32(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a q8/k8/v8 score24/w16 exact-divider composed dual-stream attention design point
- add the corresponding Nangate45 hierarchical sweep and L1 proposal/request
- name non-default exact-div softmax modules by their actual score/weight widths so `SYNTH_KEEP_MODULES` can preserve the score24/w16 block

## Why
The merged mixed/int8 quality-energy audit left `qkv8_float_exact` as the only quality-backed point and recommended measuring a composed q8/k8/v8 near-exact softmax wrapper. This adds the closest existing-generator L1 PPA point before a Layer 2 Llama7B recost.

## Validation
- generated RTL from the new config and checked the manifest/module names
- `python3 -m pytest tests/test_attention_dual_stream_composed_generator.py -k 'score24_w16 or score32_exact' -q`
- `PYTHONPATH=control_plane python3 scripts/validate_runs.py --skip_eval_queue`
