### PR TITLE
Add q20 PWL composed attention boundary probe

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_v1/evaluation_requests.json
@@ -1,0 +1,32 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_v1",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the q8/k8/v8 q20/PWL direct reciprocal-LUT composed dual-stream attention datapath as a synthesis-boundary probe.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_pwl_direct_lut_boundary_probe",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_lut_boundary.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/timing_debug_report.md"
+      ],
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+        "l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1"
+      ],
+      "expected_result": {
+        "direction": "measure_q20_pwl_direct_lut_boundary_cost",
+        "reason": "The merged direct-LUT boundary estimate marked q20 bucket8 as boundary_probe_only, while q24 requires compact reciprocal hardware before PPA."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_v1/proposal.json
@@ -1,0 +1,79 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_v1",
+  "created_utc": "2026-06-30T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Composed dual-stream attention q20/PWL direct reciprocal-LUT boundary probe",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The qkv8_q20_pwl_recip_q20_bucket8 candidate passed bounded Llama7B generation-quality checks, and the direct reciprocal-LUT boundary estimate marks q20 as boundary_probe_only rather than blocked. Measuring the concrete q8/k8/v8 q20/PWL composed wrapper establishes whether the current direct-LUT RTL is physically usable as an interim frontier point before implementing compact reciprocal hardware.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 PPA cost is paid by the generation-passing q8/k8/v8 q20/PWL direct reciprocal-LUT composed dual-stream attention wrapper, and is that cost dominated by the known direct-LUT boundary?",
+    "baselines": [
+      "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+      "l1_decoder_attention_dual_stream_composed_score24_w16_exact_div_ppa_v1",
+      "l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1"
+    ],
+    "candidate": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_ppa_v1",
+    "include": [
+      "generate RTL with q8/k8/v8 MAC/value datapath",
+      "generate q20 PWL softmax weights with q20 reciprocal bucket8 direct LUT",
+      "keep equivalence_hash disabled for PPA",
+      "run the composed datapath guard before OpenROAD",
+      "measure Nangate45 area, power, timing, and timing debug paths"
+    ],
+    "exclude": [
+      "q24 direct-LUT PPA, because the boundary result requires compact reciprocal hardware first",
+      "compact reciprocal RTL implementation",
+      "full Llama7B system-level recost"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This job measures the current direct reciprocal-LUT RTL and is explicitly a boundary probe, not the final compact reciprocal architecture.",
+    "The local composed datapath is measured independently; a dependent Layer 2 recost must substitute measured PPA into the Llama7B schedule.",
+    "Generation quality backing comes from qkv8_q20_pwl_recip_q20_bucket8 native mixed-int8 evidence, while RTL/perf equivalence for this exact q20 datapath remains a separate gate if PPA is promising."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the q8/k8/v8 q20/PWL direct reciprocal-LUT composed dual-stream attention datapath as a synthesis-boundary probe.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_pwl_direct_lut_boundary_probe",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_lut_boundary.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_q20_pwl_direct_lut_boundary_cost",
+        "reason": "The merged direct-LUT boundary estimate marked q20 bucket8 as boundary_probe_only, while q24 requires compact reciprocal hardware before PPA."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_lut_boundary.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_pwl_recip_lut_boundary__l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_softmax_replacement_generation_quality__l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1.json",
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_v1/proposal.json"
+  ]
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_lut_boundary.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_lut_boundary.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_lut_boundary"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_lut_boundary"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q12_pwl_recip_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q20_pwl_recip_lut_boundary"
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/config.json
@@ -1,0 +1,25 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "mac_accum_bits": 24,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 20,
+    "softmax_weight_bits": 20,
+    "softmax_input_frac_bits": 8,
+    "softmax_accum_bits": 32,
+    "reciprocal_bits": 20,
+    "softmax_reciprocal_lut_bucket_shift": 8,
+    "value_bits": 8,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "pwl_recip_lut"
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -279,6 +279,40 @@ def test_attention_dual_stream_composed_generator_q12_pwl_softmax(tmp_path: Path
     assert "wire [11:0] weight_00" in top_text
 
 
+def test_attention_dual_stream_composed_generator_q20_pwl_v8_softmax(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_q20_pwl_v8"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="pwl_recip_lut",
+        mac_accum_bits=24,
+        softmax_accum_bits=32,
+        softmax_score_bits=20,
+        softmax_weight_bits=20,
+        reciprocal_bits=20,
+        value_bits=8,
+        softmax_input_frac_bits=8,
+        softmax_reciprocal_lut_bucket_shift=8,
+    )
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["softmax_impl"] == "pwl_recip_lut"
+    assert manifest["mac_accum_bits"] == 24
+    assert manifest["softmax_score_bits"] == 20
+    assert manifest["softmax_weight_bits"] == 20
+    assert manifest["reciprocal_bits"] == 20
+    assert manifest["value_bits"] == 8
+    assert manifest["softmax_reciprocal_lut_bucket_shift"] == 8
+    assert "module attention_softmax_weight_q12_pwl_recip_like" in top_text
+    assert "localparam integer RECIP_BUCKET_SHIFT = 8;" in top_text
+    assert "wire [79:0] softmax_weights" in top_text
+    assert "wire [19:0] score_lane_00" in top_text
+    assert "wire [19:0] weight_00" in top_text
+    assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
+
+
 def test_attention_dual_stream_composed_generator_score32_exact_softmax(tmp_path: Path) -> None:
     design_dir = tmp_path / "attention_dual_stream_composed_score32"
     config_path = design_dir / "config.json"


### PR DESCRIPTION
## Summary
- add a q8/k8/v8 q20/PWL reciprocal-LUT composed attention config
- add a Nangate45 hierarchical sweep for the q20 direct-LUT boundary probe
- add a Layer1 proposal/evaluation request for remote-evaluator dispatch
- add generator smoke coverage for q20 PWL + v8 output wiring

## Verification
- `PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_attention_dual_stream_composed_generator.py -k "q20_pwl_v8 or q12_pwl_softmax" -q`
- `PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_attention_dual_stream_composed_generator.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py -k attention_dual_stream_composed_configs -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`

## Notes
This is intentionally a boundary probe. The merged PWL reciprocal-LUT boundary result marks q20 bucket8 as `boundary_probe_only` and q24 bucket8 as requiring compact reciprocal hardware before PPA.