### PR TITLE
docs: define qkv8 composed softmax frontier gap

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/README.md
@@ -1,0 +1,33 @@
+# Composed qkv8 Float/Exact Softmax Wrapper
+
+This proposal captures the next abstraction-removal step for the Llama7B
+mixed/int8 attention frontier.
+
+The current quality-backed candidate is `qkv8_float_exact`, with `score32_float`
+also held by the native quality gate. The measured score32 exact-divider,
+score32 reciprocal-LUT, q20/q24 PWL, and seqdiv composed wrappers are useful
+fixed-point diagnostics, but they are not the quality-backed frontier after the
+broad native quality gate. The `npu_fp16_cpp_nm*_softmaxcmp` rows are measured
+hardware proxy rows, but they are `npu_top` configurations and do not embody the
+q8/k8/v8 dual-stream composed attention wrapper.
+
+The next physical job should therefore be blocked until the RTL generator has a
+distinct composed-wrapper softmax mode for the quality-backed semantics. It
+must not alias `qkv8_float_exact` to the existing integer `exact_div`,
+`recip_lut`, or PWL implementations.
+
+Minimum implementation requirements:
+
+- Add an explicit semantic profile in the composed wrapper config, for example
+  `semantic_profile=qkv8_float_exact` or `semantic_profile=score32_float`.
+- Define the conversion boundary from q8/k8 score accumulation into the
+  floating or near-exact softmax input.
+- Define the probability representation used to multiply v8 values.
+- Update the composed-wrapper guard so that this proposal cannot accidentally
+  consume fixed-point/PWL or `npu_top` proxy metrics.
+- Queue a single bounded L1 PPA run only after generator and guard support are
+  available and the remote evaluator checkout is clean.
+
+The dependent L2 recost should use the L1 metrics from that wrapper and mark the
+result quality-backed by the existing `qkv8_float_exact`/`score32_float`
+quality evidence.

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/proposal.json
@@ -1,0 +1,101 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1",
+  "created_utc": "2026-07-02T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Composed dual-stream qkv8 quality-backed floating/near-exact softmax datapath",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The current mixed/int8 Llama7B frontier cannot be ranked by token throughput, energy, area, and precision until the quality-backed qkv8_float_exact/score32_float softmax semantics are embodied inside the composed dual-stream attention wrapper. Existing score32 exact-divider and PWL rows are measured diagnostic fixed-point datapaths, while the fp16 softmaxcmp rows are measured proxies outside the composed attention wrapper.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 PPA cost is paid by a composed q8/k8/v8 attention wrapper that preserves the quality-backed qkv8_float_exact or score32_float softmax semantics?",
+    "baselines": [
+      "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_ppa_v1",
+      "l1_decoder_attention_dual_stream_composed_q20_pwl_recip_seqdiv_pd30_ppa_v3",
+      "npu_fp16_cpp_nm2_softmaxcmp"
+    ],
+    "candidate": "l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_ppa_v1",
+    "include": [
+      "q8/k8/v8 projection/value datapath inside the composed dual-stream wrapper",
+      "softmax score/weight path matching qkv8_float_exact or score32_float quality semantics",
+      "explicit conversion boundaries between int8 score/value datapaths and floating or near-exact softmax weights",
+      "guard checks that reject accidental substitution of the existing fixed-point/PWL or npu_top fp16-softmax proxy rows",
+      "Nangate45 area, power, timing, and timing debug paths after the wrapper is implemented"
+    ],
+    "exclude": [
+      "ranking npu_fp16_cpp_nm*_softmaxcmp as a composed attention datapath",
+      "claiming score32 exact-divider or PWL softmax rows are quality-backed after the broad quality gate rejected them",
+      "new HBM/DRAM modeling",
+      "QAT or model retraining"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report",
+      "semantic_profile",
+      "quality_source_candidate_id"
+    ]
+  },
+  "implementation_plan": [
+    {
+      "step": "Add a composed-wrapper softmax mode that is distinct from existing integer softmax_impl values.",
+      "details": "npu/rtlgen/gen_attention_dual_stream_composed.py currently validates only exact_div, pow2sum, recip_lut, pwl_recip_lut, pwl_recip_div, and pwl_recip_seqdiv. Add a new mode only when the generated RTL contains the required floating or near-exact row-softmax datapath, not as an alias for fixed-point exact_div."
+    },
+    {
+      "step": "Define conversion and accumulation boundaries.",
+      "details": "The wrapper must state how q8/k8 scores become the softmax input, how probabilities are represented, and how the probability by v8 value product is accumulated. These boundaries must match the quality candidate labels qkv8_float_exact or score32_float."
+    },
+    {
+      "step": "Add a guard that records the semantic profile.",
+      "details": "check_attention_dual_stream_composed_guard.py should fail if a qkv8_float_exact measurement points at an integer/PWL softmax_impl or at the npu_top fp16-softmax proxy design."
+    },
+    {
+      "step": "Add one L1 PPA request after generator support exists.",
+      "details": "The first measured point should use the existing composed wrapper dimensions, q8/k8/v8, and a conservative single density/sweep to avoid overloading the evaluator while the q20 seqdiv queue drains."
+    },
+    {
+      "step": "Add a dependent L2 recost only after the L1 metrics are merged.",
+      "details": "The L2 recost should substitute this composed wrapper into the Llama7B schedule and mark it quality-backed by qkv8_float_exact/score32_float evidence."
+    }
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for a real composed q8/k8/v8 attention wrapper that preserves qkv8_float_exact or score32_float softmax semantics.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "quality_backed_composed_softmax_recost",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "blocked_until": [
+        "gen_attention_dual_stream_composed emits a distinct floating or near-exact softmax implementation",
+        "the composed-wrapper guard records and validates semantic_profile=qkv8_float_exact or score32_float",
+        "the evaluator source checkout is updated and able to accept new work"
+      ],
+      "run_physical": true,
+      "expected_result": {
+        "direction": "measure_quality_backed_composed_softmax_datapath",
+        "reason": "The current quality-energy audit requires a composed q8/k8/v8 wrapper with quality-backed softmax semantics before ranking the mixed/int8 frontier."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_energy_frontier__l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1.json",
+    "runs/designs/npu_blocks/npu_fp16_cpp_nm2_softmaxcmp/config_nm2_softmax.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_v1/proposal.json",
+    "npu/eval/README.md"
+  ],
+  "remaining_abstractions": [
+    "No RTL for the floating or near-exact composed softmax path exists yet.",
+    "The fp16 softmaxcmp rows are npu_top proxy rows with the existing int8 row-wise SOFTMAX wrapper, not composed q8/k8/v8 attention wrappers.",
+    "The first L1 job must be queued only after generator and guard support exists."
+  ]
+}

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -461,6 +461,16 @@ q8/k8/v8 projection path with matching high-precision or exact score-softmax
 hardware before comparing token throughput, energy, and area against the FP16
 baseline.
 
+Do not treat `runs/designs/npu_blocks/npu_fp16_cpp_nm*_softmaxcmp/metrics.csv`
+as that composed recost. Those rows are measured proxy hardware, but they are
+`npu_top` configurations with the existing dedicated row-wise SOFTMAX wrapper,
+not a composed q8/k8/v8 dual-stream attention datapath. The required L1 follow-up
+is tracked by
+`docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/`;
+it remains blocked until the composed-wrapper generator emits a distinct
+floating or near-exact softmax path and the guard records the matching semantic
+profile.
+
 The measured q12/PWL reciprocal-LUT softmax path is a candidate proxy for that
 recost, but only after a native quality gate validates the same arithmetic. In
 the mixed/int8 native evaluator, use softmax mode


### PR DESCRIPTION
## Summary\n- add a Layer 1 proposal for the missing qkv8_float_exact / score32_float composed softmax wrapper\n- clarify that fp16 softmaxcmp rows are measured proxy evidence, not composed q8/k8/v8 attention PPA\n- mark the first physical qkv8 composed-softmax job blocked until generator and guard support exist\n\n## Validation\n- python3 -m json.tool docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/proposal.json\n- git diff --check