### PR TITLE
control_plane: honor L1 boundary acceptance notes

### DIFF
--- a/control_plane/control_plane/cli/generate_l1_sweep.py
+++ b/control_plane/control_plane/cli/generate_l1_sweep.py
@@ -23,6 +23,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--item-id")
     parser.add_argument("--title")
     parser.add_argument("--objective")
+    parser.add_argument("--acceptance-notes")
     parser.add_argument("--source-commit")
     parser.add_argument("--mode", default="upsert")
     parser.add_argument("--proposal-id")
@@ -56,6 +57,7 @@ def main(argv: list[str] | None = None) -> int:
                 item_id=args.item_id,
                 title=args.title,
                 objective=args.objective,
+                acceptance_notes=args.acceptance_notes,
                 source_commit=args.source_commit,
                 mode=args.mode,
                 proposal_id=args.proposal_id,

--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -75,6 +75,7 @@ def main(argv: list[str] | None = None) -> int:
     generate_l1_parser.add_argument("--item-id")
     generate_l1_parser.add_argument("--title")
     generate_l1_parser.add_argument("--objective")
+    generate_l1_parser.add_argument("--acceptance-notes")
     generate_l1_parser.add_argument("--source-commit")
     generate_l1_parser.add_argument("--mode", default="upsert")
     generate_l1_parser.add_argument("--proposal-id")
@@ -533,6 +534,7 @@ def main(argv: list[str] | None = None) -> int:
             ("--item-id", args.item_id),
             ("--title", args.title),
             ("--objective", args.objective),
+            ("--acceptance-notes", args.acceptance_notes),
             ("--source-commit", args.source_commit),
             ("--proposal-id", args.proposal_id),
             ("--proposal-path", args.proposal_path),

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -39,6 +39,7 @@ class Layer1SweepGenerateRequest:
     item_id: str | None = None
     title: str | None = None
     objective: str | None = None
+    acceptance_notes: str | None = None
     source_commit: str | None = None
     mode: str = "upsert"
     proposal_id: str | None = None
@@ -121,6 +122,7 @@ def _upsert_evaluation_request_entry(
     objective: str,
     evaluation_mode: str,
     abstraction_layer: str | None,
+    acceptance_notes: str | None,
     source_commit: str,
 ) -> None:
     proposal_id_text = str(proposal_id or "").strip()
@@ -176,6 +178,9 @@ def _upsert_evaluation_request_entry(
     entry["objective"] = objective
     entry["evaluation_mode"] = evaluation_mode
     entry["abstraction_layer"] = str(abstraction_layer or "").strip()
+    acceptance_notes_text = str(acceptance_notes or "").strip()
+    if acceptance_notes_text:
+        entry["acceptance_notes"] = acceptance_notes_text
     entry["status"] = "pending"
     payload["proposal_id"] = str(payload.get("proposal_id") or proposal_id or "").strip()
     payload["source_commit"] = source_commit
@@ -643,6 +648,24 @@ def _default_objective(*, platform: str, config_paths: list[str], sweep_path: st
     )
 
 
+_BOUNDARY_ACCEPTANCE_PHRASES = (
+    "boundary evidence",
+    "accept timing/flow failures",
+    "allow non-ok metrics",
+    "flow_failed",
+    "failed rows as explicit boundary evidence",
+)
+
+
+def _contains_boundary_acceptance_phrase(text: str | None) -> bool:
+    lower_text = str(text or "").strip().lower()
+    if not lower_text:
+        return False
+    if "boundary" in lower_text:
+        return True
+    return any(phrase in lower_text for phrase in _BOUNDARY_ACCEPTANCE_PHRASES)
+
+
 def _effective_trial_policy(*, trial_count: int, seed_start: int, stop_after_failures: int | None) -> dict[str, int]:
     effective_trial_count = max(int(trial_count), 1)
     effective_seed_start = int(seed_start)
@@ -722,9 +745,13 @@ def _build_payload(
     evaluation_mode: str,
     abstraction_layer: str | None,
     trial_policy: dict[str, int],
+    acceptance_notes: str | None,
 ) -> dict[str, Any]:
-    lower_objective = objective.lower()
-    boundary_acceptance = "boundary" in lower_objective or "accept timing/flow failures" in lower_objective
+    acceptance_notes_text = str(acceptance_notes or "").strip()
+    boundary_acceptance = (
+        _contains_boundary_acceptance_phrase(objective)
+        or _contains_boundary_acceptance_phrase(acceptance_notes_text)
+    )
     metrics_acceptance = (
         "Each generated wrapper metrics.csv contains recorded rows with a status column; "
         "allow non-ok metrics such as flow_failed when the row is boundary evidence"
@@ -772,6 +799,7 @@ def _build_payload(
                 "Committed outputs stay lightweight (metrics.csv only; runs/index.csv is exported centrally after merge)",
                 "python3 scripts/build_runs_index.py and python3 scripts/validate_runs.py --skip_eval_queue pass",
             ],
+            "metadata": {"acceptance_notes": acceptance_notes_text},
         },
         "handoff": {
             "branch": f"eval/{item_id}/<session_id>",
@@ -804,6 +832,8 @@ def _build_payload(
             payload["developer_loop"]["abstraction"] = {
                 "layer": abstraction_layer,
             }
+    if not acceptance_notes_text:
+        payload["task"].pop("metadata", None)
     return payload
 
 
@@ -894,6 +924,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         ),
         abstraction_layer=effective_abstraction_layer,
         trial_policy=trial_policy,
+        acceptance_notes=request.acceptance_notes,
     )
     payload["source_requirement"] = build_source_requirement(
         repo_root=repo_root,
@@ -909,6 +940,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             objective=objective,
             evaluation_mode=((payload.get("developer_loop") or {}).get("evaluation") or {}).get("mode") or "",
             abstraction_layer=effective_abstraction_layer,
+            acceptance_notes=request.acceptance_notes,
             source_commit=source_commit,
         )
 

--- a/control_plane/control_plane/tests/test_cli_generate_l1.py
+++ b/control_plane/control_plane/tests/test_cli_generate_l1.py
@@ -31,6 +31,8 @@ def test_top_level_generate_l1_forwards_extended_generation_flags() -> None:
                 "measurement_only",
                 "--abstraction-layer",
                 "circuit_block",
+                "--acceptance-notes",
+                "accept timing/flow failures as boundary evidence",
                 "--trial-count",
                 "3",
                 "--seed-start",
@@ -48,6 +50,7 @@ def test_top_level_generate_l1_forwards_extended_generation_flags() -> None:
     assert forwarded[forwarded.index("--make-target") + 1] == "1_1_yosys_canonicalize"
     assert forwarded[forwarded.index("--evaluation-mode") + 1] == "measurement_only"
     assert forwarded[forwarded.index("--abstraction-layer") + 1] == "circuit_block"
+    assert forwarded[forwarded.index("--acceptance-notes") + 1] == "accept timing/flow failures as boundary evidence"
     assert forwarded[forwarded.index("--trial-count") + 1] == "3"
     assert forwarded[forwarded.index("--seed-start") + 1] == "100"
     assert forwarded[forwarded.index("--stop-after-failures") + 1] == "2"

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -578,6 +578,48 @@ def test_generate_l1_sweep_task_uses_boundary_metrics_acceptance() -> None:
             assert work_item.task_request.request_payload["task"]["acceptance"] == work_item.acceptance_rules
 
 
+def test_generate_l1_sweep_task_uses_acceptance_notes_for_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            with patch(
+                "control_plane.services.l1_task_generator._image_provided_l1_runtime_deps_available",
+                return_value=False,
+            ):
+                result = generate_l1_sweep_task(
+                    session,
+                    Layer1SweepGenerateRequest(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        objective="Measure frontier behavior across throughput settings for review.",
+                        acceptance_notes=(
+                            "Treat both ok and failed rows as explicit boundary evidence "
+                            "when flow_failed appears."
+                        ),
+                    ),
+                )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert "allow non-ok metrics" in work_item.acceptance_rules[0]
+            assert "flow_failed" in work_item.acceptance_rules[0]
+            assert (
+                work_item.task_request.request_payload["task"]["metadata"]["acceptance_notes"]
+                == "Treat both ok and failed rows as explicit boundary evidence when flow_failed appears."
+            )
+            assert work_item.task_request.request_payload["task"]["acceptance"] == work_item.acceptance_rules
+
+
 def test_generate_l1_sweep_task_requeues_failed_item_on_upsert() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -897,6 +939,7 @@ def test_generate_l1_sweep_task_records_requested_item_in_proposal_evaluation_re
                     proposal_id="prop_l1_demo_v1",
                     proposal_path="docs/proposals/prop_l1_demo_v1",
                     abstraction_layer="circuit_block",
+                    acceptance_notes="Accept flow_failed rows as explicit boundary evidence.",
                 ),
             )
 
@@ -913,6 +956,7 @@ def test_generate_l1_sweep_task_records_requested_item_in_proposal_evaluation_re
                 ),
                 "evaluation_mode": "measurement_only",
                 "abstraction_layer": "circuit_block",
+                "acceptance_notes": "Accept flow_failed rows as explicit boundary evidence.",
                 "status": "pending",
             }
         ]

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1/evaluation_requests.json
@@ -30,6 +30,40 @@
         "direction": "measure_compact_reciprocal_replacement_cost",
         "reason": "The q20 direct-LUT point failed physical flow and q24 direct-LUT was blocked by reciprocal table growth; compact reciprocal PPA is the next least-abstracted path."
       }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "prior_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1"
+      ],
+      "task_type": "l1_sweep",
+      "objective": "Rerun Nangate45 PPA for q20 and q24 PWL compact reciprocal composed dual-stream attention datapaths and accept timing/flow failures as boundary evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_q24_pwl_compact_reciprocal_boundary_probe",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_q24_pwl_recip_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Accept non-ok metrics rows such as flow_failed as explicit boundary evidence; a no-feasible-points outcome is still useful for the q20/q24 compact reciprocal frontier.",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_lut_boundary_ppa_v1",
+        "l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1"
+      ],
+      "expected_result": {
+        "direction": "measure_compact_reciprocal_boundary_cost",
+        "reason": "The first compact reciprocal run generated valid RTL but all PPA metrics rows were flow_failed; rerun with boundary-aware acceptance so the frontier can record no feasible points if the result repeats."
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add `--acceptance-notes` to Layer 1 task generation and top-level CLI forwarding
- use explicit acceptance notes, in addition to objective wording, to enable boundary-aware non-ok metrics acceptance
- preserve acceptance notes in task payload/proposal metadata
- add r2 compact reciprocal request so q20/q24 all-flow-failed PPA can be recorded as boundary evidence

## Tests
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py control_plane/control_plane/tests/test_cli_generate_l1.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`