### PR TITLE
control_plane: add score32 HBM/DRAM service closure

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -567,6 +567,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_exp_lut_service_closure_report",
     ),
     (
+        "attention_score32_exp_lut_hbm_dram_service_closure_out",
+        "attention_score32_exp_lut_hbm_dram_service_closure_report",
+    ),
+    (
         "attention_score32_exp_lut_sram_hierarchy_envelope_out",
         "attention_score32_exp_lut_sram_hierarchy_envelope_report",
     ),
@@ -1321,6 +1325,29 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
                 parts.append(f"{key}={diagnosis_dict.get(key)}")
         if "requires_hbm_dram_closure" in next_step_dict:
             parts.append(f"requires_hbm_dram_closure={next_step_dict.get('requires_hbm_dram_closure')}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            diagnosis_dict.get("decision") or evidence_payload.get("decision") or "score32_exp_lut_hbm_dram_service_closure_recorded"
+        )
+        parts = [
+            f"Decoder score32 exp-LUT HBM/DRAM service-closure evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "best_latency_us",
+            "best_latency_token_throughput_per_s",
+            "best_latency_hbm_energy_mj_per_token",
+            "best_energy_hbm_energy_mj_per_token",
+            "source_score32_latency_us",
+            "source_controller_service_cycles",
+            "remaining_abstractions",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5824,6 +5824,54 @@ def _decoder_attention_score32_exp_lut_service_closure_evidence(*, item_id: str)
     }
 
 
+def _decoder_attention_score32_exp_lut_hbm_dram_service_closure_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_score32_exp_lut_hbm_dram_service_closure__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_exp_lut_hbm_dram_service_closure__{item_id}.md"
+    sram_hierarchy_envelope = (
+        f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__"
+        "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json"
+    )
+    measured_command_control = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+        "measured_command_control_llama7b_v1.json"
+    )
+    hbm_command_calibrated = (
+        f"{base}/decoder_attention_hbm_command_calibrated_service__"
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_score32_exp_lut_sram_hierarchy_envelope": sram_hierarchy_envelope,
+            "attention_score32_exp_lut_measured_command_control": measured_command_control,
+            "attention_hbm_command_calibrated_service": hbm_command_calibrated,
+            "attention_score32_exp_lut_hbm_dram_service_closure_out": out,
+            "attention_score32_exp_lut_hbm_dram_service_closure_report": report,
+            "attention_score32_exp_lut_hbm_dram_service_closure_scope": (
+                "Close score32 exp-LUT HBM/DRAM service accounting by combining the "
+                "score32 SRAM envelope, score32 measured-command-control row, and command-calibrated "
+                "HBM service energy into a best-latency / best-energy frontier."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_score32_exp_lut_hbm_dram_service_closure",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure.py "
+                    f"--score32-sram-envelope-json {sram_hierarchy_envelope} "
+                    f"--score32-measured-command-control-json {measured_command_control} "
+                    f"--hbm-command-calibrated-service-json {hbm_command_calibrated} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__{item_id}.json"
@@ -9334,6 +9382,7 @@ def _build_payload(
         "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
         "decoder_attention_score32_exp_lut_service_closure",
         "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+        "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -9534,6 +9583,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_score32_exp_lut_service_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_exp_lut_sram_hierarchy_envelope":
             decoder_evidence = _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_score32_exp_lut_hbm_dram_service_closure":
+            decoder_evidence = _decoder_attention_score32_exp_lut_hbm_dram_service_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -5351,6 +5351,135 @@ def test_consume_l2_result_score32_exp_lut_service_closure_uses_decoder_evidence
             )
 
 
+def test_consume_l2_result_score32_exp_lut_hbm_dram_service_closure_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_score32_hbm_dram_service_closure_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_score32_hbm_dram_service_closure_v1",
+                        "kind": "architecture",
+                        "title": "Score32 exp-LUT HBM/DRAM service closure",
+                        "direct_comparison": {
+                            "primary_question": "Which frontier points are robust to HBM/DRAM service assumptions?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+                "l2_score32_hbm_dram_service_closure.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+                "l2_score32_hbm_dram_service_closure.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure_v1",
+                        "decision": "score32_exp_lut_hbm_dram_service_closure_compute_dominant",
+                        "diagnosis": {
+                            "best_latency_us": 12034.5123,
+                            "best_latency_token_throughput_per_s": 78.9,
+                            "best_latency_hbm_energy_mj_per_token": 2.34,
+                            "best_energy_hbm_energy_mj_per_token": 3.21,
+                            "source_score32_latency_us": 13567.89,
+                            "source_controller_service_cycles": 9876,
+                            "remaining_abstractions": [
+                                "cycle_accurate_hbm_controller_rtl",
+                                "hbm_vendor_current_signoff",
+                            ],
+                        },
+                        "next_step": {
+                            "requires_cycle_accurate_hbm_controller": True,
+                            "requires_vendor_hbm_current_signoff": True,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# score32 hbm dram service closure\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_score32_hbm_dram_service_closure",
+                campaign_dir_rel="runs/campaigns/npu/score32_hbm_dram_service_closure_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_score32_hbm_dram_service_closure_v1",
+                comparison={"role": "frontier_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "record_score32_hbm_dram_service_closure",
+                "expected_reason": "Use score32 HBM/DRAM service closure evidence to choose the next abstraction.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_score32_exp_lut_hbm_dram_service_closure_out": evidence_rel,
+                    "attention_score32_exp_lut_hbm_dram_service_closure_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "score32_exp_lut_hbm_dram_service_closure_compute_dominant"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert "decision=score32_exp_lut_hbm_dram_service_closure_compute_dominant" in assessment["summary"]
+            assert "best_latency_us=12034.5123" in assessment["summary"]
+            assert "best_latency_token_throughput_per_s=78.9" in assessment["summary"]
+            assert "best_latency_hbm_energy_mj_per_token=2.34" in assessment["summary"]
+            assert "best_energy_hbm_energy_mj_per_token=3.21" in assessment["summary"]
+            assert "source_score32_latency_us=13567.89" in assessment["summary"]
+            assert "source_controller_service_cycles=9876" in assessment["summary"]
+            assert "remaining_abstractions=['cycle_accurate_hbm_controller_rtl', 'hbm_vendor_current_signoff']" in assessment[
+                "summary"
+            ]
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_score32_exp_lut_hbm_dram_service_closure"
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_exp_lut_hbm_dram_service_closure_out"]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_exp_lut_hbm_dram_service_closure_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_score32_exp_lut_sram_hierarchy_envelope_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6690,6 +6690,81 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_service_closur
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_hbm_dram_service_closure_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_exp_lut_hbm_dram_service_closure",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_score32_exp_lut_hbm_dram_service_closure",
+            ]
+            assert "audit_llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure.py" in run
+            assert "--score32-sram-envelope-json" in run
+            assert "--score32-measured-command-control-json" in run
+            assert "--hbm-command-calibrated-service-json" in run
+            assert (
+                "decoder_attention_score32_exp_lut_sram_hierarchy_envelope__"
+                "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json"
+            ) in run
+            assert (
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+                "measured_command_control_llama7b_v1.json"
+            ) in run
+            assert (
+                "decoder_attention_hbm_command_calibrated_service__"
+                "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json"
+            ) in run
+            assert (
+                decoder_inputs["attention_score32_exp_lut_hbm_dram_service_closure_out"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+                "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+            )
+            assert (
+                decoder_inputs["attention_score32_exp_lut_hbm_dram_service_closure_report"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+                "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.md"
+            )
+            assert (
+                decoder_inputs["attention_score32_exp_lut_hbm_dram_service_closure_scope"].startswith(
+                    "Close score32 exp-LUT HBM/DRAM service accounting"
+                )
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+                    "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy_envelope_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -155,11 +155,18 @@ than free or heuristic assumptions.
     merged by PR #1199. It records `score32_supported=True`,
     `wrapper_metrics_match=True`, `latency_us=12519.342352`, and remaining
     abstractions `tile_local_and_shared_sram` plus `hbm_dram_service`.
+  - the SRAM hierarchy envelope audit
+    `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`
+    is merged by PR #1201. It records `score32_exp_lut_sram_hierarchy_envelope_stable`;
+    the conservative placement envelope changes HBM byte share by only
+    `0.008045196` and projects `12621.763263 us`, so the score32 frontier is
+    not materially reranked by SRAM placement efficiency alone.
   - the current immediate follow-on is
-    `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`.
-    It bounds the shared-SRAM CACTI packing assumption with an explicit macro
-    placement-efficiency envelope before deciding whether SRAM hierarchy or
-    HBM/DRAM service should be closed next.
+    `l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1`.
+    It should replace the inherited HBM service abstraction with a
+    score32-specific command/burst/row-hit HBM/DRAM service and calibrated HBM
+    energy account before treating the score32 row as the active Llama7B
+    frontier.
 - New evaluations should continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`, not the devcontainer.
 
@@ -311,9 +318,16 @@ run the already queued exp-LUT branch:
 6. Run
    `l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1`
    to replace the ideal shared-SRAM packing estimate with an explicit SRAM
-   macro placement-efficiency envelope. If the conservative envelope does not
-   materially change HBM byte share or latency, prioritize HBM/DRAM service
-   closure next; otherwise schedule a stronger SRAM macro floorplan study.
+   macro placement-efficiency envelope. This is complete: PR #1201 records a
+   stable score32 frontier under the explicit SRAM macro placement-efficiency
+   envelope.
+7. Run
+   `l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1`
+   to close the inherited HBM/DRAM service abstraction for the score32 exp-LUT
+   row. The job should combine the score32 SRAM envelope, measured
+   command-control row, and command-calibrated HBM pJ terms, then report
+   latency, throughput, HBM energy, compute energy, total energy, and remaining
+   controller/signoff abstractions.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1/analysis_report.md
@@ -1,0 +1,14 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1`
+- `candidate_id`: `l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1`
+
+## Planned Evaluation
+- Consume the merged score32 SRAM hierarchy envelope, measured command-control row, and HBM command-calibrated service result.
+- Sweep a score32-specific channel/burst/row-hit HBM/DRAM service model.
+- Report latency, token throughput, HBM energy, compute energy, total energy, and remaining HBM controller/signoff abstractions.
+
+## Recommendation
+- `pending`
+- reason: source hook and remote evaluator dispatch are still pending.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds the score32 exp-LUT HBM/DRAM service-closure audit hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit score32-specific HBM/DRAM service latency and calibrated HBM energy for the promoted Llama7B attention frontier row.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
+      "comparison_role": "score32_exp_lut_hbm_dram_service_closure_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_hbm_dram_service_closure",
+        "reason": "The result should state whether score32-specific HBM/DRAM service latency or calibrated HBM energy changes the current frontier account before moving to remaining controller/signoff abstractions."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1/proposal.json
@@ -1,0 +1,71 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+  "created_utc": "2026-07-06T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 exp-LUT HBM/DRAM service closure audit",
+  "abstraction_layer": "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
+  "hypothesis": "The promoted score32 exp-LUT Llama7B frontier can keep the current latency ranking after replacing the inherited HBM byte-share abstraction with a score32-specific command/burst/row-hit HBM/DRAM service and calibrated HBM energy account.",
+  "direct_comparison": {
+    "primary_question": "Does score32-specific HBM/DRAM service and calibrated HBM energy materially change the current score32 exp-LUT Llama7B frontier account?",
+    "include": [
+      "consume the merged score32 exp-LUT SRAM hierarchy envelope",
+      "consume the merged score32 exp-LUT measured-command-control row",
+      "consume the merged HBM command-calibrated service energy parameters",
+      "sweep channel count, per-channel bandwidth, burst size, outstanding requests, row-hit rate, row-miss penalty, and scheduler efficiency",
+      "report latency, HBM energy, compute energy, and total energy for the score32 frontier row"
+    ],
+    "exclude": [
+      "new OpenROAD PPA",
+      "new generation-quality evaluation",
+      "cycle-accurate HBM controller RTL",
+      "vendor HBM current signoff",
+      "new SRAM macro floorplan PnR"
+    ]
+  },
+  "expected_benefit": [
+    "prevents accidental reuse of older softmax-era HBM service rows for the score32 frontier",
+    "bounds whether HBM service latency can rerank the current score32 exp-LUT point",
+    "records the calibrated HBM energy contribution beside measured score32 compute energy"
+  ],
+  "risks": [
+    "the service model is still command/burst/row-hit accounting rather than controller RTL",
+    "HBM energy uses calibrated public/reference pJ terms rather than vendor signoff current traces",
+    "SRAM macro placement remains an envelope unless a follow-on floorplan PnR job is run"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit score32-specific HBM/DRAM service latency and calibrated HBM energy for the promoted Llama7B attention frontier row.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
+      "comparison_role": "score32_exp_lut_hbm_dram_service_closure_audit",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_hbm_dram_service_closure",
+        "reason": "The result should state whether score32-specific HBM/DRAM service latency or calibrated HBM energy changes the current frontier account before moving to remaining controller/signoff abstractions."
+      },
+      "status": "pending"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_hbm_command_calibrated_service__l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure.py",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1/proposal.json"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Close score32 exp-LUT HBM/DRAM service accounting for the Llama7B frontier row."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_dict(value: Any) -> JsonDict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _float_list(value: str) -> list[float]:
+    out = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not out or any(item <= 0.0 for item in out):
+        raise argparse.ArgumentTypeError("expected comma-separated positive floats")
+    return out
+
+
+def _int_list(value: str) -> list[int]:
+    out = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not out or any(item <= 0 for item in out):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return out
+
+
+def _ceil_div(numerator: int | float, denominator: int | float) -> int:
+    if numerator <= 0:
+        return 0
+    return int(math.ceil(float(numerator) / max(1.0, float(denominator))))
+
+
+def _source_score32_row(measured_command_control: JsonDict) -> JsonDict:
+    for key in ("best_requested", "best_feasible", "best_area_fit", "best"):
+        row = measured_command_control.get(key)
+        if isinstance(row, dict):
+            return dict(row)
+    return {}
+
+
+def _require_source_score32_row(measured_command_control: JsonDict) -> JsonDict:
+    row = _source_score32_row(measured_command_control)
+    required = (
+        "onchip_full_tile_bytes",
+        "tile_count",
+        "layers",
+        "clock_ns",
+        "replica_recost_latency_us",
+        "tile_hbm_cycles",
+        "replica_recost_tile_service_cycles",
+    )
+    missing = [key for key in required if key not in row]
+    if missing:
+        raise ValueError(f"score32 measured-command-control row is missing required fields: {missing}")
+    return row
+
+
+def _calibrated_hbm_energy_params(command_calibrated: JsonDict) -> JsonDict:
+    best = _as_dict(command_calibrated.get("best"))
+    energy = _as_dict(best.get("hbm_command_calibrated_energy"))
+    dram = _as_dict(best.get("hbm_dram_energy"))
+    return {
+        "read_hit_pj_per_byte": float(
+            energy.get("read_hit_pj_per_byte", dram.get("read_hit_pj_per_byte", 0.0)) or 0.0
+        ),
+        "read_miss_pj_per_byte": float(
+            energy.get("read_miss_pj_per_byte", dram.get("read_miss_pj_per_byte", 0.0)) or 0.0
+        ),
+        "write_pj_per_byte": float(energy.get("write_pj_per_byte", dram.get("write_pj_per_byte", 0.0)) or 0.0),
+        "activate_precharge_pj_per_row": float(
+            energy.get("activate_precharge_pj_per_row", dram.get("activate_precharge_pj_per_row", 0.0)) or 0.0
+        ),
+        "command_pj_per_burst": float(
+            energy.get("command_pj_per_burst", dram.get("command_pj_per_burst", 0.0)) or 0.0
+        ),
+        "source": "hbm_command_calibrated_service",
+    }
+
+
+def _hbm_service(
+    *,
+    tile_hbm_bytes: float,
+    channel_count: int,
+    channel_bandwidth_bytes_per_cycle: float,
+    burst_bytes: int,
+    outstanding: int,
+    request_overhead_cycles: int,
+    row_hit_rate: float,
+    row_miss_penalty_cycles: int,
+    scheduler_efficiency: float,
+) -> JsonDict:
+    payload_bw = channel_count * channel_bandwidth_bytes_per_cycle * scheduler_efficiency
+    payload_cycles = _ceil_div(tile_hbm_bytes, payload_bw)
+    burst_count = _ceil_div(tile_hbm_bytes, burst_bytes)
+    row_miss_count = int(math.ceil(burst_count * max(0.0, 1.0 - row_hit_rate)))
+    overhead_cycles = _ceil_div(burst_count, outstanding) * request_overhead_cycles
+    row_miss_cycles = _ceil_div(row_miss_count, outstanding) * row_miss_penalty_cycles
+    controller_service_cycles = max(1, payload_cycles + overhead_cycles + row_miss_cycles)
+    return {
+        "tile_hbm_bytes": int(math.ceil(tile_hbm_bytes)),
+        "payload_hbm_bytes_per_cycle": round(payload_bw, 6),
+        "payload_cycles": payload_cycles,
+        "burst_count": burst_count,
+        "row_miss_count": row_miss_count,
+        "overhead_cycles": overhead_cycles,
+        "row_miss_cycles": row_miss_cycles,
+        "controller_service_cycles": controller_service_cycles,
+        "effective_hbm_bytes_per_cycle": round(tile_hbm_bytes / controller_service_cycles, 6),
+    }
+
+
+def _hbm_energy(
+    *,
+    tile_hbm_bytes: float,
+    service: JsonDict,
+    params: JsonDict,
+    source_row: JsonDict,
+) -> JsonDict:
+    layers = int(source_row.get("layers", 32) or 32)
+    tile_count = int(source_row.get("tile_count", 128) or 128)
+    hidden_size = int(source_row.get("hidden_size", 4096) or 4096)
+    attention_heads = int(source_row.get("attention_heads", 32) or 32)
+    kv_heads = int(source_row.get("kv_heads", 4) or 4)
+    kv_bits = int(source_row.get("kv_bits", 8) or 8)
+    head_dim = max(1, hidden_size // max(1, attention_heads))
+    row_hit_rate = float(service["row_hit_rate"])
+    read_bytes_per_token = tile_hbm_bytes * tile_count * layers
+    write_bytes_per_token = float(2 * kv_heads * head_dim * kv_bits // 8 * layers)
+    hit_read = read_bytes_per_token * row_hit_rate
+    miss_read = read_bytes_per_token - hit_read
+    burst_bytes = max(1.0, float(service["burst_bytes"]))
+    burst_count = math.ceil((read_bytes_per_token + write_bytes_per_token) / burst_bytes)
+    miss_rows = math.ceil(miss_read / burst_bytes)
+    read_hit_pj = hit_read * float(params["read_hit_pj_per_byte"])
+    read_miss_pj = miss_read * float(params["read_miss_pj_per_byte"])
+    write_pj = write_bytes_per_token * float(params["write_pj_per_byte"])
+    activate_pj = miss_rows * float(params["activate_precharge_pj_per_row"])
+    command_pj = burst_count * float(params["command_pj_per_burst"])
+    energy_pj = read_hit_pj + read_miss_pj + write_pj + activate_pj + command_pj
+    return {
+        "energy_mj": round(energy_pj / 1.0e9, 9),
+        "energy_pj": round(energy_pj, 6),
+        "read_bytes_per_token": int(math.ceil(read_bytes_per_token)),
+        "write_bytes_per_token": int(math.ceil(write_bytes_per_token)),
+        "kv_write_model": {
+            "layers": layers,
+            "hidden_size": hidden_size,
+            "attention_heads": attention_heads,
+            "kv_heads": kv_heads,
+            "head_dim": head_dim,
+            "kv_bits": kv_bits,
+        },
+        "burst_count_per_token": burst_count,
+        "miss_row_count_per_token": miss_rows,
+        "read_hit_pj": round(read_hit_pj, 6),
+        "read_miss_pj": round(read_miss_pj, 6),
+        "write_pj": round(write_pj, 6),
+        "activate_precharge_pj": round(activate_pj, 6),
+        "command_pj": round(command_pj, 6),
+        **params,
+    }
+
+
+def _row_latency(
+    *,
+    source_row: JsonDict,
+    envelope_row: JsonDict,
+    service: JsonDict,
+) -> JsonDict:
+    source_latency = float(envelope_row["projected_latency_us_hbm_share_scaled"])
+    source_tile_hbm_cycles = int(source_row.get("tile_hbm_cycles") or source_row.get("controller_service_cycles") or 0)
+    tile_service_cycles = int(
+        source_row.get("replica_recost_tile_service_cycles") or source_row.get("tile_service_cycles") or 1
+    )
+    controller_cycles = int(service["controller_service_cycles"])
+    hbm_excess_cycles = max(0, controller_cycles - max(source_tile_hbm_cycles, tile_service_cycles))
+    tile_waves = int(source_row.get("tile_waves", 1) or 1)
+    layers = int(source_row.get("layers", 32) or 32)
+    clock_ns = float(source_row.get("clock_ns", 1.0) or 1.0)
+    added_latency_us = hbm_excess_cycles * tile_waves * layers * clock_ns / 1000.0
+    latency_us = source_latency + added_latency_us
+    return {
+        "source_latency_us": round(source_latency, 6),
+        "latency_us": round(latency_us, 6),
+        "token_throughput_per_s": round(1_000_000.0 / latency_us, 9) if latency_us > 0.0 else None,
+        "source_tile_hbm_cycles": source_tile_hbm_cycles,
+        "tile_service_cycles": tile_service_cycles,
+        "hbm_excess_cycles_per_wave": hbm_excess_cycles,
+        "hbm_added_latency_us": round(added_latency_us, 6),
+        "hbm_dominates_tile": controller_cycles > tile_service_cycles,
+    }
+
+
+def _build_row(
+    *,
+    envelope_row: JsonDict,
+    source_row: JsonDict,
+    energy_params: JsonDict,
+    channel_count: int,
+    channel_bw: float,
+    burst_bytes: int,
+    outstanding: int,
+    request_overhead: int,
+    row_hit_rate: float,
+    row_miss_penalty: int,
+    scheduler_efficiency: float,
+) -> JsonDict:
+    full_tile_bytes = int(source_row.get("onchip_full_tile_bytes", 1048576) or 1048576)
+    tile_hbm_bytes = full_tile_bytes * float(envelope_row["hbm_byte_share"])
+    service = _hbm_service(
+        tile_hbm_bytes=tile_hbm_bytes,
+        channel_count=channel_count,
+        channel_bandwidth_bytes_per_cycle=channel_bw,
+        burst_bytes=burst_bytes,
+        outstanding=outstanding,
+        request_overhead_cycles=request_overhead,
+        row_hit_rate=row_hit_rate,
+        row_miss_penalty_cycles=row_miss_penalty,
+        scheduler_efficiency=scheduler_efficiency,
+    )
+    service.update(
+        {
+            "channel_count": channel_count,
+            "channel_bandwidth_bytes_per_cycle": channel_bw,
+            "burst_bytes": burst_bytes,
+            "hbm_outstanding": outstanding,
+            "request_overhead_cycles": request_overhead,
+            "row_hit_rate": row_hit_rate,
+            "row_miss_penalty_cycles": row_miss_penalty,
+            "scheduler_efficiency": scheduler_efficiency,
+        }
+    )
+    latency = _row_latency(source_row=source_row, envelope_row=envelope_row, service=service)
+    energy = _hbm_energy(
+        tile_hbm_bytes=tile_hbm_bytes,
+        service=service,
+        params=energy_params,
+        source_row=source_row,
+    )
+    compute_power_mw = float(
+        source_row.get("substituted_compute_plus_control_power_mw")
+        or source_row.get("substituted_compute_power_mw")
+        or source_row.get("replica_recost_compute_power_mw")
+        or source_row.get("compute_power_mw")
+        or 0.0
+    )
+    compute_energy_mj = compute_power_mw * float(latency["latency_us"]) * 1.0e-6
+    total_energy_mj = compute_energy_mj + float(energy["energy_mj"])
+    return {
+        "placement_efficiency": envelope_row["placement_efficiency"],
+        "shared_sram_capacity_mib": envelope_row["shared_sram_capacity_mib"],
+        "hbm_byte_share": envelope_row["hbm_byte_share"],
+        "precision_profile": "score32_exp_lut_div",
+        "macs_per_cycle": source_row.get("replica_recost_macs_per_cycle") or source_row.get("macs_per_cycle"),
+        "hbm_service_model": "channel_burst_row_window_score32_v1",
+        **latency,
+        "hbm_service": service,
+        "hbm_command_calibrated_energy": energy,
+        "hbm_energy_mj_per_token": energy["energy_mj"],
+        "compute_power_mw": round(compute_power_mw, 6),
+        "compute_energy_mj_per_token": round(compute_energy_mj, 9),
+        "total_energy_mj_per_token": round(total_energy_mj, 9),
+        "remaining_abstractions": [
+            "HBM/DRAM service is command/burst/row-hit accounting, not cycle-accurate controller RTL.",
+            "HBM energy uses calibrated command-class pJ values, not vendor signoff current traces.",
+        ],
+    }
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    sram_envelope = _load_json(args.score32_sram_envelope_json)
+    measured_command = _load_json(args.score32_measured_command_control_json)
+    command_calibrated = _load_json(args.hbm_command_calibrated_service_json)
+    source_row = _require_source_score32_row(measured_command)
+    energy_params = _calibrated_hbm_energy_params(command_calibrated)
+    envelope_rows = list(sram_envelope.get("rows") or [])[: args.frontier_row_limit]
+    if not envelope_rows:
+        raise ValueError("score32 SRAM envelope contains no rows")
+    rows: list[JsonDict] = []
+    for envelope_row in envelope_rows:
+        for channel_count in args.channel_count:
+            for channel_bw in args.channel_bandwidth_bytes_per_cycle:
+                for burst_bytes in args.burst_bytes:
+                    for outstanding in args.hbm_outstanding:
+                        for request_overhead in args.request_overhead_cycles:
+                            for row_hit_rate in args.row_hit_rate:
+                                for row_miss_penalty in args.row_miss_penalty_cycles:
+                                    for scheduler_efficiency in args.scheduler_efficiency:
+                                        rows.append(
+                                            _build_row(
+                                                envelope_row=envelope_row,
+                                                source_row=source_row,
+                                                energy_params=energy_params,
+                                                channel_count=channel_count,
+                                                channel_bw=channel_bw,
+                                                burst_bytes=burst_bytes,
+                                                outstanding=outstanding,
+                                                request_overhead=request_overhead,
+                                                row_hit_rate=row_hit_rate,
+                                                row_miss_penalty=row_miss_penalty,
+                                                scheduler_efficiency=scheduler_efficiency,
+                                            )
+                                        )
+    rows_sorted = sorted(rows, key=lambda row: (float(row["latency_us"]), float(row["total_energy_mj_per_token"])))
+    best_latency = rows_sorted[0]
+    best_energy = min(rows, key=lambda row: (float(row["total_energy_mj_per_token"]), float(row["latency_us"])))
+    hbm_dominant_count = sum(1 for row in rows if row["hbm_dominates_tile"])
+    decision = (
+        "score32_exp_lut_hbm_dram_service_closure_compute_dominant"
+        if hbm_dominant_count == 0
+        else "score32_exp_lut_hbm_dram_service_closure_hbm_sensitive"
+    )
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure_v1",
+        "decision": decision,
+        "inputs": {
+            "score32_sram_envelope_json": str(args.score32_sram_envelope_json),
+            "score32_measured_command_control_json": str(args.score32_measured_command_control_json),
+            "hbm_command_calibrated_service_json": str(args.hbm_command_calibrated_service_json),
+        },
+        "diagnosis": {
+            "best_latency_us": best_latency["latency_us"],
+            "best_latency_token_throughput_per_s": best_latency["token_throughput_per_s"],
+            "best_latency_hbm_energy_mj_per_token": best_latency["hbm_energy_mj_per_token"],
+            "best_latency_compute_energy_mj_per_token": best_latency["compute_energy_mj_per_token"],
+            "best_latency_total_energy_mj_per_token": best_latency["total_energy_mj_per_token"],
+            "best_energy_us": best_energy["latency_us"],
+            "best_energy_token_throughput_per_s": best_energy["token_throughput_per_s"],
+            "best_energy_hbm_energy_mj_per_token": best_energy["hbm_energy_mj_per_token"],
+            "best_energy_compute_energy_mj_per_token": best_energy["compute_energy_mj_per_token"],
+            "best_energy_total_energy_mj_per_token": best_energy["total_energy_mj_per_token"],
+            "hbm_dominant_row_count": hbm_dominant_count,
+            "row_count": len(rows),
+            "source_score32_latency_us": source_row.get("replica_recost_latency_us")
+            or source_row.get("adjusted_latency_us_if_feasible"),
+            "source_controller_service_cycles": source_row.get("controller_service_cycles")
+            or source_row.get("tile_hbm_cycles"),
+            "source_tile_service_cycles": source_row.get("replica_recost_tile_service_cycles")
+            or source_row.get("tile_service_cycles"),
+            "precision_profile": "score32_exp_lut_div",
+            "remaining_abstractions": ["cycle_accurate_hbm_controller_rtl", "hbm_vendor_current_signoff"],
+        },
+        "best_latency": best_latency,
+        "best_energy": best_energy,
+        "top_rows": rows_sorted[: args.top_k],
+        "energy_params": energy_params,
+        "assumptions": [
+            "The score32 exp-LUT compute/datapath, command control, SRAM envelope, and precision evidence are inherited from merged score32 results.",
+            "HBM service is modeled with channel count, per-channel bytes/cycle, burst size, outstanding window, row-hit rate, and scheduler efficiency.",
+            "HBM energy uses the existing command-calibrated pJ parameters from the design registry calibration chain.",
+            "This is not a cycle-accurate HBM/DRAM controller RTL simulation or vendor current signoff.",
+        ],
+        "next_step": {
+            "requires_cycle_accurate_hbm_controller": True,
+            "requires_vendor_hbm_current_signoff": True,
+            "recommended_next_step": (
+                "Use this score32 HBM/DRAM service closure as the current frontier account; "
+                "next close either HBM controller RTL/timing or aggregate full-token energy ranking."
+            ),
+        },
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    diagnosis = payload["diagnosis"]
+    best = payload["best_latency"]
+    lines = [
+        "# Score32 exp-LUT HBM/DRAM Service Closure",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- best latency us: `{diagnosis['best_latency_us']}`",
+        f"- best throughput token/s: `{diagnosis['best_latency_token_throughput_per_s']}`",
+        f"- best latency HBM energy mJ/token: `{diagnosis['best_latency_hbm_energy_mj_per_token']}`",
+        f"- best latency total energy mJ/token: `{diagnosis['best_latency_total_energy_mj_per_token']}`",
+        f"- HBM-dominant rows: `{diagnosis['hbm_dominant_row_count']}` / `{diagnosis['row_count']}`",
+        "",
+        "## Best Latency",
+        "",
+        "| latency us | token/s | HBM energy mJ | total energy mJ | hbm share | efficiency | "
+        "channels | ch B/cyc | burst | outstanding | row hit | sched | service cyc |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| {latency_us} | {token_throughput_per_s} | {hbm_energy_mj_per_token} | {total_energy_mj_per_token} | {hbm_byte_share} | "
+        "{placement_efficiency} | {channel_count} | {channel_bandwidth_bytes_per_cycle} | {burst_bytes} | "
+        "{hbm_outstanding} | {row_hit_rate} | {scheduler_efficiency} | {controller_service_cycles} |".format(
+            channel_count=best["hbm_service"]["channel_count"],
+            channel_bandwidth_bytes_per_cycle=best["hbm_service"]["channel_bandwidth_bytes_per_cycle"],
+            burst_bytes=best["hbm_service"]["burst_bytes"],
+            hbm_outstanding=best["hbm_service"]["hbm_outstanding"],
+            row_hit_rate=best["hbm_service"]["row_hit_rate"],
+            scheduler_efficiency=best["hbm_service"]["scheduler_efficiency"],
+            controller_service_cycles=best["hbm_service"]["controller_service_cycles"],
+            **best,
+        ),
+        "",
+        "## Assumptions",
+        "",
+    ]
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--score32-sram-envelope-json", type=Path, required=True)
+    parser.add_argument("--score32-measured-command-control-json", type=Path, required=True)
+    parser.add_argument("--hbm-command-calibrated-service-json", type=Path, required=True)
+    parser.add_argument("--frontier-row-limit", type=int, default=5)
+    parser.add_argument("--channel-count", type=_int_list, default=[4, 8, 16])
+    parser.add_argument("--channel-bandwidth-bytes-per-cycle", type=_float_list, default=[256, 512, 1024])
+    parser.add_argument("--burst-bytes", type=_int_list, default=[256, 512, 1024])
+    parser.add_argument("--hbm-outstanding", type=_int_list, default=[4, 8, 16, 32])
+    parser.add_argument("--request-overhead-cycles", type=_int_list, default=[2, 4, 8])
+    parser.add_argument("--row-hit-rate", type=_float_list, default=[0.5, 0.75, 0.9])
+    parser.add_argument("--row-miss-penalty-cycles", type=_int_list, default=[8, 16, 32])
+    parser.add_argument("--scheduler-efficiency", type=_float_list, default=[0.6, 0.75, 0.9])
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "decision": payload["decision"], "out": str(args.out)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add score32 exp-LUT HBM/DRAM service-closure audit using SRAM envelope, measured command-control, and command-calibrated HBM service inputs
- wire the new decoder evidence layer through L2 task generation and result consumption
- add proposal records and update the Llama7B abstraction-closure plan

## Validation
- PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_score32_exp_lut_hbm_dram_service_closure_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_score32_exp_lut_hbm_dram_service_closure_uses_decoder_evidence
- PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 tests/test_runs_parsers.py
- python3 -m py_compile npu/eval/audit_llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure.py