### PR TITLE
control_plane: discover L2 proposal linkage by item

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -122,6 +122,56 @@ def _load_requested_item_entry(repo_root: Path, proposal_path: str | None, item_
     return None
 
 
+def _proposal_mentions_item(payload: dict[str, Any], item_id: str) -> bool:
+    item_retry_base = _retry_base(item_id)
+    for key in ("requested_items", "required_evaluations"):
+        values = payload.get(key)
+        if not isinstance(values, list):
+            continue
+        for entry in values:
+            if not isinstance(entry, dict):
+                continue
+            candidate_item_id = str(entry.get("item_id", "")).strip()
+            if candidate_item_id == item_id or _retry_base(candidate_item_id) == item_retry_base:
+                return True
+    return False
+
+
+def _discover_proposal_for_item(repo_root: Path, item_id: str) -> tuple[str | None, str | None]:
+    proposal_root = repo_root / "docs" / "proposals"
+    if not proposal_root.exists():
+        return None, None
+
+    matches: list[tuple[str, str]] = []
+    for proposal_dir in sorted(path for path in proposal_root.iterdir() if path.is_dir()):
+        proposal_file = proposal_dir / "proposal.json"
+        proposal_id = proposal_dir.name
+        if proposal_file.exists():
+            try:
+                proposal_payload = _load_json(proposal_file)
+            except Exception:
+                proposal_payload = {}
+            proposal_id = str(proposal_payload.get("proposal_id", "")).strip() or proposal_id
+            if _proposal_mentions_item(proposal_payload, item_id):
+                matches.append((proposal_id, str(proposal_dir.relative_to(repo_root))))
+                continue
+
+        evaluation_requests_path = proposal_dir / "evaluation_requests.json"
+        if not evaluation_requests_path.exists():
+            continue
+        try:
+            evaluation_payload = _load_json(evaluation_requests_path)
+        except Exception:
+            continue
+        if _proposal_mentions_item(evaluation_payload, item_id):
+            request_proposal_id = str(evaluation_payload.get("proposal_id", "")).strip()
+            matches.append((request_proposal_id or proposal_id, str(proposal_dir.relative_to(repo_root))))
+
+    if len(matches) == 1:
+        return matches[0]
+    return None, None
+
+
 def _resolve_requested_entry_text(
     entry: dict[str, Any] | None,
     *,
@@ -9475,8 +9525,20 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
     objective_profiles_json = (
         _repo_rel(request.objective_profiles_json, repo_root) if request.objective_profiles_json else None
     )
+    proposal_id = request.proposal_id
     proposal_path = _repo_rel(request.proposal_path, repo_root) if request.proposal_path else None
-    proposal_path = canonicalize_proposal_path(repo_root, proposal_path=proposal_path, proposal_id=request.proposal_id)
+    if not proposal_id and not proposal_path:
+        proposal_id, proposal_path = _discover_proposal_for_item(repo_root, item_id)
+    proposal_path = canonicalize_proposal_path(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
+    effective_proposal_id = str(proposal_id or "").strip()
+    if not effective_proposal_id:
+        proposal_path_text = str(proposal_path or "").strip()
+        if proposal_path_text:
+            proposal_path_obj = Path(proposal_path_text)
+            if proposal_path_obj.name == "proposal.json":
+                effective_proposal_id = str(proposal_path_obj.parent.name).strip()
+            else:
+                effective_proposal_id = str(proposal_path_obj.name).strip()
     requested_entry = _load_requested_item_entry(repo_root, proposal_path, item_id)
     effective_evaluation_mode = _resolve_requested_entry_text(
         requested_entry,
@@ -9517,7 +9579,7 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
     if request.update_proposal_files:
         _upsert_requested_item_entry(
             repo_root=repo_root,
-            proposal_id=request.proposal_id,
+            proposal_id=effective_proposal_id,
             proposal_path=proposal_path,
             item_id=item_id,
             task_type='l2_campaign',
@@ -9556,7 +9618,7 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
         jobs=request.jobs,
         batch_id=batch_id,
         objective_profiles_json=objective_profiles_json,
-        proposal_id=request.proposal_id,
+        proposal_id=effective_proposal_id,
         proposal_path=proposal_path,
         evaluation_mode=effective_evaluation_mode,
         abstraction_layer=effective_abstraction_layer,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -81,6 +81,61 @@ def _init_git_repo(repo_root: Path) -> str:
     return result.stdout.strip()
 
 
+def _write_q20_pwl_recip_div_recost_proposal(repo_root: Path) -> None:
+    proposal_dir = (
+        repo_root
+        / "docs"
+        / "proposals"
+        / "prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1"
+    )
+    proposal_dir.mkdir(parents=True)
+    proposal_id = "prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1"
+    item_id = "l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1"
+    proposal_dir.joinpath("proposal.json").write_text(
+        json.dumps(
+            {
+                "proposal_id": proposal_id,
+                "required_evaluations": [
+                    {
+                        "item_id": item_id,
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    proposal_dir.joinpath("evaluation_requests.json").write_text(
+        json.dumps(
+            {
+                "proposal_id": proposal_id,
+                "requested_items": [
+                    {
+                        "item_id": item_id,
+                        "evaluation_mode": "frontier_detail",
+                        "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+                        "comparison_role": "q20_pwl_recip_div_reduced_replica_recost",
+                        "paired_baseline_item_id": (
+                            "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1"
+                        ),
+                        "depends_on_item_ids": [
+                            "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2"
+                        ],
+                        "requires_merged_inputs": True,
+                        "requires_materialized_refs": True,
+                        "expected_result": {
+                            "direction": "record_q20_pwl_recip_div_area_fit_recost",
+                            "reason": "q20 boundary recost",
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_generate_l2_campaign_task_creates_ready_work_item() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -6146,6 +6201,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_q20_pwl_reci
         repo_root = Path(td) / "repo"
         repo_root.mkdir()
         campaign_path = _write_campaign(repo_root)
+        _write_q20_pwl_recip_div_recost_proposal(repo_root)
         source_commit = _init_git_repo(repo_root)
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         create_all(engine)
@@ -6168,6 +6224,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_q20_pwl_reci
             commands = work_item.task_request.request_payload["task"]["commands"]
             run = commands[0]["run"]
             decoder_inputs = work_item.input_manifest["decoder_contract"]
+            payload = work_item.task_request.request_payload
 
             assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
             assert (
@@ -6176,6 +6233,16 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_q20_pwl_reci
             )
             assert "--recompute-area-fit-replicas" in run
             assert "--precision-profile q8_k8_v8_a24_s20_w20_pwl_recip_div_q20_int8_compute" in run
+            assert payload["developer_loop"]["proposal_id"] == (
+                "prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1"
+            )
+            assert payload["developer_loop"]["proposal_path"] == (
+                "docs/proposals/prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1"
+            )
+            assert payload["developer_loop"]["comparison"]["role"] == "q20_pwl_recip_div_reduced_replica_recost"
+            assert payload["developer_loop"]["dependencies"]["item_ids"] == [
+                "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2"
+            ]
             assert decoder_inputs["attention_kv_composed_dual_stream_metrics"] == (
                 "runs/designs/npu_blocks/"
                 "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/"

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds q20 PWL reciprocal-divider reduced-replica recost support and should wait until the q20 PWL reciprocal-divider L1 PPA item is merged.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the measured q20 PWL reciprocal-divider composed dual-stream attention wrapper at the area-fit replica count and measured wrapper clock.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "q20_pwl_recip_div_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+        "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_q20_pwl_recip_div_area_fit_recost",
+        "reason": "The measured q20 PWL reciprocal-divider datapath is a high-cost but physically embodied softmax boundary; recost it to keep the Llama7B frontier comparison honest."
+      },
+      "status": "planned"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_v1",
+  "created_utc": "2026-07-02T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B q20 PWL reciprocal-divider composed datapath reduced-replica recost",
+  "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+  "hypothesis": "The measured q20 PWL reciprocal-divider composed datapath is a conservative, physically embodied softmax boundary. Re-costing it at the area-fit replica count will show whether the higher-precision PWL reciprocal path has any Llama7B frontier value after accounting for its measured delay, power, and area.",
+  "direct_comparison": {
+    "primary_question": "What Llama7B latency/area/energy point remains when the measured q20 PWL reciprocal-divider composed datapath is constrained to the area-fit replica count?",
+    "baseline": "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+    "candidate": "l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1",
+    "include": [
+      "consume measured q20 PWL reciprocal-divider composed datapath metrics",
+      "use the existing Llama7B sub-tile schedule structure",
+      "reduce compute replicas to the measured-area budgeted count",
+      "recompute QKV, QK, value, tile service, layer, and total latency at the measured wrapper clock",
+      "compare against the current score32/w16 reciprocal-LUT q16 reduced-replica recost"
+    ],
+    "exclude": [
+      "new native checkpoint quality run",
+      "new HBM/DRAM service model",
+      "new L1 datapath synthesis"
+    ],
+    "metrics": [
+      "decision",
+      "precision_profile",
+      "best_requested_replica_recost_area_fit_replica_count",
+      "best_requested_replica_recost_macs_per_cycle",
+      "best_requested_replica_recost_latency_us",
+      "best_requested_adjusted_speedup_vs_hbm_closed_source",
+      "best_feasible_latency_us"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the measured q20 PWL reciprocal-divider composed dual-stream attention wrapper at the area-fit replica count and measured wrapper clock.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "q20_pwl_recip_div_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+        "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_q20_pwl_recip_div_area_fit_recost",
+        "reason": "The measured q20 PWL reciprocal-divider datapath is a high-cost but physically embodied softmax boundary; recost it to keep the Llama7B frontier comparison honest."
+      }
+    }
+  ],
+  "source_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1.json",
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py"
+  ],
+  "remaining_abstractions": [
+    "This recosts the existing analytic schedule rather than running a new end-to-end simulator.",
+    "HBM/SRAM/NoC service models are inherited unchanged from the upstream sub-tile schedule.",
+    "The PWL reciprocal-divider softmax is an integer approximation boundary, not full floating-point softmax.",
+    "Quality backing remains inherited from upstream mixed-int8 evidence unless a follow-up native checkpoint quality run is scheduled."
+  ]
+}


### PR DESCRIPTION
## Summary
- add L2 proposal auto-discovery by work item when generation omits explicit proposal flags
- add q20 PWL reciprocal-divider reduced-replica proposal/evaluation request docs
- cover the q20 recost generator path so it emits non-empty developer_loop proposal linkage, comparison role, and dependency metadata

## Why
The queued q20 PWL reciprocal-divider L2 recost currently has empty developer_loop.proposal_id/proposal_path. That can reproduce the prior eligibility blocker: missing developer_loop proposal linkage. This makes the generator recover linkage from docs/proposals before dispatch.

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_q20_pwl_recip_div_recost_evidence
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue
- git diff --check HEAD~1 HEAD
- python3 -m json.tool on the new proposal/evaluation request JSON files