### PR TITLE
[codex] Add exp-LUT generation quality gate

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6812,6 +6812,68 @@ def _decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_evide
     }
 
 
+def _decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    generation_quality_baseline = (
+        f"{base}/decoder_attention_mixed_int8_generation_quality__"
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+    )
+    rtl_exact_generation_quality = (
+        f"{base}/decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__"
+        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json"
+    )
+    composed_config = (
+        "runs/designs/npu_blocks/"
+        "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+        "config.json"
+    )
+    out = f"{base}/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_mixed_int8_generation_quality_baseline": generation_quality_baseline,
+            "attention_mixed_int8_score32_w16_rtl_exact_generation_quality": rtl_exact_generation_quality,
+            "attention_score32_exp_lut_div_composed_config": composed_config,
+            "attention_mixed_int8_score32_exp_lut_div_generation_quality_out": out,
+            "attention_mixed_int8_score32_exp_lut_div_generation_quality_report": report,
+            "attention_mixed_int8_score32_exp_lut_div_generation_quality_scope": (
+                "Run a bounded native-checkpoint generation/NLL gate for the score32 exp-LUT "
+                "divider softmax bridge. This checks whether the matched native candidate can "
+                "recover generation quality before its composed RTL datapath is recosted."
+            ),
+        },
+        "commands": [
+            {
+                "name": "evaluate_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+                "run": (
+                    "bash -lc '"
+                    "MODEL_ID=${RTLGEN_MODEL_NATIVE_7B_MODEL_ID:-mistralai/Mistral-7B-v0.1}; "
+                    "EXPECTED_GQA=${RTLGEN_MODEL_NATIVE_7B_EXPECTED_GQA_GROUP_SIZE:-4}; "
+                    "MAX_PROMPTS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_MAX_PROMPTS:-8}; "
+                    "GEN_STEPS=${RTLGEN_MODEL_NATIVE_7B_GENERATION_STEPS:-8}; "
+                    "DTYPE=${RTLGEN_MODEL_NATIVE_7B_DTYPE:-bfloat16}; "
+                    "bash npu/eval/run_hf_eval_python.sh "
+                    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py "
+                    "--model-id \"$MODEL_ID\" "
+                    "--expected-gqa-group-size \"$EXPECTED_GQA\" "
+                    "--max-prompts \"$MAX_PROMPTS\" "
+                    "--generation-steps \"$GEN_STEPS\" "
+                    "--dtype \"$DTYPE\" "
+                    "--candidate score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20 "
+                    "--primary-candidate-id score32_exp_lut_div "
+                    f"--out {out} "
+                    f"--out-md {report}'"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality_evidence(
     *,
     item_id: str,
@@ -9050,6 +9112,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
+        "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
         "decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
         "decoder_attention_mixed_int8_softmax_replacement_generation_quality",
@@ -9266,6 +9329,10 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality":
             decoder_evidence = _decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_evidence(
+                item_id=item_id,
+            )
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality":
+            decoder_evidence = _decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_evidence(
                 item_id=item_id,
             )
         elif abstraction_layer_name == "decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8096,6 +8096,87 @@ def test_generate_l2_campaign_task_adds_score32_w16_rtl_exact_generation_quality
             }
 
 
+def test_generate_l2_campaign_task_adds_score32_exp_lut_div_generation_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_"
+                        "generation_quality_llama7b_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_"
+                        "generation_quality_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+                    evaluation_mode="quality_gate",
+                    comparison_role="score32_exp_lut_div_generation_quality",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+                        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "evaluate_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+            ]
+            run = commands[0]["run"]
+            assert "evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py" in run
+            assert "--candidate score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20" in run
+            assert "--primary-candidate-id score32_exp_lut_div" in run
+            assert decoder_inputs["attention_mixed_int8_generation_quality_baseline"].endswith(
+                "decoder_attention_mixed_int8_generation_quality__"
+                "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+            )
+            assert decoder_inputs["attention_mixed_int8_score32_w16_rtl_exact_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_exp_lut_div_composed_config"].endswith(
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+                "config.json"
+            )
+            assert "attention_mixed_int8_score32_exp_lut_div_generation_quality_out" in decoder_inputs
+            assert (
+                decoder_inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality_out"]
+                in work_item.expected_outputs
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+            }
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+                    "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_score24_w16_rtl_exact_generation_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/README.md
@@ -1,0 +1,13 @@
+# L2 score32 exp-LUT divider generation-quality gate
+
+This proposal is an evidence-only check for the candidate
+`score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20`.
+
+Decision target: if this candidate passes the bounded native-checkpoint generation gate,
+the exp-LUT divider bridge can advance to composed PPA recost.
+If it fails, keep the bridge as diagnostic and continue with other softmax/precision
+recovery work before any composed-PPA recost.
+
+Inputs: baseline `l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3` and
+`l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1`.
+This run is non-physical (`run_physical: false`) and requires merged inputs/materialized refs.

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run bounded native-checkpoint generation/NLL quality for score32 exp-LUT divider bridge candidate before composed-PPA recost.",
+      "candidate": "score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20",
+      "candidate_id": "score32_exp_lut_div",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+      "comparison_role": "score32_exp_lut_div_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "proceed_to_composed_ppa_recost_if_exp_lut_div_bridge_passes",
+        "reason": "A pass promotes the exp-LUT divider bridge as a quality-backed candidate for composed PPA recost; a fail keeps it diagnostic for further softmax approximation work."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/proposal.json
@@ -1,0 +1,90 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+  "created_utc": "2026-07-02T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score32 exp-LUT divider generation quality",
+  "abstraction_layer": "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+  "hypothesis": "The `score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20` candidate should recover native-checkpoint generation quality over the exact-divider bridge at the same mixed-int8 datapath boundary, enabling a quality-backed composed-PPA recost.",
+  "direct_comparison": {
+    "primary_question": "Does the exp-LUT divider bridge preserve bounded greedy generation and teacher-forced reference-token likelihood on a 7B checkpoint?",
+    "baseline": "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+    "negative_control": "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
+    "candidate": "score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20",
+    "physical_context": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
+    "include": [
+      "run native-checkpoint reference and exp-LUT bridge candidate on the same bounded prompt set",
+      "measure teacher-forced reference-token NLL under reference and candidate",
+      "measure free-running greedy exact and token-match metrics and first divergence step",
+      "decide whether the bridge is safe to submit to composed-PPA recost"
+    ],
+    "exclude": [
+      "new OpenROAD/PPA runs",
+      "training or QAT",
+      "full downstream benchmark accuracy"
+    ],
+    "metrics": [
+      "decision",
+      "candidate_id",
+      "free_run_exact_match_rate",
+      "free_run_token_match_rate",
+      "diverged_prompt_count",
+      "mean_first_divergence_step",
+      "teacher_forced_mean_reference_nll",
+      "teacher_forced_mean_candidate_nll",
+      "teacher_forced_mean_nll_delta",
+      "teacher_forced_candidate_reference_token_prob_mean"
+    ]
+  },
+  "expected_benefit": [
+    "validate whether exp-LUT divider approximation can replace exact division without quality loss",
+    "remove a likely false-positive barrier before composing and recosting at PPA",
+    "define the next mixed/int8 precision recovery path if exp-LUT bridge fails"
+  ],
+  "risks": [
+    "bounded greedy generation is not full task accuracy",
+    "prompt and generation-step defaults may miss longer-horizon divergence",
+    "quality outcome remains checkpoint/distribution dependent"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run a bounded native-checkpoint generation/NLL quality gate for score32 exp-LUT divider candidate before composing the corresponding PPA recost.",
+      "candidate": "score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20",
+      "candidate_id": "score32_exp_lut_div",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+      "comparison_role": "score32_exp_lut_div_generation_quality",
+      "cost_class": "medium",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3",
+        "l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "proceed_to_composed_ppa_recost_if_exp_lut_div_bridge_passes",
+        "reason": "If the exp-LUT divider bridge passes this quality gate, it can proceed to composed-PPA recost; if it fails, keep the candidate only as a diagnostic before further softmax/precision recovery."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_generation_quality__l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json"
+  ],
+  "source_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json",
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py",
+    "npu/eval/gen_llm_candidate_suite.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "npu/rtlgen/gen_attention_dual_stream_composed.py"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/proposal.json"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a Layer 2 generation-quality gate for the score32 exp-LUT divider softmax bridge:

- registers `decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality` in the L2 task generator
- emits an evidence-only quality job for `score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20`
- records dependencies on the existing mixed-int8 generation baseline and score32/w16 RTL-exact generation-quality control
- adds proposal docs for the quality gate
- adds generator regression coverage for the new abstraction layer

## Why

PR #1116 added the native and composed RTL exp-LUT divider bridge, but the control-plane generator could not yet materialize the matching L2 quality job. This PR closes that contract gap so the bridge can be checked on the bounded 7B generation/NLL gate before any composed-PPA recost is treated as quality-backed.

## Validation

- `python3 -m json.tool docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/proposal.json`
- `python3 -m json.tool docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/evaluation_requests.json`
- `python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py`
- `git diff --check`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k 'exp_lut_div or score32_w16_rtl_exact_generation_quality or softmax_replacement_generation_quality'`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py`
