### PR TITLE
control_plane: add score32 exp-lut wrapper promotion audit

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -559,6 +559,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_composed_datapath_physical_feasibility_report",
     ),
     (
+        "attention_score32_exp_lut_measured_wrapper_promotion_out",
+        "attention_score32_exp_lut_measured_wrapper_promotion_report",
+    ),
+    (
         "attention_integrated_abstraction_closure_out",
         "attention_integrated_abstraction_closure_report",
     ),
@@ -658,6 +662,8 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
         "best",
         "sweep_summary",
         "assumptions",
+        "next_step",
+        "source_artifacts",
     ):
         if key in evidence_payload:
             brief[key] = evidence_payload[key]
@@ -1254,6 +1260,33 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         ):
             if key in diagnosis_dict:
                 parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_score32_exp_lut_measured_wrapper_promotion_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        next_step = evidence_payload.get("next_step")
+        next_step_dict = dict(next_step) if isinstance(next_step, dict) else {}
+        outcome = str(diagnosis_dict.get("decision") or evidence_payload.get("decision") or "score32_exp_lut_measured_wrapper_promotion_recorded")
+        parts = [
+            f"Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "l2_measured_decision",
+            "l2_candidate_supported",
+            "l1_wrapper_accepted",
+            "l1_wrapper_metrics_match",
+            "l2_selected_wrapper_metrics_csv",
+            "recommended_next_step",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        if "requires_partitioned_or_cluster_validation" in next_step_dict:
+            parts.append(
+                "requires_partitioned_or_cluster_validation="
+                f"{next_step_dict.get('requires_partitioned_or_cluster_validation')}"
+            )
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5723,6 +5723,49 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     }
 
 
+def _decoder_attention_score32_exp_lut_measured_wrapper_promotion_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_score32_exp_lut_measured_wrapper_promotion__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_exp_lut_measured_wrapper_promotion__{item_id}.md"
+    measured_command_control_item = (
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+        "measured_command_control_llama7b_v1"
+    )
+    composed_decision = f"{base}/decoder_attention_composed_datapath_physical_feasibility__{measured_command_control_item}.json"
+    l1_wrapper = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_score32_exp_lut_measured_command_control": composed_decision,
+            "attention_score32_exp_lut_dual_stream_wrapper_ppa": l1_wrapper,
+            "attention_score32_exp_lut_measured_wrapper_promotion_out": out,
+            "attention_score32_exp_lut_measured_wrapper_promotion_report": report,
+            "attention_score32_exp_lut_measured_wrapper_promotion_scope": (
+                "Audit whether the reduced-replica score32 exp-LUT composed datapath schedule from "
+                "measured command-control merged evidence is backed by a measured dual-stream "
+                "score32 exp-LUT wrapper result. If not fully backed, mark the follow-up job "
+                "to validate partitioned/cluster wrapper physical schedules."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_score32_exp_lut_measured_wrapper_promotion.py "
+                    f"--measured-composed-datapath-json {composed_decision} "
+                    f"--measured-dual-stream-wrapper-json {l1_wrapper} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_integrated_abstraction_closure_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_integrated_abstraction_closure__{item_id}.json"
@@ -9176,6 +9219,7 @@ def _build_payload(
         "decoder_attention_integrated_abstraction_closure",
         "decoder_attention_integrated_energy_closure",
         "decoder_attention_hbm_energy_sensitivity",
+        "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -9370,6 +9414,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_integrated_energy_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_sensitivity":
             decoder_evidence = _decoder_attention_hbm_energy_sensitivity_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_score32_exp_lut_measured_wrapper_promotion":
+            decoder_evidence = _decoder_attention_score32_exp_lut_measured_wrapper_promotion_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6530,6 +6530,103 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_meas
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_measured_wrapper_promotion_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+            ]
+            assert "audit_llm_decoder_attention_score32_exp_lut_measured_wrapper_promotion.py" in run
+            assert (
+                "--measured-composed-datapath-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                "measured_command_control_llama7b_v1.json"
+            ) in run
+            assert (
+                "--measured-dual-stream-wrapper-json "
+                "control_plane/shadow_exports/l1_promotions/"
+                "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json"
+            ) in run
+            assert (
+                "--out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_measured_wrapper_promotion__"
+                "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json"
+            ) in run
+            assert (
+                "--out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_measured_wrapper_promotion__"
+                "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md"
+            ) in run
+            assert decoder_inputs["attention_score32_exp_lut_measured_command_control"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                "measured_command_control_llama7b_v1.json"
+            )
+            assert (
+                decoder_inputs["attention_score32_exp_lut_dual_stream_wrapper_ppa"] ==
+                "control_plane/shadow_exports/l1_promotions/"
+                "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json"
+            )
+            assert (
+                decoder_inputs["attention_score32_exp_lut_measured_wrapper_promotion_out"] ==
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_measured_wrapper_promotion__"
+                "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json"
+            )
+            assert (
+                decoder_inputs["attention_score32_exp_lut_measured_wrapper_promotion_report"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_measured_wrapper_promotion__"
+                "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md"
+            )
+            assert decoder_inputs["attention_score32_exp_lut_measured_wrapper_promotion_scope"].startswith(
+                "Audit whether the reduced-replica score32 exp-LUT composed datapath schedule"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_exp_lut_measured_wrapper_promotion__"
+                    "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_exp_lut_measured_wrapper_promotion__"
+                    "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -139,19 +139,17 @@ than free or heuristic assumptions.
     compute budget (`801` required replicas, density gain `0.998929`), while
     the q16 reciprocal-LUT recost has more logic slack but is not
     quality-backed because its generation-quality gate failed.
-  - the active follow-on branch is the score32 exp-LUT divider path:
-    `l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1`
-    and
-    `l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1`
-    are queued. The dependent recost
-    `l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1`
-    is intentionally blocked until both inputs are materialized. As of PR
-    #1127, the exp-LUT recost chain also starts with
-    `check_attention_score32_exp_lut_div_frontier_release`, which verifies the
-    primary quality candidate is `score32_exp_lut_div`, the generation-quality
-    decision is pass, and the measured composed PPA metrics/config match the
-    score32/w16 exp-LUT divider bucket-20 wrapper before any reduced-replica
-    recost can run.
+  - the active score32 exp-LUT divider path has now materialized through
+    quality, L1 composed-wrapper PPA, reduced-replica recost, command-overhead
+    sensitivity, L1 command-dispatch-control PPA, and measured command-control
+    recost. The measured command-control result is merged by PR #1194 and still
+    reports `dual_stream_feasible`.
+  - the current immediate follow-on is
+    `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`.
+    It audits whether the reduced-replica measured-command-control result is
+    directly backed by the measured score32 exp-LUT dual-stream wrapper metrics,
+    or whether a partitioned/cluster wrapper PPA validation is still required
+    before treating the reduced-replica result as promoted.
 - New evaluations should continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`, not the devcontainer.
 
@@ -289,23 +287,13 @@ run the already queued exp-LUT branch:
    `npu/eval/check_attention_exp_lut_frontier_release.py`; if that release gate
    fails, do not run or promote the exp-LUT recost row as quality-backed. Return
    to the softmax replacement design or another score32/w16 implementation.
-4. In parallel with evaluator recovery or after exp-LUT recost, prepare the
-   command-overhead sensitivity job for the selected dual-stream schedule. This
-   preparation is complete as of PR #1119; as of PR #1127 the item also runs
-   the same exp-LUT release gate before sweeping command cycles. It should
-   remain blocked until the exp-LUT quality/PPA/base-recost dependencies are
-   merged and materialized.
-5. After the exp-LUT inputs are running or complete, dispatch
-   `l1_decoder_attention_command_dispatch_control_ppa_v1` to measure the
-   central scheduler/control block that will bound the command-cycle
-   sensitivity model. Do not let it displace the already READY exp-LUT quality
-   and PPA jobs.
-6. After the L1 command-control PPA and exp-LUT recost materialize, run
-   `l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1`
-   to charge measured central control area/power/clock into the same Llama7B
-   reduced-replica point. This item also starts with the exp-LUT release gate,
-   so measured command-control cost is charged only onto a quality/PPA-matched
-   exp-LUT branch.
+4. Run
+   `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`
+   to close the reduced-replica-to-measured-wrapper promotion audit. If it
+   records a wrapper metrics match, the next frontier work should move to the
+   surviving memory/NoC/SRAM/HBM service abstractions. If it requires
+   partitioned or cluster validation, schedule that L1 wrapper PPA before
+   treating the reduced-replica score32 exp-LUT path as promoted.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending evaluation.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds the score32 exp-LUT measured-wrapper promotion audit hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit whether the score32 exp-LUT measured-command-control reduced-replica result is backed by the merged measured dual-stream wrapper PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+      "comparison_role": "score32_exp_lut_wrapper_promotion_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_score32_exp_lut_wrapper_promotion_linkage",
+        "reason": "The result should report whether the L2 selected wrapper metrics match the merged L1 wrapper PPA and whether partitioned/cluster physical validation is still required."
+      },
+      "status": "pending"
+    }
+  ],
+  "source_commit": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+  "decision": "iterate",
+  "reason": "Proposal seeded; awaiting measured-wrapper promotion audit evidence.",
+  "evidence_refs": [],
+  "next_action": "run l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+  "created_utc": "2026-07-06T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 exp-LUT measured wrapper promotion audit",
+  "abstraction_layer": "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+  "hypothesis": "The score32 exp-LUT reduced-replica measured-command-control result can be promoted without another physical wrapper run if its selected composed datapath metrics exactly match the merged L1 score32 exp-LUT dual-stream wrapper PPA.",
+  "direct_comparison": {
+    "primary_question": "Is the reduced-replica score32 exp-LUT measured-command-control L2 result directly backed by the measured L1 dual-stream wrapper metrics, or does it still require partitioned/cluster wrapper physical validation?",
+    "include": [
+      "consume the merged measured-command-control L2 decision",
+      "consume the merged L1 score32 exp-LUT dual-stream wrapper promotion",
+      "compare the selected L2 substituted wrapper metrics path against the L1 promotion metrics path",
+      "report whether partitioned or cluster wrapper validation remains required"
+    ],
+    "exclude": [
+      "new OpenROAD PPA",
+      "new quality or QAT evidence",
+      "HBM/DRAM controller modeling",
+      "NoC/SRAM service rescheduling"
+    ]
+  },
+  "expected_benefit": [
+    "closes the immediate promotion ambiguity left by the measured command-control recost",
+    "prevents an unnecessary heavy physical job if the selected L2 row already uses the measured wrapper",
+    "makes the next frontier decision explicit: either wrapper partition validation or memory/NoC/SRAM service closure"
+  ],
+  "risks": [
+    "the audit proves metric linkage only; it does not prove a monolithic 800-plus replica SoC physical closure",
+    "partitioned cluster integration could still introduce routing and clocking overhead not visible in the single-wrapper PPA"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit whether the score32 exp-LUT measured-command-control reduced-replica result is backed by the merged measured dual-stream wrapper PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+      "comparison_role": "score32_exp_lut_wrapper_promotion_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_score32_exp_lut_wrapper_promotion_linkage",
+        "reason": "The result should report whether the L2 selected wrapper metrics match the merged L1 wrapper PPA and whether partitioned/cluster physical validation is still required."
+      },
+      "status": "pending"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_exp_lut_measured_wrapper_promotion.py",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/proposal.json"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_exp_lut_measured_wrapper_promotion.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exp_lut_measured_wrapper_promotion.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Audit measured-command-control score32 exp-LUT composed datapath promotion readiness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None:
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_str(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def _load_json(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"invalid JSON object in {path}")
+    return payload
+
+
+def _diagnosis(payload: JsonDict) -> JsonDict:
+    diag = payload.get("diagnosis")
+    return diag if isinstance(diag, dict) else {}
+
+
+def _extract_candidate_metrics_csv(payload: JsonDict) -> str:
+    candidate = payload.get("best_requested")
+    if isinstance(candidate, dict):
+        value = candidate.get("substituted_compute_metrics_csv")
+        if isinstance(value, str) and value:
+            return value
+
+    best_feasible = payload.get("best_feasible")
+    if isinstance(best_feasible, dict):
+        value = best_feasible.get("substituted_compute_metrics_csv")
+        if isinstance(value, str) and value:
+            return value
+
+    best_area_fit = payload.get("best_area_fit")
+    if isinstance(best_area_fit, dict):
+        value = best_area_fit.get("substituted_compute_metrics_csv")
+        if isinstance(value, str) and value:
+            return value
+
+    for row in payload.get("rows", []):
+        if isinstance(row, dict):
+            value = row.get("substituted_compute_metrics_csv")
+            if isinstance(value, str) and value:
+                return value
+
+    value = payload.get("measured_dual_stream_composed_metrics_csv")
+    if isinstance(value, str) and value:
+        return value
+
+    return ""
+
+
+def _candidate_supported(payload: JsonDict) -> bool:
+    diagnosis = _diagnosis(payload)
+    return _as_str(diagnosis.get("decision"), "").strip() == "dual_stream_feasible"
+
+
+def _recommended_next_step_from_l2(payload: JsonDict) -> str:
+    return _as_str(_diagnosis(payload).get("recommended_next_step"), "")
+
+
+def _l1_wrapper_metrics(payload: JsonDict) -> list[str]:
+    proposals = payload.get("proposals")
+    if not isinstance(proposals, list):
+        return []
+    out: list[str] = []
+    for proposal in proposals:
+        if not isinstance(proposal, dict):
+            continue
+        metrics_ref = proposal.get("metrics_ref")
+        if not isinstance(metrics_ref, dict):
+            continue
+        metrics_csv = _as_str(metrics_ref.get("metrics_csv"))
+        if metrics_csv:
+            out.append(metrics_csv)
+    return out
+
+
+def _l1_wrapper_status(payload: JsonDict) -> bool:
+    proposals = payload.get("proposals")
+    if not isinstance(proposals, list):
+        return False
+    for proposal in proposals:
+        if not isinstance(proposal, dict):
+            continue
+        if _as_bool(proposal.get("physical_metrics_present"), False):
+            return True
+
+        metrics_ref = proposal.get("metrics_ref")
+        if not isinstance(metrics_ref, dict):
+            continue
+        if _as_str(metrics_ref.get("status")).strip().lower() == "ok" and _as_str(
+            metrics_ref.get("result_kind")
+        ).strip().lower() == "physical_metrics":
+            return True
+    return False
+
+
+def _backed_by_measured_wrapper(payload: JsonDict, wrapper_payload: JsonDict) -> bool:
+    measured_metrics_csv = _extract_candidate_metrics_csv(payload)
+    if not measured_metrics_csv:
+        return False
+
+    wrapper_metrics = _l1_wrapper_metrics(wrapper_payload)
+    if not wrapper_metrics:
+        return False
+
+    return measured_metrics_csv in wrapper_metrics
+
+
+def _build_payload(
+    *, measured_composed_json: JsonDict, dual_stream_wrapper_json: JsonDict
+) -> JsonDict:
+    l2_decision = _as_str(_diagnosis(measured_composed_json).get("decision"))
+    l2_recommended_next_step = _recommended_next_step_from_l2(measured_composed_json)
+    l2_supported = _candidate_supported(measured_composed_json)
+    wrapper_accepted = _l1_wrapper_status(dual_stream_wrapper_json)
+    wrapper_metrics_match = _backed_by_measured_wrapper(measured_composed_json, dual_stream_wrapper_json)
+
+    decision = "decoder_attention_score32_exp_lut_measured_wrapper_promotion_pending_cluster_validation"
+    recommended_next_step = (
+        "run partitioned/cluster wrapper physical validation before promoting the reduced-replica score32 exp-LUT datapath"
+    )
+    if not l2_supported:
+        decision = "decoder_attention_score32_exp_lut_measured_wrapper_promotion_blocked_by_measured_decision"
+        recommended_next_step = (
+            "revisit reduced-replica command-control schedule: the merged L2 measured-command-control "
+            "result is not dual_stream_feasible."
+        )
+    elif not wrapper_accepted:
+        recommended_next_step = (
+            "run updated partitioned/cluster wrapper physical validation for the measured command-control variant"
+        )
+    elif wrapper_metrics_match:
+        decision = "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded"
+        recommended_next_step = (
+            "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper "
+            "instead of partitioned-wrapper physical follow-up."
+        )
+    else:
+        recommended_next_step = (
+            "align the L2 measured command-control variant and L1 measured dual-stream wrapper metrics "
+            "before wrapper promotion."
+        )
+
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_exp_lut_measured_wrapper_promotion_v1",
+        "decision": decision,
+        "diagnosis": {
+            "decision": decision,
+            "recommended_next_step": recommended_next_step,
+            "l2_measured_decision": l2_decision,
+            "l2_recommended_next_step": l2_recommended_next_step,
+            "l2_candidate_supported": l2_supported,
+            "l1_wrapper_present": bool(dual_stream_wrapper_json),
+            "l1_wrapper_accepted": wrapper_accepted,
+            "l1_wrapper_metrics_match": wrapper_metrics_match,
+            "l2_selected_wrapper_metrics_csv": _extract_candidate_metrics_csv(measured_composed_json),
+        },
+        "source_artifacts": {
+            "measured_composed_decision": "decoder_attention_composed_datapath_physical_feasibility",
+            "measured_wrapper_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json",
+        },
+        "next_step": {
+            "decision_scope": "score32 exp-LUT reduced-replica composed-datapath L2 to measured wrapper promotion",
+            "recommended_next_step": recommended_next_step,
+            "requires_partitioned_or_cluster_validation": decision
+            != "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+        },
+    }
+
+
+def _write_report(payload: JsonDict, report: Path) -> None:
+    lines = [
+        "# Score32 Exp-LUT Measured Wrapper Promotion Audit",
+        "",
+        "## Decision",
+        f"- decision: `{payload['decision']}`",
+        f"- recommended_next_step: `{payload['diagnosis']['recommended_next_step']}`",
+        "",
+        "## Readiness",
+        f"- l2_measured_decision: `{payload['diagnosis']['l2_measured_decision']}`",
+        f"- l1_wrapper_accepted: `{payload['diagnosis']['l1_wrapper_accepted']}`",
+        f"- l1_wrapper_metrics_match: `{payload['diagnosis']['l1_wrapper_metrics_match']}`",
+        f"- requires_partitioned_or_cluster_validation: `{payload['next_step']['requires_partitioned_or_cluster_validation']}`",
+        "",
+        f"- l2_selected_wrapper_metrics_csv: `{payload['diagnosis']['l2_selected_wrapper_metrics_csv']}`",
+    ]
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--measured-composed-datapath-json", type=Path, required=True)
+    parser.add_argument("--measured-dual-stream-wrapper-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    measured_composed = _load_json(args.measured_composed_datapath_json)
+    dual_stream_wrapper = _load_json(args.measured_dual_stream_wrapper_json)
+
+    payload = _build_payload(
+        measured_composed_json=measured_composed,
+        dual_stream_wrapper_json=dual_stream_wrapper,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_report(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Adds a lightweight L2 evidence hook to audit whether the score32 exp-LUT measured-command-control reduced-replica result is backed by the merged measured dual-stream wrapper PPA.\n\nValidation:\n- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q -k 'score32_exp_lut_measured_wrapper_promotion or exp_lut_measured_command_control'\n- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -q -k 'endpoint_router_sram_composition or composed_datapath or mixed_int8_energy_closure'\n- python3 scripts/validate_runs.py --skip_eval_queue\n- python3 tests/test_runs_parsers.py