### PR TITLE
npu: label mixed int8 quality reports by candidate

### DIFF
--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
@@ -394,6 +394,40 @@ def _summarize_free_running_rows(rows: list[JsonDict], *, generation_steps: int,
     }
 
 
+def _candidate_label(summary: JsonDict) -> str:
+    candidate_id = str(summary.get("candidate_id") or "").strip()
+    if candidate_id:
+        return candidate_id.replace("_", " ")
+    score_bits = summary.get("score_bits")
+    weight_bits = summary.get("weight_bits")
+    softmax_mode = str(summary.get("softmax_mode") or "").strip()
+    parts: list[str] = []
+    if score_bits is not None:
+        parts.append(f"score{score_bits}")
+    if weight_bits is not None:
+        parts.append(f"w{weight_bits}")
+    if softmax_mode:
+        parts.append(softmax_mode.replace("_", " "))
+    return " ".join(parts) or "candidate"
+
+
+def _candidate_title_label(summary: JsonDict) -> str:
+    words: list[str] = []
+    for word in _candidate_label(summary).split():
+        lower = word.lower()
+        if lower in {"rtl", "pwl", "lut", "qkv"}:
+            words.append(lower.upper())
+        elif lower.startswith("q") and lower[1:].isdigit():
+            words.append(lower.upper())
+        elif lower.startswith("w") and lower[1:].isdigit():
+            words.append(lower.upper())
+        elif lower.startswith("score") and lower[5:].isdigit():
+            words.append("Score" + lower[5:])
+        else:
+            words.append(word.capitalize())
+    return " ".join(words)
+
+
 def _decision(summary: JsonDict, *, expected_gqa_group_size: int, actual_gqa_group_size: float) -> JsonDict:
     blockers: list[str] = []
     if expected_gqa_group_size > 0 and abs(actual_gqa_group_size - expected_gqa_group_size) > DIVISIBILITY_EPSILON:
@@ -413,8 +447,9 @@ def _decision(summary: JsonDict, *, expected_gqa_group_size: int, actual_gqa_gro
 
     if blockers:
         status = DECISION_HOLD
+        label = _candidate_label(summary)
         next_step = (
-            "Hold this score32 mixed/int8 generation candidate until a narrower score-precision boundary "
+            f"Hold this {label} mixed/int8 generation candidate until a narrower score-precision boundary "
             "demonstrates better free-running agreement."
         )
     else:
@@ -631,8 +666,10 @@ def build_payload(args: argparse.Namespace) -> JsonDict:
 
 
 def _write_report_md(payload: JsonDict) -> str:
+    primary_summary = payload["summary"]
+    label = _candidate_title_label(primary_summary)
     lines = [
-        "# Native-Checkpoint Mixed/Int8 Score32 Generation Quality",
+        f"# Native-Checkpoint Mixed/Int8 {label} Generation Quality",
         "",
         f"- model_id: `{payload['model']['model_id']}`",
         f"- decision: `{payload['decision']['status']}`",
@@ -675,7 +712,7 @@ def _write_report_md(payload: JsonDict) -> str:
             "",
             "- Teacher-forced rows compare against a non-quantized reference model.",
             "- Candidate applies LLaMA-style q/k/v projection quantization plus softmax approximation.",
-            "- Decision thresholds are conservative for score32-vs-reference drift in a bounded prompt sample.",
+            f"- Decision thresholds are conservative for {label}-vs-reference drift in a bounded prompt sample.",
         ]
     )
     return "\n".join(lines) + "\n"

--- a/tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
+++ b/tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
@@ -17,6 +17,7 @@ from npu.eval.evaluate_llm_decoder_model_native_mixed_int8_generation_quality im
     _resolve_candidates,
     _summarize_free_running_rows,
     _summarize_teacher_forced_rows,
+    _write_report_md,
 )
 from npu.eval import evaluate_llm_decoder_model_native_mixed_int8_attention as attention_eval
 
@@ -98,3 +99,41 @@ def test_default_candidates_resolves_score32_float() -> None:
     assert candidates[0].candidate_id == attention_eval._parse_candidate_spec(DEFAULT_CANDIDATE_SPEC).candidate_id
     assert candidates[0].score_bits == 32
     assert candidates[0].q_bits == 8
+
+
+def test_report_and_hold_message_use_primary_candidate_label() -> None:
+    summary = {
+        "candidate_id": "score24_w16_rtl_exact",
+        "score_bits": 24,
+        "weight_bits": 16,
+        "softmax_mode": "rtl_exact",
+        "teacher_forced_nll_delta_mean": 0.8,
+        "candidate_probability_assigned_to_reference_token_mean": 0.2,
+        "candidate_probability_assigned_to_reference_token_min": 0.01,
+        "free_running_match_rate": 0.5,
+        "decision_status": "mixed_int8_generation_quality_hold",
+        "free_running_first_divergence_step_mean": 0.5,
+    }
+    decision = _decision(summary, expected_gqa_group_size=4, actual_gqa_group_size=4.0)
+    summary["decision"] = decision
+    payload = {
+        "model": {"model_id": "test/model"},
+        "decision": decision,
+        "summary": summary,
+        "candidate_summaries": [summary],
+        "prompt_records": [
+            {
+                "candidate_id": "score24_w16_rtl_exact",
+                "prompt_index": 0,
+                "free_run_first_divergence_step": 0,
+                "free_run_match_count": 0,
+                "free_run_steps": 8,
+            }
+        ],
+    }
+
+    report = _write_report_md(payload)
+
+    assert "Hold this score24 w16 rtl exact mixed/int8 generation candidate" in decision["next_step"]
+    assert "# Native-Checkpoint Mixed/Int8 Score24 W16 RTL Exact Generation Quality" in report
+    assert "score32" not in report


### PR DESCRIPTION
## Summary
- derive mixed/int8 generation-quality hold messages from the primary candidate instead of hard-coded score32 wording
- label generated markdown reports with the primary candidate profile
- add a regression test for score24/w16 RTL-exact report text

## Tests
- PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py -q
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue