### PR TITLE
npu: rank score32 frontier with hbm replay

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5976,7 +5976,12 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
         "l2_decoder_attention_composed_datapath_score32_exp_lut_div_"
         "schedule_wrapper_recost_llama7b_v1.json"
     )
+    score32_hbm_controller_replay = (
+        f"{base}/decoder_attention_score32_hbm_controller_replay__"
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+    )
     use_schedule_wrapper_recost = "schedule_wrapper" in item_id
+    use_hbm_controller_replay = "hbm_controller_replay" in item_id
     score32_quality = (
         f"{base}/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
         "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
@@ -5998,6 +6003,8 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
         f"--score32-hbm-dram-service-json {score32_hbm} "
         f"--score32-measured-command-control-json {measured_command_control} "
     )
+    if use_hbm_controller_replay:
+        command += f"--score32-hbm-controller-replay-json {score32_hbm_controller_replay} "
     if use_schedule_wrapper_recost:
         command += f"--score32-physical-feasibility-json {schedule_wrapper_recost} "
     command += (
@@ -6012,6 +6019,11 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
         "inputs": {
             "attention_score32_exp_lut_hbm_dram_service_closure": score32_hbm,
             "attention_score32_exp_lut_measured_command_control": measured_command_control,
+            **(
+                {"attention_score32_hbm_controller_replay": score32_hbm_controller_replay}
+                if use_hbm_controller_replay
+                else {}
+            ),
             **(
                 {"attention_score32_exp_lut_schedule_wrapper_recost": schedule_wrapper_recost}
                 if use_schedule_wrapper_recost

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7006,6 +7006,71 @@ def test_generate_l2_campaign_task_adds_schedule_wrapper_integrated_frontier_ran
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_integrated_frontier_ranking_input() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_score32_integrated_frontier_ranking",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="score32_integrated_frontier_ranking",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "--score32-hbm-controller-replay-json" in run
+            assert (
+                "decoder_attention_score32_hbm_controller_replay__"
+                "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+            ) in run
+            assert (
+                decoder_inputs["attention_score32_hbm_controller_replay"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_hbm_controller_replay__"
+                "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+            )
+            assert (
+                decoder_inputs["attention_score32_integrated_frontier_ranking_out"].endswith(
+                    "decoder_attention_score32_integrated_frontier_ranking__"
+                    "l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1.json"
+                )
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"] == {
+                "item_ids": [
+                    "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+                ],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_compute_activity_energy_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/README.md
@@ -1,0 +1,5 @@
+# Score32 HBM Controller Replay Integrated Frontier Ranking
+
+This proposal dispatches the next score32 integrated frontier-ranking step after HBM controller replay has been merged.
+
+The ranking should consume `decoder_attention_score32_hbm_controller_replay` as the score32 HBM/DRAM source row, while preserving the existing comparator stack and schedule-wrapper handling in non-replay variants.

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+  "source_commit_note": "Dispatch should use the merged l2 generator patch that allows score32 integrated frontier ranking to consume controller replay evidence.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replace analytic HBM/DRAM accounting in score32 integrated frontier ranking with merged controller replay evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_hbm_controller_replay_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_integrated_frontier_ranking",
+        "reason": "The result should provide a deterministic replay-based score32 ranking row and keep remaining abstractions explicit before controller RTL timing work."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/proposal.json
@@ -1,0 +1,81 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+  "created_utc": "2026-07-08T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 controller-replay integrated frontier ranking",
+  "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+  "hypothesis": "The score32 frontier can now replace analytic HBM command/burst accounting with the merged controller-replay evidence, improving the fidelity of the integrated ranking while keeping prior evidence dependencies and schedule-wrapper recost behavior unchanged for schedule-wrapper variants.",
+  "direct_comparison": {
+    "primary_question": "Does bounded replay replace the analytic HBM/DRAM service abstraction in the score32 integrated frontier ranking while preserving prior comparator/evidence boundaries?",
+    "include": [
+      "consume the merged score32 HBM controller replay artifact",
+      "consume measured score32 command-control rows and generation-quality gating",
+      "consume measured exact-FP16, mixed/int8 energy, and integrated-energy frontier rows",
+      "rank latency, energy, area, quality, and remaining abstractions for the next frontier decision"
+    ],
+    "exclude": [
+      "new OpenROAD PPA synthesis",
+      "new generation-quality benchmark studies",
+      "new HBM controller RTL timing",
+      "new vendor-current HBM current-signoff traces"
+    ]
+  },
+  "expected_benefit": [
+    "replaces the old analytic command-service abstraction text with deterministic HBM controller replay evidence",
+    "keeps integrated ranking behavior consistent with existing schedule-wrapper workflow",
+    "provides a better bound for score32 latency/energy before deeper HBM-controller RTL work"
+  ],
+  "risks": [
+    "replay is still cycle-level approximation and not RTL timing",
+    "source-replay result inherits command-calibrated HBM energy from prior closure",
+    "controller locality is parameterized by replay knobs rather than measured trace-level accesses"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replace the score32 integrated frontier ranking HBM/DRAM row with merged deterministic controller-replay evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_hbm_controller_replay_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_integrated_frontier_ranking",
+        "reason": "The result should rank the current score32 frontier point with controller-replay HBM support and carry replay-specific abstraction commitments."
+      },
+      "status": "ready_to_dispatch_after_code_merge"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py",
+    "npu/eval/audit_llm_decoder_attention_score32_hbm_controller_replay.py",
+    "npu/eval/audit_llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure.py"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "HBM controller replay remains deterministic cycle-level and not RTL timing accurate.",
+    "source energy remains command-calibrated and not vendor current signoff.",
+    "row locality is still parameterized rather than measured from full physical traces."
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -47,9 +47,12 @@ def _score32_row(
     score32_hbm: JsonDict,
     measured_command: JsonDict,
     score32_quality: JsonDict,
+    score32_hbm_controller_replay: JsonDict | None = None,
     score32_physical: JsonDict | None = None,
 ) -> JsonDict:
-    best = _as_dict(score32_hbm.get("best_latency"))
+    replay_best = _as_dict(score32_hbm_controller_replay.get("best_latency")) if score32_hbm_controller_replay else {}
+    best = replay_best or _as_dict(score32_hbm.get("best_latency"))
+    uses_hbm_controller_replay = bool(replay_best)
     measured_source = score32_physical if score32_physical is not None else measured_command
     measured = _as_dict(measured_source.get("best_requested"))
     quality = _quality_status(score32_quality)
@@ -59,6 +62,11 @@ def _score32_row(
     compute_energy_mj_per_token = _as_float(best.get("compute_energy_mj_per_token"))
     hbm_energy_mj_per_token = _as_float(best.get("hbm_energy_mj_per_token"))
     total_energy_mj_per_token = _as_float(best.get("total_energy_mj_per_token"))
+    die_area_mm2 = _as_float(measured.get("die_area_mm2"))
+    compute_area_mm2 = (
+        _as_float(measured.get("replica_recost_compute_area_um2") or measured.get("compute_area_um2")) / 1.0e6
+    )
+    macs_per_cycle = _as_float(measured.get("replica_recost_macs_per_cycle") or best.get("macs_per_cycle"))
     source_artifact = "score32_hbm_dram_service_closure"
     candidate_id = "score32_exp_lut_hbm_dram_service_closure_best"
     abstraction_status = "measured_wrapper_command_control_sram_envelope_hbm_command_service"
@@ -91,6 +99,23 @@ def _score32_row(
             }
         )
 
+    if uses_hbm_controller_replay:
+        candidate_id = str(best.get("candidate_id") or "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best")
+        source_artifact = str(best.get("source_artifact") or "score32_schedule_wrapper_hbm_controller_replay")
+        abstraction_status = "measured_schedule_wrapper_sram_envelope_hbm_controller_replay"
+        remaining_abstractions = list(best.get("remaining_abstractions") or [])
+        latency_us = _as_float(best.get("latency_us"), latency_us)
+        token_throughput_per_s = _as_float(best.get("token_throughput_per_s"), token_throughput_per_s)
+        compute_energy_mj_per_token = _as_float(best.get("compute_energy_mj_per_token"), compute_energy_mj_per_token)
+        hbm_energy_mj_per_token = _as_float(best.get("hbm_energy_mj_per_token"), hbm_energy_mj_per_token)
+        total_energy_mj_per_token = _as_float(best.get("total_energy_mj_per_token"), total_energy_mj_per_token)
+        die_area_mm2 = _as_float(best.get("die_area_mm2"), _as_float(measured.get("die_area_mm2")))
+        compute_area_mm2 = _as_float(
+            best.get("compute_area_mm2"),
+            _as_float(measured.get("replica_recost_compute_area_um2") or measured.get("compute_area_um2")) / 1.0e6,
+        )
+        macs_per_cycle = _as_float(best.get("macs_per_cycle"), _as_float(measured.get("replica_recost_macs_per_cycle") or best.get("macs_per_cycle")))
+
     return {
         "candidate_id": candidate_id,
         "family": "score32_exp_lut_div",
@@ -100,12 +125,9 @@ def _score32_row(
         "energy_mj_per_token": total_energy_mj_per_token,
         "compute_energy_mj_per_token": compute_energy_mj_per_token,
         "hbm_energy_mj_per_token": hbm_energy_mj_per_token,
-        "die_area_mm2": _as_float(measured.get("die_area_mm2")),
-        "compute_area_mm2": _as_float(
-            measured.get("replica_recost_compute_area_um2") or measured.get("compute_area_um2")
-        )
-        / 1.0e6,
-        "macs_per_cycle": _as_float(measured.get("replica_recost_macs_per_cycle") or best.get("macs_per_cycle")),
+        "die_area_mm2": die_area_mm2,
+        "compute_area_mm2": _as_float(compute_area_mm2),
+        "macs_per_cycle": _as_float(macs_per_cycle),
         "precision_status": quality["status"],
         "quality_backed": quality["quality_backed"],
         "quality": quality,
@@ -203,6 +225,11 @@ def _energy_rank(rows: list[JsonDict], *, promotable_only: bool = False) -> list
 def build_report(args: argparse.Namespace) -> JsonDict:
     score32_hbm = _load_json(args.score32_hbm_dram_service_json)
     measured_command = _load_json(args.score32_measured_command_control_json)
+    score32_hbm_controller_replay = (
+        _load_json(args.score32_hbm_controller_replay_json)
+        if args.score32_hbm_controller_replay_json
+        else None
+    )
     score32_physical = _load_json(args.score32_physical_feasibility_json) if args.score32_physical_feasibility_json else None
     score32_quality = _load_json(args.score32_quality_json)
     measured_compute = _load_json(args.measured_compute_energy_json)
@@ -210,7 +237,13 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     integrated = _load_json(args.integrated_energy_json)
 
     rows = [
-        _score32_row(score32_hbm, measured_command, score32_quality, score32_physical),
+        _score32_row(
+            score32_hbm,
+            measured_command,
+            score32_quality,
+            score32_hbm_controller_replay,
+            score32_physical,
+        ),
         _prior_row(
             candidate_id=str(_best_row(measured_compute).get("candidate_id") or "measured_fp16_compute_energy_best"),
             family="measured_exact_fp16_gqa8_kv8",
@@ -261,6 +294,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "inputs": {
             "score32_hbm_dram_service_json": str(args.score32_hbm_dram_service_json),
             "score32_measured_command_control_json": str(args.score32_measured_command_control_json),
+            "score32_hbm_controller_replay_json": str(args.score32_hbm_controller_replay_json)
+            if args.score32_hbm_controller_replay_json
+            else None,
             "score32_physical_feasibility_json": str(args.score32_physical_feasibility_json)
             if args.score32_physical_feasibility_json
             else None,
@@ -306,7 +342,13 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "promotable_energy_rank": promotable_energy_rank,
         "assumptions": [
             "Rows are ranked by explicit metrics from merged evidence; no new PPA is synthesized in this audit.",
-            "The score32 row is quality-backed by the bounded generation-quality gate and measured through wrapper, command-control, SRAM-envelope, and HBM/DRAM service closure.",
+            (
+                "The score32 row is quality-backed by the bounded generation-quality gate and measured through "
+                "wrapper, command-control, SRAM-envelope, and HBM/DRAM service closure."
+                if not args.score32_hbm_controller_replay_json
+                else "The score32 row is quality-backed by the bounded generation-quality gate and measured through "
+                "wrapper, command-control, SRAM-envelope, and deterministic cycle-level HBM controller replay."
+            ),
             "The mixed-int8 energy row is retained as a fast non-promotable latency candidate because its precision path is not promoted by the current real-checkpoint evidence.",
             "The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible.",
         ],
@@ -362,6 +404,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--score32-hbm-dram-service-json", type=Path, required=True)
     parser.add_argument("--score32-measured-command-control-json", type=Path, required=True)
+    parser.add_argument("--score32-hbm-controller-replay-json", type=Path)
     parser.add_argument("--score32-physical-feasibility-json", type=Path)
     parser.add_argument("--score32-quality-json", type=Path, required=True)
     parser.add_argument("--measured-compute-energy-json", type=Path, required=True)


### PR DESCRIPTION
## Summary
- let the score32 integrated frontier ranking consume HBM controller replay evidence
- wire the L2 generator and proposal bundle for the replay-integrated ranking job
- add focused generator coverage and validate the replay row with current Llama7B artifacts

## Tests
- PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "score32_hbm_controller_replay_integrated_frontier_ranking or score32_integrated_frontier_ranking_evidence or schedule_wrapper_integrated_frontier_ranking_input"
- python3 -m json.tool docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/proposal.json
- python3 -m json.tool docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
- python3 -m py_compile npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py control_plane/control_plane/services/l2_task_generator.py
- python3 npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py ... --score32-hbm-controller-replay-json ...
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check