### PR TITLE
npu: add score32 exp-lut parallelism recost path

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1223,6 +1223,8 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1",
         "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
+        "llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
+        "llm_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
         "llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1",
     }:
         diagnosis = evidence_payload.get("diagnosis")
@@ -1248,6 +1250,10 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             if model == "llm_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1"
             else "Decoder composed dual-stream physical feasibility evidence (score32/w16 recip-lut q16 reduced-replica recost)"
             if model == "llm_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1"
+            else "Decoder composed dual-stream physical feasibility evidence (score32 exp-LUT reduced-replica recost)"
+            if model == "llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1"
+            else "Decoder composed dual-stream physical feasibility evidence (score32 exp-LUT parallelism recost)"
+            if model == "llm_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1"
             else "Decoder composed dual-stream physical feasibility evidence (q20 PWL reciprocal-divider reduced-replica recost)"
             if model == "llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1"
             else "Decoder dual-stream physical feasibility evidence"

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5525,6 +5525,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     score32_reduced_replica = "score32_w16_exact_div_reduced_replica" in item_id
     score32_recip_lut_q16_reduced_replica = "score32_w16_recip_lut_q16_reduced_replica" in item_id
     score32_exp_lut_div_reduced_replica = "score32_exp_lut_div_reduced_replica" in item_id
+    score32_exp_lut_div_parallelism_recost = "score32_exp_lut_div_parallelism_recost" in item_id
     command_overhead = "command_overhead" in item_id
     measured_command_control = "measured_command_control" in item_id
     q20_pwl_recip_div_reduced_replica = "q20_pwl_recip_div_reduced_replica" in item_id
@@ -5553,6 +5554,21 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         composed_dual_stream_metrics = (
             "runs/designs/npu_blocks/"
             "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+            "metrics.csv"
+        )
+    elif score32_exp_lut_div_parallelism_recost:
+        composed_dual_stream_metrics = (
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20/"
+            "metrics.csv,"
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v8_8x8_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/"
+            "metrics.csv,"
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v8_8x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/"
+            "metrics.csv,"
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_composed_int8_q8k8v8_4x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/"
             "metrics.csv"
         )
     elif q20_pwl_recip_div_reduced_replica:
@@ -5606,6 +5622,9 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     elif score32_exp_lut_div_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute"
+    elif score32_exp_lut_div_parallelism_recost:
+        model_name = "llm_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1"
+        precision_profile = "q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute"
     elif q20_pwl_recip_div_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a24_s20_w20_pwl_recip_div_q20_int8_compute"
@@ -5624,7 +5643,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     else:
         model_name = "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
         precision_profile = "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
-    if score32_exp_lut_div_reduced_replica:
+    if score32_exp_lut_div_reduced_replica or score32_exp_lut_div_parallelism_recost:
         quality_gate = (
             f"{base}/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
             "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
@@ -5638,6 +5657,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         or score32_split2_reduced_replica
         or score32_recip_lut_q16_reduced_replica
         or score32_exp_lut_div_reduced_replica
+        or score32_exp_lut_div_parallelism_recost
         or q20_pwl_recip_div_reduced_replica
     )
     command_overhead_flags = ""

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7146,6 +7146,69 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            estimate_commands = [
+                command for command in commands
+                if command["name"] == "estimate_decoder_attention_composed_datapath_physical_feasibility"
+            ]
+            run = estimate_commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert len(estimate_commands) == 1
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1"
+                in run
+            )
+            assert "--recompute-area-fit-replicas" in run
+            assert "--precision-profile q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute" in run
+            assert decoder_inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+            )
+            assert "attention_score32_exp_lut_div_frontier_release_gate" not in decoder_inputs
+            assert decoder_inputs["attention_kv_composed_dual_stream_metrics"].count("metrics.csv") == 4
+            for design_name in (
+                "attention_dual_stream_composed_int8_q8k8v8_16x8_p8_ppc2_nohash_score32_w16_exp_lut_div_b20",
+                "attention_dual_stream_composed_int8_q8k8v8_8x8_p8_ppc1_nohash_score32_w16_exp_lut_div_b20",
+                "attention_dual_stream_composed_int8_q8k8v8_8x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20",
+                "attention_dual_stream_composed_int8_q8k8v8_4x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20",
+            ):
+                expected = f"runs/designs/npu_blocks/{design_name}/metrics.csv"
+                assert expected in decoder_inputs["attention_kv_composed_dual_stream_metrics"]
+                assert f"--composed-dual-stream-metrics {expected}" in run
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_split2_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -178,11 +178,15 @@ than free or heuristic assumptions.
     Score32 is `5.788540788x` faster but `6.059343405x` higher energy than
     that reference.
   - the current immediate follow-on is
-    `l2_decoder_attention_score32_compute_activity_energy_llama7b_v1`. It
-    should replace the wall-time compute-energy ambiguity with explicit
-    active-cycle duty and clock-gating bounds before deciding whether the next
-    target is score32 circuit energy reduction or a lower-energy mixed/int8
-    quality closure.
+    `l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_ppa_v1`.
+    The score32 compute-activity audit is merged and records active duty
+    `0.957495485`, best clock-gated total energy
+    `479.505988187 mJ/token`, and
+    `5.871684274x` higher energy than the measured exact-FP16 reference. Since
+    clock gating is only a small correction, the next target is measured
+    score32 exp-LUT circuit parallelism: reduce local compute/value parallelism,
+    measure PPA, then recost Llama7B latency/energy/area with per-variant
+    block MACs/cycle.
 - New evaluations should continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`, not the devcontainer.
 
@@ -359,7 +363,19 @@ run the already queued exp-LUT branch:
    the score32 wall-time compute-energy ambiguity. The result should derive
    compute active duty from the measured command-control cycle fields, sweep
    idle-power fractions, and state whether clock-gating/active-cycle accounting
-   can close the score32 energy gap.
+   can close the score32 energy gap. This is complete: PR #1209 records that
+   score32 remains energy-worse after ideal clock-gating bounds.
+10. Run
+    `l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_ppa_v1`
+    to measure reduced-parallel score32 exp-LUT composed wrapper variants
+    (`8x8`, `8x4`, and `4x4`) against the current `16x8` wrapper. This closes
+    the immediate circuit-level question left by the activity audit: whether
+    lower local parallelism can materially reduce score32 power/area.
+11. After the L1 parallelism metrics merge, run
+    `l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1`.
+    This recost must consume each wrapper's generated manifest/config
+    `total_macs` so latency, replica count, area, and energy are not
+    accidentally inherited from the full `16x8` wrapper.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds the reduced-parallel score32 exp-LUT configs and recost MAC-accounting fix.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure reduced-parallel score32 exp-LUT composed wrapper PPA on Nangate45.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_exp_lut_parallelism_ppa",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_8x8_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_8x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_4x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20_parallelism.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_result": {
+        "direction": "measure_score32_exp_lut_parallelism_ppa",
+        "reason": "The dependent L2 recost needs measured area, power, timing, and block MACs/cycle for lower-parallel score32 exp-LUT wrappers."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_v1/proposal.json
@@ -1,0 +1,63 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_v1",
+  "created_utc": "2026-07-06T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Score32 exp-LUT composed wrapper parallelism sweep",
+  "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+  "hypothesis": "The current score32 exp-LUT Llama7B point is throughput-leading but energy-worse. Reducing local composed-wrapper compute/value parallelism may expose lower-power and lower-area points whose added cycles are acceptable for the Llama7B schedule.",
+  "direct_comparison": {
+    "primary_question": "How do Nangate45 area, power, and timing change when the quality-backed score32 exp-LUT composed wrapper is measured at lower local parallelism?",
+    "baseline": "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+    "candidates": [
+      "attention_dual_stream_composed_int8_q8k8v8_8x8_p8_ppc1_nohash_score32_w16_exp_lut_div_b20",
+      "attention_dual_stream_composed_int8_q8k8v8_8x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20",
+      "attention_dual_stream_composed_int8_q8k8v8_4x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20"
+    ],
+    "include": [
+      "same score32 exp-LUT divider softmax semantics as the current score32 frontier",
+      "reduced MAC-array dimensions",
+      "reduced value lanes and partials-per-cycle",
+      "generated manifest total_macs so L2 recost can use the measured block MACs/cycle",
+      "Nangate45 area, power, timing, and timing-debug report for each variant"
+    ],
+    "exclude": [
+      "new precision quality gate",
+      "new HBM/DRAM model",
+      "claiming energy improvement before the dependent L2 recost"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure reduced-parallel score32 exp-LUT composed wrapper PPA on Nangate45.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_dual_stream_composed_datapath",
+      "comparison_role": "score32_exp_lut_parallelism_ppa",
+      "paired_baseline_item_id": "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_ppa_v1",
+      "configs": [
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_8x8_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_8x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json",
+        "runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_4x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20_parallelism.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_result": {
+        "direction": "measure_score32_exp_lut_parallelism_ppa",
+        "reason": "The dependent L2 recost needs measured area, power, timing, and block MACs/cycle for lower-parallel score32 exp-LUT wrappers."
+      },
+      "status": "pending"
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_dual_stream_composed.py",
+    "npu/eval/check_attention_dual_stream_composed_guard.py",
+    "runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20_parallelism.json"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_compute_activity_energy__l2_decoder_attention_score32_compute_activity_energy_llama7b_v1.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+  "source_commit_note": "Dispatch after the L1 score32 exp-LUT parallelism PPA item is merged.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost Llama7B score32 exp-LUT attention using measured composed-wrapper parallelism variants.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_parallelism_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_compute_activity_energy_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_ppa_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_score32_compute_activity_energy_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_score32_exp_lut_parallelism_tradeoff",
+        "reason": "The result should identify whether reduced local parallelism improves score32 Llama7B energy/area enough to justify the latency loss."
+      },
+      "status": "blocked"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1/proposal.json
@@ -1,0 +1,57 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+  "created_utc": "2026-07-06T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 exp-LUT parallelism Llama7B recost",
+  "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+  "hypothesis": "A lower-parallel score32 exp-LUT wrapper may reduce compute power and area enough that the Llama7B token energy improves, even if token latency increases relative to the current 16x8 score32 throughput frontier.",
+  "direct_comparison": {
+    "primary_question": "Which measured score32 exp-LUT wrapper parallelism point gives the best Llama7B latency, energy, and area tradeoff under the same quality-backed precision semantics?",
+    "baseline": "l2_decoder_attention_score32_compute_activity_energy_llama7b_v1",
+    "include": [
+      "base 16x8 score32 exp-LUT wrapper metrics",
+      "new reduced-parallel score32 exp-LUT wrapper metrics",
+      "manifest/config-derived block MACs/cycle for each wrapper",
+      "same score32 exp-LUT generation-quality evidence",
+      "area-fit replica recost against the Llama7B schedule"
+    ],
+    "exclude": [
+      "new precision quality run",
+      "new HBM/DRAM controller model",
+      "new command-dispatch-control measurement"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost Llama7B score32 exp-LUT attention using measured composed-wrapper parallelism variants.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_parallelism_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_compute_activity_energy_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_ppa_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_score32_compute_activity_energy_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_score32_exp_lut_parallelism_tradeoff",
+        "reason": "The result should identify whether reduced local parallelism improves score32 Llama7B energy/area enough to justify the latency loss."
+      },
+      "status": "blocked"
+    }
+  ],
+  "source_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ],
+  "knowledge_refs": [
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_parallelism_v1/proposal.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_compute_activity_energy__l2_decoder_attention_score32_compute_activity_energy_llama7b_v1.json"
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -119,6 +119,41 @@ def _load_composed_semantic_profile(path: Path) -> str:
     return "fixed_point"
 
 
+def _load_composed_total_macs(path: Path) -> int | None:
+    design_dir = path.parent
+    manifest_path = design_dir / "verilog" / "attention_dual_stream_composed_manifest.json"
+    config_path = design_dir / "config.json"
+    if manifest_path.exists():
+        try:
+            manifest = _load_json(manifest_path)
+        except json.JSONDecodeError:
+            manifest = {}
+        try:
+            total_macs = int(manifest.get("total_macs"))
+        except (TypeError, ValueError):
+            total_macs = 0
+        if total_macs > 0:
+            return total_macs
+    if config_path.exists():
+        try:
+            payload = _load_json(config_path)
+        except json.JSONDecodeError:
+            payload = {}
+        comp = payload.get("attention_dual_stream_composed") if isinstance(payload, dict) else None
+        if isinstance(comp, dict):
+            try:
+                streams = int(comp.get("streams", 2))
+                array_m = int(comp.get("array_m", 16))
+                array_n = int(comp.get("array_n", 8))
+                k_unroll = int(comp.get("k_unroll", 1))
+            except (TypeError, ValueError):
+                return None
+            total_macs = streams * array_m * array_n * k_unroll
+            if total_macs > 0:
+                return total_macs
+    return None
+
+
 def _parse_composed_metric_inputs(values: Any) -> list[Path]:
     if not values:
         return []
@@ -159,11 +194,13 @@ def _load_composed_variants(paths: list[Path]) -> list[JsonDict]:
     variants: list[JsonDict] = []
     for path in paths:
         metrics = _best_ok_compute_metrics(path)
+        total_macs = _load_composed_total_macs(path)
         metrics.update(
             {
                 "composed_variant_label": _infer_composed_precision_profile(path),
                 "composed_variant_name": _compose_variant_name(path),
                 "composed_semantic_profile": _load_composed_semantic_profile(path),
+                "composed_total_macs_per_cycle": total_macs,
             }
         )
         variants.append(metrics)
@@ -333,7 +370,10 @@ def _row_with_budget(
         composed_area = float(composed_dual_stream.get("block_area_um2") or composed_dual_stream["die_area_um2"])
         composed_clock_ns = float(composed_dual_stream["critical_path_ns"])
         composed_power = float(composed_dual_stream["total_power_mw"])
-        source_block_macs_per_cycle = int(source_row["measured_block_macs_per_cycle"])
+        source_block_macs_per_cycle = int(
+            composed_dual_stream.get("composed_total_macs_per_cycle")
+            or source_row["measured_block_macs_per_cycle"]
+        )
         composed_replica_count = int(
             math.ceil(float(source_row["macs_per_cycle"]) / max(1, source_block_macs_per_cycle))
         )

--- a/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20_parallelism.json
+++ b/runs/campaigns/npu/attention_dual_stream_composed_v1/sweeps/nangate45_dual_stream_composed_hier_score32_w16_exp_lut_div_b20_parallelism.json
@@ -1,0 +1,33 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_dual_stream_composed_v1_hier_score32_w16_exp_lut_div_b20_parallelism"
+    ],
+    "FLOW_VARIANT": [
+      "attention_dual_stream_composed_v1_hier_score32_w16_exp_lut_div_b20_parallelism"
+    ],
+    "CLOCK_PERIOD": [
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_KEEP_MODULES": [
+      "int8_mac_s8s8_acc32 attention_softmax_weight_score32_w16_exp_lut_div_b20_like attention_full_value_stream_q8v8_p8_ppc2"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_dual_stream_composed_v1_hier_score32_w16_exp_lut_div_b20_parallelism"
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_4x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_4x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json
@@ -1,0 +1,26 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_4x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 4,
+    "array_n": 4,
+    "k_unroll": 1,
+    "mac_accum_bits": 32,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 32,
+    "softmax_weight_bits": 16,
+    "softmax_input_frac_bits": 28,
+    "softmax_accum_bits": 40,
+    "reciprocal_bits": 16,
+    "softmax_reciprocal_lut_bucket_shift": 20,
+    "value_bits": 8,
+    "value_lanes": 4,
+    "partials": 8,
+    "partials_per_cycle": 1,
+    "stream_buffer_bits": 512,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "exp_lut_div",
+    "semantic_profile": "score32_exp_lut_div"
+  }
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_8x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_8x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json
@@ -1,0 +1,26 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_8x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 8,
+    "array_n": 4,
+    "k_unroll": 1,
+    "mac_accum_bits": 32,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 32,
+    "softmax_weight_bits": 16,
+    "softmax_input_frac_bits": 28,
+    "softmax_accum_bits": 40,
+    "reciprocal_bits": 16,
+    "softmax_reciprocal_lut_bucket_shift": 20,
+    "value_bits": 8,
+    "value_lanes": 8,
+    "partials": 8,
+    "partials_per_cycle": 1,
+    "stream_buffer_bits": 512,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "exp_lut_div",
+    "semantic_profile": "score32_exp_lut_div"
+  }
+}

--- a/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_8x8_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json
+++ b/runs/designs/npu_blocks/attention_dual_stream_composed_int8_q8k8v8_8x8_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/config.json
@@ -1,0 +1,26 @@
+{
+  "top_name": "attention_dual_stream_composed_int8_q8k8v8_8x8_p8_ppc1_nohash_score32_w16_exp_lut_div_b20",
+  "attention_dual_stream_composed": {
+    "streams": 2,
+    "array_m": 8,
+    "array_n": 8,
+    "k_unroll": 1,
+    "mac_accum_bits": 32,
+    "softmax_row_elems": 8,
+    "softmax_score_bits": 32,
+    "softmax_weight_bits": 16,
+    "softmax_input_frac_bits": 28,
+    "softmax_accum_bits": 40,
+    "reciprocal_bits": 16,
+    "softmax_reciprocal_lut_bucket_shift": 20,
+    "value_bits": 8,
+    "value_lanes": 8,
+    "partials": 8,
+    "partials_per_cycle": 1,
+    "stream_buffer_bits": 512,
+    "equivalence_hash": false,
+    "softmax_pipeline_stages": 1,
+    "softmax_impl": "exp_lut_div",
+    "semantic_profile": "score32_exp_lut_div"
+  }
+}

--- a/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -417,6 +417,102 @@ def test_composed_wrapper_semantic_profile_prefers_generated_manifest(tmp_path: 
     assert result["best_requested"]["measured_dual_stream_composed_semantic_profile"] == "score32_w16_recip_lut_q16"
 
 
+def test_composed_wrapper_total_macs_prefers_generated_manifest_then_config(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    _write_json(
+        source,
+        {
+            "model": "unit_source",
+            "best_by_compute_mode": [
+                {
+                    "compute_mode": "dual_mac",
+                    "latency_us": 1.6,
+                    "source_latency_us": 3.2,
+                    "latency_speedup_vs_hbm_closed_source": 2.0,
+                    "cluster_count": 1,
+                    "compute_area_multiplier": 1.0,
+                    "compute_area_um2": 180.0,
+                    "compute_budget_um2": 260.0,
+                    "measured_l1_overhead_area_um2": 10.0,
+                    "local_datapath_area_um2": 4.0,
+                    "softmax_weight_generator_area_um2": 2.0,
+                    "logic_area_used_um2": 250.0,
+                    "required_stream_buffer_bytes": 16,
+                    "available_local_capacity_bytes": 32,
+                    "measured_block_area_um2": 45.0,
+                    "measured_block_clock_ns": 1.0,
+                    "measured_block_macs_per_cycle": 128,
+                    "measured_block_power_mw": 1.0,
+                    "compute_replica_count": 2,
+                    "compute_arch": "dense_gemm_16x8_k1_p1",
+                    "macs_per_cycle": 256,
+                    "clock_ns": 1.0,
+                    "layers": 1,
+                    "qkv_cycles": 10,
+                    "tile_qk_cycles": 80,
+                    "tile_stats_cycles": 8,
+                    "tile_value_cycles": 80,
+                    "tile_hbm_cycles": 10,
+                    "tile_local_sram_cycles": 1,
+                    "tile_shared_path_cycles": 1,
+                    "tile_waves": 1,
+                    "command_dispatch_cycles": 0,
+                    "cross_tile_reduction_cycles": 0,
+                    "kv_write_cycles": 0,
+                    "subtile_count": 1,
+                    "subtile_buffer_count": 1,
+                    "prefetch_distance": 0,
+                    "normalize_strategy": "online_correction",
+                    "online_rescale_penalty_cycles": 0,
+                    "subtile_stats_cycles": 8,
+                    "subtile_hbm_cycles": 10,
+                    "subtile_aux_memory_cycles": 1,
+                    "tile_service_cycles": 88,
+                }
+            ],
+        },
+    )
+    full_metrics = tmp_path / "full" / "metrics.csv"
+    half_metrics = tmp_path / "half" / "metrics.csv"
+    _write_metrics(full_metrics, die_area=90.0, power_mw=1.0, instance_area=90.0)
+    _write_metrics(half_metrics, die_area=40.0, power_mw=0.5, instance_area=40.0)
+    _write_json(
+        full_metrics.parent / "verilog" / "attention_dual_stream_composed_manifest.json",
+        {
+            "semantic_profile": "score32_exp_lut_div",
+            "total_macs": 256,
+        },
+    )
+    _write_json(
+        half_metrics.parent / "config.json",
+        {
+            "attention_dual_stream_composed": {
+                "streams": 2,
+                "array_m": 8,
+                "array_n": 4,
+                "k_unroll": 1,
+                "semantic_profile": "score32_exp_lut_div",
+            },
+        },
+    )
+
+    result = build_report(
+        _args(
+            tmp_path,
+            source=source,
+            composed_metrics=[str(full_metrics), str(half_metrics)],
+            recompute_area_fit_replicas=True,
+        )
+    )
+
+    rows_by_name = {row["substituted_compute_arch"]: row for row in result["rows"]}
+    assert rows_by_name["full"]["substituted_block_macs_per_cycle"] == 256
+    assert rows_by_name["full"]["substituted_compute_replica_count"] == 1
+    assert rows_by_name["half"]["substituted_block_macs_per_cycle"] == 64
+    assert rows_by_name["half"]["substituted_compute_replica_count"] == 4
+    assert rows_by_name["half"]["replica_recost_macs_per_cycle"] == 256
+
+
 def test_composed_wrapper_can_recost_area_fit_replica_count(tmp_path: Path) -> None:
     source = tmp_path / "source.json"
     _write_json(


### PR DESCRIPTION
## Summary
- add reduced-parallel score32 exp-LUT composed-wrapper configs for 8x8, 8x4, and 4x4 local compute/value points
- add a score32 exp-LUT parallelism L1 proposal and dependent L2 recost proposal
- fix L2 recost accounting so composed-wrapper variants use generated manifest/config `total_macs` rather than inheriting the full source block MACs/cycle
- wire the L2 generator and result consumer for the score32 exp-LUT parallelism recost item

## Why
The score32 compute-activity audit showed active duty is already high, so clock gating only reduces total score32 energy by about 3.1%. The next useful frontier step is to measure lower-parallel score32 exp-LUT wrappers and recost Llama7B latency/energy/area with honest per-variant MAC throughput.

## Validation
- Generated RTL and guard passed for all three new configs in `/tmp/rtlgen-config-check`
- `PYTHONPATH=.:control_plane pytest -q tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py::test_composed_wrapper_total_macs_prefers_generated_manifest_then_config control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_evidence`
- `PYTHONPATH=.:control_plane pytest -q tests/test_attention_dual_stream_composed_generator.py`
- `PYTHONPATH=.:control_plane pytest -q tests/test_llm_decoder_attention_kv_dual_stream_physical_feasibility.py tests/test_attention_dual_stream_composed_generator.py`
- `PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_lut_div_reduced_replica_evidence control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_evidence`
- `python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py`
- `git diff --check`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `python3 tests/test_runs_parsers.py`
