### PR TITLE
control_plane: preserve L2 proposal request metadata

### DIFF
--- a/control_plane/control_plane/cli/generate_l2_campaign.py
+++ b/control_plane/control_plane/cli/generate_l2_campaign.py
@@ -34,7 +34,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--expected-reason")
     parser.add_argument("--comparison-role")
     parser.add_argument("--paired-baseline-item-id")
-    parser.add_argument("--depends-on-item-id", action="append", default=[])
+    parser.add_argument("--depends-on-item-id", action="append")
     parser.add_argument("--requires-merged-inputs", action="store_true")
     parser.add_argument("--requires-materialized-refs", action="store_true")
     parser.add_argument("--no-run-physical", action="store_true")

--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -144,7 +144,7 @@ def main(argv: list[str] | None = None) -> int:
     generate_l2_parser.add_argument("--expected-reason")
     generate_l2_parser.add_argument("--comparison-role")
     generate_l2_parser.add_argument("--paired-baseline-item-id")
-    generate_l2_parser.add_argument("--depends-on-item-id", action="append", default=[])
+    generate_l2_parser.add_argument("--depends-on-item-id", action="append")
     generate_l2_parser.add_argument("--requires-merged-inputs", action="store_true")
     generate_l2_parser.add_argument("--requires-materialized-refs", action="store_true")
     generate_l2_parser.add_argument("--no-run-physical", action="store_true")

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -187,6 +187,24 @@ def _resolve_requested_entry_text(
     return candidate or None
 
 
+def _resolve_requested_entry_expected_result_text(
+    entry: dict[str, Any] | None,
+    *,
+    key: str,
+    explicit: str | None,
+) -> str | None:
+    resolved = str(explicit or "").strip()
+    if resolved:
+        return resolved
+    if not isinstance(entry, dict):
+        return None
+    expected_result = entry.get("expected_result")
+    if not isinstance(expected_result, dict):
+        return None
+    candidate = str(expected_result.get(key, "")).strip()
+    return candidate or None
+
+
 def _resolve_requested_entry_list(
     entry: dict[str, Any] | None,
     *,
@@ -9575,6 +9593,16 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
         key="requires_materialized_refs",
         explicit=request.requires_materialized_refs,
     )
+    effective_expected_direction = _resolve_requested_entry_expected_result_text(
+        requested_entry,
+        key="direction",
+        explicit=request.expected_direction,
+    )
+    effective_expected_reason = _resolve_requested_entry_expected_result_text(
+        requested_entry,
+        key="reason",
+        explicit=request.expected_reason,
+    )
     source_commit = _resolve_source_commit(repo_root, request.source_commit)
     if request.update_proposal_files:
         _upsert_requested_item_entry(
@@ -9591,8 +9619,8 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
             depends_on_item_ids=effective_depends_on_item_ids,
             requires_merged_inputs=effective_requires_merged_inputs,
             requires_materialized_refs=effective_requires_materialized_refs,
-            expected_direction=request.expected_direction,
-            expected_reason=request.expected_reason,
+            expected_direction=effective_expected_direction,
+            expected_reason=effective_expected_reason,
             source_commit=source_commit,
         )
     expected_outputs = _build_expected_outputs(
@@ -9622,8 +9650,8 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
         proposal_path=proposal_path,
         evaluation_mode=effective_evaluation_mode,
         abstraction_layer=effective_abstraction_layer,
-        expected_direction=request.expected_direction,
-        expected_reason=request.expected_reason,
+        expected_direction=effective_expected_direction,
+        expected_reason=effective_expected_reason,
         comparison_role=effective_comparison_role,
         paired_baseline_item_id=effective_paired_baseline_item_id,
         depends_on_item_ids=effective_depends_on_item_ids,

--- a/control_plane/control_plane/tests/test_cli_generate_l2.py
+++ b/control_plane/control_plane/tests/test_cli_generate_l2.py
@@ -1,0 +1,51 @@
+"""Layer 2 generation CLI coverage."""
+
+from __future__ import annotations
+
+from control_plane.cli import generate_l2_campaign
+from control_plane.services.l2_task_generator import Layer2TaskGenerateResult
+
+
+class _SessionContext:
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+
+def test_generate_l2_campaign_cli_omitted_dependencies_remain_unspecified(monkeypatch) -> None:
+    captured = {}
+
+    monkeypatch.setattr(generate_l2_campaign, "build_engine", lambda _database_url: object())
+    monkeypatch.setattr(generate_l2_campaign, "create_all", lambda _engine: None)
+    monkeypatch.setattr(generate_l2_campaign, "build_session_factory", lambda _engine: _SessionContext)
+
+    def fake_generate(_session: object, request: object) -> Layer2TaskGenerateResult:
+        captured["depends_on_item_ids"] = request.depends_on_item_ids
+        return Layer2TaskGenerateResult(
+            item_id="l2_demo",
+            status="applied",
+            work_item_id="wi",
+            task_request_id="tr",
+        )
+
+    monkeypatch.setattr(generate_l2_campaign, "generate_l2_campaign_task", fake_generate)
+
+    result = generate_l2_campaign.main(
+        [
+            "--database-url",
+            "sqlite+pysqlite:///:memory:",
+            "--repo-root",
+            "/tmp/repo",
+            "--campaign-path",
+            "runs/campaigns/demo/campaign.json",
+            "--item-id",
+            "l2_demo",
+            "--no-auto-dispatch",
+        ]
+    )
+
+    assert result == 0
+    assert captured["depends_on_item_ids"] is None
+

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -119,7 +119,9 @@ def _write_q20_pwl_recip_div_recost_proposal(repo_root: Path) -> None:
                             "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1"
                         ),
                         "depends_on_item_ids": [
-                            "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2"
+                            "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+                            "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+                            "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1",
                         ],
                         "requires_merged_inputs": True,
                         "requires_materialized_refs": True,
@@ -6241,8 +6243,14 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_q20_pwl_reci
             )
             assert payload["developer_loop"]["comparison"]["role"] == "q20_pwl_recip_div_reduced_replica_recost"
             assert payload["developer_loop"]["dependencies"]["item_ids"] == [
-                "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2"
+                "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_div_ppa_v2",
+                "l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+                "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1",
             ]
+            assert payload["developer_loop"]["evaluation"]["expected_direction"] == (
+                "record_q20_pwl_recip_div_area_fit_recost"
+            )
+            assert payload["developer_loop"]["evaluation"]["expected_reason"] == "q20 boundary recost"
             assert decoder_inputs["attention_kv_composed_dual_stream_metrics"] == (
                 "runs/designs/npu_blocks/"
                 "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/"


### PR DESCRIPTION
## Summary
- keep omitted --depends-on-item-id as None in both L2 CLI entry points, so proposal dependencies can be inherited
- resolve developer_loop expected_direction/expected_reason from proposal requested_items.expected_result when explicit flags are omitted
- add CLI coverage for omitted dependency flags and strengthen q20 proposal-linkage coverage

## Why
After #1109, proposal ID/path were recovered, but a no-flag CLI upsert still converted omitted dependencies into an explicit empty list and left expected_result fields empty. That weakens dependency gates and review metadata for proposal-discovered work items.

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_cli_generate_l2.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_q20_pwl_recip_div_recost_evidence
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_cli_generate_l2.py control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python scripts/validate_runs.py --skip_eval_queue
- git diff --check