### PR TITLE
[codex] add q20 pwl divider recost profile

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1193,6 +1193,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+        "llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1",
     }:
         diagnosis = evidence_payload.get("diagnosis")
         diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
@@ -1217,6 +1218,8 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             if model == "llm_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1"
             else "Decoder composed dual-stream physical feasibility evidence (score32/w16 recip-lut q16 reduced-replica recost)"
             if model == "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1"
+            else "Decoder composed dual-stream physical feasibility evidence (q20 PWL reciprocal-divider reduced-replica recost)"
+            if model == "llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1"
             else "Decoder dual-stream physical feasibility evidence"
         )
         parts = [

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5455,6 +5455,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     score32_split2_reduced_replica = "score32_w16_exact_div_split2_reduced_replica" in item_id
     score32_reduced_replica = "score32_w16_exact_div_reduced_replica" in item_id
     score32_recip_lut_q16_reduced_replica = "score32_w16_recip_lut_q16_reduced_replica" in item_id
+    q20_pwl_recip_div_reduced_replica = "q20_pwl_recip_div_reduced_replica" in item_id
     score32_frontier = "score32_w16_exact_div_frontier" in item_id
     variant_frontier = "variant_frontier" in item_id
     composed_dual_stream_metrics = (
@@ -5475,6 +5476,12 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         composed_dual_stream_metrics = (
             "runs/designs/npu_blocks/"
             "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/metrics.csv"
+        )
+    elif q20_pwl_recip_div_reduced_replica:
+        composed_dual_stream_metrics = (
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/"
+            "metrics.csv"
         )
     elif score32_frontier or score32_reduced_replica:
         composed_dual_stream_metrics = (
@@ -5508,6 +5515,9 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     elif score32_recip_lut_q16_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a32_s32_w16_recip_lut_q16_int8_compute"
+    elif q20_pwl_recip_div_reduced_replica:
+        model_name = "llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1"
+        precision_profile = "q8_k8_v8_a24_s20_w20_pwl_recip_div_q20_int8_compute"
     elif score32_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a32_s32_w16_exact_div_int8_compute"
@@ -5550,7 +5560,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
                     f"--quality-gate-json {quality_gate} "
                     f"--precision-profile {precision_profile} "
                     f"--model-name {model_name} "
-                    f"{'--recompute-area-fit-replicas ' if score24_reduced_replica or score32_reduced_replica or score32_split2_reduced_replica or score32_recip_lut_q16_reduced_replica else ''}"
+                    f"{'--recompute-area-fit-replicas ' if score24_reduced_replica or score32_reduced_replica or score32_split2_reduced_replica or score32_recip_lut_q16_reduced_replica or q20_pwl_recip_div_reduced_replica else ''}"
                     "--frontier-row-limit 8 "
                     "--buffer-area-um2-per-byte 0.0 "
                     f"--out {out} "

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -2373,6 +2373,30 @@ def test_decoder_evidence_summary_recognizes_composed_datapath_score32_recip_lut
     assert "best_requested_replica_recost_latency_us=9900.0" in summary
 
 
+def test_decoder_evidence_summary_recognizes_composed_datapath_q20_pwl_recip_div_reduced_replica_model() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/composed_datapath_q20_pwl_recip_div_reduced_replica.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1",
+            "diagnosis": {
+                "decision": "dual_stream_area_blocked",
+                "precision_profile": "q8_k8_v8_a24_s20_w20_pwl_recip_div_q20_int8_compute",
+                "best_requested_mode": "dual_mac",
+                "best_requested_replica_recost_enabled": True,
+                "best_requested_replica_recost_area_fit_replica_count": 512,
+                "best_requested_replica_recost_macs_per_cycle": 65536,
+                "best_requested_replica_recost_latency_us": 12000.0,
+                "best_feasible_latency_us": 12000.0,
+            },
+        },
+    )
+
+    assert outcome == "dual_stream_area_blocked"
+    assert "q20 PWL reciprocal-divider reduced-replica recost" in summary
+    assert "precision_profile=q8_k8_v8_a24_s20_w20_pwl_recip_div_q20_int8_compute" in summary
+    assert "best_requested_replica_recost_area_fit_replica_count=512" in summary
+
+
 def _seed_succeeded_l2_campaign(session: Session, repo_root: Path) -> tuple[str, str]:
     campaign_dir = repo_root / "runs" / "campaigns" / "npu" / "demo_campaign"
     schedule_rel = "runs/campaigns/npu/demo_campaign/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6141,6 +6141,61 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_q12_pwl_fron
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_q20_pwl_recip_div_recost_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1"
+                in run
+            )
+            assert "--recompute-area-fit-replicas" in run
+            assert "--precision-profile q8_k8_v8_a24_s20_w20_pwl_recip_div_q20_int8_compute" in run
+            assert decoder_inputs["attention_kv_composed_dual_stream_metrics"] == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/"
+                "metrics.csv"
+            )
+            assert (
+                "--composed-dual-stream-metrics runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/"
+                "metrics.csv "
+                in run
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_frontier_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary

Adds a Layer 2 composed-datapath recost profile for the newly measured q20 PWL reciprocal-divider RTL datapath.

The new profile:
- selects `attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/metrics.csv`
- labels the precision as `q8_k8_v8_a24_s20_w20_pwl_recip_div_q20_int8_compute`
- enables reduced-replica area-fit recosting
- adds result-consumer summary wording for the q20 PWL reciprocal-divider recost

Direct probe result from the merged q20/div PPA rows:
- decision: `dual_stream_feasible`
- adjusted latency: `13676.407776 us`
- speedup vs HBM-closed source: `0.156389x`
- area-fit replicas: `739`
- MAC/cycle after recost: `94592`
- logic slack: `194331.0692 um2`

This makes the measured q20/divider datapath available as an explicit Llama7B recost point, and the direct probe shows it is an upper-cost boundary rather than the likely frontier.

## Validation

- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k q20_pwl_recip_div -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -k q20_pwl_recip_div -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py`
- `git diff --check`
