### PR TITLE
npu: apply mixed int8 quality invalidation

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6012,6 +6012,10 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(
         f"{base}/decoder_attention_mixed_int8_energy_closure__"
         "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json"
     )
+    mixed_int8_quality_backed_frontier = (
+        f"{base}/decoder_attention_mixed_int8_quality_backed_frontier__"
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
+    )
     integrated_energy = (
         f"{base}/decoder_attention_integrated_energy_closure__"
         "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json"
@@ -6031,6 +6035,7 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(
         f"--score32-quality-json {score32_quality} "
         f"--measured-compute-energy-json {measured_compute} "
         f"--mixed-int8-energy-json {mixed_int8} "
+        f"--mixed-int8-quality-backed-frontier-json {mixed_int8_quality_backed_frontier} "
         f"--integrated-energy-json {integrated_energy} "
         f"--out {out} "
         f"--out-md {report}"
@@ -6057,6 +6062,7 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(
             "attention_score32_exp_lut_generation_quality": score32_quality,
             "attention_measured_compute_energy_closure": measured_compute,
             "attention_mixed_int8_energy_closure": mixed_int8,
+            "attention_mixed_int8_quality_backed_frontier": mixed_int8_quality_backed_frontier,
             "attention_integrated_energy_closure": integrated_energy,
             "attention_score32_integrated_frontier_ranking_out": out,
             "attention_score32_integrated_frontier_ranking_report": report,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7046,6 +7046,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_
             decoder_inputs = work_item.input_manifest["decoder_contract"]
 
             assert "--score32-hbm-controller-replay-json" in run
+            assert "--mixed-int8-quality-backed-frontier-json" in run
             assert (
                 "decoder_attention_score32_hbm_controller_replay__"
                 "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
@@ -7055,6 +7056,10 @@ def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_
                 == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_score32_hbm_controller_replay__"
                 "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_mixed_int8_quality_backed_frontier"].endswith(
+                "decoder_attention_mixed_int8_quality_backed_frontier__"
+                "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json"
             )
             assert (
                 decoder_inputs["attention_score32_integrated_frontier_ranking_out"].endswith(

--- a/docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/README.md
@@ -1,0 +1,3 @@
+# Score32 Quality-Aware HBM Controller PPA Recost Frontier
+
+This proposal corrects the integrated Llama7B frontier ranking by consuming the merged mixed/int8 quality-backed frontier. The old 634.77 token/s low-precision score/softmax row remains useful measured evidence, but it must be labeled quality-invalidated rather than pending promotion.

--- a/docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,33 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1",
+  "source_commit_note": "Dispatch after the quality-aware integrated ranking implementation is merged.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Correct the recosted score32 Llama7B frontier with merged mixed/int8 quality invalidation and nested energy-component evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_quality_aware_hbm_controller_ppa_recost_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_quality_aware_score32_hbm_controller_ppa_recost_frontier",
+        "reason": "Use merged quality evidence to invalidate stale low-precision rows before ranking."
+      },
+      "status": "ready_to_dispatch_after_implementation_merge"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json
@@ -1,0 +1,59 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1",
+  "created_utc": "2026-07-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Quality-aware score32 HBM-controller PPA recost frontier",
+  "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+  "hypothesis": "Consuming the existing quality-backed frontier will explicitly invalidate the stale low-precision mixed/int8 row while preserving score32 as the best precision-safe throughput candidate and exact-FP16 as the energy reference.",
+  "direct_comparison": {
+    "primary_question": "Which measured Llama7B rows remain rankable after controller PPA recost and merged quality invalidation evidence?",
+    "include": [
+      "consume the exact HBM-controller PPA recost result",
+      "consume mixed/int8 quality-backed frontier invalidation evidence",
+      "retain invalidated measured rows as historical evidence without promotion",
+      "report correct nested compute and HBM energy components",
+      "rerank throughput, energy, area, and precision"
+    ],
+    "exclude": [
+      "new PPA synthesis",
+      "new checkpoint training",
+      "vendor HBM current-signoff data"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Correct the recosted score32 Llama7B frontier with merged mixed/int8 quality invalidation and nested energy-component evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_quality_aware_hbm_controller_ppa_recost_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_quality_aware_score32_hbm_controller_ppa_recost_frontier",
+        "reason": "The old low-precision mixed/int8 row must be explicitly quality-invalidated; score32 should remain the precision-safe throughput winner."
+      },
+      "status": "ready_to_dispatch_after_implementation_merge"
+    }
+  ],
+  "remaining_abstractions_after_this_step": [
+    "HBM energy is command-calibrated rather than vendor current-signoff backed.",
+    "NoC and SRAM energy remain profile-scaled.",
+    "The score32 generation-quality gate is bounded rather than a complete Llama7B downstream-task suite."
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -283,6 +283,9 @@ def _prior_row(
     promotable: bool,
     remaining_abstractions: list[str],
 ) -> JsonDict:
+    energy_components = _as_dict(row.get("energy_components"))
+    compute_component = _as_dict(energy_components.get("compute"))
+    hbm_component = _as_dict(energy_components.get("hbm"))
     return {
         "candidate_id": candidate_id,
         "family": family,
@@ -290,8 +293,12 @@ def _prior_row(
         "latency_us": _as_float(row.get("latency_us")),
         "token_throughput_per_s": _as_float(row.get("token_throughput_per_s")),
         "energy_mj_per_token": _as_float(row.get("energy_mj")),
-        "compute_energy_mj_per_token": _as_float(_as_dict(row.get("energy_components")).get("compute_mj")),
-        "hbm_energy_mj_per_token": _as_float(_as_dict(row.get("energy_components")).get("hbm_mj")),
+        "compute_energy_mj_per_token": _as_float(
+            compute_component.get("energy_mj", energy_components.get("compute_mj"))
+        ),
+        "hbm_energy_mj_per_token": _as_float(
+            hbm_component.get("energy_mj", energy_components.get("hbm_mj"))
+        ),
         "die_area_mm2": _as_float(row.get("die_area_mm2")),
         "compute_area_mm2": _as_float(row.get("compute_area_um2")) / 1.0e6,
         "macs_per_cycle": _as_float(row.get("macs_per_cycle")),
@@ -326,6 +333,44 @@ def _abstract_integrated_row(integrated_energy: JsonDict) -> JsonDict:
         ],
         "promotable": False,
     }
+
+
+def _apply_mixed_int8_quality_frontier(row: JsonDict, quality_frontier: JsonDict | None) -> JsonDict:
+    if quality_frontier is None:
+        return row
+    candidate_id = str(row.get("candidate_id") or "")
+    invalidated = next(
+        (
+            dict(item)
+            for item in quality_frontier.get("invalidated_energy_candidates", [])
+            if isinstance(item, dict) and str(item.get("candidate_id") or "") == candidate_id
+        ),
+        None,
+    )
+    if invalidated is None:
+        return row
+    reason = str(invalidated.get("reason") or "mixed/int8 candidate failed the quality-backed frontier gate")
+    result = dict(row)
+    result.update(
+        {
+            "precision_status": "quality_invalidated_low_precision_score_softmax",
+            "quality_backed": False,
+            "promotable": False,
+            "abstraction_status": "measured_int8_compute_quality_invalidated",
+            "quality_invalidation": {
+                "source_model": quality_frontier.get("model"),
+                "source_decision": quality_frontier.get("decision"),
+                "candidate_id": candidate_id,
+                "precision_profile": _as_dict(invalidated.get("precision")).get("precision_profile"),
+                "reason": reason,
+            },
+            "remaining_abstractions": [
+                "quality_invalidated_by_broad_native_attention_shadow",
+                reason,
+            ],
+        }
+    )
+    return result
 
 
 def _rank_rows(rows: list[JsonDict], *, promotable_only: bool = False) -> list[JsonDict]:
@@ -371,8 +416,30 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     score32_quality = _load_json(args.score32_quality_json)
     measured_compute = _load_json(args.measured_compute_energy_json)
     mixed_int8 = _load_json(args.mixed_int8_energy_json)
+    mixed_int8_quality_frontier = (
+        _load_json(args.mixed_int8_quality_backed_frontier_json)
+        if args.mixed_int8_quality_backed_frontier_json
+        else None
+    )
     integrated = _load_json(args.integrated_energy_json)
 
+    mixed_int8_row = _apply_mixed_int8_quality_frontier(
+        _prior_row(
+            candidate_id=str(_best_row(mixed_int8).get("candidate_id") or "mixed_int8_energy_best"),
+            family="mixed_int8_compute",
+            source_artifact="mixed_int8_energy_closure_r2",
+            row=_best_row(mixed_int8),
+            precision_status="latency_candidate_pending_real_checkpoint_quality",
+            quality_backed=False,
+            abstraction_status="measured_int8_compute_with_source_backed_hbm_energy",
+            promotable=False,
+            remaining_abstractions=[
+                "real_checkpoint_quality_not_promoted_for_this_compute_path",
+                "source_backed_aggregate_hbm_energy_not_vendor_current_signoff",
+            ],
+        ),
+        mixed_int8_quality_frontier,
+    )
     rows = [
         _score32_row(
             score32_hbm,
@@ -396,20 +463,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                 "profile_scaled_noc_sram_energy",
             ],
         ),
-        _prior_row(
-            candidate_id=str(_best_row(mixed_int8).get("candidate_id") or "mixed_int8_energy_best"),
-            family="mixed_int8_compute",
-            source_artifact="mixed_int8_energy_closure_r2",
-            row=_best_row(mixed_int8),
-            precision_status="latency_candidate_pending_real_checkpoint_quality",
-            quality_backed=False,
-            abstraction_status="measured_int8_compute_with_source_backed_hbm_energy",
-            promotable=False,
-            remaining_abstractions=[
-                "real_checkpoint_quality_not_promoted_for_this_compute_path",
-                "source_backed_aggregate_hbm_energy_not_vendor_current_signoff",
-            ],
-        ),
+        mixed_int8_row,
         _abstract_integrated_row(integrated),
     ]
 
@@ -445,6 +499,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "score32_quality_json": str(args.score32_quality_json),
             "measured_compute_energy_json": str(args.measured_compute_energy_json),
             "mixed_int8_energy_json": str(args.mixed_int8_energy_json),
+            "mixed_int8_quality_backed_frontier_json": str(args.mixed_int8_quality_backed_frontier_json)
+            if args.mixed_int8_quality_backed_frontier_json
+            else None,
             "integrated_energy_json": str(args.integrated_energy_json),
         },
         "diagnosis": {
@@ -471,6 +528,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                 score32.get("score32_hbm_controller_replay_ppa")
             ).get("controller_clock_ok"),
             "score32_quality_status": score32["precision_status"],
+            "mixed_int8_quality_status": mixed_int8_row["precision_status"],
             "score32_vs_measured_fp16_energy_ratio": round(
                 score32["energy_mj_per_token"] / max(1.0e-12, best_energy_safe["energy_mj_per_token"]), 9
             ),
@@ -509,16 +567,24 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                     "Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing."
                 )
             ),
-            "The mixed-int8 energy row is retained as a fast non-promotable latency candidate because its precision path is not promoted by the current real-checkpoint evidence.",
+            (
+                "The old mixed-int8 energy row is retained only as measured historical evidence because the "
+                "quality-backed frontier invalidated its low-precision score/softmax profile."
+                if mixed_int8_row.get("quality_invalidation")
+                else "The mixed-int8 energy row is retained as a fast non-promotable latency candidate because "
+                "its precision path is not promoted by the current real-checkpoint evidence."
+            ),
             "The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible.",
         ],
         "next_step": {
             "recommended_next_step": (
                 "Use score32 as the current precision-safe throughput frontier and measured exact-FP16 as the "
-                "energy reference; next reduce score32 compute energy or validate a lower-energy mixed/int8 path."
+                "energy reference; next reduce score32 compute energy or build a quality-backed q8/k8/v8 path "
+                "with high-precision score/softmax."
             ),
             "score32_energy_reduction_required_for_energy_best": True,
-            "mixed_int8_requires_quality_closure": True,
+            "mixed_int8_requires_quality_closure": not bool(mixed_int8_row.get("quality_invalidation")),
+            "mixed_int8_old_candidate_quality_invalidated": bool(mixed_int8_row.get("quality_invalidation")),
         },
     }
 
@@ -570,6 +636,7 @@ def main() -> int:
     parser.add_argument("--score32-quality-json", type=Path, required=True)
     parser.add_argument("--measured-compute-energy-json", type=Path, required=True)
     parser.add_argument("--mixed-int8-energy-json", type=Path, required=True)
+    parser.add_argument("--mixed-int8-quality-backed-frontier-json", type=Path)
     parser.add_argument("--integrated-energy-json", type=Path, required=True)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)

--- a/tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -19,6 +19,7 @@ def _args(tmp_path: Path) -> Namespace:
         score32_quality_json=tmp_path / "score32_quality.json",
         measured_compute_energy_json=tmp_path / "measured_compute.json",
         mixed_int8_energy_json=tmp_path / "mixed_int8.json",
+        mixed_int8_quality_backed_frontier_json=None,
         integrated_energy_json=tmp_path / "integrated.json",
     )
 
@@ -109,7 +110,10 @@ def _populate_inputs(tmp_path: Path) -> None:
                 "die_area_mm2": 2.9,
                 "compute_area_um2": 3200000,
                 "macs_per_cycle": 256,
-                "energy_components": {"compute_mj": 2.5, "hbm_mj": 1.5},
+                "energy_components": {
+                    "compute": {"energy_mj": 2.5},
+                    "hbm": {"energy_mj": 1.5},
+                },
             },
         },
     )
@@ -260,3 +264,39 @@ def test_integrated_frontier_ranking_with_controller_replay_ppa_records_clock_mi
         "HBM replay controller requires pipelining or a schedule-clock recost to meet timing."
         in score32_row["remaining_abstractions"]
     )
+
+
+def test_integrated_frontier_ranking_invalidates_stale_mixed_int8_energy_row(tmp_path: Path) -> None:
+    _populate_inputs(tmp_path)
+    args = _args(tmp_path)
+    args.mixed_int8_quality_backed_frontier_json = tmp_path / "mixed_int8_quality_frontier.json"
+    _write_json(
+        args.mixed_int8_quality_backed_frontier_json,
+        {
+            "model": "llm_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+            "decision": "mixed_int8_quality_backed_frontier_recost_required",
+            "invalidated_energy_candidates": [
+                {
+                    "candidate_id": "mixed_int8_energy",
+                    "precision": {"precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"},
+                    "reason": "low-precision score/softmax path failed the quality-backed frontier gate",
+                }
+            ],
+        },
+    )
+
+    report = build_report(args)
+    mixed_row = report["rows"][2]
+
+    assert mixed_row["precision_status"] == "quality_invalidated_low_precision_score_softmax"
+    assert mixed_row["compute_energy_mj_per_token"] == 2.5
+    assert mixed_row["hbm_energy_mj_per_token"] == 1.5
+    assert mixed_row["abstraction_status"] == "measured_int8_compute_quality_invalidated"
+    assert mixed_row["quality_invalidation"]["precision_profile"] == (
+        "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute"
+    )
+    assert report["diagnosis"]["mixed_int8_quality_status"] == (
+        "quality_invalidated_low_precision_score_softmax"
+    )
+    assert report["next_step"]["mixed_int8_old_candidate_quality_invalidated"] is True
+    assert report["next_step"]["mixed_int8_requires_quality_closure"] is False


### PR DESCRIPTION
## Summary\n\n- consume the merged mixed/int8 quality-backed frontier in score32 integrated rankings\n- explicitly mark the stale q8/k8/v6 low-precision score/softmax row as quality-invalidated\n- preserve its measured throughput and energy as historical evidence without promotion\n- read both nested and legacy flat energy-component schemas\n- add a linked quality-aware Llama7B frontier evaluation\n\n## Corrected interpretation\n\nThe 634.77 token/s mixed-int8 row is not pending generic quality closure. Its q8/k8/v6/a24/s8/w8 reciprocal-LUT profile was already invalidated by the quality-backed frontier. The current quality-backed throughput winner remains q8/k8/v8 with score32 exp-LUT/div.\n\n## Validation\n\n- 4 audit tests passed\n- 2 focused L2 generator tests passed\n- actual merged-evidence audit reports 1.537236 mJ compute and 134.144613 mJ HBM for the invalidated row\n- scripts/validate_runs.py --skip_eval_queue passed\n- proposal JSON, Python compilation, and git diff --check passed