### PR TITLE
eval: run score32 exp-lut measured wrapper promotion audit

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json
@@ -1,0 +1,107 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-06T09:41:50.161664Z",
+  "item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+  "run_key": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1_run_21c02f26440cc217",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "636af107a21652571d024749ce453e11fe576667",
+  "review_metadata_source_commit": "636af107a21652571d024749ce453e11fe576667",
+  "objective": "Audit whether the score32 exp-LUT measured-command-control reduced-replica result is backed by the merged measured dual-stream wrapper PPA.",
+  "input_manifest": {
+    "decoder_contract": {
+      "attention_score32_exp_lut_dual_stream_wrapper_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json",
+      "attention_score32_exp_lut_measured_command_control": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+      "attention_score32_exp_lut_measured_wrapper_promotion_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+      "attention_score32_exp_lut_measured_wrapper_promotion_scope": "Audit whether the reduced-replica score32 exp-LUT composed datapath schedule from measured command-control merged evidence is backed by a measured dual-stream score32 exp-LUT wrapper result. If not fully backed, mark the follow-up job to validate partitioned/cluster wrapper physical schedules.",
+      "attention_score32_exp_lut_measured_wrapper_promotion_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md"
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+    "arch_id": "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+    "macro_mode": "evidence_only",
+    "outcome": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+    "title": "Score32 exp-LUT measured wrapper promotion audit",
+    "primary_question": "Is the reduced-replica score32 exp-LUT measured-command-control L2 result directly backed by the measured L1 dual-stream wrapper metrics, or does it still require partitioned/cluster wrapper physical validation?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "score32_exp_lut_wrapper_promotion_audit",
+    "abstraction_layer": "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+    "expected_direction": "close_score32_exp_lut_wrapper_promotion_linkage",
+    "expected_reason": "The result should report whether the L2 selected wrapper metrics match the merged L1 wrapper PPA and whether partitioned/cluster physical validation is still required.",
+    "summary": "Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.",
+    "outcome": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+    "title": "Score32 exp-LUT measured wrapper promotion audit",
+    "kind": "architecture",
+    "primary_question": "Is the reduced-replica score32 exp-LUT measured-command-control L2 result directly backed by the measured L1 dual-stream wrapper metrics, or does it still require partitioned/cluster wrapper physical validation?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "score32_exp_lut_wrapper_promotion_audit",
+    "outcome": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+    "summary": "Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+    "decoder_quality": {
+      "diagnosis": {
+        "decision": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+        "l1_wrapper_accepted": true,
+        "l1_wrapper_metrics_match": true,
+        "l1_wrapper_present": true,
+        "l2_candidate_supported": true,
+        "l2_measured_decision": "dual_stream_feasible",
+        "l2_recommended_next_step": "promote dual-stream schedule into a measured RTL/PPA wrapper",
+        "l2_selected_wrapper_metrics_csv": "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv",
+        "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up."
+      },
+      "next_step": {
+        "decision_scope": "score32 exp-LUT reduced-replica composed-datapath L2 to measured wrapper promotion",
+        "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.",
+        "requires_partitioned_or_cluster_validation": false
+      },
+      "source_artifacts": {
+        "measured_composed_decision": "decoder_attention_composed_datapath_physical_feasibility",
+        "measured_wrapper_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json"
+      }
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+    "decoder_attention_score32_exp_lut_measured_wrapper_promotion_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+    "decoder_attention_score32_exp_lut_measured_wrapper_promotion_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {
+      "decision": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+      "l1_wrapper_accepted": true,
+      "l1_wrapper_metrics_match": true,
+      "l1_wrapper_present": true,
+      "l2_candidate_supported": true,
+      "l2_measured_decision": "dual_stream_feasible",
+      "l2_recommended_next_step": "promote dual-stream schedule into a measured RTL/PPA wrapper",
+      "l2_selected_wrapper_metrics_csv": "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv",
+      "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up."
+    },
+    "next_step": {
+      "decision_scope": "score32 exp-LUT reduced-replica composed-datapath L2 to measured wrapper promotion",
+      "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.",
+      "requires_partitioned_or_cluster_validation": false
+    },
+    "source_artifacts": {
+      "measured_composed_decision": "decoder_attention_composed_datapath_physical_feasibility",
+      "measured_wrapper_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json"
+    }
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/evaluated.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/evaluated.json
@@ -1,0 +1,107 @@
+{
+  "flow": "openroad",
+  "task": {
+    "inputs": {
+      "decoder_contract": {
+        "attention_score32_exp_lut_dual_stream_wrapper_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json",
+        "attention_score32_exp_lut_measured_command_control": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+        "attention_score32_exp_lut_measured_wrapper_promotion_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+        "attention_score32_exp_lut_measured_wrapper_promotion_scope": "Audit whether the reduced-replica score32 exp-LUT composed datapath schedule from measured command-control merged evidence is backed by a measured dual-stream score32 exp-LUT wrapper result. If not fully backed, mark the follow-up job to validate partitioned/cluster wrapper physical schedules.",
+        "attention_score32_exp_lut_measured_wrapper_promotion_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md"
+      }
+    },
+    "commands": [
+      {
+        "run": "python3 npu/eval/audit_llm_decoder_attention_score32_exp_lut_measured_wrapper_promotion.py --measured-composed-datapath-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json --measured-dual-stream-wrapper-json control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md",
+        "name": "audit_decoder_attention_score32_exp_lut_measured_wrapper_promotion"
+      },
+      {
+        "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+        "name": "validate_runs"
+      }
+    ],
+    "objective": "Audit whether the score32 exp-LUT measured-command-control reduced-replica result is backed by the merged measured dual-stream wrapper PPA.",
+    "acceptance": [
+      "Write all declared decoder evidence artifacts",
+      "Keep evidence artifact paths repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "source_mode": "src_verilog",
+    "expected_outputs": [
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md"
+    ]
+  },
+  "layer": "layer2",
+  "state": "evaluated",
+  "title": "Score32 exp-LUT measured wrapper promotion audit",
+  "result": {
+    "branch": "eval/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/s20260706t094150z",
+    "completed_utc": "2026-07-06T09:41:49.521378Z",
+    "evaluator_id": "control_plane",
+    "executor": "@control_plane",
+    "host": "b7c2d9c80c1c",
+    "identity_block": "[role:evaluator][account:control_plane][session:s20260706t094150z][host:b7c2d9c80c1c][item:l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1]",
+    "metrics_rows": [],
+    "metrics_exempt_reason": "evidence_only_decoder_evidence",
+    "queue_item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+    "session_id": "s20260706t094150z",
+    "status": "ok",
+    "summary": "2/2 commands succeeded"
+  },
+  "handoff": {
+    "branch": "eval/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/s20260706t094150z",
+    "pr_title": "eval: run score32 exp-lut measured wrapper promotion audit",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "pr_body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260706t094150z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1"
+    },
+    "identity_block_format": "[role:evaluator][account:<evaluator_id>][session:<session_id>][host:<host>][item:<queue_item_id>]"
+  },
+  "item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+  "version": 0.1,
+  "platform": "nangate45",
+  "priority": 1,
+  "created_utc": "2026-07-06T09:41:37.338214Z",
+  "requested_by": "control_plane",
+  "developer_loop": {
+    "comparison": {
+      "role": "score32_exp_lut_wrapper_promotion_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1"
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "The result should report whether the L2 selected wrapper metrics match the merged L1 wrapper PPA and whether partitioned/cluster physical validation is still required.",
+      "expected_direction": "close_score32_exp_lut_wrapper_promotion_linkage"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_score32_exp_lut_measured_wrapper_promotion"
+    },
+    "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json"
+  },
+  "source_requirement": {
+    "repo": "",
+    "reason": "evaluator runtime must contain the queued job source commit",
+    "version": 1,
+    "required_ref": "origin/master",
+    "required_sha": "636af107a21652571d024749ce453e11fe576667",
+    "requires_daemon_restart": true
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/pr_body.md
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/pr_body.md
@@ -1,0 +1,40 @@
+## Summary
+- item_id: `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`
+- run_key: `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1_run_21c02f26440cc217`
+- layer: `layer2`
+- task_type: `l2_campaign`
+- status: `ok`
+- summary: `2/2 commands succeeded`
+- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/evaluated.json`
+- metrics_rows_count: `0`
+- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json`
+
+## Developer Context
+- proposal_id: `prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`
+- proposal_path: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json`
+- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
+- execution_source_commit: `636af107a21652571d024749ce453e11fe576667`
+- review_metadata_source_commit: `636af107a21652571d024749ce453e11fe576667`
+
+## Evaluation Mode
+- evaluation_mode: `frontier_detail`
+- abstraction_layer: `decoder_attention_score32_exp_lut_measured_wrapper_promotion`
+- comparison_role: `score32_exp_lut_wrapper_promotion_audit`
+- expected_direction: `close_score32_exp_lut_wrapper_promotion_linkage`
+- expected_reason: `The result should report whether the L2 selected wrapper metrics match the merged L1 wrapper PPA and whether partitioned/cluster physical validation is still required.`
+- expectation_status: `unspecified`
+- evaluation_summary: `Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.`
+
+## Focused Comparison
+- primary_question: `Is the reduced-replica score32 exp-LUT measured-command-control L2 result directly backed by the measured L1 dual-stream wrapper metrics, or does it still require partitioned/cluster wrapper physical validation?`
+- comparison_role: `score32_exp_lut_wrapper_promotion_audit`
+- proposal_outcome: `decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded`
+- comparison_summary: `Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.`
+- baseline_ref: `None`
+- baseline_item_id: `None`
+
+## Checklist
+- [ ] Commit lightweight campaign artifacts only
+- [ ] Include metrics row references in result.metrics_rows
+- [ ] Keep committed result_path fields repo-portable
+- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing

--- a/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/review_package.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/review_package.json
@@ -1,0 +1,184 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-06T09:41:52.114735Z",
+  "control_plane_source_commit": "636af107a21652571d024749ce453e11fe576667",
+  "review_metadata_source_commit": "636af107a21652571d024749ce453e11fe576667",
+  "item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+  "run_key": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1_run_21c02f26440cc217",
+  "layer": "layer2",
+  "flow": "openroad",
+  "task_type": "l2_campaign",
+  "source_commit": "636af107a21652571d024749ce453e11fe576667",
+  "queue_snapshot": {
+    "path": "control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/evaluated.json",
+    "result": {
+      "branch": "eval/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/s20260706t094150z",
+      "completed_utc": "2026-07-06T09:41:49.521378Z",
+      "evaluator_id": "control_plane",
+      "executor": "@control_plane",
+      "host": "b7c2d9c80c1c",
+      "identity_block": "[role:evaluator][account:control_plane][session:s20260706t094150z][host:b7c2d9c80c1c][item:l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1]",
+      "metrics_rows": [],
+      "metrics_exempt_reason": "evidence_only_decoder_evidence",
+      "queue_item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+      "session_id": "s20260706t094150z",
+      "status": "ok",
+      "summary": "2/2 commands succeeded"
+    }
+  },
+  "review_artifact": {
+    "kind": "decision_proposal",
+    "path": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+    "storage_mode": "repo",
+    "sha256": "7eb9627a3a56c52fcc0a59ec523e0bea3d2becef42280460a75767eb659a3aa6",
+    "payload": {
+      "version": 0.1,
+      "generated_utc": "2026-07-06T09:41:50.161664Z",
+      "item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+      "run_key": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1_run_21c02f26440cc217",
+      "layer": "layer2",
+      "flow": "openroad",
+      "platform": "nangate45",
+      "task_type": "l2_campaign",
+      "source_commit": "636af107a21652571d024749ce453e11fe576667",
+      "review_metadata_source_commit": "636af107a21652571d024749ce453e11fe576667",
+      "objective": "Audit whether the score32 exp-LUT measured-command-control reduced-replica result is backed by the merged measured dual-stream wrapper PPA.",
+      "input_manifest": {
+        "decoder_contract": {
+          "attention_score32_exp_lut_dual_stream_wrapper_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json",
+          "attention_score32_exp_lut_measured_command_control": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+          "attention_score32_exp_lut_measured_wrapper_promotion_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+          "attention_score32_exp_lut_measured_wrapper_promotion_scope": "Audit whether the reduced-replica score32 exp-LUT composed datapath schedule from measured command-control merged evidence is backed by a measured dual-stream score32 exp-LUT wrapper result. If not fully backed, mark the follow-up job to validate partitioned/cluster wrapper physical schedules.",
+          "attention_score32_exp_lut_measured_wrapper_promotion_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md"
+        }
+      },
+      "recommendation": {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+        "arch_id": "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+        "macro_mode": "evidence_only",
+        "outcome": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded"
+      },
+      "objective_profiles": [],
+      "evaluation_record": {
+        "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+        "title": "Score32 exp-LUT measured wrapper promotion audit",
+        "primary_question": "Is the reduced-replica score32 exp-LUT measured-command-control L2 result directly backed by the measured L1 dual-stream wrapper metrics, or does it still require partitioned/cluster wrapper physical validation?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "score32_exp_lut_wrapper_promotion_audit",
+        "abstraction_layer": "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+        "expected_direction": "close_score32_exp_lut_wrapper_promotion_linkage",
+        "expected_reason": "The result should report whether the L2 selected wrapper metrics match the merged L1 wrapper PPA and whether partitioned/cluster physical validation is still required.",
+        "summary": "Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.",
+        "outcome": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+        "expectation_status": "unspecified"
+      },
+      "proposal_assessment": {
+        "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+        "title": "Score32 exp-LUT measured wrapper promotion audit",
+        "kind": "architecture",
+        "primary_question": "Is the reduced-replica score32 exp-LUT measured-command-control L2 result directly backed by the measured L1 dual-stream wrapper metrics, or does it still require partitioned/cluster wrapper physical validation?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "score32_exp_lut_wrapper_promotion_audit",
+        "outcome": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+        "summary": "Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.",
+        "baseline_ref": null,
+        "baseline_item_id": null,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+        "decoder_quality": {
+          "diagnosis": {
+            "decision": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+            "l1_wrapper_accepted": true,
+            "l1_wrapper_metrics_match": true,
+            "l1_wrapper_present": true,
+            "l2_candidate_supported": true,
+            "l2_measured_decision": "dual_stream_feasible",
+            "l2_recommended_next_step": "promote dual-stream schedule into a measured RTL/PPA wrapper",
+            "l2_selected_wrapper_metrics_csv": "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv",
+            "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up."
+          },
+          "next_step": {
+            "decision_scope": "score32 exp-LUT reduced-replica composed-datapath L2 to measured wrapper promotion",
+            "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.",
+            "requires_partitioned_or_cluster_validation": false
+          },
+          "source_artifacts": {
+            "measured_composed_decision": "decoder_attention_composed_datapath_physical_feasibility",
+            "measured_wrapper_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json"
+          }
+        }
+      },
+      "source_refs": {
+        "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+        "decoder_attention_score32_exp_lut_measured_wrapper_promotion_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+        "decoder_attention_score32_exp_lut_measured_wrapper_promotion_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md"
+      },
+      "decoder_quality": {
+        "diagnosis": {
+          "decision": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+          "l1_wrapper_accepted": true,
+          "l1_wrapper_metrics_match": true,
+          "l1_wrapper_present": true,
+          "l2_candidate_supported": true,
+          "l2_measured_decision": "dual_stream_feasible",
+          "l2_recommended_next_step": "promote dual-stream schedule into a measured RTL/PPA wrapper",
+          "l2_selected_wrapper_metrics_csv": "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv",
+          "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up."
+        },
+        "next_step": {
+          "decision_scope": "score32 exp-LUT reduced-replica composed-datapath L2 to measured wrapper promotion",
+          "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.",
+          "requires_partitioned_or_cluster_validation": false
+        },
+        "source_artifacts": {
+          "measured_composed_decision": "decoder_attention_composed_datapath_physical_feasibility",
+          "measured_wrapper_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json"
+        }
+      }
+    }
+  },
+  "developer_loop": {
+    "comparison": {
+      "role": "score32_exp_lut_wrapper_promotion_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1"
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "The result should report whether the L2 selected wrapper metrics match the merged L1 wrapper PPA and whether partitioned/cluster physical validation is still required.",
+      "expected_direction": "close_score32_exp_lut_wrapper_promotion_linkage"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_score32_exp_lut_measured_wrapper_promotion"
+    },
+    "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json"
+  },
+  "submission_history": null,
+  "pr_payload": {
+    "branch": "eval/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/s20260706t094150z",
+    "title": "eval: run score32 exp-lut measured wrapper promotion audit",
+    "body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260706t094150z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1"
+    },
+    "body_md": "## Summary\n- item_id: `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`\n- run_key: `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1_run_21c02f26440cc217`\n- layer: `layer2`\n- task_type: `l2_campaign`\n- status: `ok`\n- summary: `2/2 commands succeeded`\n- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/evaluated.json`\n- metrics_rows_count: `0`\n- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json`\n\n## Developer Context\n- proposal_id: `prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`\n- proposal_path: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json`\n- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`\n- execution_source_commit: `636af107a21652571d024749ce453e11fe576667`\n- review_metadata_source_commit: `636af107a21652571d024749ce453e11fe576667`\n\n## Evaluation Mode\n- evaluation_mode: `frontier_detail`\n- abstraction_layer: `decoder_attention_score32_exp_lut_measured_wrapper_promotion`\n- comparison_role: `score32_exp_lut_wrapper_promotion_audit`\n- expected_direction: `close_score32_exp_lut_wrapper_promotion_linkage`\n- expected_reason: `The result should report whether the L2 selected wrapper metrics match the merged L1 wrapper PPA and whether partitioned/cluster physical validation is still required.`\n- expectation_status: `unspecified`\n- evaluation_summary: `Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.`\n\n## Focused Comparison\n- primary_question: `Is the reduced-replica score32 exp-LUT measured-command-control L2 result directly backed by the measured L1 dual-stream wrapper metrics, or does it still require partitioned/cluster wrapper physical validation?`\n- comparison_role: `score32_exp_lut_wrapper_promotion_audit`\n- proposal_outcome: `decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded`\n- comparison_summary: `Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.`\n- baseline_ref: `None`\n- baseline_item_id: `None`\n\n## Checklist\n- [ ] Commit lightweight campaign artifacts only\n- [ ] Include metrics row references in result.metrics_rows\n- [ ] Keep committed result_path fields repo-portable\n- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing\n",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ]
+  }
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json
@@ -1,0 +1,25 @@
+{
+  "decision": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+  "diagnosis": {
+    "decision": "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded",
+    "l1_wrapper_accepted": true,
+    "l1_wrapper_metrics_match": true,
+    "l1_wrapper_present": true,
+    "l2_candidate_supported": true,
+    "l2_measured_decision": "dual_stream_feasible",
+    "l2_recommended_next_step": "promote dual-stream schedule into a measured RTL/PPA wrapper",
+    "l2_selected_wrapper_metrics_csv": "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv",
+    "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up."
+  },
+  "model": "llm_decoder_attention_score32_exp_lut_measured_wrapper_promotion_v1",
+  "next_step": {
+    "decision_scope": "score32 exp-LUT reduced-replica composed-datapath L2 to measured wrapper promotion",
+    "recommended_next_step": "promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.",
+    "requires_partitioned_or_cluster_validation": false
+  },
+  "source_artifacts": {
+    "measured_composed_decision": "decoder_attention_composed_datapath_physical_feasibility",
+    "measured_wrapper_ppa": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1.json"
+  },
+  "version": 1
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.md
@@ -1,0 +1,13 @@
+# Score32 Exp-LUT Measured Wrapper Promotion Audit
+
+## Decision
+- decision: `decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded`
+- recommended_next_step: `promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.`
+
+## Readiness
+- l2_measured_decision: `dual_stream_feasible`
+- l1_wrapper_accepted: `True`
+- l1_wrapper_metrics_match: `True`
+- requires_partitioned_or_cluster_validation: `False`
+
+- l2_selected_wrapper_metrics_csv: `runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv`


### PR DESCRIPTION
## Summary
- item_id: `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`
- run_key: `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1_run_21c02f26440cc217`
- layer: `layer2`
- task_type: `l2_campaign`
- status: `ok`
- summary: `2/2 commands succeeded`
- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/evaluated.json`
- metrics_rows_count: `0`
- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json`

## Developer Context
- proposal_id: `prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`
- proposal_path: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json`
- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
- execution_source_commit: `636af107a21652571d024749ce453e11fe576667`
- review_metadata_source_commit: `636af107a21652571d024749ce453e11fe576667`

## Evaluation Mode
- evaluation_mode: `frontier_detail`
- abstraction_layer: `decoder_attention_score32_exp_lut_measured_wrapper_promotion`
- comparison_role: `score32_exp_lut_wrapper_promotion_audit`
- expected_direction: `close_score32_exp_lut_wrapper_promotion_linkage`
- expected_reason: `The result should report whether the L2 selected wrapper metrics match the merged L1 wrapper PPA and whether partitioned/cluster physical validation is still required.`
- expectation_status: `unspecified`
- evaluation_summary: `Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.`

## Focused Comparison
- primary_question: `Is the reduced-replica score32 exp-LUT measured-command-control L2 result directly backed by the measured L1 dual-stream wrapper metrics, or does it still require partitioned/cluster wrapper physical validation?`
- comparison_role: `score32_exp_lut_wrapper_promotion_audit`
- proposal_outcome: `decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded`
- comparison_summary: `Decoder score32 exp-LUT measured-wrapper promotion evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json: decision=decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded; l2_measured_decision=dual_stream_feasible; l2_candidate_supported=True; l1_wrapper_accepted=True; l1_wrapper_metrics_match=True; l2_selected_wrapper_metrics_csv=runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/metrics.csv; recommended_next_step=promote reduced-replica score32 exp-LUT datapath using the measured dual-stream wrapper instead of partitioned-wrapper physical follow-up.; requires_partitioned_or_cluster_validation=False.`
- baseline_ref: `None`
- baseline_item_id: `None`

## Checklist
- [ ] Commit lightweight campaign artifacts only
- [ ] Include metrics row references in result.metrics_rows
- [ ] Keep committed result_path fields repo-portable
- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing
