### PR TITLE
control_plane: consume HBM replay controller PPA in ranking

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5958,7 +5958,11 @@ def _decoder_attention_score32_hbm_controller_replay_evidence(*, item_id: str) -
     }
 
 
-def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: str) -> dict[str, Any]:
+def _decoder_attention_score32_integrated_frontier_ranking_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None = None,
+) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_integrated_frontier_ranking__{item_id}.json"
     report = f"{base}/decoder_attention_score32_integrated_frontier_ranking__{item_id}.md"
@@ -5979,6 +5983,16 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
     score32_hbm_controller_replay = (
         f"{base}/decoder_attention_score32_hbm_controller_replay__"
         "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+    )
+    use_hbm_controller_replay_ppa = any(
+        str(dep).startswith("l1_decoder_attention_hbm_replay_controller_ppa_v1")
+        for dep in (depends_on_item_ids or [])
+    )
+    score32_hbm_controller_replay_ppa = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_decoder_attention_hbm_replay_controller_ppa_v1.json"
+        if use_hbm_controller_replay_ppa
+        else None
     )
     use_schedule_wrapper_recost = "schedule_wrapper" in item_id
     use_hbm_controller_replay = "hbm_controller_replay" in item_id
@@ -6005,6 +6019,8 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
     )
     if use_hbm_controller_replay:
         command += f"--score32-hbm-controller-replay-json {score32_hbm_controller_replay} "
+        if score32_hbm_controller_replay_ppa:
+            command += f"--score32-hbm-controller-replay-ppa-json {score32_hbm_controller_replay_ppa} "
     if use_schedule_wrapper_recost:
         command += f"--score32-physical-feasibility-json {schedule_wrapper_recost} "
     command += (
@@ -6022,6 +6038,11 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(*, item_id: 
             **(
                 {"attention_score32_hbm_controller_replay": score32_hbm_controller_replay}
                 if use_hbm_controller_replay
+                else {}
+            ),
+            **(
+                {"attention_score32_hbm_controller_replay_ppa_json": score32_hbm_controller_replay_ppa}
+                if score32_hbm_controller_replay_ppa
                 else {}
             ),
             **(
@@ -9822,7 +9843,10 @@ def _build_payload(
         elif abstraction_layer_name == "decoder_attention_score32_hbm_controller_replay":
             decoder_evidence = _decoder_attention_score32_hbm_controller_replay_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_integrated_frontier_ranking":
-            decoder_evidence = _decoder_attention_score32_integrated_frontier_ranking_evidence(item_id=item_id)
+            decoder_evidence = _decoder_attention_score32_integrated_frontier_ranking_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+            )
         elif abstraction_layer_name == "decoder_attention_score32_compute_activity_energy":
             decoder_evidence = _decoder_attention_score32_compute_activity_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7071,6 +7071,60 @@ def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_
             }
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_integrated_frontier_ranking_ppa_dependency(
+) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_score32_integrated_frontier_ranking",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="score32_hbm_controller_replay_integrated_frontier_ranking",
+                    depends_on_item_ids=[
+                        "l1_decoder_attention_hbm_replay_controller_ppa_v1",
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "--score32-hbm-controller-replay-ppa-json" in run
+            assert (
+                "control_plane/shadow_exports/l1_promotions/"
+                "l1_decoder_attention_hbm_replay_controller_ppa_v1.json"
+            ) in run
+            assert (
+                decoder_inputs["attention_score32_hbm_controller_replay_ppa_json"]
+                == "control_plane/shadow_exports/l1_promotions/"
+                "l1_decoder_attention_hbm_replay_controller_ppa_v1.json"
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_compute_activity_energy_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1/README.md
@@ -1,0 +1,5 @@
+# Score32 HBM Replay Controller RTL-PPA Integrated Frontier Ranking
+
+This proposal queues the post-controller-PPA ranking step for the score32 Llama7B frontier.
+
+It should run after `l1_decoder_attention_hbm_replay_controller_ppa_v1` has merged. The ranking consumes the existing deterministic HBM replay result and adds the measured Nangate45 RTL PPA evidence for the replay controller control path. It does not claim vendor HBM PHY or DRAM current-signoff closure.

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,33 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1",
+  "source_commit_note": "Dispatch after the L2 generator patch that adds optional score32 HBM replay controller PPA input support is merged and after l1_decoder_attention_hbm_replay_controller_ppa_v1 is merged.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rank the current score32 HBM replay Llama7B frontier row while consuming measured RTL PPA evidence for the HBM replay controller control path.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l1_decoder_attention_hbm_replay_controller_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_integrated_frontier_ranking_with_replay_controller_ppa",
+        "reason": "The result should keep HBM PHY/current-signoff caveats explicit while replacing the replay-controller RTL-timing abstraction with a measured controller-control PPA reference."
+      },
+      "status": "ready_to_dispatch_after_l1_result_merge"
+    }
+  ],
+  "source_commit": "03af3a1c8d98e77d3a2eb5d5358b06f33482f38b"
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1/proposal.json
@@ -1,0 +1,81 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1",
+  "created_utc": "2026-07-08T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 HBM replay controller RTL-PPA integrated Llama7B frontier ranking",
+  "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+  "hypothesis": "After the measured HBM replay controller PPA lands, the integrated score32 Llama7B frontier ranking should consume it so the promoted score32 row records controller-control RTL timing evidence instead of leaving the deterministic replay timing abstraction unresolved.",
+  "direct_comparison": {
+    "primary_question": "Does adding measured replay-controller RTL PPA evidence change the abstraction status or ranking of the current score32 Llama7B frontier point?",
+    "include": [
+      "consume the merged deterministic score32 HBM controller replay artifact",
+      "consume the merged L1 HBM replay controller PPA promotion",
+      "match the controller PPA proposal to the replay best row channel count when possible",
+      "consume measured score32 command-control rows and generation-quality gating",
+      "rank latency, energy, area, precision status, and remaining abstractions against current frontier rows"
+    ],
+    "exclude": [
+      "new OpenROAD PPA synthesis inside the L2 ranking task",
+      "new generation-quality benchmark studies",
+      "vendor HBM PHY timing",
+      "vendor HBM current-signoff traces",
+      "full DRAM RTL simulation"
+    ]
+  },
+  "expected_benefit": [
+    "removes the replay-controller-not-RTL-timing abstraction from the current precision-safe throughput frontier",
+    "keeps the HBM/DRAM energy and PHY caveats explicit instead of over-promoting the result",
+    "prepares a cleaner next frontier decision after the control-path PPA evidence is merged"
+  ],
+  "risks": [
+    "the controller PPA measures the replay controller control block, not vendor HBM PHY or DRAM arrays",
+    "the ranking remains an evidence audit and does not synthesize new circuits",
+    "HBM energy remains command-calibrated rather than vendor current-signoff backed"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rank the current score32 HBM replay Llama7B frontier row while consuming measured RTL PPA evidence for the HBM replay controller control path.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l1_decoder_attention_hbm_replay_controller_ppa_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_integrated_frontier_ranking_with_replay_controller_ppa",
+        "reason": "The result should keep score32 as a precision-safe Llama7B frontier candidate if metrics remain unchanged, but replace the replay-controller RTL-timing abstraction with the measured controller-control PPA reference."
+      },
+      "status": "ready_to_dispatch_after_l1_result_merge"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_hbm_replay_controller_ppa_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py",
+    "npu/eval/audit_llm_decoder_attention_score32_hbm_controller_replay.py",
+    "npu/rtlgen/gen_attention_hbm_replay_controller.py",
+    "docs/proposals/prop_l1_decoder_attention_hbm_replay_controller_v1/proposal.json"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "HBM PHY and DRAM arrays are not vendor-signoff timing models.",
+    "HBM energy remains command-calibrated and not vendor current-signoff backed.",
+    "The L2 ranking consumes evidence and does not run a full cycle-accurate token-level RTL system simulation."
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -26,6 +26,13 @@ def _as_float(value: Any, default: float = 0.0) -> float:
         return default
 
 
+def _opt_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _quality_status(score32_quality: JsonDict) -> JsonDict:
     decision = score32_quality.get("decision")
     decision_dict = _as_dict(decision)
@@ -43,11 +50,73 @@ def _quality_status(score32_quality: JsonDict) -> JsonDict:
     }
 
 
+def _extract_ppa_best_metrics(ppa_payload: JsonDict, *, channel_count: int | None = None) -> JsonDict | None:
+    preferred_markers = []
+    if channel_count is not None and channel_count > 0:
+        preferred_markers = [f"_c{channel_count}/", f"_c{channel_count}_"]
+
+    proposal_metrics: list[JsonDict] = []
+    for proposal in ppa_payload.get("proposals", []):
+        if not isinstance(proposal, dict):
+            continue
+        if not isinstance(proposal.get("metric_summary"), dict):
+            continue
+        metrics_ref = _as_dict(proposal.get("metrics_ref"))
+        if str(metrics_ref.get("status") or "").strip() != "ok":
+            continue
+        metric_summary = _as_dict(proposal.get("metric_summary"))
+        critical_path = _opt_float(metric_summary.get("critical_path_ns"))
+        die_area = _opt_float(metric_summary.get("die_area"))
+        total_power = _opt_float(metric_summary.get("total_power_mw"))
+        if any(v is not None for v in (critical_path, die_area, total_power)):
+            proposal_metrics.append(
+                {
+                    "critical_path_ns_best": critical_path,
+                    "die_area_best": die_area,
+                    "total_power_mw_best": total_power,
+                    "source": "proposals",
+                    "artifact_item_id": ppa_payload.get("item_id"),
+                    "metrics_csv": metrics_ref.get("metrics_csv"),
+                }
+            )
+
+    if proposal_metrics:
+        if preferred_markers:
+            for metrics in proposal_metrics:
+                metrics_csv = str(metrics.get("metrics_csv") or "")
+                if any(marker in metrics_csv for marker in preferred_markers):
+                    return metrics
+        return proposal_metrics[0]
+
+    trial_summary = _as_dict(ppa_payload.get("trial_summary"))
+    metrics = _as_dict(trial_summary.get("metrics"))
+    if metrics:
+        critical_path = _opt_float(_as_dict(metrics.get("critical_path_ns")).get("best"))
+        die_area = _opt_float(_as_dict(metrics.get("die_area")).get("best"))
+        total_power = _opt_float(_as_dict(metrics.get("total_power_mw")).get("best"))
+        if any(v is not None for v in (critical_path, die_area, total_power)):
+            return {
+                "critical_path_ns_best": critical_path,
+                "die_area_best": die_area,
+                "total_power_mw_best": total_power,
+                "source": "trial_summary",
+                "artifact_item_id": ppa_payload.get("item_id"),
+            }
+    return None
+
+
+def _load_ppa_metrics(path: Path | None, *, channel_count: int | None = None) -> JsonDict | None:
+    if path is None:
+        return None
+    return _extract_ppa_best_metrics(_load_json(path), channel_count=channel_count)
+
+
 def _score32_row(
     score32_hbm: JsonDict,
     measured_command: JsonDict,
     score32_quality: JsonDict,
     score32_hbm_controller_replay: JsonDict | None = None,
+    score32_hbm_controller_replay_ppa: JsonDict | None = None,
     score32_physical: JsonDict | None = None,
 ) -> JsonDict:
     replay_best = _as_dict(score32_hbm_controller_replay.get("best_latency")) if score32_hbm_controller_replay else {}
@@ -103,7 +172,17 @@ def _score32_row(
         candidate_id = str(best.get("candidate_id") or "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best")
         source_artifact = str(best.get("source_artifact") or "score32_schedule_wrapper_hbm_controller_replay")
         abstraction_status = "measured_schedule_wrapper_sram_envelope_hbm_controller_replay"
-        remaining_abstractions = list(best.get("remaining_abstractions") or [])
+        if score32_hbm_controller_replay_ppa is not None:
+            remaining_abstractions = [
+                item
+                for item in list(best.get("remaining_abstractions") or [])
+                if "deterministic cycle-level" not in str(item).lower()
+            ]
+            remaining_abstractions.append(
+                "HBM replay controller control timing is backed by measured Nangate45 RTL PPA."
+            )
+        else:
+            remaining_abstractions = list(best.get("remaining_abstractions") or [])
         latency_us = _as_float(best.get("latency_us"), latency_us)
         token_throughput_per_s = _as_float(best.get("token_throughput_per_s"), token_throughput_per_s)
         compute_energy_mj_per_token = _as_float(best.get("compute_energy_mj_per_token"), compute_energy_mj_per_token)
@@ -115,6 +194,7 @@ def _score32_row(
             _as_float(measured.get("replica_recost_compute_area_um2") or measured.get("compute_area_um2")) / 1.0e6,
         )
         macs_per_cycle = _as_float(best.get("macs_per_cycle"), _as_float(measured.get("replica_recost_macs_per_cycle") or best.get("macs_per_cycle")))
+        remaining_abstractions = sorted(set(remaining_abstractions))
 
     return {
         "candidate_id": candidate_id,
@@ -131,6 +211,7 @@ def _score32_row(
         "precision_status": quality["status"],
         "quality_backed": quality["quality_backed"],
         "quality": quality,
+        "score32_hbm_controller_replay_ppa": score32_hbm_controller_replay_ppa,
         "abstraction_status": abstraction_status,
         "remaining_abstractions": remaining_abstractions,
         "promotable": bool(quality["quality_backed"]),
@@ -230,6 +311,13 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         if args.score32_hbm_controller_replay_json
         else None
     )
+    replay_channel_count = None
+    if score32_hbm_controller_replay is not None:
+        replay_channel_count = int(_as_float(_as_dict(score32_hbm_controller_replay.get("best_latency")).get("channel_count")))
+    score32_hbm_controller_replay_ppa = _load_ppa_metrics(
+        args.score32_hbm_controller_replay_ppa_json,
+        channel_count=replay_channel_count,
+    )
     score32_physical = _load_json(args.score32_physical_feasibility_json) if args.score32_physical_feasibility_json else None
     score32_quality = _load_json(args.score32_quality_json)
     measured_compute = _load_json(args.measured_compute_energy_json)
@@ -242,6 +330,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             measured_command,
             score32_quality,
             score32_hbm_controller_replay,
+            score32_hbm_controller_replay_ppa,
             score32_physical,
         ),
         _prior_row(
@@ -297,6 +386,10 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "score32_hbm_controller_replay_json": str(args.score32_hbm_controller_replay_json)
             if args.score32_hbm_controller_replay_json
             else None,
+            "score32_hbm_controller_replay_ppa_json": str(args.score32_hbm_controller_replay_ppa_json)
+            if args.score32_hbm_controller_replay_ppa_json
+            else None,
+            "score32_hbm_controller_replay_ppa_metrics": score32_hbm_controller_replay_ppa,
             "score32_physical_feasibility_json": str(args.score32_physical_feasibility_json)
             if args.score32_physical_feasibility_json
             else None,
@@ -346,8 +439,14 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                 "The score32 row is quality-backed by the bounded generation-quality gate and measured through "
                 "wrapper, command-control, SRAM-envelope, and HBM/DRAM service closure."
                 if not args.score32_hbm_controller_replay_json
-                else "The score32 row is quality-backed by the bounded generation-quality gate and measured through "
-                "wrapper, command-control, SRAM-envelope, and deterministic cycle-level HBM controller replay."
+                else (
+                    "The score32 row is quality-backed by the bounded generation-quality gate and measured through "
+                    "wrapper, command-control, SRAM-envelope, and deterministic cycle-level HBM controller replay."
+                    if args.score32_hbm_controller_replay_ppa_json is None
+                    else "The score32 row is quality-backed by the bounded generation-quality gate and measured "
+                    "through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured "
+                    "Nangate45 RTL PPA for the replay controller control path."
+                )
             ),
             "The mixed-int8 energy row is retained as a fast non-promotable latency candidate because its precision path is not promoted by the current real-checkpoint evidence.",
             "The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible.",
@@ -405,6 +504,7 @@ def main() -> int:
     parser.add_argument("--score32-hbm-dram-service-json", type=Path, required=True)
     parser.add_argument("--score32-measured-command-control-json", type=Path, required=True)
     parser.add_argument("--score32-hbm-controller-replay-json", type=Path)
+    parser.add_argument("--score32-hbm-controller-replay-ppa-json", type=Path)
     parser.add_argument("--score32-physical-feasibility-json", type=Path)
     parser.add_argument("--score32-quality-json", type=Path, required=True)
     parser.add_argument("--measured-compute-energy-json", type=Path, required=True)

--- a/tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -1,0 +1,217 @@
+from argparse import Namespace
+import json
+from pathlib import Path
+
+from npu.eval.audit_llm_decoder_attention_score32_integrated_frontier_ranking import build_report
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _args(tmp_path: Path) -> Namespace:
+    return Namespace(
+        score32_hbm_dram_service_json=tmp_path / "score32_hbm_service.json",
+        score32_measured_command_control_json=tmp_path / "measured_command.json",
+        score32_hbm_controller_replay_json=tmp_path / "score32_replay.json",
+        score32_hbm_controller_replay_ppa_json=None,
+        score32_physical_feasibility_json=None,
+        score32_quality_json=tmp_path / "score32_quality.json",
+        measured_compute_energy_json=tmp_path / "measured_compute.json",
+        mixed_int8_energy_json=tmp_path / "mixed_int8.json",
+        integrated_energy_json=tmp_path / "integrated.json",
+    )
+
+
+def _populate_inputs(tmp_path: Path) -> None:
+    args = _args(tmp_path)
+    _write_json(
+        args.score32_hbm_dram_service_json,
+        {
+            "best_latency": {
+                "candidate_id": "score32_exp_lut_hbm_dram_service_closure_best",
+                "latency_us": 120,
+                "token_throughput_per_s": 8300,
+                "compute_energy_mj_per_token": 1.5,
+                "hbm_energy_mj_per_token": 0.8,
+                "total_energy_mj_per_token": 2.3,
+                "die_area_mm2": 2.4,
+                "compute_area_mm2": 1.9,
+                "macs_per_cycle": 512,
+            }
+        },
+    )
+    _write_json(
+        args.score32_measured_command_control_json,
+        {
+            "best_requested": {
+                "die_area_mm2": 2.4,
+            }
+        },
+    )
+    _write_json(
+        args.score32_hbm_controller_replay_json,
+        {
+            "best_latency": {
+                "candidate_id": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+                "latency_us": 100,
+                "token_throughput_per_s": 10000,
+                "compute_energy_mj_per_token": 1.2,
+                "hbm_energy_mj_per_token": 0.7,
+                "total_energy_mj_per_token": 1.9,
+                "die_area_mm2": 1.7,
+                "compute_area_mm2": 1.2,
+                "macs_per_cycle": 768,
+                "channel_count": 4,
+                "remaining_abstractions": [
+                    "controller replay is deterministic cycle-level but not RTL-timing accurate",
+                    "does not include vendor HBM current signoff",
+                ],
+            }
+        },
+    )
+    _write_json(
+        args.score32_quality_json,
+        {
+            "decision": {
+                "status": "mixed_int8_generation_quality_pass"
+            },
+            "best_candidate": {
+                "decision_status": "mixed_int8_generation_quality_pass",
+                "candidate_id": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+            },
+        },
+    )
+    _write_json(
+        args.measured_compute_energy_json,
+        {
+            "best": {
+                "candidate_id": "measured_fp16_compute",
+                "latency_us": 140,
+                "token_throughput_per_s": 7142,
+                "energy_mj": 3.0,
+                "die_area_mm2": 3.3,
+                "compute_area_um2": 2800000,
+                "macs_per_cycle": 256,
+                "energy_components": {"compute_mj": 1.8, "hbm_mj": 1.2},
+            },
+        },
+    )
+    _write_json(
+        args.mixed_int8_energy_json,
+        {
+            "best": {
+                "candidate_id": "mixed_int8_energy",
+                "latency_us": 160,
+                "token_throughput_per_s": 6250,
+                "energy_mj": 4.0,
+                "die_area_mm2": 2.9,
+                "compute_area_um2": 3200000,
+                "macs_per_cycle": 256,
+                "energy_components": {"compute_mj": 2.5, "hbm_mj": 1.5},
+            },
+        },
+    )
+    _write_json(
+        args.integrated_energy_json,
+        {
+            "best": {
+                "candidate_id": "integrated",
+                "latency_us": 250,
+                "token_throughput_per_s": 4000,
+                "energy_mj": 5.0,
+                "die_area_mm2": 4.0,
+                "energy_components": {"compute_mj": 3.0, "hbm_mj": 2.0},
+                "compute_area_um2": 1800000,
+                "macs_per_cycle": 128,
+            },
+        },
+    )
+
+
+def test_integrated_frontier_ranking_default_controller_replay_marks_deterministic_abstraction(tmp_path: Path) -> None:
+    _populate_inputs(tmp_path)
+    args = _args(tmp_path)
+
+    report = build_report(args)
+
+    score32_row = report["rows"][0]
+    assert score32_row["candidate_id"] == "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best"
+    assert "controller replay is deterministic cycle-level but not RTL-timing accurate" in score32_row[
+        "remaining_abstractions"
+    ]
+    assert score32_row["score32_hbm_controller_replay_ppa"] is None
+    assert report["inputs"]["score32_hbm_controller_replay_ppa_json"] is None
+    assert any(
+        "deterministic cycle-level HBM controller replay." in item for item in report["assumptions"]
+    )
+
+
+def test_integrated_frontier_ranking_with_controller_replay_ppa_marks_rtl_timing_backed(tmp_path: Path) -> None:
+    _populate_inputs(tmp_path)
+    args = _args(tmp_path)
+    args.score32_hbm_controller_replay_ppa_json = tmp_path / "replay_ppa.json"
+    _write_json(
+        args.score32_hbm_controller_replay_ppa_json,
+        {
+            "item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v1",
+            "proposals": [
+                {
+                    "metrics_ref": {
+                        "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c8/metrics.csv",
+                        "status": "ok",
+                    },
+                    "metric_summary": {
+                        "critical_path_ns": 0.37,
+                        "die_area": 22222.0,
+                        "total_power_mw": 0.03,
+                    },
+                },
+                {
+                    "metrics_ref": {
+                        "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+                        "status": "ok",
+                    },
+                    "metric_summary": {
+                        "critical_path_ns": 0.42,
+                        "die_area": 12450.0,
+                        "total_power_mw": 0.014,
+                    },
+                },
+            ],
+            "trial_summary": {
+                "metrics": {}
+            },
+        },
+    )
+
+    report = build_report(args)
+    score32_row = report["rows"][0]
+
+    assert score32_row["candidate_id"] == "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best"
+    assert score32_row["score32_hbm_controller_replay_ppa"] == {
+        "critical_path_ns_best": 0.42,
+        "die_area_best": 12450.0,
+        "total_power_mw_best": 0.014,
+        "source": "proposals",
+        "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v1",
+        "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+    }
+    assert "HBM replay controller control timing is backed by measured Nangate45 RTL PPA." in score32_row[
+        "remaining_abstractions"
+    ]
+    assert "controller replay is deterministic cycle-level but not RTL-timing accurate" not in score32_row[
+        "remaining_abstractions"
+    ]
+    assert report["inputs"]["score32_hbm_controller_replay_ppa_json"] == str(args.score32_hbm_controller_replay_ppa_json)
+    assert report["inputs"]["score32_hbm_controller_replay_ppa_metrics"] == {
+        "critical_path_ns_best": 0.42,
+        "die_area_best": 12450.0,
+        "total_power_mw_best": 0.014,
+        "source": "proposals",
+        "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v1",
+        "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+    }
+    assert any(
+        "RTL PPA for the replay controller control path." in item for item in report["assumptions"]
+    )


### PR DESCRIPTION
## Summary
- add optional score32 HBM replay controller PPA input to the integrated frontier ranking audit
- wire L2 task generation to pass the L1 promotion when the dependency is present
- add a follow-up proposal for the RTL-PPA-backed score32 HBM replay frontier ranking

## Validation
- PYTHONPATH=control_plane:. pytest -q tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py control_plane/control_plane/tests/test_l2_task_generator.py -k 'score32_hbm_controller_replay_integrated_frontier_ranking or integrated_frontier_ranking'
- PYTHONPATH=control_plane:. pytest -q control_plane/control_plane/tests/test_l2_task_generator.py tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
- python3 scripts/validate_runs.py --skip_eval_queue
- git diff --check