### PR TITLE
[codex] Prepare exp-LUT PPA recost path

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5523,6 +5523,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     score32_split2_reduced_replica = "score32_w16_exact_div_split2_reduced_replica" in item_id
     score32_reduced_replica = "score32_w16_exact_div_reduced_replica" in item_id
     score32_recip_lut_q16_reduced_replica = "score32_w16_recip_lut_q16_reduced_replica" in item_id
+    score32_exp_lut_div_reduced_replica = "score32_exp_lut_div_reduced_replica" in item_id
     q20_pwl_recip_div_reduced_replica = "q20_pwl_recip_div_reduced_replica" in item_id
     score32_frontier = "score32_w16_exact_div_frontier" in item_id
     variant_frontier = "variant_frontier" in item_id
@@ -5544,6 +5545,12 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         composed_dual_stream_metrics = (
             "runs/designs/npu_blocks/"
             "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/metrics.csv"
+        )
+    elif score32_exp_lut_div_reduced_replica:
+        composed_dual_stream_metrics = (
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+            "metrics.csv"
         )
     elif q20_pwl_recip_div_reduced_replica:
         composed_dual_stream_metrics = (
@@ -5583,6 +5590,9 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     elif score32_recip_lut_q16_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a32_s32_w16_recip_lut_q16_int8_compute"
+    elif score32_exp_lut_div_reduced_replica:
+        model_name = "llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1"
+        precision_profile = "q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute"
     elif q20_pwl_recip_div_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a24_s20_w20_pwl_recip_div_q20_int8_compute"
@@ -5601,10 +5611,26 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     else:
         model_name = "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
         precision_profile = "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
+    if score32_exp_lut_div_reduced_replica:
+        quality_gate = (
+            f"{base}/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+            "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+        )
+        quality_gate_input_name = "attention_mixed_int8_score32_exp_lut_div_generation_quality"
+    else:
+        quality_gate_input_name = "attention_mixed_precision_quality"
+    recompute_area_fit = (
+        score24_reduced_replica
+        or score32_reduced_replica
+        or score32_split2_reduced_replica
+        or score32_recip_lut_q16_reduced_replica
+        or score32_exp_lut_div_reduced_replica
+        or q20_pwl_recip_div_reduced_replica
+    )
     return {
         "inputs": {
             "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
-            "attention_mixed_precision_quality": quality_gate,
+            quality_gate_input_name: quality_gate,
             "attention_kv_full_value_tile_metrics": full_value_tile_metrics,
             "attention_kv_softmax_weight_metrics": softmax_weight_metrics,
             "attention_kv_composed_dual_stream_metrics": composed_dual_stream_metrics,
@@ -5628,7 +5654,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
                     f"--quality-gate-json {quality_gate} "
                     f"--precision-profile {precision_profile} "
                     f"--model-name {model_name} "
-                    f"{'--recompute-area-fit-replicas ' if score24_reduced_replica or score32_reduced_replica or score32_split2_reduced_replica or score32_recip_lut_q16_reduced_replica or q20_pwl_recip_div_reduced_replica else ''}"
+                    f"{'--recompute-area-fit-replicas ' if recompute_area_fit else ''}"
                     "--frontier-row-limit 8 "
                     "--buffer-area-um2-per-byte 0.0 "
                     f"--out {out} "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6480,6 +6480,71 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_reci
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_lut_div_reduced_replica_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1"
+                in run
+            )
+            assert "--recompute-area-fit-replicas" in run
+            assert "--precision-profile q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute" in run
+            assert decoder_inputs["attention_kv_composed_dual_stream_metrics"] == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+                "metrics.csv"
+            )
+            assert decoder_inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+            )
+            assert (
+                "--quality-gate-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json "
+                in run
+            )
+            assert (
+                "--composed-dual-stream-metrics runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+                "metrics.csv "
+                in run
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_split2_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/README.md
@@ -1,0 +1,12 @@
+# L1 score32 exp-LUT divider composed datapath PPA
+
+This proposal measures the concrete composed dual-stream datapath for
+`score32_exp_lut_div`:
+
+- config: `runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json`
+- sweep: `runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20.json`
+- item: `l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1`
+
+The run measures local Nangate45 PPA only. The result becomes eligible for
+Llama7B reduced-replica recost only after the matching generation-quality gate
+is available.

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/evaluation_requests.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds score32 exp-LUT divider composed datapath generation, config, and sweep files.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for q8/k8/v8/a32/s32/w16 composed dual-stream attention with bucket20 exp-LUT divider softmax.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_exp_lut_div_quality_recost",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_score32_exp_lut_div_b20_datapath",
+        "reason": "This measures the concrete exp-LUT divider softmax bridge before the Llama7B reduced-replica recost uses it."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/proposal.json
@@ -1,0 +1,75 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1",
+  "created_utc": "2026-07-02T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Composed dual-stream attention score32 exp-LUT divider datapath",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The score32 exp-LUT divider bridge can replace the exact-divider or reciprocal-LUT softmax abstraction with a concrete bucketed exp LUT plus divider datapath, pending quality evidence.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 PPA cost and timing are achieved by the score32 exp-LUT divider composed dual-stream attention datapath?",
+    "baselines": [
+      "l1_decoder_attention_dual_stream_composed_score32_w16_exact_div_ppa_v1",
+      "l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_ppa_v1"
+    ],
+    "candidate": "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+    "include": [
+      "generate RTL with q8/k8/v8, a32/s32, w16, bucket20 exp-LUT divider softmax",
+      "run the composed datapath semantic guard before OpenROAD",
+      "measure Nangate45 area, power, timing, and timing debug paths"
+    ],
+    "exclude": [
+      "native checkpoint generation quality; that is the dependent L2 quality gate",
+      "Llama7B system-level recost; that is a dependent L2 item",
+      "training or QAT"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This measures local composed datapath PPA only.",
+    "The row is not quality-backed until the score32 exp-LUT generation-quality gate passes.",
+    "The Llama7B system-level point is a dependent reduced-replica Layer 2 recost."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for q8/k8/v8/a32/s32/w16 composed dual-stream attention with bucket20 exp-LUT divider softmax.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_exp_lut_div_quality_recost",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_w16_recip_lut_q16_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_score32_exp_lut_div_b20_datapath",
+        "reason": "This measures the concrete exp-LUT divider softmax bridge before the Llama7B reduced-replica recost uses it."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/proposal.json",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_recip_lut_q16/metrics.csv",
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exact_div/metrics.csv"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/README.md
@@ -1,0 +1,20 @@
+# Llama7B score32 exp-LUT divider composed datapath reduced-replica recost
+
+This proposal adds one L2 composed-PPA recost task for the score32 exp-LUT divider datapath.
+
+Item: `l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1`  
+Task type: `l2_campaign`  
+Mode: `frontier_detail`  
+Abstraction: `decoder_attention_composed_datapath_physical_feasibility`  
+Comparison role: `score32_exp_lut_div_reduced_replica_recost`  
+Baseline: `l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2`
+
+Dependencies:
+- `l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1` (expected L1 source id)
+- `l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1`
+- `l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2`
+
+Execution is blocked until merged inputs and materialized references are present.
+`run_physical` is `false` for this task.
+
+Decision rule: recost the exp-LUT composed datapath **only after** the quality gate and L1 PPA dependencies are available; do not mark this as quality-backed unless the quality gate passes.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds score32 exp-LUT divider composed-PPA reduced-replica task wiring.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the score32 exp-LUT divider composed datapath for Llama7B at area-fit replica count once quality and L1 PPA conditions are met.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_div_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "recost_score32_exp_lut_div_composed_datapath_after_quality_gate",
+        "reason": "Record this recost only if the score32 exp-LUT quality gate passes and the L1 exp-LUT PPA baseline is available; otherwise keep as blocked dependency, not quality-backed."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/proposal.json
@@ -1,0 +1,72 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+  "created_utc": "2026-07-02T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score32 exp-LUT divider composed datapath reduced-replica recost",
+  "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+  "hypothesis": "The score32 exp-LUT divider composed datapath should be recosted at the measured area-fit replica count, but only after the exp-LUT divider quality gate passes and the L1 exp-LUT PPA datapath run is available.",
+  "direct_comparison": {
+    "primary_question": "What Llama7B latency/area/energy point is defined by the measured score32 exp-LUT divider composed datapath when bound by the same reduced-replica constraints?",
+    "baseline": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+    "candidate": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+    "candidate_id": "score32_exp_lut_div",
+    "include": [
+      "load measured score32 exp-LUT divider composed datapath PPA artifacts",
+      "recompute Llama7B QKV, tile service, layer, and total latency at measured wrapper clock",
+      "record area-fit replica count and latency row under quality-gated candidate condition"
+    ],
+    "exclude": [
+      "new native-checkpoint quality campaign",
+      "new router/HBM/DRAM service model work",
+      "new L1 datapath synthesis"
+    ],
+    "metrics": [
+      "decision",
+      "precision_profile",
+      "best_requested_replica_recost_area_fit_replica_count",
+      "best_requested_replica_recost_latency_us",
+      "best_requested_replica_recost_energy_pj"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the score32 exp-LUT divider composed datapath for Llama7B at the area-fit replica count once quality and L1 PPA inputs are available.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_div_reduced_replica_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "recost_exp_lut_div_composed_datapath_after_quality_gate_and_l1_ppa",
+        "reason": "Recost the exp-LUT composed datapath only after the L1 exp-LUT divider gate is available and the L2 quality gate passes; do not treat this as quality-backed until the quality decision is affirmative."
+      }
+    }
+  ],
+  "source_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20.json",
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/proposal.json"
+  ],
+  "remaining_abstractions": [
+    "This is a composed-PPA recost, not a new quality gate run.",
+    "The underlying service model remains inherited from the source Llama7B subtile schedule.",
+    "Do not promote this row as quality-backed unless the referenced quality gate is explicitly passing."
+  ]
+}

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_score32_w16_exp_lut_div_b20"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_score32_w16_exp_lut_div_b20"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc32 attention_softmax_weight_score32_w16_exp_lut_div_b20_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_score32_w16_exp_lut_div_b20"
+}


### PR DESCRIPTION
## Summary

Prepares the dependency-gated composed-PPA recost path for the score32 exp-LUT divider bridge:

- adds an L1 sweep/proposal for `l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1`
- adds an L2 reduced-replica recost proposal for `l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1`
- teaches the L2 physical-feasibility generator to use the exp-LUT metrics path, precision profile, model name, and the matched exp-LUT generation-quality JSON
- adds regression coverage so this recost cannot accidentally fall back to the old default recip-LUT metrics or mixed-precision quality gate

## Why

PR #1117 queued the native generation-quality gate for `score32_exp_lut_div`. The next abstraction to remove is the physical cost of the corresponding composed RTL wrapper and then the Llama7B reduced-replica recost. This PR prepares both jobs while keeping the L2 recost dependency-gated on the quality result and L1 PPA metrics.

## Validation

- `python3 -m json.tool` on the new L1 proposal JSON, L2 proposal JSON, and exp-LUT sweep JSON
- `python3 -m py_compile control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py`
- `git diff --check`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k 'exp_lut_div_reduced_replica or score32_exp_lut_div_generation_quality'`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l1_task_generator.py -k 'dual_stream_composed'`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l1_task_generator.py`
