### PR TITLE
[codex] recost exp-LUT attention with measured command control

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5525,6 +5525,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     score32_recip_lut_q16_reduced_replica = "score32_w16_recip_lut_q16_reduced_replica" in item_id
     score32_exp_lut_div_reduced_replica = "score32_exp_lut_div_reduced_replica" in item_id
     command_overhead = "command_overhead" in item_id
+    measured_command_control = "measured_command_control" in item_id
     q20_pwl_recip_div_reduced_replica = "q20_pwl_recip_div_reduced_replica" in item_id
     score32_frontier = "score32_w16_exact_div_frontier" in item_id
     variant_frontier = "variant_frontier" in item_id
@@ -5582,6 +5583,15 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         f"--composed-dual-stream-metrics {path}"
         for path in composed_dual_stream_metrics.split(",")
     )
+    command_dispatch_control_metrics = (
+        "runs/designs/npu_blocks/attention_command_dispatch_c8_q16/metrics.csv,"
+        "runs/designs/npu_blocks/attention_command_dispatch_c16_q32/metrics.csv,"
+        "runs/designs/npu_blocks/attention_command_dispatch_c32_q64/metrics.csv"
+    )
+    command_dispatch_control_metrics_flags = " ".join(
+        f"--command-dispatch-control-metrics {path}"
+        for path in command_dispatch_control_metrics.split(",")
+    )
     if score24_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a24_s24_w16_exact_div_int8_compute"
@@ -5632,6 +5642,10 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     if command_overhead:
         model_name = f"{model_name}_command_overhead"
         command_overhead_flags = "--command-cycles-per-tile 0,1,4,16 --command-cycles-per-wave 0,8,32 "
+    measured_command_control_flags = ""
+    if measured_command_control:
+        model_name = f"{model_name}_measured_command_control"
+        measured_command_control_flags = f"{command_dispatch_control_metrics_flags} "
     return {
         "inputs": {
             "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
@@ -5639,13 +5653,20 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
             "attention_kv_full_value_tile_metrics": full_value_tile_metrics,
             "attention_kv_softmax_weight_metrics": softmax_weight_metrics,
             "attention_kv_composed_dual_stream_metrics": composed_dual_stream_metrics,
+            **(
+                {"attention_command_dispatch_control_metrics": command_dispatch_control_metrics}
+                if measured_command_control
+                else {}
+            ),
             "attention_composed_datapath_physical_feasibility_out": out,
             "attention_composed_datapath_physical_feasibility_report": report,
             "attention_composed_datapath_physical_feasibility_scope": (
                 "Use the composed dual-stream RTL wrapper PPA "
                 "as a bounded next-step feasibility model, replacing separate full-value/softmax substitutions "
                 "while keeping the upstream source schedule. If command-overhead mode is requested, sweep "
-                "nonzero per-tile and per-wave command-dispatch cycles before recosting the composed datapath."
+                "nonzero per-tile and per-wave command-dispatch cycles before recosting the composed datapath. "
+                "If measured-command-control mode is requested, charge measured central command-dispatch "
+                "control area/power/clock from the L1 command-dispatch control run."
             ),
         },
         "commands": [
@@ -5662,6 +5683,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
                     f"--model-name {model_name} "
                     f"{'--recompute-area-fit-replicas ' if recompute_area_fit else ''}"
                     f"{command_overhead_flags}"
+                    f"{measured_command_control_flags}"
                     "--frontier-row-limit 8 "
                     "--buffer-area-um2-per-byte 0.0 "
                     f"--out {out} "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6431,6 +6431,67 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_comm
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_measured_command_control() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                        "measured_command_control_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1_measured_command_control"
+                in run
+            )
+            assert "--recompute-area-fit-replicas" in run
+            assert "--command-cycles-per-tile" not in run
+            assert "--command-cycles-per-wave" not in run
+            assert "--command-dispatch-control-metrics runs/designs/npu_blocks/attention_command_dispatch_c8_q16/metrics.csv" in run
+            assert "--command-dispatch-control-metrics runs/designs/npu_blocks/attention_command_dispatch_c16_q32/metrics.csv" in run
+            assert "--command-dispatch-control-metrics runs/designs/npu_blocks/attention_command_dispatch_c32_q64/metrics.csv" in run
+            assert decoder_inputs["attention_command_dispatch_control_metrics"] == (
+                "runs/designs/npu_blocks/attention_command_dispatch_c8_q16/metrics.csv,"
+                "runs/designs/npu_blocks/attention_command_dispatch_c16_q32/metrics.csv,"
+                "runs/designs/npu_blocks/attention_command_dispatch_c32_q64/metrics.csv"
+            )
+            assert decoder_inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                    "measured_command_control_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -254,6 +254,11 @@ than free or heuristic assumptions.
      can later replace or bound the per-tile/per-wave command-cycle sensitivity
      with measured control PPA, while leaving distributed control fanout as an
      explicit remaining abstraction.
+   - Follow-on recost path:
+     `prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1`
+     consumes the L1 command-dispatch-control PPA and charges the selected
+     measured central control variant into the score32 exp-LUT reduced-replica
+     Llama7B recost.
 
 7. Integrated schedule closure audit
    - Scope: rerun the Llama7B attention schedule with measured compute,
@@ -285,6 +290,10 @@ run the already queued exp-LUT branch:
    central scheduler/control block that will bound the command-cycle
    sensitivity model. Do not let it displace the already READY exp-LUT quality
    and PPA jobs.
+6. After the L1 command-control PPA and exp-LUT recost materialize, run
+   `l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1`
+   to charge measured central control area/power/clock into the same Llama7B
+   reduced-replica point.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/README.md
@@ -1,0 +1,14 @@
+# Llama7B score32 exp-LUT divider measured command-control recost
+
+This proposal adds a dependency-gated L2 recost that consumes the measured L1
+attention command-dispatch/control PPA and charges it to the score32 exp-LUT
+divider reduced-replica Llama7B schedule.
+
+It is distinct from the command-overhead sensitivity job:
+
+- command-overhead sensitivity sweeps assumed per-tile/per-wave cycles
+- measured command-control recost charges measured central scheduler/control
+  area, power, and clock
+
+The result should run only after the exp-LUT quality/PPA/base-recost chain and
+the L1 command-dispatch-control PPA item have materialized.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds measured command-dispatch-control consumption to the dual-stream composed recost path.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the score32 exp-LUT divider reduced-replica Llama7B point after charging measured central command-dispatch/control PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_div_measured_command_control_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+        "l1_decoder_attention_command_dispatch_control_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "charge_measured_command_control_to_exp_lut_recost",
+        "reason": "This replaces a purely idealized scheduler/control area-power assumption with measured central command-dispatch PPA before final frontier promotion."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/proposal.json
@@ -1,0 +1,77 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1",
+  "created_utc": "2026-07-03T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B score32 exp-LUT divider measured command-control recost",
+  "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+  "hypothesis": "The selected score32 exp-LUT divider reduced-replica point should remain interpretable after charging a measured central command-dispatch/control block, but this must be checked explicitly before treating scheduler/control as bounded.",
+  "direct_comparison": {
+    "primary_question": "How much do measured central command-dispatch/control area, power, and clock move the score32 exp-LUT divider reduced-replica Llama7B point?",
+    "baselines": [
+      "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+      "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_command_overhead_llama7b_v1"
+    ],
+    "candidate": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+    "include": [
+      "reuse the measured score32 exp-LUT divider composed datapath PPA artifact",
+      "reuse the matched exp-LUT generation-quality gate",
+      "consume the L1 attention command-dispatch-control PPA for 8/16/32 clusters",
+      "select the smallest command-dispatch-control variant covering each L2 schedule row cluster count",
+      "charge central command-control area and power and require command-control clock compatibility"
+    ],
+    "exclude": [
+      "distributed per-cluster control fanout",
+      "new NoC/HBM controller detail",
+      "training or QAT"
+    ],
+    "metrics": [
+      "best_requested_measured_command_dispatch_control_area_um2",
+      "best_requested_command_dispatch_control_clock_ok",
+      "best_requested_logic_slack_um2",
+      "best_requested_replica_recost_latency_us",
+      "best_feasible_latency_us"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the score32 exp-LUT divider reduced-replica Llama7B point after charging measured central command-dispatch/control PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_div_measured_command_control_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+        "l1_decoder_attention_command_dispatch_control_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "charge_measured_command_control_to_exp_lut_recost",
+        "reason": "This replaces a purely idealized scheduler/control area-power assumption with measured central command-dispatch PPA before final frontier promotion."
+      },
+      "status": "pending"
+    }
+  ],
+  "source_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "runs/designs/npu_blocks/attention_command_dispatch_c8_q16/metrics.csv",
+    "runs/designs/npu_blocks/attention_command_dispatch_c16_q32/metrics.csv",
+    "runs/designs/npu_blocks/attention_command_dispatch_c32_q64/metrics.csv"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l1_decoder_attention_command_dispatch_control_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/proposal.json"
+  ],
+  "remaining_abstractions": [
+    "Distributed command fanout and per-cluster local decode remain explicit future work.",
+    "This recost still uses the upstream analytic Llama7B schedule and measured local datapath PPA.",
+    "The result is quality-backed only if the referenced exp-LUT generation-quality gate passes."
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -170,6 +170,85 @@ def _load_composed_variants(paths: list[Path]) -> list[JsonDict]:
     return variants
 
 
+def _infer_command_dispatch_clusters(path: Path) -> int | None:
+    config_path = path.parent / "config.json"
+    if config_path.exists():
+        try:
+            payload = _load_json(config_path)
+        except json.JSONDecodeError:
+            payload = {}
+        ctrl = payload.get("attention_command_dispatch") if isinstance(payload, dict) else None
+        if isinstance(ctrl, dict):
+            try:
+                clusters = int(ctrl.get("clusters"))
+            except (TypeError, ValueError):
+                clusters = 0
+            if clusters > 0:
+                return clusters
+    match = re.search(r"(?:^|_)c(\d+)(?:_|$)", path.parent.name)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _load_command_dispatch_control_variants(paths: list[Path]) -> list[JsonDict]:
+    variants: list[JsonDict] = []
+    for path in paths:
+        metrics = _best_ok_compute_metrics(path)
+        clusters = _infer_command_dispatch_clusters(path)
+        if clusters is None:
+            raise RuntimeError(
+                "could not infer command-dispatch cluster count from metrics path; "
+                f"add a sibling config.json with attention_command_dispatch.clusters: {path}"
+            )
+        metrics.update(
+            {
+                "command_dispatch_control_cluster_count": clusters,
+                "command_dispatch_control_variant_name": path.parent.name,
+            }
+        )
+        variants.append(metrics)
+    variants.sort(
+        key=lambda row: (
+            int(row["command_dispatch_control_cluster_count"]),
+            float(row["block_area_um2"]),
+            float(row["critical_path_ns"]),
+        )
+    )
+    return variants
+
+
+def _select_command_dispatch_control_variant(
+    variants: list[JsonDict],
+    *,
+    clusters: int,
+) -> JsonDict | None:
+    if not variants:
+        return None
+    covering = [
+        row
+        for row in variants
+        if int(row["command_dispatch_control_cluster_count"]) >= clusters
+    ]
+    if covering:
+        return min(
+            covering,
+            key=lambda row: (
+                int(row["command_dispatch_control_cluster_count"]),
+                float(row["block_area_um2"]),
+                float(row["critical_path_ns"]),
+            ),
+        )
+    return max(
+        variants,
+        key=lambda row: (
+            int(row["command_dispatch_control_cluster_count"]),
+            -float(row["block_area_um2"]),
+            -float(row["critical_path_ns"]),
+        ),
+    )
+
+
 def _with_command_overhead(source_row: JsonDict, *, per_tile: int | None, per_wave: int | None) -> JsonDict:
     if per_tile is None and per_wave is None:
         return dict(source_row)
@@ -225,6 +304,7 @@ def _row_with_budget(
     softmax_weight: JsonDict,
     composed_dual_stream: JsonDict | None,
     compute_block: JsonDict | None,
+    command_dispatch_control: JsonDict | None,
     compute_block_macs_per_cycle: int | None,
     compute_arch_name: str | None,
     buffer_area_um2_per_byte: float,
@@ -241,6 +321,9 @@ def _row_with_budget(
     current_logic_used = float(source_row["logic_area_used_um2"])
     required_buffer_bytes = int(source_row.get("required_stream_buffer_bytes", source_row.get("tile_local_buffer_bytes", 0)))
     available_local_capacity = int(source_row.get("available_local_capacity_bytes", source_row.get("local_capacity_bytes_per_cluster", 0)))
+    control_area = float(command_dispatch_control["block_area_um2"]) if command_dispatch_control else 0.0
+    control_clock_ns = float(command_dispatch_control["critical_path_ns"]) if command_dispatch_control else 0.0
+    control_power_mw = float(command_dispatch_control["total_power_mw"]) if command_dispatch_control else 0.0
 
     measured_stream_area = float(full_value_tile["die_area_um2"])
     measured_softmax_area = float(softmax_weight["die_area_um2"])
@@ -316,7 +399,7 @@ def _row_with_budget(
         compute_area_required = base_compute_area * compute_multiplier
     logic_used_required = current_logic_used + (compute_area_required - current_compute_area) + (
         selected_l1_overhead - current_l1_overhead
-    )
+    ) + control_area
     logic_slack_required = compute_budget - logic_used_required
     compute_area_over_budget = max(0.0, logic_used_required - compute_budget)
     required_compute_density_gain = (
@@ -332,7 +415,10 @@ def _row_with_budget(
     replica_shortfall = max(0, replica_count_required - replica_count_budgeted)
     area_fit = logic_slack_required >= 0.0
     buffer_fit = required_buffer_bytes <= available_local_capacity
-    feasible = area_fit and buffer_fit
+    command_dispatch_control_clock_ok = (
+        command_dispatch_control is None or control_clock_ns <= float(source_row["clock_ns"])
+    )
+    feasible = area_fit and buffer_fit and command_dispatch_control_clock_ok
 
     if feasible:
         if use_composed_dual_stream and composed_clock_ns > 0.0 and source_clock_ns > 0.0:
@@ -389,6 +475,28 @@ def _row_with_budget(
             "selected_local_datapath_area_um2_per_cluster": round(selected_local_datapath_area, 6),
             "selected_l1_overhead_area_um2": round(selected_l1_overhead, 6),
             "compute_area_required_um2": round(compute_area_required, 6),
+            "measured_command_dispatch_control_metrics_csv": (
+                command_dispatch_control["metrics_csv"] if command_dispatch_control else None
+            ),
+            "measured_command_dispatch_control_variant_name": (
+                command_dispatch_control["command_dispatch_control_variant_name"]
+                if command_dispatch_control
+                else None
+            ),
+            "measured_command_dispatch_control_cluster_count": (
+                command_dispatch_control["command_dispatch_control_cluster_count"]
+                if command_dispatch_control
+                else None
+            ),
+            "measured_command_dispatch_control_area_um2": (
+                round(control_area, 6) if command_dispatch_control else None
+            ),
+            "measured_command_dispatch_control_clock_ns": (
+                round(control_clock_ns, 6) if command_dispatch_control else None
+            ),
+            "measured_command_dispatch_control_power_mw": (
+                round(control_power_mw, 6) if command_dispatch_control else None
+            ),
             "compute_area_multiplier_required": compute_multiplier,
             "compute_substitution_enabled": compute_substitution_enabled,
             "source_compute_arch": source_row.get("compute_arch"),
@@ -405,6 +513,9 @@ def _row_with_budget(
             "substituted_compute_replica_count": target_replica_count if compute_substitution_enabled else None,
             "substituted_compute_area_um2": round(base_compute_area, 6) if compute_substitution_enabled else None,
             "substituted_compute_power_mw": round(base_compute_power, 6) if compute_substitution_enabled else None,
+            "substituted_compute_plus_control_power_mw": (
+                round(base_compute_power + control_power_mw, 6) if compute_substitution_enabled else None
+            ),
             "substituted_compute_variant_label": (
                 composed_dual_stream["composed_variant_label"] if use_composed_dual_stream else None
             ),
@@ -421,6 +532,7 @@ def _row_with_budget(
             "local_datapath_clock_ok": float(full_value_tile["critical_path_ns"]) <= float(source_row["clock_ns"]),
             "softmax_weight_clock_ok": float(softmax_weight["critical_path_ns"]) <= float(source_row["clock_ns"]),
             "compute_clock_ok": target_block_clock <= float(source_row["clock_ns"]),
+            "command_dispatch_control_clock_ok": command_dispatch_control_clock_ok,
             "area_fit": area_fit,
             "buffer_fit": buffer_fit,
             "physical_feasible": feasible,
@@ -453,6 +565,9 @@ def _row_with_budget(
             logic_area_used_um2=current_logic_used,
             selected_l1_overhead_area_um2=selected_l1_overhead,
             current_l1_overhead_area_um2=current_l1_overhead,
+            command_dispatch_control_area_um2=control_area,
+            command_dispatch_control_power_mw=control_power_mw,
+            command_dispatch_control_clock_ok=command_dispatch_control_clock_ok,
             buffer_fit=buffer_fit,
         )
         out.update(recost)
@@ -479,6 +594,9 @@ def _area_fit_replica_recost(
     logic_area_used_um2: float,
     selected_l1_overhead_area_um2: float,
     current_l1_overhead_area_um2: float,
+    command_dispatch_control_area_um2: float,
+    command_dispatch_control_power_mw: float,
+    command_dispatch_control_clock_ok: bool,
     buffer_fit: bool,
 ) -> JsonDict:
     new_macs = max(1, int(area_fit_replica_count) * max(1, int(block_macs_per_cycle)))
@@ -500,12 +618,12 @@ def _area_fit_replica_recost(
     compute_power = int(area_fit_replica_count) * block_power_mw
     logic_required = logic_area_used_um2 + (compute_area - current_compute_area_um2) + (
         selected_l1_overhead_area_um2 - current_l1_overhead_area_um2
-    )
+    ) + command_dispatch_control_area_um2
     logic_slack = compute_budget_um2 - logic_required
     compute_over_budget = max(0.0, logic_required - compute_budget_um2)
     density_gain = compute_area / max(1.0, compute_budget_um2 - selected_l1_overhead_area_um2)
     area_fit = logic_required <= compute_budget_um2
-    recost_feasible = area_fit and buffer_fit
+    recost_feasible = area_fit and buffer_fit and command_dispatch_control_clock_ok
     source_latency_us = float(source_row["latency_us"])
     latency_us = float(scheduled["latency_us"])
     return {
@@ -530,9 +648,14 @@ def _area_fit_replica_recost(
         "replica_recost_buffer_fit": buffer_fit,
         "replica_recost_physical_feasible": recost_feasible,
         "replica_recost_compute_clock_ok": True,
+        "replica_recost_command_dispatch_control_clock_ok": command_dispatch_control_clock_ok,
         "substituted_compute_replica_count": int(area_fit_replica_count),
         "substituted_compute_area_um2": round(compute_area, 6),
         "substituted_compute_power_mw": round(compute_power, 6),
+        "substituted_compute_plus_control_power_mw": round(
+            compute_power + command_dispatch_control_power_mw,
+            6,
+        ),
         "compute_area_required_um2": round(compute_area, 6),
         "logic_area_used_required_um2": round(logic_required, 6),
         "logic_area_slack_required_um2": round(logic_slack, 6),
@@ -541,6 +664,7 @@ def _area_fit_replica_recost(
         "replica_count_required": int(area_fit_replica_count),
         "replica_count_shortfall": 0 if area_fit else max(0, target_replica_count - area_fit_replica_count),
         "compute_clock_ok": True if recost_feasible else block_clock_ns <= source_clock_ns,
+        "command_dispatch_control_clock_ok": command_dispatch_control_clock_ok,
         "area_fit": True if recost_feasible else area_fit,
         "physical_feasible": recost_feasible,
         "adjusted_latency_us_if_feasible": latency_us if recost_feasible else None,
@@ -655,7 +779,9 @@ def _compute_stage_cycles(row: JsonDict, *, subtiles: int, compute_mode: str) ->
 
 def _effective_selection_key(row: JsonDict) -> tuple[float, float, float, str]:
     substituted_area = row.get("substituted_compute_area_um2")
-    substituted_power = row.get("substituted_compute_power_mw")
+    substituted_power = row.get("substituted_compute_plus_control_power_mw")
+    if substituted_power is None:
+        substituted_power = row.get("substituted_compute_power_mw")
     if substituted_area is None:
         substituted_area = row.get("compute_area_required_um2")
     if substituted_area is None:
@@ -679,6 +805,14 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     softmax_weight = _best_ok_metrics(args.softmax_weight_metrics)
     composed_dual_stream_metrics = _parse_composed_metric_inputs(getattr(args, "composed_dual_stream_metrics", None))
     composed_variants = _load_composed_variants(composed_dual_stream_metrics) if composed_dual_stream_metrics else []
+    command_dispatch_control_metrics = _parse_composed_metric_inputs(
+        getattr(args, "command_dispatch_control_metrics", None)
+    )
+    command_dispatch_control_variants = (
+        _load_command_dispatch_control_variants(command_dispatch_control_metrics)
+        if command_dispatch_control_metrics
+        else []
+    )
     compute_block = _best_ok_compute_metrics(args.compute_block_metrics) if args.compute_block_metrics else None
     quality_gate = _load_json(args.quality_gate_json) if args.quality_gate_json else None
     rows: list[JsonDict] = []
@@ -689,6 +823,10 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             for per_wave in command_cycles_per_wave_overrides
         ]
         for row in overhead_rows:
+            command_dispatch_control = _select_command_dispatch_control_variant(
+                command_dispatch_control_variants,
+                clusters=int(row["cluster_count"]),
+            )
             if composed_variants:
                 for composed_dual_stream in composed_variants:
                     rows.append(
@@ -698,6 +836,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                             softmax_weight=softmax_weight,
                             composed_dual_stream=composed_dual_stream,
                             compute_block=compute_block,
+                            command_dispatch_control=command_dispatch_control,
                             compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
                             compute_arch_name=args.compute_arch_name,
                             buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
@@ -713,6 +852,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                         softmax_weight=softmax_weight,
                         composed_dual_stream=None,
                         compute_block=compute_block,
+                        command_dispatch_control=command_dispatch_control,
                         compute_block_macs_per_cycle=args.compute_block_macs_per_cycle,
                         compute_arch_name=args.compute_arch_name,
                         buffer_area_um2_per_byte=args.buffer_area_um2_per_byte,
@@ -739,11 +879,15 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         assumptions.append(
             "When composed dual-stream wrapper substitution is enabled, full-value and softmax measurements are treated as folded into the measured dual-stream RTL wrapper, and wrapper clock is used to scale feasible latency if it differs from source schedule clock."
         )
-    elif compute_block:
+    if command_dispatch_control_variants:
+        assumptions.append(
+            "When command-dispatch control metrics are provided, the smallest measured dispatcher variant covering the schedule cluster count is added as a central logic-area and power term; its clock must meet the schedule clock for measured-control feasibility."
+        )
+    if not composed_variants and compute_block:
         assumptions.append(
             "When compute-block substitution is enabled, measured block area/power/clock replace the source dense compute block, but the upstream schedule latency is not recomputed; this is an area-feasibility substitution and a conservative latency view when the substituted block clock is no slower than the source clock."
         )
-    else:
+    elif not composed_variants:
         assumptions.append("No compute-block substitution was requested; dense compute area comes from the source schedule.")
     return {
         "version": 1,
@@ -756,6 +900,11 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "softmax_weight_metrics": str(args.softmax_weight_metrics),
             "composed_dual_stream_metrics": (
                 [str(path) for path in composed_dual_stream_metrics] if composed_dual_stream_metrics else None
+            ),
+            "command_dispatch_control_metrics": (
+                [str(path) for path in command_dispatch_control_metrics]
+                if command_dispatch_control_metrics
+                else None
             ),
             "compute_block_metrics": str(args.compute_block_metrics) if args.compute_block_metrics else None,
             "compute_block_macs_per_cycle": args.compute_block_macs_per_cycle,
@@ -799,6 +948,18 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             ),
             "best_requested_substituted_compute_area_um2": best_requested.get("substituted_compute_area_um2"),
             "best_requested_compute_clock_ok": best_requested.get("compute_clock_ok"),
+            "best_requested_command_dispatch_control_variant": best_requested.get(
+                "measured_command_dispatch_control_variant_name"
+            ),
+            "best_requested_command_dispatch_control_cluster_count": best_requested.get(
+                "measured_command_dispatch_control_cluster_count"
+            ),
+            "best_requested_command_dispatch_control_area_um2": best_requested.get(
+                "measured_command_dispatch_control_area_um2"
+            ),
+            "best_requested_command_dispatch_control_clock_ok": best_requested.get(
+                "command_dispatch_control_clock_ok"
+            ),
             "best_requested_replica_recost_enabled": best_requested.get("replica_recost_enabled"),
             "best_requested_replica_recost_area_fit_replica_count": best_requested.get(
                 "replica_recost_area_fit_replica_count"
@@ -845,6 +1006,9 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         f"- best requested substituted compute variant: `{diag['best_requested_substituted_compute_variant_label']}`",
         f"- best requested substituted compute semantic profile: `{diag['best_requested_substituted_compute_semantic_profile']}`",
         f"- best requested substituted compute area um2: `{diag['best_requested_substituted_compute_area_um2']}`",
+        f"- best requested command dispatch control variant: `{diag['best_requested_command_dispatch_control_variant']}`",
+        f"- best requested command dispatch control area um2: `{diag['best_requested_command_dispatch_control_area_um2']}`",
+        f"- best requested command dispatch control clock ok: `{diag['best_requested_command_dispatch_control_clock_ok']}`",
         f"- recommended next step: `{diag['recommended_next_step']}`",
         "",
         "## Best Requested",
@@ -860,13 +1024,14 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         "",
         "## Rows",
         "",
-        "| mode | latency us | area fit | feasible | substituted variant | semantic profile | logic slack um2 | local datapath/cluster | compute area required |",
-        "|---|---:|---|---|---|---|---:|---:|---:|",
+        "| mode | latency us | area fit | feasible | substituted variant | semantic profile | command ctrl | logic slack um2 | local datapath/cluster | compute area required |",
+        "|---|---:|---|---|---|---|---|---:|---:|---:|",
     ]
     for row in payload["rows"]:
         lines.append(
             "| {compute_mode} | {latency_us} | {area_fit} | {physical_feasible} | "
             "{substituted_compute_variant_label} | {substituted_compute_semantic_profile} | "
+            "{measured_command_dispatch_control_variant_name} | "
             "{logic_area_slack_required_um2} | {selected_local_datapath_area_um2_per_cluster} | "
             "{compute_area_required_um2} |".format(**row)
         )
@@ -882,6 +1047,7 @@ def main() -> int:
     parser.add_argument("--full-value-tile-metrics", type=Path, required=True)
     parser.add_argument("--softmax-weight-metrics", type=Path, required=True)
     parser.add_argument("--composed-dual-stream-metrics", type=Path, action="append")
+    parser.add_argument("--command-dispatch-control-metrics", type=Path, action="append")
     parser.add_argument("--compute-block-metrics", type=Path)
     parser.add_argument("--compute-block-macs-per-cycle", type=int)
     parser.add_argument("--compute-arch-name")

--- a/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -36,6 +36,7 @@ def _args(
     source: Path,
     compute_metrics: Path | None = None,
     composed_metrics: list[str] | None = None,
+    command_dispatch_control_metrics: list[str] | None = None,
     recompute_area_fit_replicas: bool = False,
 ) -> argparse.Namespace:
     full_value = tmp_path / "full_value.csv"
@@ -48,6 +49,7 @@ def _args(
         softmax_weight_metrics=softmax,
         compute_block_metrics=compute_metrics,
         composed_dual_stream_metrics=composed_metrics,
+        command_dispatch_control_metrics=command_dispatch_control_metrics,
         compute_block_macs_per_cycle=128 if compute_metrics else None,
         compute_arch_name="dense_gemm_int8_16x8_k1_p1" if compute_metrics else None,
         quality_gate_json=None,
@@ -56,6 +58,8 @@ def _args(
         frontier_row_limit=8,
         buffer_area_um2_per_byte=0.0,
         recompute_area_fit_replicas=recompute_area_fit_replicas,
+        command_cycles_per_tile=None,
+        command_cycles_per_wave=None,
     )
 
 
@@ -204,6 +208,93 @@ def test_multi_composed_wrapper_variants_use_effective_variant_clock(tmp_path: P
     # source schedule latency is 100 us, so the q12 clock is 2/4 => 50 us
     assert result["diagnosis"]["best_requested_adjusted_latency_us_if_feasible"] == 50.0
     assert result["diagnosis"]["best_feasible_latency_us"] == 50.0
+
+
+def test_command_dispatch_control_metrics_are_charged_once_per_schedule(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    _write_json(
+        source,
+        {
+            "model": "unit_source",
+            "best_by_compute_mode": [
+                {
+                    "compute_mode": "dual_mac",
+                    "latency_us": 100.0,
+                    "latency_speedup_vs_hbm_closed_source": 4.0,
+                    "tile_service_cycles": 12,
+                    "cluster_count": 12,
+                    "compute_area_multiplier": 1.0,
+                    "compute_area_um2": 120.0,
+                    "compute_budget_um2": 1000.0,
+                    "measured_l1_overhead_area_um2": 20.0,
+                    "local_datapath_area_um2": 10.0,
+                    "softmax_weight_generator_area_um2": 5.0,
+                    "logic_area_used_um2": 150.0,
+                    "required_stream_buffer_bytes": 16,
+                    "available_local_capacity_bytes": 32,
+                    "measured_block_area_um2": 120.0,
+                    "measured_block_clock_ns": 4.0,
+                    "measured_block_macs_per_cycle": 128,
+                    "measured_block_power_mw": 4.0,
+                    "compute_replica_count": 1,
+                    "compute_arch": "dense_gemm_16x8_k1_p1",
+                    "macs_per_cycle": 128,
+                    "clock_ns": 4.0,
+                }
+            ],
+        },
+    )
+    metrics_c8 = tmp_path / "attention_command_dispatch_c8_q16" / "metrics.csv"
+    metrics_c16 = tmp_path / "attention_command_dispatch_c16_q32" / "metrics.csv"
+    metrics_c32 = tmp_path / "attention_command_dispatch_c32_q64" / "metrics.csv"
+    _write_metrics(metrics_c8, die_area=4.0, power_mw=0.04, instance_area=4.0)
+    _write_metrics(metrics_c16, die_area=7.0, power_mw=0.07, instance_area=7.0)
+    _write_metrics(metrics_c32, die_area=14.0, power_mw=0.14, instance_area=14.0)
+    for clusters, path in [(8, metrics_c8), (16, metrics_c16), (32, metrics_c32)]:
+        _write_json(
+            path.parent / "config.json",
+            {
+                "top_name": path.parent.name,
+                "attention_command_dispatch": {
+                    "clusters": clusters,
+                    "queue_depth": 16,
+                    "tile_id_bits": 16,
+                    "wave_id_bits": 12,
+                    "base_token_bits": 18,
+                    "max_inflight_per_cluster": 4,
+                },
+            },
+        )
+
+    baseline = build_report(_args(tmp_path, source=source))
+    measured_control = build_report(
+        _args(
+            tmp_path,
+            source=source,
+            command_dispatch_control_metrics=[
+                str(metrics_c8),
+                str(metrics_c16),
+                str(metrics_c32),
+            ],
+        )
+    )
+
+    assert baseline["best_requested"]["measured_command_dispatch_control_variant_name"] is None
+    assert measured_control["inputs"]["command_dispatch_control_metrics"] == [
+        str(metrics_c8),
+        str(metrics_c16),
+        str(metrics_c32),
+    ]
+    assert (
+        measured_control["best_requested"]["measured_command_dispatch_control_variant_name"]
+        == "attention_command_dispatch_c16_q32"
+    )
+    assert measured_control["best_requested"]["measured_command_dispatch_control_cluster_count"] == 16
+    assert measured_control["best_requested"]["measured_command_dispatch_control_area_um2"] == 7.0
+    assert measured_control["best_requested"]["command_dispatch_control_clock_ok"] is True
+    assert measured_control["best_requested"]["logic_area_used_required_um2"] == (
+        baseline["best_requested"]["logic_area_used_required_um2"] + 7.0
+    )
 
 
 def test_composed_q12_pwl_wrapper_variant_label_is_concise(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add L2 estimator support for charging measured attention command-dispatch/control PPA into the score32 exp-LUT reduced-replica recost
- wire a dependency-gated measured-command-control L2 campaign item and proposal
- record command-control variant, area, power, and clock feasibility in the recost output

## Validation

- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py control_plane/control_plane/services/l2_task_generator.py`
- `PYTHONPATH=. pytest -q tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k 'exp_lut_measured_command_control or exp_lut_command_overhead or score32_exp_lut_div_reduced_replica'`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
