### PR TITLE
Add compact reciprocal PWL attention datapath

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1/evaluation_requests.json
@@ -1,0 +1,35 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for q20 and q24 PWL compact reciprocal composed dual-stream attention datapaths after direct reciprocal-LUT q20/q24 proved infeasible or blocked.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_q24_pwl_compact_reciprocal_probe",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_q24_pwl_recip_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/timing_debug_report.md"
+      ],
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_ppa_v1",
+        "l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1"
+      ],
+      "expected_result": {
+        "direction": "measure_compact_reciprocal_replacement_cost",
+        "reason": "The q20 direct-LUT point failed physical flow and q24 direct-LUT was blocked by reciprocal table growth; compact reciprocal PPA is the next least-abstracted path."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1/proposal.json
@@ -1,0 +1,85 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1",
+  "created_utc": "2026-07-01T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Composed dual-stream attention q20/q24 PWL compact reciprocal datapath",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The q20 direct reciprocal-LUT boundary probe failed both OpenROAD density points, and the q24 boundary estimate was blocked by direct-LUT case growth. Replacing only the reciprocal table with a compact divider while preserving the same PWL weight and bucketed reciprocal arithmetic removes the LUT-size artifact without changing the quality candidate semantics.",
+  "direct_comparison": {
+    "primary_question": "Can the generation-passing q20/q24 PWL softmax candidates become physically measurable when the direct reciprocal case table is replaced by a compact reciprocal divider?",
+    "baselines": [
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_ppa_v1",
+      "l1_decoder_attention_dual_stream_composed_q12_pwl_softmax_ppa_v1",
+      "l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1"
+    ],
+    "candidate": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1",
+    "include": [
+      "generate q8/k8/v8 composed attention RTL for q20 and q24 PWL softmax",
+      "use the same bucket8 reciprocal rounding formula as the direct-LUT model",
+      "compute reciprocal with divider logic instead of a generated case table",
+      "keep equivalence_hash disabled for PPA",
+      "run the composed datapath guard before OpenROAD",
+      "measure Nangate45 area, power, timing, and timing debug paths"
+    ],
+    "exclude": [
+      "quality re-evaluation, because arithmetic semantics are intended to match the q20/q24 PWL candidates already evaluated",
+      "full Llama7B system recost",
+      "multi-cycle reciprocal scheduling"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This measures a single-cycle compact reciprocal divider inside the local composed datapath; a later architecture may pipeline or share this reciprocal unit.",
+    "The local composed datapath is measured independently; a dependent Layer 2 recost must substitute measured PPA into the Llama7B schedule.",
+    "RTL/perf equivalence for the new compact reciprocal implementation remains a separate gate if PPA is promising."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for q20 and q24 PWL compact reciprocal composed dual-stream attention datapaths after direct reciprocal-LUT q20/q24 proved infeasible or blocked.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_q24_pwl_compact_reciprocal_probe",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_q24_pwl_recip_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_compact_reciprocal_replacement_cost",
+        "reason": "The q20 direct-LUT point failed physical flow and q24 direct-LUT was blocked by reciprocal table growth; compact reciprocal PPA is the next least-abstracted path."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "tests/test_attention_dual_stream_composed_generator.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_q24_pwl_recip_div.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_pwl_recip_lut_boundary__l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_softmax_replacement_generation_quality__l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1.json"
+  ]
+}

--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -51,7 +51,7 @@ def main() -> int:
         raise SystemExit("expected exactly one shared softmax instance")
     if "stream_buf_0" not in top_text or "stream_buf_1" not in top_text:
         raise SystemExit("missing dual stream buffer registers")
-    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut", "pwl_recip_lut"}:
+    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut", "pwl_recip_lut", "pwl_recip_div"}:
         raise SystemExit(f"unsupported softmax_impl={softmax_impl}")
     if not 24 <= mac_accum_bits <= 32:
         raise SystemExit(f"unsupported mac_accum_bits={mac_accum_bits}")
@@ -117,17 +117,27 @@ def main() -> int:
             raise SystemExit("reciprocal-LUT replacement must not contain pow2 denominator shift logic")
         if "/ sum_weight" in top_text or "/ sum_weight_q" in top_text:
             raise SystemExit("reciprocal-LUT replacement must not contain a sum_weight divider")
-    if softmax_impl == "pwl_recip_lut":
+    if softmax_impl in {"pwl_recip_lut", "pwl_recip_div"}:
         if softmax_score_bits < 12 or softmax_weight_bits < 12:
             raise SystemExit("PWL reciprocal softmax should keep at least 12-bit scores and weights")
         for token in (
             "function [ACCUM_BITS-1:0] pwl_weight",
-            "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut",
             "reciprocal_bucket",
             "lane_scaled",
         ):
             if token not in top_text:
                 raise SystemExit(f"missing PWL reciprocal softmax token: {token}")
+        if softmax_impl == "pwl_recip_lut":
+            if "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut" not in top_text:
+                raise SystemExit("missing PWL reciprocal LUT function")
+            if "/ reciprocal_denominator" in top_text:
+                raise SystemExit("PWL reciprocal LUT mode must not contain compact reciprocal divider")
+        if softmax_impl == "pwl_recip_div":
+            for token in ("RECIPROCAL_NUMERATOR", "reciprocal_denominator", "/ reciprocal_denominator"):
+                if token not in top_text:
+                    raise SystemExit(f"missing compact PWL reciprocal divider token: {token}")
+            if "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut" in top_text:
+                raise SystemExit("compact PWL reciprocal divider must not contain reciprocal LUT case table")
         if "denom_shift" in top_text:
             raise SystemExit("PWL reciprocal softmax must not contain pow2 denominator shift logic")
         if "/ sum_weight" in top_text or "/ sum_weight_q" in top_text:

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -111,14 +111,14 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.softmax_input_frac_bits must be in [0, 16]")
     if softmax_reciprocal_lut_bucket_shift < 0 or softmax_reciprocal_lut_bucket_shift > 12:
         raise SystemExit("attention_dual_stream_composed.softmax_reciprocal_lut_bucket_shift must be in [0, 12]")
-    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut", "pwl_recip_lut"}:
+    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut", "pwl_recip_lut", "pwl_recip_div"}:
         raise SystemExit(
-            "attention_dual_stream_composed.softmax_impl must be exact_div, pow2sum, recip_lut, or pwl_recip_lut"
+            "attention_dual_stream_composed.softmax_impl must be exact_div, pow2sum, recip_lut, pwl_recip_lut, or pwl_recip_div"
         )
     if softmax_internal_pipeline_stages and softmax_impl != "exact_div":
         raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages requires exact_div")
-    if softmax_impl == "pwl_recip_lut" and softmax_internal_pipeline_stages:
-        raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages is not supported for pwl_recip_lut")
+    if softmax_impl in {"pwl_recip_lut", "pwl_recip_div"} and softmax_internal_pipeline_stages:
+        raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages is not supported for PWL reciprocal softmax")
     return comp
 
 
@@ -166,7 +166,7 @@ def _softmax_module(
     output_scale = (1 << weight_bits) - 1
     shift_exp_max_weight = 128
     pwl_max_weight = output_scale
-    max_weight = pwl_max_weight if implementation == "pwl_recip_lut" else shift_exp_max_weight
+    max_weight = pwl_max_weight if implementation in {"pwl_recip_lut", "pwl_recip_div"} else shift_exp_max_weight
     product_bits = accum_bits + weight_bits
     hash_port = ",\n    output reg  [31:0]          weight_hash" if equivalence_hash else ""
     hash_reg = "  reg [31:0] next_hash;\n" if equivalence_hash else ""
@@ -179,17 +179,20 @@ def _softmax_module(
     )
     hash_seq = "    weight_hash <= next_hash;\n" if equivalence_hash else ""
     max_sum_weight = row_elems * max_weight
-    recip_lut_cases = "\n".join(
-        f"      {accum_bits}'d{denom}: reciprocal_lut = {reciprocal_bits + weight_bits}'d{((output_scale << reciprocal_bits) + (denom >> 1)) // denom};"
-        for denom in range(1, max_sum_weight + 1)
-    )
-    if implementation == "pwl_recip_lut":
+    recip_lut_cases = ""
+    if implementation in {"recip_lut"}:
+        recip_lut_cases = "\n".join(
+            f"      {accum_bits}'d{denom}: reciprocal_lut = {reciprocal_bits + weight_bits}'d{((output_scale << reciprocal_bits) + (denom >> 1)) // denom};"
+            for denom in range(1, max_sum_weight + 1)
+        )
+    if implementation in {"pwl_recip_lut", "pwl_recip_div"}:
         reciprocal_bucket_step = 1 << reciprocal_lut_bucket_shift
         max_bucket = (max_sum_weight + reciprocal_bucket_step - 1) >> reciprocal_lut_bucket_shift
-        recip_lut_cases = "\n".join(
-            f"      {accum_bits}'d{bucket}: reciprocal_lut = {reciprocal_bits + weight_bits}'d{((output_scale << reciprocal_bits) + ((bucket << reciprocal_lut_bucket_shift) >> 1)) // (bucket << reciprocal_lut_bucket_shift)};"
-            for bucket in range(1, max_bucket + 1)
-        )
+        if implementation == "pwl_recip_lut":
+            recip_lut_cases = "\n".join(
+                f"      {accum_bits}'d{bucket}: reciprocal_lut = {reciprocal_bits + weight_bits}'d{((output_scale << reciprocal_bits) + ((bucket << reciprocal_lut_bucket_shift) >> 1)) // (bucket << reciprocal_lut_bucket_shift)};"
+                for bucket in range(1, max_bucket + 1)
+            )
         input_scale = 1 << input_frac_bits
         x2 = 2 * input_scale
         x4 = 4 * input_scale
@@ -199,6 +202,45 @@ def _softmax_module(
         y2 = int(math.exp(-2.0) * output_scale + 0.5)
         y4 = int(math.exp(-4.0) * output_scale + 0.5)
         y8 = int(math.exp(-8.0) * output_scale + 0.5)
+        reciprocal_width = reciprocal_bits + weight_bits
+        reciprocal_numerator = output_scale << reciprocal_bits
+        reciprocal_div_regs = (
+            "  reg [ACCUM_BITS-1:0] reciprocal_denominator;\n"
+            "  reg [RECIPROCAL_WIDTH-1:0] reciprocal_numer;\n"
+            if implementation == "pwl_recip_div"
+            else ""
+        )
+        reciprocal_numerator_param = (
+            f"  localparam [RECIPROCAL_WIDTH-1:0] RECIPROCAL_NUMERATOR = {reciprocal_width}'d{reciprocal_numerator};\n"
+            if implementation == "pwl_recip_div"
+            else ""
+        )
+        reciprocal_function = (
+            f"""
+  function [RECIPROCAL_WIDTH-1:0] reciprocal_lut;
+    input [ACCUM_BITS-1:0] bucket;
+    begin
+      case (bucket)
+      {accum_bits}'d0: reciprocal_lut = {{RECIPROCAL_WIDTH{{1'b0}}}};
+{recip_lut_cases}
+      default: reciprocal_lut = {{RECIPROCAL_WIDTH{{1'b0}}}};
+      endcase
+    end
+  endfunction
+"""
+            if implementation == "pwl_recip_lut"
+            else ""
+        )
+        reciprocal_assign = (
+            "    reciprocal_q = reciprocal_lut(reciprocal_bucket);"
+            if implementation == "pwl_recip_lut"
+            else """    reciprocal_denominator = reciprocal_bucket << RECIP_BUCKET_SHIFT;
+    reciprocal_numer = RECIPROCAL_NUMERATOR + (reciprocal_denominator >> 1);
+    if (reciprocal_denominator != {ACCUM_BITS{1'b0}})
+      reciprocal_q = reciprocal_numer / reciprocal_denominator;
+    else
+      reciprocal_q = {RECIPROCAL_WIDTH{1'b0}};"""
+        )
         return f"""(* keep_hierarchy = 1 *)
 module {module_name} (
     input  wire                  clk,
@@ -221,6 +263,7 @@ module {module_name} (
   localparam integer PWL_Y2 = {y2};
   localparam integer PWL_Y4 = {y4};
   localparam integer PWL_Y8 = {y8};
+{reciprocal_numerator_param.rstrip()}
 
   integer i;
   integer signed lane_val;
@@ -230,6 +273,7 @@ module {module_name} (
   reg [ACCUM_BITS-1:0] sum_weight;
   reg [ACCUM_BITS-1:0] reciprocal_bucket;
   reg [RECIPROCAL_WIDTH-1:0] reciprocal_q;
+{reciprocal_div_regs.rstrip()}
   reg [PRODUCT_BITS+RECIPROCAL_WIDTH-1:0] lane_scaled;
   reg [WEIGHT_BITS-1:0] lane_out;
   reg [{weight_row_width - 1}:0] next_weights;
@@ -275,17 +319,7 @@ module {module_name} (
       end
     end
   endfunction
-
-  function [RECIPROCAL_WIDTH-1:0] reciprocal_lut;
-    input [ACCUM_BITS-1:0] bucket;
-    begin
-      case (bucket)
-      {accum_bits}'d0: reciprocal_lut = {{RECIPROCAL_WIDTH{{1'b0}}}};
-{recip_lut_cases}
-      default: reciprocal_lut = {{RECIPROCAL_WIDTH{{1'b0}}}};
-      endcase
-    end
-  endfunction
+{reciprocal_function.rstrip()}
 
   always @(*) begin
     row_max = -(1 << (SCORE_BITS - 1));
@@ -306,7 +340,7 @@ module {module_name} (
     end
 
     reciprocal_bucket = (sum_weight + {accum_bits}'d{reciprocal_bucket_step - 1}) >> RECIP_BUCKET_SHIFT;
-    reciprocal_q = reciprocal_lut(reciprocal_bucket);
+{reciprocal_assign}
     next_weights = {{{weight_row_width}{{1'b0}}}};
 {hash_init.rstrip()}
     for (i = 0; i < ROW_ELEMS; i = i + 1) begin
@@ -804,6 +838,8 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     softmax_weight_row_width = row_elems * softmax_weight_bits
     if softmax_impl == "pwl_recip_lut":
         softmax_name = "attention_softmax_weight_q12_pwl_recip_like"
+    elif softmax_impl == "pwl_recip_div":
+        softmax_name = f"attention_softmax_weight_q{softmax_score_bits}_pwl_recip_div_like"
     elif softmax_impl == "exact_div" and (softmax_score_bits, softmax_weight_bits) != (8, 8):
         softmax_name = f"attention_softmax_weight_score{softmax_score_bits}_w{softmax_weight_bits}_exact_div_like"
     elif softmax_impl == "recip_lut" and (softmax_score_bits, softmax_weight_bits) == (32, 16):
@@ -1101,8 +1137,8 @@ endmodule
         "components": {
             "compute": "two signed-int8 dense GEMM streams",
             "softmax_weight": (
-                "one shared q12 PWL reciprocal-normalized generator"
-                if softmax_impl == "pwl_recip_lut"
+                "one shared PWL reciprocal-normalized generator"
+                if softmax_impl in {"pwl_recip_lut", "pwl_recip_div"}
                 else (
                     "one shared score32/w16 shift-exp reciprocal-LUT-normalized generator"
                     if softmax_score_bits == 32 and softmax_weight_bits == 16 and softmax_impl == "recip_lut"

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_q24_pwl_recip_div.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_q24_pwl_recip_div.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q20_q24_pwl_recip_div"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q20_q24_pwl_recip_div"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q20_pwl_recip_div_like attention_softmax_weight_q24_pwl_recip_div_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q20_q24_pwl_recip_div"
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json
@@ -1,0 +1,25 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "mac_accum_bits": 24,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 20,
+    "softmax_weight_bits": 20,
+    "softmax_input_frac_bits": 8,
+    "softmax_accum_bits": 32,
+    "reciprocal_bits": 20,
+    "softmax_reciprocal_lut_bucket_shift": 8,
+    "value_bits": 8,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "pwl_recip_div"
+  }
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json
@@ -1,0 +1,25 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "mac_accum_bits": 24,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 24,
+    "softmax_weight_bits": 24,
+    "softmax_input_frac_bits": 8,
+    "softmax_accum_bits": 40,
+    "reciprocal_bits": 24,
+    "softmax_reciprocal_lut_bucket_shift": 8,
+    "value_bits": 8,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "pwl_recip_div"
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -313,6 +313,46 @@ def test_attention_dual_stream_composed_generator_q20_pwl_v8_softmax(tmp_path: P
     assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
 
 
+def test_attention_dual_stream_composed_generator_q24_pwl_compact_recip_v8_softmax(
+    tmp_path: Path,
+) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_q24_pwl_div_v8"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="pwl_recip_div",
+        mac_accum_bits=24,
+        softmax_accum_bits=40,
+        softmax_score_bits=24,
+        softmax_weight_bits=24,
+        reciprocal_bits=24,
+        value_bits=8,
+        softmax_input_frac_bits=8,
+        softmax_reciprocal_lut_bucket_shift=8,
+    )
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["softmax_impl"] == "pwl_recip_div"
+    assert manifest["mac_accum_bits"] == 24
+    assert manifest["softmax_accum_bits"] == 40
+    assert manifest["softmax_score_bits"] == 24
+    assert manifest["softmax_weight_bits"] == 24
+    assert manifest["reciprocal_bits"] == 24
+    assert manifest["value_bits"] == 8
+    assert manifest["softmax_reciprocal_lut_bucket_shift"] == 8
+    assert "module attention_softmax_weight_q24_pwl_recip_div_like" in top_text
+    assert "localparam [RECIPROCAL_WIDTH-1:0] RECIPROCAL_NUMERATOR = 48'd281474959933440;" in top_text
+    assert "reciprocal_numer = RECIPROCAL_NUMERATOR + (reciprocal_denominator >> 1);" in top_text
+    assert "reciprocal_q = reciprocal_numer / reciprocal_denominator;" in top_text
+    assert "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut" not in top_text
+    assert "wire [95:0] softmax_weights" in top_text
+    assert "wire [23:0] score_lane_00" in top_text
+    assert "wire [23:0] weight_00" in top_text
+    assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
+
+
 def test_attention_dual_stream_composed_generator_score32_exact_softmax(tmp_path: Path) -> None:
     design_dir = tmp_path / "attention_dual_stream_composed_score32"
     config_path = design_dir / "config.json"


### PR DESCRIPTION
## Summary
- add `pwl_recip_div` softmax mode for composed dual-stream attention
- preserve the PWL bucket8 reciprocal rounding formula while replacing generated reciprocal case tables with divider logic
- add q20/q24 v8 composed attention configs and a shared Nangate45 sweep
- add Layer1 proposal/evaluation request for remote PPA dispatch
- extend generator/guard tests to prove q24 compact mode does not emit a reciprocal LUT

## Verification
- `PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_attention_dual_stream_composed_generator.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py -k "attention_dual_stream_composed_configs or emits_commands_for_each_integrated_block_config" -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
- q20/q24 compact generator smoke + composed guard