### PR TITLE
npu: add score32 HBM controller replay audit

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5908,6 +5908,56 @@ def _decoder_attention_score32_exp_lut_hbm_dram_service_closure_evidence(*, item
     }
 
 
+def _decoder_attention_score32_hbm_controller_replay_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_score32_hbm_controller_replay__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_hbm_controller_replay__{item_id}.md"
+    score32_hbm = (
+        f"{base}/decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+    )
+    schedule_wrapper_recost = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_"
+        "schedule_wrapper_recost_llama7b_v1.json"
+    )
+    return {
+        "inputs": {
+            "attention_score32_exp_lut_hbm_dram_service_closure": score32_hbm,
+            "attention_score32_exp_lut_schedule_wrapper_recost": schedule_wrapper_recost,
+            "attention_score32_hbm_controller_replay_out": out,
+            "attention_score32_hbm_controller_replay_report": report,
+            "attention_score32_hbm_controller_replay_scope": (
+                "Replace the score32 analytic HBM service formula with a deterministic "
+                "cycle-level controller replay over burst requests, channel queues, row-buffer "
+                "state, outstanding windows, request overhead, row-miss penalty, and scheduler gaps."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_score32_hbm_controller_replay",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_score32_hbm_controller_replay.py "
+                    f"--score32-hbm-dram-service-json {score32_hbm} "
+                    f"--score32-physical-feasibility-json {schedule_wrapper_recost} "
+                    "--channel-count 4,8,16 "
+                    "--channel-bandwidth-bytes-per-cycle 256,512,1024 "
+                    "--burst-bytes 512,1024 "
+                    "--hbm-outstanding 4,8,16,32 "
+                    "--request-overhead-cycles 2,4,8 "
+                    "--row-miss-penalty-cycles 8,16,32 "
+                    "--row-span-bursts 1,4,16 "
+                    "--scheduler-gap-cycles 0,1,2 "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_integrated_frontier_ranking__{item_id}.json"
@@ -9552,6 +9602,7 @@ def _build_payload(
         "decoder_attention_score32_exp_lut_service_closure",
         "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
         "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
+        "decoder_attention_score32_hbm_controller_replay",
         "decoder_attention_score32_integrated_frontier_ranking",
         "decoder_attention_score32_compute_activity_energy",
         "decoder_attention_hbm_dram_service_energy",
@@ -9756,6 +9807,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_exp_lut_hbm_dram_service_closure":
             decoder_evidence = _decoder_attention_score32_exp_lut_hbm_dram_service_closure_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_score32_hbm_controller_replay":
+            decoder_evidence = _decoder_attention_score32_hbm_controller_replay_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_integrated_frontier_ranking":
             decoder_evidence = _decoder_attention_score32_integrated_frontier_ranking_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_compute_activity_energy":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -6833,6 +6833,65 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_hbm_dram_servi
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_hbm_controller_replay",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:1]] == [
+                "audit_decoder_attention_score32_hbm_controller_replay",
+            ]
+            assert "audit_llm_decoder_attention_score32_hbm_controller_replay.py" in run
+            assert "--score32-hbm-dram-service-json" in run
+            assert "--score32-physical-feasibility-json" in run
+            assert "--row-span-bursts 1,4,16" in run
+            assert (
+                decoder_inputs["attention_score32_exp_lut_hbm_dram_service_closure"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+                "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+            )
+            assert (
+                decoder_inputs["attention_score32_exp_lut_schedule_wrapper_recost"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_"
+                "schedule_wrapper_recost_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_hbm_controller_replay_out"].endswith(
+                "decoder_attention_score32_hbm_controller_replay__"
+                "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_hbm_controller_replay_scope"].startswith(
+                "Replace the score32 analytic HBM service formula"
+            )
+            assert decoder_inputs["attention_score32_hbm_controller_replay_out"] in work_item.expected_outputs
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_integrated_frontier_ranking_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1/README.md
@@ -1,0 +1,13 @@
+# Score32 HBM Controller Replay
+
+This proposal replaces the score32 schedule-wrapper frontier's analytic HBM
+service formula with deterministic cycle-level replay of the burst stream.
+
+The job does not add new PPA or quality evaluation. It consumes the merged
+score32 HBM service closure and schedule-wrapper recost, then sweeps controller
+parameters for channel queues, row-window locality, request overhead, row-miss
+penalty, scheduler gap, and outstanding requests.
+
+The result is intended to feed a follow-on integrated frontier ranking. Remaining
+abstractions after this step are HBM controller RTL timing, vendor current
+signoff, and measured address-trace locality.

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merge commit that adds the score32 HBM controller replay audit and L2 generator hook.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replay the score32 schedule-wrapper HBM burst stream through a deterministic controller model and report the resulting Llama7B latency and energy.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_hbm_controller_replay",
+      "comparison_role": "score32_hbm_controller_replay",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "replace_analytic_hbm_service_with_controller_replay",
+        "reason": "The result should show whether deterministic HBM controller replay changes the score32 schedule-wrapper latency, energy, and remaining-abstraction account."
+      },
+      "status": "ready_to_dispatch_after_code_merge"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1/proposal.json
@@ -1,0 +1,73 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+  "created_utc": "2026-07-08T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 schedule-wrapper HBM controller replay",
+  "abstraction_layer": "decoder_attention_score32_hbm_controller_replay",
+  "hypothesis": "The current precision-safe score32 schedule-wrapper frontier is still charged with an analytic HBM service formula. Replaying the score32 tile HBM burst stream through deterministic channel queues, row-window state, request overhead, row-miss penalty, scheduler gap, and outstanding-request limits should bound the cycle-level HBM-controller cost before a full RTL controller exists.",
+  "direct_comparison": {
+    "primary_question": "Does replacing analytic score32 HBM service with deterministic cycle-level controller replay materially move the precision-safe Llama7B throughput or energy point?",
+    "include": [
+      "consume the merged score32 HBM/DRAM service closure",
+      "consume the merged score32 schedule-wrapper physical recost",
+      "sweep channel count, per-channel bandwidth, burst size, row span, row miss penalty, request overhead, scheduler gap, and outstanding window",
+      "report replay service cycles, latency delta, throughput, energy, area, and remaining HBM abstractions"
+    ],
+    "exclude": [
+      "new OpenROAD PPA",
+      "HBM controller RTL timing",
+      "vendor HBM current signoff",
+      "new generation-quality evaluation"
+    ]
+  },
+  "expected_benefit": [
+    "reduces the score32 frontier HBM service abstraction from a closed-form estimate to a deterministic cycle replay",
+    "bounds whether the schedule-wrapper frontier remains throughput-best when HBM replay cycles exceed the source HBM/service budget",
+    "produces a concrete artifact that can be consumed by a follow-on integrated frontier ranking"
+  ],
+  "risks": [
+    "the replay is deterministic and cycle-level but still not RTL timing",
+    "HBM energy remains inherited from the command-calibrated service closure rather than vendor signoff current traces",
+    "row locality is controlled by replay parameters rather than measured physical address traces"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replay the score32 schedule-wrapper HBM burst stream through a deterministic controller model and report the resulting Llama7B latency and energy.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_hbm_controller_replay",
+      "comparison_role": "score32_hbm_controller_replay",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "replace_analytic_hbm_service_with_controller_replay",
+        "reason": "The result should show whether deterministic HBM controller replay changes the score32 schedule-wrapper latency, energy, and remaining-abstraction account."
+      },
+      "status": "ready_to_dispatch_after_code_merge"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_hbm_controller_replay.py",
+    "npu/eval/audit_llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure.py",
+    "npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "HBM controller replay is deterministic cycle-level modeling, not RTL timing.",
+    "HBM energy remains command-calibrated and not vendor current signoff.",
+    "Row locality is parameterized rather than measured from physical address traces."
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_hbm_controller_replay.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_hbm_controller_replay.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""Deterministic cycle-level replay of score32 HBM traffic for the schedule wrapper frontier.
+
+This model replaces the analytic row-hit model with a deterministic burst scheduler over
+channels, fixed row-window state, request overhead, row-miss penalty, scheduler gap, and a
+global outstanding request window.
+"""
+
+from __future__ import annotations
+
+import argparse
+import heapq
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_dict(value: Any) -> JsonDict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None:
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None:
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_int_list(value: str) -> list[int]:
+    parsed = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not parsed:
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    if any(item <= 0 for item in parsed):
+        raise argparse.ArgumentTypeError("all values must be strictly positive")
+    return parsed
+
+
+def _parse_int_list_optional_zero(value: str) -> list[int]:
+    parsed = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not parsed:
+        raise argparse.ArgumentTypeError("expected comma-separated integers")
+    if any(item < 0 for item in parsed):
+        raise argparse.ArgumentTypeError("all values must be non-negative")
+    return parsed
+
+
+def _parse_float_list(value: str) -> list[float]:
+    parsed = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not parsed:
+        raise argparse.ArgumentTypeError("expected comma-separated positive floats")
+    if any(item <= 0.0 for item in parsed):
+        raise argparse.ArgumentTypeError("all values must be strictly positive")
+    return parsed
+
+
+def _parse_float_list_01(value: str) -> list[float]:
+    parsed = [float(item.strip()) for item in value.split(",") if item.strip()]
+    if not parsed:
+        raise argparse.ArgumentTypeError("expected comma-separated floats")
+    if any(item < 0.0 or item > 1.0 for item in parsed):
+        raise argparse.ArgumentTypeError("all values must be in [0,1]")
+    return parsed
+
+
+def _ceil_div(numerator: int | float, denominator: int | float) -> int:
+    if numerator <= 0:
+        return 0
+    return int(math.ceil(float(numerator) / max(1.0, float(denominator))))
+
+
+def _clamp(v: float, min_value: float = 0.0, max_value: float = 1.0) -> float:
+    return max(min_value, min(max_value, v))
+
+
+def _pick_row(payload: JsonDict, keys: tuple[str, ...]) -> JsonDict:
+    for key in keys:
+        row = _as_dict(payload.get(key))
+        if row:
+            return row
+    return {}
+
+
+def _find_score32_best_latency(payload: JsonDict) -> JsonDict:
+    return _pick_row(payload, ("best_latency", "best", "best_requested", "best_feasible"))
+
+
+def _find_score32_best_requested(payload: JsonDict) -> JsonDict:
+    return _pick_row(payload, ("best_requested", "best_area_fit", "best_feasible", "best"))
+
+
+def _tile_hbm_bytes(physical_row: JsonDict, source_row: JsonDict) -> int:
+    full_tile_bytes = _as_float(physical_row.get("onchip_full_tile_bytes"), 0.0)
+    if full_tile_bytes <= 0.0:
+        full_tile_bytes = _as_float(physical_row.get("tile_bytes"), _as_float(source_row.get("onchip_full_tile_bytes"), 0.0))
+    byte_share = _as_float(physical_row.get("hbm_byte_share"), _as_float(source_row.get("hbm_byte_share"), 1.0))
+    byte_share = _clamp(byte_share, 0.0, 1.0)
+    if full_tile_bytes <= 0.0:
+        full_tile_bytes = 1024.0 * 1024.0
+    return max(1, int(math.ceil(full_tile_bytes * byte_share)))
+
+
+def _build_burst_stream(
+    *,
+    tile_hbm_bytes: int,
+    burst_bytes: int,
+    channel_count: int,
+    row_span_bursts: int,
+    row_hit_rate: float,
+) -> tuple[list[int], list[bool], int, int]:
+    burst_count = _ceil_div(tile_hbm_bytes, max(1, burst_bytes))
+    if burst_count == 0:
+        return [], [], 0, 0
+
+    channels = [i % channel_count for i in range(burst_count)]
+    per_channel_burst_idx = [0] * channel_count
+    per_channel_row = [-1] * channel_count
+    row_span = max(1, row_span_bursts)
+    miss_flags = [False] * burst_count
+
+    for burst_idx, ch in enumerate(channels):
+        row_idx = per_channel_burst_idx[ch] // row_span
+        if per_channel_row[ch] != row_idx:
+            miss_flags[burst_idx] = True
+            per_channel_row[ch] = row_idx
+        per_channel_burst_idx[ch] += 1
+
+    deterministic_miss_count = sum(miss_flags)
+    target_hit_rate = _clamp(row_hit_rate, 0.0, 1.0)
+    target_miss_count = int(math.ceil(burst_count * (1.0 - target_hit_rate)))
+    required_miss_count = max(deterministic_miss_count, target_miss_count)
+
+    added = 0
+    if required_miss_count > deterministic_miss_count:
+        for i in range(burst_count):
+            if added + deterministic_miss_count >= required_miss_count:
+                break
+            if not miss_flags[i]:
+                miss_flags[i] = True
+                added += 1
+
+    final_miss_count = sum(miss_flags)
+    return channels, miss_flags, burst_count, final_miss_count
+
+
+def _simulate_replay_cycles(
+    *,
+    channel_count: int,
+    channel_bandwidth_bytes_per_cycle: float,
+    burst_bytes: int,
+    channels: list[int],
+    miss_flags: list[bool],
+    request_overhead_cycles: int,
+    row_miss_penalty_cycles: int,
+    scheduler_gap_cycles: int,
+    outstanding: int,
+    scheduler_efficiency: float,
+) -> int:
+    burst_count = len(channels)
+    if burst_count == 0:
+        return 0
+
+    effective_bw = max(1.0, float(channel_bandwidth_bytes_per_cycle) * _clamp(scheduler_efficiency, 0.01, 1.0))
+    payload_cycle_per_burst = _ceil_div(burst_bytes, effective_bw)
+    channel_ready = [0.0] * channel_count
+    active: list[float] = []
+    now = 0.0
+
+    for burst_idx, ch in enumerate(channels):
+        base_cycles = payload_cycle_per_burst + int(request_overhead_cycles) + int(scheduler_gap_cycles)
+        miss_cycles = int(row_miss_penalty_cycles) if miss_flags[burst_idx] else 0
+        burst_cycles = base_cycles + miss_cycles
+
+        while True:
+            while active and active[0] <= now:
+                heapq.heappop(active)
+            start = max(now, channel_ready[ch])
+            while active and active[0] <= start:
+                heapq.heappop(active)
+            if len(active) < max(1, outstanding):
+                break
+            now = active[0]
+
+        finish = start + burst_cycles
+        channel_ready[ch] = finish
+        heapq.heappush(active, finish)
+
+    while active:
+        now = heapq.heappop(active)
+    return int(math.ceil(now))
+
+
+def _build_replay_row(
+    *,
+    source_row: JsonDict,
+    source_latency_us: float,
+    source_tile_hbm_cycles: int,
+    source_tile_service_cycles: int,
+    compute_power_mw: float,
+    hbm_energy_mj_per_token: float,
+    die_area_mm2: float,
+    compute_area_mm2: float,
+    macs_per_cycle: float,
+    tile_hbm_bytes: int,
+    channel_count: int,
+    channel_bandwidth_bytes_per_cycle: float,
+    burst_bytes: int,
+    row_span_bursts: int,
+    row_hit_rate: float,
+    request_overhead_cycles: int,
+    row_miss_penalty_cycles: int,
+    hbm_outstanding: int,
+    scheduler_gap_cycles: int,
+    scheduler_efficiency: float,
+) -> JsonDict:
+    channels, miss_flags, burst_count, miss_count = _build_burst_stream(
+        tile_hbm_bytes=tile_hbm_bytes,
+        burst_bytes=burst_bytes,
+        channel_count=channel_count,
+        row_span_bursts=row_span_bursts,
+        row_hit_rate=row_hit_rate,
+    )
+
+    replay_service_cycles = _simulate_replay_cycles(
+        channel_count=channel_count,
+        channel_bandwidth_bytes_per_cycle=channel_bandwidth_bytes_per_cycle,
+        burst_bytes=burst_bytes,
+        channels=channels,
+        miss_flags=miss_flags,
+        request_overhead_cycles=request_overhead_cycles,
+        row_miss_penalty_cycles=row_miss_penalty_cycles,
+        scheduler_gap_cycles=scheduler_gap_cycles,
+        outstanding=hbm_outstanding,
+        scheduler_efficiency=scheduler_efficiency,
+    )
+
+    dominant_source_cycles = max(1, source_tile_hbm_cycles, source_tile_service_cycles)
+    hbm_excess_cycles = max(0, replay_service_cycles - dominant_source_cycles)
+    tile_waves = max(1, _as_int(source_row.get("tile_waves"), 1))
+    layers = max(1, _as_int(source_row.get("layers"), 32))
+    clock_ns = _as_float(source_row.get("clock_ns"), 1.0)
+    added_latency_us = hbm_excess_cycles * tile_waves * layers * clock_ns / 1000.0
+    replay_latency_us = source_latency_us + added_latency_us
+    compute_energy_mj = compute_power_mw * replay_latency_us * 1e-6
+    total_energy_mj = hbm_energy_mj_per_token + compute_energy_mj
+
+    return {
+        "candidate_id": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+        "family": "score32_exp_lut_div",
+        "source_artifact": "score32_schedule_wrapper_hbm_controller_replay",
+        "precision_status": "mixed_int8_generation_quality_pass",
+        "quality_backed": True,
+        "promotable": True,
+        "die_area_mm2": round(die_area_mm2, 6),
+        "compute_area_mm2": round(compute_area_mm2, 6),
+        "macs_per_cycle": round(macs_per_cycle, 6),
+        "channel_count": channel_count,
+        "channel_bandwidth_bytes_per_cycle": round(_as_float(channel_bandwidth_bytes_per_cycle), 6),
+        "burst_bytes": burst_bytes,
+        "row_span_bursts": row_span_bursts,
+        "row_hit_rate": row_hit_rate,
+        "request_overhead_cycles": request_overhead_cycles,
+        "row_miss_penalty_cycles": row_miss_penalty_cycles,
+        "hbm_outstanding": hbm_outstanding,
+        "scheduler_gap_cycles": scheduler_gap_cycles,
+        "scheduler_efficiency": round(_as_float(scheduler_efficiency), 6),
+        "tile_hbm_bytes": tile_hbm_bytes,
+        "burst_count": burst_count,
+        "deterministic_row_miss_count": miss_count,
+        "replay_service_cycles": replay_service_cycles,
+        "source_tile_hbm_cycles": source_tile_hbm_cycles,
+        "source_tile_service_cycles": source_tile_service_cycles,
+        "dominant_source_cycles": dominant_source_cycles,
+        "hbm_excess_cycles": hbm_excess_cycles,
+        "replay_effective_hbm_bytes_per_cycle": round(tile_hbm_bytes / max(1, replay_service_cycles), 6),
+        "hbm_added_latency_us": round(added_latency_us, 6),
+        "source_latency_us": round(source_latency_us, 6),
+        "latency_us": round(replay_latency_us, 6),
+        "token_throughput_per_s": round(1_000_000.0 / replay_latency_us, 9) if replay_latency_us > 0.0 else 0.0,
+        "hbm_dominates_tile": replay_service_cycles > dominant_source_cycles,
+        "compute_power_mw": round(compute_power_mw, 6),
+        "compute_energy_mj_per_token": round(compute_energy_mj, 9),
+        "hbm_energy_mj_per_token": round(hbm_energy_mj_per_token, 9),
+        "total_energy_mj_per_token": round(total_energy_mj, 9),
+        "remaining_abstractions": [
+            "controller replay is deterministic cycle-level but not RTL-timing accurate",
+            "does not include vendor HBM current signoff",
+        ],
+    }
+
+
+def _hbm_energy_from_source(row: JsonDict) -> float:
+    if not row:
+        return 0.0
+    direct = _as_float(row.get("hbm_energy_mj_per_token"))
+    if direct > 0.0:
+        return direct
+    command = _as_dict(row.get("hbm_command_calibrated_energy"))
+    return _as_float(command.get("energy_mj"), direct)
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    hbm_closure = _load_json(args.score32_hbm_dram_service_json)
+    physical = _load_json(args.score32_physical_feasibility_json)
+
+    closure_row = _find_score32_best_latency(hbm_closure)
+    if not closure_row:
+        raise ValueError("score32 HBM closure JSON has no best-latency row")
+
+    physical_row = _find_score32_best_requested(physical)
+    if not physical_row:
+        raise ValueError("score32 physical feasibility JSON has no best_requested-style row")
+
+    tile_hbm_bytes = _tile_hbm_bytes(physical_row=physical_row, source_row=closure_row)
+    hbm_energy_mj_per_token = _hbm_energy_from_source(closure_row)
+    source_latency_us = _as_float(
+        physical_row.get("replica_recost_latency_us") or closure_row.get("source_latency_us") or closure_row.get("latency_us")
+    )
+    source_tile_hbm_cycles = _as_int(
+        physical_row.get("tile_hbm_cycles")
+        or physical_row.get("controller_service_cycles")
+        or physical_row.get("onchip_hbm_cycles_inherited"),
+        1,
+    )
+    source_tile_service_cycles = _as_int(
+        physical_row.get("replica_recost_tile_service_cycles")
+        or physical_row.get("tile_service_cycles")
+        or source_tile_hbm_cycles,
+        1,
+    )
+
+    compute_power_mw = _as_float(
+        physical_row.get("substituted_compute_plus_control_power_mw")
+        or physical_row.get("replica_recost_compute_plus_control_power_mw")
+        or physical_row.get("substituted_compute_power_mw")
+        or physical_row.get("replica_recost_compute_power_mw")
+        or physical_row.get("logic_power_mw")
+        or closure_row.get("compute_power_mw")
+        or 0.0
+    )
+    die_area_mm2 = _as_float(physical_row.get("die_area_mm2"), _as_float(closure_row.get("die_area_mm2"), 0.0))
+    compute_area_mm2 = _as_float(
+        physical_row.get("replica_recost_compute_area_um2")
+        or physical_row.get("compute_area_required_um2")
+        or physical_row.get("substituted_compute_area_um2")
+        or physical_row.get("compute_area_um2"),
+        0.0,
+    ) / 1.0e6
+    macs_per_cycle = _as_float(
+        physical_row.get("replica_recost_macs_per_cycle")
+        or physical_row.get("macs_per_cycle")
+        or closure_row.get("macs_per_cycle"),
+        0.0,
+    )
+
+    rows: list[JsonDict] = []
+    for channel_count in args.channel_count_list:
+        for channel_bw in args.channel_bandwidth_bytes_per_cycle_list:
+            for burst_bytes in args.burst_bytes_list:
+                for row_span in args.row_span_bursts_list:
+                    for row_hit_rate in args.row_hit_rate_list:
+                        for overhead in args.request_overhead_cycles_list:
+                            for miss_penalty in args.row_miss_penalty_cycles_list:
+                                for hbm_outstanding in args.hbm_outstanding_list:
+                                    for scheduler_gap in args.scheduler_gap_cycles_list:
+                                        for sched_eff in args.scheduler_efficiency_list:
+                                            rows.append(
+                                                _build_replay_row(
+                                                    source_row=physical_row,
+                                                    source_latency_us=source_latency_us,
+                                                    source_tile_hbm_cycles=max(1, source_tile_hbm_cycles),
+                                                    source_tile_service_cycles=max(1, source_tile_service_cycles),
+                                                    compute_power_mw=compute_power_mw,
+                                                    hbm_energy_mj_per_token=hbm_energy_mj_per_token,
+                                                    die_area_mm2=die_area_mm2,
+                                                    compute_area_mm2=compute_area_mm2,
+                                                    macs_per_cycle=macs_per_cycle,
+                                                    tile_hbm_bytes=tile_hbm_bytes,
+                                                    channel_count=max(1, int(channel_count)),
+                                                    channel_bandwidth_bytes_per_cycle=float(channel_bw),
+                                                    burst_bytes=max(1, int(burst_bytes)),
+                                                    row_span_bursts=max(1, int(row_span)),
+                                                    row_hit_rate=float(row_hit_rate),
+                                                    request_overhead_cycles=max(0, int(overhead)),
+                                                    row_miss_penalty_cycles=max(0, int(miss_penalty)),
+                                                    hbm_outstanding=max(1, int(hbm_outstanding)),
+                                                    scheduler_gap_cycles=max(0, int(scheduler_gap)),
+                                                    scheduler_efficiency=float(sched_eff),
+                                                )
+                                            )
+
+    rows_sorted = sorted(rows, key=lambda row: (row["latency_us"], row["total_energy_mj_per_token"]))
+    best_latency = rows_sorted[0]
+    best_energy = min(rows, key=lambda row: (row["total_energy_mj_per_token"], row["latency_us"]))
+
+    decision = (
+        "score32_hbm_controller_replay_hbm_sensitive"
+        if bool(best_latency.get("hbm_dominates_tile"))
+        else "score32_hbm_controller_replay_compute_dominant"
+    )
+
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_hbm_controller_replay_v1",
+        "decision": decision,
+        "inputs": {
+            "score32_hbm_dram_service_json": str(args.score32_hbm_dram_service_json),
+            "score32_physical_feasibility_json": str(args.score32_physical_feasibility_json),
+            "channel_count_list": args.channel_count_list,
+            "channel_bandwidth_bytes_per_cycle_list": args.channel_bandwidth_bytes_per_cycle_list,
+            "burst_bytes_list": args.burst_bytes_list,
+            "row_span_bursts_list": args.row_span_bursts_list,
+            "row_hit_rate_list": args.row_hit_rate_list,
+            "request_overhead_cycles_list": args.request_overhead_cycles_list,
+            "row_miss_penalty_cycles_list": args.row_miss_penalty_cycles_list,
+            "hbm_outstanding_list": args.hbm_outstanding_list,
+            "scheduler_gap_cycles_list": args.scheduler_gap_cycles_list,
+            "scheduler_efficiency_list": args.scheduler_efficiency_list,
+        },
+        "diagnosis": {
+            "best_latency_us": best_latency["latency_us"],
+            "best_latency_total_energy_mj_per_token": best_latency["total_energy_mj_per_token"],
+            "best_latency_token_throughput_per_s": best_latency["token_throughput_per_s"],
+            "best_latency_hbm_dominates_tile": bool(best_latency.get("hbm_dominates_tile")),
+            "best_latency_row_miss_count": best_latency["deterministic_row_miss_count"],
+            "best_energy_us": best_energy["latency_us"],
+            "best_energy_total_energy_mj_per_token": best_energy["total_energy_mj_per_token"],
+            "best_energy_hbm_service_cycles": best_energy["replay_service_cycles"],
+            "best_requested_row_latency_us": source_latency_us,
+            "hbm_energy_source": hbm_energy_mj_per_token,
+            "compute_power_mw_source": compute_power_mw,
+            "row_count": len(rows),
+            "remaining_abstractions": [
+                "controller replay is deterministic cycle-level, not RTL timing",
+                "vendor HBM current signoff is not represented",
+            ],
+        },
+        "best_latency": best_latency,
+        "best_energy": best_energy,
+        "top_rows": rows_sorted[: args.top_k],
+        "assumptions": [
+            "Replay builds a deterministic burst stream with round-robin channel interleave.",
+            "Each channel has row-window state with misses determined by row_span_bursts and adjusted to hit_rate.",
+            "Per-request cycles include burst transfer payload, request overhead, row-miss penalty, and scheduler gap.",
+            "Outstanding requests are enforced as a global in-flight limit.",
+            "Replay latency is added to the schedule-wrapper recost source latency by mapping replay-cycle delta vs source HBM/service cycles.",
+            "HBM energy is inherited from the score32 HBM closure; compute energy is rebuilt from physical wrapper compute power.",
+        ],
+        "next_step": {
+            "requires_cycle_accurate_hbm_controller_rtl": True,
+            "requires_vendor_hbm_current_signoff": True,
+            "recommended_next_step": (
+                "Use this deterministic replay as the current schedule-wrapper HBM abstraction, then replace with "
+                "cycle-accurate controller timing before collapsing HBM abstraction for final frontier ranking."
+            ),
+        },
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best_latency"]
+    diagnosis = payload["diagnosis"]
+    lines = [
+        "# Score32 HBM Controller Replay",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- best latency us: `{diagnosis['best_latency_us']}`",
+        f"- best throughput token/s: `{diagnosis['best_latency_token_throughput_per_s']}`",
+        f"- best latency total energy mJ/token: `{diagnosis['best_latency_total_energy_mj_per_token']}`",
+        f"- best hbm-dominant: `{diagnosis['best_latency_hbm_dominates_tile']}`",
+        "",
+        "## Best Replay Row",
+        "",
+        "| ch | ch B/cyc | burst | row span | miss penalty | miss count | overhead | out | gap | row hit | eff | service cyc | added us | latency us | throughput |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| {channel_count} | {channel_bandwidth_bytes_per_cycle} | {burst_bytes} | {row_span_bursts} | {row_miss_penalty_cycles} | {deterministic_row_miss_count} | {request_overhead_cycles} | {hbm_outstanding} | {scheduler_gap_cycles} | {row_hit_rate} | {scheduler_efficiency} | {replay_service_cycles} | {hbm_added_latency_us} | {latency_us} | {token_throughput_per_s} |".format(
+            **best
+        ),
+        "",
+        "## Top 10",
+        "",
+        "| rank | latency us | total energy | throughput | channels | out | burst | row span | misses | service cyc |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for i, row in enumerate(payload["top_rows"][:10], start=1):
+        lines.append(
+            "| {rank} | {latency_us} | {total_energy_mj_per_token} | {token_throughput_per_s} | {channel_count} | {hbm_outstanding} | {burst_bytes} | {row_span_bursts} | {deterministic_row_miss_count} | {replay_service_cycles} |".format(
+                rank=i,
+                **row,
+            )
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--score32-hbm-dram-service-json", type=Path, required=True)
+    parser.add_argument("--score32-physical-feasibility-json", type=Path, required=True)
+    parser.add_argument(
+        "--channel-count",
+        "--channel-count-list",
+        dest="channel_count_list",
+        type=_parse_int_list,
+        default=[4, 8],
+    )
+    parser.add_argument(
+        "--channel-bandwidth-bytes-per-cycle",
+        "--channel-bandwidth-bytes-per-cycle-list",
+        dest="channel_bandwidth_bytes_per_cycle_list",
+        type=_parse_float_list,
+        default=[256.0, 512.0],
+    )
+    parser.add_argument(
+        "--burst-bytes",
+        "--burst-bytes-list",
+        dest="burst_bytes_list",
+        type=_parse_int_list,
+        default=[256, 512],
+    )
+    parser.add_argument(
+        "--row-span-bursts",
+        "--row-span-bursts-list",
+        dest="row_span_bursts_list",
+        type=_parse_int_list,
+        default=[1, 2, 4],
+    )
+    parser.add_argument(
+        "--row-hit-rate",
+        "--row-hit-rate-list",
+        dest="row_hit_rate_list",
+        type=_parse_float_list_01,
+        default=[0.8, 0.95],
+    )
+    parser.add_argument(
+        "--request-overhead-cycles",
+        "--request-overhead-cycles-list",
+        dest="request_overhead_cycles_list",
+        type=_parse_int_list_optional_zero,
+        default=[2, 4],
+    )
+    parser.add_argument(
+        "--row-miss-penalty-cycles",
+        "--row-miss-penalty-cycles-list",
+        dest="row_miss_penalty_cycles_list",
+        type=_parse_int_list_optional_zero,
+        default=[8, 16],
+    )
+    parser.add_argument(
+        "--hbm-outstanding",
+        "--hbm-outstanding-list",
+        dest="hbm_outstanding_list",
+        type=_parse_int_list,
+        default=[4, 8],
+    )
+    parser.add_argument(
+        "--scheduler-gap-cycles",
+        "--scheduler-gap-cycles-list",
+        dest="scheduler_gap_cycles_list",
+        type=_parse_int_list_optional_zero,
+        default=[0, 1],
+    )
+    parser.add_argument(
+        "--scheduler-efficiency",
+        "--scheduler-efficiency-list",
+        dest="scheduler_efficiency_list",
+        type=_parse_float_list,
+        default=[0.75, 0.9],
+    )
+    parser.add_argument("--top-k", type=int, default=20)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "decision": payload["decision"],
+                "out": str(args.out),
+                "best_latency_us": payload["diagnosis"]["best_latency_us"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_llm_decoder_attention_score32_hbm_controller_replay.py
+++ b/tests/test_audit_llm_decoder_attention_score32_hbm_controller_replay.py
@@ -1,0 +1,133 @@
+from argparse import Namespace
+import json
+from pathlib import Path
+
+from npu.eval.audit_llm_decoder_attention_score32_hbm_controller_replay import (
+    _simulate_replay_cycles,
+    build_report,
+)
+
+
+def test_row_misses_increase_replay_cycles() -> None:
+    channels = [0, 1, 0, 1]
+    miss_flags_no = [False, False, False, False]
+    miss_flags_yes = [True, True, True, True]
+
+    without_miss = _simulate_replay_cycles(
+        channel_count=2,
+        channel_bandwidth_bytes_per_cycle=256,
+        burst_bytes=128,
+        channels=channels,
+        miss_flags=miss_flags_no,
+        request_overhead_cycles=2,
+        row_miss_penalty_cycles=16,
+        scheduler_gap_cycles=0,
+        outstanding=4,
+        scheduler_efficiency=0.9,
+    )
+    with_miss = _simulate_replay_cycles(
+        channel_count=2,
+        channel_bandwidth_bytes_per_cycle=256,
+        burst_bytes=128,
+        channels=channels,
+        miss_flags=miss_flags_yes,
+        request_overhead_cycles=2,
+        row_miss_penalty_cycles=16,
+        scheduler_gap_cycles=0,
+        outstanding=4,
+        scheduler_efficiency=0.9,
+    )
+
+    assert with_miss > without_miss
+
+
+def test_larger_outstanding_does_not_worsen_replay_cycles() -> None:
+    channels = [0, 1, 0, 1, 0, 1, 0, 1]
+    miss_flags = [True, False, False, True, False, False, False, True]
+
+    tight = _simulate_replay_cycles(
+        channel_count=2,
+        channel_bandwidth_bytes_per_cycle=64,
+        burst_bytes=256,
+        channels=channels,
+        miss_flags=miss_flags,
+        request_overhead_cycles=4,
+        row_miss_penalty_cycles=12,
+        scheduler_gap_cycles=1,
+        outstanding=1,
+        scheduler_efficiency=0.85,
+    )
+    roomy = _simulate_replay_cycles(
+        channel_count=2,
+        channel_bandwidth_bytes_per_cycle=64,
+        burst_bytes=256,
+        channels=channels,
+        miss_flags=miss_flags,
+        request_overhead_cycles=4,
+        row_miss_penalty_cycles=12,
+        scheduler_gap_cycles=1,
+        outstanding=4,
+        scheduler_efficiency=0.85,
+    )
+
+    assert roomy <= tight
+
+
+def test_build_report_includes_best_latency_and_diagnosis(tmp_path: Path) -> None:
+    score32_hbm = tmp_path / "score32_hbm.json"
+    score32_physical = tmp_path / "score32_physical.json"
+    score32_hbm.write_text(
+        json.dumps(
+            {
+                "best_latency": {
+                    "latency_us": 12.5,
+                    "source_latency_us": 12.5,
+                    "hbm_energy_mj_per_token": 0.5,
+                    "compute_power_mw": 200.0,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    score32_physical.write_text(
+        json.dumps(
+            {
+                "best_requested": {
+                    "onchip_full_tile_bytes": 1048576,
+                    "hbm_byte_share": 1.0,
+                    "replica_recost_latency_us": 12.5,
+                    "tile_hbm_cycles": 100,
+                    "replica_recost_tile_service_cycles": 90,
+                    "tile_waves": 1,
+                    "layers": 32,
+                    "clock_ns": 1.0,
+                    "replica_recost_compute_power_mw": 150.0,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    args = Namespace(
+        score32_hbm_dram_service_json=score32_hbm,
+        score32_physical_feasibility_json=score32_physical,
+        channel_count_list=[1],
+        channel_bandwidth_bytes_per_cycle_list=[128],
+        burst_bytes_list=[256],
+        row_span_bursts_list=[1],
+        row_hit_rate_list=[1.0],
+        request_overhead_cycles_list=[2],
+        row_miss_penalty_cycles_list=[8],
+        hbm_outstanding_list=[4],
+        scheduler_gap_cycles_list=[0],
+        scheduler_efficiency_list=[1.0],
+        top_k=5,
+    )
+
+    report = build_report(args)
+    assert "best_latency" in report
+    assert "diagnosis" in report
+    assert "best_latency_us" in report["diagnosis"]
+    assert "best_latency_total_energy_mj_per_token" in report["diagnosis"]
+    assert isinstance(report["top_rows"], list)
+    assert len(report["top_rows"]) == 1


### PR DESCRIPTION
## Summary
- add deterministic score32 HBM controller replay audit for the schedule-wrapper Llama7B frontier
- wire a new L2 abstraction layer and proposal for evaluator dispatch
- add focused replay and generator tests

## Validation
- python3 -m json.tool docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1/proposal.json
- python3 -m json.tool docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1/evaluation_requests.json
- PYTHONPATH=. /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q tests/test_audit_llm_decoder_attention_score32_hbm_controller_replay.py
- PYTHONPATH=.:control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k 'score32_hbm_controller_replay or score32_exp_lut_hbm_dram_service_closure or schedule_wrapper_integrated_frontier_ranking'
- python3 npu/eval/audit_llm_decoder_attention_score32_hbm_controller_replay.py --score32-hbm-dram-service-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json --score32-physical-feasibility-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json --out /tmp/score32-replay-smoke/out.json --out-md /tmp/score32-replay-smoke/out.md
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check