### PR TITLE
[codex] add score32 schedule wrapper recost support

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5526,6 +5526,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     score32_recip_lut_q16_reduced_replica = "score32_w16_recip_lut_q16_reduced_replica" in item_id
     score32_exp_lut_div_reduced_replica = "score32_exp_lut_div_reduced_replica" in item_id
     score32_exp_lut_div_parallelism_recost = "score32_exp_lut_div_parallelism_recost" in item_id
+    score32_exp_lut_div_schedule_wrapper_recost = "score32_exp_lut_div_schedule_wrapper_recost" in item_id
     command_overhead = "command_overhead" in item_id
     measured_command_control = "measured_command_control" in item_id
     q20_pwl_recip_div_reduced_replica = "q20_pwl_recip_div_reduced_replica" in item_id
@@ -5570,6 +5571,13 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
             "runs/designs/npu_blocks/"
             "attention_dual_stream_composed_int8_q8k8v8_4x4_p8_ppc1_nohash_score32_w16_exp_lut_div_b20/"
             "metrics.csv"
+        )
+    elif score32_exp_lut_div_schedule_wrapper_recost:
+        composed_dual_stream_metrics = (
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv,"
+            "runs/designs/npu_blocks/"
+            "attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c4/metrics.csv"
         )
     elif q20_pwl_recip_div_reduced_replica:
         composed_dual_stream_metrics = (
@@ -5625,6 +5633,9 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     elif score32_exp_lut_div_parallelism_recost:
         model_name = "llm_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1"
         precision_profile = "q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute"
+    elif score32_exp_lut_div_schedule_wrapper_recost:
+        model_name = "llm_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+        precision_profile = "q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute"
     elif q20_pwl_recip_div_reduced_replica:
         model_name = "llm_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1"
         precision_profile = "q8_k8_v8_a24_s20_w20_pwl_recip_div_q20_int8_compute"
@@ -5643,7 +5654,11 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
     else:
         model_name = "llm_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1"
         precision_profile = "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
-    if score32_exp_lut_div_reduced_replica or score32_exp_lut_div_parallelism_recost:
+    if (
+        score32_exp_lut_div_reduced_replica
+        or score32_exp_lut_div_parallelism_recost
+        or score32_exp_lut_div_schedule_wrapper_recost
+    ):
         quality_gate = (
             f"{base}/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
             "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
@@ -5658,6 +5673,7 @@ def _decoder_attention_composed_datapath_physical_feasibility_evidence(*, item_i
         or score32_recip_lut_q16_reduced_replica
         or score32_exp_lut_div_reduced_replica
         or score32_exp_lut_div_parallelism_recost
+        or score32_exp_lut_div_schedule_wrapper_recost
         or q20_pwl_recip_div_reduced_replica
     )
     command_overhead_flags = ""

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6530,6 +6530,74 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_meas
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_schedule_wrapper_recost() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_"
+                        "schedule_wrapper_recost_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_composed_datapath_physical_feasibility",
+                    evaluation_mode="frontier_detail",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert commands[0]["name"] == "estimate_decoder_attention_composed_datapath_physical_feasibility"
+            assert "check_attention_score32_exp_lut_div_frontier_release" not in [c["name"] for c in commands]
+            assert (
+                "--model-name llm_decoder_attention_composed_datapath_score32_exp_lut_div_"
+                "schedule_wrapper_recost_llama7b_v1"
+                in run
+            )
+            assert "--recompute-area-fit-replicas" in run
+            assert "--command-dispatch-control-metrics" not in run
+            assert (
+                "--composed-dual-stream-metrics "
+                "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv"
+                in run
+            )
+            assert (
+                "--composed-dual-stream-metrics "
+                "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c4/metrics.csv"
+                in run
+            )
+            assert decoder_inputs["attention_kv_composed_dual_stream_metrics"] == (
+                "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv,"
+                "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c4/metrics.csv"
+            )
+            assert decoder_inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality"].endswith(
+                "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+                "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_composed_datapath_physical_feasibility__"
+                    "l2_decoder_attention_composed_datapath_score32_exp_lut_div_"
+                    "schedule_wrapper_recost_llama7b_v1.json"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_measured_wrapper_promotion_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -194,6 +194,11 @@ than free or heuristic assumptions.
     8x8 ppc1 dual-stream datapath. The purpose is to replace the modeled sum
     of command control plus local datapath with measured schedule-wrapper PPA
     before the full Llama7B array is recosted.
+  - the prepared dependent recost is
+    `l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1`.
+    It must wait for the schedule-wrapper L1 PR to merge, then consume the
+    c2/c4 metrics as measured compute/control blocks with manifest-derived
+    wrapper MAC counts.
 - New evaluations should continue to dispatch only to the remote evaluator
   `eval-daemon-b7c2d9c80c1c`, not the devcontainer.
 
@@ -391,9 +396,11 @@ run the already queued exp-LUT branch:
     reduces the remaining scheduler/control abstraction by putting central
     dispatch, local ready/valid issue, local completion accounting, and the
     selected composed datapath replicas into one measured RTL/PPA wrapper. The
-    follow-on L2 recost should scale from this wrapper evidence and keep
-    external SRAM, NoC, HBM/DRAM service, and full-array physical signoff as
-    explicit remaining abstractions.
+    follow-on L2 item is
+    `l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1`.
+    It should scale from this wrapper evidence and keep external SRAM, NoC,
+    HBM/DRAM service, and full-array physical signoff as explicit remaining
+    abstractions.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1/README.md
@@ -1,0 +1,10 @@
+# Llama7B score32 exp-LUT schedule-wrapper recost
+
+This proposal adds the L2 follow-on for the measured score32 exp-LUT
+dual-stream schedule-wrapper PPA.
+
+Item: `l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1`
+
+The recost consumes the bounded c2/c4 schedule-wrapper metrics and substitutes
+them into the Llama7B area-fit replica model. This replaces the previous modeled
+composition of separate datapath, command-dispatch, and local schedule overhead.

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost Llama7B score32 exp-LUT attention using measured c2/c4 dual-stream schedule-wrapper PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_schedule_wrapper_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_schedule_wrapper_score32_exp_lut_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "replace_modeled_schedule_control_with_measured_wrapper",
+        "reason": "The result should show whether measured bounded schedule/control wrapper overhead changes the current score32 exp-LUT Llama7B frontier ranking."
+      },
+      "status": "blocked"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1/proposal.json
@@ -1,0 +1,58 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+  "created_utc": "2026-07-07T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 exp-LUT schedule-wrapper Llama7B recost",
+  "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+  "hypothesis": "The current score32 exp-LUT Llama7B recost still scales measured datapaths plus modeled command/control composition. Substituting the measured c2/c4 schedule-wrapper slices should expose whether local issue/done accounting and central dispatch materially change area-fit token latency, energy, and ranking.",
+  "direct_comparison": {
+    "primary_question": "Does measured bounded schedule-wrapper PPA change the score32 exp-LUT Llama7B frontier versus the prior parallelism recost?",
+    "baseline": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+    "include": [
+      "c2/c4 schedule-wrapper metrics",
+      "manifest-derived wrapper MACs/cycle",
+      "same score32 exp-LUT quality evidence",
+      "area-fit replica recost against the Llama7B schedule"
+    ],
+    "exclude": [
+      "full 856-replica place-and-route",
+      "new precision quality run",
+      "new HBM/DRAM controller RTL"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost Llama7B score32 exp-LUT attention using measured c2/c4 dual-stream schedule-wrapper PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_composed_datapath_physical_feasibility",
+      "comparison_role": "score32_exp_lut_schedule_wrapper_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_dual_stream_schedule_wrapper_score32_exp_lut_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "replace_modeled_schedule_control_with_measured_wrapper",
+        "reason": "The result should show whether measured bounded schedule/control wrapper overhead changes the current score32 exp-LUT Llama7B frontier ranking."
+      },
+      "status": "blocked"
+    }
+  ],
+  "source_refs": [
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "docs/proposals/prop_l1_decoder_attention_dual_stream_schedule_wrapper_score32_exp_lut_v1/proposal.json"
+  ],
+  "remaining_abstractions": [
+    "The L1 input is a bounded c2/c4 wrapper slice, not a full-chip implementation.",
+    "External SRAM, NoC, HBM/DRAM service, and package-level memory energy remain from the existing Llama7B model.",
+    "The recost scales the measured wrapper by area-fit replicas rather than executing a cycle-accurate full-array token replay."
+  ]
+}

--- a/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
+++ b/npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py
@@ -101,8 +101,9 @@ def _compose_variant_name(path: Path) -> str:
 def _load_composed_semantic_profile(path: Path) -> str:
     design_dir = path.parent
     manifest_path = design_dir / "verilog" / "attention_dual_stream_composed_manifest.json"
+    schedule_manifest_path = design_dir / "verilog" / "attention_dual_stream_schedule_wrapper_manifest.json"
     config_path = design_dir / "config.json"
-    for candidate in (manifest_path, config_path):
+    for candidate in (manifest_path, schedule_manifest_path, config_path):
         if not candidate.exists():
             continue
         try:
@@ -111,8 +112,15 @@ def _load_composed_semantic_profile(path: Path) -> str:
             continue
         if candidate == manifest_path:
             profile = payload.get("semantic_profile")
+        elif candidate == schedule_manifest_path:
+            datapath = payload.get("datapath_manifest")
+            profile = datapath.get("semantic_profile") if isinstance(datapath, dict) else None
         else:
             comp = payload.get("attention_dual_stream_composed")
+            if not isinstance(comp, dict):
+                wrapper = payload.get("attention_dual_stream_schedule_wrapper")
+                datapath = wrapper.get("datapath") if isinstance(wrapper, dict) else None
+                comp = datapath if isinstance(datapath, dict) else None
             profile = comp.get("semantic_profile") if isinstance(comp, dict) else None
         if isinstance(profile, str) and profile.strip():
             return profile.strip()
@@ -122,10 +130,22 @@ def _load_composed_semantic_profile(path: Path) -> str:
 def _load_composed_total_macs(path: Path) -> int | None:
     design_dir = path.parent
     manifest_path = design_dir / "verilog" / "attention_dual_stream_composed_manifest.json"
+    schedule_manifest_path = design_dir / "verilog" / "attention_dual_stream_schedule_wrapper_manifest.json"
     config_path = design_dir / "config.json"
     if manifest_path.exists():
         try:
             manifest = _load_json(manifest_path)
+        except json.JSONDecodeError:
+            manifest = {}
+        try:
+            total_macs = int(manifest.get("total_macs"))
+        except (TypeError, ValueError):
+            total_macs = 0
+        if total_macs > 0:
+            return total_macs
+    if schedule_manifest_path.exists():
+        try:
+            manifest = _load_json(schedule_manifest_path)
         except json.JSONDecodeError:
             manifest = {}
         try:
@@ -140,6 +160,16 @@ def _load_composed_total_macs(path: Path) -> int | None:
         except json.JSONDecodeError:
             payload = {}
         comp = payload.get("attention_dual_stream_composed") if isinstance(payload, dict) else None
+        if not isinstance(comp, dict):
+            wrapper = payload.get("attention_dual_stream_schedule_wrapper") if isinstance(payload, dict) else None
+            if isinstance(wrapper, dict):
+                datapath = wrapper.get("datapath")
+                clusters = int(wrapper.get("clusters", 1))
+                comp = datapath if isinstance(datapath, dict) else None
+            else:
+                clusters = 1
+        else:
+            clusters = 1
         if isinstance(comp, dict):
             try:
                 streams = int(comp.get("streams", 2))
@@ -148,10 +178,29 @@ def _load_composed_total_macs(path: Path) -> int | None:
                 k_unroll = int(comp.get("k_unroll", 1))
             except (TypeError, ValueError):
                 return None
-            total_macs = streams * array_m * array_n * k_unroll
+            total_macs = clusters * streams * array_m * array_n * k_unroll
             if total_macs > 0:
                 return total_macs
     return None
+
+
+def _load_composed_variant_kind(path: Path) -> str:
+    design_dir = path.parent
+    if (design_dir / "verilog" / "attention_dual_stream_schedule_wrapper_manifest.json").exists():
+        return "dual_stream_schedule_wrapper"
+    if (design_dir / "verilog" / "attention_dual_stream_composed_manifest.json").exists():
+        return "dual_stream_composed_datapath"
+    config_path = design_dir / "config.json"
+    if config_path.exists():
+        try:
+            payload = _load_json(config_path)
+        except json.JSONDecodeError:
+            payload = {}
+        if isinstance(payload.get("attention_dual_stream_schedule_wrapper"), dict):
+            return "dual_stream_schedule_wrapper"
+        if isinstance(payload.get("attention_dual_stream_composed"), dict):
+            return "dual_stream_composed_datapath"
+    return "unknown_composed_compute_block"
 
 
 def _parse_composed_metric_inputs(values: Any) -> list[Path]:
@@ -199,6 +248,7 @@ def _load_composed_variants(paths: list[Path]) -> list[JsonDict]:
             {
                 "composed_variant_label": _infer_composed_precision_profile(path),
                 "composed_variant_name": _compose_variant_name(path),
+                "composed_variant_kind": _load_composed_variant_kind(path),
                 "composed_semantic_profile": _load_composed_semantic_profile(path),
                 "composed_total_macs_per_cycle": total_macs,
             }
@@ -416,6 +466,7 @@ def _row_with_budget(
             composed_dual_stream.get("composed_variant_name")
             or "attention_dual_stream_composed_int8_q8k8v6_16x8_p8_ppc2_nohash_softmax_recip_lut_q10"
         )
+        composed_variant_kind = str(composed_dual_stream.get("composed_variant_kind") or "dual_stream_composed_datapath")
         compute_area_required = base_compute_area
     elif compute_block is None:
         base_compute_area = current_compute_area
@@ -426,6 +477,7 @@ def _row_with_budget(
         target_block_clock = float(source_row["measured_block_clock_ns"])
         target_block_power = float(source_row.get("measured_block_power_mw", 0.0))
         target_arch = str(source_row.get("compute_arch", ""))
+        composed_variant_kind = None
         compute_area_required = base_compute_area * compute_multiplier
     else:
         target_block_area = float(compute_block["block_area_um2"])
@@ -436,6 +488,7 @@ def _row_with_budget(
         target_block_power = float(compute_block["total_power_mw"])
         base_compute_power = target_replica_count * target_block_power
         target_arch = str(compute_arch_name or source_row.get("compute_arch", ""))
+        composed_variant_kind = None
         compute_area_required = base_compute_area * compute_multiplier
     logic_used_required = current_logic_used + (compute_area_required - current_compute_area) + (
         selected_l1_overhead - current_l1_overhead
@@ -480,7 +533,9 @@ def _row_with_budget(
     out.update(
         {
             "dual_stream_physical_model": (
-                "measured_dual_stream_composed_budget_v1"
+                "measured_dual_stream_schedule_wrapper_budget_v1"
+                if use_composed_dual_stream and composed_variant_kind == "dual_stream_schedule_wrapper"
+                else "measured_dual_stream_composed_budget_v1"
                 if use_composed_dual_stream
                 else "measured_full_value_tile_budget_v1"
             ),
@@ -503,6 +558,7 @@ def _row_with_budget(
                     "measured_dual_stream_composed_precision_profile": composed_dual_stream[
                         "composed_variant_label"
                     ],
+                    "measured_dual_stream_composed_variant_kind": composed_variant_kind,
                     "measured_dual_stream_composed_semantic_profile": composed_dual_stream[
                         "composed_semantic_profile"
                     ],
@@ -562,6 +618,7 @@ def _row_with_budget(
             "substituted_compute_semantic_profile": (
                 composed_dual_stream["composed_semantic_profile"] if use_composed_dual_stream else None
             ),
+            "substituted_compute_variant_kind": composed_variant_kind if use_composed_dual_stream else None,
             "logic_area_used_required_um2": round(logic_used_required, 6),
             "logic_area_slack_required_um2": round(logic_slack_required, 6),
             "compute_area_over_budget_um2": round(compute_area_over_budget, 6),
@@ -986,6 +1043,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "best_requested_substituted_compute_semantic_profile": best_requested.get(
                 "substituted_compute_semantic_profile"
             ),
+            "best_requested_substituted_compute_variant_kind": best_requested.get(
+                "substituted_compute_variant_kind"
+            ),
             "best_requested_substituted_compute_area_um2": best_requested.get("substituted_compute_area_um2"),
             "best_requested_compute_clock_ok": best_requested.get("compute_clock_ok"),
             "best_requested_command_dispatch_control_variant": best_requested.get(
@@ -1044,6 +1104,7 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         f"- best requested compute substitution: `{diag['best_requested_compute_substitution_enabled']}`",
         f"- best requested substituted compute arch: `{diag['best_requested_substituted_compute_arch']}`",
         f"- best requested substituted compute variant: `{diag['best_requested_substituted_compute_variant_label']}`",
+        f"- best requested substituted compute kind: `{diag['best_requested_substituted_compute_variant_kind']}`",
         f"- best requested substituted compute semantic profile: `{diag['best_requested_substituted_compute_semantic_profile']}`",
         f"- best requested substituted compute area um2: `{diag['best_requested_substituted_compute_area_um2']}`",
         f"- best requested command dispatch control variant: `{diag['best_requested_command_dispatch_control_variant']}`",

--- a/tests/test_attention_dual_stream_schedule_wrapper_generator.py
+++ b/tests/test_attention_dual_stream_schedule_wrapper_generator.py
@@ -3,6 +3,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+from npu.eval.estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility import (
+    _load_composed_semantic_profile,
+    _load_composed_total_macs,
+    _load_composed_variant_kind,
+)
+
 
 def _write_config(config_path: Path, *, clusters: int = 2) -> None:
     config_path.parent.mkdir(parents=True)
@@ -102,3 +108,31 @@ def test_attention_dual_stream_schedule_wrapper_generator_guard_and_syntax(tmp_p
     assert "local_issue_valid" in top_text
     assert "cluster_done_valid" in top_text
     assert "datapath_result_fold" in top_text
+
+
+def test_schedule_wrapper_metrics_are_loaded_as_composed_compute_variant(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_dual_stream_schedule_wrapper_smoke_c4"
+    config_path = design_dir / "config.json"
+    _write_config(config_path, clusters=4)
+
+    subprocess.run(
+        [
+            sys.executable,
+            "npu/rtlgen/gen_attention_dual_stream_schedule_wrapper.py",
+            "--config",
+            str(config_path),
+            "--out",
+            str(design_dir / "verilog"),
+        ],
+        check=True,
+    )
+    metrics_path = design_dir / "metrics.csv"
+    metrics_path.write_text(
+        "design,status,critical_path_ns,die_area,total_power_mw,instance_area_um2,param_hash,tag,result_path\n"
+        "attention_dual_stream_schedule_wrapper_smoke_c4,ok,12.5,1000,3.25,900,abc,tag,out\n",
+        encoding="utf-8",
+    )
+
+    assert _load_composed_variant_kind(metrics_path) == "dual_stream_schedule_wrapper"
+    assert _load_composed_semantic_profile(metrics_path) == "score32_exp_lut_div"
+    assert _load_composed_total_macs(metrics_path) == 32


### PR DESCRIPTION
## Summary\n- teach the L2 dual-stream physical feasibility estimator to consume measured schedule-wrapper manifests/configs as compute/control block variants\n- add L2 task-generator support and proposal docs for the score32 exp-LUT schedule-wrapper recost\n- document the L1 schedule-wrapper PPA -> L2 recost path\n\n## Validation\n- PYTHONPATH=.:control_plane pytest -q tests/test_attention_dual_stream_schedule_wrapper_generator.py control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_schedule_wrapper_recost\n- PYTHONPATH=.:control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_measured_command_control control_plane/control_plane/tests/test_l2_task_generator.py::test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_schedule_wrapper_recost control_plane/control_plane/tests/test_l2_result_consumer.py::test_decoder_evidence_summary_recognizes_composed_datapath_score32_reduced_replica_model\n- python3 -m py_compile npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py control_plane/control_plane/services/l2_task_generator.py\n- python3 scripts/validate_runs.py\n- python3 tests/test_runs_parsers.py\n- git diff --check