### PR TITLE
control_plane: add score32 compute activity energy audit

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -575,6 +575,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_integrated_frontier_ranking_report",
     ),
     (
+        "attention_score32_compute_activity_energy_out",
+        "attention_score32_compute_activity_energy_report",
+    ),
+    (
         "attention_score32_exp_lut_sram_hierarchy_envelope_out",
         "attention_score32_exp_lut_sram_hierarchy_envelope_report",
     ),
@@ -1375,6 +1379,33 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "score32_die_area_mm2",
             "score32_quality_status",
             "current_recommended_candidate",
+            "remaining_abstractions",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_score32_compute_activity_energy_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            diagnosis_dict.get("decision")
+            or evidence_payload.get("decision")
+            or "score32_compute_activity_energy_recorded"
+        )
+        parts = [
+            f"Decoder score32 compute-activity energy evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "compute_active_duty",
+            "wall_time_compute_energy_mj_per_token",
+            "best_clock_gated_compute_energy_mj_per_token",
+            "best_clock_gated_total_energy_mj_per_token",
+            "energy_reduction_fraction_vs_wall_time",
+            "clock_gated_score32_vs_measured_fp16_energy_ratio",
+            "score32_latency_us",
+            "recommended_next_step",
             "remaining_abstractions",
         ):
             if key in diagnosis_dict:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5939,6 +5939,56 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
     }
 
 
+def _decoder_attention_score32_compute_activity_energy_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_score32_compute_activity_energy__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_compute_activity_energy__{item_id}.md"
+    score32_hbm = (
+        f"{base}/decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+    )
+    measured_command_control = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
+        "measured_command_control_llama7b_v1.json"
+    )
+    integrated_ranking = (
+        f"{base}/decoder_attention_score32_integrated_frontier_ranking__"
+        "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_score32_exp_lut_hbm_dram_service_closure": score32_hbm,
+            "attention_score32_exp_lut_measured_command_control": measured_command_control,
+            "attention_score32_integrated_frontier_ranking": integrated_ranking,
+            "attention_score32_compute_activity_energy_out": out,
+            "attention_score32_compute_activity_energy_report": report,
+            "attention_score32_compute_activity_energy_scope": (
+                "Replace the score32 wall-time compute-energy ambiguity with explicit active-cycle "
+                "duty accounting from the measured command-control row. Sweep idle-power fractions "
+                "to bound clock-gating benefit and report whether score32 remains energy-worse than "
+                "the measured exact-FP16 reference."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_score32_compute_activity_energy",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_score32_compute_activity_energy.py "
+                    f"--score32-hbm-dram-service-json {score32_hbm} "
+                    f"--score32-measured-command-control-json {measured_command_control} "
+                    f"--score32-integrated-frontier-ranking-json {integrated_ranking} "
+                    "--idle-power-fraction 0.0,0.05,0.1,0.25,1.0 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__{item_id}.json"
@@ -9451,6 +9501,7 @@ def _build_payload(
         "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
         "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
         "decoder_attention_score32_integrated_frontier_ranking",
+        "decoder_attention_score32_compute_activity_energy",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -9655,6 +9706,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_score32_exp_lut_hbm_dram_service_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_integrated_frontier_ranking":
             decoder_evidence = _decoder_attention_score32_integrated_frontier_ranking_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_score32_compute_activity_energy":
+            decoder_evidence = _decoder_attention_score32_compute_activity_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -5610,6 +5610,128 @@ def test_consume_l2_result_score32_integrated_frontier_ranking_uses_decoder_evid
             )
 
 
+def test_consume_l2_result_score32_compute_activity_energy_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_l2_score32_compute_activity_energy_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_score32_compute_activity_energy_v1",
+                        "kind": "architecture",
+                        "title": "Score32 compute activity energy",
+                        "direct_comparison": {
+                            "primary_question": "Does clock gating close the score32 energy gap?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_compute_activity_energy__"
+                "l2_score32_compute_activity_energy.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_compute_activity_energy__"
+                "l2_score32_compute_activity_energy.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_score32_compute_activity_energy_v1",
+                        "decision": "score32_compute_activity_energy_still_energy_worse",
+                        "diagnosis": {
+                            "compute_active_duty": 0.957495485,
+                            "wall_time_compute_energy_mj_per_token": 360.550392645,
+                            "best_clock_gated_compute_energy_mj_per_token": 345.225372946,
+                            "best_clock_gated_total_energy_mj_per_token": 479.505988187,
+                            "energy_reduction_fraction_vs_wall_time": 0.030970209,
+                            "clock_gated_score32_vs_measured_fp16_energy_ratio": 5.871684274,
+                            "score32_latency_us": 12532.357427,
+                            "recommended_next_step": "prioritize lower-power score32 datapath variants",
+                            "remaining_abstractions": [
+                                "compute active duty is derived from L2 cycle accounting",
+                            ],
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# score32 compute activity energy\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_score32_compute_activity_energy",
+                campaign_dir_rel="runs/campaigns/npu/score32_compute_activity_energy_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path="docs/proposals/prop_l2_score32_compute_activity_energy_v1",
+                comparison={"role": "energy_closure"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "record_score32_compute_activity_energy",
+                "expected_reason": "Close score32 wall-time compute-energy ambiguity.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_score32_compute_activity_energy",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_score32_compute_activity_energy_out": evidence_rel,
+                    "attention_score32_compute_activity_energy_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "score32_compute_activity_energy_still_energy_worse"
+            assert assessment["decoder_evidence_ref"] == evidence_rel
+            assert "compute_active_duty=0.957495485" in assessment["summary"]
+            assert "wall_time_compute_energy_mj_per_token=360.550392645" in assessment["summary"]
+            assert "best_clock_gated_compute_energy_mj_per_token=345.225372946" in assessment["summary"]
+            assert "best_clock_gated_total_energy_mj_per_token=479.505988187" in assessment["summary"]
+            assert "clock_gated_score32_vs_measured_fp16_energy_ratio=5.871684274" in assessment["summary"]
+            assert "recommended_next_step=prioritize lower-power score32 datapath variants" in assessment["summary"]
+            assert (
+                decision_payload["evaluation_record"]["abstraction_layer"]
+                == "decoder_attention_score32_compute_activity_energy"
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_compute_activity_energy_out"]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_compute_activity_energy_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_score32_exp_lut_sram_hierarchy_envelope_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6832,6 +6832,65 @@ def test_generate_l2_campaign_task_adds_attention_score32_integrated_frontier_ra
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_compute_activity_energy_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_compute_activity_energy_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_compute_activity_energy",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_score32_compute_activity_energy",
+            ]
+            assert "audit_llm_decoder_attention_score32_compute_activity_energy.py" in run
+            assert "--score32-hbm-dram-service-json" in run
+            assert "--score32-measured-command-control-json" in run
+            assert "--score32-integrated-frontier-ranking-json" in run
+            assert "--idle-power-fraction 0.0,0.05,0.1,0.25,1.0" in run
+            assert (
+                "decoder_attention_score32_integrated_frontier_ranking__"
+                "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1.json"
+            ) in run
+            assert (
+                decoder_inputs["attention_score32_compute_activity_energy_out"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_compute_activity_energy__"
+                "l2_decoder_attention_score32_compute_activity_energy_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_compute_activity_energy_scope"].startswith(
+                "Replace the score32 wall-time compute-energy ambiguity"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_score32_compute_activity_energy__"
+                    "l2_decoder_attention_score32_compute_activity_energy_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy_envelope_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -169,11 +169,20 @@ than free or heuristic assumptions.
     `134.280615241 mJ/token`, compute energy `360.550392645 mJ/token`, and
     total energy `494.831007886 mJ/token`. Remaining abstractions are
     cycle-accurate HBM controller RTL and vendor HBM current signoff.
+  - the integrated score32 frontier ranking
+    `l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1` is
+    merged by PR #1205. It records score32 as the current precision-safe
+    throughput frontier at `79.793447149 token/s`, `12532.357427 us/token`,
+    `494.831007886 mJ/token`, and `800.0 mm2`. The measured exact-FP16 row
+    remains the promotable energy reference at `81.66413005453946 mJ/token`.
+    Score32 is `5.788540788x` faster but `6.059343405x` higher energy than
+    that reference.
   - the current immediate follow-on is
-    `l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1`.
-    It should compare the newly closed score32 row against measured exact-FP16,
-    mixed/int8, and older integrated rows across throughput, energy, area, and
-    precision status before selecting the next architecture-improvement target.
+    `l2_decoder_attention_score32_compute_activity_energy_llama7b_v1`. It
+    should replace the wall-time compute-energy ambiguity with explicit
+    active-cycle duty and clock-gating bounds before deciding whether the next
+    target is score32 circuit energy reduction or a lower-energy mixed/int8
+    quality closure.
 - New evaluations should continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`, not the devcontainer.
 
@@ -342,7 +351,15 @@ run the already queued exp-LUT branch:
    exact-FP16, and mixed/int8 evidence. The result should explicitly distinguish
    promotable precision-safe rows from planning-only or quality-unclosed rows,
    then identify the current throughput frontier, energy reference, and next
-   architecture target.
+   architecture target. This is complete: PR #1205 records score32 as the
+   precision-safe throughput frontier and measured exact-FP16 as the energy
+   reference.
+9. Run
+   `l2_decoder_attention_score32_compute_activity_energy_llama7b_v1` to close
+   the score32 wall-time compute-energy ambiguity. The result should derive
+   compute active duty from the measured command-control cycle fields, sweep
+   idle-power fractions, and state whether clock-gating/active-cycle accounting
+   can close the score32 energy gap.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_score32_compute_activity_energy_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_compute_activity_energy_llama7b_v1/analysis_report.md
@@ -1,0 +1,14 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_score32_compute_activity_energy_llama7b_v1`
+- `candidate_id`: `l2_decoder_attention_score32_compute_activity_energy_llama7b_v1`
+
+## Planned Evaluation
+- Derive score32 compute-active duty from merged measured command-control cycle fields.
+- Sweep idle-power fractions to bound clock-gating benefit.
+- Compare best clock-gated score32 total energy with the measured exact-FP16 energy reference.
+
+## Recommendation
+- `pending`
+- reason: source hook and remote evaluator dispatch are still pending.

--- a/docs/proposals/prop_l2_decoder_attention_score32_compute_activity_energy_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_compute_activity_energy_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_compute_activity_energy_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds the score32 compute-activity energy audit hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_compute_activity_energy_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Bound score32 exp-LUT compute energy using active-cycle duty and idle-power fractions.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_compute_activity_energy",
+      "comparison_role": "score32_compute_activity_energy_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_compute_activity_energy",
+        "reason": "The result should state whether active-cycle/clock-gating accounting changes the score32 energy ranking versus the measured exact-FP16 reference."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_compute_activity_energy_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_compute_activity_energy_llama7b_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_compute_activity_energy_llama7b_v1",
+  "created_utc": "2026-07-06T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 compute activity energy closure",
+  "abstraction_layer": "decoder_attention_score32_compute_activity_energy",
+  "hypothesis": "The score32 exp-LUT energy gap is not primarily caused by charging compute power over idle wall time; explicit active-cycle accounting will show high duty factor and keep score32 energy worse than the measured exact-FP16 reference.",
+  "direct_comparison": {
+    "primary_question": "Does clock-gating/active-cycle accounting materially reduce score32 energy enough to change the current Llama7B energy ranking?",
+    "include": [
+      "consume the score32 HBM/DRAM service closure",
+      "consume the score32 measured command-control row",
+      "consume the score32 integrated frontier ranking",
+      "derive compute active duty from tile service cycles, tile waves, and layer cycles",
+      "sweep idle-power fractions to bound clock-gating benefit",
+      "compare the best clock-gated score32 total energy to the measured exact-FP16 energy reference"
+    ],
+    "exclude": [
+      "new OpenROAD PPA",
+      "new gate-level switching activity simulation",
+      "new generation-quality evaluation",
+      "new HBM controller RTL"
+    ]
+  },
+  "expected_benefit": [
+    "removes ambiguity in the score32 wall-time compute-energy assumption",
+    "determines whether clock gating is enough before spending effort on circuit-level energy optimization",
+    "clarifies the next frontier target after integrated ranking"
+  ],
+  "risks": [
+    "active duty is derived from L2 schedule accounting rather than RTL toggle traces",
+    "idle-power fractions are analytic scenarios",
+    "if duty is high, the result will mainly rule out a cheap energy fix rather than improve the architecture"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_compute_activity_energy_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Bound score32 exp-LUT compute energy using active-cycle duty and idle-power fractions.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_compute_activity_energy",
+      "comparison_role": "score32_compute_activity_energy_closure",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_compute_activity_energy",
+        "reason": "The result should state whether active-cycle/clock-gating accounting changes the score32 energy ranking versus the measured exact-FP16 reference."
+      },
+      "status": "pending"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_compute_activity_energy.py",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md",
+    "docs/proposals/prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1/proposal.json"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_compute_activity_energy.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_compute_activity_energy.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Bound score32 exp-LUT compute energy by explicit active-cycle accounting."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_dict(value: Any) -> JsonDict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_ratio(num: float, den: float) -> float:
+    return num / den if den else 0.0
+
+
+def _measured_fp16_energy_reference(integrated_ranking: JsonDict) -> JsonDict:
+    for row in integrated_ranking.get("promotable_energy_rank") or []:
+        if isinstance(row, dict) and row.get("family") == "measured_exact_fp16_gqa8_kv8":
+            return dict(row)
+    for row in integrated_ranking.get("rows") or []:
+        if isinstance(row, dict) and row.get("family") == "measured_exact_fp16_gqa8_kv8":
+            return dict(row)
+    return {}
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    score32_hbm = _load_json(args.score32_hbm_dram_service_json)
+    measured_command = _load_json(args.score32_measured_command_control_json)
+    integrated_ranking = _load_json(args.score32_integrated_frontier_ranking_json)
+
+    score32 = _as_dict(score32_hbm.get("best_latency"))
+    command_row = _as_dict(measured_command.get("best_requested"))
+    fp16_ref = _measured_fp16_energy_reference(integrated_ranking)
+
+    tile_service_cycles = _as_int(
+        command_row.get("replica_recost_tile_service_cycles") or command_row.get("tile_service_cycles"), 1
+    )
+    layer_cycles = _as_int(command_row.get("replica_recost_layer_cycles") or command_row.get("layer_cycles"), 1)
+    tile_waves = _as_int(command_row.get("tile_waves"), 1)
+    layers = _as_int(command_row.get("layers"), 32)
+    active_cycles_per_layer = tile_service_cycles * tile_waves
+    active_cycles_total = active_cycles_per_layer * layers
+    layer_cycles_total = layer_cycles * layers
+    compute_active_duty = min(1.0, _safe_ratio(active_cycles_per_layer, layer_cycles))
+
+    wall_latency_us = _as_float(score32.get("latency_us"))
+    compute_power_mw = _as_float(score32.get("compute_power_mw"))
+    wall_compute_energy_mj = _as_float(score32.get("compute_energy_mj_per_token"))
+    hbm_energy_mj = _as_float(score32.get("hbm_energy_mj_per_token"))
+    active_compute_energy_mj = wall_compute_energy_mj * compute_active_duty
+    idle_compute_energy_mj = max(0.0, wall_compute_energy_mj - active_compute_energy_mj)
+
+    rows: list[JsonDict] = []
+    for idle_power_fraction in args.idle_power_fraction:
+        idle_energy_mj = idle_compute_energy_mj * idle_power_fraction
+        compute_energy_mj = active_compute_energy_mj + idle_energy_mj
+        total_energy_mj = compute_energy_mj + hbm_energy_mj
+        rows.append(
+            {
+                "scenario": f"idle_power_fraction_{idle_power_fraction:g}",
+                "idle_power_fraction": idle_power_fraction,
+                "latency_us": wall_latency_us,
+                "token_throughput_per_s": _as_float(score32.get("token_throughput_per_s")),
+                "compute_power_mw": compute_power_mw,
+                "compute_active_duty": round(compute_active_duty, 9),
+                "active_cycles_per_layer": active_cycles_per_layer,
+                "layer_cycles": layer_cycles,
+                "active_cycles_total": active_cycles_total,
+                "layer_cycles_total": layer_cycles_total,
+                "wall_compute_energy_mj_per_token": round(wall_compute_energy_mj, 9),
+                "active_compute_energy_mj_per_token": round(active_compute_energy_mj, 9),
+                "idle_compute_energy_mj_per_token": round(idle_energy_mj, 9),
+                "clock_gated_compute_energy_mj_per_token": round(compute_energy_mj, 9),
+                "hbm_energy_mj_per_token": round(hbm_energy_mj, 9),
+                "total_energy_mj_per_token": round(total_energy_mj, 9),
+                "energy_reduction_vs_wall_time": round(wall_compute_energy_mj + hbm_energy_mj - total_energy_mj, 9),
+                "energy_reduction_fraction_vs_wall_time": round(
+                    _safe_ratio(wall_compute_energy_mj + hbm_energy_mj - total_energy_mj, wall_compute_energy_mj + hbm_energy_mj),
+                    9,
+                ),
+            }
+        )
+
+    best_clock_gated = min(rows, key=lambda row: _as_float(row["total_energy_mj_per_token"]))
+    fp16_energy = _as_float(fp16_ref.get("energy_mj_per_token"))
+    fp16_throughput = _as_float(fp16_ref.get("token_throughput_per_s"))
+    still_energy_worse = bool(fp16_energy and best_clock_gated["total_energy_mj_per_token"] > fp16_energy)
+    decision = (
+        "score32_compute_activity_energy_still_energy_worse"
+        if still_energy_worse
+        else "score32_compute_activity_energy_can_match_energy_reference"
+    )
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_compute_activity_energy_v1",
+        "decision": decision,
+        "inputs": {
+            "score32_hbm_dram_service_json": str(args.score32_hbm_dram_service_json),
+            "score32_measured_command_control_json": str(args.score32_measured_command_control_json),
+            "score32_integrated_frontier_ranking_json": str(args.score32_integrated_frontier_ranking_json),
+        },
+        "diagnosis": {
+            "decision": decision,
+            "compute_active_duty": round(compute_active_duty, 9),
+            "active_cycles_per_layer": active_cycles_per_layer,
+            "layer_cycles": layer_cycles,
+            "wall_time_compute_energy_mj_per_token": round(wall_compute_energy_mj, 9),
+            "best_clock_gated_compute_energy_mj_per_token": best_clock_gated["clock_gated_compute_energy_mj_per_token"],
+            "best_clock_gated_total_energy_mj_per_token": best_clock_gated["total_energy_mj_per_token"],
+            "wall_time_total_energy_mj_per_token": round(wall_compute_energy_mj + hbm_energy_mj, 9),
+            "energy_reduction_fraction_vs_wall_time": best_clock_gated["energy_reduction_fraction_vs_wall_time"],
+            "score32_latency_us": wall_latency_us,
+            "score32_token_throughput_per_s": _as_float(score32.get("token_throughput_per_s")),
+            "measured_fp16_energy_reference_mj_per_token": fp16_energy,
+            "measured_fp16_token_throughput_per_s": fp16_throughput,
+            "clock_gated_score32_vs_measured_fp16_energy_ratio": round(
+                _safe_ratio(best_clock_gated["total_energy_mj_per_token"], fp16_energy), 9
+            ),
+            "clock_gated_score32_vs_measured_fp16_throughput_ratio": round(
+                _safe_ratio(_as_float(score32.get("token_throughput_per_s")), fp16_throughput), 9
+            ),
+            "recommended_next_step": (
+                "Clock gating does not erase the score32 energy gap; prioritize lower-power score32/softmax "
+                "datapath variants or quality-close a lower-energy mixed/int8 path."
+                if still_energy_worse
+                else "Clock-gated score32 can match the measured-FP16 energy reference; carry this energy model into ranking."
+            ),
+            "remaining_abstractions": [
+                "compute active duty is derived from L2 cycle accounting, not RTL toggle activity",
+                "idle power fractions are analytic clock-gating scenarios, not gate-level power simulation",
+            ],
+        },
+        "best_clock_gated": best_clock_gated,
+        "rows": rows,
+        "measured_fp16_energy_reference": fp16_ref,
+        "assumptions": [
+            "Score32 compute power is inherited from measured dual-stream composed PPA and measured command-control recost.",
+            "Active compute cycles use replica_recost_tile_service_cycles * tile_waves per layer.",
+            "Idle energy is swept as a fraction of the non-active wall-time compute-energy remainder.",
+            "HBM energy is unchanged from the score32 HBM/DRAM service closure.",
+        ],
+        "next_step": {
+            "recommended_next_step": (
+                "Explore score32 datapath energy reduction and lower-power quality-backed mixed/int8 variants; "
+                "clock gating alone is a small correction because the active duty is high."
+            ),
+            "requires_score32_datapath_energy_optimization": still_energy_worse,
+        },
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    d = payload["diagnosis"]
+    lines = [
+        "# Score32 Compute Activity Energy",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- compute active duty: `{d['compute_active_duty']}`",
+        f"- wall-time compute energy mJ/token: `{d['wall_time_compute_energy_mj_per_token']}`",
+        f"- best clock-gated compute energy mJ/token: `{d['best_clock_gated_compute_energy_mj_per_token']}`",
+        f"- best clock-gated total energy mJ/token: `{d['best_clock_gated_total_energy_mj_per_token']}`",
+        f"- measured-FP16 energy reference mJ/token: `{d['measured_fp16_energy_reference_mj_per_token']}`",
+        f"- clock-gated score32 / measured-FP16 energy ratio: `{d['clock_gated_score32_vs_measured_fp16_energy_ratio']}`",
+        "",
+        "## Scenarios",
+        "",
+        "| idle power fraction | compute mJ | total mJ | reduction vs wall |",
+        "|---:|---:|---:|---:|",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {idle_power_fraction} | {clock_gated_compute_energy_mj_per_token} | "
+            "{total_energy_mj_per_token} | {energy_reduction_fraction_vs_wall_time} |".format(**row)
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _idle_power_fractions(value: str) -> list[float]:
+    fractions = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not fractions or any(item < 0.0 or item > 1.0 for item in fractions):
+        raise argparse.ArgumentTypeError("expected comma-separated fractions in [0,1]")
+    return fractions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--score32-hbm-dram-service-json", type=Path, required=True)
+    parser.add_argument("--score32-measured-command-control-json", type=Path, required=True)
+    parser.add_argument("--score32-integrated-frontier-ranking-json", type=Path, required=True)
+    parser.add_argument("--idle-power-fraction", type=_idle_power_fractions, default=[0.0, 0.05, 0.1, 0.25, 1.0])
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "decision": payload["decision"], "out": str(args.out)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a score32 compute-activity energy audit script
- wire the new `decoder_attention_score32_compute_activity_energy` evidence path into L2 generation and result consumption
- document the next closure step after integrated score32 ranking

## Why
The integrated score32 frontier shows score32 as the current precision-safe throughput frontier, but its compute energy was still reported as wall-time energy. This audit derives active-cycle duty from the measured command-control row and sweeps idle-power fractions so the next decision is based on an explicit clock-gating bound.

## Validation
- `python3 -m py_compile npu/eval/audit_llm_decoder_attention_score32_compute_activity_energy.py`
- standalone audit script run against merged score32 HBM, command-control, and ranking artifacts
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_score32_compute_activity_energy_evidence control_plane/control_plane/tests/test_l2_result_consumer.py::test_consume_l2_result_score32_compute_activity_energy_uses_decoder_evidence`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py`
- `git diff --check`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `python3 tests/test_runs_parsers.py`
