### PR TITLE
control_plane: add PWL reciprocal LUT boundary gate

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -539,6 +539,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_mixed_int8_softmax_replacement_generation_quality_report",
     ),
     (
+        "attention_pwl_recip_lut_boundary_out",
+        "attention_pwl_recip_lut_boundary_report",
+    ),
+    (
         "attention_mixed_int8_quality_backed_frontier_out",
         "attention_mixed_int8_quality_backed_frontier_report",
     ),
@@ -822,6 +826,45 @@ def _decoder_recommendation_override(
 
 def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, Any]) -> tuple[str, str]:
     model = str(evidence_payload.get("model", "")).strip()
+    if evidence_payload.get("estimator") == "attention_pwl_recip_lut_boundary_v1":
+        outcome = str(evidence_payload.get("decision") or "attention_pwl_recip_lut_boundary_recorded")
+        parts = [
+            f"Decoder attention PWL reciprocal-LUT boundary evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "candidate_count",
+            "reasonable_direct_lut_candidate_count",
+            "boundary_probe_candidate_count",
+            "blocked_direct_lut_candidate_count",
+        ):
+            if key in evidence_payload:
+                parts.append(f"{key}={evidence_payload.get(key)}")
+        rows = evidence_payload.get("candidate_rows")
+        if isinstance(rows, list):
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                candidate_id = str(row.get("candidate_id") or "").strip()
+                if candidate_id in {
+                    "qkv8_q12_pwl_recip_q12_bucket8",
+                    "qkv8_q20_pwl_recip_q20_bucket8",
+                    "qkv8_q24_pwl_recip_q24_bucket8",
+                }:
+                    parts.append(
+                        "{candidate_id}_cases={cases}".format(
+                            candidate_id=candidate_id,
+                            cases=row.get("reciprocal_case_count"),
+                        )
+                    )
+                    parts.append(
+                        "{candidate_id}_verdict={verdict}".format(
+                            candidate_id=candidate_id,
+                            verdict=row.get("direct_lut_verdict"),
+                        )
+                    )
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
     if evidence_payload.get("quality_gate") == "mixed_int8_attention_shadow" and isinstance(
         evidence_payload.get("decision"),
         dict,

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6925,6 +6925,47 @@ def _decoder_attention_mixed_int8_softmax_replacement_generation_quality_evidenc
     }
 
 
+def _decoder_attention_pwl_recip_lut_boundary_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    softmax_replacement_quality = (
+        f"{base}/decoder_attention_mixed_int8_softmax_replacement_generation_quality__"
+        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1.json"
+    )
+    score24_rtl_exact_quality = (
+        f"{base}/decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality__"
+        "l2_decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality_llama7b_v1_r2.json"
+    )
+    out = f"{base}/decoder_attention_pwl_recip_lut_boundary__{item_id}.json"
+    report = f"{base}/decoder_attention_pwl_recip_lut_boundary__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_mixed_int8_softmax_replacement_generation_quality": softmax_replacement_quality,
+            "attention_mixed_int8_score24_w16_rtl_exact_generation_quality": score24_rtl_exact_quality,
+            "attention_pwl_recip_lut_boundary_out": out,
+            "attention_pwl_recip_lut_boundary_report": report,
+            "attention_pwl_recip_lut_boundary_scope": (
+                "Estimate direct reciprocal-LUT case growth for the generation-passing q20/q24 "
+                "PWL softmax candidates before launching composed OpenROAD PPA."
+            ),
+        },
+        "commands": [
+            {
+                "name": "estimate_attention_pwl_recip_lut_boundary",
+                "run": (
+                    "python3 npu/eval/estimate_attention_pwl_recip_lut_boundary.py "
+                    "--candidate qkv8_q12_pwl_recip_q12_bucket8:s=12,w=12,r=12,bucket=8,row_elems=8,accum_bits=28 "
+                    "--candidate qkv8_q20_pwl_recip_q20_bucket8:s=20,w=20,r=20,bucket=8,row_elems=8,accum_bits=32 "
+                    "--candidate qkv8_q24_pwl_recip_q24_bucket8:s=24,w=24,r=24,bucket=8,row_elems=8,accum_bits=40 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_quality_backed_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     energy_closure = (
@@ -8934,6 +8975,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
         "decoder_attention_mixed_int8_softmax_replacement_generation_quality",
+        "decoder_attention_pwl_recip_lut_boundary",
         "decoder_attention_mixed_int8_quality_backed_frontier",
         "decoder_attention_mixed_int8_quality_energy_frontier",
         "decoder_attention_kv_dual_stream_physical_feasibility",
@@ -9162,6 +9204,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_mixed_int8_softmax_replacement_generation_quality_evidence(
                 item_id=item_id,
             )
+        elif abstraction_layer_name == "decoder_attention_pwl_recip_lut_boundary":
+            decoder_evidence = _decoder_attention_pwl_recip_lut_boundary_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_backed_frontier":
             decoder_evidence = _decoder_attention_mixed_int8_quality_backed_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_mixed_int8_quality_energy_frontier":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -6861,3 +6861,171 @@ def test_consume_l2_result_paired_comparison_matches_model_rows_by_model_id() ->
             assert matched_rows[1]["model_id"] == "model_b"
             assert matched_rows[1]["metrics"]["latency_ms_mean"]["baseline"] == 0.8
             assert matched_rows[1]["metrics"]["latency_ms_mean"]["candidate"] == 0.7
+
+
+def test_consume_l2_result_attention_pwl_recip_lut_boundary_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            item_id = "l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1"
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1"
+            )
+            proposal_dir.mkdir(parents=True)
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+                        "kind": "architecture",
+                        "title": "PWL reciprocal LUT boundary",
+                        "direct_comparison": {
+                            "primary_question": "Should q20/q24 PWL direct-LUT candidates go to PPA?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                f"decoder_attention_pwl_recip_lut_boundary__{item_id}.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                f"decoder_attention_pwl_recip_lut_boundary__{item_id}.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "estimator": "attention_pwl_recip_lut_boundary_v1",
+                        "decision": "compact_reciprocal_required_for_widest_points",
+                        "candidate_count": 3,
+                        "reasonable_direct_lut_candidate_count": 1,
+                        "boundary_probe_candidate_count": 1,
+                        "blocked_direct_lut_candidate_count": 1,
+                        "candidate_rows": [
+                            {
+                                "candidate_id": "qkv8_q12_pwl_recip_q12_bucket8",
+                                "score_bits": 12,
+                                "weight_bits": 12,
+                                "reciprocal_bits": 12,
+                                "bucket_shift": 8,
+                                "reciprocal_case_count": 128,
+                                "direct_lut_verdict": "direct_lut_ppa_reasonable",
+                            },
+                            {
+                                "candidate_id": "qkv8_q20_pwl_recip_q20_bucket8",
+                                "score_bits": 20,
+                                "weight_bits": 20,
+                                "reciprocal_bits": 20,
+                                "bucket_shift": 8,
+                                "reciprocal_case_count": 32768,
+                                "direct_lut_verdict": "boundary_probe_only",
+                            },
+                            {
+                                "candidate_id": "qkv8_q24_pwl_recip_q24_bucket8",
+                                "score_bits": 24,
+                                "weight_bits": 24,
+                                "reciprocal_bits": 24,
+                                "bucket_shift": 8,
+                                "reciprocal_case_count": 524288,
+                                "direct_lut_verdict": "requires_compact_reciprocal_before_ppa",
+                            },
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# boundary\n")
+
+            task_request = TaskRequest(
+                request_key=f"l2_campaign:{item_id}",
+                source="test",
+                requested_by="@tester",
+                title=f"Layer2 {item_id}",
+                description="pwl recip lut boundary",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": item_id,
+                    "layer": "layer2",
+                    "flow": "openroad",
+                    "developer_loop": {
+                        "proposal_id": "prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+                        "proposal_path": str(proposal_dir.relative_to(repo_root) / "proposal.json"),
+                        "evaluation": {"mode": "frontier_followup"},
+                        "abstraction": {"layer": "decoder_attention_pwl_recip_lut_boundary"},
+                        "comparison": {"role": "pwl_recip_lut_synthesis_boundary"},
+                    },
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key=f"l2_campaign:{item_id}",
+                task_request_id=task_request.id,
+                item_id=item_id,
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="src_verilog",
+                input_manifest={
+                    "decoder_contract": {
+                        "attention_pwl_recip_lut_boundary_out": evidence_rel,
+                        "attention_pwl_recip_lut_boundary_report": report_rel,
+                    }
+                },
+                command_manifest=[],
+                expected_outputs=[evidence_rel, report_rel],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+            session.add(
+                Run(
+                    run_key=f"{item_id}_run_1",
+                    work_item_id=work_item.id,
+                    attempt=1,
+                    executor_type=ExecutorType.INTERNAL_WORKER,
+                    status=RunStatus.SUCCEEDED,
+                    started_at=utcnow(),
+                    completed_at=utcnow(),
+                    checkout_commit="deadbeef",
+                    result_summary="2/2 commands succeeded",
+                )
+            )
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert (
+                decision_payload["proposal_assessment"]["outcome"]
+                == "compact_reciprocal_required_for_widest_points"
+            )
+            assert "qkv8_q24_pwl_recip_q24_bucket8_cases=524288" in decision_payload["proposal_assessment"][
+                "summary"
+            ]
+            assert (
+                decision_payload["source_refs"]["decoder_attention_pwl_recip_lut_boundary_out"]
+                == evidence_rel
+            )

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -9689,3 +9689,54 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_router_sram_s
                 )
                 for output in expected_outputs
             )
+
+
+def test_generate_l2_campaign_task_adds_attention_pwl_recip_lut_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_pwl_recip_lut_boundary",
+                    evaluation_mode="frontier_followup",
+                    comparison_role="pwl_recip_lut_synthesis_boundary",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+                        "l2_decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality_llama7b_v1_r2",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            run = commands[0]["run"]
+
+            assert commands[0]["name"] == "estimate_attention_pwl_recip_lut_boundary"
+            assert "estimate_attention_pwl_recip_lut_boundary.py" in run
+            assert "qkv8_q20_pwl_recip_q20_bucket8:s=20,w=20,r=20,bucket=8" in run
+            assert "qkv8_q24_pwl_recip_q24_bucket8:s=24,w=24,r=24,bucket=8" in run
+            assert "attention_pwl_recip_lut_boundary_out" in decoder_inputs
+            assert decoder_inputs["attention_pwl_recip_lut_boundary_out"] in work_item.expected_outputs
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_pwl_recip_lut_boundary",
+            }

--- a/docs/proposals/prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,39 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Estimate direct reciprocal-LUT size for q12/q20/q24 bucket8 PWL softmax candidates before launching q20/q24 composed attention PPA.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_pwl_recip_lut_boundary",
+      "comparison_role": "pwl_recip_lut_synthesis_boundary",
+      "cost_class": "small",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "commands": [
+        {
+          "name": "estimate_attention_pwl_recip_lut_boundary",
+          "run": "python3 npu/eval/estimate_attention_pwl_recip_lut_boundary.py --candidate qkv8_q12_pwl_recip_q12_bucket8:s=12,w=12,r=12,bucket=8,row_elems=8,accum_bits=28 --candidate qkv8_q20_pwl_recip_q20_bucket8:s=20,w=20,r=20,bucket=8,row_elems=8,accum_bits=32 --candidate qkv8_q24_pwl_recip_q24_bucket8:s=24,w=24,r=24,bucket=8,row_elems=8,accum_bits=40 --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_pwl_recip_lut_boundary__l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_pwl_recip_lut_boundary__l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1.md"
+        },
+        {
+          "name": "validate_runs",
+          "run": "python3 scripts/validate_runs.py --skip_eval_queue"
+        }
+      ],
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_pwl_recip_lut_boundary__l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_pwl_recip_lut_boundary__l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1.md"
+      ],
+      "expected_result": {
+        "direction": "bound_direct_lut_before_q20_q24_ppa",
+        "reason": "q20/q24 PWL candidates passed bounded generation quality, but direct reciprocal-LUT case count grows with weight precision; avoid dispatching a q24 OpenROAD job that mostly measures LUT explosion."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1/proposal.json
@@ -1,0 +1,46 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+  "title": "Bound direct PWL reciprocal-LUT size before q20/q24 composed attention PPA",
+  "layer": "layer2",
+  "abstraction_layer": "decoder_attention_pwl_recip_lut_boundary",
+  "objective": "Decide whether the generation-passing q20/q24 PWL reciprocal softmax candidates should be measured with the current direct-LUT RTL implementation or require a compact reciprocal implementation first.",
+  "context": {
+    "quality_evidence": [
+      "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
+      "l2_decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality_llama7b_v1_r2"
+    ],
+    "motivation": "score24/w16 RTL exact-divide is physically attractive but failed direct generation quality. q20/q24 PWL reciprocal candidates passed bounded generation quality, but the current RTL generator emits one reciprocal case per bucketed denominator, so q24 may be a synthesis-size artifact rather than an architecture point."
+  },
+  "candidate_points": [
+    {
+      "candidate_id": "qkv8_q12_pwl_recip_q12_bucket8",
+      "purpose": "Measured direct-LUT reference point already used for q12/PWL composed attention.",
+      "score_bits": 12,
+      "weight_bits": 12,
+      "reciprocal_bits": 12,
+      "bucket_shift": 8
+    },
+    {
+      "candidate_id": "qkv8_q20_pwl_recip_q20_bucket8",
+      "purpose": "Generation-passing candidate; decide whether direct-LUT PPA is only a boundary probe.",
+      "score_bits": 20,
+      "weight_bits": 20,
+      "reciprocal_bits": 20,
+      "bucket_shift": 8
+    },
+    {
+      "candidate_id": "qkv8_q24_pwl_recip_q24_bucket8",
+      "purpose": "Generation-passing candidate; decide whether direct-LUT PPA must be replaced by compact reciprocal hardware first.",
+      "score_bits": 24,
+      "weight_bits": 24,
+      "reciprocal_bits": 24,
+      "bucket_shift": 8
+    }
+  ],
+  "review_questions": [
+    "How many reciprocal denominator cases does the current direct-LUT RTL emit for q12, q20, and q24 bucket8 PWL softmax?",
+    "Which of q20/q24 is reasonable to send to OpenROAD as-is, and which should instead get a compact reciprocal RTL implementation?",
+    "Does the result keep PPA measurements from being polluted by a known direct-LUT explosion?"
+  ],
+  "expected_decision": "q12 should remain direct-LUT measurable; q20 should be treated as a synthesis-boundary probe if measured; q24 should require a compact reciprocal implementation before composed PPA."
+}

--- a/npu/eval/estimate_attention_pwl_recip_lut_boundary.py
+++ b/npu/eval/estimate_attention_pwl_recip_lut_boundary.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Estimate direct reciprocal-LUT size for composed PWL softmax candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+WARN_CASES = 8192
+BLOCK_CASES = 65536
+
+
+@dataclass(frozen=True)
+class Candidate:
+    candidate_id: str
+    source: str
+    row_elems: int
+    score_bits: int
+    weight_bits: int
+    reciprocal_bits: int
+    bucket_shift: int
+    accum_bits: int
+    softmax_impl: str
+
+
+def _load_json(path: Path) -> JsonDict:
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _as_int(value: Any, *, name: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise SystemExit(f"{name} must be an integer, got {value!r}") from exc
+
+
+def _candidate_from_config(path: Path) -> Candidate:
+    payload = _load_json(path)
+    comp = payload.get("attention_dual_stream_composed")
+    if not isinstance(comp, dict):
+        raise SystemExit(f"missing attention_dual_stream_composed object: {path}")
+    candidate_id = str(payload.get("top_name") or path.parent.name or path.stem).strip()
+    softmax_impl = str(comp.get("softmax_impl") or "exact_div").strip()
+    return Candidate(
+        candidate_id=candidate_id,
+        source=path.as_posix(),
+        row_elems=_as_int(comp.get("softmax_row_elems", 8), name=f"{path}: softmax_row_elems"),
+        score_bits=_as_int(comp.get("softmax_score_bits", 8), name=f"{path}: softmax_score_bits"),
+        weight_bits=_as_int(comp.get("softmax_weight_bits", 8), name=f"{path}: softmax_weight_bits"),
+        reciprocal_bits=_as_int(comp.get("reciprocal_bits", 10), name=f"{path}: reciprocal_bits"),
+        bucket_shift=_as_int(
+            comp.get("softmax_reciprocal_lut_bucket_shift", 0),
+            name=f"{path}: softmax_reciprocal_lut_bucket_shift",
+        ),
+        accum_bits=_as_int(comp.get("softmax_accum_bits", 24), name=f"{path}: softmax_accum_bits"),
+        softmax_impl=softmax_impl,
+    )
+
+
+def _parse_candidate_spec(spec: str) -> Candidate:
+    name, sep, rest = spec.partition(":")
+    if not sep:
+        raise SystemExit(f"candidate spec must be name:key=value,...: {spec}")
+    fields: dict[str, str] = {}
+    for part in rest.split(","):
+        key, eq, value = part.partition("=")
+        if not eq:
+            raise SystemExit(f"candidate field must be key=value in {spec}: {part}")
+        fields[key.strip()] = value.strip()
+    return Candidate(
+        candidate_id=name.strip(),
+        source=f"candidate:{spec}",
+        row_elems=_as_int(fields.get("row_elems", 8), name=f"{name}: row_elems"),
+        score_bits=_as_int(fields.get("score_bits", fields.get("s", 8)), name=f"{name}: score_bits"),
+        weight_bits=_as_int(fields.get("weight_bits", fields.get("w", 8)), name=f"{name}: weight_bits"),
+        reciprocal_bits=_as_int(fields.get("reciprocal_bits", fields.get("r", 10)), name=f"{name}: reciprocal_bits"),
+        bucket_shift=_as_int(fields.get("bucket_shift", fields.get("bucket", 0)), name=f"{name}: bucket_shift"),
+        accum_bits=_as_int(fields.get("accum_bits", 24), name=f"{name}: accum_bits"),
+        softmax_impl=fields.get("softmax_impl", "pwl_recip_lut"),
+    )
+
+
+def estimate_candidate(candidate: Candidate) -> JsonDict:
+    output_scale = (1 << candidate.weight_bits) - 1
+    max_sum_weight = candidate.row_elems * output_scale
+    bucket_step = 1 << candidate.bucket_shift
+    case_count = math.ceil(max_sum_weight / bucket_step)
+    entry_bits = candidate.reciprocal_bits + candidate.weight_bits
+    rom_bits = case_count * entry_bits
+    denom_address_bits = max(1, math.ceil(math.log2(case_count + 1)))
+    direct_lut_verdict = "not_applicable"
+    next_step = "Candidate does not use the direct PWL reciprocal-LUT implementation."
+    if candidate.softmax_impl == "pwl_recip_lut":
+        if case_count > BLOCK_CASES:
+            direct_lut_verdict = "requires_compact_reciprocal_before_ppa"
+            next_step = (
+                "Do not launch direct-LUT OpenROAD PPA for this point; first implement a compact reciprocal "
+                "approximation or a coarser denominator schedule."
+            )
+        elif case_count > WARN_CASES:
+            direct_lut_verdict = "boundary_probe_only"
+            next_step = (
+                "Treat direct-LUT PPA as a synthesis-boundary probe, not as the final architecture point."
+            )
+        else:
+            direct_lut_verdict = "direct_lut_ppa_reasonable"
+            next_step = "Direct-LUT PPA is small enough to measure as a concrete candidate."
+    return {
+        "candidate_id": candidate.candidate_id,
+        "source": candidate.source,
+        "softmax_impl": candidate.softmax_impl,
+        "row_elems": candidate.row_elems,
+        "score_bits": candidate.score_bits,
+        "weight_bits": candidate.weight_bits,
+        "reciprocal_bits": candidate.reciprocal_bits,
+        "bucket_shift": candidate.bucket_shift,
+        "bucket_step": bucket_step,
+        "max_sum_weight": max_sum_weight,
+        "reciprocal_case_count": case_count,
+        "reciprocal_entry_bits": entry_bits,
+        "reciprocal_rom_bits": rom_bits,
+        "denominator_address_bits": denom_address_bits,
+        "direct_lut_warn_case_threshold": WARN_CASES,
+        "direct_lut_block_case_threshold": BLOCK_CASES,
+        "direct_lut_verdict": direct_lut_verdict,
+        "next_step": next_step,
+    }
+
+
+def build_payload(candidates: list[Candidate]) -> JsonDict:
+    rows = [estimate_candidate(candidate) for candidate in candidates]
+    ranked = sorted(rows, key=lambda row: int(row["reciprocal_case_count"]))
+    blocked = [row for row in rows if row["direct_lut_verdict"] == "requires_compact_reciprocal_before_ppa"]
+    boundary = [row for row in rows if row["direct_lut_verdict"] == "boundary_probe_only"]
+    reasonable = [row for row in rows if row["direct_lut_verdict"] == "direct_lut_ppa_reasonable"]
+    if blocked:
+        decision = "compact_reciprocal_required_for_widest_points"
+    elif boundary:
+        decision = "direct_lut_boundary_probe"
+    elif reasonable:
+        decision = "direct_lut_ppa_reasonable"
+    else:
+        decision = "no_pwl_recip_lut_candidates"
+    return {
+        "version": 1,
+        "estimator": "attention_pwl_recip_lut_boundary_v1",
+        "threshold_basis": {
+            "warning": (
+                "Engineering guardrail: above this many generated Verilog reciprocal case entries, "
+                "use direct-LUT PPA only to find synthesis-boundary behavior."
+            ),
+            "blocking": (
+                "Engineering guardrail: above this many generated Verilog reciprocal case entries, "
+                "measure a compact reciprocal architecture before direct-LUT OpenROAD PPA."
+            ),
+            "direct_lut_warn_case_threshold": WARN_CASES,
+            "direct_lut_block_case_threshold": BLOCK_CASES,
+        },
+        "decision": decision,
+        "candidate_count": len(rows),
+        "reasonable_direct_lut_candidate_count": len(reasonable),
+        "boundary_probe_candidate_count": len(boundary),
+        "blocked_direct_lut_candidate_count": len(blocked),
+        "candidate_rows": ranked,
+    }
+
+
+def _write_report_md(payload: JsonDict) -> str:
+    lines = [
+        "# Attention PWL Reciprocal-LUT Boundary",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- candidate_count: `{payload['candidate_count']}`",
+        f"- warning_cases: `{payload['threshold_basis']['direct_lut_warn_case_threshold']}`",
+        f"- blocking_cases: `{payload['threshold_basis']['direct_lut_block_case_threshold']}`",
+        "",
+        "## Candidates",
+        "",
+        "| candidate_id | score_bits | weight_bits | recip_bits | bucket_shift | cases | rom_bits | verdict |",
+        "|---|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["candidate_rows"]:
+        lines.append(
+            "| {candidate_id} | {score_bits} | {weight_bits} | {reciprocal_bits} | {bucket_shift} | {reciprocal_case_count} | {reciprocal_rom_bits} | {direct_lut_verdict} |".format(
+                **row
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "- Case counts are generated-Verilog reciprocal denominator cases for the current direct-LUT PWL implementation.",
+            "- This is a synthesis-risk guardrail, not a PPA result.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", action="append", default=[], help="Composed attention config.json path")
+    ap.add_argument(
+        "--candidate",
+        action="append",
+        default=[],
+        help="name:key=value,...; keys include s/score_bits,w/weight_bits,r/reciprocal_bits,bucket/bucket_shift,row_elems",
+    )
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--out-md", required=True)
+    args = ap.parse_args()
+
+    candidates = [_candidate_from_config(Path(path)) for path in args.config]
+    candidates.extend(_parse_candidate_spec(spec) for spec in args.candidate)
+    if not candidates:
+        raise SystemExit("at least one --config or --candidate is required")
+
+    payload = build_payload(candidates)
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(_write_report_md(payload), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_estimate_attention_pwl_recip_lut_boundary.py
+++ b/tests/test_estimate_attention_pwl_recip_lut_boundary.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import npu.eval.estimate_attention_pwl_recip_lut_boundary as boundary
+
+
+def _candidate(name: str, bits: int) -> boundary.Candidate:
+    return boundary.Candidate(
+        candidate_id=name,
+        source=f"test:{name}",
+        row_elems=8,
+        score_bits=bits,
+        weight_bits=bits,
+        reciprocal_bits=bits,
+        bucket_shift=8,
+        accum_bits=max(24, bits + 8),
+        softmax_impl="pwl_recip_lut",
+    )
+
+
+def test_boundary_estimator_separates_q12_q20_q24_direct_lut_sizes() -> None:
+    payload = boundary.build_payload(
+        [
+            _candidate("q12", 12),
+            _candidate("q20", 20),
+            _candidate("q24", 24),
+        ]
+    )
+    rows = {row["candidate_id"]: row for row in payload["candidate_rows"]}
+
+    assert rows["q12"]["reciprocal_case_count"] == 128
+    assert rows["q12"]["direct_lut_verdict"] == "direct_lut_ppa_reasonable"
+    assert rows["q20"]["reciprocal_case_count"] == 32768
+    assert rows["q20"]["direct_lut_verdict"] == "boundary_probe_only"
+    assert rows["q24"]["reciprocal_case_count"] == 524288
+    assert rows["q24"]["direct_lut_verdict"] == "requires_compact_reciprocal_before_ppa"
+    assert payload["decision"] == "compact_reciprocal_required_for_widest_points"
+
+
+def test_boundary_estimator_loads_composed_attention_config(tmp_path: Path) -> None:
+    config = tmp_path / "design" / "config.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_q20_pwl",
+                "attention_dual_stream_composed": {
+                    "softmax_impl": "pwl_recip_lut",
+                    "softmax_row_elems": 8,
+                    "softmax_score_bits": 20,
+                    "softmax_weight_bits": 20,
+                    "reciprocal_bits": 20,
+                    "softmax_reciprocal_lut_bucket_shift": 8,
+                    "softmax_accum_bits": 32,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    candidate = boundary._candidate_from_config(config)
+    row = boundary.estimate_candidate(candidate)
+
+    assert candidate.candidate_id == "attention_q20_pwl"
+    assert row["reciprocal_case_count"] == 32768
+    assert row["reciprocal_rom_bits"] == 32768 * 40
+
+
+def test_report_mentions_guardrail_not_ppa_result() -> None:
+    payload = boundary.build_payload([_candidate("q24", 24)])
+    report = boundary._write_report_md(payload)
+
+    assert "requires_compact_reciprocal_before_ppa" in report
+    assert "not a PPA result" in report


### PR DESCRIPTION
## Summary
- add a lightweight estimator for direct PWL reciprocal-LUT case growth on q12/q20/q24 bucket8 softmax candidates
- wire a Layer 2 evidence-only job for `decoder_attention_pwl_recip_lut_boundary`
- add proposal docs and focused generator/consumer/unit tests

## Boundary Smoke Result
- q12 bucket8: 128 cases, direct-LUT PPA reasonable
- q20 bucket8: 32768 cases, boundary probe only
- q24 bucket8: 524288 cases, compact reciprocal required before PPA

## Tests
- `PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_estimate_attention_pwl_recip_lut_boundary.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'pwl_recip_lut_boundary' -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -k 'pwl_recip_lut_boundary' -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
