### PR TITLE
rtlgen: guard composed softmax semantic profiles

### DIFF
--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -9,6 +9,17 @@ import re
 from pathlib import Path
 
 
+INTEGER_SOFTMAX_IMPLS = {
+    "exact_div",
+    "pow2sum",
+    "recip_lut",
+    "pwl_recip_lut",
+    "pwl_recip_div",
+    "pwl_recip_seqdiv",
+}
+QUALITY_BACKED_FLOAT_PROFILES = {"qkv8_float_exact", "score32_float"}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--design-dir", required=True)
@@ -29,6 +40,7 @@ def main() -> int:
     streams = int(manifest["streams"])
     equivalence_hash = bool(manifest.get("equivalence_hash", False))
     softmax_impl = str(manifest.get("softmax_impl", "exact_div"))
+    semantic_profile = str(manifest.get("semantic_profile", "fixed_point"))
     softmax_pipeline_stages = int(manifest.get("softmax_pipeline_stages", 0))
     softmax_internal_pipeline_stages = int(manifest.get("softmax_internal_pipeline_stages", 0))
     softmax_latency_stages = int(manifest.get("softmax_latency_stages", 1))
@@ -52,8 +64,13 @@ def main() -> int:
         raise SystemExit("expected exactly one shared softmax instance")
     if "stream_buf_0" not in top_text or "stream_buf_1" not in top_text:
         raise SystemExit("missing dual stream buffer registers")
-    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut", "pwl_recip_lut", "pwl_recip_div", "pwl_recip_seqdiv"}:
+    if softmax_impl not in INTEGER_SOFTMAX_IMPLS:
         raise SystemExit(f"unsupported softmax_impl={softmax_impl}")
+    if semantic_profile in QUALITY_BACKED_FLOAT_PROFILES and softmax_impl in INTEGER_SOFTMAX_IMPLS:
+        raise SystemExit(
+            f"semantic_profile={semantic_profile} requires a distinct floating or near-exact softmax "
+            f"implementation; softmax_impl={softmax_impl} is fixed-point diagnostic hardware"
+        )
     if not 24 <= mac_accum_bits <= 32:
         raise SystemExit(f"unsupported mac_accum_bits={mac_accum_bits}")
     if not 2 <= softmax_score_bits <= 32:
@@ -201,6 +218,7 @@ def main() -> int:
                 "value_streams": value_instances,
                 "equivalence_hash": equivalence_hash,
                 "softmax_impl": softmax_impl,
+                "semantic_profile": semantic_profile,
                 "softmax_score_bits": softmax_score_bits,
                 "softmax_weight_bits": softmax_weight_bits,
                 "softmax_pipeline_stages": softmax_pipeline_stages,

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -43,6 +43,29 @@ def _as_str(config: dict[str, Any], key: str, default: str) -> str:
     return str(config.get(key, default)).strip()
 
 
+_INTEGER_SOFTMAX_IMPLS = {
+    "exact_div",
+    "pow2sum",
+    "recip_lut",
+    "pwl_recip_lut",
+    "pwl_recip_div",
+    "pwl_recip_seqdiv",
+}
+_QUALITY_BACKED_FLOAT_PROFILES = {"qkv8_float_exact", "score32_float"}
+_SUPPORTED_SEMANTIC_PROFILES = _QUALITY_BACKED_FLOAT_PROFILES | {
+    "fixed_point",
+    "score24_w16_exact_div",
+    "score32_w16_exact_div",
+    "score32_w16_recip_lut_q16",
+    "q12_pwl_recip_lut",
+    "q20_pwl_recip_lut",
+    "q20_pwl_recip_div",
+    "q20_pwl_recip_seqdiv",
+    "q24_pwl_recip_div",
+    "q24_pwl_recip_seqdiv",
+}
+
+
 def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     comp = cfg.get("attention_dual_stream_composed")
     if not isinstance(comp, dict):
@@ -60,6 +83,7 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
     softmax_internal_pipeline_stages = _as_int(comp, "softmax_internal_pipeline_stages", 0)
     softmax_impl = _as_str(comp, "softmax_impl", "exact_div")
+    semantic_profile = _as_str(comp, "semantic_profile", "fixed_point")
     mac_accum_bits = _as_int(comp, "mac_accum_bits", 24)
     softmax_score_bits = _as_int(comp, "softmax_score_bits", 8)
     softmax_weight_bits = _as_int(comp, "softmax_weight_bits", 8)
@@ -117,10 +141,21 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.softmax_input_frac_bits must be in [0, 16]")
     if softmax_reciprocal_lut_bucket_shift < 0 or softmax_reciprocal_lut_bucket_shift > 12:
         raise SystemExit("attention_dual_stream_composed.softmax_reciprocal_lut_bucket_shift must be in [0, 12]")
-    if softmax_impl not in {"exact_div", "pow2sum", "recip_lut", "pwl_recip_lut", "pwl_recip_div", "pwl_recip_seqdiv"}:
+    if softmax_impl not in _INTEGER_SOFTMAX_IMPLS:
         raise SystemExit(
             "attention_dual_stream_composed.softmax_impl must be exact_div, pow2sum, recip_lut, "
             "pwl_recip_lut, pwl_recip_div, or pwl_recip_seqdiv"
+        )
+    if semantic_profile not in _SUPPORTED_SEMANTIC_PROFILES:
+        raise SystemExit(
+            "attention_dual_stream_composed.semantic_profile must be one of: "
+            + ", ".join(sorted(_SUPPORTED_SEMANTIC_PROFILES))
+        )
+    if semantic_profile in _QUALITY_BACKED_FLOAT_PROFILES and softmax_impl in _INTEGER_SOFTMAX_IMPLS:
+        raise SystemExit(
+            "attention_dual_stream_composed.semantic_profile="
+            f"{semantic_profile} requires a distinct floating or near-exact softmax implementation; "
+            f"softmax_impl={softmax_impl} is a fixed-point diagnostic implementation"
         )
     if softmax_internal_pipeline_stages and softmax_impl != "exact_div":
         raise SystemExit("attention_dual_stream_composed.softmax_internal_pipeline_stages requires exact_div")
@@ -136,6 +171,7 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
                 "reciprocal_bits + softmax_weight_bits for the current one-bit-per-cycle seqdiv"
             )
     comp["softmax_reciprocal_div_cycles"] = softmax_reciprocal_div_cycles
+    comp["semantic_profile"] = semantic_profile
     return comp
 
 
@@ -1027,6 +1063,7 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
     softmax_pipeline_stages = _as_int(comp, "softmax_pipeline_stages", 0)
     softmax_internal_pipeline_stages = _as_int(comp, "softmax_internal_pipeline_stages", 0)
     softmax_impl = _as_str(comp, "softmax_impl", "exact_div")
+    semantic_profile = _as_str(comp, "semantic_profile", "fixed_point")
     score_mix_bits = mac_accum_bits
     softmax_latency_stages = (
         softmax_reciprocal_div_cycles if softmax_impl == "pwl_recip_seqdiv" else 1 + softmax_internal_pipeline_stages
@@ -1345,6 +1382,7 @@ endmodule
         "stream_buffer_bits_per_stream": stream_buffer_bits,
         "equivalence_hash": equivalence_hash,
         "softmax_impl": softmax_impl,
+        "semantic_profile": semantic_profile,
         "softmax_pipeline_stages": softmax_pipeline_stages,
         "softmax_internal_pipeline_stages": softmax_internal_pipeline_stages,
         "softmax_latency_stages": softmax_latency_stages,

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -17,6 +17,7 @@ def _write_config(
     softmax_weight_bits: int | None = None,
     reciprocal_bits: int | None = None,
     value_bits: int | None = None,
+    semantic_profile: str | None = None,
     softmax_input_frac_bits: int | None = None,
     softmax_reciprocal_lut_bucket_shift: int | None = None,
     softmax_reciprocal_div_cycles: int | None = None,
@@ -55,6 +56,8 @@ def _write_config(
         comp["reciprocal_bits"] = reciprocal_bits
     if value_bits is not None:
         comp["value_bits"] = value_bits
+    if semantic_profile is not None:
+        comp["semantic_profile"] = semantic_profile
     if softmax_input_frac_bits is not None:
         comp["softmax_input_frac_bits"] = softmax_input_frac_bits
     if softmax_reciprocal_lut_bucket_shift is not None:
@@ -128,6 +131,7 @@ def test_attention_dual_stream_composed_generator_ppa_guard_and_syntax(tmp_path:
     assert manifest["value_lanes_per_stream"] == 4
     assert manifest["equivalence_hash"] is False
     assert manifest["softmax_impl"] == "exact_div"
+    assert manifest["semantic_profile"] == "fixed_point"
     assert manifest["softmax_pipeline_stages"] == 0
     assert manifest["softmax_internal_pipeline_stages"] == 0
     assert manifest["softmax_latency_stages"] == 1
@@ -141,6 +145,72 @@ def test_attention_dual_stream_composed_generator_ppa_guard_and_syntax(tmp_path:
     assert "result_hash" not in top_text
     assert "softmax_weight_hash" not in top_text
     assert "softmax_scores_pipe_0" not in top_text
+
+
+def test_attention_dual_stream_composed_generator_rejects_float_quality_profile_alias(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_qkv8_alias"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        semantic_profile="qkv8_float_exact",
+        mac_accum_bits=32,
+        softmax_score_bits=32,
+        softmax_weight_bits=16,
+        reciprocal_bits=16,
+        value_bits=8,
+        softmax_impl="exact_div",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/rtlgen/gen_attention_dual_stream_composed.py",
+            "--config",
+            str(config_path),
+            "--out",
+            str(design_dir / "verilog"),
+        ],
+        check=False,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "requires a distinct floating or near-exact softmax implementation" in result.stderr
+
+
+def test_attention_dual_stream_composed_guard_rejects_float_quality_profile_alias(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_guard_qkv8_alias"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        mac_accum_bits=32,
+        softmax_score_bits=32,
+        softmax_weight_bits=16,
+        reciprocal_bits=16,
+        value_bits=8,
+        softmax_impl="recip_lut",
+    )
+    _generate_and_check(design_dir, config_path, run_composed_guard=False)
+    manifest_path = design_dir / "verilog" / "attention_dual_stream_composed_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["semantic_profile"] = "score32_float"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_dual_stream_composed_guard.py",
+            "--design-dir",
+            str(design_dir),
+        ],
+        check=False,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "requires a distinct floating or near-exact softmax implementation" in result.stderr
 
 
 def test_attention_dual_stream_composed_generator_equivalence_hash_mode(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- record a semantic_profile in composed dual-stream attention manifests\n- reject qkv8_float_exact and score32_float semantic profiles when they are paired with existing fixed-point/PWL softmax implementations\n- add generator and guard regressions so quality-backed labels cannot alias diagnostic hardware rows\n\n## Validation\n- pytest -q tests/test_attention_dual_stream_composed_generator.py\n- git diff --check