### PR TITLE
rtlgen: add score32 exp-lut softmax bridge

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/README.md
@@ -40,6 +40,12 @@ generation-quality artifact failed, so an integer W16 exact-divider row must not
 stand in for `score32_float` or `qkv8_float_exact` without a new matching quality
 gate.
 
+The first implemented bridge toward that contract is `exp_lut_div`: signed
+fixed-point score input, bucketed `exp(-delta)` LUT, exact row-sum divider, and
+unsigned quantized probability weights. It is measurable in the composed wrapper
+but remains diagnostic until the matching native quality candidate, for example
+`score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20`, passes.
+
 The dependent L2 recost should use the L1 metrics from that wrapper and mark the
 result quality-backed by the existing `qkv8_float_exact`/`score32_float`
 quality evidence.

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/semantic_contract.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/semantic_contract.md
@@ -63,12 +63,18 @@ the q8/k8/v8 composed attention wrapper.
 
 ## Next Implementable Target
 
-The next implementation should not reuse `softmax_impl=exact_div`,
-`recip_lut`, or any PWL implementation with a quality-backed semantic profile.
-It should introduce a distinct composed softmax implementation, for example a
-range-reduced exp datapath plus exact divider or sequential divider, and pair it
-with a native quality candidate that matches the same output probability
-representation.
+The next implementation should not reuse `softmax_impl=exact_div`, `recip_lut`,
+or any PWL implementation with a quality-backed semantic profile. The initial
+bridge mode is:
+
+- native quality candidate:
+  `score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20`
+- composed RTL config:
+  `runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json`
+- score representation: signed S32 fixed-point with 28 fractional bits
+- probability representation: unsigned W16 normalized weights
+- exp implementation: bucketed `exp(-delta)` LUT with bucket shift 20
+- normalization: exact row-sum divider
 
 The first PPA job should remain blocked until both are true:
 

--- a/npu/eval/check_attention_dual_stream_composed_guard.py
+++ b/npu/eval/check_attention_dual_stream_composed_guard.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 INTEGER_SOFTMAX_IMPLS = {
     "exact_div",
+    "exp_lut_div",
     "pow2sum",
     "recip_lut",
     "pwl_recip_lut",
@@ -140,6 +141,14 @@ def main() -> int:
             raise SystemExit("reciprocal-LUT replacement must not contain pow2 denominator shift logic")
         if "/ sum_weight" in top_text or "/ sum_weight_q" in top_text:
             raise SystemExit("reciprocal-LUT replacement must not contain a sum_weight divider")
+    if softmax_impl == "exp_lut_div":
+        for token in ("function [ACCUM_BITS-1:0] exp_lut", "EXP_BUCKET_SHIFT", "EXP_MAX_DELTA", "/ sum_weight"):
+            if token not in top_text:
+                raise SystemExit(f"missing exp-LUT exact-divider softmax token: {token}")
+        if "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut" in top_text:
+            raise SystemExit("exp-LUT exact-divider mode must not contain reciprocal LUT normalization")
+        if "pwl_weight" in top_text:
+            raise SystemExit("exp-LUT exact-divider mode must not contain PWL exp approximation")
     if softmax_impl in {"pwl_recip_lut", "pwl_recip_div", "pwl_recip_seqdiv"}:
         if softmax_score_bits < 12 or softmax_weight_bits < 12:
             raise SystemExit("PWL reciprocal softmax should keep at least 12-bit scores and weights")

--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
@@ -129,6 +129,19 @@ def _pwl_reciprocal_mode(mode: str) -> tuple[int, int]:
     return reciprocal_bits, bucket_shift
 
 
+def _exp_lut_div_mode(mode: str) -> int:
+    prefix = "exp_lut_div_bucket"
+    if not mode.startswith(prefix):
+        return -1
+    try:
+        bucket_shift = int(mode[len(prefix) :])
+    except ValueError as exc:
+        raise ValueError(f"unsupported softmax mode: {mode}") from exc
+    if bucket_shift < 0 or bucket_shift > 24:
+        raise ValueError(f"unsupported softmax mode: {mode}")
+    return bucket_shift
+
+
 def _quantize_symmetric_list(values: list[float], bits: int) -> tuple[list[int], float]:
     if bits >= 24:
         return [int(round(value * 1024.0)) for value in values], 1.0 / 1024.0
@@ -239,6 +252,55 @@ def _pwl_recip_lut_softmax(
         lane_scaled = (weight * reciprocal_q) + (1 << (reciprocal_bits - 1))
         lane_scaled >>= reciprocal_bits
         lanes.append(min(output_scale, lane_scaled))
+    return [lane / float(output_scale) for lane in lanes]
+
+
+def _exp_lut_div_softmax(
+    logits: list[float],
+    *,
+    score_bits: int,
+    weight_bits: int,
+    bucket_shift: int,
+    input_frac_bits: int | None = None,
+) -> list[float]:
+    if score_bits < 5 or score_bits > 32:
+        raise ValueError("exp_lut_div softmax expects score_bits in [5, 32]")
+    if weight_bits < 2 or weight_bits > 24:
+        raise ValueError("exp_lut_div softmax expects weight_bits in [2, 24]")
+    if bucket_shift < 0 or bucket_shift > 24:
+        raise ValueError("exp_lut_div softmax expects bucket_shift in [0, 24]")
+    if not logits:
+        return []
+
+    if input_frac_bits is None:
+        input_frac_bits = _score_input_frac_bits(score_bits)
+    input_scale = 1 << input_frac_bits
+    output_scale = (1 << weight_bits) - 1
+    min_score = -(1 << (score_bits - 1))
+    max_score = (1 << (score_bits - 1)) - 1
+    q_logits = [
+        max(min_score, min(max_score, int(round(value * input_scale))))
+        for value in logits
+    ]
+    row_max = max(q_logits)
+    bucket_step = 1 << bucket_shift
+    max_delta = 8 * input_scale
+    max_bucket = (max_delta + (bucket_step >> 1)) >> bucket_shift
+
+    exp_weights: list[int] = []
+    for value in q_logits:
+        delta = max(0, min(max_delta, row_max - value))
+        bucket = min(max_bucket, (delta + (bucket_step >> 1)) >> bucket_shift)
+        exp_arg = (bucket * bucket_step) / float(input_scale)
+        exp_weights.append(int(math.exp(-exp_arg) * output_scale + 0.5))
+
+    sum_weight = sum(exp_weights)
+    if sum_weight <= 0:
+        return _safe_exp_softmax(logits)
+    lanes = [
+        min(output_scale, ((weight * output_scale) + (sum_weight >> 1)) // sum_weight)
+        for weight in exp_weights
+    ]
     return [lane / float(output_scale) for lane in lanes]
 
 
@@ -381,6 +443,7 @@ def _parse_candidate_spec(spec: Any) -> CandidateConfig:
                     part in {"float_quantized", "float_exact", "rtl_exact", "rtl_pow2sum"}
                     or part.startswith("rtl_recip_lut_q")
                     or part.startswith("pwl_recip_lut_q")
+                    or part.startswith("exp_lut_div_bucket")
                 ):
                     if softmax_mode:
                         raise ValueError(f"candidate spec {spec!r} has duplicate softmax mode tokens")
@@ -451,6 +514,11 @@ def _parse_candidate_list(value: str) -> list[CandidateConfig]:
 
 def _parse_softmax_mode(value: str) -> str:
     supported = {"float_quantized", "float_exact", "rtl_exact", "rtl_pow2sum", "rtl_recip_lut_q8"}
+    if value.startswith("exp_lut_div_bucket"):
+        bucket_shift = _exp_lut_div_mode(value)
+        if bucket_shift < 0:
+            raise argparse.ArgumentTypeError(f"unsupported softmax mode: {value}")
+        return value
     if value.startswith("pwl_recip_lut_q"):
         reciprocal_bits, _ = _pwl_reciprocal_mode(value)
         if reciprocal_bits <= 0:
@@ -741,6 +809,14 @@ def _softmax_patch(score_bits: int, weight_bits: int, softmax_mode: str):
         if softmax_mode == "float_exact":
             out = _safe_exp_softmax(values)
             return torch.tensor(out, dtype=torch.float32, device=row.device).reshape(row.shape)
+        if softmax_mode.startswith("exp_lut_div_bucket"):
+            out = _exp_lut_div_softmax(
+                values,
+                score_bits=score_bits,
+                weight_bits=weight_bits,
+                bucket_shift=_exp_lut_div_mode(softmax_mode),
+            )
+            return torch.tensor(out, dtype=row.dtype if row.dtype.is_floating_point else torch.float32, device=row.device).reshape(row.shape)
         if softmax_mode.startswith("pwl_recip_lut_q"):
             reciprocal_bits, bucket_shift = _pwl_reciprocal_mode(softmax_mode)
             out = _pwl_recip_lut_softmax(

--- a/npu/rtlgen/gen_attention_dual_stream_composed.py
+++ b/npu/rtlgen/gen_attention_dual_stream_composed.py
@@ -45,6 +45,7 @@ def _as_str(config: dict[str, Any], key: str, default: str) -> str:
 
 _INTEGER_SOFTMAX_IMPLS = {
     "exact_div",
+    "exp_lut_div",
     "pow2sum",
     "recip_lut",
     "pwl_recip_lut",
@@ -57,6 +58,7 @@ _SUPPORTED_SEMANTIC_PROFILES = _QUALITY_BACKED_FLOAT_PROFILES | {
     "score24_w16_exact_div",
     "score32_w16_exact_div",
     "score32_w16_recip_lut_q16",
+    "score32_exp_lut_div",
     "q12_pwl_recip_lut",
     "q20_pwl_recip_lut",
     "q20_pwl_recip_div",
@@ -137,14 +139,22 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
         raise SystemExit("attention_dual_stream_composed.softmax_weight_bits must be in [2, 24]")
     if reciprocal_bits < 2 or reciprocal_bits > 24:
         raise SystemExit("attention_dual_stream_composed.reciprocal_bits must be in [2, 24]")
-    if softmax_input_frac_bits < 0 or softmax_input_frac_bits > 16:
-        raise SystemExit("attention_dual_stream_composed.softmax_input_frac_bits must be in [0, 16]")
-    if softmax_reciprocal_lut_bucket_shift < 0 or softmax_reciprocal_lut_bucket_shift > 12:
-        raise SystemExit("attention_dual_stream_composed.softmax_reciprocal_lut_bucket_shift must be in [0, 12]")
     if softmax_impl not in _INTEGER_SOFTMAX_IMPLS:
         raise SystemExit(
-            "attention_dual_stream_composed.softmax_impl must be exact_div, pow2sum, recip_lut, "
+            "attention_dual_stream_composed.softmax_impl must be exact_div, exp_lut_div, pow2sum, recip_lut, "
             "pwl_recip_lut, pwl_recip_div, or pwl_recip_seqdiv"
+        )
+    max_input_frac_bits = 28 if softmax_impl == "exp_lut_div" else 16
+    if softmax_input_frac_bits < 0 or softmax_input_frac_bits > max_input_frac_bits:
+        raise SystemExit(
+            "attention_dual_stream_composed.softmax_input_frac_bits must be in "
+            f"[0, {max_input_frac_bits}] for softmax_impl={softmax_impl}"
+        )
+    max_bucket_shift = 24 if softmax_impl == "exp_lut_div" else 12
+    if softmax_reciprocal_lut_bucket_shift < 0 or softmax_reciprocal_lut_bucket_shift > max_bucket_shift:
+        raise SystemExit(
+            "attention_dual_stream_composed.softmax_reciprocal_lut_bucket_shift must be in "
+            f"[0, {max_bucket_shift}] for softmax_impl={softmax_impl}"
         )
     if semantic_profile not in _SUPPORTED_SEMANTIC_PROFILES:
         raise SystemExit(
@@ -582,6 +592,99 @@ module {module_name} (
         lane_out = OUTPUT_SCALE;
       else
         lane_out = lane_scaled[WEIGHT_BITS-1:0];
+      next_weights[(i*WEIGHT_BITS) +: WEIGHT_BITS] = lane_out;
+{hash_update.rstrip()}
+    end
+  end
+
+  always @(posedge clk) begin
+    weights <= next_weights;
+{hash_seq.rstrip()}
+  end
+endmodule
+"""
+    if implementation == "exp_lut_div":
+        input_scale = 1 << input_frac_bits
+        bucket_step = 1 << reciprocal_lut_bucket_shift
+        max_delta = 8 * input_scale
+        max_bucket = (max_delta + (bucket_step >> 1)) >> reciprocal_lut_bucket_shift
+        exp_lut_cases = "\n".join(
+            f"      {accum_bits}'d{bucket}: exp_lut = {accum_bits}'d{int(math.exp(-((bucket * bucket_step) / float(input_scale))) * output_scale + 0.5)};"
+            for bucket in range(0, max_bucket + 1)
+        )
+        return f"""(* keep_hierarchy = 1 *)
+module {module_name} (
+    input  wire                  clk,
+    input  wire [{score_row_width - 1}:0] scores,
+    output reg  [{weight_row_width - 1}:0] weights{hash_port}
+);
+  localparam integer ROW_ELEMS = {row_elems};
+  localparam integer SCORE_BITS = {score_bits};
+  localparam integer WEIGHT_BITS = {weight_bits};
+  localparam integer ACCUM_BITS = {accum_bits};
+  localparam integer PRODUCT_BITS = {product_bits};
+  localparam integer OUTPUT_SCALE = {output_scale};
+  localparam integer INPUT_FRAC_BITS = {input_frac_bits};
+  localparam integer EXP_BUCKET_SHIFT = {reciprocal_lut_bucket_shift};
+  localparam [ACCUM_BITS-1:0] EXP_MAX_DELTA = {accum_bits}'d{max_delta};
+  localparam [ACCUM_BITS-1:0] EXP_MAX_BUCKET = {accum_bits}'d{max_bucket};
+
+  integer i;
+  integer signed lane_val;
+  integer signed row_max;
+  reg [ACCUM_BITS-1:0] delta_q;
+  reg [ACCUM_BITS-1:0] exp_bucket;
+  reg [ACCUM_BITS-1:0] exp_weight [0:ROW_ELEMS-1];
+  reg [ACCUM_BITS-1:0] sum_weight;
+  reg [PRODUCT_BITS-1:0] numer;
+  reg [WEIGHT_BITS-1:0] lane_out;
+  reg [{weight_row_width - 1}:0] next_weights;
+{hash_reg.rstrip()}
+
+  function [ACCUM_BITS-1:0] exp_lut;
+    input [ACCUM_BITS-1:0] bucket;
+    begin
+      case (bucket)
+{exp_lut_cases}
+      default: exp_lut = {{ACCUM_BITS{{1'b0}}}};
+      endcase
+    end
+  endfunction
+
+  always @(*) begin
+    row_max = -(1 << (SCORE_BITS - 1));
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
+      if (lane_val > row_max)
+        row_max = lane_val;
+    end
+
+    sum_weight = {{ACCUM_BITS{{1'b0}}}};
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      lane_val = $signed(scores[(i*SCORE_BITS) +: SCORE_BITS]);
+      if (row_max > lane_val)
+        delta_q = row_max - lane_val;
+      else
+        delta_q = {{ACCUM_BITS{{1'b0}}}};
+      if (delta_q > EXP_MAX_DELTA)
+        delta_q = EXP_MAX_DELTA;
+      exp_bucket = (delta_q + ({accum_bits}'d{bucket_step} >> 1)) >> EXP_BUCKET_SHIFT;
+      if (exp_bucket > EXP_MAX_BUCKET)
+        exp_bucket = EXP_MAX_BUCKET;
+      exp_weight[i] = exp_lut(exp_bucket);
+      sum_weight = sum_weight + exp_weight[i];
+    end
+
+    next_weights = {{{weight_row_width}{{1'b0}}}};
+{hash_init.rstrip()}
+    for (i = 0; i < ROW_ELEMS; i = i + 1) begin
+      numer = (exp_weight[i] * OUTPUT_SCALE) + (sum_weight >> 1);
+      if (sum_weight != 0)
+        lane_out = numer / sum_weight;
+      else
+        lane_out = {{WEIGHT_BITS{{1'b0}}}};
+      if (lane_out > OUTPUT_SCALE)
+        lane_out = OUTPUT_SCALE;
       next_weights[(i*WEIGHT_BITS) +: WEIGHT_BITS] = lane_out;
 {hash_update.rstrip()}
     end
@@ -1080,6 +1183,8 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
         softmax_name = f"attention_softmax_weight_q{softmax_score_bits}_pwl_recip_div_like"
     elif softmax_impl == "pwl_recip_seqdiv":
         softmax_name = f"attention_softmax_weight_q{softmax_score_bits}_pwl_recip_seqdiv_like"
+    elif softmax_impl == "exp_lut_div":
+        softmax_name = f"attention_softmax_weight_score{softmax_score_bits}_w{softmax_weight_bits}_exp_lut_div_b{softmax_reciprocal_lut_bucket_shift}_like"
     elif softmax_impl == "exact_div" and (softmax_score_bits, softmax_weight_bits) != (8, 8):
         softmax_name = f"attention_softmax_weight_score{softmax_score_bits}_w{softmax_weight_bits}_exact_div_like"
     elif softmax_impl == "recip_lut" and (softmax_score_bits, softmax_weight_bits) == (32, 16):
@@ -1396,6 +1501,8 @@ endmodule
                 if softmax_impl == "pwl_recip_seqdiv"
                 else "one shared PWL reciprocal-normalized generator"
                 if softmax_impl in {"pwl_recip_lut", "pwl_recip_div"}
+                else "one shared bucketed-exp LUT exact-divider-normalized generator"
+                if softmax_impl == "exp_lut_div"
                 else (
                     "one shared score32/w16 shift-exp reciprocal-LUT-normalized generator"
                     if softmax_score_bits == 32 and softmax_weight_bits == 16 and softmax_impl == "recip_lut"
@@ -1410,6 +1517,18 @@ endmodule
             if equivalence_hash
             else "PPA mode exposes softmax weights, value accumulators, and score mixes directly; equivalence hash disabled"
         ),
+        "score_probability_contract": {
+            "score_representation": "signed fixed-point score slices from composed MAC accumulators",
+            "score_input_frac_bits": softmax_input_frac_bits,
+            "probability_representation": f"unsigned q{softmax_weight_bits} normalized weights",
+            "exp_implementation": "bucketed_exp_lut" if softmax_impl == "exp_lut_div" else softmax_impl,
+            "normalization": "exact row-sum divider" if softmax_impl == "exp_lut_div" else "implementation-specific",
+            "quality_status": (
+                "requires matching native quality gate before quality-backed ranking"
+                if softmax_impl == "exp_lut_div"
+                else "diagnostic unless semantic_profile is quality-backed and guard-supported"
+            ),
+        },
     }
     (out_path / "attention_dual_stream_composed_manifest.json").write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json
@@ -1,0 +1,26 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 16,
+    "array_n": 8,
+    "k_unroll": 1,
+    "mac_accum_bits": 32,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 32,
+    "softmax_weight_bits": 16,
+    "softmax_input_frac_bits": 28,
+    "softmax_accum_bits": 40,
+    "reciprocal_bits": 16,
+    "softmax_reciprocal_lut_bucket_shift": 20,
+    "value_bits": 8,
+    "value_lanes": 16,
+    "partials": 8,
+    "partials_per_cycle": 2,
+    "stream_buffer_bits": 1024,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "exp_lut_div",
+    "semantic_profile": "score32_exp_lut_div"
+  }
+}

--- a/tests/test_attention_dual_stream_composed_generator.py
+++ b/tests/test_attention_dual_stream_composed_generator.py
@@ -27,6 +27,11 @@ FRONTIER_CONFIG_SEMANTIC_PROFILES = {
     ): "score32_w16_recip_lut_q16",
     (
         "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+        "config.json"
+    ): "score32_exp_lut_div",
+    (
+        "runs/designs/npu_blocks/"
         "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_q12_pwl_recip_q12/"
         "config.json"
     ): "q12_pwl_recip_lut",
@@ -710,6 +715,45 @@ def test_attention_dual_stream_composed_generator_score32_v8_recip_lut_q16_softm
     assert "/ sum_weight_q" not in top_text
     assert "wire [63:0] softmax_weights" in top_text
     assert "module attention_full_value_stream_q8v8_p8_ppc2" in top_text
+
+
+def test_attention_dual_stream_composed_generator_score32_exp_lut_div_softmax(
+    tmp_path: Path,
+) -> None:
+    design_dir = tmp_path / "attention_dual_stream_composed_score32_exp_lut_div"
+    config_path = design_dir / "config.json"
+    _write_config(
+        config_path,
+        softmax_pipeline_stages=1,
+        softmax_impl="exp_lut_div",
+        semantic_profile="score32_exp_lut_div",
+        mac_accum_bits=32,
+        softmax_accum_bits=40,
+        softmax_score_bits=32,
+        softmax_weight_bits=16,
+        softmax_input_frac_bits=28,
+        softmax_reciprocal_lut_bucket_shift=20,
+        value_bits=8,
+    )
+
+    top_text = _generate_and_check(design_dir, config_path)
+
+    manifest = json.loads((design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").read_text())
+    assert manifest["mac_module"] == "int8_mac_s8s8_acc32"
+    assert manifest["softmax_impl"] == "exp_lut_div"
+    assert manifest["semantic_profile"] == "score32_exp_lut_div"
+    assert manifest["softmax_score_bits"] == 32
+    assert manifest["softmax_weight_bits"] == 16
+    assert manifest["softmax_input_frac_bits"] == 28
+    assert manifest["softmax_reciprocal_lut_bucket_shift"] == 20
+    assert manifest["score_probability_contract"]["exp_implementation"] == "bucketed_exp_lut"
+    assert "module attention_softmax_weight_score32_w16_exp_lut_div_b20_like" in top_text
+    assert "function [ACCUM_BITS-1:0] exp_lut" in top_text
+    assert "localparam integer EXP_BUCKET_SHIFT = 20" in top_text
+    assert "EXP_MAX_DELTA" in top_text
+    assert "numer / sum_weight" in top_text
+    assert "function [RECIPROCAL_WIDTH-1:0] reciprocal_lut" not in top_text
+    assert "function [ACCUM_BITS-1:0] pwl_weight" not in top_text
 
 
 def test_attention_dual_stream_composed_generator_score32_v8_exact_softmax_divider_operand_pipeline(

--- a/tests/test_llm_decoder_model_native_mixed_int8_attention.py
+++ b/tests/test_llm_decoder_model_native_mixed_int8_attention.py
@@ -9,6 +9,7 @@ import pytest
 from npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention import (
     _collect_reference_rows,
     _decision,
+    _exp_lut_div_softmax,
     _iter_llama_attention_modules,
     _load_runtime_modules,
     _load_prompts,
@@ -139,6 +140,21 @@ def test_pwl_softmax_uses_score_precision_for_input_fraction() -> None:
     )
 
     assert q12 != q24
+
+
+def test_exp_lut_div_softmax_mode_matches_range_and_precision() -> None:
+    logits = [1.0, 2.0, 0.5, 1.8]
+
+    q24 = _exp_lut_div_softmax(logits, score_bits=24, weight_bits=16, bucket_shift=12)
+    q32 = _exp_lut_div_softmax(logits, score_bits=32, weight_bits=16, bucket_shift=22)
+
+    assert len(q24) == len(logits)
+    assert len(q32) == len(logits)
+    assert max(range(len(q24)), key=q24.__getitem__) == 1
+    assert max(range(len(q32)), key=q32.__getitem__) == 1
+    assert all(0.0 <= value <= 1.0 for value in q24)
+    assert all(0.0 <= value <= 1.0 for value in q32)
+    assert q24 != q32
 
 
 def test_fake_attention_patch_quantizes_qkv_once_and_restores() -> None:
@@ -274,6 +290,12 @@ def test_parse_candidate_spec_and_list_compatibility() -> None:
     assert q16_rtl.score_bits == 32
     assert q16_rtl.weight_bits == 16
     assert q16_rtl.softmax_mode == "rtl_recip_lut_q16"
+
+    exp_lut = _parse_candidate_spec("score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20")
+    assert exp_lut.candidate_id == "score32_exp_lut_div"
+    assert exp_lut.score_bits == 32
+    assert exp_lut.weight_bits == 16
+    assert exp_lut.softmax_mode == "exp_lut_div_bucket20"
 
     with pytest.raises(ValueError):
         _parse_candidate_spec("qkv8_score8:r8")


### PR DESCRIPTION
## Summary
- Add native evaluator support for a matched `exp_lut_div_bucketN` mixed/int8 softmax mode.
- Add composed RTL generator support for `softmax_impl=exp_lut_div`, including manifest score/probability contract fields and guard checks.
- Add the first score32/w16 exp-LUT divider composed config and proposal notes.

## Important scope
This is a concrete bridge candidate, not a quality-backed frontier row yet. The next job should run the native quality gate for:\n\n`score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20`\n\nOnly if that passes should we queue the corresponding composed PPA run.

## Validation
- python3 -m py_compile npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py npu/rtlgen/gen_attention_dual_stream_composed.py npu/eval/check_attention_dual_stream_composed_guard.py
- python3 -m json.tool docs/proposals/prop_l1_decoder_attention_dual_stream_composed_qkv8_float_exact_softmax_v1/proposal.json
- python3 -m json.tool runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json
- git diff --check
- PYTHONPATH=. pytest -q tests/test_llm_decoder_model_native_mixed_int8_attention.py tests/test_attention_dual_stream_composed_generator.py
- python3 npu/rtlgen/gen_attention_dual_stream_composed.py --config runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json --out /tmp/rtlgen-exp-lut-div-smoke/verilog
- python3 npu/eval/check_attention_dual_stream_composed_guard.py --design-dir /tmp/rtlgen-exp-lut-div-smoke
- /oss-cad-suite/bin/iverilog -g2012 -o /tmp/rtlgen-exp-lut-div-smoke/simv /tmp/rtlgen-exp-lut-div-smoke/verilog/top.v