### PR TITLE
control_plane: serialize block sweep worker leases

### DIFF
--- a/control_plane/control_plane/services/dispatcher_service.py
+++ b/control_plane/control_plane/services/dispatcher_service.py
@@ -12,7 +12,12 @@ from control_plane.models.enums import LeaseStatus, WorkItemState
 from control_plane.models.worker_leases import WorkerLease
 from control_plane.models.worker_machines import WorkerMachine
 from control_plane.models.work_items import WorkItem
-from control_plane.services.scheduler import NoEligibleWorkItem, assign_work_item
+from control_plane.services.scheduler import (
+    NoEligibleWorkItem,
+    assign_work_item,
+    machine_has_active_exclusive_work,
+    work_item_requires_exclusive_worker,
+)
 
 
 @dataclass(frozen=True)
@@ -45,12 +50,34 @@ def _as_comparable_utc(dt):
 
 
 def _machine_available_slots(session: Session, machine: WorkerMachine) -> int:
+    if machine_has_active_exclusive_work(session, machine.id):
+        return 0
     active = (
         session.query(WorkerLease)
         .filter(WorkerLease.machine_id == machine.id, WorkerLease.status == LeaseStatus.ACTIVE)
         .count()
     )
     return max(0, int(machine.slot_capacity or 1) - active)
+
+
+def _machine_has_reserved_work(session: Session, machine: WorkerMachine) -> bool:
+    return (
+        session.query(WorkItem)
+        .filter(WorkItem.assigned_machine_key == machine.machine_key)
+        .filter(WorkItem.state.in_([WorkItemState.READY, WorkItemState.LEASED, WorkItemState.RUNNING]))
+        .count()
+        > 0
+    )
+
+
+def _machine_has_reserved_exclusive_work(session: Session, machine: WorkerMachine) -> bool:
+    rows = (
+        session.query(WorkItem)
+        .filter(WorkItem.assigned_machine_key == machine.machine_key)
+        .filter(WorkItem.state.in_([WorkItemState.READY, WorkItemState.LEASED, WorkItemState.RUNNING]))
+        .all()
+    )
+    return any(work_item_requires_exclusive_worker(row) for row in rows)
 
 
 def _machine_matches_item(machine: WorkerMachine, work_item: WorkItem) -> bool:
@@ -86,8 +113,14 @@ def _next_unassigned_item_for_machine(session: Session, machine: WorkerMachine) 
         .filter(~WorkItem.leases.any(WorkerLease.status == LeaseStatus.ACTIVE))
         .order_by(WorkItem.priority.desc(), WorkItem.created_at.asc(), WorkItem.item_id.asc())
     )
+    has_reserved = _machine_has_reserved_work(session, machine)
+    has_reserved_exclusive = _machine_has_reserved_exclusive_work(session, machine)
+    if has_reserved_exclusive:
+        return None
     for item in query.all():
         if _machine_matches_item(machine, item):
+            if work_item_requires_exclusive_worker(item) and has_reserved:
+                continue
             return item
     return None
 
@@ -139,6 +172,10 @@ def auto_dispatch_item(
             return AutoDispatchItemResult(item_id=item_id, status="skipped", reason="machine_has_no_capacity")
         if not _machine_matches_item(machine, work_item):
             return AutoDispatchItemResult(item_id=item_id, status="skipped", reason="machine_capability_mismatch")
+        if _machine_has_reserved_exclusive_work(session, machine):
+            return AutoDispatchItemResult(item_id=item_id, status="skipped", reason="machine_has_reserved_exclusive_work")
+        if work_item_requires_exclusive_worker(work_item) and _machine_has_reserved_work(session, machine):
+            return AutoDispatchItemResult(item_id=item_id, status="skipped", reason="exclusive_item_requires_empty_worker")
         return _assign(machine.machine_key)
 
     candidates = [
@@ -147,6 +184,8 @@ def auto_dispatch_item(
         if _is_machine_dispatchable(machine, freshness_seconds=freshness_seconds)
         and _machine_available_slots(session, machine) > 0
         and _machine_matches_item(machine, work_item)
+        and not _machine_has_reserved_exclusive_work(session, machine)
+        and not (work_item_requires_exclusive_worker(work_item) and _machine_has_reserved_work(session, machine))
     ]
     if not candidates:
         return AutoDispatchItemResult(item_id=item_id, status="skipped", reason="no_eligible_machine")

--- a/control_plane/control_plane/services/scheduler.py
+++ b/control_plane/control_plane/services/scheduler.py
@@ -62,6 +62,53 @@ def _effective_filter(machine_capabilities: dict[str, Any], capability_filter: d
     return merged
 
 
+def _boolish(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def work_item_requires_exclusive_worker(work_item: WorkItem) -> bool:
+    """Return whether the item should occupy a worker by itself.
+
+    OpenROAD block sweeps are host-heavy and can freeze evaluator machines when
+    several are launched together. The explicit manifest flag lets future jobs
+    opt into the same scheduling behavior without relying on command names.
+    """
+
+    inputs = dict(work_item.input_manifest or {})
+    resources = dict(inputs.get("worker_resources") or {})
+    if _boolish(resources.get("exclusive_worker")) or _boolish(resources.get("exclusive")):
+        return True
+    for command in work_item.command_manifest or []:
+        run_text = str((command or {}).get("run") or "")
+        if "run_block_sweep.py" in run_text:
+            return True
+    return False
+
+
+def machine_has_active_exclusive_work(session: Session, machine_id: str) -> bool:
+    active = (
+        session.query(WorkItem)
+        .join(WorkerLease, WorkerLease.work_item_id == WorkItem.id)
+        .filter(WorkerLease.machine_id == machine_id)
+        .filter(WorkerLease.status == LeaseStatus.ACTIVE)
+        .all()
+    )
+    return any(work_item_requires_exclusive_worker(item) for item in active)
+
+
+def machine_active_lease_count(session: Session, machine_id: str) -> int:
+    return (
+        session.query(WorkerLease)
+        .filter(WorkerLease.machine_id == machine_id)
+        .filter(WorkerLease.status == LeaseStatus.ACTIVE)
+        .count()
+    )
+
+
 def select_next_work_item(
     session: Session,
     *,
@@ -70,6 +117,12 @@ def select_next_work_item(
     capability_filter: dict[str, Any] | None = None,
 ) -> WorkItem:
     effective = _effective_filter(machine_capabilities or {}, capability_filter)
+    machine = None
+    if machine_key:
+        machine = session.query(WorkerMachine).filter(WorkerMachine.machine_key == machine_key).one_or_none()
+        if machine is not None and machine_has_active_exclusive_work(session, machine.id):
+            raise NoEligibleWorkItem("worker already has active exclusive work")
+
     query = (
         session.query(WorkItem)
         .filter(WorkItem.state == WorkItemState.READY)
@@ -87,7 +140,9 @@ def select_next_work_item(
     if machine_key:
         order_cols.append(case((WorkItem.assigned_machine_key == machine_key, 0), else_=1).asc())
     query = query.order_by(*order_cols, WorkItem.priority.desc(), WorkItem.created_at.asc(), WorkItem.item_id.asc())
-    item = query.first()
-    if item is None:
-        raise NoEligibleWorkItem("no eligible work item for the requested capability filter")
-    return item
+    active_count = machine_active_lease_count(session, machine.id) if machine is not None else 0
+    for item in query.all():
+        if work_item_requires_exclusive_worker(item) and active_count > 0:
+            continue
+        return item
+    raise NoEligibleWorkItem("no eligible work item for the requested capability filter")

--- a/control_plane/control_plane/tests/test_dispatcher_service.py
+++ b/control_plane/control_plane/tests/test_dispatcher_service.py
@@ -19,7 +19,15 @@ def make_session() -> Session:
     return Session(engine)
 
 
-def _seed_ready_item(session: Session, *, item_id: str, platform: str, priority: int = 1) -> None:
+def _seed_ready_item(
+    session: Session,
+    *,
+    item_id: str,
+    platform: str,
+    priority: int = 1,
+    command_manifest: list[dict[str, str]] | None = None,
+    input_manifest: dict | None = None,
+) -> None:
     task = TaskRequest(
         request_key=f"queue:{item_id}",
         source="test",
@@ -44,8 +52,8 @@ def _seed_ready_item(session: Session, *, item_id: str, platform: str, priority:
             task_type="l2_campaign",
             state=WorkItemState.DISPATCH_PENDING,
             priority=priority,
-            input_manifest={},
-            command_manifest=[],
+            input_manifest=input_manifest or {},
+            command_manifest=command_manifest or [],
             expected_outputs=[],
             acceptance_rules=[],
         )
@@ -107,6 +115,32 @@ def test_dispatch_ready_items_respects_slot_capacity_and_existing_assignment() -
         assert item_b.state == WorkItemState.DISPATCH_PENDING
 
 
+def test_dispatch_ready_items_assigns_only_one_exclusive_block_sweep_per_machine() -> None:
+    with make_session() as session:
+        upsert_worker_machine(
+            session,
+            machine_key="eval-a",
+            hostname="eval-a",
+            role="evaluator",
+            slot_capacity=16,
+            capabilities={"platform": "nangate45", "flow": "openroad"},
+        )
+        block_sweep = [{"name": "ppa", "run": "python3 npu/synth/run_block_sweep.py --sweep sweep.json"}]
+        _seed_ready_item(session, item_id="exclusive_a", platform="nangate45", priority=5, command_manifest=block_sweep)
+        _seed_ready_item(session, item_id="exclusive_b", platform="nangate45", priority=4, command_manifest=block_sweep)
+        _seed_ready_item(session, item_id="normal_c", platform="nangate45", priority=3)
+
+        results = dispatch_ready_items(session, DispatchReadyRequest())
+
+        assert [row.item_id for row in results] == ["exclusive_a"]
+        exclusive_b = session.query(WorkItem).filter_by(item_id="exclusive_b").one()
+        normal_c = session.query(WorkItem).filter_by(item_id="normal_c").one()
+        assert exclusive_b.assigned_machine_key is None
+        assert exclusive_b.state == WorkItemState.DISPATCH_PENDING
+        assert normal_c.assigned_machine_key is None
+        assert normal_c.state == WorkItemState.DISPATCH_PENDING
+
+
 def test_auto_dispatch_item_assigns_single_matching_machine() -> None:
     with make_session() as session:
         upsert_worker_machine(
@@ -130,6 +164,42 @@ def test_auto_dispatch_item_assigns_single_matching_machine() -> None:
         item = session.query(WorkItem).filter_by(item_id="item_a").one()
         assert item.assigned_machine_key == "eval-a"
         assert item.state == WorkItemState.READY
+
+
+def test_auto_dispatch_item_skips_exclusive_when_machine_has_reserved_work() -> None:
+    with make_session() as session:
+        upsert_worker_machine(
+            session,
+            machine_key="eval-a",
+            hostname="eval-a",
+            role="evaluator",
+            slot_capacity=16,
+            capabilities={"platform": "nangate45", "flow": "openroad"},
+        )
+        _seed_ready_item(session, item_id="normal_a", platform="nangate45", priority=5)
+        _seed_ready_item(
+            session,
+            item_id="exclusive_b",
+            platform="nangate45",
+            priority=4,
+            command_manifest=[{"name": "ppa", "run": "python3 npu/synth/run_block_sweep.py --sweep sweep.json"}],
+        )
+        normal = session.query(WorkItem).filter_by(item_id="normal_a").one()
+        normal.assigned_machine_key = "eval-a"
+        normal.state = WorkItemState.READY
+        session.commit()
+
+        result = auto_dispatch_item(session, item_id="exclusive_b", machine_key="eval-a")
+
+        assert result == AutoDispatchItemResult(
+            item_id="exclusive_b",
+            status="skipped",
+            machine_key=None,
+            reason="exclusive_item_requires_empty_worker",
+        )
+        exclusive = session.query(WorkItem).filter_by(item_id="exclusive_b").one()
+        assert exclusive.assigned_machine_key is None
+        assert exclusive.state == WorkItemState.DISPATCH_PENDING
 
 
 def test_auto_dispatch_item_repairs_assigned_dispatch_pending_item() -> None:

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import tempfile
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -20,7 +21,7 @@ from control_plane.models.work_items import WorkItem
 from control_plane.models.worker_leases import WorkerLease
 from control_plane.models.worker_machines import WorkerMachine
 from control_plane.services.lease_service import acquire_next_lease, expire_stale_leases, heartbeat_lease
-from control_plane.services.scheduler import assign_work_item
+from control_plane.services.scheduler import NoEligibleWorkItem, assign_work_item
 
 
 def make_session() -> Session:
@@ -106,6 +107,67 @@ def test_acquire_next_lease_selects_matching_highest_priority_item() -> None:
         assert item_b.state == WorkItemState.LEASED
         lease = session.query(WorkerLease).filter_by(lease_token=result.lease_token).one()
         assert lease.status == LeaseStatus.ACTIVE
+
+
+def test_acquire_next_lease_blocks_parallel_work_behind_exclusive_block_sweep() -> None:
+    with make_session() as session:
+        _, item_b = seed_ready_items(session)
+        from control_plane.services.lease_service import upsert_worker_machine
+
+        upsert_worker_machine(session, machine_key="machine-1", slot_capacity=16)
+        item_b.command_manifest = [
+            {"name": "ppa", "run": "python3 npu/synth/run_block_sweep.py --sweep sweep.json"}
+        ]
+        assign_work_item(session, item_id=item_b.item_id, machine_key="machine-1")
+        acquired = acquire_next_lease(
+            session,
+            machine_key="machine-1",
+            capabilities={"platform": "nangate45", "flow": "openroad"},
+            lease_seconds=900,
+            slot_capacity=16,
+        )
+        assert acquired.item_id == item_b.item_id
+
+        task = TaskRequest(
+            request_key="queue:item_c",
+            source="test",
+            requested_by="tester",
+            title="item c",
+            description="objective c",
+            layer="layer2",
+            flow="openroad",
+            priority=4,
+            request_payload={"item_id": "item_c"},
+        )
+        session.add(task)
+        session.flush()
+        item_c = WorkItem(
+            work_item_key="queue:item_c",
+            task_request_id=task.id,
+            item_id="item_c",
+            layer="layer2",
+            flow="openroad",
+            platform="nangate45",
+            task_type="l2_campaign",
+            state=WorkItemState.DISPATCH_PENDING,
+            priority=4,
+            input_manifest={},
+            command_manifest=[],
+            expected_outputs=[],
+            acceptance_rules=[],
+        )
+        session.add(item_c)
+        session.commit()
+        assign_work_item(session, item_id=item_c.item_id, machine_key="machine-1")
+
+        with pytest.raises(NoEligibleWorkItem, match="exclusive work"):
+            acquire_next_lease(
+                session,
+                machine_key="machine-1",
+                capabilities={"platform": "nangate45", "flow": "openroad"},
+                lease_seconds=900,
+                slot_capacity=16,
+            )
 
 
 def test_acquire_next_lease_persists_capability_filter() -> None:


### PR DESCRIPTION
## Summary
- treat OpenROAD `run_block_sweep.py` work items as exclusive worker jobs
- allow future jobs to opt into the same behavior with `input_manifest.worker_resources.exclusive_worker` or `exclusive`
- prevent both dispatcher assignment and worker lease acquisition from stacking work behind an exclusive block sweep on the same evaluator

## Context
The remote evaluator froze when four reciprocal PPA v2 jobs entered `run_block_sweep` concurrently on a worker advertising 16 slots. We manually held those jobs unassigned, but the control plane should encode this scheduling constraint so high-capacity evaluators do not launch several block sweeps at once.

Related recovery issue: #1101

## Tests
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_dispatcher_service.py control_plane/control_plane/tests/test_leases.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_dispatcher_service.py control_plane/control_plane/tests/test_leases.py control_plane/control_plane/tests/test_worker_daemon.py::test_next_trial_index_reuses_slot_after_stale_lease_cleanup control_plane/control_plane/tests/test_operator_status.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
