### PR TITLE
npu: recost hbm replay controller ppa

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1/README.md
@@ -1,0 +1,5 @@
+# Score32 HBM Replay Controller RTL-PPA Recost
+
+This proposal folds the merged c4 HBM replay-controller Nangate45 area, power, and critical path into the current score32 Llama7B frontier row.
+
+It follows the evidence-only ranking in `prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1`. The recost keeps the fixed die area unchanged, adds controller area to the measured logic subtotal, adds controller active energy over token latency, and checks the measured controller critical path against the schedule clock.

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,32 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+  "source_commit_note": "Dispatch after the replay-controller PPA recost implementation is merged.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the current score32 HBM replay Llama7B frontier with measured replay-controller area, active energy, and timing margin.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_integrated_frontier_ranking_with_replay_controller_ppa_recost",
+        "reason": "Fold the measured controller cost into the score32 totals and preserve the ranking only if the recosted evidence supports it."
+      },
+      "status": "ready_to_dispatch_after_implementation_merge"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+  "created_utc": "2026-07-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 HBM replay controller RTL-PPA exact recost",
+  "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+  "hypothesis": "Folding measured c4 replay-controller area and active energy into the score32 Llama7B row will close the remaining controller-cost accounting gap without changing the precision-safe throughput ranking.",
+  "direct_comparison": {
+    "primary_question": "Does exact replay-controller PPA recost change the score32 Llama7B throughput, energy, area, precision, or promotability ranking?",
+    "include": [
+      "add measured replay-controller die area to the score32 logic-area subtotal",
+      "add measured controller power multiplied by token latency to score32 energy",
+      "check measured controller critical path against the schedule clock",
+      "rerank promotable latency and energy rows"
+    ],
+    "exclude": [
+      "vendor HBM PHY or DRAM-array timing",
+      "vendor HBM current-signoff energy",
+      "new precision training or checkpoint evaluation"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the current score32 HBM replay Llama7B frontier with measured replay-controller area, active energy, and timing margin.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_score32_integrated_frontier_ranking_with_replay_controller_ppa_recost",
+        "reason": "The controller should meet the schedule clock and add only a small measured area and energy increment, leaving score32 as the precision-safe throughput frontier."
+      },
+      "status": "ready_to_dispatch_after_implementation_merge"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_hbm_replay_controller_ppa_v2.json"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "HBM PHY and DRAM arrays are not vendor-signoff timing models.",
+    "HBM energy remains command-calibrated rather than vendor current-signoff backed.",
+    "NoC and SRAM energy remain profile-scaled rather than full token-level RTL activity signoff.",
+    "Precision evidence remains bounded by the current real-checkpoint generation-quality gate."
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -179,7 +179,7 @@ def _score32_row(
                 if "deterministic cycle-level" not in str(item).lower()
             ]
             remaining_abstractions.append(
-                "HBM replay controller control timing is backed by measured Nangate45 RTL PPA."
+                "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA."
             )
         else:
             remaining_abstractions = list(best.get("remaining_abstractions") or [])
@@ -196,6 +196,55 @@ def _score32_row(
         macs_per_cycle = _as_float(best.get("macs_per_cycle"), _as_float(measured.get("replica_recost_macs_per_cycle") or best.get("macs_per_cycle")))
         remaining_abstractions = sorted(set(remaining_abstractions))
 
+    controller_ppa_recost = None
+    if uses_hbm_controller_replay and score32_hbm_controller_replay_ppa is not None:
+        controller_area_mm2 = round(
+            _as_float(score32_hbm_controller_replay_ppa.get("die_area_best")) / 1.0e6,
+            12,
+        )
+        controller_power_mw = _as_float(score32_hbm_controller_replay_ppa.get("total_power_mw_best"))
+        controller_energy_mj_per_token = round(controller_power_mw * latency_us * 1.0e-6, 12)
+        controller_critical_path_ns = _opt_float(
+            score32_hbm_controller_replay_ppa.get("critical_path_ns_best")
+        )
+        schedule_clock_ns = _opt_float(measured.get("clock_ns"))
+        controller_clock_ok = (
+            controller_critical_path_ns <= schedule_clock_ns
+            if controller_critical_path_ns is not None and schedule_clock_ns is not None
+            else None
+        )
+        controller_clock_margin_ns = (
+            round(schedule_clock_ns - controller_critical_path_ns, 12)
+            if controller_critical_path_ns is not None and schedule_clock_ns is not None
+            else None
+        )
+        compute_area_mm2 = round(compute_area_mm2 + controller_area_mm2, 12)
+        compute_energy_mj_per_token = round(
+            compute_energy_mj_per_token + controller_energy_mj_per_token,
+            12,
+        )
+        total_energy_mj_per_token = round(
+            total_energy_mj_per_token + controller_energy_mj_per_token,
+            12,
+        )
+        controller_ppa_recost = {
+            **score32_hbm_controller_replay_ppa,
+            "controller_area_mm2": controller_area_mm2,
+            "controller_power_mw": controller_power_mw,
+            "controller_energy_mj_per_token": controller_energy_mj_per_token,
+            "schedule_clock_ns": schedule_clock_ns,
+            "controller_clock_ok": controller_clock_ok,
+            "controller_clock_margin_ns": controller_clock_margin_ns,
+        }
+        abstraction_status = "measured_schedule_wrapper_sram_envelope_hbm_controller_replay_ppa_recost"
+        if controller_clock_ok is False:
+            remaining_abstractions = sorted(
+                {
+                    *remaining_abstractions,
+                    "HBM replay controller requires pipelining or a schedule-clock recost to meet timing.",
+                }
+            )
+
     return {
         "candidate_id": candidate_id,
         "family": "score32_exp_lut_div",
@@ -211,7 +260,7 @@ def _score32_row(
         "precision_status": quality["status"],
         "quality_backed": quality["quality_backed"],
         "quality": quality,
-        "score32_hbm_controller_replay_ppa": score32_hbm_controller_replay_ppa,
+        "score32_hbm_controller_replay_ppa": controller_ppa_recost,
         "abstraction_status": abstraction_status,
         "remaining_abstractions": remaining_abstractions,
         "promotable": bool(quality["quality_backed"]),
@@ -409,6 +458,18 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "score32_token_throughput_per_s": score32["token_throughput_per_s"],
             "score32_total_energy_mj_per_token": score32["energy_mj_per_token"],
             "score32_die_area_mm2": score32["die_area_mm2"],
+            "score32_compute_plus_controller_area_mm2": score32["compute_area_mm2"],
+            "score32_controller_area_mm2": _as_float(
+                _as_dict(score32.get("score32_hbm_controller_replay_ppa")).get("controller_area_mm2")
+            ),
+            "score32_controller_energy_mj_per_token": _as_float(
+                _as_dict(score32.get("score32_hbm_controller_replay_ppa")).get(
+                    "controller_energy_mj_per_token"
+                )
+            ),
+            "score32_controller_clock_ok": _as_dict(
+                score32.get("score32_hbm_controller_replay_ppa")
+            ).get("controller_clock_ok"),
             "score32_quality_status": score32["precision_status"],
             "score32_vs_measured_fp16_energy_ratio": round(
                 score32["energy_mj_per_token"] / max(1.0e-12, best_energy_safe["energy_mj_per_token"]), 9
@@ -445,7 +506,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                     if args.score32_hbm_controller_replay_ppa_json is None
                     else "The score32 row is quality-backed by the bounded generation-quality gate and measured "
                     "through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured "
-                    "Nangate45 RTL PPA for the replay controller control path."
+                    "Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing."
                 )
             ),
             "The mixed-int8 energy row is retained as a fast non-promotable latency candidate because its precision path is not promoted by the current real-checkpoint evidence.",

--- a/tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -46,6 +46,7 @@ def _populate_inputs(tmp_path: Path) -> None:
         {
             "best_requested": {
                 "die_area_mm2": 2.4,
+                "clock_ns": 2.0,
             }
         },
     )
@@ -196,8 +197,21 @@ def test_integrated_frontier_ranking_with_controller_replay_ppa_marks_rtl_timing
         "source": "proposals",
         "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v1",
         "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+        "controller_area_mm2": 0.01245,
+        "controller_power_mw": 0.014,
+        "controller_energy_mj_per_token": 0.0000014,
+        "schedule_clock_ns": 2.0,
+        "controller_clock_ok": True,
+        "controller_clock_margin_ns": 1.58,
     }
-    assert "HBM replay controller control timing is backed by measured Nangate45 RTL PPA." in score32_row[
+    assert score32_row["compute_area_mm2"] == 1.21245
+    assert score32_row["compute_energy_mj_per_token"] == 1.2000014
+    assert score32_row["energy_mj_per_token"] == 1.9000014
+    assert (
+        score32_row["abstraction_status"]
+        == "measured_schedule_wrapper_sram_envelope_hbm_controller_replay_ppa_recost"
+    )
+    assert "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA." in score32_row[
         "remaining_abstractions"
     ]
     assert "controller replay is deterministic cycle-level but not RTL-timing accurate" not in score32_row[
@@ -212,6 +226,37 @@ def test_integrated_frontier_ranking_with_controller_replay_ppa_marks_rtl_timing
         "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v1",
         "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
     }
-    assert any(
-        "RTL PPA for the replay controller control path." in item for item in report["assumptions"]
+    assert report["diagnosis"]["score32_controller_area_mm2"] == 0.01245
+    assert report["diagnosis"]["score32_controller_energy_mj_per_token"] == 0.0000014
+    assert report["diagnosis"]["score32_controller_clock_ok"] is True
+    assert any("RTL PPA recost for replay-controller area" in item for item in report["assumptions"])
+
+
+def test_integrated_frontier_ranking_with_controller_replay_ppa_records_clock_miss(tmp_path: Path) -> None:
+    _populate_inputs(tmp_path)
+    args = _args(tmp_path)
+    args.score32_hbm_controller_replay_ppa_json = tmp_path / "replay_ppa_clock_miss.json"
+    _write_json(
+        args.score32_hbm_controller_replay_ppa_json,
+        {
+            "item_id": "l1_decoder_attention_hbm_replay_controller_ppa_clock_miss",
+            "trial_summary": {
+                "metrics": {
+                    "critical_path_ns": {"best": 2.5},
+                    "die_area": {"best": 10000.0},
+                    "total_power_mw": {"best": 0.02},
+                }
+            },
+        },
+    )
+
+    report = build_report(args)
+    score32_row = report["rows"][0]
+    recost = score32_row["score32_hbm_controller_replay_ppa"]
+
+    assert recost["controller_clock_ok"] is False
+    assert recost["controller_clock_margin_ns"] == -0.5
+    assert (
+        "HBM replay controller requires pipelining or a schedule-clock recost to meet timing."
+        in score32_row["remaining_abstractions"]
     )


### PR DESCRIPTION
## Summary\n\n- fold measured c4 HBM replay-controller macro area into the score32 logic-area subtotal\n- fold a conservative full-token active-energy upper bound from measured controller power into token energy\n- record controller timing margin against the measured schedule clock and flag a clock miss\n- add a linked L2 recost proposal for the post-merge ranking\n\n## Measured impact\n\n- controller macro area: 0.0289102009 mm2\n- controller active-energy upper bound: 0.001396754106 mJ/token\n- controller critical path: 2.2087 ns against 5.9811 ns schedule clock\n- timing margin: 3.7724 ns\n- score32 ranking remains the precision-safe throughput frontier in the local recost\n\n## Validation\n\n- 3 focused audit tests passed\n- scripts/validate_runs.py --skip_eval_queue passed\n- proposal JSON parses\n- Python compilation and git diff --check passed