### PR TITLE
control_plane: add score24 w16 composed recost

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1141,6 +1141,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         "llm_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
         "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
         "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
+        "llm_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1",
@@ -1159,6 +1160,8 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             if model == "llm_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1"
             else "Decoder composed dual-stream physical feasibility evidence (softmax-recip LUT variant frontier)"
             if model == "llm_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1"
+            else "Decoder composed dual-stream physical feasibility evidence (score24/w16 exact-div reduced-replica recost)"
+            if model == "llm_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1"
             else "Decoder composed dual-stream physical feasibility evidence (score32/w16 exact-div frontier)"
             if model == "llm_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1"
             else "Decoder composed dual-stream physical feasibility evidence (score32/w16 exact-div reduced-replica recost)"

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5451,6 +5451,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         "attention_softmax_weight_int8_r8_acc24_recip_q10_wrapper/metrics.csv"
     )
     q12_pwl_frontier = "q12_pwl_softmax_frontier" in item_id
+    score24_reduced_replica = "score24_w16_exact_div_reduced_replica" in item_id
     score32_split2_reduced_replica = "score32_w16_exact_div_split2_reduced_replica" in item_id
     score32_reduced_replica = "score32_w16_exact_div_reduced_replica" in item_id
     score32_recip_lut_q16_reduced_replica = "score32_w16_recip_lut_q16_reduced_replica" in item_id
@@ -5460,7 +5461,12 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         "runs/designs/npu_blocks/"
         "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10/metrics.csv"
     )
-    if score32_split2_reduced_replica:
+    if score24_reduced_replica:
+        composed_dual_stream_metrics = (
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/metrics.csv"
+        )
+    elif score32_split2_reduced_replica:
         composed_dual_stream_metrics = (
             "runs/designs/npu_blocks/"
             "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/metrics.csv"
@@ -5493,7 +5499,10 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         f"--composed-dual-stream-metrics {path}"
         for path in composed_dual_stream_metrics.split(",")
     )
-    if score32_split2_reduced_replica:
+    if score24_reduced_replica:
+        model_name = "llm_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1"
+        precision_profile = "q8_k8_v8_a24_s24_w16_exact_div_int8_compute"
+    elif score32_split2_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a32_s32_w16_exact_div_int8_compute"
     elif score32_recip_lut_q16_reduced_replica:
@@ -5541,7 +5550,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
                     f"--quality-gate-json {quality_gate} "
                     f"--precision-profile {precision_profile} "
                     f"--model-name {model_name} "
-                    f"{'--recompute-area-fit-replicas ' if score32_reduced_replica or score32_split2_reduced_replica or score32_recip_lut_q16_reduced_replica else ''}"
+                    f"{'--recompute-area-fit-replicas ' if score24_reduced_replica or score32_reduced_replica or score32_split2_reduced_replica or score32_recip_lut_q16_reduced_replica else ''}"
                     "--frontier-row-limit 8 "
                     "--buffer-area-um2-per-byte 0.0 "
                     f"--out {out} "

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -2144,6 +2144,31 @@ def test_decoder_evidence_summary_recognizes_composed_datapath_score32_reduced_r
     assert "best_requested_replica_recost_latency_us=10100.0" in summary
 
 
+def test_decoder_evidence_summary_recognizes_composed_datapath_score24_reduced_replica_model() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/composed_datapath_score24_reduced_replica.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1",
+            "diagnosis": {
+                "decision": "dual_stream_feasible",
+                "precision_profile": "q8_k8_v8_a24_s24_w16_exact_div_int8_compute",
+                "best_requested_mode": "dual_mac",
+                "best_requested_replica_recost_enabled": True,
+                "best_requested_replica_recost_area_fit_replica_count": 900,
+                "best_requested_replica_recost_macs_per_cycle": 115200,
+                "best_requested_replica_recost_latency_us": 8800.0,
+                "best_feasible_latency_us": 8800.0,
+            },
+        },
+    )
+
+    assert outcome == "dual_stream_feasible"
+    assert "score24/w16 exact-div reduced-replica recost" in summary
+    assert "precision_profile=q8_k8_v8_a24_s24_w16_exact_div_int8_compute" in summary
+    assert "best_requested_replica_recost_area_fit_replica_count=900" in summary
+    assert "best_requested_replica_recost_latency_us=8800.0" in summary
+
+
 def test_decoder_evidence_summary_recognizes_composed_datapath_score32_split2_reduced_replica_model() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/composed_datapath_score32_split2_reduced_replica.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6242,6 +6242,59 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_redu
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_reduced_replica_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1"
+                in run
+            )
+            assert "--recompute-area-fit-replicas" in run
+            assert "--precision-profile q8_k8_v8_a24_s24_w16_exact_div_int8_compute" in run
+            assert decoder_inputs["attention_kv_composed_dual_stream_metrics"] == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/metrics.csv"
+            )
+            assert (
+                "--composed-dual-stream-metrics runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/metrics.csv "
+                in run
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_recip_lut_q16_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds score24/w16 reduced-replica recost support and should wait until the score24/w16 L1 PPA item is merged.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the measured q8/k8/v8 score24/w16 exact-div composed dual-stream attention wrapper at the area-fit replica count and measured wrapper clock.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score24_quality_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score24_area_fit_recost",
+        "reason": "The mixed/int8 quality-energy frontier selected qkv8_float_exact as the only quality-backed point; this substitutes the closest measured score24/w16 q8/k8/v8 wrapper into the Llama7B schedule."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_v1",
+  "created_utc": "2026-06-29T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score24/w16 exact-div composed datapath reduced-replica recost",
+  "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+  "hypothesis": "The measured q8/k8/v8 score24/w16 exact-divider composed datapath may be a closer physical proxy for the quality-backed qkv8_float_exact frontier than the prior score32/w16 datapath. A reduced-replica recost will show the area-fit token throughput and energy direction before deeper quality or full-system closure work.",
+  "direct_comparison": {
+    "primary_question": "What Llama7B latency/area/energy point remains when the measured score24/w16 exact-div composed datapath is constrained to the area-fit replica count?",
+    "baseline": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+    "candidate": "l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1",
+    "include": [
+      "consume measured score24/w16 exact-div composed datapath metrics",
+      "use the existing Llama7B sub-tile schedule structure",
+      "reduce compute replicas to the measured-area budgeted count",
+      "recompute QKV, QK, value, tile service, layer, and total latency at the measured wrapper clock",
+      "compare against the prior score32/w16 exact-div reduced-replica recost"
+    ],
+    "exclude": [
+      "new native checkpoint quality run",
+      "new HBM/DRAM service model",
+      "new L1 datapath synthesis"
+    ],
+    "metrics": [
+      "decision",
+      "precision_profile",
+      "best_requested_replica_recost_area_fit_replica_count",
+      "best_requested_replica_recost_macs_per_cycle",
+      "best_requested_replica_recost_latency_us",
+      "best_requested_adjusted_speedup_vs_hbm_closed_source",
+      "best_feasible_latency_us"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the measured q8/k8/v8 score24/w16 exact-div composed dual-stream attention wrapper at the area-fit replica count and measured wrapper clock.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score24_quality_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score24_area_fit_recost",
+        "reason": "The mixed/int8 quality-energy frontier selected qkv8_float_exact as the only quality-backed point; this substitutes the closest measured score24/w16 q8/k8/v8 wrapper into the Llama7B schedule."
+      }
+    }
+  ],
+  "source_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2.json",
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py"
+  ],
+  "remaining_abstractions": [
+    "This recosts the existing analytic schedule rather than running a new end-to-end simulator.",
+    "HBM/SRAM/NoC service models are inherited unchanged from the upstream sub-tile schedule.",
+    "The measured exact-divider softmax structure is an integer near-exact wrapper, not full floating exp hardware.",
+    "Quality backing is inherited from qkv8_float_exact attention-shadow evidence; score24 exact-divider RTL quality should be checked if this PPA point is promising."
+  ]
+}


### PR DESCRIPTION
## Summary
- add L2 generator support for score24/w16 exact-div reduced-replica Llama7B recosts
- add result-consumer labeling for the score24/w16 composed datapath model
- add the dependent L2 proposal/request that waits on the score24/w16 L1 PPA result

## Why
The merged quality-energy audit selected `qkv8_float_exact` as the only quality-backed mixed/int8 point and requested a composed q8/k8/v8 near-exact softmax wrapper measurement. PR #1077 added the L1 score24/w16 wrapper; this prepares the L2 recost that will substitute its measured PPA into the Llama7B schedule after the L1 result merges.

## Validation
- `PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'score24_reduced_replica or score32_reduced_replica' -q`
- `PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -k 'score24_reduced_replica or score32_reduced_replica' -q`
- `PYTHONPATH=control_plane python3 scripts/validate_runs.py --skip_eval_queue`
