### PR TITLE
[codex] retract cross-proposal revision evidence

### DIFF
--- a/control_plane/control_plane/services/proposal_finalizer.py
+++ b/control_plane/control_plane/services/proposal_finalizer.py
@@ -50,6 +50,12 @@ class ProposalFinalizeResult:
     skip_reason: str | None
 
 
+@dataclass(frozen=True)
+class _RevisionInvalidationResult:
+    invalidated_item_ids: list[str]
+    touched_paths: list[Path]
+
+
 _RETRY_SUFFIX_RE = re.compile(r"_r\d+$")
 
 
@@ -468,6 +474,66 @@ def _apply_revision_invalidations(
     return invalidated
 
 
+def _candidate_evaluation_request_paths(repo_root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for base_rel in ("docs/proposals", "docs/developer_loop"):
+        base = repo_root / base_rel
+        if not base.exists():
+            continue
+        paths.extend(sorted(base.glob("*/evaluation_requests.json")))
+    return paths
+
+
+def _apply_cross_proposal_revision_invalidations(
+    repo_root: Path,
+    *,
+    current_evaluation_requests_path: Path,
+    current_item_id: str,
+    revision: dict[str, Any],
+    artifact_rel: str,
+    already_invalidated_item_ids: list[str],
+) -> _RevisionInvalidationResult:
+    invalidated_item_ids = _revision_invalidated_item_ids(revision)
+    if not invalidated_item_ids:
+        return _RevisionInvalidationResult(invalidated_item_ids=[], touched_paths=[])
+    remaining = [item_id for item_id in invalidated_item_ids if item_id not in set(already_invalidated_item_ids)]
+    if not remaining:
+        return _RevisionInvalidationResult(invalidated_item_ids=[], touched_paths=[])
+
+    reason = str(revision.get("reason", revision.get("revision_reason", ""))).strip()
+    invalidated_at = utcnow().isoformat().replace("+00:00", "Z")
+    found: list[str] = []
+    touched_paths: list[Path] = []
+    current_eval_path = current_evaluation_requests_path.resolve()
+    for evaluation_requests_path in _candidate_evaluation_request_paths(repo_root):
+        if evaluation_requests_path.resolve() == current_eval_path:
+            continue
+        payload = _load_json(evaluation_requests_path)
+        requested_items = payload.get("requested_items")
+        if not isinstance(requested_items, list):
+            continue
+        changed = False
+        for entry in requested_items:
+            if not isinstance(entry, dict):
+                continue
+            item_id = str(entry.get("item_id", "")).strip()
+            if item_id not in remaining or item_id == current_item_id:
+                continue
+            entry["status"] = "retracted"
+            entry["retracted_utc"] = invalidated_at
+            entry["retracted_by_item_id"] = current_item_id
+            entry["retraction_reason"] = reason
+            entry["replacement_artifact"] = artifact_rel
+            if item_id not in found:
+                found.append(item_id)
+            changed = True
+        if changed:
+            _write_json(evaluation_requests_path, payload)
+            touched_paths.append(evaluation_requests_path)
+    ordered_found = [item_id for item_id in invalidated_item_ids if item_id in set(found)]
+    return _RevisionInvalidationResult(invalidated_item_ids=ordered_found, touched_paths=touched_paths)
+
+
 def _mark_merged_requested_item(
     entry: dict[str, Any],
     *,
@@ -694,6 +760,13 @@ def _prepare_repo(repo_root: Path) -> str:
 def finalize_after_merge(session: Session, request: ProposalFinalizeRequest) -> ProposalFinalizeResult:
     repo_root = Path(request.repo_root).resolve()
     work_item, run = _resolve_run(session, request)
+    merge_commit = request.merge_commit
+    prepared_repo_head: str | None = None
+    if request.git_publish:
+        prepared_repo_head = _prepare_repo(repo_root)
+        if not merge_commit:
+            merge_commit = prepared_repo_head
+
     proposal_path = _proposal_path(repo_root, work_item)
     if proposal_path is None:
         return ProposalFinalizeResult(
@@ -705,13 +778,6 @@ def finalize_after_merge(session: Session, request: ProposalFinalizeRequest) -> 
             skipped=True,
             skip_reason="work item has no developer_loop proposal metadata",
         )
-
-    merge_commit = request.merge_commit
-    prepared_repo_head: str | None = None
-    if request.git_publish:
-        prepared_repo_head = _prepare_repo(repo_root)
-        if not merge_commit:
-            merge_commit = prepared_repo_head
 
     _scaffold_proposal_artifacts(repo_root, work_item=work_item, run=run, proposal_path=proposal_path)
     proposal_payload = _load_json(proposal_path)
@@ -829,6 +895,7 @@ def finalize_after_merge(session: Session, request: ProposalFinalizeRequest) -> 
         merged_utc=merged_utc,
     )
     invalidated_item_ids: list[str] = []
+    revision_touched_paths: list[Path] = []
     if is_revision:
         matched_entry["revision"] = revision_payload
         matched_entry["revision_of_decision"] = existing_decision or str(promotion_result.get("decision", "")).strip()
@@ -838,6 +905,18 @@ def finalize_after_merge(session: Session, request: ProposalFinalizeRequest) -> 
             revision=revision_payload,
             artifact_rel=artifact_rel,
         )
+        cross_revision = _apply_cross_proposal_revision_invalidations(
+            repo_root,
+            current_evaluation_requests_path=evaluation_requests_path,
+            current_item_id=work_item.item_id,
+            revision=revision_payload,
+            artifact_rel=artifact_rel,
+            already_invalidated_item_ids=invalidated_item_ids,
+        )
+        invalidated_item_ids.extend(
+            item_id for item_id in cross_revision.invalidated_item_ids if item_id not in invalidated_item_ids
+        )
+        revision_touched_paths.extend(cross_revision.touched_paths)
     evaluation_requests["source_commit"] = str(payload.get("source_commit") or run.checkout_commit or work_item.source_commit or "")
     ready_items = _refresh_ready_items([entry for entry in requested_items if isinstance(entry, dict)])
 
@@ -927,6 +1006,7 @@ def finalize_after_merge(session: Session, request: ProposalFinalizeRequest) -> 
             str(promotion_result_path.relative_to(repo_root)),
             str(analysis_report_path.relative_to(repo_root)),
         ]
+        rel_paths.extend(str(path.relative_to(repo_root)) for path in revision_touched_paths)
         if not run_index_refresh.skipped:
             rel_paths.append("runs/index.csv")
         _run_git(repo_root, "add", *rel_paths)

--- a/control_plane/control_plane/tests/test_proposal_finalizer.py
+++ b/control_plane/control_plane/tests/test_proposal_finalizer.py
@@ -1497,6 +1497,158 @@ def test_finalize_revision_retracts_invalidated_merged_item_after_promotion() ->
         assert updated_result["revision"]["invalidated_item_ids"] == ["revision_demo_r1"]
 
 
+def test_finalize_revision_retracts_invalidated_item_in_another_proposal() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        old_proposal_dir = _seed_repo_files(
+            repo_root,
+            "prop_l1_cross_revision_old_v1",
+            [
+                {
+                    "item_id": "cross_revision_old_r1",
+                    "task_type": "l1_sweep",
+                    "objective": "old wrong config",
+                    "status": "merged",
+                    "merged_pr_number": 10,
+                }
+            ],
+        )
+        proposal_id = "prop_l1_cross_revision_new_v1"
+        proposal_dir = _seed_repo_files(
+            repo_root,
+            proposal_id,
+            [
+                {
+                    "item_id": "cross_revision_new_r1",
+                    "task_type": "l1_sweep",
+                    "objective": "new corrected config",
+                    "status": "artifact_sync",
+                    "revision": {
+                        "reason": "wrong_configuration",
+                        "invalidates_item_ids": ["cross_revision_old_r1"],
+                    },
+                }
+            ],
+        )
+        old_result_path = old_proposal_dir / "promotion_result.json"
+        old_result = json.loads(old_result_path.read_text())
+        old_result.update(
+            {
+                "decision": "iterate",
+                "pr_number": 10,
+                "merge_commit": "oldmerge",
+                "merged_utc": "2026-03-25T04:00:00Z",
+            }
+        )
+        old_result_path.write_text(json.dumps(old_result, indent=2) + "\n")
+
+        payload_path = repo_root / "control_plane" / "shadow_exports" / "l1_promotions" / "cross_revision_new_r1.json"
+        _write(
+            payload_path,
+            json.dumps(
+                {
+                    "item_id": "cross_revision_new_r1",
+                    "run_key": "cross_revision_new_r1_run_1",
+                    "source_commit": "abc123",
+                    "proposals": [
+                        {
+                            "metrics_ref": {"metrics_csv": "runs/designs/demo/metrics.csv", "platform": "nangate45", "status": "ok"},
+                            "metric_summary": {"critical_path_ns": 1.0, "die_area": 100.0, "total_power_mw": 0.01},
+                        }
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+        with _session() as session:
+            task = TaskRequest(
+                request_key="l1:cross_revision_new_r1",
+                source="test",
+                requested_by="tester",
+                title="revision l1",
+                description="new corrected config",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "developer_loop": {
+                        "proposal_id": proposal_id,
+                        "proposal_path": str((proposal_dir / "proposal.json").relative_to(repo_root)),
+                    },
+                    "task": {"objective": "new corrected config"},
+                },
+            )
+            session.add(task)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key="l1:cross_revision_new_r1",
+                task_request_id=task.id,
+                item_id="cross_revision_new_r1",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l1_sweep",
+                state=WorkItemState.MERGED,
+                priority=1,
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=["runs/designs/demo/metrics.csv"],
+                acceptance_rules=[],
+                source_commit="abc123",
+            )
+            session.add(work_item)
+            session.flush()
+            run = Run(
+                run_key="cross_revision_new_r1_run_1",
+                work_item_id=work_item.id,
+                attempt=1,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="abc123",
+                result_summary="ok",
+                result_payload={"queue_result": {"status": "ok"}},
+            )
+            session.add(run)
+            session.flush()
+            session.add(
+                Artifact(
+                    run_id=run.id,
+                    kind="promotion_proposal",
+                    storage_mode="repo",
+                    path=str(payload_path.relative_to(repo_root)),
+                    sha256="x",
+                    metadata_={},
+                )
+            )
+            session.commit()
+
+            result = finalize_after_merge(
+                session,
+                ProposalFinalizeRequest(
+                    repo_root=str(repo_root),
+                    item_id="cross_revision_new_r1",
+                    pr_number=11,
+                    merge_commit="newmerge",
+                    merged_utc="2026-03-26T04:00:00Z",
+                    git_publish=False,
+                ),
+            )
+
+        assert result.skipped is False
+        old_requests = json.loads((old_proposal_dir / "evaluation_requests.json").read_text())
+        old_entry = old_requests["requested_items"][0]
+        assert old_entry["status"] == "retracted"
+        assert old_entry["retraction_reason"] == "wrong_configuration"
+        assert old_entry["retracted_by_item_id"] == "cross_revision_new_r1"
+        assert old_entry["replacement_artifact"] == "control_plane/shadow_exports/l1_promotions/cross_revision_new_r1.json"
+        updated_result = json.loads((proposal_dir / "promotion_result.json").read_text())
+        assert updated_result["revision"]["invalidated_item_ids"] == ["cross_revision_old_r1"]
+
+
 def test_finalize_seeded_iterate_l1_proposal_advances_instead_of_skipping() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/evaluation_requests.json
@@ -9,6 +9,19 @@
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
       "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+            "pr_number": 1096,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json"
       ],
@@ -24,6 +37,19 @@
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
       "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+            "pr_number": 1096,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
       ],
@@ -39,6 +65,19 @@
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
       "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+            "pr_number": 1098,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json"
       ],
@@ -54,6 +93,19 @@
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
       "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+            "pr_number": 1098,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json"
       ],

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/proposal.json
@@ -54,6 +54,19 @@
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
       "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+            "pr_number": 1096,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json"
       ],
@@ -73,6 +86,19 @@
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
       "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+            "pr_number": 1096,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
       ],
@@ -92,6 +118,19 @@
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
       "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+            "pr_number": 1098,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json"
       ],
@@ -111,6 +150,19 @@
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
       "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+            "pr_number": 1098,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json"
       ],


### PR DESCRIPTION
## Summary
- teach proposal finalization to retract invalidated requested items in other proposal directories, not only the current proposal
- keep finalization repo refresh before proposal lookup for git-published finalization
- add revision metadata to the corrected q20/q24 reciprocal keep-module jobs so PR #1096/#1098 evidence is removed from the active decision path when v2 results merge

## Root Cause
The corrected reciprocal proposal declared the invalidated old q20/q24 shared keep-module inputs in prose, but the queue request entries did not carry `revision` metadata. Even with metadata, the finalizer only marked invalidated entries found in the current proposal's `evaluation_requests.json`; the invalid rows here live in earlier proposal directories.

## Validation
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_proposal_finalizer.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py control_plane/control_plane/tests/test_cli_generate_l1.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_submission_status.py::test_assess_submission_eligibility_allows_revision_after_promotion -q`
- `git diff --check`

Note: the broader `test_submission_status.py` file still has unrelated fixture failures around canonical runs evidence/proposal linkage when run as a whole; the revision-specific test passes.
