### PR TITLE
control_plane: add score32 exp-lut service closure audit

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -563,6 +563,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_exp_lut_measured_wrapper_promotion_report",
     ),
     (
+        "attention_score32_exp_lut_service_closure_out",
+        "attention_score32_exp_lut_service_closure_report",
+    ),
+    (
         "attention_integrated_abstraction_closure_out",
         "attention_integrated_abstraction_closure_report",
     ),
@@ -1287,6 +1291,32 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
                 "requires_partitioned_or_cluster_validation="
                 f"{next_step_dict.get('requires_partitioned_or_cluster_validation')}"
             )
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_score32_exp_lut_service_closure_audit_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        next_step = evidence_payload.get("next_step")
+        next_step_dict = dict(next_step) if isinstance(next_step, dict) else {}
+        outcome = str(evidence_payload.get("decision") or "score32_exp_lut_service_closure_recorded")
+        parts = [
+            f"Decoder score32 exp-LUT service-closure evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "score32_supported",
+            "wrapper_metrics_match",
+            "selected_semantic_profile",
+            "latency_us",
+            "source_latency_us",
+            "macs_per_cycle",
+            "dominant_tile_resource",
+            "remaining_abstractions",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        if "requires_hbm_dram_closure" in next_step_dict:
+            parts.append(f"requires_hbm_dram_closure={next_step_dict.get('requires_hbm_dram_closure')}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5766,6 +5766,64 @@ def _decoder_attention_score32_exp_lut_measured_wrapper_promotion_evidence(*, it
     }
 
 
+def _decoder_attention_score32_exp_lut_service_closure_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_score32_exp_lut_service_closure__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_exp_lut_service_closure__{item_id}.md"
+    measured_command_control_item = (
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+        "measured_command_control_llama7b_v1"
+    )
+    measured_command_control = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__{measured_command_control_item}.json"
+    )
+    wrapper_promotion = (
+        f"{base}/decoder_attention_score32_exp_lut_measured_wrapper_promotion__"
+        "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json"
+    )
+    endpoint_router_sram = (
+        f"{base}/decoder_attention_kv_endpoint_router_sram_composition__"
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json"
+    )
+    measured_sram = (
+        f"{base}/decoder_attention_kv_measured_sram_rebalance__"
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_score32_exp_lut_measured_command_control": measured_command_control,
+            "attention_score32_exp_lut_measured_wrapper_promotion": wrapper_promotion,
+            "attention_kv_endpoint_router_sram_composition": endpoint_router_sram,
+            "attention_kv_measured_sram_rebalance": measured_sram,
+            "attention_score32_exp_lut_service_closure_out": out,
+            "attention_score32_exp_lut_service_closure_report": report,
+            "attention_score32_exp_lut_service_closure_scope": (
+                "Audit the score32 exp-LUT measured-command-control row against the measured "
+                "wrapper promotion and inherited endpoint/router/SRAM service evidence. Record "
+                "which service components are measured, which are measured estimates, and which "
+                "remain inherited HBM/DRAM abstractions before using this row as the Llama7B "
+                "frontier baseline."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_score32_exp_lut_service_closure",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_score32_exp_lut_service_closure.py "
+                    f"--measured-command-control-json {measured_command_control} "
+                    f"--wrapper-promotion-json {wrapper_promotion} "
+                    f"--endpoint-router-sram-composition-json {endpoint_router_sram} "
+                    f"--measured-sram-rebalance-json {measured_sram} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_integrated_abstraction_closure_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_integrated_abstraction_closure__{item_id}.json"
@@ -9220,6 +9278,7 @@ def _build_payload(
         "decoder_attention_integrated_energy_closure",
         "decoder_attention_hbm_energy_sensitivity",
         "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
+        "decoder_attention_score32_exp_lut_service_closure",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -9416,6 +9475,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_hbm_energy_sensitivity_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_exp_lut_measured_wrapper_promotion":
             decoder_evidence = _decoder_attention_score32_exp_lut_measured_wrapper_promotion_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_score32_exp_lut_service_closure":
+            decoder_evidence = _decoder_attention_score32_exp_lut_service_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -5233,6 +5233,124 @@ def test_consume_l2_result_frontier_attention_measured_sram_rebalance_uses_decod
             )
 
 
+def test_consume_l2_result_score32_exp_lut_service_closure_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_score32_service_closure_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_score32_service_closure_v1",
+                        "kind": "architecture",
+                        "title": "Score32 exp-LUT service closure",
+                        "direct_comparison": {
+                            "primary_question": "Which service components remain abstract for score32 exp-LUT?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_service_closure__l2_score32_service_closure.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_service_closure__l2_score32_service_closure.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_score32_exp_lut_service_closure_audit_v1",
+                        "decision": "score32_exp_lut_service_closure_recorded",
+                        "diagnosis": {
+                            "score32_supported": True,
+                            "wrapper_metrics_match": True,
+                            "selected_semantic_profile": "score32_exp_lut_div",
+                            "latency_us": 12519.342352,
+                            "source_latency_us": 1575.373891,
+                            "macs_per_cycle": 104320,
+                            "dominant_tile_resource": "pipeline_attention",
+                            "remaining_abstractions": [
+                                "tile_local_and_shared_sram",
+                                "hbm_dram_service",
+                            ],
+                        },
+                        "next_step": {
+                            "requires_hbm_dram_closure": True,
+                            "requires_new_wrapper_ppa": False,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# score32 service closure\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_score32_service_closure",
+                campaign_dir_rel="runs/campaigns/npu/score32_service_closure_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_score32_service_closure_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "record_score32_service_closure",
+                "expected_reason": "Use the score32 exp-LUT service closure record to choose the next abstraction.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_score32_exp_lut_service_closure",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_score32_exp_lut_service_closure_out": evidence_rel,
+                    "attention_score32_exp_lut_service_closure_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "score32_exp_lut_service_closure_recorded"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert "score32_supported=True" in assessment["summary"]
+            assert "latency_us=12519.342352" in assessment["summary"]
+            assert "requires_hbm_dram_closure=True" in assessment["summary"]
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_score32_exp_lut_service_closure"
+            )
+            assert decision_payload["source_refs"]["decoder_attention_score32_exp_lut_service_closure_out"] == evidence_rel
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_exp_lut_service_closure_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_frontier_attention_measured_hbm_service_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6627,6 +6627,69 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_measured_wrapp
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_service_closure_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_exp_lut_service_closure",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_score32_exp_lut_service_closure",
+            ]
+            assert "audit_llm_decoder_attention_score32_exp_lut_service_closure.py" in run
+            assert "--measured-command-control-json" in run
+            assert "--wrapper-promotion-json" in run
+            assert "--endpoint-router-sram-composition-json" in run
+            assert "--measured-sram-rebalance-json" in run
+            assert (
+                "decoder_attention_score32_exp_lut_measured_wrapper_promotion__"
+                "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json"
+            ) in run
+            assert (
+                "decoder_attention_kv_endpoint_router_sram_composition__"
+                "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json"
+            ) in run
+            assert (
+                decoder_inputs["attention_score32_exp_lut_service_closure_out"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_service_closure__"
+                "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_exp_lut_service_closure_scope"].startswith(
+                "Audit the score32 exp-LUT measured-command-control row"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_exp_lut_service_closure__"
+                    "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -144,12 +144,17 @@ than free or heuristic assumptions.
     sensitivity, L1 command-dispatch-control PPA, and measured command-control
     recost. The measured command-control result is merged by PR #1194 and still
     reports `dual_stream_feasible`.
+  - the wrapper-promotion audit
+    `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`
+    is merged by PR #1197. It records `l1_wrapper_metrics_match=True` and
+    `requires_partitioned_or_cluster_validation=False`, so the reduced-replica
+    score32 exp-LUT row can be treated as backed by the measured dual-stream
+    wrapper metrics.
   - the current immediate follow-on is
-    `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`.
-    It audits whether the reduced-replica measured-command-control result is
-    directly backed by the measured score32 exp-LUT dual-stream wrapper metrics,
-    or whether a partitioned/cluster wrapper PPA validation is still required
-    before treating the reduced-replica result as promoted.
+    `l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1`. It
+    records which service components of the promoted score32 exp-LUT row are
+    measured, measured estimates, or inherited models before using the row as
+    the next Llama7B frontier baseline.
 - New evaluations should continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`, not the devcontainer.
 
@@ -289,11 +294,15 @@ run the already queued exp-LUT branch:
    to the softmax replacement design or another score32/w16 implementation.
 4. Run
    `l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1`
-   to close the reduced-replica-to-measured-wrapper promotion audit. If it
-   records a wrapper metrics match, the next frontier work should move to the
-   surviving memory/NoC/SRAM/HBM service abstractions. If it requires
-   partitioned or cluster validation, schedule that L1 wrapper PPA before
-   treating the reduced-replica score32 exp-LUT path as promoted.
+   to close the reduced-replica-to-measured-wrapper promotion audit. This is
+   complete: PR #1197 records a wrapper metrics match and no required
+   partitioned/cluster wrapper validation.
+5. Run
+   `l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1` to record
+   the measured/inherited service provenance of the promoted score32 exp-LUT
+   row. If it records score32 support, choose the next frontier from its
+   remaining abstractions, currently expected to be HBM/DRAM service closure or
+   a stronger placed SRAM hierarchy model.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/analysis_report.md
@@ -1,0 +1,6 @@
+# Analysis Report
+
+Pending evaluation.
+
+This proposal records the service provenance of the promoted score32 exp-LUT
+Llama7B attention row before using it as the next frontier baseline.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds the score32 exp-LUT service-closure audit hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit service-component provenance for the promoted score32 exp-LUT Llama7B attention row.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exp_lut_service_closure",
+      "comparison_role": "score32_exp_lut_service_closure_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4",
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_exp_lut_service_closure",
+        "reason": "The result should state whether score32 exp-LUT is supported by measured wrapper evidence and list remaining inherited service abstractions before the next frontier job."
+      },
+      "status": "pending"
+    }
+  ],
+  "source_commit": null
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+  "decision": "pending",
+  "reason": "Evaluation not yet run.",
+  "evidence_refs": [],
+  "next_action": "dispatch l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+  "decision": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+  "created_utc": "2026-07-06T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 exp-LUT service closure audit",
+  "abstraction_layer": "decoder_attention_score32_exp_lut_service_closure",
+  "hypothesis": "After the measured-wrapper promotion audit, the score32 exp-LUT Llama7B row can become the active compute/service baseline only if its measured wrapper, command-control, endpoint/router/SRAM, and inherited HBM/DRAM provenance are recorded explicitly.",
+  "direct_comparison": {
+    "primary_question": "Which service components are measured, measured-estimated, or still inherited for the promoted score32 exp-LUT Llama7B attention row?",
+    "include": [
+      "consume the merged score32 exp-LUT measured-command-control result",
+      "consume the merged score32 exp-LUT measured-wrapper promotion result",
+      "consume the endpoint/router/SRAM composition evidence",
+      "consume the measured-SRAM rebalance evidence",
+      "record remaining HBM/DRAM and SRAM packing abstractions explicitly"
+    ],
+    "exclude": [
+      "new OpenROAD PPA",
+      "new generation-quality evaluation",
+      "new HBM/DRAM controller calibration",
+      "new NoC topology search"
+    ]
+  },
+  "expected_benefit": [
+    "prevents accidental mixing of old softmax-era service rows with the promoted score32 exp-LUT compute row",
+    "creates a stable provenance record for the current Llama7B frontier baseline",
+    "identifies the next abstraction to close before claiming a fully embodied architecture point"
+  ],
+  "risks": [
+    "the audit is a provenance and accounting closure, not a new physical integration run",
+    "HBM/DRAM service and SRAM macro packing remain modeled until their dedicated closure jobs replace them"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit service-component provenance for the promoted score32 exp-LUT Llama7B attention row.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exp_lut_service_closure",
+      "comparison_role": "score32_exp_lut_service_closure_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4",
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_exp_lut_service_closure",
+        "reason": "The result should state whether score32 exp-LUT is supported by measured wrapper evidence and list remaining inherited service abstractions before the next frontier job."
+      },
+      "status": "pending"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_exp_lut_service_closure.py",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_v1/proposal.json"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_exp_lut_service_closure.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exp_lut_service_closure.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Audit service provenance for the score32 exp-LUT Llama7B attention row."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_dict(value: Any) -> JsonDict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _first_dict(*values: Any) -> JsonDict:
+    for value in values:
+        if isinstance(value, dict):
+            return dict(value)
+    return {}
+
+
+def _pick(row: JsonDict, keys: tuple[str, ...]) -> JsonDict:
+    return {key: row.get(key) for key in keys if key in row}
+
+
+def _selected_score32_row(payload: JsonDict) -> JsonDict:
+    return _first_dict(
+        payload.get("best_requested"),
+        payload.get("best_area_fit"),
+        payload.get("best_feasible"),
+        payload.get("best"),
+    )
+
+
+def _wrapper_backed(promotion: JsonDict, row: JsonDict) -> bool:
+    diagnosis = _as_dict(promotion.get("diagnosis"))
+    if not bool(diagnosis.get("l1_wrapper_accepted")):
+        return False
+    if not bool(diagnosis.get("l1_wrapper_metrics_match")):
+        return False
+    if not bool(diagnosis.get("l2_candidate_supported")):
+        return False
+    selected_metrics = str(diagnosis.get("l2_selected_wrapper_metrics_csv") or "")
+    row_metrics = str(row.get("measured_dual_stream_composed_metrics_csv") or row.get("substituted_compute_metrics_csv") or "")
+    return bool(selected_metrics and row_metrics and selected_metrics == row_metrics)
+
+
+def _service_components(
+    *,
+    row: JsonDict,
+    composition: JsonDict,
+    measured_sram: JsonDict,
+) -> list[JsonDict]:
+    closure_flags = _as_dict(composition.get("closure_flags"))
+    closure_diagnosis = _as_dict(composition.get("closure_diagnosis"))
+    measured_sram_best = _as_dict(measured_sram.get("best"))
+    return [
+        {
+            "component": "compute_datapath",
+            "status": "measured",
+            "source": row.get("measured_dual_stream_composed_metrics_csv")
+            or row.get("substituted_compute_metrics_csv"),
+            "details": _pick(
+                row,
+                (
+                    "substituted_compute_semantic_profile",
+                    "substituted_compute_replica_count",
+                    "replica_recost_area_fit_replica_count",
+                    "replica_recost_macs_per_cycle",
+                    "replica_recost_latency_us",
+                    "measured_command_dispatch_control_metrics_csv",
+                ),
+            ),
+        },
+        {
+            "component": "command_dispatch_control",
+            "status": "measured" if row.get("measured_command_dispatch_control_metrics_csv") else "missing",
+            "source": row.get("measured_command_dispatch_control_metrics_csv"),
+            "details": _pick(
+                row,
+                (
+                    "measured_command_dispatch_control_variant_name",
+                    "measured_command_dispatch_control_cluster_count",
+                    "measured_command_dispatch_control_area_um2",
+                    "measured_command_dispatch_control_clock_ns",
+                    "command_dispatch_control_clock_ok",
+                ),
+            ),
+        },
+        {
+            "component": "endpoint_ready_valid",
+            "status": "measured" if closure_flags.get("endpoint_ppa_width_matched") else "measured_with_width_note",
+            "source": composition.get("endpoint_ready_valid_json"),
+            "details": {
+                "endpoint_width_ratio_vs_measured_ppa": closure_diagnosis.get(
+                    "endpoint_width_ratio_vs_measured_ppa"
+                ),
+                "endpoint_ppa_width_matched": closure_flags.get("endpoint_ppa_width_matched"),
+            },
+        },
+        {
+            "component": "router_fifo_noc",
+            "status": "measured_segmented"
+            if closure_flags.get("router_ppa_width_matched") and closure_flags.get("fifo_ppa_width_matched")
+            else "measured_with_lane_replication",
+            "source": {
+                "composition": composition.get("selected_frontier", {}).get("noc_router_metrics_csv")
+                if isinstance(composition.get("selected_frontier"), dict)
+                else None,
+                "segmented_l1_promotion": composition.get("segmented_l1_promotion_json"),
+            },
+            "details": _pick(
+                closure_diagnosis,
+                (
+                    "router_lanes_for_link",
+                    "router_lanes_for_packet",
+                    "fifo_lanes_for_link",
+                    "router_boundary_status",
+                    "fifo_boundary_status",
+                ),
+            ),
+        },
+        {
+            "component": "tile_local_and_shared_sram",
+            "status": "measured_capacity_estimate",
+            "source": measured_sram.get("local_sram_capacity_json"),
+            "details": _pick(
+                measured_sram_best,
+                (
+                    "measured_tile_local_sram_area_um2",
+                    "measured_shared_sram_capacity_mib",
+                    "measured_shared_sram_used_area_um2",
+                    "local_capacity_bytes_per_cluster",
+                    "abstract_local_capacity_bytes_per_cluster_replaced",
+                ),
+            ),
+        },
+        {
+            "component": "hbm_dram_service",
+            "status": "inherited_model",
+            "source": row.get("measured_hbm_service_model") or row.get("hbm_service_model"),
+            "details": _pick(
+                row,
+                (
+                    "measured_hbm_service_model",
+                    "effective_hbm_bytes_per_cycle",
+                    "channel_count",
+                    "channel_bandwidth_bytes_per_cycle",
+                    "hbm_byte_share",
+                    "controller_service_cycles",
+                    "tile_hbm_cycles",
+                ),
+            ),
+        },
+    ]
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    measured_command = _load_json(args.measured_command_control_json)
+    wrapper_promotion = _load_json(args.wrapper_promotion_json)
+    composition = _load_json(args.endpoint_router_sram_composition_json)
+    measured_sram = _load_json(args.measured_sram_rebalance_json)
+
+    row = _selected_score32_row(measured_command)
+    diagnosis = _as_dict(measured_command.get("diagnosis"))
+    promotion_diagnosis = _as_dict(wrapper_promotion.get("diagnosis"))
+    wrapper_backed = _wrapper_backed(wrapper_promotion, row)
+    command_decision = str(diagnosis.get("decision") or "")
+    promotion_decision = str(promotion_diagnosis.get("decision") or wrapper_promotion.get("decision") or "")
+    score32_supported = (
+        command_decision == "dual_stream_feasible"
+        and promotion_decision == "decoder_attention_score32_exp_lut_measured_wrapper_promotion_recorded"
+        and wrapper_backed
+    )
+    decision = (
+        "score32_exp_lut_service_closure_recorded"
+        if score32_supported
+        else "score32_exp_lut_service_closure_blocked"
+    )
+    service_components = _service_components(row=row, composition=composition, measured_sram=measured_sram)
+    remaining_abstractions = [
+        item["component"]
+        for item in service_components
+        if str(item.get("status", "")).startswith("inherited")
+        or str(item.get("status", "")).endswith("_estimate")
+    ]
+
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_exp_lut_service_closure_audit_v1",
+        "decision": decision,
+        "inputs": {
+            "measured_command_control_json": str(args.measured_command_control_json),
+            "wrapper_promotion_json": str(args.wrapper_promotion_json),
+            "endpoint_router_sram_composition_json": str(args.endpoint_router_sram_composition_json),
+            "measured_sram_rebalance_json": str(args.measured_sram_rebalance_json),
+        },
+        "diagnosis": {
+            "score32_supported": score32_supported,
+            "measured_command_decision": command_decision,
+            "wrapper_promotion_decision": promotion_decision,
+            "wrapper_metrics_match": wrapper_backed,
+            "selected_semantic_profile": row.get("substituted_compute_semantic_profile"),
+            "selected_wrapper_metrics_csv": row.get("measured_dual_stream_composed_metrics_csv")
+            or row.get("substituted_compute_metrics_csv"),
+            "latency_us": row.get("replica_recost_latency_us") or row.get("adjusted_latency_us_if_feasible"),
+            "source_latency_us": row.get("latency_us"),
+            "macs_per_cycle": row.get("replica_recost_macs_per_cycle") or row.get("macs_per_cycle"),
+            "dominant_tile_resource": row.get("dominant_tile_resource"),
+            "remaining_abstractions": remaining_abstractions,
+        },
+        "service_components": service_components,
+        "selected_score32_row": _pick(
+            row,
+            (
+                "latency_us",
+                "adjusted_latency_us_if_feasible",
+                "replica_recost_latency_us",
+                "replica_recost_macs_per_cycle",
+                "replica_recost_area_fit_replica_count",
+                "dominant_tile_resource",
+                "substituted_compute_semantic_profile",
+                "measured_dual_stream_composed_metrics_csv",
+                "measured_command_dispatch_control_metrics_csv",
+                "measured_sram_rebalance_model",
+                "measured_hbm_service_model",
+                "hbm_byte_share",
+                "effective_hbm_bytes_per_cycle",
+            ),
+        ),
+        "next_step": {
+            "recommended_next_step": (
+                "Use this score32 exp-LUT row as the quality-backed compute/service baseline, "
+                "then close the inherited HBM/DRAM service or replace SRAM macro packing with a placed memory hierarchy."
+            )
+            if score32_supported
+            else "Resolve wrapper promotion or measured command-control support before service closure.",
+            "requires_hbm_dram_closure": True,
+            "requires_new_wrapper_ppa": False,
+        },
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    diagnosis = payload["diagnosis"]
+    lines = [
+        "# Score32 exp-LUT Service Closure Audit",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- score32 supported: `{diagnosis['score32_supported']}`",
+        f"- wrapper metrics match: `{diagnosis['wrapper_metrics_match']}`",
+        f"- latency us: `{diagnosis.get('latency_us')}`",
+        f"- MAC/cycle: `{diagnosis.get('macs_per_cycle')}`",
+        f"- remaining abstractions: `{', '.join(diagnosis.get('remaining_abstractions') or [])}`",
+        "",
+        "## Components",
+        "",
+        "| component | status | source |",
+        "|---|---|---|",
+    ]
+    for item in payload["service_components"]:
+        source = item.get("source")
+        if isinstance(source, dict):
+            source = ", ".join(f"{key}={value}" for key, value in source.items() if value)
+        lines.append(f"| {item['component']} | {item['status']} | {source or ''} |")
+    lines.extend(
+        [
+            "",
+            "## Next Step",
+            "",
+            f"- {payload['next_step']['recommended_next_step']}",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--measured-command-control-json", type=Path, required=True)
+    parser.add_argument("--wrapper-promotion-json", type=Path, required=True)
+    parser.add_argument("--endpoint-router-sram-composition-json", type=Path, required=True)
+    parser.add_argument("--measured-sram-rebalance-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "decision": payload["decision"], "out": str(args.out)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a lightweight score32 exp-LUT service-closure audit that records measured vs inherited service provenance
- wire the audit into L2 generation/result consumption and add proposal linkage
- update the Llama7B abstraction closure plan after the measured-wrapper promotion merge

## Validation
- python3 npu/eval/audit_llm_decoder_attention_score32_exp_lut_service_closure.py --measured-command-control-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json --wrapper-promotion-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_measured_wrapper_promotion__l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1.json --endpoint-router-sram-composition-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json --measured-sram-rebalance-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json --out /tmp/score32_service_closure.json --out-md /tmp/score32_service_closure.md
- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q -k 'score32_exp_lut_service_closure or score32_exp_lut_measured_wrapper_promotion'
- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -q -k 'score32_exp_lut_service_closure or measured_sram_rebalance'
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 tests/test_runs_parsers.py