### PR TITLE
control_plane: preserve lease history across stale retries

### DIFF
--- a/control_plane/control_plane/migrations/versions/0007_fix_active_lease_index.py
+++ b/control_plane/control_plane/migrations/versions/0007_fix_active_lease_index.py
@@ -1,0 +1,35 @@
+"""fix active worker lease partial-index predicate"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0007_fix_active_lease_index"
+down_revision = "0006_run_index_extended_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("uq_worker_leases_active_work_item", table_name="worker_leases")
+    op.create_index(
+        "uq_worker_leases_active_work_item",
+        "worker_leases",
+        ["work_item_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'ACTIVE'"),
+        sqlite_where=sa.text("status = 'ACTIVE'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_worker_leases_active_work_item", table_name="worker_leases")
+    op.create_index(
+        "uq_worker_leases_active_work_item",
+        "worker_leases",
+        ["work_item_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'active'"),
+        sqlite_where=sa.text("status = 'active'"),
+    )

--- a/control_plane/control_plane/models/worker_leases.py
+++ b/control_plane/control_plane/models/worker_leases.py
@@ -18,7 +18,8 @@ class WorkerLease(Base):
             "uq_worker_leases_active_work_item",
             "work_item_id",
             unique=True,
-            postgresql_where=text("status = 'active'"),
+            postgresql_where=text("status = 'ACTIVE'"),
+            sqlite_where=text("status = 'ACTIVE'"),
         ),
     )
 

--- a/control_plane/control_plane/services/lease_service.py
+++ b/control_plane/control_plane/services/lease_service.py
@@ -159,6 +159,7 @@ def acquire_next_lease(
         lease = (
             session.query(WorkerLease)
             .filter(WorkerLease.work_item_id == work_item.id)
+            .filter(WorkerLease.status == LeaseStatus.ACTIVE)
             .order_by(WorkerLease.leased_at.desc(), WorkerLease.id.desc())
             .first()
         )

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -226,6 +226,21 @@ def test_expire_stale_leases_requeues_assigned_nonterminal_work_as_ready() -> No
         assert run.completed_at is not None
         assert run.failure_category == "lease_expired"
 
+        reacquired = acquire_next_lease(
+            session,
+            machine_key="machine-1",
+            capabilities={"platform": "nangate45", "flow": "openroad"},
+            lease_seconds=1,
+        )
+        new_lease = session.query(WorkerLease).filter_by(lease_token=reacquired.lease_token).one()
+        session.refresh(run)
+        session.refresh(lease)
+
+        assert new_lease.id != lease.id
+        assert new_lease.status == LeaseStatus.ACTIVE
+        assert lease.status == LeaseStatus.EXPIRED
+        assert run.lease_id == lease.id
+
 
 def test_lease_routes_work_in_process() -> None:
     with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- create a fresh worker lease row when a stale/released lease is re-acquired instead of reusing historical lease rows
- fix the active worker-lease partial-index predicate to match stored enum values and add SQLite parity for tests
- add regression coverage that stale lease cleanup preserves the old run's lease while the retry gets a new active lease

## Context
The remote reciprocal PPA jobs froze the evaluator and then restarted as new attempts. The DB showed old and new attempts pointing at the same active lease row, which made status/diagnostics double-count active work and lose historical lease attribution.

Related recovery issue: #1101

## Tests
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_leases.py control_plane/control_plane/tests/test_run_service.py control_plane/control_plane/tests/test_operator_status.py control_plane/control_plane/tests/test_worker_daemon.py::test_next_trial_index_reuses_slot_after_stale_lease_cleanup -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

Note: `test_worker_executor.py::test_worker_stops_retrying_after_max_attempts` currently fails on this checkout because its seed creates an unassigned READY item while the scheduler requires the supplied worker machine key; I did not change that behavior in this patch.
