### PR TITLE
configs: label composed attention semantic profiles

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/README.md
@@ -28,6 +28,12 @@ Minimum implementation requirements:
 - Queue a single bounded L1 PPA run only after generator and guard support are
   available and the remote evaluator checkout is clean.
 
+Existing measured fixed-point/PWL composed configs should carry diagnostic
+semantic profiles such as `score32_w16_exact_div`, `score32_w16_recip_lut_q16`,
+or `q20_pwl_recip_seqdiv`. These labels are not quality-backed profiles; they
+exist so recost and ranking code can distinguish measured diagnostic hardware
+from the future qkv8/score32 floating or near-exact composed wrapper.
+
 The dependent L2 recost should use the L1 metrics from that wrapper and mark the
 result quality-backed by the existing `qkv8_float_exact`/`score32_float`
 quality evidence.

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/config.json
@@ -19,6 +19,7 @@
     "stream_buffer_bits": 1024,
     "equivalence_hash": false,
     "softmax_pipeline_stages": 1,
-    "softmax_impl": "pwl_recip_lut"
+    "softmax_impl": "pwl_recip_lut",
+    "semantic_profile": "q12_pwl_recip_lut"
   }
 }

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/config.json
@@ -19,6 +19,7 @@
     "equivalence_hash": false,
     "softmax_pipeline_stages": 1,
     "softmax_internal_pipeline_stages": 1,
-    "softmax_impl": "exact_div"
+    "softmax_impl": "exact_div",
+    "semantic_profile": "score24_w16_exact_div"
   }
 }

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/config.json
@@ -19,6 +19,7 @@
         "equivalence_hash": false,
         "softmax_pipeline_stages": 1,
         "softmax_internal_pipeline_stages": 1,
-        "softmax_impl": "exact_div"
+        "softmax_impl": "exact_div",
+        "semantic_profile": "score32_w16_exact_div"
     }
 }

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/config.json
@@ -19,6 +19,7 @@
     "equivalence_hash": false,
     "softmax_pipeline_stages": 1,
     "softmax_internal_pipeline_stages": 2,
-    "softmax_impl": "exact_div"
+    "softmax_impl": "exact_div",
+    "semantic_profile": "score32_w16_exact_div"
   }
 }

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/config.json
@@ -19,6 +19,7 @@
     "equivalence_hash": false,
     "softmax_pipeline_stages": 1,
     "softmax_internal_pipeline_stages": 0,
-    "softmax_impl": "recip_lut"
+    "softmax_impl": "recip_lut",
+    "semantic_profile": "score32_w16_recip_lut_q16"
   }
 }

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/config.json
@@ -20,6 +20,7 @@
     "stream_buffer_bits": 1024,
     "equivalence_hash": false,
     "softmax_pipeline_stages": 1,
-    "softmax_impl": "pwl_recip_div"
+    "softmax_impl": "pwl_recip_div",
+    "semantic_profile": "q20_pwl_recip_div"
   }
 }

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/config.json
@@ -20,6 +20,7 @@
     "stream_buffer_bits": 1024,
     "equivalence_hash": false,
     "softmax_pipeline_stages": 1,
-    "softmax_impl": "pwl_recip_lut"
+    "softmax_impl": "pwl_recip_lut",
+    "semantic_profile": "q20_pwl_recip_lut"
   }
 }

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/config.json
@@ -21,6 +21,7 @@
     "stream_buffer_bits": 1024,
     "equivalence_hash": false,
     "softmax_pipeline_stages": 1,
-    "softmax_impl": "pwl_recip_seqdiv"
+    "softmax_impl": "pwl_recip_seqdiv",
+    "semantic_profile": "q20_pwl_recip_seqdiv"
   }
 }

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/config.json
@@ -20,6 +20,7 @@
     "stream_buffer_bits": 1024,
     "equivalence_hash": false,
     "softmax_pipeline_stages": 1,
-    "softmax_impl": "pwl_recip_div"
+    "softmax_impl": "pwl_recip_div",
+    "semantic_profile": "q24_pwl_recip_div"
   }
 }

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/config.json
@@ -21,6 +21,7 @@
     "stream_buffer_bits": 1024,
     "equivalence_hash": false,
     "softmax_pipeline_stages": 1,
-    "softmax_impl": "pwl_recip_seqdiv"
+    "softmax_impl": "pwl_recip_seqdiv",
+    "semantic_profile": "q24_pwl_recip_seqdiv"
   }
 }

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -4,6 +4,60 @@ import sys
 from pathlib import Path
 
 
+FRONTIER_CONFIG_SEMANTIC_PROFILES = {
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score24_w16_exact_div/"
+        "config.json"
+    ): "score24_w16_exact_div",
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/"
+        "config.json"
+    ): "score32_w16_exact_div",
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div_split2/"
+        "config.json"
+    ): "score32_w16_exact_div",
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/"
+        "config.json"
+    ): "score32_w16_recip_lut_q16",
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/"
+        "config.json"
+    ): "q12_pwl_recip_lut",
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_q20_bucket8/"
+        "config.json"
+    ): "q20_pwl_recip_lut",
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_div_q20_bucket8/"
+        "config.json"
+    ): "q20_pwl_recip_div",
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q20_pwl_recip_seqdiv_q20_bucket8_lat40/"
+        "config.json"
+    ): "q20_pwl_recip_seqdiv",
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_div_q24_bucket8/"
+        "config.json"
+    ): "q24_pwl_recip_div",
+    (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_softmax_q24_pwl_recip_seqdiv_q24_bucket8_lat48/"
+        "config.json"
+    ): "q24_pwl_recip_seqdiv",
+}
+
+
 def _write_config(
     config_path: Path,
     *,
@@ -116,6 +170,14 @@ def _generate_and_check(
         check=True,
     )
     return (design_dir / "verilog" / "top.v").read_text(encoding="utf-8")
+
+
+def test_attention_dual_stream_frontier_configs_record_semantic_profiles() -> None:
+    for config_rel, expected_profile in FRONTIER_CONFIG_SEMANTIC_PROFILES.items():
+        config = json.loads(Path(config_rel).read_text(encoding="utf-8"))
+        comp = config["attention_dual_stream_composed"]
+        assert comp["semantic_profile"] == expected_profile
+        assert comp["semantic_profile"] not in {"qkv8_float_exact", "score32_float"}
 
 
 def test_attention_dual_stream_composed_generator_ppa_guard_and_syntax(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- add diagnostic semantic_profile labels to measured composed attention frontier configs\n- document that these labels distinguish fixed-point/PWL diagnostic rows from the future quality-backed qkv8/score32 wrapper\n- add a regression that locks the committed frontier configs to their intended semantic labels\n\n## Validation\n- pytest -q tests/test_attention_dual_stream_composed_generator.py\n- python3 -m json.tool on modified config.json files\n- git diff --check