### PR TITLE
control_plane: consume score32 HBM replay evidence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -571,6 +571,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_exp_lut_hbm_dram_service_closure_report",
     ),
     (
+        "attention_score32_hbm_controller_replay_out",
+        "attention_score32_hbm_controller_replay_report",
+    ),
+    (
         "attention_score32_integrated_frontier_ranking_out",
         "attention_score32_integrated_frontier_ranking_report",
     ),
@@ -1358,6 +1362,33 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "best_energy_hbm_energy_mj_per_token",
             "source_score32_latency_us",
             "source_controller_service_cycles",
+            "remaining_abstractions",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_score32_hbm_controller_replay_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            diagnosis_dict.get("decision")
+            or evidence_payload.get("decision")
+            or "score32_hbm_controller_replay_recorded"
+        )
+        parts = [
+            f"Decoder score32 HBM controller replay evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "best_latency_us",
+            "best_latency_token_throughput_per_s",
+            "best_latency_total_energy_mj_per_token",
+            "best_latency_hbm_dominates_tile",
+            "best_latency_row_miss_count",
+            "best_requested_row_latency_us",
+            "compute_power_mw_source",
+            "hbm_energy_source",
             "remaining_abstractions",
         ):
             if key in diagnosis_dict:

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -450,7 +450,7 @@ def test_consume_l2_result_frontier_attention_mixed_int8_high_score_boundary_use
                     "attention_mixed_int8_high_score_boundary_report": report_rel,
                 }
             }
-            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            work_item.expected_outputs = [evidence_rel, report_rel]
             session.commit()
 
             consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
@@ -555,7 +555,7 @@ def test_consume_l2_result_frontier_attention_mixed_int8_broad_native_quality_us
                     "attention_mixed_int8_broad_native_quality_report": report_rel,
                 }
             }
-            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            work_item.expected_outputs = [evidence_rel, report_rel]
             session.commit()
 
             consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
@@ -4623,6 +4623,131 @@ def test_consume_l2_result_hbm_dram_service_energy_uses_decoder_evidence() -> No
             assert decision_payload["source_refs"]["decoder_attention_hbm_dram_service_energy_out"] == evidence_rel
             assert (
                 decision_payload["source_refs"]["decoder_attention_hbm_dram_service_energy_report"]
+                == report_rel
+            )
+
+
+def test_consume_l2_result_score32_hbm_controller_replay_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+                        "kind": "architecture",
+                        "title": "Score32 HBM controller replay",
+                        "direct_comparison": {
+                            "primary_question": "Does controller replay move the score32 frontier?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_hbm_controller_replay__"
+                "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_hbm_controller_replay__"
+                "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "model": "llm_decoder_attention_score32_hbm_controller_replay_v1",
+                        "decision": "score32_hbm_controller_replay_hbm_sensitive",
+                        "diagnosis": {
+                            "best_latency_us": 13137.332951,
+                            "best_latency_token_throughput_per_s": 76.118950761,
+                            "best_latency_total_energy_mj_per_token": 475.583270364,
+                            "best_latency_hbm_dominates_tile": True,
+                            "best_latency_row_miss_count": 504,
+                            "best_requested_row_latency_us": 12814.257853,
+                            "remaining_abstractions": [
+                                "controller replay is deterministic cycle-level, not RTL timing",
+                                "vendor HBM current signoff is not represented",
+                            ],
+                        },
+                        "best_latency": {
+                            "candidate_id": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+                            "latency_us": 13137.332951,
+                            "total_energy_mj_per_token": 475.583270364,
+                            "die_area_mm2": 800.0,
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# score32 hbm controller replay\n")
+            item_id = "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1"
+            _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id=item_id,
+                campaign_dir_rel="runs/campaigns/npu/score32_hbm_controller_replay_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path=(
+                    "docs/proposals/"
+                    "prop_l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1"
+                ),
+                comparison={"role": "score32_hbm_controller_replay"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "replace_analytic_hbm_service_with_controller_replay",
+                "expected_reason": "Use deterministic replay evidence for the next frontier account.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_score32_hbm_controller_replay",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_score32_hbm_controller_replay_out": evidence_rel,
+                    "attention_score32_hbm_controller_replay_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [evidence_rel, report_rel]
+            session.commit()
+
+            result = consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert result.recommended_arch_id == "decoder_attention_score32_hbm_controller_replay"
+            assert decision_payload["proposal_assessment"]["outcome"] == (
+                "score32_hbm_controller_replay_hbm_sensitive"
+            )
+            assert "best_latency_us=13137.332951" in decision_payload["proposal_assessment"]["summary"]
+            assert decision_payload["recommendation"]["source"] == "decoder_evidence"
+            assert decision_payload["source_refs"]["decoder_attention_score32_hbm_controller_replay_out"] == evidence_rel
+            assert (
+                decision_payload["source_refs"]["decoder_attention_score32_hbm_controller_replay_report"]
                 == report_rel
             )
 


### PR DESCRIPTION
## Summary
- register score32 HBM controller replay as decoder evidence output
- add model-specific L2 review summary for replay diagnosis
- add focused consumer regression for evidence-only replay items

## Validation
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k 'score32_hbm_controller_replay or hbm_dram_service_energy'
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check