### PR TITLE
[codex] add schedule-wrapper integrated frontier ranking hook

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5921,6 +5921,12 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
         "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_"
         "measured_command_control_llama7b_v1.json"
     )
+    schedule_wrapper_recost = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_"
+        "schedule_wrapper_recost_llama7b_v1.json"
+    )
+    use_schedule_wrapper_recost = "schedule_wrapper" in item_id
     score32_quality = (
         f"{base}/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
         "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
@@ -5937,10 +5943,30 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
         f"{base}/decoder_attention_integrated_energy_closure__"
         "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
     )
+    command = (
+        "python3 npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py "
+        f"--score32-hbm-dram-service-json {score32_hbm} "
+        f"--score32-measured-command-control-json {measured_command_control} "
+    )
+    if use_schedule_wrapper_recost:
+        command += f"--score32-physical-feasibility-json {schedule_wrapper_recost} "
+    command += (
+        f"--score32-quality-json {score32_quality} "
+        f"--measured-compute-energy-json {measured_compute} "
+        f"--mixed-int8-energy-json {mixed_int8} "
+        f"--integrated-energy-json {integrated_energy} "
+        f"--out {out} "
+        f"--out-md {report}"
+    )
     return {
         "inputs": {
             "attention_score32_exp_lut_hbm_dram_service_closure": score32_hbm,
             "attention_score32_exp_lut_measured_command_control": measured_command_control,
+            **(
+                {"attention_score32_exp_lut_schedule_wrapper_recost": schedule_wrapper_recost}
+                if use_schedule_wrapper_recost
+                else {}
+            ),
             "attention_score32_exp_lut_generation_quality": score32_quality,
             "attention_measured_compute_energy_closure": measured_compute,
             "attention_mixed_int8_energy_closure": mixed_int8,
@@ -5957,17 +5983,7 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
         "commands": [
             {
                 "name": "audit_decoder_attention_score32_integrated_frontier_ranking",
-                "run": (
-                    "python3 npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py "
-                    f"--score32-hbm-dram-service-json {score32_hbm} "
-                    f"--score32-measured-command-control-json {measured_command_control} "
-                    f"--score32-quality-json {score32_quality} "
-                    f"--measured-compute-energy-json {measured_compute} "
-                    f"--mixed-int8-energy-json {mixed_int8} "
-                    f"--integrated-energy-json {integrated_energy} "
-                    f"--out {out} "
-                    f"--out-md {report}"
-                ),
+                "run": command,
             },
         ],
         "expected_outputs": [out, report],

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6900,6 +6900,53 @@ def test_generate_l2_campaign_task_adds_attention_score32_integrated_frontier_ra
             )
 
 
+def test_generate_l2_campaign_task_adds_schedule_wrapper_integrated_frontier_ranking_input() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_integrated_frontier_ranking",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "--score32-physical-feasibility-json" in run
+            assert (
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_"
+                "schedule_wrapper_recost_llama7b_v1.json"
+            ) in run
+            assert (
+                decoder_inputs["attention_score32_exp_lut_schedule_wrapper_recost"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_"
+                "schedule_wrapper_recost_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_integrated_frontier_ranking_out"].endswith(
+                "decoder_attention_score32_integrated_frontier_ranking__"
+                "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1.json"
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_compute_activity_energy_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1/README.md
@@ -1,0 +1,5 @@
+# Score32 Schedule-Wrapper Integrated Frontier Ranking
+
+This proposal queues the post-recost ranking step for the score32 exp-LUT Llama7B frontier.
+
+It should run only after `l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1` has merged. The ranking consumes that physical-feasibility artifact as the score32 row and reuses the existing HBM/DRAM service closure because the measured schedule-wrapper change does not alter token memory traffic.

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,30 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds optional schedule-wrapper physical-feasibility input support to the score32 integrated frontier-ranking audit.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rank the score32 exp-LUT schedule-wrapper recost against current Llama7B frontier alternatives.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_schedule_wrapper_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_schedule_wrapper_integrated_frontier_ranking",
+        "reason": "The result should show whether measured schedule-wrapper overhead changes the current precision-safe Llama7B score32 recommendation."
+      },
+      "status": "blocked"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1/proposal.json
@@ -1,0 +1,80 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+  "created_utc": "2026-07-07T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 schedule-wrapper integrated Llama7B frontier ranking",
+  "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+  "hypothesis": "After the measured c2/c4 schedule-wrapper recost lands, the integrated Llama7B frontier ranking should consume that recost directly so the score32 row reflects measured schedule/control wrapper overhead instead of the older separated command-control composition.",
+  "direct_comparison": {
+    "primary_question": "Does substituting measured schedule-wrapper recost into the integrated Llama7B frontier ranking change the precision-safe throughput, energy, or area decision?",
+    "include": [
+      "consume the schedule-wrapper physical-feasibility recost",
+      "reuse score32 HBM/DRAM service and energy closure for unchanged memory traffic",
+      "consume the score32 mixed-int8 generation-quality gate",
+      "compare against measured exact-FP16, mixed/int8 energy, and abstract planning rows",
+      "report promotable latency rank, promotable energy rank, area, precision status, and remaining abstractions"
+    ],
+    "exclude": [
+      "new OpenROAD PPA",
+      "new generation-quality evaluation",
+      "new HBM controller RTL",
+      "vendor HBM current-signoff traces"
+    ]
+  },
+  "expected_benefit": [
+    "keeps the integrated frontier ranking synchronized with the latest abstraction-removal result",
+    "prevents the older measured-command-control score32 row from remaining the promoted frontier after schedule-wrapper data lands",
+    "makes the next architecture decision compare token throughput, energy, area, and precision on the same evidence set"
+  ],
+  "risks": [
+    "HBM/DRAM service and energy are reused from the score32 HBM closure because wrapper recost does not change token memory traffic",
+    "the ranking remains an evidence audit and does not synthesize new circuits",
+    "the quality status is still the bounded Llama7B generation-quality gate rather than a broader downstream task suite"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rank the score32 exp-LUT schedule-wrapper recost against current Llama7B frontier alternatives.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_schedule_wrapper_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_schedule_wrapper_integrated_frontier_ranking",
+        "reason": "The result should show whether measured schedule-wrapper overhead changes the current precision-safe Llama7B score32 recommendation."
+      },
+      "status": "blocked"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py",
+    "npu/eval/estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility.py",
+    "docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1/proposal.json"
+  ],
+  "remaining_abstractions": [
+    "HBM/DRAM service remains command/burst/row-hit accounting, not cycle-accurate controller RTL.",
+    "HBM energy remains calibrated command-class pJ accounting, not vendor current-signoff traces.",
+    "The schedule-wrapper recost scales measured c2/c4 wrapper slices rather than executing a cycle-accurate full-array token replay."
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -43,30 +43,74 @@ def _quality_status(score32_quality: JsonDict) -> JsonDict:
     }
 
 
-def _score32_row(score32_hbm: JsonDict, measured_command: JsonDict, score32_quality: JsonDict) -> JsonDict:
+def _score32_row(
+    score32_hbm: JsonDict,
+    measured_command: JsonDict,
+    score32_quality: JsonDict,
+    score32_physical: JsonDict | None = None,
+) -> JsonDict:
     best = _as_dict(score32_hbm.get("best_latency"))
-    measured = _as_dict(measured_command.get("best_requested"))
+    measured_source = score32_physical if score32_physical is not None else measured_command
+    measured = _as_dict(measured_source.get("best_requested"))
     quality = _quality_status(score32_quality)
+    uses_physical_recost = score32_physical is not None
+    latency_us = _as_float(best.get("latency_us"))
+    token_throughput_per_s = _as_float(best.get("token_throughput_per_s"))
+    compute_energy_mj_per_token = _as_float(best.get("compute_energy_mj_per_token"))
+    hbm_energy_mj_per_token = _as_float(best.get("hbm_energy_mj_per_token"))
+    total_energy_mj_per_token = _as_float(best.get("total_energy_mj_per_token"))
+    source_artifact = "score32_hbm_dram_service_closure"
+    candidate_id = "score32_exp_lut_hbm_dram_service_closure_best"
+    abstraction_status = "measured_wrapper_command_control_sram_envelope_hbm_command_service"
+    remaining_abstractions = list(best.get("remaining_abstractions") or [])
+
+    if uses_physical_recost:
+        latency_us = _as_float(
+            measured.get("replica_recost_latency_us") or measured.get("adjusted_latency_us_if_feasible"),
+            latency_us,
+        )
+        if latency_us > 0:
+            token_throughput_per_s = 1_000_000.0 / latency_us
+        compute_power_mw = _as_float(
+            measured.get("substituted_compute_plus_control_power_mw")
+            or measured.get("logic_power_mw")
+            or measured.get("compute_power_mw")
+            or best.get("compute_power_mw")
+        )
+        if compute_power_mw > 0 and latency_us > 0:
+            compute_energy_mj_per_token = compute_power_mw * latency_us * 1.0e-6
+            total_energy_mj_per_token = compute_energy_mj_per_token + hbm_energy_mj_per_token
+        source_artifact = "score32_schedule_wrapper_recost_with_hbm_service"
+        candidate_id = "score32_exp_lut_schedule_wrapper_hbm_service_best"
+        abstraction_status = "measured_schedule_wrapper_recost_sram_envelope_hbm_command_service"
+        remaining_abstractions = sorted(
+            {
+                *remaining_abstractions,
+                *list(score32_physical.get("remaining_abstractions") or []),
+                "HBM/DRAM service and energy are reused from the score32 HBM closure because the wrapper recost does not change token memory traffic.",
+            }
+        )
+
     return {
-        "candidate_id": "score32_exp_lut_hbm_dram_service_closure_best",
+        "candidate_id": candidate_id,
         "family": "score32_exp_lut_div",
-        "source_artifact": "score32_hbm_dram_service_closure",
-        "latency_us": _as_float(best.get("latency_us")),
-        "token_throughput_per_s": _as_float(best.get("token_throughput_per_s")),
-        "energy_mj_per_token": _as_float(best.get("total_energy_mj_per_token")),
-        "compute_energy_mj_per_token": _as_float(best.get("compute_energy_mj_per_token")),
-        "hbm_energy_mj_per_token": _as_float(best.get("hbm_energy_mj_per_token")),
+        "source_artifact": source_artifact,
+        "latency_us": latency_us,
+        "token_throughput_per_s": token_throughput_per_s,
+        "energy_mj_per_token": total_energy_mj_per_token,
+        "compute_energy_mj_per_token": compute_energy_mj_per_token,
+        "hbm_energy_mj_per_token": hbm_energy_mj_per_token,
         "die_area_mm2": _as_float(measured.get("die_area_mm2")),
         "compute_area_mm2": _as_float(
             measured.get("replica_recost_compute_area_um2") or measured.get("compute_area_um2")
         )
         / 1.0e6,
-        "macs_per_cycle": _as_float(best.get("macs_per_cycle")),
+        "macs_per_cycle": _as_float(measured.get("replica_recost_macs_per_cycle") or best.get("macs_per_cycle")),
         "precision_status": quality["status"],
         "quality_backed": quality["quality_backed"],
         "quality": quality,
-        "abstraction_status": "measured_wrapper_command_control_sram_envelope_hbm_command_service",
-        "remaining_abstractions": list(best.get("remaining_abstractions") or []),
+        "abstraction_status": abstraction_status,
+        "remaining_abstractions": remaining_abstractions,
         "promotable": bool(quality["quality_backed"]),
     }
 
@@ -159,13 +203,14 @@ def _energy_rank(rows: list[JsonDict], *, promotable_only: bool = False) -> list
 def build_report(args: argparse.Namespace) -> JsonDict:
     score32_hbm = _load_json(args.score32_hbm_dram_service_json)
     measured_command = _load_json(args.score32_measured_command_control_json)
+    score32_physical = _load_json(args.score32_physical_feasibility_json) if args.score32_physical_feasibility_json else None
     score32_quality = _load_json(args.score32_quality_json)
     measured_compute = _load_json(args.measured_compute_energy_json)
     mixed_int8 = _load_json(args.mixed_int8_energy_json)
     integrated = _load_json(args.integrated_energy_json)
 
     rows = [
-        _score32_row(score32_hbm, measured_command, score32_quality),
+        _score32_row(score32_hbm, measured_command, score32_quality, score32_physical),
         _prior_row(
             candidate_id=str(_best_row(measured_compute).get("candidate_id") or "measured_fp16_compute_energy_best"),
             family="measured_exact_fp16_gqa8_kv8",
@@ -216,6 +261,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "inputs": {
             "score32_hbm_dram_service_json": str(args.score32_hbm_dram_service_json),
             "score32_measured_command_control_json": str(args.score32_measured_command_control_json),
+            "score32_physical_feasibility_json": str(args.score32_physical_feasibility_json)
+            if args.score32_physical_feasibility_json
+            else None,
             "score32_quality_json": str(args.score32_quality_json),
             "measured_compute_energy_json": str(args.measured_compute_energy_json),
             "mixed_int8_energy_json": str(args.mixed_int8_energy_json),
@@ -314,6 +362,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--score32-hbm-dram-service-json", type=Path, required=True)
     parser.add_argument("--score32-measured-command-control-json", type=Path, required=True)
+    parser.add_argument("--score32-physical-feasibility-json", type=Path)
     parser.add_argument("--score32-quality-json", type=Path, required=True)
     parser.add_argument("--measured-compute-energy-json", type=Path, required=True)
     parser.add_argument("--mixed-int8-energy-json", type=Path, required=True)


### PR DESCRIPTION
## Summary
- add optional score32 physical-feasibility input to the integrated frontier-ranking audit
- wire schedule-wrapper integrated-ranking item IDs to consume the schedule-wrapper recost artifact
- add a blocked follow-on proposal for the post-recost Llama7B frontier ranking

## Validation
- PYTHONPATH=/tmp/rtlgen-compact-recip/control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest control_plane/control_plane/tests/test_l2_task_generator.py -k 'integrated_frontier_ranking'
- python3 scripts/validate_runs.py --skip_eval_queue
- python3 npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py ... --score32-physical-feasibility-json ...
- git diff --check