### PR TITLE
eval: carry composed semantic profiles into recosts

### DIFF
--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -98,6 +98,27 @@ def _compose_variant_name(path: Path) -> str:
     return path.parent.name
 
 
+def _load_composed_semantic_profile(path: Path) -> str:
+    design_dir = path.parent
+    manifest_path = design_dir / "verilog" / "attention_dual_stream_composed_manifest.json"
+    config_path = design_dir / "config.json"
+    for candidate in (manifest_path, config_path):
+        if not candidate.exists():
+            continue
+        try:
+            payload = _load_json(candidate)
+        except json.JSONDecodeError:
+            continue
+        if candidate == manifest_path:
+            profile = payload.get("semantic_profile")
+        else:
+            comp = payload.get("attention_dual_stream_composed")
+            profile = comp.get("semantic_profile") if isinstance(comp, dict) else None
+        if isinstance(profile, str) and profile.strip():
+            return profile.strip()
+    return "fixed_point"
+
+
 def _parse_composed_metric_inputs(values: Any) -> list[Path]:
     if not values:
         return []
@@ -127,6 +148,7 @@ def _load_composed_variants(paths: list[Path]) -> list[JsonDict]:
             {
                 "composed_variant_label": _infer_composed_precision_profile(path),
                 "composed_variant_name": _compose_variant_name(path),
+                "composed_semantic_profile": _load_composed_semantic_profile(path),
             }
         )
         variants.append(metrics)
@@ -320,6 +342,9 @@ def _row_with_budget(
                     "measured_dual_stream_composed_precision_profile": composed_dual_stream[
                         "composed_variant_label"
                     ],
+                    "measured_dual_stream_composed_semantic_profile": composed_dual_stream[
+                        "composed_semantic_profile"
+                    ],
                 }
                 if use_composed_dual_stream
                 else {}
@@ -347,6 +372,9 @@ def _row_with_budget(
             "substituted_compute_power_mw": round(base_compute_power, 6) if compute_substitution_enabled else None,
             "substituted_compute_variant_label": (
                 composed_dual_stream["composed_variant_label"] if use_composed_dual_stream else None
+            ),
+            "substituted_compute_semantic_profile": (
+                composed_dual_stream["composed_semantic_profile"] if use_composed_dual_stream else None
             ),
             "logic_area_used_required_um2": round(logic_used_required, 6),
             "logic_area_slack_required_um2": round(logic_slack_required, 6),
@@ -721,6 +749,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "best_requested_compute_substitution_enabled": best_requested.get("compute_substitution_enabled"),
             "best_requested_substituted_compute_arch": best_requested.get("substituted_compute_arch"),
             "best_requested_substituted_compute_variant_label": best_requested.get("substituted_compute_variant_label"),
+            "best_requested_substituted_compute_semantic_profile": best_requested.get(
+                "substituted_compute_semantic_profile"
+            ),
             "best_requested_substituted_compute_area_um2": best_requested.get("substituted_compute_area_um2"),
             "best_requested_compute_clock_ok": best_requested.get("compute_clock_ok"),
             "best_requested_replica_recost_enabled": best_requested.get("replica_recost_enabled"),
@@ -767,29 +798,30 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         f"- best requested compute substitution: `{diag['best_requested_compute_substitution_enabled']}`",
         f"- best requested substituted compute arch: `{diag['best_requested_substituted_compute_arch']}`",
         f"- best requested substituted compute variant: `{diag['best_requested_substituted_compute_variant_label']}`",
+        f"- best requested substituted compute semantic profile: `{diag['best_requested_substituted_compute_semantic_profile']}`",
         f"- best requested substituted compute area um2: `{diag['best_requested_substituted_compute_area_um2']}`",
         f"- recommended next step: `{diag['recommended_next_step']}`",
         "",
         "## Best Requested",
         "",
-        "| mode | latency us | speedup | area fit | buffer fit | substituted variant | logic slack um2 | area over budget | "
+        "| mode | latency us | speedup | area fit | buffer fit | substituted variant | semantic profile | logic slack um2 | area over budget | "
         "density gain | required replicas | budget replicas | req buffer bytes |",
-        "|---|---:|---:|---|---|---|---:|---:|---:|---:|---:|---:|",
+        "|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|",
         "| {compute_mode} | {latency_us} | {latency_speedup_vs_hbm_closed_source} | {area_fit} | {buffer_fit} | "
-        "{substituted_compute_variant_label} | "
+        "{substituted_compute_variant_label} | {substituted_compute_semantic_profile} | "
         "{logic_area_slack_required_um2} | {compute_area_over_budget_um2} | "
         "{required_compute_density_gain} | {replica_count_required} | "
         "{replica_count_budgeted_at_current_compute_area} | {required_stream_buffer_bytes} |".format(**best),
         "",
         "## Rows",
         "",
-        "| mode | latency us | area fit | feasible | substituted variant | logic slack um2 | local datapath/cluster | compute area required |",
-        "|---|---:|---|---|---|---:|---:|---:|",
+        "| mode | latency us | area fit | feasible | substituted variant | semantic profile | logic slack um2 | local datapath/cluster | compute area required |",
+        "|---|---:|---|---|---|---|---:|---:|---:|",
     ]
     for row in payload["rows"]:
         lines.append(
             "| {compute_mode} | {latency_us} | {area_fit} | {physical_feasible} | "
-            "{substituted_compute_variant_label} | "
+            "{substituted_compute_variant_label} | {substituted_compute_semantic_profile} | "
             "{logic_area_slack_required_um2} | {selected_local_datapath_area_um2_per_cluster} | "
             "{compute_area_required_um2} |".format(**row)
         )

--- a/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -247,11 +247,83 @@ def test_composed_q12_pwl_wrapper_variant_label_is_concise(tmp_path: Path) -> No
         / "metrics.csv"
     )
     _write_metrics(metrics, die_area=30.0, power_mw=0.7, instance_area=28.0)
+    _write_json(
+        metrics.parent / "config.json",
+        {
+            "top_name": "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12",
+            "attention_dual_stream_composed": {
+                "softmax_impl": "pwl_recip_lut",
+                "semantic_profile": "q12_pwl_recip_lut",
+            },
+        },
+    )
 
     result = build_report(_args(tmp_path, source=source, composed_metrics=[str(metrics)]))
 
     assert result["diagnosis"]["best_requested_substituted_compute_variant_label"] == "q12_pwl"
+    assert result["diagnosis"]["best_requested_substituted_compute_semantic_profile"] == "q12_pwl_recip_lut"
     assert result["best_requested"]["substituted_compute_variant_label"] == "q12_pwl"
+    assert result["best_requested"]["substituted_compute_semantic_profile"] == "q12_pwl_recip_lut"
+
+
+def test_composed_wrapper_semantic_profile_prefers_generated_manifest(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    _write_json(
+        source,
+        {
+            "model": "unit_source",
+            "best_by_compute_mode": [
+                {
+                    "compute_mode": "dual_mac",
+                    "latency_us": 100.0,
+                    "latency_speedup_vs_hbm_closed_source": 4.0,
+                    "tile_service_cycles": 12,
+                    "cluster_count": 1,
+                    "compute_area_multiplier": 1.0,
+                    "compute_area_um2": 120.0,
+                    "compute_budget_um2": 1000.0,
+                    "measured_l1_overhead_area_um2": 20.0,
+                    "local_datapath_area_um2": 10.0,
+                    "softmax_weight_generator_area_um2": 5.0,
+                    "logic_area_used_um2": 150.0,
+                    "required_stream_buffer_bytes": 16,
+                    "available_local_capacity_bytes": 32,
+                    "measured_block_area_um2": 120.0,
+                    "measured_block_clock_ns": 4.0,
+                    "measured_block_macs_per_cycle": 128,
+                    "measured_block_power_mw": 4.0,
+                    "compute_replica_count": 1,
+                    "compute_arch": "dense_gemm_16x8_k1_p1",
+                    "macs_per_cycle": 128,
+                    "clock_ns": 4.0,
+                }
+            ],
+        },
+    )
+    metrics = tmp_path / "score32" / "metrics.csv"
+    _write_metrics(metrics, die_area=30.0, power_mw=0.7, instance_area=28.0)
+    _write_json(
+        metrics.parent / "config.json",
+        {
+            "attention_dual_stream_composed": {
+                "semantic_profile": "score32_w16_exact_div",
+            },
+        },
+    )
+    _write_json(
+        metrics.parent / "verilog" / "attention_dual_stream_composed_manifest.json",
+        {
+            "semantic_profile": "score32_w16_recip_lut_q16",
+        },
+    )
+
+    result = build_report(_args(tmp_path, source=source, composed_metrics=[str(metrics)]))
+
+    assert (
+        result["diagnosis"]["best_requested_substituted_compute_semantic_profile"]
+        == "score32_w16_recip_lut_q16"
+    )
+    assert result["best_requested"]["measured_dual_stream_composed_semantic_profile"] == "score32_w16_recip_lut_q16"
 
 
 def test_composed_wrapper_can_recost_area_fit_replica_count(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- read composed wrapper semantic_profile from generated manifest or design config next to metrics.csv\n- propagate semantic profile into recost rows, diagnostics, and markdown reports\n- add tests for config fallback and manifest precedence\n\n## Validation\n- PYTHONPATH=. pytest -q tests/test_attention_dual_stream_composed_generator.py tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py\n- git diff --check