### PR TITLE
[codex] flag legacy source reconcile bootstrap

### DIFF
--- a/control_plane/control_plane/services/operator_status.py
+++ b/control_plane/control_plane/services/operator_status.py
@@ -27,6 +27,9 @@ from control_plane.services.run_index_query import comparative_run_index
 from control_plane.services.trial_variance import load_seed_trial_variance
 
 
+_SOURCE_RECONCILER_TRACKED_SNAPSHOT_COMMIT = "989f3b00"
+
+
 def _as_comparable_utc(dt):
     if dt is None:
         return None
@@ -83,6 +86,41 @@ def _source_head_satisfies_requirement(*, repo_root: str, worker_head: str, requ
     except (OSError, RuntimeError):
         return False
     return result.returncode == 0
+
+
+def _source_reconciler_has_tracked_snapshot_support(*, repo_root: str, worker_head: str) -> bool:
+    worker = str(worker_head or "").strip()
+    if not worker:
+        return False
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(Path(repo_root).resolve()),
+                "merge-base",
+                "--is-ancestor",
+                _SOURCE_RECONCILER_TRACKED_SNAPSHOT_COMMIT,
+                worker,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, RuntimeError):
+        return False
+    return result.returncode == 0
+
+
+def _last_progress_is_legacy_tracked_modification_block(last_progress: dict[str, Any] | None) -> bool:
+    if not last_progress:
+        return False
+    return (
+        str(last_progress.get("phase") or "") == "source_reconcile"
+        and str(last_progress.get("status") or "") == "blocked"
+        and "service repo has tracked local modifications; refusing automatic checkout"
+        in str(last_progress.get("message") or "")
+    )
 
 
 @dataclass(frozen=True)
@@ -191,7 +229,17 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
             if not satisfied:
                 source_blocked_items.append(row)
         worker_attention = None
-        if active_slots == 0 and source_blocked_items:
+        if (
+            active_slots == 0
+            and source_blocked_items
+            and _last_progress_is_legacy_tracked_modification_block(last_progress)
+            and not _source_reconciler_has_tracked_snapshot_support(
+                repo_root=request.repo_root,
+                worker_head=worker_head,
+            )
+        ):
+            worker_attention = "old_source_reconciler_bootstrap_required"
+        elif active_slots == 0 and source_blocked_items:
             worker_attention = "assigned_ready_requires_newer_source"
         elif active_slots == 0 and assigned_ready > 0 and last_seen_at is not None and last_seen_at >= fresh_machine_cutoff:
             if last_progress is None:

--- a/control_plane/control_plane/tests/test_operator_status.py
+++ b/control_plane/control_plane/tests/test_operator_status.py
@@ -428,6 +428,55 @@ def test_operator_status_flags_assigned_ready_source_requirement_mismatch() -> N
         assert "stalled_workers=1" in status.health_summary["message"]
 
 
+def test_operator_status_flags_old_source_reconciler_bootstrap_requirement() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    now = utcnow()
+    with tempfile.TemporaryDirectory() as td:
+        with Session(engine) as session:
+            machine = WorkerMachine(
+                machine_key="worker-legacy-reconcile",
+                hostname="eval-host",
+                executor_kind="local_process",
+                capabilities={
+                    "flow": "openroad",
+                    "platform": "nangate45",
+                    "worker_source": {
+                        "head": "e955237e6164bbaa2a6817a87ba689c7df4a7345",
+                        "repo_root": "/workspaces/rtlgen-eval-clean",
+                    },
+                    "last_progress": {
+                        "phase": "source_reconcile",
+                        "status": "blocked",
+                        "item_id": "needs_new_source",
+                        "message": "service repo has tracked local modifications; refusing automatic checkout",
+                        "current_sha": "e955237e6164bbaa2a6817a87ba689c7df4a7345",
+                        "required_sha": "99337b77f24d954b59e1318f6c0b52b28f3cb78f",
+                    },
+                },
+                role="evaluator",
+                slot_capacity=4,
+                last_seen_at=now,
+            )
+            session.add(machine)
+            session.flush()
+            ready_item = _seed_item(session, item_id="needs_new_source", state=WorkItemState.READY)
+            ready_item.assigned_machine_key = machine.machine_key
+            ready_item.source_commit = "99337b77f24d954b59e1318f6c0b52b28f3cb78f"
+            session.commit()
+
+            status = load_operator_status(session, OperatorStatusRequest(recent_limit=5, repo_root=td))
+
+        row = next(r for r in status.evaluator_machines if r["machine_key"] == "worker-legacy-reconcile")
+        assert row["assigned_ready"] == 1
+        assert row["active_slots"] == 0
+        assert row["worker_attention"] == "old_source_reconciler_bootstrap_required"
+        assert row["last_progress"]["message"] == (
+            "service repo has tracked local modifications; refusing automatic checkout"
+        )
+        assert "stalled_workers=1" in status.health_summary["message"]
+
+
 def test_operator_status_reports_empty_capability_stalled_worker() -> None:
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
     create_all(engine)


### PR DESCRIPTION
## Summary

- add an operator-status attention flag for old evaluator workers stuck before tracked-modification snapshot support
- detect the legacy `service repo has tracked local modifications; refusing automatic checkout` source-reconcile blocker
- keep the generic newer-source mismatch flag for current workers and other source mismatches

## Validation

- `python3 -m py_compile control_plane/control_plane/services/operator_status.py`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_operator_status.py -k 'source_requirement_mismatch or old_source_reconciler_bootstrap_requirement or empty_capability or assigned_ready_worker_with_progress'`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_operator_status.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
