### PR TITLE
[codex] split reciprocal ppa density sweeps

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/evaluation_requests.json
@@ -2,12 +2,12 @@
   "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1",
   "requested_items": [
     {
-      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd30_ppa_v3",
       "task_type": "l1_sweep",
-      "objective": "Rerun q20 compact reciprocal PWL composed attention PPA with a q20-only keep-module sweep.",
+      "objective": "Rerun q20 compact reciprocal PWL composed attention PPA with a q20-only keep-module sweep. Split to a single PLACE_DENSITY=0.3 point so evaluator crashes do not lose both density points.",
       "evaluation_mode": "frontier_correction",
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
-      "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules",
+      "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules_pd30",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
       "revision": {
         "reason": "wrong_configuration",
@@ -25,17 +25,63 @@
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd30.json",
       "out_root": "runs/designs/npu_blocks",
-      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job."
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.3.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.3,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd30 item as the retry shape."
+      }
     },
     {
-      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd40_ppa_v3",
       "task_type": "l1_sweep",
-      "objective": "Rerun q24 compact reciprocal PWL composed attention PPA with a q24-only keep-module sweep.",
+      "objective": "Rerun q20 compact reciprocal PWL composed attention PPA with a q20-only keep-module sweep. Split to a single PLACE_DENSITY=0.4 point so evaluator crashes do not lose both density points.",
       "evaluation_mode": "frontier_correction",
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
-      "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules",
+      "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules_pd40",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+            "pr_number": 1096,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd40.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.4.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.4,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd40 item as the retry shape."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd30_ppa_v3",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 compact reciprocal PWL composed attention PPA with a q24-only keep-module sweep. Split to a single PLACE_DENSITY=0.3 point so evaluator crashes do not lose both density points.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules_pd30",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
       "revision": {
         "reason": "wrong_configuration",
@@ -53,17 +99,63 @@
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd30.json",
       "out_root": "runs/designs/npu_blocks",
-      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job."
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.3.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.3,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd30 item as the retry shape."
+      }
     },
     {
-      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd40_ppa_v3",
       "task_type": "l1_sweep",
-      "objective": "Rerun q20 sequential reciprocal PWL composed attention PPA with a q20-only keep-module sweep.",
+      "objective": "Rerun q24 compact reciprocal PWL composed attention PPA with a q24-only keep-module sweep. Split to a single PLACE_DENSITY=0.4 point so evaluator crashes do not lose both density points.",
       "evaluation_mode": "frontier_correction",
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
-      "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules",
+      "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules_pd40",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+            "pr_number": 1096,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd40.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.4.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.4,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd40 item as the retry shape."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd30_ppa_v3",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q20 sequential reciprocal PWL composed attention PPA with a q20-only keep-module sweep. Split to a single PLACE_DENSITY=0.3 point so evaluator crashes do not lose both density points.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules_pd30",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
       "revision": {
         "reason": "wrong_configuration",
@@ -81,17 +173,63 @@
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd30.json",
       "out_root": "runs/designs/npu_blocks",
-      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job."
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.3.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.3,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd30 item as the retry shape."
+      }
     },
     {
-      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2",
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd40_ppa_v3",
       "task_type": "l1_sweep",
-      "objective": "Rerun q24 sequential reciprocal PWL composed attention PPA with a q24-only keep-module sweep.",
+      "objective": "Rerun q20 sequential reciprocal PWL composed attention PPA with a q20-only keep-module sweep. Split to a single PLACE_DENSITY=0.4 point so evaluator crashes do not lose both density points.",
       "evaluation_mode": "frontier_correction",
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
-      "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules",
+      "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules_pd40",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+            "pr_number": 1098,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd40.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.4.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.4,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd40 item as the retry shape."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd30_ppa_v3",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 sequential reciprocal PWL composed attention PPA with a q24-only keep-module sweep. Split to a single PLACE_DENSITY=0.3 point so evaluator crashes do not lose both density points.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules_pd30",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
       "revision": {
         "reason": "wrong_configuration",
@@ -109,10 +247,75 @@
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd30.json",
       "out_root": "runs/designs/npu_blocks",
-      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job."
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.3.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.3,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd30 item as the retry shape."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd40_ppa_v3",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 sequential reciprocal PWL composed attention PPA with a q24-only keep-module sweep. Split to a single PLACE_DENSITY=0.4 point so evaluator crashes do not lose both density points.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules_pd40",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+            "pr_number": 1098,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd40.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.4.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.4,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd40 item as the retry shape."
+      }
     }
   ],
-  "source_commit": "53f922aa7778e634be3b34c3e978ad296724ddc8"
+  "source_commit": "53f922aa7778e634be3b34c3e978ad296724ddc8",
+  "resource_recovery": {
+    "reason": "remote evaluator froze while running the corrected reciprocal PPA block sweep; split each density point into its own item",
+    "superseded_item_ids": [
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2"
+    ],
+    "replacement_item_ids": [
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd40_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd40_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd40_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd40_ppa_v3"
+    ]
+  }
 }

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_pwl_recip_corrected_keep_modules_v1/proposal.json
@@ -4,9 +4,9 @@
   "created_by": "developer_agent",
   "layer": "layer1",
   "kind": "circuit",
-  "title": "Corrected q20/q24 PWL reciprocal keep-module sweeps",
+  "title": "Corrected q20/q24 PWL reciprocal single-density keep-module sweeps",
   "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
-  "hypothesis": "The prior shared q20/q24 compact-div and seqdiv sweeps recorded flow_failed rows because each single-precision RTL was synthesized with a union SYNTH_KEEP_MODULES list that referenced the other precision's softmax module. Splitting the sweeps by precision removes that setup error and can distinguish real physical boundary behavior from invalid flow configuration.",
+  "hypothesis": "The prior shared q20/q24 compact-div and seqdiv sweeps recorded flow_failed rows because each single-precision RTL was synthesized with a union SYNTH_KEEP_MODULES list that referenced the other precision's softmax module. Splitting the sweeps by precision removes that setup error and can distinguish real physical boundary behavior from invalid flow configuration. The recovery revision also splits each physical density point into a separate work item because the two-density OpenROAD block sweep destabilized the remote evaluator; this keeps each attempt salvageable and bounded.",
   "direct_comparison": {
     "primary_question": "With precision-specific keep-module lists, which q20/q24 PWL reciprocal datapath points are physically measurable in Nangate45?",
     "invalidated_inputs": [
@@ -14,22 +14,28 @@
       "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
     ],
     "candidate_items": [
-      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
-      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
-      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
-      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2"
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd40_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd40_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd40_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd40_ppa_v3"
     ],
     "include": [
       "q20 and q24 compact combinational reciprocal PWL softmax datapaths",
       "q20 and q24 one-bit-per-cycle sequential reciprocal PWL softmax datapaths",
       "precision-specific SYNTH_KEEP_MODULES containing only modules present in each generated RTL",
       "the composed datapath guard before OpenROAD",
-      "Nangate45 area, power, timing, and timing debug paths when the flow reaches reports"
+      "Nangate45 area, power, timing, and timing debug paths when the flow reaches reports",
+      "single-density PLACE_DENSITY=0.3 and PLACE_DENSITY=0.4 recovery sweeps for each reciprocal point"
     ],
     "exclude": [
       "quality re-evaluation",
       "full Llama7B system recost",
-      "multi-bit reciprocal divider exploration"
+      "multi-bit reciprocal divider exploration",
+      "retrying the four two-density v2 items as the primary recovery path"
     ],
     "metrics": [
       "critical_path_ns",
@@ -43,16 +49,17 @@
   "remaining_abstractions": [
     "This is still local composed datapath PPA; a dependent Layer 2 recost must substitute measured rows into the Llama7B model.",
     "The sequential reciprocal point uses fixed one-bit-per-cycle latency only.",
-    "Full RTL/perf equivalence for a physically promising reciprocal datapath remains a separate follow-up gate."
+    "Full RTL/perf equivalence for a physically promising reciprocal datapath remains a separate follow-up gate.",
+    "Single-density PPA recovery still does not solve host-level OpenROAD resource saturation; it only bounds each work item and preserves partial density evidence."
   ],
   "required_evaluations": [
     {
-      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd30_ppa_v3",
       "task_type": "l1_sweep",
-      "objective": "Rerun q20 compact reciprocal PWL composed attention PPA with a q20-only keep-module sweep.",
+      "objective": "Rerun q20 compact reciprocal PWL composed attention PPA with a q20-only keep-module sweep. Split to a single PLACE_DENSITY=0.3 point so evaluator crashes do not lose both density points.",
       "evaluation_mode": "frontier_correction",
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
-      "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules",
+      "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules_pd30",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
       "revision": {
         "reason": "wrong_configuration",
@@ -70,21 +77,63 @@
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd30.json",
       "out_root": "runs/designs/npu_blocks",
-      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job.",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.3.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.3,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
       "expected_result": {
-        "direction": "correct_invalid_shared_keep_modules",
-        "reason": "The prior shared q20/q24 compact-div sweep could fail before real synthesis because q20 RTL does not define the q24 softmax module."
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd30 item as the retry shape."
       }
     },
     {
-      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd40_ppa_v3",
       "task_type": "l1_sweep",
-      "objective": "Rerun q24 compact reciprocal PWL composed attention PPA with a q24-only keep-module sweep.",
+      "objective": "Rerun q20 compact reciprocal PWL composed attention PPA with a q20-only keep-module sweep. Split to a single PLACE_DENSITY=0.4 point so evaluator crashes do not lose both density points.",
       "evaluation_mode": "frontier_correction",
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
-      "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules",
+      "comparison_role": "q20_pwl_compact_reciprocal_corrected_keep_modules_pd40",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+            "pr_number": 1096,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd40.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.4.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.4,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd40 item as the retry shape."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd30_ppa_v3",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 compact reciprocal PWL composed attention PPA with a q24-only keep-module sweep. Split to a single PLACE_DENSITY=0.3 point so evaluator crashes do not lose both density points.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules_pd30",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
       "revision": {
         "reason": "wrong_configuration",
@@ -102,21 +151,63 @@
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd30.json",
       "out_root": "runs/designs/npu_blocks",
-      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job.",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.3.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.3,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
       "expected_result": {
-        "direction": "correct_invalid_shared_keep_modules",
-        "reason": "The prior shared q20/q24 compact-div sweep could fail before real synthesis because q24 RTL does not define the q20 softmax module."
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd30 item as the retry shape."
       }
     },
     {
-      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd40_ppa_v3",
       "task_type": "l1_sweep",
-      "objective": "Rerun q20 sequential reciprocal PWL composed attention PPA with a q20-only keep-module sweep.",
+      "objective": "Rerun q24 compact reciprocal PWL composed attention PPA with a q24-only keep-module sweep. Split to a single PLACE_DENSITY=0.4 point so evaluator crashes do not lose both density points.",
       "evaluation_mode": "frontier_correction",
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
-      "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules",
+      "comparison_role": "q24_pwl_compact_reciprocal_corrected_keep_modules_pd40",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_ppa_v1_r2",
+            "pr_number": 1096,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd40.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.4.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.4,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd40 item as the retry shape."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd30_ppa_v3",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q20 sequential reciprocal PWL composed attention PPA with a q20-only keep-module sweep. Split to a single PLACE_DENSITY=0.3 point so evaluator crashes do not lose both density points.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules_pd30",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
       "revision": {
         "reason": "wrong_configuration",
@@ -134,21 +225,63 @@
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd30.json",
       "out_root": "runs/designs/npu_blocks",
-      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job.",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.3.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.3,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
       "expected_result": {
-        "direction": "correct_invalid_shared_keep_modules",
-        "reason": "The prior shared q20/q24 seqdiv sweep failed q20 setup with missing q24 softmax module."
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd30 item as the retry shape."
       }
     },
     {
-      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2",
+      "item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd40_ppa_v3",
       "task_type": "l1_sweep",
-      "objective": "Rerun q24 sequential reciprocal PWL composed attention PPA with a q24-only keep-module sweep.",
+      "objective": "Rerun q20 sequential reciprocal PWL composed attention PPA with a q20-only keep-module sweep. Split to a single PLACE_DENSITY=0.4 point so evaluator crashes do not lose both density points.",
       "evaluation_mode": "frontier_correction",
       "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
-      "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules",
+      "comparison_role": "q20_pwl_sequential_reciprocal_corrected_keep_modules_pd40",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+            "pr_number": 1098,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd40.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.4.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.4,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd40 item as the retry shape."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd30_ppa_v3",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 sequential reciprocal PWL composed attention PPA with a q24-only keep-module sweep. Split to a single PLACE_DENSITY=0.3 point so evaluator crashes do not lose both density points.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules_pd30",
       "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
       "revision": {
         "reason": "wrong_configuration",
@@ -166,12 +299,54 @@
       "configs": [
         "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json"
       ],
-      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv.json",
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd30.json",
       "out_root": "runs/designs/npu_blocks",
-      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job.",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.3.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.3,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
       "expected_result": {
-        "direction": "correct_invalid_shared_keep_modules",
-        "reason": "The prior shared q20/q24 seqdiv sweep may fail q24 setup with missing q20 softmax module."
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd30 item as the retry shape."
+      }
+    },
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd40_ppa_v3",
+      "task_type": "l1_sweep",
+      "objective": "Rerun q24 sequential reciprocal PWL composed attention PPA with a q24-only keep-module sweep. Split to a single PLACE_DENSITY=0.4 point so evaluator crashes do not lose both density points.",
+      "evaluation_mode": "frontier_correction",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "q24_pwl_sequential_reciprocal_corrected_keep_modules_pd40",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+      "revision": {
+        "reason": "wrong_configuration",
+        "invalidates_item_ids": [
+          "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1"
+        ],
+        "invalidates": [
+          {
+            "item_id": "l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_ppa_v1",
+            "pr_number": 1098,
+            "reason": "shared q20/q24 keep-module sweep referenced softmax modules absent from each single-precision RTL"
+          }
+        ]
+      },
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd40.json",
+      "out_root": "runs/designs/npu_blocks",
+      "acceptance_notes": "Accept timing/route flow failures as boundary evidence only after the keep-module setup guard passes; missing keep modules are invalid setup and must fail the job. Single-density recovery item: this request must contain only PLACE_DENSITY=0.4.",
+      "recovery_of_item_id": "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2",
+      "resource_control": {
+        "split_reason": "two-density block sweep destabilized the evaluator host",
+        "place_density": 0.4,
+        "dispatch_policy": "single active OpenROAD block sweep on the evaluator"
+      },
+      "expected_result": {
+        "resource_recovery": "Supersedes the two-density item l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2 for crash recovery; preserve any valid v2 result if it completes, but use this pd40 item as the retry shape."
       }
     }
   ],
@@ -181,10 +356,37 @@
     "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div.json",
     "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div.json",
     "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv.json",
-    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv.json"
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd30.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd40.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd30.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd40.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd30.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd40.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd30.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd40.json"
   ],
   "knowledge_refs": [
     "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_div_v1/proposal.json",
     "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_q20_q24_pwl_recip_seqdiv_v1/proposal.json"
-  ]
+  ],
+  "resource_recovery": {
+    "reason": "remote evaluator froze while running the corrected reciprocal PPA block sweep; split each density point into its own item",
+    "superseded_item_ids": [
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_ppa_v2",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_ppa_v2",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_ppa_v2"
+    ],
+    "replacement_item_ids": [
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_pd40_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_div_pd40_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd40_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd30_ppa_v3",
+      "l1_decoder_attention_dual_stream_composed_q24_pwl_recip_seqdiv_pd40_ppa_v3"
+    ]
+  }
 }

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd30.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd30.json
@@ -1,0 +1,32 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_div_pd30"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_div_pd30"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q20_pwl_recip_div_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q20_pwl_recip_div_pd30"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd40.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_div_pd40.json
@@ -1,0 +1,32 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_div_pd40"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_div_pd40"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q20_pwl_recip_div_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q20_pwl_recip_div_pd40"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd30.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd30.json
@@ -1,0 +1,32 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_seqdiv_pd30"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_seqdiv_pd30"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q20_pwl_recip_seqdiv_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q20_pwl_recip_seqdiv_pd30"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd40.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q20_pwl_recip_seqdiv_pd40.json
@@ -1,0 +1,32 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_seqdiv_pd40"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q20_pwl_recip_seqdiv_pd40"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q20_pwl_recip_seqdiv_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q20_pwl_recip_seqdiv_pd40"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd30.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd30.json
@@ -1,0 +1,32 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_div_pd30"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_div_pd30"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q24_pwl_recip_div_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q24_pwl_recip_div_pd30"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd40.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_div_pd40.json
@@ -1,0 +1,32 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_div_pd40"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_div_pd40"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q24_pwl_recip_div_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q24_pwl_recip_div_pd40"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd30.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd30.json
@@ -1,0 +1,32 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_seqdiv_pd30"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_seqdiv_pd30"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q24_pwl_recip_seqdiv_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q24_pwl_recip_seqdiv_pd30"
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd40.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_q24_pwl_recip_seqdiv_pd40.json
@@ -1,0 +1,32 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_seqdiv_pd40"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_q24_pwl_recip_seqdiv_pd40"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc24 attention_softmax_weight_q24_pwl_recip_seqdiv_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_q24_pwl_recip_seqdiv_pd40"
+}


### PR DESCRIPTION
## Summary
- split the corrected q20/q24 reciprocal PPA proposal from four two-density v2 jobs into eight single-density v3 recovery jobs
- add pd30/pd40 sweep files with distinct TAG/FLOW_VARIANT names so partial results do not collide with the original v2 runs
- record the evaluator-crash recovery rationale in proposal.json and evaluation_requests.json

## Why
The remote evaluator became unreliable while running the corrected reciprocal OpenROAD block sweep. The active v2 item contains two PLACE_DENSITY points, so a crash can lose both points and force a large retry. The v3 shape bounds each work item to one physical point while preserving any valid v2 result if it completes.

## Validation
- python3 -m json.tool on updated proposal/request files and new sweep files
- direct assertion that every new split sweep has exactly one PLACE_DENSITY and matching density suffix
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l1_task_generator.py control_plane/control_plane/tests/test_run_block_sweep.py control_plane/control_plane/tests/test_dispatcher_service.py control_plane/control_plane/tests/test_leases.py -q
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue
- git diff --check