### PR TITLE
[codex] add exp-lut command overhead recost

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5524,6 +5524,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     score32_reduced_replica = "score32_w16_exact_div_reduced_replica" in item_id
     score32_recip_lut_q16_reduced_replica = "score32_w16_recip_lut_q16_reduced_replica" in item_id
     score32_exp_lut_div_reduced_replica = "score32_exp_lut_div_reduced_replica" in item_id
+    command_overhead = "command_overhead" in item_id
     q20_pwl_recip_div_reduced_replica = "q20_pwl_recip_div_reduced_replica" in item_id
     score32_frontier = "score32_w16_exact_div_frontier" in item_id
     variant_frontier = "variant_frontier" in item_id
@@ -5627,6 +5628,10 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         or score32_exp_lut_div_reduced_replica
         or q20_pwl_recip_div_reduced_replica
     )
+    command_overhead_flags = ""
+    if command_overhead:
+        model_name = f"{model_name}_command_overhead"
+        command_overhead_flags = "--command-cycles-per-tile 0,1,4,16 --command-cycles-per-wave 0,8,32 "
     return {
         "inputs": {
             "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
@@ -5639,7 +5644,8 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
             "attention_composed_datapath_physical_feasibility_scope": (
                 "Use the composed dual-stream RTL wrapper PPA "
                 "as a bounded next-step feasibility model, replacing separate full-value/softmax substitutions "
-                "while keeping the upstream source schedule."
+                "while keeping the upstream source schedule. If command-overhead mode is requested, sweep "
+                "nonzero per-tile and per-wave command-dispatch cycles before recosting the composed datapath."
             ),
         },
         "commands": [
@@ -5655,6 +5661,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
                     f"--precision-profile {precision_profile} "
                     f"--model-name {model_name} "
                     f"{'--recompute-area-fit-replicas ' if recompute_area_fit else ''}"
+                    f"{command_overhead_flags}"
                     "--frontier-row-limit 8 "
                     "--buffer-area-um2-per-byte 0.0 "
                     f"--out {out} "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6372,6 +6372,65 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_redu
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_command_overhead() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                        "command_overhead_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1_command_overhead"
+                in run
+            )
+            assert "--recompute-area-fit-replicas" in run
+            assert "--command-cycles-per-tile 0,1,4,16" in run
+            assert "--command-cycles-per-wave 0,8,32" in run
+            assert "--precision-profile q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute" in run
+            assert decoder_inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_kv_composed_dual_stream_metrics"] == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+                "metrics.csv"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                    "command_overhead_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -123,16 +123,29 @@ than free or heuristic assumptions.
     teacher-forced mean NLL delta `1.5337108926816854`, top-1 match
     `0.515625`, free-run exact match `0.0`, and free-run token match
     `0.078125`
-  - the pending diagnostic item
+  - the exact-divide RTL diagnostic item
     `l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1`
-    is queued at source commit
-    `cd87b3692ad7076b0f924ce3d866cfc0c6cc92d2` to separate reciprocal-LUT
-    precision loss from the shared RTL softmax exponent/weight approximation
-  - successor routes are prepared but intentionally not dispatched yet:
-    `l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1`
-    for the reciprocal-precision branch, and
+    is merged and also failed the generation-quality gate with the same
+    teacher-forced mean NLL delta `1.533711`, free-run exact match `0.0`, and
+    free-run token match `0.078125`. This indicates the reciprocal-LUT was not
+    the dominant quality loss; the shared RTL softmax exponent/weight path is
+    the problem.
+  - the softmax-replacement quality item
     `l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1`
-    for the softmax-replacement branch
+    is merged and restored the replacement branch enough to continue physical
+    cost exploration.
+  - measured composed-PPA reduced-replica recosts exist for score32 exact-div
+    and score32 q16 reciprocal-LUT. Exact-div is area-fit only at a near-full
+    compute budget (`801` required replicas, density gain `0.998929`), while
+    the q16 reciprocal-LUT recost has more logic slack but is not
+    quality-backed because its generation-quality gate failed.
+  - the active follow-on branch is the score32 exp-LUT divider path:
+    `l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1`
+    and
+    `l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1`
+    are queued. The dependent recost
+    `l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1`
+    is intentionally blocked until both inputs are materialized.
 - New evaluations should continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`, not the devcontainer.
 
@@ -164,14 +177,16 @@ than free or heuristic assumptions.
      with a more explicit controller, arbitration, and contention model.
    - Status: partially bounded by the HBM energy sensitivity result, the merged
      HBM/DRAM command-service energy result, and the source-backed aggregate HBM
-     energy calibration result, but not cycle-accurate. The aggregate
-     source-backed calibration preserved the selected family but changed the
-     dominant component to HBM.
-   - Next result: run
-     `l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1`,
-     consuming the merged HBM/DRAM service-energy result and source-backed HBM
-     energy calibration result, to retain command-mix and row-hit sensitivity
-     while calibrating to the HBM2 aggregate pJ/bit anchor.
+     energy calibration result, plus the command-calibrated service result, but
+     not cycle-accurate. The command-calibrated result preserved the selected
+     energy family under row-hit sensitivity, but still reports analytic
+     row-hit service, globally scaled HBM command energy, profile-scaled
+     NoC/SRAM energy, and scaled compute energy.
+   - Next result: keep HBM/DRAM as a bounded planning model for now, and move
+     the immediate frontier work to quality-backed exp-LUT physical recost and
+     explicit scheduler/control overhead accounting. A later HBM/controller job
+     should replace the row-hit analytic model with a cycle service model only
+     after the compute/softmax frontier is quality-backed.
 
 3. Composed q12/PWL softmax datapath density recovery
    - Scope: score max, exponent approximation, sum accumulation, reciprocal
@@ -196,12 +211,14 @@ than free or heuristic assumptions.
    - Scope: close the quality gap between the passing `score32_float`
      mixed-int8 baseline and an RTL-realizable score32/w16 softmax path.
    - Status: q16 reciprocal-LUT RTL softmax failed the bounded Llama7B
-     generation-quality gate. The RTL exact-divide diagnostic is queued to
-     determine whether the failure is dominated by reciprocal precision or by
-     the shared RTL softmax exponent/weight approximation.
-   - Next result: run the queued RTL exact-divide diagnostic on the remote
-     evaluator. If exact-divide passes, sweep reciprocal precision. If
-     exact-divide fails, dispatch the softmax replacement quality sweep.
+     generation-quality gate, and the RTL exact-divide diagnostic failed with
+     the same quality signature. The reciprocal precision branch should not be
+     promoted. The replacement branch is now the active path; the score32
+     exp-LUT divider datapath and matching generation-quality gate are queued.
+   - Next result: run the queued exp-LUT quality gate and exp-LUT L1 PPA on the
+     remote evaluator, then release the blocked exp-LUT reduced-replica L2
+     recost only if the quality gate passes and the measured PPA row is
+     materialized.
 
 5. SRAM timing and energy
    - Scope: tile-local score/value buffering, KV tile reads, partial-value
@@ -219,6 +236,20 @@ than free or heuristic assumptions.
      payload/cycle and arbitration-latency bounds under the selected
      producer/reducer traffic mix.
 
+6a. Command/scheduler/control overhead
+   - Scope: account for command generation, tile assignment, per-wave launch,
+     ready/valid backpressure, and control distribution in the Llama7B
+     composed-attention schedule.
+   - Status: the current reduced-replica rows still carry
+     `command_cycles_per_tile=0` and `command_cycles_per_wave=0`. The on-chip
+     endpoint/router/SRAM and HBM service models bound data movement, but the
+     command path is still idealized in the rows used for score32 exact-div and
+     reciprocal-LUT recost.
+   - Next result: create a command-overhead sensitivity or measured
+     scheduler-control job that sweeps nonzero per-tile and per-wave overhead
+     for the selected dual-stream schedule, then feeds the result into the same
+     Llama7B recost path.
+
 7. Integrated schedule closure audit
    - Scope: rerun the Llama7B attention schedule with measured compute,
      full-value tile, softmax, SRAM, NoC, HBM, and precision evidence.
@@ -228,22 +259,22 @@ than free or heuristic assumptions.
 
 ## Ordering
 
-The current first step is the RTL exact-divide generation-quality diagnostic:
-`l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1`.
-It should stay pinned to source commit
-`cd87b3692ad7076b0f924ce3d866cfc0c6cc92d2` unless the evaluator cannot run
-that commit. The successor branch is conditional:
+The current first step is to unblock the remote evaluator source checkout and
+run the already queued exp-LUT branch:
 
-1. If RTL exact-divide passes the quality gate, dispatch
-   `l2_decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality_llama7b_v1`
-   to find the smallest reciprocal-LUT precision that preserves quality.
-2. If RTL exact-divide fails, dispatch
-   `l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1`
-   to replace the shared RTL softmax approximation before spending more PPA
-   runs on reciprocal precision.
-3. After one quality branch passes, run physical PPA for the selected
-   score32/w16 softmax embodiment and then feed that measured cost back into
-   the Llama7B integrated schedule.
+1. Run `l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1`.
+   This decides whether the replacement score32 exp-LUT divider path is
+   quality-backed.
+2. Run `l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1`.
+   This measures the matching composed RTL wrapper PPA.
+3. If both inputs pass/materialize, release
+   `l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1`
+   to recost the Llama7B point. If the quality gate fails, do not promote the
+   exp-LUT row as quality-backed; return to the softmax replacement design.
+4. In parallel with evaluator recovery or after exp-LUT recost, prepare the
+   command-overhead sensitivity job for the selected dual-stream schedule,
+   because current score32 reduced-replica rows still assume zero command
+   cycles.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/README.md
@@ -1,0 +1,19 @@
+# Llama7B score32 exp-LUT divider command-overhead recost
+
+This proposal adds a dependency-gated L2 recost for the score32 exp-LUT divider
+composed datapath with nonzero command-dispatch overhead.
+
+Item: `l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_command_overhead_llama7b_v1`
+Task type: `l2_campaign`
+Mode: `frontier_detail`
+Abstraction: `decoder_attention_composed_datapath_physical_feasibility`
+Comparison role: `score32_exp_lut_div_command_overhead_recost`
+
+Dependencies:
+- `l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1`
+- `l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1`
+- `l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1`
+
+The recost sweeps command cycles per tile and per wave before applying the same
+area-fit replica recost. It should not be treated as quality-backed unless the
+referenced exp-LUT generation-quality gate passes.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: developer_agent
+- approved_utc: 2026-07-02T00:00:00Z
+- allowed_evaluations:
+  - l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_command_overhead_llama7b_v1
+- note: Dependency-gated command-overhead sensitivity for the score32 exp-LUT divider reduced-replica recost.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds command-overhead override support to the dual-stream composed recost path.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_command_overhead_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the score32 exp-LUT divider composed datapath under nonzero command-dispatch cycle assumptions after quality and L1 PPA conditions are met.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_div_command_overhead_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "bound_command_overhead_on_exp_lut_composed_datapath",
+        "reason": "Sweep nonzero per-tile and per-wave command cycles in the same exp-LUT reduced-replica recost path; do not mark quality-backed if the exp-LUT quality gate fails."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1",
+  "created_utc": "2026-07-02T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score32 exp-LUT divider command-overhead recost",
+  "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+  "hypothesis": "The score32 exp-LUT divider composed datapath should remain interpretable after charging nonzero command-dispatch overhead, but the overhead must be swept explicitly before treating the reduced-replica schedule as a practical frontier point.",
+  "direct_comparison": {
+    "primary_question": "How much does nonzero per-tile and per-wave command-dispatch overhead move the score32 exp-LUT divider reduced-replica Llama7B latency point?",
+    "baseline": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+    "candidate": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_command_overhead_llama7b_v1",
+    "include": [
+      "reuse the measured score32 exp-LUT divider composed datapath PPA artifact",
+      "reuse the matched exp-LUT generation-quality gate as a dependency",
+      "sweep command_cycles_per_tile values 0, 1, 4, and 16",
+      "sweep command_cycles_per_wave values 0, 8, and 32",
+      "recompute area-fit replica latency after injecting command-dispatch cycles"
+    ],
+    "exclude": [
+      "new native-checkpoint quality campaign",
+      "new OpenROAD/PPA run",
+      "new HBM/DRAM controller model",
+      "new NoC/router physical synthesis"
+    ],
+    "metrics": [
+      "decision",
+      "precision_profile",
+      "command_overhead_variant",
+      "command_dispatch_cycles",
+      "replica_recost_latency_us",
+      "replica_recost_layer_cycles",
+      "replica_recost_area_fit_replica_count"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_command_overhead_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the score32 exp-LUT divider composed datapath under nonzero command-dispatch cycle assumptions after the exp-LUT quality and PPA inputs are available.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_div_command_overhead_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "bound_command_overhead_on_exp_lut_composed_datapath",
+        "reason": "Record whether command-dispatch overhead materially changes the exp-LUT reduced-replica latency ranking; keep the result dependency-gated and non-promotable if the exp-LUT quality gate fails."
+      }
+    }
+  ],
+  "source_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/proposal.json"
+  ],
+  "remaining_abstractions": [
+    "Command overhead is swept as cycle sensitivity, not measured from command-distribution RTL.",
+    "HBM/DRAM and NoC/SRAM service remain inherited from the upstream source schedule.",
+    "The result is only quality-backed if the referenced exp-LUT generation-quality gate passes."
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -140,6 +140,21 @@ def _parse_composed_metric_inputs(values: Any) -> list[Path]:
     return paths
 
 
+def _int_override_list(text: str | None) -> list[int | None]:
+    if text is None or not str(text).strip():
+        return [None]
+    values: list[int | None] = []
+    for piece in str(text).split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        value = int(piece)
+        if value < 0:
+            raise argparse.ArgumentTypeError("command cycle overrides must be non-negative")
+        values.append(value)
+    return values or [None]
+
+
 def _load_composed_variants(paths: list[Path]) -> list[JsonDict]:
     variants: list[JsonDict] = []
     for path in paths:
@@ -153,6 +168,26 @@ def _load_composed_variants(paths: list[Path]) -> list[JsonDict]:
         )
         variants.append(metrics)
     return variants
+
+
+def _with_command_overhead(source_row: JsonDict, *, per_tile: int | None, per_wave: int | None) -> JsonDict:
+    if per_tile is None and per_wave is None:
+        return dict(source_row)
+    row = dict(source_row)
+    command_cycles_per_tile = int(row.get("command_cycles_per_tile", 0)) if per_tile is None else int(per_tile)
+    command_cycles_per_wave = int(row.get("command_cycles_per_wave", 0)) if per_wave is None else int(per_wave)
+    command_dispatch_cycles = int(row["tile_count"]) * command_cycles_per_tile + int(row["tile_waves"]) * command_cycles_per_wave
+    row.update(
+        {
+            "command_cycles_per_tile": command_cycles_per_tile,
+            "command_cycles_per_wave": command_cycles_per_wave,
+            "command_dispatch_cycles": command_dispatch_cycles,
+            "command_overhead_override_enabled": True,
+            "command_overhead_variant": f"ct{command_cycles_per_tile}_cw{command_cycles_per_wave}",
+        }
+    )
+    row.update(_scheduled_subtile_pipeline(row))
+    return row
 
 
 def _source_rows(payload: JsonDict, *, limit: int) -> list[JsonDict]:
@@ -638,6 +673,8 @@ def _effective_selection_key(row: JsonDict) -> tuple[float, float, float, str]:
 def build_report(args: argparse.Namespace) -> JsonDict:
     source = _load_json(args.subtile_pipeline_json)
     source_rows = _source_rows(source, limit=args.frontier_row_limit)
+    command_cycles_per_tile_overrides = _int_override_list(args.command_cycles_per_tile)
+    command_cycles_per_wave_overrides = _int_override_list(args.command_cycles_per_wave)
     full_value_tile = _best_ok_metrics(args.full_value_tile_metrics)
     softmax_weight = _best_ok_metrics(args.softmax_weight_metrics)
     composed_dual_stream_metrics = _parse_composed_metric_inputs(getattr(args, "composed_dual_stream_metrics", None))
@@ -645,15 +682,36 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     compute_block = _best_ok_compute_metrics(args.compute_block_metrics) if args.compute_block_metrics else None
     quality_gate = _load_json(args.quality_gate_json) if args.quality_gate_json else None
     rows: list[JsonDict] = []
-    for row in source_rows:
-        if composed_variants:
-            for composed_dual_stream in composed_variants:
+    for source_row in source_rows:
+        overhead_rows = [
+            _with_command_overhead(source_row, per_tile=per_tile, per_wave=per_wave)
+            for per_tile in command_cycles_per_tile_overrides
+            for per_wave in command_cycles_per_wave_overrides
+        ]
+        for row in overhead_rows:
+            if composed_variants:
+                for composed_dual_stream in composed_variants:
+                    rows.append(
+                        _row_with_budget(
+                            row,
+                            full_value_tile=full_value_tile,
+                            softmax_weight=softmax_weight,
+                            composed_dual_stream=composed_dual_stream,
+                            compute_block=compute_block,
+                            compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
+                            compute_arch_name=args.compute_arch_name,
+                            buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
+                            precision_profile=args.precision_profile,
+                            recompute_area_fit_replicas=args.recompute_area_fit_replicas,
+                        )
+                    )
+            else:
                 rows.append(
                     _row_with_budget(
                         row,
                         full_value_tile=full_value_tile,
                         softmax_weight=softmax_weight,
-                        composed_dual_stream=composed_dual_stream,
+                        composed_dual_stream=None,
                         compute_block=compute_block,
                         compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
                         compute_arch_name=args.compute_arch_name,
@@ -662,21 +720,6 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                         recompute_area_fit_replicas=args.recompute_area_fit_replicas,
                     )
                 )
-        else:
-            rows.append(
-                _row_with_budget(
-                    row,
-                    full_value_tile=full_value_tile,
-                    softmax_weight=softmax_weight,
-                    composed_dual_stream=None,
-                    compute_block=compute_block,
-                    compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
-                    compute_arch_name=args.compute_arch_name,
-                    buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
-                    precision_profile=args.precision_profile,
-                    recompute_area_fit_replicas=args.recompute_area_fit_replicas,
-                )
-            )
     feasible_rows = [row for row in rows if row["physical_feasible"]]
     best_requested = min(rows, key=_effective_selection_key) if rows else None
     best_feasible = min(feasible_rows, key=_effective_selection_key) if feasible_rows else None
@@ -721,6 +764,8 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "precision_profile": args.precision_profile,
             "buffer_area_um2_per_byte": args.buffer_area_um2_per_byte,
             "recompute_area_fit_replicas": args.recompute_area_fit_replicas,
+            "command_cycles_per_tile": args.command_cycles_per_tile,
+            "command_cycles_per_wave": args.command_cycles_per_wave,
         },
         "quality_gate": {
             "decision": (quality_gate or {}).get("diagnosis", {}).get("decision"),
@@ -848,6 +893,20 @@ def main() -> int:
     )
     parser.add_argument("--frontier-row-limit", type=int, default=8)
     parser.add_argument("--buffer-area-um2-per-byte", type=float, default=0.0)
+    parser.add_argument(
+        "--command-cycles-per-tile",
+        help=(
+            "Optional comma-separated command-dispatch cycle overrides per tile. "
+            "When omitted, source row command cycles are preserved."
+        ),
+    )
+    parser.add_argument(
+        "--command-cycles-per-wave",
+        help=(
+            "Optional comma-separated command-dispatch cycle overrides per wave. "
+            "When omitted, source row command cycles are preserved."
+        ),
+    )
     parser.add_argument(
         "--recompute-area-fit-replicas",
         action="store_true",


### PR DESCRIPTION
## Summary
- add command-cycle override support to the dual-stream composed datapath recost script
- wire a dependency-gated exp-LUT reduced-replica command-overhead L2 item
- add a proposal workspace and update the Llama7B abstraction-closure plan to reflect current score32/exp-LUT state
- add a generator regression test for the new command-overhead item

## Why
The current score32 reduced-replica rows still assume `command_cycles_per_tile=0` and `command_cycles_per_wave=0`. This PR makes command dispatch overhead an explicit sensitivity path before treating the exp-LUT composed datapath as a practical Llama7B frontier point.

## Validation
- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py control_plane/control_plane/services/l2_task_generator.py control_plane/control_plane/tests/test_l2_task_generator.py`
- exact-div smoke run with `--command-cycles-per-tile 0,4 --command-cycles-per-wave 0,16`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_command_overhead`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`

## Notes
The new item is intentionally dependency-gated behind exp-LUT quality, exp-LUT PPA, and the base exp-LUT reduced-replica recost. It should run on the remote evaluator after that source checkout is clean.
