### PR TITLE
control_plane: add score32 exp-lut sram envelope audit

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -567,6 +567,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_exp_lut_service_closure_report",
     ),
     (
+        "attention_score32_exp_lut_sram_hierarchy_envelope_out",
+        "attention_score32_exp_lut_sram_hierarchy_envelope_report",
+    ),
+    (
         "attention_integrated_abstraction_closure_out",
         "attention_integrated_abstraction_closure_report",
     ),
@@ -1311,6 +1315,36 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "source_latency_us",
             "macs_per_cycle",
             "dominant_tile_resource",
+            "remaining_abstractions",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        if "requires_hbm_dram_closure" in next_step_dict:
+            parts.append(f"requires_hbm_dram_closure={next_step_dict.get('requires_hbm_dram_closure')}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        next_step = evidence_payload.get("next_step")
+        next_step_dict = dict(next_step) if isinstance(next_step, dict) else {}
+        outcome = str(evidence_payload.get("decision") or "score32_exp_lut_sram_hierarchy_envelope_recorded")
+        parts = [
+            f"Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "score32_supported",
+            "source_score32_latency_us",
+            "source_hbm_byte_share",
+            "nominal_efficiency",
+            "nominal_shared_sram_capacity_mib",
+            "nominal_hbm_byte_share",
+            "conservative_efficiency",
+            "conservative_shared_sram_capacity_mib",
+            "conservative_hbm_byte_share",
+            "conservative_hbm_share_delta",
+            "conservative_projected_latency_us_hbm_share_scaled",
             "remaining_abstractions",
         ):
             if key in diagnosis_dict:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5824,6 +5824,60 @@ def _decoder_attention_score32_exp_lut_service_closure_evidence(*, item_id: str)
     }
 
 
+def _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__{item_id}.md"
+    service_closure = (
+        f"{base}/decoder_attention_score32_exp_lut_service_closure__"
+        "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json"
+    )
+    measured_sram = (
+        f"{base}/decoder_attention_kv_measured_sram_rebalance__"
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json"
+    )
+    local_capacity = _decoder_attention_local_sram_capacity_source(item_id=item_id)
+    endpoint_router_sram = (
+        f"{base}/decoder_attention_kv_endpoint_router_sram_composition__"
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json"
+    )
+    return {
+        "inputs": {
+            "attention_score32_exp_lut_service_closure": service_closure,
+            "attention_kv_measured_sram_rebalance": measured_sram,
+            "attention_local_sram_capacity": local_capacity,
+            "attention_kv_endpoint_router_sram_composition": endpoint_router_sram,
+            "attention_score32_exp_lut_sram_hierarchy_envelope_out": out,
+            "attention_score32_exp_lut_sram_hierarchy_envelope_report": report,
+            "attention_score32_exp_lut_sram_hierarchy_envelope_scope": (
+                "Replace the prior score32 exp-LUT SRAM packing abstraction with an explicit "
+                "macro-placement envelope. Reserve tile-local SRAM and endpoint/router/FIFO area, "
+                "sweep shared-SRAM macro placement efficiency, and report whether the score32 "
+                "frontier latency/HBM-share conclusion changes before HBM/DRAM closure."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py "
+                    f"--service-closure-json {service_closure} "
+                    f"--measured-sram-rebalance-json {measured_sram} "
+                    f"--local-sram-capacity-json {local_capacity} "
+                    f"--endpoint-router-sram-composition-json {endpoint_router_sram} "
+                    "--placement-efficiency 1.0,0.85,0.75,0.65,0.55 "
+                    "--nominal-efficiency 0.75 "
+                    "--placement-overhead-fraction 0.05 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_integrated_abstraction_closure_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_integrated_abstraction_closure__{item_id}.json"
@@ -9279,6 +9333,7 @@ def _build_payload(
         "decoder_attention_hbm_energy_sensitivity",
         "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
         "decoder_attention_score32_exp_lut_service_closure",
+        "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -9477,6 +9532,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_score32_exp_lut_measured_wrapper_promotion_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_exp_lut_service_closure":
             decoder_evidence = _decoder_attention_score32_exp_lut_service_closure_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_score32_exp_lut_sram_hierarchy_envelope":
+            decoder_evidence = _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -5351,6 +5351,131 @@ def test_consume_l2_result_score32_exp_lut_service_closure_uses_decoder_evidence
             )
 
 
+def test_consume_l2_result_score32_exp_lut_sram_hierarchy_envelope_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_score32_sram_envelope_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_score32_sram_envelope_v1",
+                        "kind": "architecture",
+                        "title": "Score32 exp-LUT SRAM hierarchy envelope",
+                        "direct_comparison": {
+                            "primary_question": "Does SRAM macro placement efficiency rerank score32 exp-LUT?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_score32_sram_envelope.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_score32_sram_envelope.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_v1",
+                        "decision": "score32_exp_lut_sram_hierarchy_envelope_stable",
+                        "diagnosis": {
+                            "score32_supported": True,
+                            "source_score32_latency_us": 12519.342352,
+                            "source_hbm_byte_share": 0.983398438,
+                            "nominal_efficiency": 0.75,
+                            "nominal_shared_sram_capacity_mib": 47.8125,
+                            "nominal_hbm_byte_share": 0.988327026,
+                            "conservative_efficiency": 0.55,
+                            "conservative_shared_sram_capacity_mib": 35.046875,
+                            "conservative_hbm_byte_share": 0.991443634,
+                            "conservative_hbm_share_delta": 0.008045196,
+                            "conservative_projected_latency_us_hbm_share_scaled": 12621.763263,
+                            "remaining_abstractions": [
+                                "hbm_dram_service",
+                                "sram_macro_floorplan_pnr",
+                            ],
+                        },
+                        "next_step": {
+                            "requires_hbm_dram_closure": True,
+                            "requires_full_sram_macro_floorplan": True,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# score32 sram envelope\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_score32_sram_envelope",
+                campaign_dir_rel="runs/campaigns/npu/score32_sram_envelope_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_score32_sram_envelope_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "record_score32_sram_hierarchy_envelope",
+                "expected_reason": "Use SRAM placement-envelope sensitivity to choose the next abstraction.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_score32_exp_lut_sram_hierarchy_envelope_out": evidence_rel,
+                    "attention_score32_exp_lut_sram_hierarchy_envelope_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "score32_exp_lut_sram_hierarchy_envelope_stable"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert "nominal_shared_sram_capacity_mib=47.8125" in assessment["summary"]
+            assert "conservative_hbm_share_delta=0.008045196" in assessment["summary"]
+            assert "requires_hbm_dram_closure=True" in assessment["summary"]
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_score32_exp_lut_sram_hierarchy_envelope"
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_exp_lut_sram_hierarchy_envelope_out"]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_exp_lut_sram_hierarchy_envelope_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_frontier_attention_measured_hbm_service_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6690,6 +6690,66 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_service_closur
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy_envelope_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+            ]
+            assert "audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py" in run
+            assert "--service-closure-json" in run
+            assert "--measured-sram-rebalance-json" in run
+            assert "--local-sram-capacity-json" in run
+            assert "--endpoint-router-sram-composition-json" in run
+            assert "--placement-efficiency 1.0,0.85,0.75,0.65,0.55" in run
+            assert (
+                "decoder_attention_score32_exp_lut_service_closure__"
+                "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json"
+            ) in run
+            assert (
+                decoder_inputs["attention_score32_exp_lut_sram_hierarchy_envelope_out"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_sram_hierarchy_envelope__"
+                "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_exp_lut_sram_hierarchy_envelope_scope"].startswith(
+                "Replace the prior score32 exp-LUT SRAM packing abstraction"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_exp_lut_sram_hierarchy_envelope__"
+                    "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -150,11 +150,16 @@ than free or heuristic assumptions.
     `requires_partitioned_or_cluster_validation=False`, so the reduced-replica
     score32 exp-LUT row can be treated as backed by the measured dual-stream
     wrapper metrics.
+  - the service-closure audit
+    `l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1` is
+    merged by PR #1199. It records `score32_supported=True`,
+    `wrapper_metrics_match=True`, `latency_us=12519.342352`, and remaining
+    abstractions `tile_local_and_shared_sram` plus `hbm_dram_service`.
   - the current immediate follow-on is
-    `l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1`. It
-    records which service components of the promoted score32 exp-LUT row are
-    measured, measured estimates, or inherited models before using the row as
-    the next Llama7B frontier baseline.
+    `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`.
+    It bounds the shared-SRAM CACTI packing assumption with an explicit macro
+    placement-efficiency envelope before deciding whether SRAM hierarchy or
+    HBM/DRAM service should be closed next.
 - New evaluations should continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`, not the devcontainer.
 
@@ -300,9 +305,15 @@ run the already queued exp-LUT branch:
 5. Run
    `l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1` to record
    the measured/inherited service provenance of the promoted score32 exp-LUT
-   row. If it records score32 support, choose the next frontier from its
-   remaining abstractions, currently expected to be HBM/DRAM service closure or
-   a stronger placed SRAM hierarchy model.
+   row. This is complete: PR #1199 records score32 support and identifies
+   SRAM capacity placement plus HBM/DRAM service as the remaining service
+   abstractions.
+6. Run
+   `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`
+   to replace the ideal shared-SRAM packing estimate with an explicit SRAM
+   macro placement-efficiency envelope. If the conservative envelope does not
+   materially change HBM byte share or latency, prioritize HBM/DRAM service
+   closure next; otherwise schedule a stronger SRAM macro floorplan study.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/analysis_report.md
@@ -1,0 +1,7 @@
+# Analysis Report
+
+Pending evaluation.
+
+This proposal bounds the score32 exp-LUT SRAM capacity estimate with explicit
+SRAM macro placement-efficiency assumptions before the next Llama7B frontier
+job chooses between HBM/DRAM closure and deeper SRAM floorplanning.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds the score32 exp-LUT SRAM hierarchy envelope audit hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit SRAM macro placement-envelope sensitivity for the promoted score32 exp-LUT Llama7B attention row.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+      "comparison_role": "score32_exp_lut_sram_hierarchy_envelope_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_local_sram_capacity_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_sram_hierarchy_envelope",
+        "reason": "The result should bound shared-SRAM capacity and HBM-share sensitivity under explicit macro placement efficiency before choosing the next frontier abstraction."
+      },
+      "status": "pending"
+    }
+  ],
+  "source_commit": null
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+  "decision": "pending",
+  "reason": "Evaluation not yet run.",
+  "evidence_refs": [],
+  "next_action": "dispatch l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+  "decision": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+  "created_utc": "2026-07-06T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 exp-LUT SRAM hierarchy placement envelope",
+  "abstraction_layer": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+  "hypothesis": "The promoted score32 exp-LUT Llama7B frontier is not materially reranked by replacing ideal shared-SRAM CACTI packing with an explicit SRAM macro placement-efficiency envelope; HBM/DRAM service remains the dominant unresolved service abstraction.",
+  "direct_comparison": {
+    "primary_question": "Does a physically constrained SRAM macro placement envelope materially change the score32 exp-LUT frontier latency/HBM-share conclusion?",
+    "include": [
+      "consume the merged score32 exp-LUT service-closure result",
+      "consume the measured-SRAM rebalance result",
+      "consume the local SRAM CACTI macro library",
+      "reserve tile-local SRAM and endpoint/router/FIFO area before packing shared SRAM",
+      "sweep shared-SRAM macro placement efficiency and report HBM-share/latency sensitivity"
+    ],
+    "exclude": [
+      "new SRAM compiler floorplan PnR",
+      "new OpenROAD logic PPA",
+      "new HBM/DRAM controller calibration",
+      "new precision or generation-quality evaluation"
+    ]
+  },
+  "expected_benefit": [
+    "bounds the current SRAM CACTI packing abstraction using an explicit physical placement envelope",
+    "tests whether SRAM hierarchy realism can rerank the active score32 exp-LUT Llama7B point",
+    "clarifies whether the next abstraction should be full SRAM macro floorplanning or HBM/DRAM closure"
+  ],
+  "risks": [
+    "placement efficiency is still a parametric envelope, not an SRAM macro floorplan",
+    "latency sensitivity only scales the inherited HBM byte-share term and does not replace HBM/DRAM service modeling"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit SRAM macro placement-envelope sensitivity for the promoted score32 exp-LUT Llama7B attention row.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+      "comparison_role": "score32_exp_lut_sram_hierarchy_envelope_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_local_sram_capacity_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_sram_hierarchy_envelope",
+        "reason": "The result should bound shared-SRAM capacity and HBM-share sensitivity under explicit macro placement efficiency before choosing the next frontier abstraction."
+      },
+      "status": "pending"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_v1/proposal.json"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Audit SRAM hierarchy placement envelope for the score32 exp-LUT Llama7B row."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_dict(value: Any) -> JsonDict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _ceil_div(numerator: int | float, denominator: int | float) -> int:
+    if numerator <= 0:
+        return 0
+    return int(math.ceil(float(numerator) / max(1.0, float(denominator))))
+
+
+def _float_list(text: str) -> list[float]:
+    values: list[float] = []
+    for piece in text.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        value = float(piece)
+        if value <= 0.0 or value > 1.0:
+            raise argparse.ArgumentTypeError("efficiency values must be in (0, 1]")
+        values.append(value)
+    if not values:
+        raise argparse.ArgumentTypeError("at least one efficiency value is required")
+    return values
+
+
+def _macro_library(capacity_payload: JsonDict) -> list[JsonDict]:
+    metrics_json = capacity_payload.get("sram_metrics_json")
+    if not metrics_json:
+        raise ValueError("local SRAM capacity payload is missing sram_metrics_json")
+    metrics_path = Path(str(metrics_json))
+    if not metrics_path.is_absolute():
+        metrics_path = _REPO_ROOT / metrics_path
+    metrics = _load_json(metrics_path)
+    macros: list[JsonDict] = []
+    for entry in metrics.get("instances", []):
+        if not isinstance(entry, dict):
+            continue
+        instance = _as_dict(entry.get("instance"))
+        metric = _as_dict(entry.get("metrics"))
+        size_bytes = int(instance.get("size_bytes", 0) or 0)
+        area_um2 = float(metric.get("area_um2", 0.0) or 0.0)
+        if size_bytes <= 0 or area_um2 <= 0.0:
+            continue
+        macros.append(
+            {
+                "name": str(instance.get("name") or f"sram_{size_bytes}"),
+                "size_bytes": size_bytes,
+                "area_um2": area_um2,
+                "read_energy_pj": float(metric.get("read_energy_pj", 0.0) or 0.0),
+                "write_energy_pj": float(metric.get("write_energy_pj", 0.0) or 0.0),
+                "access_time_ns": float(metric.get("access_time_ns", 0.0) or 0.0),
+                "bytes_per_um2": size_bytes / area_um2,
+            }
+        )
+    if not macros:
+        raise ValueError(f"no usable SRAM macro metrics found in {metrics_path}")
+    return sorted(macros, key=lambda item: (float(item["bytes_per_um2"]), int(item["size_bytes"])), reverse=True)
+
+
+def _pack_capacity(*, macro_area_budget_um2: float, macros: list[JsonDict]) -> JsonDict:
+    remaining = max(0.0, float(macro_area_budget_um2))
+    selected: list[JsonDict] = []
+    total_bytes = 0
+    total_area = 0.0
+    total_read = 0.0
+    total_write = 0.0
+    max_access = 0.0
+    for macro in macros:
+        count = int(math.floor((remaining + 1e-6) / float(macro["area_um2"])))
+        if count <= 0:
+            continue
+        area = count * float(macro["area_um2"])
+        size = count * int(macro["size_bytes"])
+        selected.append(
+            {
+                "name": macro["name"],
+                "count": count,
+                "size_bytes_each": int(macro["size_bytes"]),
+                "area_um2_each": round(float(macro["area_um2"]), 6),
+                "size_bytes_total": size,
+                "macro_area_um2_total": round(area, 6),
+            }
+        )
+        total_bytes += size
+        total_area += area
+        total_read += count * float(macro["read_energy_pj"])
+        total_write += count * float(macro["write_energy_pj"])
+        max_access = max(max_access, float(macro["access_time_ns"]))
+        remaining -= area
+    return {
+        "capacity_bytes": total_bytes,
+        "capacity_mib": round(total_bytes / (1024 * 1024), 6),
+        "macro_area_um2": round(total_area, 6),
+        "unused_macro_area_budget_um2": round(max(0.0, remaining), 6),
+        "read_energy_pj": round(total_read, 6),
+        "write_energy_pj": round(total_write, 6),
+        "max_access_time_ns": round(max_access, 6),
+        "selected_macros": selected,
+    }
+
+
+def _score32_row(service_closure: JsonDict) -> JsonDict:
+    return _as_dict(service_closure.get("selected_score32_row"))
+
+
+def _best_measured_sram_row(measured_sram: JsonDict) -> JsonDict:
+    return _as_dict(measured_sram.get("best"))
+
+
+def _build_row(
+    *,
+    efficiency: float,
+    placement_overhead_fraction: float,
+    score32_row: JsonDict,
+    measured_sram_row: JsonDict,
+    composition_quantities: JsonDict,
+    local_capacity_payload: JsonDict,
+    macros: list[JsonDict],
+) -> JsonDict:
+    sram_budget_um2 = float(composition_quantities["sram_budget_area_um2"])
+    tile_area_um2 = float(composition_quantities["tile_sram_total_area_um2_for_active_clusters"])
+    service_area_um2 = float(composition_quantities.get("scaled_local_service_area_all_clusters_um2", 0.0) or 0.0)
+    shared_envelope_budget_um2 = max(0.0, sram_budget_um2 - tile_area_um2 - service_area_um2)
+    macro_area_budget_um2 = shared_envelope_budget_um2 * efficiency * (1.0 - placement_overhead_fraction)
+    pack = _pack_capacity(macro_area_budget_um2=macro_area_budget_um2, macros=macros)
+    kv_cache_bytes = int(round(float(measured_sram_row["kv_cache_mib"]) * 1024.0 * 1024.0))
+    shared_byte_share = min(kv_cache_bytes, int(pack["capacity_bytes"])) / kv_cache_bytes if kv_cache_bytes else 0.0
+    hbm_byte_share = max(0.0, 1.0 - shared_byte_share)
+    source_hbm_share = float(measured_sram_row.get("hbm_byte_share", score32_row.get("hbm_byte_share", 1.0)))
+    hbm_share_scale = hbm_byte_share / max(1e-12, source_hbm_share)
+    source_latency_us = float(score32_row.get("replica_recost_latency_us") or score32_row.get("adjusted_latency_us_if_feasible") or 0.0)
+    source_hbm_cycles = int(score32_row.get("tile_hbm_cycles") or score32_row.get("controller_service_cycles") or 0)
+    projected_hbm_cycles = int(math.ceil(source_hbm_cycles * hbm_share_scale)) if source_hbm_cycles else None
+    projected_latency_us = source_latency_us * max(1.0, hbm_share_scale)
+    return {
+        "placement_efficiency": round(efficiency, 6),
+        "placement_overhead_fraction": round(placement_overhead_fraction, 6),
+        "sram_budget_area_um2": round(sram_budget_um2, 6),
+        "tile_local_sram_area_um2": round(tile_area_um2, 6),
+        "endpoint_router_fifo_area_um2": round(service_area_um2, 6),
+        "shared_sram_envelope_budget_um2": round(shared_envelope_budget_um2, 6),
+        "shared_sram_macro_area_budget_um2": round(macro_area_budget_um2, 6),
+        "shared_sram_capacity_mib": pack["capacity_mib"],
+        "shared_sram_macro_area_um2": pack["macro_area_um2"],
+        "shared_sram_envelope_area_um2": round(pack["macro_area_um2"] / efficiency if efficiency else 0.0, 6),
+        "shared_sram_pack": pack,
+        "shared_byte_share": round(shared_byte_share, 9),
+        "hbm_byte_share": round(hbm_byte_share, 9),
+        "hbm_share_scale_vs_measured_sram": round(hbm_share_scale, 9),
+        "source_score32_latency_us": round(source_latency_us, 6),
+        "projected_latency_us_hbm_share_scaled": round(projected_latency_us, 6),
+        "source_tile_hbm_cycles": source_hbm_cycles,
+        "projected_tile_hbm_cycles": projected_hbm_cycles,
+        "tile_local_capacity_bytes_per_cluster": int(composition_quantities["tile_sram_allocated_bytes_per_cluster"]),
+        "replaced_abstract_local_capacity_bytes_per_cluster": int(
+            measured_sram_row.get("abstract_local_capacity_bytes_per_cluster_replaced", 0)
+            or _as_dict(local_capacity_payload.get("selected_frontier")).get("local_capacity_bytes_per_cluster", 0)
+        ),
+        "fits_sram_area_budget": (pack["macro_area_um2"] / efficiency if efficiency else 0.0)
+        + tile_area_um2
+        + service_area_um2
+        <= sram_budget_um2 + 1e-6,
+    }
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    service_closure = _load_json(args.service_closure_json)
+    measured_sram = _load_json(args.measured_sram_rebalance_json)
+    local_capacity = _load_json(args.local_sram_capacity_json)
+    composition = _load_json(args.endpoint_router_sram_composition_json)
+    score32_row = _score32_row(service_closure)
+    measured_sram_row = _best_measured_sram_row(measured_sram)
+    quantities = _as_dict(composition.get("composition_quantities"))
+    macros = _macro_library(local_capacity)
+
+    rows = [
+        _build_row(
+            efficiency=efficiency,
+            placement_overhead_fraction=args.placement_overhead_fraction,
+            score32_row=score32_row,
+            measured_sram_row=measured_sram_row,
+            composition_quantities=quantities,
+            local_capacity_payload=local_capacity,
+            macros=macros,
+        )
+        for efficiency in args.placement_efficiency
+    ]
+    rows_sorted = sorted(rows, key=lambda item: float(item["placement_efficiency"]), reverse=True)
+    conservative = min(rows_sorted, key=lambda item: float(item["placement_efficiency"]))
+    nominal = min(rows_sorted, key=lambda item: abs(float(item["placement_efficiency"]) - args.nominal_efficiency))
+    hbm_share_delta = float(conservative["hbm_byte_share"]) - float(measured_sram_row["hbm_byte_share"])
+    decision = (
+        "score32_exp_lut_sram_hierarchy_envelope_stable"
+        if hbm_share_delta <= args.max_hbm_share_delta_for_stable
+        else "score32_exp_lut_sram_hierarchy_envelope_changes_frontier"
+    )
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_v1",
+        "decision": decision,
+        "inputs": {
+            "service_closure_json": str(args.service_closure_json),
+            "measured_sram_rebalance_json": str(args.measured_sram_rebalance_json),
+            "local_sram_capacity_json": str(args.local_sram_capacity_json),
+            "endpoint_router_sram_composition_json": str(args.endpoint_router_sram_composition_json),
+        },
+        "diagnosis": {
+            "score32_supported": _as_dict(service_closure.get("diagnosis")).get("score32_supported"),
+            "selected_semantic_profile": _as_dict(service_closure.get("diagnosis")).get("selected_semantic_profile"),
+            "source_score32_latency_us": score32_row.get("replica_recost_latency_us")
+            or score32_row.get("adjusted_latency_us_if_feasible"),
+            "source_hbm_byte_share": measured_sram_row.get("hbm_byte_share"),
+            "nominal_efficiency": nominal["placement_efficiency"],
+            "nominal_shared_sram_capacity_mib": nominal["shared_sram_capacity_mib"],
+            "nominal_hbm_byte_share": nominal["hbm_byte_share"],
+            "conservative_efficiency": conservative["placement_efficiency"],
+            "conservative_shared_sram_capacity_mib": conservative["shared_sram_capacity_mib"],
+            "conservative_hbm_byte_share": conservative["hbm_byte_share"],
+            "conservative_hbm_share_delta": round(hbm_share_delta, 9),
+            "conservative_projected_latency_us_hbm_share_scaled": conservative[
+                "projected_latency_us_hbm_share_scaled"
+            ],
+            "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr",
+            "remaining_abstractions": ["hbm_dram_service", "sram_macro_floorplan_pnr"],
+        },
+        "rows": rows_sorted,
+        "sram_macro_library": macros,
+        "next_step": {
+            "recommended_next_step": (
+                "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope "
+                "does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity."
+            ),
+            "requires_hbm_dram_closure": True,
+            "requires_full_sram_macro_floorplan": True,
+        },
+        "assumptions": [
+            "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+            "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+            "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+            "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    diagnosis = payload["diagnosis"]
+    lines = [
+        "# Score32 exp-LUT SRAM Hierarchy Envelope",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- source score32 latency us: `{diagnosis.get('source_score32_latency_us')}`",
+        f"- source hbm share: `{diagnosis.get('source_hbm_byte_share')}`",
+        f"- nominal efficiency: `{diagnosis.get('nominal_efficiency')}`",
+        f"- nominal shared MiB: `{diagnosis.get('nominal_shared_sram_capacity_mib')}`",
+        f"- nominal hbm share: `{diagnosis.get('nominal_hbm_byte_share')}`",
+        f"- conservative efficiency: `{diagnosis.get('conservative_efficiency')}`",
+        f"- conservative shared MiB: `{diagnosis.get('conservative_shared_sram_capacity_mib')}`",
+        f"- conservative hbm share delta: `{diagnosis.get('conservative_hbm_share_delta')}`",
+        "",
+        "## Sweep",
+        "",
+        "| efficiency | shared MiB | hbm share | projected latency us | shared envelope um2 | fits |",
+        "|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {placement_efficiency} | {shared_sram_capacity_mib} | {hbm_byte_share} | "
+            "{projected_latency_us_hbm_share_scaled} | {shared_sram_envelope_area_um2} | "
+            "{fits_sram_area_budget} |".format(**row)
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    lines.extend(["", "## Next Step", "", f"- {payload['next_step']['recommended_next_step']}"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--service-closure-json", type=Path, required=True)
+    parser.add_argument("--measured-sram-rebalance-json", type=Path, required=True)
+    parser.add_argument("--local-sram-capacity-json", type=Path, required=True)
+    parser.add_argument("--endpoint-router-sram-composition-json", type=Path, required=True)
+    parser.add_argument("--placement-efficiency", type=_float_list, default=[1.0, 0.85, 0.75, 0.65, 0.55])
+    parser.add_argument("--nominal-efficiency", type=float, default=0.75)
+    parser.add_argument("--placement-overhead-fraction", type=float, default=0.05)
+    parser.add_argument("--max-hbm-share-delta-for-stable", type=float, default=0.01)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    if args.placement_overhead_fraction < 0.0 or args.placement_overhead_fraction >= 1.0:
+        raise SystemExit("--placement-overhead-fraction must be in [0, 1)")
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "decision": payload["decision"], "out": str(args.out)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a score32 exp-LUT SRAM hierarchy placement-envelope audit
- wire the audit into L2 generation/result consumption and proposal linkage
- update the Llama7B closure plan after the service-closure merge

## Smoke Result
- decision: score32_exp_lut_sram_hierarchy_envelope_stable
- nominal efficiency 0.75: shared SRAM 47.8125 MiB, hbm_byte_share 0.988327026
- conservative efficiency 0.55: shared SRAM 35.046875 MiB, hbm_byte_share delta 0.008045196

## Validation
- python3 npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py --service-closure-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json --measured-sram-rebalance-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json --local-sram-capacity-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json --endpoint-router-sram-composition-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json --out /tmp/score32_sram_envelope.json --out-md /tmp/score32_sram_envelope.md
- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -q -k 'score32_exp_lut_sram_hierarchy_envelope or score32_exp_lut_service_closure'
- PYTHONPATH=control_plane python3 -m pytest control_plane/control_plane/tests/test_l2_result_consumer.py -q -k 'score32_exp_lut_sram_hierarchy_envelope or score32_exp_lut_service_closure'
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 tests/test_runs_parsers.py
- python3 -m py_compile npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py