### PR TITLE
control_plane: add score32 integrated frontier ranking

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -571,6 +571,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_exp_lut_hbm_dram_service_closure_report",
     ),
     (
+        "attention_score32_integrated_frontier_ranking_out",
+        "attention_score32_integrated_frontier_ranking_report",
+    ),
+    (
         "attention_score32_exp_lut_sram_hierarchy_envelope_out",
         "attention_score32_exp_lut_sram_hierarchy_envelope_report",
     ),
@@ -1344,6 +1348,33 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "best_energy_hbm_energy_mj_per_token",
             "source_score32_latency_us",
             "source_controller_service_cycles",
+            "remaining_abstractions",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_score32_integrated_frontier_ranking_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            diagnosis_dict.get("decision")
+            or evidence_payload.get("decision")
+            or "score32_integrated_frontier_ranking_recorded"
+        )
+        parts = [
+            f"Decoder score32 integrated frontier ranking recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "best_latency_candidate",
+            "best_energy_candidate",
+            "best_precision_safe_candidate",
+            "score32_latency_us",
+            "score32_total_energy_mj_per_token",
+            "score32_die_area_mm2",
+            "score32_quality_status",
+            "current_recommended_candidate",
             "remaining_abstractions",
         ):
             if key in diagnosis_dict:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5872,6 +5872,73 @@ def _decoder_attention_score32_exp_lut_hbm_dram_service_closure_evidence(*, item
     }
 
 
+def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_score32_integrated_frontier_ranking__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_integrated_frontier_ranking__{item_id}.md"
+    score32_hbm = (
+        f"{base}/decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+    )
+    measured_command_control = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+        "measured_command_control_llama7b_v1.json"
+    )
+    score32_quality = (
+        f"{base}/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+    )
+    measured_compute = (
+        f"{base}/decoder_attention_measured_compute_energy_closure__"
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json"
+    )
+    mixed_int8 = (
+        f"{base}/decoder_attention_mixed_int8_energy_closure__"
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json"
+    )
+    integrated_energy = (
+        f"{base}/decoder_attention_integrated_energy_closure__"
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
+    )
+    return {
+        "inputs": {
+            "attention_score32_exp_lut_hbm_dram_service_closure": score32_hbm,
+            "attention_score32_exp_lut_measured_command_control": measured_command_control,
+            "attention_score32_exp_lut_generation_quality": score32_quality,
+            "attention_measured_compute_energy_closure": measured_compute,
+            "attention_mixed_int8_energy_closure": mixed_int8,
+            "attention_integrated_energy_closure": integrated_energy,
+            "attention_score32_integrated_frontier_ranking_out": out,
+            "attention_score32_integrated_frontier_ranking_report": report,
+            "attention_score32_integrated_frontier_ranking_scope": (
+                "Rank the closed score32 exp-LUT Llama7B attention row against prior integrated, "
+                "measured-compute, and mixed/int8 energy evidence. Report latency, energy, area, "
+                "precision status, promotability, and remaining abstractions without promoting "
+                "planning-only or quality-unclosed rows."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_score32_integrated_frontier_ranking",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py "
+                    f"--score32-hbm-dram-service-json {score32_hbm} "
+                    f"--score32-measured-command-control-json {measured_command_control} "
+                    f"--score32-quality-json {score32_quality} "
+                    f"--measured-compute-energy-json {measured_compute} "
+                    f"--mixed-int8-energy-json {mixed_int8} "
+                    f"--integrated-energy-json {integrated_energy} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__{item_id}.json"
@@ -9383,6 +9450,7 @@ def _build_payload(
         "decoder_attention_score32_exp_lut_service_closure",
         "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
         "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
+        "decoder_attention_score32_integrated_frontier_ranking",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -9585,6 +9653,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_exp_lut_hbm_dram_service_closure":
             decoder_evidence = _decoder_attention_score32_exp_lut_hbm_dram_service_closure_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_score32_integrated_frontier_ranking":
+            decoder_evidence = _decoder_attention_score32_integrated_frontier_ranking_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -5480,6 +5480,136 @@ def test_consume_l2_result_score32_exp_lut_hbm_dram_service_closure_uses_decoder
             )
 
 
+def test_consume_l2_result_score32_integrated_frontier_ranking_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_score32_integrated_frontier_ranking_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_score32_integrated_frontier_ranking_v1",
+                        "kind": "architecture",
+                        "title": "Score32 integrated frontier ranking",
+                        "direct_comparison": {
+                            "primary_question": "Which candidate is the current precision-safe frontier?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_integrated_frontier_ranking__"
+                "l2_score32_integrated_frontier_ranking.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_integrated_frontier_ranking__"
+                "l2_score32_integrated_frontier_ranking.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_score32_integrated_frontier_ranking_v1",
+                        "decision": "score32_integrated_frontier_best_precision_safe_throughput",
+                        "diagnosis": {
+                            "best_latency_candidate": "abstract_planning_only",
+                            "best_energy_candidate": "abstract_planning_only",
+                            "best_precision_safe_candidate": "score32_exp_lut_hbm_dram_service_closure_best",
+                            "score32_latency_us": 12532.357427,
+                            "score32_total_energy_mj_per_token": 494.831007886,
+                            "score32_die_area_mm2": 800.0,
+                            "score32_quality_status": "mixed_int8_generation_quality_pass",
+                            "current_recommended_candidate": "score32_exp_lut_hbm_dram_service_closure_best",
+                            "remaining_abstractions": [
+                                "cycle_accurate_hbm_controller_rtl",
+                                "hbm_vendor_current_signoff",
+                            ],
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# score32 integrated frontier ranking\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_score32_integrated_frontier_ranking",
+                campaign_dir_rel="runs/campaigns/npu/score32_integrated_frontier_ranking_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_score32_integrated_frontier_ranking_v1",
+                comparison={"role": "frontier_ranking"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "record_score32_integrated_frontier_ranking",
+                "expected_reason": "Rank score32 against current Llama7B frontier alternatives.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_score32_integrated_frontier_ranking",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_score32_integrated_frontier_ranking_out": evidence_rel,
+                    "attention_score32_integrated_frontier_ranking_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "score32_integrated_frontier_best_precision_safe_throughput"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert "best_latency_candidate=abstract_planning_only" in assessment["summary"]
+            assert "best_energy_candidate=abstract_planning_only" in assessment["summary"]
+            assert (
+                "best_precision_safe_candidate=score32_exp_lut_hbm_dram_service_closure_best"
+                in assessment["summary"]
+            )
+            assert "score32_latency_us=12532.357427" in assessment["summary"]
+            assert "score32_total_energy_mj_per_token=494.831007886" in assessment["summary"]
+            assert "score32_die_area_mm2=800.0" in assessment["summary"]
+            assert "score32_quality_status=mixed_int8_generation_quality_pass" in assessment["summary"]
+            assert "current_recommended_candidate=score32_exp_lut_hbm_dram_service_closure_best" in assessment[
+                "summary"
+            ]
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_score32_integrated_frontier_ranking"
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_integrated_frontier_ranking_out"]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_integrated_frontier_ranking_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_score32_exp_lut_sram_hierarchy_envelope_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6765,6 +6765,73 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_hbm_dram_servi
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_integrated_frontier_ranking_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_integrated_frontier_ranking",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_score32_integrated_frontier_ranking",
+            ]
+            assert "audit_llm_decoder_attention_score32_integrated_frontier_ranking.py" in run
+            assert "--score32-hbm-dram-service-json" in run
+            assert "--score32-measured-command-control-json" in run
+            assert "--score32-quality-json" in run
+            assert "--measured-compute-energy-json" in run
+            assert "--mixed-int8-energy-json" in run
+            assert "--integrated-energy-json" in run
+            assert (
+                "decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+                "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+            ) in run
+            assert (
+                "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+            ) in run
+            assert (
+                decoder_inputs["attention_score32_integrated_frontier_ranking_out"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_integrated_frontier_ranking__"
+                "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1.json"
+            )
+            assert (
+                decoder_inputs["attention_score32_integrated_frontier_ranking_scope"].startswith(
+                    "Rank the closed score32 exp-LUT Llama7B attention row"
+                )
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_integrated_frontier_ranking__"
+                    "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy_envelope_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -161,12 +161,19 @@ than free or heuristic assumptions.
     the conservative placement envelope changes HBM byte share by only
     `0.008045196` and projects `12621.763263 us`, so the score32 frontier is
     not materially reranked by SRAM placement efficiency alone.
+  - the score32 HBM/DRAM service closure
+    `l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1`
+    is merged by PR #1203. It records
+    `score32_exp_lut_hbm_dram_service_closure_hbm_sensitive`, best latency
+    `12532.357427 us/token`, throughput `79.793447149 token/s`, HBM energy
+    `134.280615241 mJ/token`, compute energy `360.550392645 mJ/token`, and
+    total energy `494.831007886 mJ/token`. Remaining abstractions are
+    cycle-accurate HBM controller RTL and vendor HBM current signoff.
   - the current immediate follow-on is
-    `l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1`.
-    It should replace the inherited HBM service abstraction with a
-    score32-specific command/burst/row-hit HBM/DRAM service and calibrated HBM
-    energy account before treating the score32 row as the active Llama7B
-    frontier.
+    `l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1`.
+    It should compare the newly closed score32 row against measured exact-FP16,
+    mixed/int8, and older integrated rows across throughput, energy, area, and
+    precision status before selecting the next architecture-improvement target.
 - New evaluations should continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`, not the devcontainer.
 
@@ -327,7 +334,15 @@ run the already queued exp-LUT branch:
    row. The job should combine the score32 SRAM envelope, measured
    command-control row, and command-calibrated HBM pJ terms, then report
    latency, throughput, HBM energy, compute energy, total energy, and remaining
-   controller/signoff abstractions.
+   controller/signoff abstractions. This is complete: PR #1203 records the
+   score32 row as HBM-sensitive but keeps the same latency-scale frontier.
+8. Run
+   `l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1` to
+   rank the closed score32 row against the prior integrated, measured
+   exact-FP16, and mixed/int8 evidence. The result should explicitly distinguish
+   promotable precision-safe rows from planning-only or quality-unclosed rows,
+   then identify the current throughput frontier, energy reference, and next
+   architecture target.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1/analysis_report.md
@@ -1,0 +1,14 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1`
+- `candidate_id`: `l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1`
+
+## Planned Evaluation
+- Compare the closed score32 exp-LUT row with prior integrated, measured exact-FP16, and mixed/int8 evidence.
+- Report promotable latency and energy rankings with area, precision status, and remaining abstractions.
+- Exclude planning-only and quality-unclosed rows from promotion while keeping them visible for context.
+
+## Recommendation
+- `pending`
+- reason: source hook and remote evaluator dispatch are still pending.

--- a/docs/proposals/prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,30 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds the score32 integrated frontier-ranking audit hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rank the closed score32 exp-LUT Llama7B attention row against current integrated, measured-compute, and mixed/int8 frontier evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_integrated_frontier_ranking",
+        "reason": "The result should identify the current promotable throughput and energy frontier candidates while explicitly excluding abstract or quality-unclosed rows from promotion."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1/proposal.json
@@ -1,0 +1,78 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
+  "created_utc": "2026-07-06T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 integrated Llama7B frontier ranking",
+  "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+  "hypothesis": "After score32 exp-LUT HBM/DRAM service closure, the score32 row is the current precision-safe throughput frontier, while measured exact-FP16 remains the energy reference; non-quality-backed and abstract rows must remain visible but excluded from promotion.",
+  "direct_comparison": {
+    "primary_question": "Which Llama7B attention candidate is currently best when latency, energy, area, and precision evidence are compared together?",
+    "include": [
+      "consume the merged score32 exp-LUT HBM/DRAM service closure",
+      "consume the score32 measured command-control row and bounded generation-quality gate",
+      "consume measured exact-FP16 compute-energy closure",
+      "consume mixed/int8 energy closure as a non-promotable latency candidate",
+      "consume older integrated-energy closure as planning-only evidence",
+      "report promotable latency rank, promotable energy rank, area, precision status, and remaining abstractions"
+    ],
+    "exclude": [
+      "new OpenROAD PPA",
+      "new generation-quality evaluation",
+      "new HBM controller RTL",
+      "new SRAM macro floorplan PnR",
+      "scalarizing latency, energy, area, and precision into one opaque score"
+    ]
+  },
+  "expected_benefit": [
+    "turns the recent component-closure chain into a directly inspectable architecture ranking",
+    "prevents abstract or quality-unclosed rows from being mistaken for promotable frontier points",
+    "identifies whether the next useful work is score32 energy reduction or lower-precision quality closure"
+  ],
+  "risks": [
+    "the audit ranks existing evidence only and does not synthesize new circuits",
+    "remaining HBM vendor-current and cycle-accurate controller abstractions are reported but not closed",
+    "the ranking depends on the bounded generation-quality gate rather than a full task-suite accuracy study"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rank the closed score32 exp-LUT Llama7B attention row against current integrated, measured-compute, and mixed/int8 frontier evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_integrated_frontier_ranking",
+        "reason": "The result should identify the current promotable throughput and energy frontier candidates while explicitly excluding abstract or quality-unclosed rows from promotion."
+      },
+      "status": "pending"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_measured_compute_energy_closure_llama7b_v1/proposal.json"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Rank the closed score32 Llama7B attention row against prior frontier evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_dict(value: Any) -> JsonDict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _quality_status(score32_quality: JsonDict) -> JsonDict:
+    decision = score32_quality.get("decision")
+    decision_dict = _as_dict(decision)
+    best = _as_dict(score32_quality.get("best_candidate"))
+    status = str(decision_dict.get("status") or best.get("decision_status") or "unknown")
+    return {
+        "status": status,
+        "candidate_id": best.get("candidate_id"),
+        "teacher_forced_nll_delta_mean": best.get("teacher_forced_nll_delta_mean"),
+        "free_running_match_rate": best.get("free_running_match_rate"),
+        "candidate_probability_assigned_to_reference_token_mean": best.get(
+            "candidate_probability_assigned_to_reference_token_mean"
+        ),
+        "quality_backed": status.endswith("_pass"),
+    }
+
+
+def _score32_row(score32_hbm: JsonDict, measured_command: JsonDict, score32_quality: JsonDict) -> JsonDict:
+    best = _as_dict(score32_hbm.get("best_latency"))
+    measured = _as_dict(measured_command.get("best_requested"))
+    quality = _quality_status(score32_quality)
+    return {
+        "candidate_id": "score32_exp_lut_hbm_dram_service_closure_best",
+        "family": "score32_exp_lut_div",
+        "source_artifact": "score32_hbm_dram_service_closure",
+        "latency_us": _as_float(best.get("latency_us")),
+        "token_throughput_per_s": _as_float(best.get("token_throughput_per_s")),
+        "energy_mj_per_token": _as_float(best.get("total_energy_mj_per_token")),
+        "compute_energy_mj_per_token": _as_float(best.get("compute_energy_mj_per_token")),
+        "hbm_energy_mj_per_token": _as_float(best.get("hbm_energy_mj_per_token")),
+        "die_area_mm2": _as_float(measured.get("die_area_mm2")),
+        "compute_area_mm2": _as_float(
+            measured.get("replica_recost_compute_area_um2") or measured.get("compute_area_um2")
+        )
+        / 1.0e6,
+        "macs_per_cycle": _as_float(best.get("macs_per_cycle")),
+        "precision_status": quality["status"],
+        "quality_backed": quality["quality_backed"],
+        "quality": quality,
+        "abstraction_status": "measured_wrapper_command_control_sram_envelope_hbm_command_service",
+        "remaining_abstractions": list(best.get("remaining_abstractions") or []),
+        "promotable": bool(quality["quality_backed"]),
+    }
+
+
+def _best_row(source: JsonDict) -> JsonDict:
+    return _as_dict(source.get("best"))
+
+
+def _prior_row(
+    *,
+    candidate_id: str,
+    family: str,
+    source_artifact: str,
+    row: JsonDict,
+    precision_status: str,
+    quality_backed: bool,
+    abstraction_status: str,
+    promotable: bool,
+    remaining_abstractions: list[str],
+) -> JsonDict:
+    return {
+        "candidate_id": candidate_id,
+        "family": family,
+        "source_artifact": source_artifact,
+        "latency_us": _as_float(row.get("latency_us")),
+        "token_throughput_per_s": _as_float(row.get("token_throughput_per_s")),
+        "energy_mj_per_token": _as_float(row.get("energy_mj")),
+        "compute_energy_mj_per_token": _as_float(_as_dict(row.get("energy_components")).get("compute_mj")),
+        "hbm_energy_mj_per_token": _as_float(_as_dict(row.get("energy_components")).get("hbm_mj")),
+        "die_area_mm2": _as_float(row.get("die_area_mm2")),
+        "compute_area_mm2": _as_float(row.get("compute_area_um2")) / 1.0e6,
+        "macs_per_cycle": _as_float(row.get("macs_per_cycle")),
+        "precision_status": precision_status,
+        "quality_backed": quality_backed,
+        "abstraction_status": abstraction_status,
+        "remaining_abstractions": remaining_abstractions,
+        "promotable": promotable,
+    }
+
+
+def _abstract_integrated_row(integrated_energy: JsonDict) -> JsonDict:
+    row = _best_row(integrated_energy)
+    return {
+        "candidate_id": str(row.get("candidate_id") or row.get("arch_id") or "abstract_integrated_energy_best"),
+        "family": "abstract_integrated_gqa8_kv8",
+        "source_artifact": "integrated_energy_closure_r2",
+        "latency_us": _as_float(row.get("latency_us")),
+        "token_throughput_per_s": _as_float(row.get("token_throughput_per_s")),
+        "energy_mj_per_token": _as_float(row.get("energy_mj")),
+        "compute_energy_mj_per_token": _as_float(_as_dict(row.get("energy_components")).get("compute_mj")),
+        "hbm_energy_mj_per_token": _as_float(_as_dict(row.get("energy_components")).get("hbm_mj")),
+        "die_area_mm2": _as_float(row.get("die_area_mm2")),
+        "compute_area_mm2": 0.0,
+        "macs_per_cycle": _as_float(row.get("macs_per_cycle")),
+        "precision_status": "planning_only_native_gqa8_kv8",
+        "quality_backed": False,
+        "abstraction_status": "abstract_compute_target_infeasible_after_measured_compute_closure",
+        "remaining_abstractions": [
+            "abstract_compute_capacity",
+            "parameterized_energy",
+        ],
+        "promotable": False,
+    }
+
+
+def _rank_rows(rows: list[JsonDict], *, promotable_only: bool = False) -> list[JsonDict]:
+    candidates = [row for row in rows if (row.get("promotable") or not promotable_only)]
+    return sorted(
+        candidates,
+        key=lambda row: (
+            _as_float(row.get("latency_us"), 1.0e99),
+            _as_float(row.get("energy_mj_per_token"), 1.0e99),
+            _as_float(row.get("die_area_mm2"), 1.0e99),
+        ),
+    )
+
+
+def _energy_rank(rows: list[JsonDict], *, promotable_only: bool = False) -> list[JsonDict]:
+    candidates = [row for row in rows if (row.get("promotable") or not promotable_only)]
+    return sorted(
+        candidates,
+        key=lambda row: (
+            _as_float(row.get("energy_mj_per_token"), 1.0e99),
+            _as_float(row.get("latency_us"), 1.0e99),
+            _as_float(row.get("die_area_mm2"), 1.0e99),
+        ),
+    )
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    score32_hbm = _load_json(args.score32_hbm_dram_service_json)
+    measured_command = _load_json(args.score32_measured_command_control_json)
+    score32_quality = _load_json(args.score32_quality_json)
+    measured_compute = _load_json(args.measured_compute_energy_json)
+    mixed_int8 = _load_json(args.mixed_int8_energy_json)
+    integrated = _load_json(args.integrated_energy_json)
+
+    rows = [
+        _score32_row(score32_hbm, measured_command, score32_quality),
+        _prior_row(
+            candidate_id=str(_best_row(measured_compute).get("candidate_id") or "measured_fp16_compute_energy_best"),
+            family="measured_exact_fp16_gqa8_kv8",
+            source_artifact="measured_compute_energy_closure",
+            row=_best_row(measured_compute),
+            precision_status="conservative_native_gqa8_kv8",
+            quality_backed=True,
+            abstraction_status="measured_compute_with_source_backed_hbm_energy",
+            promotable=True,
+            remaining_abstractions=[
+                "source_backed_aggregate_hbm_energy_not_vendor_current_signoff",
+                "profile_scaled_noc_sram_energy",
+            ],
+        ),
+        _prior_row(
+            candidate_id=str(_best_row(mixed_int8).get("candidate_id") or "mixed_int8_energy_best"),
+            family="mixed_int8_compute",
+            source_artifact="mixed_int8_energy_closure_r2",
+            row=_best_row(mixed_int8),
+            precision_status="latency_candidate_pending_real_checkpoint_quality",
+            quality_backed=False,
+            abstraction_status="measured_int8_compute_with_source_backed_hbm_energy",
+            promotable=False,
+            remaining_abstractions=[
+                "real_checkpoint_quality_not_promoted_for_this_compute_path",
+                "source_backed_aggregate_hbm_energy_not_vendor_current_signoff",
+            ],
+        ),
+        _abstract_integrated_row(integrated),
+    ]
+
+    latency_rank = _rank_rows(rows)
+    energy_rank = _energy_rank(rows)
+    promotable_latency_rank = _rank_rows(rows, promotable_only=True)
+    promotable_energy_rank = _energy_rank(rows, promotable_only=True)
+    best_precision_safe = promotable_latency_rank[0]
+    best_energy_safe = promotable_energy_rank[0]
+    score32 = rows[0]
+    decision = (
+        "score32_integrated_frontier_best_precision_safe_throughput"
+        if best_precision_safe["candidate_id"] == score32["candidate_id"]
+        else "score32_integrated_frontier_ranking_recorded"
+    )
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_integrated_frontier_ranking_v1",
+        "decision": decision,
+        "inputs": {
+            "score32_hbm_dram_service_json": str(args.score32_hbm_dram_service_json),
+            "score32_measured_command_control_json": str(args.score32_measured_command_control_json),
+            "score32_quality_json": str(args.score32_quality_json),
+            "measured_compute_energy_json": str(args.measured_compute_energy_json),
+            "mixed_int8_energy_json": str(args.mixed_int8_energy_json),
+            "integrated_energy_json": str(args.integrated_energy_json),
+        },
+        "diagnosis": {
+            "decision": decision,
+            "best_latency_candidate": latency_rank[0]["candidate_id"],
+            "best_energy_candidate": energy_rank[0]["candidate_id"],
+            "best_precision_safe_candidate": best_precision_safe["candidate_id"],
+            "best_precision_safe_energy_candidate": best_energy_safe["candidate_id"],
+            "current_recommended_candidate": best_precision_safe["candidate_id"],
+            "score32_latency_us": score32["latency_us"],
+            "score32_token_throughput_per_s": score32["token_throughput_per_s"],
+            "score32_total_energy_mj_per_token": score32["energy_mj_per_token"],
+            "score32_die_area_mm2": score32["die_area_mm2"],
+            "score32_quality_status": score32["precision_status"],
+            "score32_vs_measured_fp16_energy_ratio": round(
+                score32["energy_mj_per_token"] / max(1.0e-12, best_energy_safe["energy_mj_per_token"]), 9
+            ),
+            "score32_vs_measured_fp16_throughput_ratio": round(
+                score32["token_throughput_per_s"] / max(1.0e-12, best_energy_safe["token_throughput_per_s"]), 9
+            ),
+            "excluded_fastest_candidate": latency_rank[0]["candidate_id"]
+            if not latency_rank[0].get("promotable")
+            else None,
+            "remaining_abstractions": sorted(
+                {
+                    item
+                    for row in rows
+                    if row.get("promotable")
+                    for item in list(row.get("remaining_abstractions") or [])
+                }
+            ),
+        },
+        "rows": rows,
+        "latency_rank": latency_rank,
+        "energy_rank": energy_rank,
+        "promotable_latency_rank": promotable_latency_rank,
+        "promotable_energy_rank": promotable_energy_rank,
+        "assumptions": [
+            "Rows are ranked by explicit metrics from merged evidence; no new PPA is synthesized in this audit.",
+            "The score32 row is quality-backed by the bounded generation-quality gate and measured through wrapper, command-control, SRAM-envelope, and HBM/DRAM service closure.",
+            "The mixed-int8 energy row is retained as a fast non-promotable latency candidate because its precision path is not promoted by the current real-checkpoint evidence.",
+            "The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible.",
+        ],
+        "next_step": {
+            "recommended_next_step": (
+                "Use score32 as the current precision-safe throughput frontier and measured exact-FP16 as the "
+                "energy reference; next reduce score32 compute energy or validate a lower-energy mixed/int8 path."
+            ),
+            "score32_energy_reduction_required_for_energy_best": True,
+            "mixed_int8_requires_quality_closure": True,
+        },
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    d = payload["diagnosis"]
+    lines = [
+        "# Score32 Integrated Frontier Ranking",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- best latency candidate: `{d['best_latency_candidate']}`",
+        f"- best energy candidate: `{d['best_energy_candidate']}`",
+        f"- best precision-safe throughput candidate: `{d['best_precision_safe_candidate']}`",
+        f"- current recommended candidate: `{d['current_recommended_candidate']}`",
+        f"- score32 latency us: `{d['score32_latency_us']}`",
+        f"- score32 total energy mJ/token: `{d['score32_total_energy_mj_per_token']}`",
+        f"- score32 die area mm2: `{d['score32_die_area_mm2']}`",
+        f"- score32 quality status: `{d['score32_quality_status']}`",
+        "",
+        "## Promotable Latency Rank",
+        "",
+        "| candidate | latency us | token/s | energy mJ/token | area mm2 | precision |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["promotable_latency_rank"]:
+        lines.append(
+            "| {candidate_id} | {latency_us} | {token_throughput_per_s} | {energy_mj_per_token} | "
+            "{die_area_mm2} | {precision_status} |".format(**row)
+        )
+    lines.extend(["", "## All Rows", "", "| candidate | promotable | latency us | energy mJ/token | status |", "|---|---:|---:|---:|---|"])
+    for row in payload["latency_rank"]:
+        lines.append(
+            "| {candidate_id} | {promotable} | {latency_us} | {energy_mj_per_token} | "
+            "{abstraction_status} |".format(**row)
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--score32-hbm-dram-service-json", type=Path, required=True)
+    parser.add_argument("--score32-measured-command-control-json", type=Path, required=True)
+    parser.add_argument("--score32-quality-json", type=Path, required=True)
+    parser.add_argument("--measured-compute-energy-json", type=Path, required=True)
+    parser.add_argument("--mixed-int8-energy-json", type=Path, required=True)
+    parser.add_argument("--integrated-energy-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "decision": payload["decision"], "out": str(args.out)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add score32 integrated Llama7B frontier-ranking audit
- compare closed score32 evidence against measured exact-FP16, mixed/int8, and older integrated rows
- wire the new L2 decoder evidence layer and update the abstraction-closure plan

## Validation
- python3 -m py_compile npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
- python3 npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py ... --out /tmp/score32_integrated_rank.json --out-md /tmp/score32_integrated_rank.md
- PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_score32_integrated_frontier_ranking_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_score32_integrated_frontier_ranking_uses_decoder_evidence
- PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 tests/test_runs_parsers.py