### PR TITLE
eval: run score32 exp-lut sram hierarchy placement envelope

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json
@@ -1,0 +1,129 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-06T10:11:41.587436Z",
+  "item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+  "run_key": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1_run_3527a58e1b41c4e9",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "b759c0945ffb23a9f331b41e5d4d714cb58eb9c5",
+  "review_metadata_source_commit": "b759c0945ffb23a9f331b41e5d4d714cb58eb9c5",
+  "objective": "Audit SRAM macro placement-envelope sensitivity for the promoted score32 exp-LUT Llama7B attention row.",
+  "input_manifest": {
+    "decoder_contract": {
+      "attention_local_sram_capacity": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json",
+      "attention_kv_measured_sram_rebalance": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json",
+      "attention_score32_exp_lut_service_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json",
+      "attention_kv_endpoint_router_sram_composition": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+      "attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+      "attention_score32_exp_lut_sram_hierarchy_envelope_scope": "Replace the prior score32 exp-LUT SRAM packing abstraction with an explicit macro-placement envelope. Reserve tile-local SRAM and endpoint/router/FIFO area, sweep shared-SRAM macro placement efficiency, and report whether the score32 frontier latency/HBM-share conclusion changes before HBM/DRAM closure.",
+      "attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.md"
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+    "arch_id": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+    "macro_mode": "evidence_only",
+    "outcome": "score32_exp_lut_sram_hierarchy_envelope_stable"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+    "title": "Score32 exp-LUT SRAM hierarchy placement envelope",
+    "primary_question": "Does a physically constrained SRAM macro placement envelope materially change the score32 exp-LUT frontier latency/HBM-share conclusion?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "score32_exp_lut_sram_hierarchy_envelope_audit",
+    "abstraction_layer": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+    "expected_direction": "record_score32_sram_hierarchy_envelope",
+    "expected_reason": "The result should bound shared-SRAM capacity and HBM-share sensitivity under explicit macro placement efficiency before choosing the next frontier abstraction.",
+    "summary": "Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.",
+    "outcome": "score32_exp_lut_sram_hierarchy_envelope_stable",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+    "title": "Score32 exp-LUT SRAM hierarchy placement envelope",
+    "kind": "architecture",
+    "primary_question": "Does a physically constrained SRAM macro placement envelope materially change the score32 exp-LUT frontier latency/HBM-share conclusion?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "score32_exp_lut_sram_hierarchy_envelope_audit",
+    "outcome": "score32_exp_lut_sram_hierarchy_envelope_stable",
+    "summary": "Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+    "decoder_quality": {
+      "diagnosis": {
+        "conservative_efficiency": 0.55,
+        "conservative_hbm_byte_share": 0.991443634,
+        "conservative_hbm_share_delta": 0.008045196,
+        "conservative_projected_latency_us_hbm_share_scaled": 12621.763263,
+        "conservative_shared_sram_capacity_mib": 35.046875,
+        "nominal_efficiency": 0.75,
+        "nominal_hbm_byte_share": 0.988327026,
+        "nominal_shared_sram_capacity_mib": 47.8125,
+        "remaining_abstractions": [
+          "hbm_dram_service",
+          "sram_macro_floorplan_pnr"
+        ],
+        "score32_supported": true,
+        "selected_semantic_profile": "score32_exp_lut_div",
+        "source_hbm_byte_share": 0.983398438,
+        "source_score32_latency_us": 12519.342352,
+        "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+      },
+      "assumptions": [
+        "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+        "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+        "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+        "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+      ],
+      "next_step": {
+        "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+        "requires_full_sram_macro_floorplan": true,
+        "requires_hbm_dram_closure": true
+      }
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+    "decoder_attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+    "decoder_attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {
+      "conservative_efficiency": 0.55,
+      "conservative_hbm_byte_share": 0.991443634,
+      "conservative_hbm_share_delta": 0.008045196,
+      "conservative_projected_latency_us_hbm_share_scaled": 12621.763263,
+      "conservative_shared_sram_capacity_mib": 35.046875,
+      "nominal_efficiency": 0.75,
+      "nominal_hbm_byte_share": 0.988327026,
+      "nominal_shared_sram_capacity_mib": 47.8125,
+      "remaining_abstractions": [
+        "hbm_dram_service",
+        "sram_macro_floorplan_pnr"
+      ],
+      "score32_supported": true,
+      "selected_semantic_profile": "score32_exp_lut_div",
+      "source_hbm_byte_share": 0.983398438,
+      "source_score32_latency_us": 12519.342352,
+      "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+    },
+    "assumptions": [
+      "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+      "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+      "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+      "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+    ],
+    "next_step": {
+      "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+      "requires_full_sram_macro_floorplan": true,
+      "requires_hbm_dram_closure": true
+    }
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/evaluated.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/evaluated.json
@@ -1,0 +1,111 @@
+{
+  "flow": "openroad",
+  "task": {
+    "inputs": {
+      "decoder_contract": {
+        "attention_local_sram_capacity": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json",
+        "attention_kv_measured_sram_rebalance": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json",
+        "attention_score32_exp_lut_service_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json",
+        "attention_kv_endpoint_router_sram_composition": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+        "attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+        "attention_score32_exp_lut_sram_hierarchy_envelope_scope": "Replace the prior score32 exp-LUT SRAM packing abstraction with an explicit macro-placement envelope. Reserve tile-local SRAM and endpoint/router/FIFO area, sweep shared-SRAM macro placement efficiency, and report whether the score32 frontier latency/HBM-share conclusion changes before HBM/DRAM closure.",
+        "attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.md"
+      }
+    },
+    "commands": [
+      {
+        "run": "python3 npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py --service-closure-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json --measured-sram-rebalance-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json --local-sram-capacity-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json --endpoint-router-sram-composition-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json --placement-efficiency 1.0,0.85,0.75,0.65,0.55 --nominal-efficiency 0.75 --placement-overhead-fraction 0.05 --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.md",
+        "name": "audit_decoder_attention_score32_exp_lut_sram_hierarchy_envelope"
+      },
+      {
+        "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+        "name": "validate_runs"
+      }
+    ],
+    "objective": "Audit SRAM macro placement-envelope sensitivity for the promoted score32 exp-LUT Llama7B attention row.",
+    "acceptance": [
+      "Write all declared decoder evidence artifacts",
+      "Keep evidence artifact paths repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "source_mode": "src_verilog",
+    "expected_outputs": [
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.md"
+    ]
+  },
+  "layer": "layer2",
+  "state": "evaluated",
+  "title": "Score32 exp-LUT SRAM hierarchy placement envelope",
+  "result": {
+    "branch": "eval/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/s20260706t101141z",
+    "completed_utc": "2026-07-06T10:11:40.950459Z",
+    "evaluator_id": "control_plane",
+    "executor": "@control_plane",
+    "host": "b7c2d9c80c1c",
+    "identity_block": "[role:evaluator][account:control_plane][session:s20260706t101141z][host:b7c2d9c80c1c][item:l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1]",
+    "metrics_rows": [],
+    "metrics_exempt_reason": "evidence_only_decoder_evidence",
+    "queue_item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+    "session_id": "s20260706t101141z",
+    "status": "ok",
+    "summary": "2/2 commands succeeded"
+  },
+  "handoff": {
+    "branch": "eval/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/s20260706t101141z",
+    "pr_title": "eval: run score32 exp-lut sram hierarchy placement envelope",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "pr_body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260706t101141z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1"
+    },
+    "identity_block_format": "[role:evaluator][account:<evaluator_id>][session:<session_id>][host:<host>][item:<queue_item_id>]"
+  },
+  "item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+  "version": 0.1,
+  "platform": "nangate45",
+  "priority": 1,
+  "created_utc": "2026-07-06T10:11:30.512943Z",
+  "requested_by": "control_plane",
+  "developer_loop": {
+    "comparison": {
+      "role": "score32_exp_lut_sram_hierarchy_envelope_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1"
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "The result should bound shared-SRAM capacity and HBM-share sensitivity under explicit macro placement efficiency before choosing the next frontier abstraction.",
+      "expected_direction": "record_score32_sram_hierarchy_envelope"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope"
+    },
+    "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_local_sram_capacity_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json"
+  },
+  "source_requirement": {
+    "repo": "",
+    "reason": "evaluator runtime must contain the queued job source commit",
+    "version": 1,
+    "required_ref": "origin/master",
+    "required_sha": "b759c0945ffb23a9f331b41e5d4d714cb58eb9c5",
+    "requires_daemon_restart": true
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/pr_body.md
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/pr_body.md
@@ -1,0 +1,40 @@
+## Summary
+- item_id: `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`
+- run_key: `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1_run_3527a58e1b41c4e9`
+- layer: `layer2`
+- task_type: `l2_campaign`
+- status: `ok`
+- summary: `2/2 commands succeeded`
+- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/evaluated.json`
+- metrics_rows_count: `0`
+- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json`
+
+## Developer Context
+- proposal_id: `prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`
+- proposal_path: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json`
+- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
+- execution_source_commit: `b759c0945ffb23a9f331b41e5d4d714cb58eb9c5`
+- review_metadata_source_commit: `b759c0945ffb23a9f331b41e5d4d714cb58eb9c5`
+
+## Evaluation Mode
+- evaluation_mode: `frontier_detail`
+- abstraction_layer: `decoder_attention_score32_exp_lut_sram_hierarchy_envelope`
+- comparison_role: `score32_exp_lut_sram_hierarchy_envelope_audit`
+- expected_direction: `record_score32_sram_hierarchy_envelope`
+- expected_reason: `The result should bound shared-SRAM capacity and HBM-share sensitivity under explicit macro placement efficiency before choosing the next frontier abstraction.`
+- expectation_status: `unspecified`
+- evaluation_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`
+
+## Focused Comparison
+- primary_question: `Does a physically constrained SRAM macro placement envelope materially change the score32 exp-LUT frontier latency/HBM-share conclusion?`
+- comparison_role: `score32_exp_lut_sram_hierarchy_envelope_audit`
+- proposal_outcome: `score32_exp_lut_sram_hierarchy_envelope_stable`
+- comparison_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`
+- baseline_ref: `None`
+- baseline_item_id: `None`
+
+## Checklist
+- [ ] Commit lightweight campaign artifacts only
+- [ ] Include metrics row references in result.metrics_rows
+- [ ] Keep committed result_path fields repo-portable
+- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing

--- a/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/review_package.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/review_package.json
@@ -1,0 +1,208 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-06T10:11:43.138557Z",
+  "control_plane_source_commit": "b759c0945ffb23a9f331b41e5d4d714cb58eb9c5",
+  "review_metadata_source_commit": "b759c0945ffb23a9f331b41e5d4d714cb58eb9c5",
+  "item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+  "run_key": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1_run_3527a58e1b41c4e9",
+  "layer": "layer2",
+  "flow": "openroad",
+  "task_type": "l2_campaign",
+  "source_commit": "b759c0945ffb23a9f331b41e5d4d714cb58eb9c5",
+  "queue_snapshot": {
+    "path": "control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/evaluated.json",
+    "result": {
+      "branch": "eval/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/s20260706t101141z",
+      "completed_utc": "2026-07-06T10:11:40.950459Z",
+      "evaluator_id": "control_plane",
+      "executor": "@control_plane",
+      "host": "b7c2d9c80c1c",
+      "identity_block": "[role:evaluator][account:control_plane][session:s20260706t101141z][host:b7c2d9c80c1c][item:l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1]",
+      "metrics_rows": [],
+      "metrics_exempt_reason": "evidence_only_decoder_evidence",
+      "queue_item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+      "session_id": "s20260706t101141z",
+      "status": "ok",
+      "summary": "2/2 commands succeeded"
+    }
+  },
+  "review_artifact": {
+    "kind": "decision_proposal",
+    "path": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+    "storage_mode": "repo",
+    "sha256": "4899371ce9f68eda62f94106906fba7e599e739ca496ac3944f001b0daba6101",
+    "payload": {
+      "version": 0.1,
+      "generated_utc": "2026-07-06T10:11:41.587436Z",
+      "item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+      "run_key": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1_run_3527a58e1b41c4e9",
+      "layer": "layer2",
+      "flow": "openroad",
+      "platform": "nangate45",
+      "task_type": "l2_campaign",
+      "source_commit": "b759c0945ffb23a9f331b41e5d4d714cb58eb9c5",
+      "review_metadata_source_commit": "b759c0945ffb23a9f331b41e5d4d714cb58eb9c5",
+      "objective": "Audit SRAM macro placement-envelope sensitivity for the promoted score32 exp-LUT Llama7B attention row.",
+      "input_manifest": {
+        "decoder_contract": {
+          "attention_local_sram_capacity": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json",
+          "attention_kv_measured_sram_rebalance": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json",
+          "attention_score32_exp_lut_service_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json",
+          "attention_kv_endpoint_router_sram_composition": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+          "attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+          "attention_score32_exp_lut_sram_hierarchy_envelope_scope": "Replace the prior score32 exp-LUT SRAM packing abstraction with an explicit macro-placement envelope. Reserve tile-local SRAM and endpoint/router/FIFO area, sweep shared-SRAM macro placement efficiency, and report whether the score32 frontier latency/HBM-share conclusion changes before HBM/DRAM closure.",
+          "attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.md"
+        }
+      },
+      "recommendation": {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+        "arch_id": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+        "macro_mode": "evidence_only",
+        "outcome": "score32_exp_lut_sram_hierarchy_envelope_stable"
+      },
+      "objective_profiles": [],
+      "evaluation_record": {
+        "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+        "title": "Score32 exp-LUT SRAM hierarchy placement envelope",
+        "primary_question": "Does a physically constrained SRAM macro placement envelope materially change the score32 exp-LUT frontier latency/HBM-share conclusion?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "score32_exp_lut_sram_hierarchy_envelope_audit",
+        "abstraction_layer": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+        "expected_direction": "record_score32_sram_hierarchy_envelope",
+        "expected_reason": "The result should bound shared-SRAM capacity and HBM-share sensitivity under explicit macro placement efficiency before choosing the next frontier abstraction.",
+        "summary": "Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.",
+        "outcome": "score32_exp_lut_sram_hierarchy_envelope_stable",
+        "expectation_status": "unspecified"
+      },
+      "proposal_assessment": {
+        "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+        "title": "Score32 exp-LUT SRAM hierarchy placement envelope",
+        "kind": "architecture",
+        "primary_question": "Does a physically constrained SRAM macro placement envelope materially change the score32 exp-LUT frontier latency/HBM-share conclusion?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "score32_exp_lut_sram_hierarchy_envelope_audit",
+        "outcome": "score32_exp_lut_sram_hierarchy_envelope_stable",
+        "summary": "Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.",
+        "baseline_ref": null,
+        "baseline_item_id": null,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+        "decoder_quality": {
+          "diagnosis": {
+            "conservative_efficiency": 0.55,
+            "conservative_hbm_byte_share": 0.991443634,
+            "conservative_hbm_share_delta": 0.008045196,
+            "conservative_projected_latency_us_hbm_share_scaled": 12621.763263,
+            "conservative_shared_sram_capacity_mib": 35.046875,
+            "nominal_efficiency": 0.75,
+            "nominal_hbm_byte_share": 0.988327026,
+            "nominal_shared_sram_capacity_mib": 47.8125,
+            "remaining_abstractions": [
+              "hbm_dram_service",
+              "sram_macro_floorplan_pnr"
+            ],
+            "score32_supported": true,
+            "selected_semantic_profile": "score32_exp_lut_div",
+            "source_hbm_byte_share": 0.983398438,
+            "source_score32_latency_us": 12519.342352,
+            "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+          },
+          "assumptions": [
+            "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+            "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+            "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+            "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+          ],
+          "next_step": {
+            "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+            "requires_full_sram_macro_floorplan": true,
+            "requires_hbm_dram_closure": true
+          }
+        }
+      },
+      "source_refs": {
+        "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+        "decoder_attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+        "decoder_attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.md"
+      },
+      "decoder_quality": {
+        "diagnosis": {
+          "conservative_efficiency": 0.55,
+          "conservative_hbm_byte_share": 0.991443634,
+          "conservative_hbm_share_delta": 0.008045196,
+          "conservative_projected_latency_us_hbm_share_scaled": 12621.763263,
+          "conservative_shared_sram_capacity_mib": 35.046875,
+          "nominal_efficiency": 0.75,
+          "nominal_hbm_byte_share": 0.988327026,
+          "nominal_shared_sram_capacity_mib": 47.8125,
+          "remaining_abstractions": [
+            "hbm_dram_service",
+            "sram_macro_floorplan_pnr"
+          ],
+          "score32_supported": true,
+          "selected_semantic_profile": "score32_exp_lut_div",
+          "source_hbm_byte_share": 0.983398438,
+          "source_score32_latency_us": 12519.342352,
+          "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+        },
+        "assumptions": [
+          "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+          "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+          "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+          "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+        ],
+        "next_step": {
+          "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+          "requires_full_sram_macro_floorplan": true,
+          "requires_hbm_dram_closure": true
+        }
+      }
+    }
+  },
+  "developer_loop": {
+    "comparison": {
+      "role": "score32_exp_lut_sram_hierarchy_envelope_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1"
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "The result should bound shared-SRAM capacity and HBM-share sensitivity under explicit macro placement efficiency before choosing the next frontier abstraction.",
+      "expected_direction": "record_score32_sram_hierarchy_envelope"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_score32_exp_lut_sram_hierarchy_envelope"
+    },
+    "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
+        "l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1",
+        "l2_decoder_attention_local_sram_capacity_llama7b_v1",
+        "l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json"
+  },
+  "submission_history": null,
+  "pr_payload": {
+    "branch": "eval/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/s20260706t101141z",
+    "title": "eval: run score32 exp-lut sram hierarchy placement envelope",
+    "body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260706t101141z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1"
+    },
+    "body_md": "## Summary\n- item_id: `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`\n- run_key: `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1_run_3527a58e1b41c4e9`\n- layer: `layer2`\n- task_type: `l2_campaign`\n- status: `ok`\n- summary: `2/2 commands succeeded`\n- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/evaluated.json`\n- metrics_rows_count: `0`\n- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json`\n\n## Developer Context\n- proposal_id: `prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`\n- proposal_path: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json`\n- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`\n- execution_source_commit: `b759c0945ffb23a9f331b41e5d4d714cb58eb9c5`\n- review_metadata_source_commit: `b759c0945ffb23a9f331b41e5d4d714cb58eb9c5`\n\n## Evaluation Mode\n- evaluation_mode: `frontier_detail`\n- abstraction_layer: `decoder_attention_score32_exp_lut_sram_hierarchy_envelope`\n- comparison_role: `score32_exp_lut_sram_hierarchy_envelope_audit`\n- expected_direction: `record_score32_sram_hierarchy_envelope`\n- expected_reason: `The result should bound shared-SRAM capacity and HBM-share sensitivity under explicit macro placement efficiency before choosing the next frontier abstraction.`\n- expectation_status: `unspecified`\n- evaluation_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`\n\n## Focused Comparison\n- primary_question: `Does a physically constrained SRAM macro placement envelope materially change the score32 exp-LUT frontier latency/HBM-share conclusion?`\n- comparison_role: `score32_exp_lut_sram_hierarchy_envelope_audit`\n- proposal_outcome: `score32_exp_lut_sram_hierarchy_envelope_stable`\n- comparison_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`\n- baseline_ref: `None`\n- baseline_item_id: `None`\n\n## Checklist\n- [ ] Commit lightweight campaign artifacts only\n- [ ] Include metrics row references in result.metrics_rows\n- [ ] Keep committed result_path fields repo-portable\n- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing\n",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ]
+  }
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json
@@ -1,0 +1,326 @@
+{
+  "assumptions": [
+    "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+    "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+    "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+    "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+  ],
+  "decision": "score32_exp_lut_sram_hierarchy_envelope_stable",
+  "diagnosis": {
+    "conservative_efficiency": 0.55,
+    "conservative_hbm_byte_share": 0.991443634,
+    "conservative_hbm_share_delta": 0.008045196,
+    "conservative_projected_latency_us_hbm_share_scaled": 12621.763263,
+    "conservative_shared_sram_capacity_mib": 35.046875,
+    "nominal_efficiency": 0.75,
+    "nominal_hbm_byte_share": 0.988327026,
+    "nominal_shared_sram_capacity_mib": 47.8125,
+    "remaining_abstractions": [
+      "hbm_dram_service",
+      "sram_macro_floorplan_pnr"
+    ],
+    "score32_supported": true,
+    "selected_semantic_profile": "score32_exp_lut_div",
+    "source_hbm_byte_share": 0.983398438,
+    "source_score32_latency_us": 12519.342352,
+    "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+  },
+  "inputs": {
+    "endpoint_router_sram_composition_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+    "local_sram_capacity_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json",
+    "measured_sram_rebalance_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json",
+    "service_closure_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json"
+  },
+  "model": "llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_v1",
+  "next_step": {
+    "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+    "requires_full_sram_macro_floorplan": true,
+    "requires_hbm_dram_closure": true
+  },
+  "rows": [
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.984420776,
+      "hbm_share_scale_vs_measured_sram": 1.001039597,
+      "placement_efficiency": 1.0,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12532.357427,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "shared_byte_share": 0.015579224,
+      "shared_sram_capacity_mib": 63.8125,
+      "shared_sram_envelope_area_um2": 225752530.670304,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 225813296.354603,
+      "shared_sram_macro_area_um2": 225752530.670304,
+      "shared_sram_pack": {
+        "capacity_bytes": 66912256,
+        "capacity_mib": 63.8125,
+        "macro_area_um2": 225752530.670304,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 45664.697,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 255,
+            "macro_area_um2_total": 225061909.5894,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 66846720
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 4,
+            "macro_area_um2_total": 690621.080904,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 65536
+          }
+        ],
+        "unused_macro_area_budget_um2": 60765.684299,
+        "write_energy_pj": 159377.788
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    },
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.986747742,
+      "hbm_share_scale_vs_measured_sram": 1.003405846,
+      "placement_efficiency": 0.85,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12561.981305,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "shared_byte_share": 0.013252258,
+      "shared_sram_capacity_mib": 54.28125,
+      "shared_sram_envelope_area_um2": 225727744.261661,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 191941301.901413,
+      "shared_sram_macro_area_um2": 191868582.622412,
+      "shared_sram_pack": {
+        "capacity_bytes": 56918016,
+        "capacity_mib": 54.28125,
+        "macro_area_um2": 191868582.622412,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 38720.657,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 217,
+            "macro_area_um2_total": 191523272.08196,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 56885248
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 2,
+            "macro_area_um2_total": 345310.540452,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 32768
+          }
+        ],
+        "unused_macro_area_budget_um2": 72719.279001,
+        "write_energy_pj": 135456.344
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    },
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.988327026,
+      "hbm_share_scale_vs_measured_sram": 1.005011792,
+      "placement_efficiency": 0.75,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12582.086691,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "shared_byte_share": 0.011672974,
+      "shared_sram_capacity_mib": 47.8125,
+      "shared_sram_envelope_area_um2": 225688539.122645,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 169359972.265952,
+      "shared_sram_macro_area_um2": 169266404.341984,
+      "shared_sram_pack": {
+        "capacity_bytes": 50135040,
+        "capacity_mib": 47.8125,
+        "macro_area_um2": 169266404.341984,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 34303.225,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 191,
+            "macro_area_um2_total": 168575783.26108,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 50069504
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 4,
+            "macro_area_um2_total": 690621.080904,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 65536
+          }
+        ],
+        "unused_macro_area_budget_um2": 93567.923968,
+        "write_energy_pj": 119499.388
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    },
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.989864349,
+      "hbm_share_scale_vs_measured_sram": 1.006575068,
+      "placement_efficiency": 0.65,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12601.657876,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "shared_byte_share": 0.010135651,
+      "shared_sram_capacity_mib": 41.515625,
+      "shared_sram_envelope_area_um2": 225666992.975855,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 146778642.630492,
+      "shared_sram_macro_area_um2": 146683545.434306,
+      "shared_sram_pack": {
+        "capacity_bytes": 43532288,
+        "capacity_mib": 41.515625,
+        "macro_area_um2": 146683545.434306,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 29567.901,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 166,
+            "macro_area_um2_total": 146510890.16408,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 43515904
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 1,
+            "macro_area_um2_total": 172655.270226,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 16384
+          }
+        ],
+        "unused_macro_area_budget_um2": 95097.196186,
+        "write_energy_pj": 103556.422
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    },
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.991443634,
+      "hbm_share_scale_vs_measured_sram": 1.008181014,
+      "placement_efficiency": 0.55,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12621.763263,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "shared_byte_share": 0.008556366,
+      "shared_sram_capacity_mib": 35.046875,
+      "shared_sram_envelope_area_um2": 225602485.734324,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 124197312.995032,
+      "shared_sram_macro_area_um2": 124081367.153878,
+      "shared_sram_pack": {
+        "capacity_bytes": 36749312,
+        "capacity_mib": 35.046875,
+        "macro_area_um2": 124081367.153878,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 25150.469,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 140,
+            "macro_area_um2_total": 123563401.3432,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 36700160
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 3,
+            "macro_area_um2_total": 517965.810678,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 49152
+          }
+        ],
+        "unused_macro_area_budget_um2": 115945.841154,
+        "write_energy_pj": 87599.466
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    }
+  ],
+  "sram_macro_library": [
+    {
+      "access_time_ns": 1.22148,
+      "area_um2": 882595.7238800001,
+      "bytes_per_um2": 0.2970148086006836,
+      "name": "local_capacity_chunk_02_256kib",
+      "read_energy_pj": 177.523,
+      "size_bytes": 262144,
+      "write_energy_pj": 623.1
+    },
+    {
+      "access_time_ns": 6.39009,
+      "area_um2": 71282253.00800002,
+      "bytes_per_um2": 0.23536315551245401,
+      "name": "local_capacity_chunk_00_16384kib",
+      "read_energy_pj": 3403.82,
+      "size_bytes": 16777216,
+      "write_energy_pj": 4126.839999999999
+    },
+    {
+      "access_time_ns": 2.80412,
+      "area_um2": 9338999.8472,
+      "bytes_per_um2": 0.22455852171673005,
+      "name": "local_capacity_chunk_01_2048kib",
+      "read_energy_pj": 1001.04,
+      "size_bytes": 2097152,
+      "write_energy_pj": 1361.25
+    },
+    {
+      "access_time_ns": 0.389435,
+      "area_um2": 172655.270226,
+      "bytes_per_um2": 0.09489429415362699,
+      "name": "local_capacity_chunk_03_16kib",
+      "read_energy_pj": 99.083,
+      "size_bytes": 16384,
+      "write_energy_pj": 121.822
+    }
+  ],
+  "version": 1
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.md
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.md
@@ -1,0 +1,32 @@
+# Score32 exp-LUT SRAM Hierarchy Envelope
+
+- decision: `score32_exp_lut_sram_hierarchy_envelope_stable`
+- source score32 latency us: `12519.342352`
+- source hbm share: `0.983398438`
+- nominal efficiency: `0.75`
+- nominal shared MiB: `47.8125`
+- nominal hbm share: `0.988327026`
+- conservative efficiency: `0.55`
+- conservative shared MiB: `35.046875`
+- conservative hbm share delta: `0.008045196`
+
+## Sweep
+
+| efficiency | shared MiB | hbm share | projected latency us | shared envelope um2 | fits |
+|---:|---:|---:|---:|---:|---|
+| 1.0 | 63.8125 | 0.984420776 | 12532.357427 | 225752530.670304 | True |
+| 0.85 | 54.28125 | 0.986747742 | 12561.981305 | 225727744.261661 | True |
+| 0.75 | 47.8125 | 0.988327026 | 12582.086691 | 225688539.122645 | True |
+| 0.65 | 41.515625 | 0.989864349 | 12601.657876 | 225666992.975855 | True |
+| 0.55 | 35.046875 | 0.991443634 | 12621.763263 | 225602485.734324 | True |
+
+## Assumptions
+
+- SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.
+- Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.
+- Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.
+- Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited.
+
+## Next Step
+
+- Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.


### PR DESCRIPTION
## Summary
- item_id: `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`
- run_key: `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1_run_3527a58e1b41c4e9`
- layer: `layer2`
- task_type: `l2_campaign`
- status: `ok`
- summary: `2/2 commands succeeded`
- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/evaluated.json`
- metrics_rows_count: `0`
- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json`

## Developer Context
- proposal_id: `prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`
- proposal_path: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json`
- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
- execution_source_commit: `b759c0945ffb23a9f331b41e5d4d714cb58eb9c5`
- review_metadata_source_commit: `b759c0945ffb23a9f331b41e5d4d714cb58eb9c5`

## Evaluation Mode
- evaluation_mode: `frontier_detail`
- abstraction_layer: `decoder_attention_score32_exp_lut_sram_hierarchy_envelope`
- comparison_role: `score32_exp_lut_sram_hierarchy_envelope_audit`
- expected_direction: `record_score32_sram_hierarchy_envelope`
- expected_reason: `The result should bound shared-SRAM capacity and HBM-share sensitivity under explicit macro placement efficiency before choosing the next frontier abstraction.`
- expectation_status: `unspecified`
- evaluation_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`

## Focused Comparison
- primary_question: `Does a physically constrained SRAM macro placement envelope materially change the score32 exp-LUT frontier latency/HBM-share conclusion?`
- comparison_role: `score32_exp_lut_sram_hierarchy_envelope_audit`
- proposal_outcome: `score32_exp_lut_sram_hierarchy_envelope_stable`
- comparison_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_stable; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=47.8125; nominal_hbm_byte_share=0.988327026; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=35.046875; conservative_hbm_byte_share=0.991443634; conservative_hbm_share_delta=0.008045196; conservative_projected_latency_us_hbm_share_scaled=12621.763263; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`
- baseline_ref: `None`
- baseline_item_id: `None`

## Checklist
- [ ] Commit lightweight campaign artifacts only
- [ ] Include metrics row references in result.metrics_rows
- [ ] Keep committed result_path fields repo-portable
- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing
