### PR TITLE
[codex] materialize score32 exp-lut quality decision

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json
@@ -1,0 +1,70 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-05T12:09:48.331688Z",
+  "item_id": "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+  "run_key": "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1_run_eeda56dd3eb7bd46",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "99337b77f24d954b59e1318f6c0b52b28f3cb78f",
+  "review_metadata_source_commit": "fb31adcb182bf713bcfecdc8ebbed58eac389dcc",
+  "objective": "Run bounded native-checkpoint generation/NLL quality for score32 exp-LUT divider bridge before composed-PPA recost.",
+  "input_manifest": {
+    "decoder_contract": {
+      "attention_score32_exp_lut_div_composed_config": "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/config.json",
+      "attention_mixed_int8_generation_quality_baseline": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_generation_quality__l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1_r3.json",
+      "attention_mixed_int8_score32_w16_rtl_exact_generation_quality": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality__l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1.json",
+      "attention_mixed_int8_score32_exp_lut_div_generation_quality_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+      "attention_mixed_int8_score32_exp_lut_div_generation_quality_scope": "Run a bounded native-checkpoint generation/NLL gate for the score32 exp-LUT divider softmax bridge. This checks whether the matched native candidate can recover generation quality before its composed RTL datapath is recosted.",
+      "attention_mixed_int8_score32_exp_lut_div_generation_quality_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.md"
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+    "arch_id": "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+    "macro_mode": "evidence_only",
+    "outcome": "mixed_int8_generation_quality_pass"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+    "title": "Llama7B score32 exp-LUT divider generation quality",
+    "primary_question": "Does the exp-LUT divider bridge preserve bounded greedy generation and teacher-forced reference-token likelihood on a 7B checkpoint?",
+    "evaluation_mode": "quality_gate",
+    "comparison_role": "score32_exp_lut_div_generation_quality",
+    "abstraction_layer": "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+    "expected_direction": "proceed_to_composed_ppa_recost_if_exp_lut_div_bridge_passes",
+    "expected_reason": "A pass promotes the exp-LUT divider bridge as a quality-backed candidate for composed PPA recost; a fail keeps it diagnostic for further softmax approximation work.",
+    "summary": "Decoder mixed/int8 generation quality evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json: decision=mixed_int8_generation_quality_pass; candidate_id=score32_exp_lut_div; prompt_count=8; generation_steps=8; free_run_exact_match_rate=0.875; free_run_token_match_rate=0.890625; diverged_prompt_count=1; mean_first_divergence_step=7.0; teacher_forced_mean_reference_nll=1.073770096930964; teacher_forced_mean_candidate_nll=1.0746646922933087; teacher_forced_mean_nll_delta=0.0008945953623444368; teacher_forced_reference_token_prob_mean=0.4479845997119758; teacher_forced_candidate_reference_token_prob_mean=0.44889021134685153; next_step=Candidate passed the bounded generation-quality gate; route this score configuration into the native-checkpoint quality evidence stream.",
+    "outcome": "mixed_int8_generation_quality_pass",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+    "title": "Llama7B score32 exp-LUT divider generation quality",
+    "kind": "architecture",
+    "primary_question": "Does the exp-LUT divider bridge preserve bounded greedy generation and teacher-forced reference-token likelihood on a 7B checkpoint?",
+    "evaluation_mode": "quality_gate",
+    "comparison_role": "score32_exp_lut_div_generation_quality",
+    "outcome": "mixed_int8_generation_quality_pass",
+    "summary": "Decoder mixed/int8 generation quality evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json: decision=mixed_int8_generation_quality_pass; candidate_id=score32_exp_lut_div; prompt_count=8; generation_steps=8; free_run_exact_match_rate=0.875; free_run_token_match_rate=0.890625; diverged_prompt_count=1; mean_first_divergence_step=7.0; teacher_forced_mean_reference_nll=1.073770096930964; teacher_forced_mean_candidate_nll=1.0746646922933087; teacher_forced_mean_nll_delta=0.0008945953623444368; teacher_forced_reference_token_prob_mean=0.4479845997119758; teacher_forced_candidate_reference_token_prob_mean=0.44889021134685153; next_step=Candidate passed the bounded generation-quality gate; route this score configuration into the native-checkpoint quality evidence stream.",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+    "decoder_quality": {
+      "diagnosis": {}
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+    "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+    "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {}
+  }
+}


### PR DESCRIPTION
## Summary
- force-add the score32 exp-LUT divider generation-quality L2 decision artifact under control_plane/shadow_exports/l2_decisions
- unblock dependent L2 reduced-replica artifact sync, which requires merged dependencies to have materialized decision artifacts

## Root Cause
PR #1184 was created manually after fixing the L2 consumer allow-list. It published the quality evidence JSON/MD, but skipped the ignored control_plane/shadow_exports/l2_decisions decision proposal. The dependency gate for l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1 requires that decision artifact when requires_materialized_refs is set.

## Validation
- python3 scripts/validate_runs.py --skip_eval_queue
