### PR TITLE
[codex] gate exp-LUT frontier recost release

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5508,6 +5508,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_composed_datapath_physical_feasibility__{item_id}.json"
     report = f"{base}/decoder_attention_composed_datapath_physical_feasibility__{item_id}.md"
+    exp_lut_release_gate = f"{base}/decoder_attention_score32_exp_lut_div_frontier_release_gate__{item_id}.json"
     subtile_pipeline = _decoder_attention_kv_dual_stream_physical_feasibility_source(item_id=item_id)
     quality_gate = f"{base}/decoder_attention_mixed_precision_quality__l2_decoder_attention_mixed_precision_quality_llama7b_v1.json"
     full_value_tile_metrics = (
@@ -5583,6 +5584,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         f"--composed-dual-stream-metrics {path}"
         for path in composed_dual_stream_metrics.split(",")
     )
+    exp_lut_composed_config = composed_dual_stream_metrics.replace("/metrics.csv", "/config.json")
     command_dispatch_control_metrics = (
         "runs/designs/npu_blocks/attention_command_dispatch_c8_q16/metrics.csv,"
         "runs/designs/npu_blocks/attention_command_dispatch_c16_q32/metrics.csv,"
@@ -5646,6 +5648,30 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     if measured_command_control:
         model_name = f"{model_name}_measured_command_control"
         measured_command_control_flags = f"{command_dispatch_control_metrics_flags} "
+    release_gate_inputs = (
+        {
+            "attention_score32_exp_lut_div_frontier_release_gate": exp_lut_release_gate,
+            "attention_score32_exp_lut_div_composed_config": exp_lut_composed_config,
+        }
+        if score32_exp_lut_div_reduced_replica
+        else {}
+    )
+    release_gate_commands = (
+        [
+            {
+                "name": "check_attention_score32_exp_lut_div_frontier_release",
+                "run": (
+                    "python3 npu/eval/check_attention_exp_lut_frontier_release.py "
+                    f"--quality-json {quality_gate} "
+                    f"--metrics-csv {composed_dual_stream_metrics} "
+                    f"--config-json {exp_lut_composed_config} "
+                    f"--out {exp_lut_release_gate}"
+                ),
+            }
+        ]
+        if score32_exp_lut_div_reduced_replica
+        else []
+    )
     return {
         "inputs": {
             "attention_kv_subtile_pipeline_schedule": subtile_pipeline,
@@ -5653,6 +5679,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
             "attention_kv_full_value_tile_metrics": full_value_tile_metrics,
             "attention_kv_softmax_weight_metrics": softmax_weight_metrics,
             "attention_kv_composed_dual_stream_metrics": composed_dual_stream_metrics,
+            **release_gate_inputs,
             **(
                 {"attention_command_dispatch_control_metrics": command_dispatch_control_metrics}
                 if measured_command_control
@@ -5670,6 +5697,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
             ),
         },
         "commands": [
+            *release_gate_commands,
             {
                 "name": "estimate_decoder_attention_composed_datapath_physical_feasibility",
                 "run": (
@@ -5691,7 +5719,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
                 ),
             },
         ],
-        "expected_outputs": [out, report],
+        "expected_outputs": [*([exp_lut_release_gate] if score32_exp_lut_div_reduced_replica else []), out, report],
     }
 
 

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6400,10 +6400,24 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_comm
 
             work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
             commands = work_item.task_request.request_payload["task"]["commands"]
-            run = commands[0]["run"]
+            gate_run = commands[0]["run"]
+            run = commands[1]["run"]
             decoder_inputs = work_item.input_manifest["decoder_contract"]
 
+            assert commands[0]["name"] == "check_attention_score32_exp_lut_div_frontier_release"
             assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert "npu/eval/check_attention_exp_lut_frontier_release.py" in gate_run
+            assert "--expected-candidate-id" not in gate_run
+            assert decoder_inputs["attention_score32_exp_lut_div_frontier_release_gate"].endswith(
+                "decoder_attention_score32_exp_lut_div_frontier_release_gate__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                "command_overhead_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_exp_lut_div_composed_config"] == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+                "config.json"
+            )
             assert (
                 "--model-name llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1_command_overhead"
                 in run
@@ -6420,6 +6434,14 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_comm
                 "runs/designs/npu_blocks/"
                 "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
                 "metrics.csv"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_exp_lut_div_frontier_release_gate__"
+                    "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                    "command_overhead_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
             )
             assert any(
                 output.endswith(
@@ -6459,10 +6481,18 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_meas
 
             work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
             commands = work_item.task_request.request_payload["task"]["commands"]
-            run = commands[0]["run"]
+            gate_run = commands[0]["run"]
+            run = commands[1]["run"]
             decoder_inputs = work_item.input_manifest["decoder_contract"]
 
+            assert commands[0]["name"] == "check_attention_score32_exp_lut_div_frontier_release"
             assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert "npu/eval/check_attention_exp_lut_frontier_release.py" in gate_run
+            assert decoder_inputs["attention_score32_exp_lut_div_frontier_release_gate"].endswith(
+                "decoder_attention_score32_exp_lut_div_frontier_release_gate__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                "measured_command_control_llama7b_v1.json"
+            )
             assert (
                 "--model-name llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1_measured_command_control"
                 in run
@@ -6481,6 +6511,14 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_meas
             assert decoder_inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality"].endswith(
                 "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
                 "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_exp_lut_div_frontier_release_gate__"
+                    "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                    "measured_command_control_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
             )
             assert any(
                 output.endswith(
@@ -6625,10 +6663,25 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_
 
             work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
             commands = work_item.task_request.request_payload["task"]["commands"]
-            run = commands[0]["run"]
+            gate_run = commands[0]["run"]
+            run = commands[1]["run"]
             decoder_inputs = work_item.input_manifest["decoder_contract"]
 
+            assert commands[0]["name"] == "check_attention_score32_exp_lut_div_frontier_release"
             assert "estimate_decoder_attention_composed_datapath_physical_feasibility" in [c["name"] for c in commands]
+            assert "npu/eval/check_attention_exp_lut_frontier_release.py" in gate_run
+            assert "--quality-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/" in gate_run
+            assert "--metrics-csv runs/designs/npu_blocks/" in gate_run
+            assert "--config-json runs/designs/npu_blocks/" in gate_run
+            assert decoder_inputs["attention_score32_exp_lut_div_frontier_release_gate"].endswith(
+                "decoder_attention_score32_exp_lut_div_frontier_release_gate__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_exp_lut_div_composed_config"] == (
+                "runs/designs/npu_blocks/"
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+                "config.json"
+            )
             assert (
                 "--model-name llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1"
                 in run
@@ -6655,6 +6708,13 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_
                 "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
                 "metrics.csv "
                 in run
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_exp_lut_div_frontier_release_gate__"
+                    "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
             )
             assert any(
                 output.endswith(

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_command_overhead_llama7b_v1/evaluation_gate.md
@@ -6,3 +6,4 @@
 - allowed_evaluations:
   - l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_command_overhead_llama7b_v1
 - note: Dependency-gated command-overhead sensitivity for the score32 exp-LUT divider reduced-replica recost.
+- release_gate: The generated L2 task must run `npu/eval/check_attention_exp_lut_frontier_release.py` before recosting. The gate must confirm the score32 exp-LUT generation-quality result passes and the composed PPA metrics/config are the bucket-20 exp-LUT wrapper.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/README.md
@@ -12,3 +12,9 @@ It is distinct from the command-overhead sensitivity job:
 
 The result should run only after the exp-LUT quality/PPA/base-recost chain and
 the L1 command-dispatch-control PPA item have materialized.
+
+The generated task runs the same score32 exp-LUT release gate as the base
+reduced-replica recost before charging command-control PPA. That gate verifies
+the primary quality candidate is `score32_exp_lut_div`, the generation-quality
+decision is pass, and the composed datapath metrics/config are the bucket-20
+exp-LUT divider wrapper.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1/README.md
@@ -17,4 +17,14 @@ Dependencies:
 Execution is blocked until merged inputs and materialized references are present.
 `run_physical` is `false` for this task.
 
-Decision rule: recost the exp-LUT composed datapath **only after** the quality gate and L1 PPA dependencies are available; do not mark this as quality-backed unless the quality gate passes.
+Decision rule: recost the exp-LUT composed datapath **only after** the quality
+gate and L1 PPA dependencies are available; do not mark this as quality-backed
+unless the quality gate passes.
+
+The generated task first runs
+`npu/eval/check_attention_exp_lut_frontier_release.py` and writes
+`decoder_attention_score32_exp_lut_div_frontier_release_gate__<item>.json`.
+That release gate verifies the primary quality candidate is
+`score32_exp_lut_div`, the bounded generation-quality decision is pass, and the
+L1 metrics/config match the score32/w16 exp-LUT divider bucket-20 wrapper before
+the physical recost command can run.

--- a/npu/eval/check_attention_exp_lut_frontier_release.py
+++ b/npu/eval/check_attention_exp_lut_frontier_release.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Release gate for the score32 exp-LUT attention frontier."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+PASS_STATUS = "mixed_int8_generation_quality_pass"
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _check_quality(payload: JsonDict, *, expected_candidate_id: str) -> tuple[JsonDict, list[str]]:
+    failures: list[str] = []
+    summary = payload.get("candidate_summary")
+    if not isinstance(summary, dict):
+        summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        return {}, ["quality payload is missing candidate_summary/summary"]
+
+    decision = payload.get("decision")
+    if not isinstance(decision, dict):
+        decision = summary.get("decision")
+    if not isinstance(decision, dict):
+        decision = {}
+
+    candidate_id = str(summary.get("candidate_id") or "")
+    decision_status = str(decision.get("status") or summary.get("decision_status") or "")
+    if candidate_id != expected_candidate_id:
+        failures.append(f"quality candidate_id {candidate_id!r} does not match {expected_candidate_id!r}")
+    if decision_status != PASS_STATUS:
+        failures.append(f"quality decision status {decision_status!r} does not match {PASS_STATUS!r}")
+
+    thresholds = decision.get("thresholds")
+    if not isinstance(thresholds, dict):
+        thresholds = {}
+    nll_delta = _float(summary.get("teacher_forced_mean_nll_delta"))
+    if nll_delta == 0.0 and "teacher_forced_nll_delta_mean" in summary:
+        nll_delta = _float(summary.get("teacher_forced_nll_delta_mean"))
+    max_nll_delta = _float(thresholds.get("teacher_forced_mean_nll_delta_max"), 0.4)
+    candidate_ref_prob = _float(summary.get("teacher_forced_candidate_reference_token_prob_mean"))
+    if candidate_ref_prob == 0.0 and "candidate_probability_assigned_to_reference_token_mean" in summary:
+        candidate_ref_prob = _float(summary.get("candidate_probability_assigned_to_reference_token_mean"))
+    min_candidate_ref_prob = _float(
+        thresholds.get("teacher_forced_candidate_reference_token_prob_mean_min"),
+        0.1,
+    )
+    free_run_match = _float(summary.get("free_run_token_match_rate"))
+    if free_run_match == 0.0 and "free_running_match_rate" in summary:
+        free_run_match = _float(summary.get("free_running_match_rate"))
+    min_free_run_match = _float(thresholds.get("free_running_match_rate_min"), 0.75)
+
+    if nll_delta > max_nll_delta:
+        failures.append(f"teacher-forced mean NLL delta {nll_delta:g} exceeds {max_nll_delta:g}")
+    if candidate_ref_prob < min_candidate_ref_prob:
+        failures.append(
+            f"candidate reference-token probability {candidate_ref_prob:g} is below {min_candidate_ref_prob:g}"
+        )
+    if free_run_match < min_free_run_match:
+        failures.append(f"free-run token match {free_run_match:g} is below {min_free_run_match:g}")
+
+    precision = payload.get("precision")
+    if not isinstance(precision, dict):
+        precision = summary
+    expected_precision = {
+        "q_bits": 8,
+        "k_bits": 8,
+        "v_bits": 8,
+        "score_bits": 32,
+        "weight_bits": 16,
+    }
+    for key, expected in expected_precision.items():
+        if _int(precision.get(key), -1) != expected:
+            failures.append(f"quality precision {key}={precision.get(key)!r} does not match {expected}")
+    softmax_mode = str(precision.get("softmax_mode") or summary.get("softmax_mode") or "")
+    if "exp_lut_div" not in softmax_mode:
+        failures.append(f"quality softmax_mode {softmax_mode!r} is not an exp_lut_div mode")
+
+    return {
+        "candidate_id": candidate_id,
+        "decision_status": decision_status,
+        "teacher_forced_mean_nll_delta": nll_delta,
+        "teacher_forced_candidate_reference_token_prob_mean": candidate_ref_prob,
+        "free_run_token_match_rate": free_run_match,
+        "softmax_mode": softmax_mode,
+    }, failures
+
+
+def _check_config(payload: JsonDict, *, expected_bucket_shift: int) -> tuple[JsonDict, list[str]]:
+    failures: list[str] = []
+    cfg = payload.get("attention_dual_stream_composed")
+    if not isinstance(cfg, dict):
+        return {}, ["config is missing attention_dual_stream_composed"]
+
+    top_name = str(payload.get("top_name") or "")
+    semantic_profile = str(cfg.get("semantic_profile") or "")
+    softmax_impl = str(cfg.get("softmax_impl") or "")
+    bucket_shift = _int(cfg.get("softmax_reciprocal_lut_bucket_shift"), -1)
+    if semantic_profile != "score32_exp_lut_div":
+        failures.append(f"semantic_profile {semantic_profile!r} does not match 'score32_exp_lut_div'")
+    if softmax_impl != "exp_lut_div":
+        failures.append(f"softmax_impl {softmax_impl!r} does not match 'exp_lut_div'")
+    if bucket_shift != expected_bucket_shift:
+        failures.append(f"softmax bucket shift {bucket_shift} does not match {expected_bucket_shift}")
+    if _int(cfg.get("softmax_score_bits"), -1) != 32:
+        failures.append("softmax_score_bits is not 32")
+    if _int(cfg.get("softmax_weight_bits"), -1) != 16:
+        failures.append("softmax_weight_bits is not 16")
+    if _int(cfg.get("value_bits"), -1) != 8:
+        failures.append("value_bits is not 8")
+    if "score32_w16_exp_lut_div" not in top_name:
+        failures.append(f"top_name {top_name!r} does not name the score32 w16 exp-LUT divider wrapper")
+    return {
+        "top_name": top_name,
+        "semantic_profile": semantic_profile,
+        "softmax_impl": softmax_impl,
+        "softmax_reciprocal_lut_bucket_shift": bucket_shift,
+        "equivalence_hash": bool(cfg.get("equivalence_hash")),
+    }, failures
+
+
+def _check_metrics(path: Path, *, expected_design: str) -> tuple[JsonDict, list[str]]:
+    failures: list[str] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    ok_rows = [row for row in rows if str(row.get("status") or "").lower() == "ok"]
+    if not ok_rows:
+        return {"row_count": len(rows), "ok_row_count": 0}, ["metrics CSV has no ok rows"]
+    for row in ok_rows:
+        design = str(row.get("design") or "")
+        if design != expected_design:
+            failures.append(f"metrics design {design!r} does not match config top_name {expected_design!r}")
+            break
+    best = min(
+        ok_rows,
+        key=lambda row: (
+            _float(row.get("critical_path_ns"), 1.0e30),
+            _float(row.get("instance_area_um2"), _float(row.get("stdcell_area_um2"), 1.0e30)),
+        ),
+    )
+    critical_path_ns = _float(best.get("critical_path_ns"))
+    area_um2 = _float(best.get("instance_area_um2"), _float(best.get("stdcell_area_um2")))
+    power_mw = _float(best.get("total_power_mw"))
+    if critical_path_ns <= 0.0:
+        failures.append("best metrics row has non-positive critical_path_ns")
+    if area_um2 <= 0.0:
+        failures.append("best metrics row has non-positive area")
+    if power_mw <= 0.0:
+        failures.append("best metrics row has non-positive total_power_mw")
+    return {
+        "row_count": len(rows),
+        "ok_row_count": len(ok_rows),
+        "best_param_hash": best.get("param_hash"),
+        "best_tag": best.get("tag"),
+        "critical_path_ns": critical_path_ns,
+        "area_um2": area_um2,
+        "total_power_mw": power_mw,
+    }, failures
+
+
+def build_payload(args: argparse.Namespace) -> JsonDict:
+    quality = _load_json(args.quality_json)
+    config = _load_json(args.config_json)
+    quality_summary, quality_failures = _check_quality(
+        quality,
+        expected_candidate_id=args.expected_candidate_id,
+    )
+    config_summary, config_failures = _check_config(config, expected_bucket_shift=args.expected_bucket_shift)
+    metrics_summary, metrics_failures = _check_metrics(
+        args.metrics_csv,
+        expected_design=str(config.get("top_name") or ""),
+    )
+    failures = quality_failures + config_failures + metrics_failures
+    return {
+        "version": 1,
+        "model": "attention_score32_exp_lut_div_frontier_release_gate_v1",
+        "release_ready": not failures,
+        "failures": failures,
+        "inputs": {
+            "quality_json": str(args.quality_json),
+            "metrics_csv": str(args.metrics_csv),
+            "config_json": str(args.config_json),
+            "expected_candidate_id": args.expected_candidate_id,
+            "expected_bucket_shift": args.expected_bucket_shift,
+        },
+        "quality": quality_summary,
+        "config": config_summary,
+        "metrics": metrics_summary,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quality-json", required=True, type=Path)
+    parser.add_argument("--metrics-csv", required=True, type=Path)
+    parser.add_argument("--config-json", required=True, type=Path)
+    parser.add_argument("--expected-candidate-id", default="score32_exp_lut_div")
+    parser.add_argument("--expected-bucket-shift", type=int, default=20)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+
+    payload = build_payload(args)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    if payload["release_ready"]:
+        return 0
+    for failure in payload["failures"]:
+        print(f"release gate failed: {failure}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_attention_exp_lut_frontier_release_gate.py
+++ b/tests/test_attention_exp_lut_frontier_release_gate.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from npu.eval.check_attention_exp_lut_frontier_release import build_payload
+
+
+def _quality_payload(*, status: str = "mixed_int8_generation_quality_pass", candidate_id: str = "score32_exp_lut_div"):
+    return {
+        "quality_gate": "mixed_int8_generation_quality",
+        "candidate_summary": {
+            "candidate_id": candidate_id,
+            "decision_status": status,
+            "teacher_forced_mean_nll_delta": 0.05,
+            "teacher_forced_candidate_reference_token_prob_mean": 0.44,
+            "free_run_token_match_rate": 0.875,
+            "q_bits": 8,
+            "k_bits": 8,
+            "v_bits": 8,
+            "score_bits": 32,
+            "weight_bits": 16,
+            "softmax_mode": "exp_lut_div_bucket20",
+        },
+        "precision": {
+            "candidate_id": candidate_id,
+            "q_bits": 8,
+            "k_bits": 8,
+            "v_bits": 8,
+            "score_bits": 32,
+            "weight_bits": 16,
+            "softmax_mode": "exp_lut_div_bucket20",
+        },
+        "decision": {
+            "status": status,
+            "thresholds": {
+                "teacher_forced_mean_nll_delta_max": 0.4,
+                "teacher_forced_candidate_reference_token_prob_mean_min": 0.1,
+                "free_running_match_rate_min": 0.75,
+            },
+        },
+    }
+
+
+def _config_payload():
+    return {
+        "top_name": "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20",
+        "attention_dual_stream_composed": {
+            "softmax_score_bits": 32,
+            "softmax_weight_bits": 16,
+            "softmax_reciprocal_lut_bucket_shift": 20,
+            "value_bits": 8,
+            "softmax_impl": "exp_lut_div",
+            "semantic_profile": "score32_exp_lut_div",
+            "equivalence_hash": False,
+        },
+    }
+
+
+def _write_inputs(tmp_path: Path, *, quality=None, config=None, metrics_text: str | None = None):
+    quality_path = tmp_path / "quality.json"
+    config_path = tmp_path / "config.json"
+    metrics_path = tmp_path / "metrics.csv"
+    quality_path.write_text(__import__("json").dumps(quality or _quality_payload()) + "\n", encoding="utf-8")
+    config_path.write_text(__import__("json").dumps(config or _config_payload()) + "\n", encoding="utf-8")
+    design = _config_payload()["top_name"]
+    metrics_path.write_text(
+        metrics_text
+        or (
+            "design,status,critical_path_ns,instance_area_um2,stdcell_area_um2,total_power_mw,param_hash,tag\n"
+            f"{design},ok,9.75,360000,360000,8.2,abc123,exp_lut\n"
+        ),
+        encoding="utf-8",
+    )
+    return quality_path, metrics_path, config_path
+
+
+def _args(quality_path: Path, metrics_path: Path, config_path: Path) -> Namespace:
+    return Namespace(
+        quality_json=quality_path,
+        metrics_csv=metrics_path,
+        config_json=config_path,
+        expected_candidate_id="score32_exp_lut_div",
+        expected_bucket_shift=20,
+    )
+
+
+def test_exp_lut_frontier_release_gate_passes_matching_quality_and_ppa(tmp_path: Path) -> None:
+    quality_path, metrics_path, config_path = _write_inputs(tmp_path)
+
+    payload = build_payload(_args(quality_path, metrics_path, config_path))
+
+    assert payload["release_ready"] is True
+    assert payload["failures"] == []
+    assert payload["quality"]["candidate_id"] == "score32_exp_lut_div"
+    assert payload["config"]["semantic_profile"] == "score32_exp_lut_div"
+    assert payload["metrics"]["ok_row_count"] == 1
+
+
+def test_exp_lut_frontier_release_gate_rejects_quality_hold(tmp_path: Path) -> None:
+    quality_path, metrics_path, config_path = _write_inputs(
+        tmp_path,
+        quality=_quality_payload(status="mixed_int8_generation_quality_hold"),
+    )
+
+    payload = build_payload(_args(quality_path, metrics_path, config_path))
+
+    assert payload["release_ready"] is False
+    assert any("quality decision status" in failure for failure in payload["failures"])
+
+
+def test_exp_lut_frontier_release_gate_rejects_wrong_wrapper_profile(tmp_path: Path) -> None:
+    config = _config_payload()
+    config["attention_dual_stream_composed"]["semantic_profile"] = "score32_w16_recip_lut_q16"
+    quality_path, metrics_path, config_path = _write_inputs(tmp_path, config=config)
+
+    payload = build_payload(_args(quality_path, metrics_path, config_path))
+
+    assert payload["release_ready"] is False
+    assert any("semantic_profile" in failure for failure in payload["failures"])


### PR DESCRIPTION
## Summary

- add a score32 exp-LUT divider frontier release gate that validates quality pass status, candidate identity, wrapper config, and ok PPA metrics
- run the release gate before every score32 exp-LUT reduced-replica recost variant, including command-overhead and measured-command-control recosts
- document the release gate in the affected proposals

## Validation

- `python3 -m py_compile npu/eval/check_attention_exp_lut_frontier_release.py control_plane/control_plane/services/l2_task_generator.py`
- `PYTHONPATH=. pytest -q tests/test_attention_exp_lut_frontier_release_gate.py`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k 'exp_lut_command_overhead or exp_lut_measured_command_control or score32_exp_lut_div_reduced_replica'`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
