### PR TITLE
[codex] validate synth keep modules before sweep

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/evaluation_requests.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q20 compact reciprocal PWL composed attention PPA with a q20-only keep-module sweep.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job."
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 compact reciprocal PWL composed attention PPA with a q24-only keep-module sweep.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job."
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q20 sequential reciprocal PWL composed attention PPA with a q20-only keep-module sweep.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job."
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 sequential reciprocal PWL composed attention PPA with a q24-only keep-module sweep.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job."
+    }
+  ],
+  "source_commit": "53f922aa7778e634be3b34c3e978ad296724ddc8"
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/proposal.json
@@ -1,0 +1,138 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1",
+  "created_utc": "2026-07-01T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Corrected q20/q24 PWL reciprocal keep-module sweeps",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The prior shared q20/q24 compact-div and seqdiv sweeps recorded flow_failed rows because each single-precision RTL was synthesized with a union SYNTH_KEEP_MODULES list that referenced the other precision's softmax module. Splitting the sweeps by precision removes that setup error and can distinguish real physical boundary behavior from invalid flow configuration.",
+  "direct_comparison": {
+    "primary_question": "With precision-specific keep-module lists, which q20/q24 PWL reciprocal datapath points are physically measurable in Nangate45?",
+    "invalidated_inputs": [
+      "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
+    ],
+    "candidate_items": [
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2"
+    ],
+    "include": [
+      "q20 and q24 compact combinational reciprocal PWL softmax datapaths",
+      "q20 and q24 one-bit-per-cycle sequential reciprocal PWL softmax datapaths",
+      "precision-specific SYNTH_KEEP_MODULES containing only modules present in each generated RTL",
+      "the composed datapath guard before OpenROAD",
+      "Nangate45 area, power, timing, and timing debug paths when the flow reaches reports"
+    ],
+    "exclude": [
+      "quality re-evaluation",
+      "full Llama7B system recost",
+      "multi-bit reciprocal divider exploration"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report",
+      "failure_stage"
+    ]
+  },
+  "remaining_abstractions": [
+    "This is still local composed datapath PPA; a dependent Layer 2 recost must substitute measured rows into the Llama7B model.",
+    "The sequential reciprocal point uses fixed one-bit-per-cycle latency only.",
+    "Full RTL/perf equivalence for a physically promising reciprocal datapath remains a separate follow-up gate."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q20 compact reciprocal PWL composed attention PPA with a q20-only keep-module sweep.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job.",
+      "expected_result": {
+        "direction": "correct_invalid_shared_keep_modules",
+        "reason": "The prior shared q20/q24 compact-div sweep could fail before real synthesis because q20 RTL does not define the q24 softmax module."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 compact reciprocal PWL composed attention PPA with a q24-only keep-module sweep.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job.",
+      "expected_result": {
+        "direction": "correct_invalid_shared_keep_modules",
+        "reason": "The prior shared q20/q24 compact-div sweep could fail before real synthesis because q24 RTL does not define the q20 softmax module."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q20 sequential reciprocal PWL composed attention PPA with a q20-only keep-module sweep.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job.",
+      "expected_result": {
+        "direction": "correct_invalid_shared_keep_modules",
+        "reason": "The prior shared q20/q24 seqdiv sweep failed q20 setup with missing q24 softmax module."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 sequential reciprocal PWL composed attention PPA with a q24-only keep-module sweep.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job.",
+      "expected_result": {
+        "direction": "correct_invalid_shared_keep_modules",
+        "reason": "The prior shared q20/q24 seqdiv sweep may fail q24 setup with missing q20 softmax module."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/synth/run_block_sweep.py",
+    "tests/test_run_block_sweep_mode_compare.py",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_v1/proposal.json"
+  ]
+}

--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -48,6 +48,70 @@ def sha1_verilog_dir(verilog_dir: Path) -> str:
     return hashlib.sha1(payload.encode()).hexdigest()[:12]
 
 
+def parse_boolish(value: object, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return bool(text)
+
+
+def synth_keep_module_names(value: object) -> List[str]:
+    if value is None:
+        return []
+    raw_items: List[str] = []
+    if isinstance(value, list):
+        raw_items = [str(item) for item in value]
+    else:
+        raw_items = [str(value)]
+    names: List[str] = []
+    for raw in raw_items:
+        names.extend(token.strip() for token in raw.split() if token.strip())
+    return names
+
+
+def verilog_module_names(verilog_dir: Path) -> set[str]:
+    names: set[str] = set()
+    pattern = re.compile(r"^\s*module\s+([A-Za-z_][A-Za-z0-9_$]*)\b")
+    for path in sorted(verilog_dir.glob("*.v")):
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            match = pattern.match(line)
+            if match:
+                names.add(match.group(1))
+    return names
+
+
+def validate_synth_keep_modules(
+    *,
+    verilog_dir: Path,
+    sweep_params: Dict[str, object],
+    macro_manifest: Optional[Dict[str, object]],
+) -> None:
+    if not parse_boolish(sweep_params.get("CHECK_SYNTH_KEEP_MODULES"), default=True):
+        return
+    requested = synth_keep_module_names(sweep_params.get("SYNTH_KEEP_MODULES"))
+    if not requested:
+        return
+    available = verilog_module_names(verilog_dir)
+    if macro_manifest is not None:
+        available.update(
+            str(name).strip()
+            for name in macro_manifest.get("blackboxes", [])
+            if str(name).strip()
+        )
+    missing = sorted(name for name in requested if name not in available)
+    if missing:
+        raise ValueError(
+            "SYNTH_KEEP_MODULES references modules not present in generated RTL: "
+            f"{', '.join(missing)}. Available modules: {', '.join(sorted(available))}"
+        )
+
+
 def load_json(path: Path):
     with path.open() as f:
         return json.load(f)
@@ -1633,6 +1697,11 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
             "compare_group": compare_group,
         }
 
+    validate_synth_keep_modules(
+        verilog_dir=verilog_dir,
+        sweep_params=sweep_params,
+        macro_manifest=macro_manifest,
+    )
     ensure_design_assets(
         design_name,
         platform,

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_div"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_div"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q20_pwl_recip_div_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q20_pwl_recip_div"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_seqdiv"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_seqdiv"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q20_pwl_recip_seqdiv_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q20_pwl_recip_seqdiv"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_div"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_div"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q24_pwl_recip_div_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q24_pwl_recip_div"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_seqdiv"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_seqdiv"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q24_pwl_recip_seqdiv_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q24_pwl_recip_seqdiv"
+}

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -287,6 +287,82 @@ class ModeCompareRegressionTest(unittest.TestCase):
             self.assertIn("flow_failed", metrics_text)
             self.assertTrue((tmp / "out" / "demo_design" / "work").is_dir())
 
+    def test_synth_keep_modules_must_exist_in_generated_rtl(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done);\n"
+                "  helper u_helper(.clk(clk), .done(done));\n"
+                "endmodule\n"
+                "module helper(input clk, output done);\n"
+                "  assign done = clk;\n"
+                "endmodule\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                {"helper", "npu_top"},
+                self.run_block_sweep.verilog_module_names(verilog_dir),
+            )
+            with self.assertRaisesRegex(ValueError, "missing_helper"):
+                self.run_block_sweep.validate_synth_keep_modules(
+                    verilog_dir=verilog_dir,
+                    sweep_params={"SYNTH_KEEP_MODULES": "helper missing_helper"},
+                    macro_manifest=None,
+                )
+
+    def test_run_single_rejects_missing_synth_keep_module_before_openroad(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done);\n"
+                "  assign done = clk;\n"
+                "endmodule\n",
+                encoding="utf-8",
+            )
+
+            old_run = self.run_block_sweep.subprocess.run
+            calls = []
+
+            def fake_run(cmd, *, cwd, check, env):
+                calls.append(cmd)
+                raise AssertionError("OpenROAD should not run for invalid keep modules")
+
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                with self.assertRaisesRegex(ValueError, "missing_mod"):
+                    self.run_block_sweep.run_single(
+                        design_dir=design_dir,
+                        design_name="demo_design",
+                        platform="nangate45",
+                        top="npu_top",
+                        verilog_dir=verilog_dir,
+                        sdc_template=None,
+                        sweep_params={
+                            "TAG": "demo_fail",
+                            "FLOW_VARIANT": "demo_fail",
+                            "CLOCK_PERIOD": 10.0,
+                            "CORE_AREA": "0 0 100 100",
+                            "SYNTH_KEEP_MODULES": "npu_top missing_mod",
+                        },
+                        out_root=tmp / "out",
+                        skip_existing=False,
+                        dry_run=False,
+                        force_copy=True,
+                        make_target=None,
+                        macro_manifest=None,
+                    )
+            finally:
+                self.run_block_sweep.subprocess.run = old_run
+
+            self.assertEqual([], calls)
+
     def test_append_metrics_replaces_same_run_identity(self):
         with tempfile.TemporaryDirectory() as td:
             metrics_path = Path(td) / "metrics.csv"


### PR DESCRIPTION
## Summary
- fail `run_block_sweep.py` setup early when `SYNTH_KEEP_MODULES` references modules absent from generated RTL
- add regression coverage for keep-module parsing and pre-OpenROAD rejection
- add corrected per-precision q20/q24 compact-div and seqdiv sweeps so each flow keeps only modules present in that RTL
- add a follow-up L1 proposal to rerun the invalid shared keep-module evidence

## Root Cause
The shared q20/q24 PWL reciprocal sweeps used a union `SYNTH_KEEP_MODULES` list. A q20 generated design does not define the q24 softmax module, so Yosys failed during hierarchy with `ERROR: No such module: attention_softmax_weight_q24_pwl_recip_seqdiv_like`. Those rows were recorded as `flow_failed`, which made an invalid setup look like boundary evidence.

## Validation
- `PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_run_block_sweep_mode_compare.py -q`
- local bad-sweep smoke check: old shared q20/q24 seqdiv sweep now fails before OpenROAD with missing q24 module
- generated RTL keep-module check for all four corrected sweep/config pairs
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py control_plane/control_plane/tests/test_cli_generate_l1.py -q`
