### PR TITLE
[codex] snapshot dirty service repo before source update

### DIFF
--- a/control_plane/control_plane/services/source_reconciler.py
+++ b/control_plane/control_plane/services/source_reconciler.py
@@ -281,6 +281,38 @@ def _quarantine_untracked_checkout_blockers(repo_root: Path, paths: list[str], t
     return quarantine_dir
 
 
+def _snapshot_tracked_modifications(repo_root: Path, status: str, target: str) -> Path:
+    """Preserve tracked service-repo edits before resetting for source checkout."""
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    snapshot_dir = _source_quarantine_root() / f"{repo_root.name}-tracked-modifications-{stamp}-{os.getpid()}"
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    diff = _run_git(repo_root, "diff", check=False).stdout
+    diff_cached = _run_git(repo_root, "diff", "--cached", check=False).stdout
+    (snapshot_dir / "status.txt").write_text(status, encoding="utf-8")
+    (snapshot_dir / "diff.patch").write_text(diff, encoding="utf-8")
+    (snapshot_dir / "diff_cached.patch").write_text(diff_cached, encoding="utf-8")
+    manifest = {
+        "repo_root": str(repo_root),
+        "target": target,
+        "status": status.splitlines(),
+        "created_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "files": {
+            "status": "status.txt",
+            "diff": "diff.patch",
+            "diff_cached": "diff_cached.patch",
+        },
+    }
+    (snapshot_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    try:
+        _run_git(repo_root, "reset", "--hard", "HEAD")
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise SourceReconciliationError(
+            f"failed to reset tracked service-repo modifications after snapshot at {snapshot_dir}: {exc}"
+        ) from exc
+    return snapshot_dir
+
+
 def _checkout_error_message(target: str, exc: Exception, context: str | None = None) -> str:
     stderr = str(getattr(exc, "stderr", "") or "").strip()
     prefix = f"failed to checkout source target {target}"
@@ -465,16 +497,19 @@ def _reconcile_service_repo_source_locked(
         target = update_ref
 
     _recover_stale_git_index_lock(repo_path)
-    if _git_stdout(repo_path, "status", "--porcelain", "--untracked-files=no"):
-        return SourceReconciliationResult(
-            status="blocked",
-            required_sha=required,
-            current_sha=current,
-            source_commit_relation=relation,
-            message="service repo has tracked local modifications; refusing automatic checkout",
-        )
+    dirty_status = _git_stdout(repo_path, "status", "--porcelain", "--untracked-files=no")
+    tracked_snapshot_dir: Path | None = None
+    if dirty_status:
+        tracked_snapshot_dir = _snapshot_tracked_modifications(repo_path, dirty_status, target)
 
-    quarantine_paths = _checkout_source_target(repo_path, target)
+    try:
+        quarantine_paths = _checkout_source_target(repo_path, target)
+    except SourceReconciliationError as exc:
+        if tracked_snapshot_dir is not None:
+            raise SourceReconciliationError(
+                f"{exc}; tracked modifications snapshot at {tracked_snapshot_dir}"
+            ) from exc
+        raise
 
     new_head = _current_head(repo_path)
     new_relation = _source_relation(repo_path, required, new_head)
@@ -488,6 +523,11 @@ def _reconcile_service_repo_source_locked(
         )
 
     message = f"service repo updated to {target}"
+    all_quarantine_paths = tuple(
+        str(path) for path in ([tracked_snapshot_dir] if tracked_snapshot_dir is not None else [])
+    ) + tuple(str(path) for path in quarantine_paths)
+    if tracked_snapshot_dir is not None:
+        message = f"{message}; snapshotted tracked modifications at {tracked_snapshot_dir}"
     if quarantine_paths:
         message = f"{message}; quarantined untracked checkout blockers at {', '.join(str(path) for path in quarantine_paths)}"
 
@@ -498,7 +538,7 @@ def _reconcile_service_repo_source_locked(
         source_commit_relation=new_relation,
         restart_required=True,
         message=message,
-        quarantine_paths=tuple(str(path) for path in quarantine_paths),
+        quarantine_paths=all_quarantine_paths,
     )
 
 

--- a/control_plane/control_plane/tests/test_source_reconciler.py
+++ b/control_plane/control_plane/tests/test_source_reconciler.py
@@ -188,3 +188,67 @@ def test_reconcile_service_repo_quarantines_untracked_checkout_blockers(
     assert (quarantine_dir / blocker_rel).read_text(encoding="utf-8") == "generated,old\n"
     assert (quarantine_dir / "manifest.json").exists()
     assert "quarantined untracked checkout blockers" in (result.message or "")
+
+
+def test_reconcile_service_repo_snapshots_tracked_modifications_before_update(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    first, required = _init_repo_with_stale_head(repo_root)
+    tracked = repo_root / "README.md"
+    tracked.write_text("local diagnostic edit\n", encoding="utf-8")
+    monkeypatch.setenv("RTLCP_SOURCE_QUARANTINE_ROOT", str(tmp_path / "quarantine"))
+
+    result = reconcile_service_repo_source(
+        repo_root=str(repo_root),
+        required_sha=required,
+        update_ref="origin/master",
+        allow_update=True,
+    )
+
+    assert result.status == "updated"
+    assert result.required_sha == required
+    assert _run("git", "-C", str(repo_root), "rev-parse", "HEAD") == required
+    assert first != required
+    assert len(result.quarantine_paths) == 1
+    snapshot_dir = Path(result.quarantine_paths[0])
+    assert snapshot_dir.is_dir()
+    assert (snapshot_dir / "status.txt").read_text(encoding="utf-8") == "M README.md"
+    assert "local diagnostic edit" in (snapshot_dir / "diff.patch").read_text(encoding="utf-8")
+    assert (snapshot_dir / "diff_cached.patch").exists()
+    assert (snapshot_dir / "manifest.json").exists()
+    assert "snapshotted tracked modifications" in (result.message or "")
+    assert not _run("git", "-C", str(repo_root), "status", "--porcelain", "--untracked-files=no")
+
+
+def test_reconcile_service_repo_reports_snapshot_path_when_checkout_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _, required = _init_repo_with_stale_head(repo_root)
+    (repo_root / "README.md").write_text("local diagnostic edit\n", encoding="utf-8")
+    monkeypatch.setenv("RTLCP_SOURCE_QUARANTINE_ROOT", str(tmp_path / "quarantine"))
+
+    def _fail_checkout(repo: Path, target: str) -> tuple[Path, ...]:
+        raise SourceReconciliationError("forced checkout failure")
+
+    monkeypatch.setattr(source_reconciler, "_checkout_source_target", _fail_checkout)
+
+    with pytest.raises(SourceReconciliationError) as exc_info:
+        reconcile_service_repo_source(
+            repo_root=str(repo_root),
+            required_sha=required,
+            update_ref="origin/master",
+            allow_update=True,
+        )
+
+    message = str(exc_info.value)
+    assert "forced checkout failure" in message
+    assert "tracked modifications snapshot at" in message
+    snapshot_dirs = list((tmp_path / "quarantine").glob("repo-tracked-modifications-*"))
+    assert len(snapshot_dirs) == 1
+    assert "local diagnostic edit" in (snapshot_dirs[0] / "diff.patch").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Makes evaluator source reconciliation recover from tracked local modifications in the service repo.

Before this change, a dirty `/workspaces/rtlgen-eval-clean` service checkout blocked automatic source updates with:

`service repo has tracked local modifications; refusing automatic checkout`

Now the reconciler:
- snapshots tracked service-repo edits under the source quarantine root
- preserves `status.txt`, `diff.patch`, `diff_cached.patch`, and `manifest.json`
- resets the service repo after the snapshot so checkout can proceed
- includes the snapshot path in success messages and in checkout-failure errors

This targets the recurring evaluator refresh blocker without dropping diagnostic evidence.

## Validation

- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_source_reconciler.py control_plane/control_plane/tests/test_worker_daemon.py -q`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py`
- `git diff --check`
