### PR TITLE
eval: run quality-aware score32 hbm-controller ppa recost frontier

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json
@@ -1,0 +1,152 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-10T10:45:30.106124Z",
+  "item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+  "run_key": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1_run_44f9371d9a1b3d21",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "3ee947a3dd8f67e932782ea1cd6b3a24f73bac44",
+  "review_metadata_source_commit": "3ee947a3dd8f67e932782ea1cd6b3a24f73bac44",
+  "objective": "Correct the recosted score32 Llama7B frontier with merged mixed/int8 quality invalidation and nested energy-component evidence.",
+  "input_manifest": {
+    "decoder_contract": {
+      "attention_integrated_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json",
+      "attention_mixed_int8_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+      "attention_score32_hbm_controller_replay": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json",
+      "attention_measured_compute_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json",
+      "attention_mixed_int8_quality_backed_frontier": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+      "attention_score32_exp_lut_generation_quality": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+      "attention_score32_hbm_controller_replay_ppa_json": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_hbm_replay_controller_ppa_v2.json",
+      "attention_score32_integrated_frontier_ranking_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+      "attention_score32_exp_lut_hbm_dram_service_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json",
+      "attention_score32_exp_lut_measured_command_control": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+      "attention_score32_integrated_frontier_ranking_scope": "Rank the closed score32 exp-LUT Llama7B attention row against prior integrated, measured-compute, and mixed/int8 energy evidence. Report latency, energy, area, precision status, promotability, and remaining abstractions without promoting planning-only or quality-unclosed rows.",
+      "attention_score32_integrated_frontier_ranking_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.md"
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+    "arch_id": "decoder_attention_score32_integrated_frontier_ranking",
+    "macro_mode": "evidence_only",
+    "outcome": "score32_integrated_frontier_best_precision_safe_throughput"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1",
+    "title": "Quality-aware score32 HBM-controller PPA recost frontier",
+    "primary_question": "Which measured Llama7B rows remain rankable after controller PPA recost and merged quality invalidation evidence?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "score32_quality_aware_hbm_controller_ppa_recost_frontier",
+    "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+    "expected_direction": "record_quality_aware_score32_hbm_controller_ppa_recost_frontier",
+    "expected_reason": "Use merged quality evidence to invalidate stale low-precision rows before ranking.",
+    "summary": "Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].",
+    "outcome": "score32_integrated_frontier_best_precision_safe_throughput",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1",
+    "title": "Quality-aware score32 HBM-controller PPA recost frontier",
+    "kind": "architecture",
+    "primary_question": "Which measured Llama7B rows remain rankable after controller PPA recost and merged quality invalidation evidence?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "score32_quality_aware_hbm_controller_ppa_recost_frontier",
+    "outcome": "score32_integrated_frontier_best_precision_safe_throughput",
+    "summary": "Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+    "decoder_quality": {
+      "diagnosis": {
+        "best_energy_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+        "best_latency_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+        "best_precision_safe_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+        "best_precision_safe_energy_candidate": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+        "current_recommended_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+        "decision": "score32_integrated_frontier_best_precision_safe_throughput",
+        "excluded_fastest_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+        "mixed_int8_quality_status": "quality_invalidated_low_precision_score_softmax",
+        "remaining_abstractions": [
+          "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+          "does not include vendor HBM current signoff",
+          "profile_scaled_noc_sram_energy",
+          "source_backed_aggregate_hbm_energy_not_vendor_current_signoff"
+        ],
+        "score32_compute_plus_controller_area_mm2": 296.8263662009,
+        "score32_controller_area_mm2": 0.0289102009,
+        "score32_controller_clock_ok": true,
+        "score32_controller_energy_mj_per_token": 0.001396754106,
+        "score32_die_area_mm2": 800.0,
+        "score32_latency_us": 12814.257853,
+        "score32_quality_status": "mixed_int8_generation_quality_pass",
+        "score32_token_throughput_per_s": 78.038073798,
+        "score32_total_energy_mj_per_token": 467.191305313106,
+        "score32_vs_measured_fp16_energy_ratio": 5.720887555,
+        "score32_vs_measured_fp16_throughput_ratio": 5.661198874
+      },
+      "assumptions": [
+        "Rows are ranked by explicit metrics from merged evidence; no new PPA is synthesized in this audit.",
+        "The score32 row is quality-backed by the bounded generation-quality gate and measured through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing.",
+        "The old mixed-int8 energy row is retained only as measured historical evidence because the quality-backed frontier invalidated its low-precision score/softmax profile.",
+        "The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible."
+      ],
+      "next_step": {
+        "mixed_int8_old_candidate_quality_invalidated": true,
+        "mixed_int8_requires_quality_closure": false,
+        "recommended_next_step": "Use score32 as the current precision-safe throughput frontier and measured exact-FP16 as the energy reference; next reduce score32 compute energy or build a quality-backed q8/k8/v8 path with high-precision score/softmax.",
+        "score32_energy_reduction_required_for_energy_best": true
+      }
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+    "decoder_attention_score32_integrated_frontier_ranking_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+    "decoder_attention_score32_integrated_frontier_ranking_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {
+      "best_energy_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+      "best_latency_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+      "best_precision_safe_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+      "best_precision_safe_energy_candidate": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+      "current_recommended_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+      "decision": "score32_integrated_frontier_best_precision_safe_throughput",
+      "excluded_fastest_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+      "mixed_int8_quality_status": "quality_invalidated_low_precision_score_softmax",
+      "remaining_abstractions": [
+        "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+        "does not include vendor HBM current signoff",
+        "profile_scaled_noc_sram_energy",
+        "source_backed_aggregate_hbm_energy_not_vendor_current_signoff"
+      ],
+      "score32_compute_plus_controller_area_mm2": 296.8263662009,
+      "score32_controller_area_mm2": 0.0289102009,
+      "score32_controller_clock_ok": true,
+      "score32_controller_energy_mj_per_token": 0.001396754106,
+      "score32_die_area_mm2": 800.0,
+      "score32_latency_us": 12814.257853,
+      "score32_quality_status": "mixed_int8_generation_quality_pass",
+      "score32_token_throughput_per_s": 78.038073798,
+      "score32_total_energy_mj_per_token": 467.191305313106,
+      "score32_vs_measured_fp16_energy_ratio": 5.720887555,
+      "score32_vs_measured_fp16_throughput_ratio": 5.661198874
+    },
+    "assumptions": [
+      "Rows are ranked by explicit metrics from merged evidence; no new PPA is synthesized in this audit.",
+      "The score32 row is quality-backed by the bounded generation-quality gate and measured through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing.",
+      "The old mixed-int8 energy row is retained only as measured historical evidence because the quality-backed frontier invalidated its low-precision score/softmax profile.",
+      "The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible."
+    ],
+    "next_step": {
+      "mixed_int8_old_candidate_quality_invalidated": true,
+      "mixed_int8_requires_quality_closure": false,
+      "recommended_next_step": "Use score32 as the current precision-safe throughput frontier and measured exact-FP16 as the energy reference; next reduce score32 compute energy or build a quality-backed q8/k8/v8 path with high-precision score/softmax.",
+      "score32_energy_reduction_required_for_energy_best": true
+    }
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/evaluated.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/evaluated.json
@@ -1,0 +1,121 @@
+{
+  "flow": "openroad",
+  "task": {
+    "inputs": {
+      "decoder_contract": {
+        "attention_integrated_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json",
+        "attention_mixed_int8_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+        "attention_score32_hbm_controller_replay": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json",
+        "attention_measured_compute_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json",
+        "attention_mixed_int8_quality_backed_frontier": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+        "attention_score32_exp_lut_generation_quality": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+        "attention_score32_hbm_controller_replay_ppa_json": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_hbm_replay_controller_ppa_v2.json",
+        "attention_score32_integrated_frontier_ranking_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+        "attention_score32_exp_lut_hbm_dram_service_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json",
+        "attention_score32_exp_lut_measured_command_control": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+        "attention_score32_integrated_frontier_ranking_scope": "Rank the closed score32 exp-LUT Llama7B attention row against prior integrated, measured-compute, and mixed/int8 energy evidence. Report latency, energy, area, precision status, promotability, and remaining abstractions without promoting planning-only or quality-unclosed rows.",
+        "attention_score32_integrated_frontier_ranking_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.md"
+      }
+    },
+    "commands": [
+      {
+        "run": "python3 npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py --score32-hbm-dram-service-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json --score32-measured-command-control-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json --score32-hbm-controller-replay-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json --score32-hbm-controller-replay-ppa-json control_plane/shadow_exports/l1_promotions/l1_decoder_attention_hbm_replay_controller_ppa_v2.json --score32-quality-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json --measured-compute-energy-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json --mixed-int8-energy-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json --mixed-int8-quality-backed-frontier-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json --integrated-energy-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.md",
+        "name": "audit_decoder_attention_score32_integrated_frontier_ranking"
+      },
+      {
+        "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+        "name": "validate_runs"
+      }
+    ],
+    "objective": "Correct the recosted score32 Llama7B frontier with merged mixed/int8 quality invalidation and nested energy-component evidence.",
+    "acceptance": [
+      "Write all declared decoder evidence artifacts",
+      "Keep evidence artifact paths repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "source_mode": "src_verilog",
+    "expected_outputs": [
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.md"
+    ]
+  },
+  "layer": "layer2",
+  "state": "evaluated",
+  "title": "Quality-aware score32 HBM-controller PPA recost frontier",
+  "result": {
+    "branch": "eval/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/s20260710t104530z",
+    "completed_utc": "2026-07-10T10:45:29.426883Z",
+    "evaluator_id": "control_plane",
+    "executor": "@control_plane",
+    "host": "b7c2d9c80c1c",
+    "identity_block": "[role:evaluator][account:control_plane][session:s20260710t104530z][host:b7c2d9c80c1c][item:l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1]",
+    "metrics_rows": [],
+    "metrics_exempt_reason": "evidence_only_decoder_evidence",
+    "queue_item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+    "session_id": "s20260710t104530z",
+    "status": "ok",
+    "summary": "2/2 commands succeeded"
+  },
+  "handoff": {
+    "branch": "eval/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/s20260710t104530z",
+    "pr_title": "eval: run quality-aware score32 hbm-controller ppa recost frontier",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "pr_body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260710t104530z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1"
+    },
+    "identity_block_format": "[role:evaluator][account:<evaluator_id>][session:<session_id>][host:<host>][item:<queue_item_id>]"
+  },
+  "item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+  "version": 0.1,
+  "platform": "nangate45",
+  "priority": 1,
+  "created_utc": "2026-07-10T10:44:43.210973Z",
+  "requested_by": "developer_agent",
+  "developer_loop": {
+    "comparison": {
+      "role": "score32_quality_aware_hbm_controller_ppa_recost_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1"
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "Use merged quality evidence to invalidate stale low-precision rows before ranking.",
+      "expected_direction": "record_quality_aware_score32_hbm_controller_ppa_recost_frontier"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_score32_integrated_frontier_ranking"
+    },
+    "proposal_id": "prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json"
+  },
+  "source_requirement": {
+    "repo": "",
+    "reason": "evaluator runtime must contain the queued job source commit",
+    "version": 1,
+    "required_ref": "origin/master",
+    "required_sha": "3ee947a3dd8f67e932782ea1cd6b3a24f73bac44",
+    "requires_daemon_restart": true
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/pr_body.md
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/pr_body.md
@@ -1,0 +1,40 @@
+## Summary
+- item_id: `l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1`
+- run_key: `l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1_run_44f9371d9a1b3d21`
+- layer: `layer2`
+- task_type: `l2_campaign`
+- status: `ok`
+- summary: `2/2 commands succeeded`
+- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/evaluated.json`
+- metrics_rows_count: `0`
+- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json`
+
+## Developer Context
+- proposal_id: `prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1`
+- proposal_path: `docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json`
+- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
+- execution_source_commit: `3ee947a3dd8f67e932782ea1cd6b3a24f73bac44`
+- review_metadata_source_commit: `3ee947a3dd8f67e932782ea1cd6b3a24f73bac44`
+
+## Evaluation Mode
+- evaluation_mode: `frontier_detail`
+- abstraction_layer: `decoder_attention_score32_integrated_frontier_ranking`
+- comparison_role: `score32_quality_aware_hbm_controller_ppa_recost_frontier`
+- expected_direction: `record_quality_aware_score32_hbm_controller_ppa_recost_frontier`
+- expected_reason: `Use merged quality evidence to invalidate stale low-precision rows before ranking.`
+- expectation_status: `unspecified`
+- evaluation_summary: `Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].`
+
+## Focused Comparison
+- primary_question: `Which measured Llama7B rows remain rankable after controller PPA recost and merged quality invalidation evidence?`
+- comparison_role: `score32_quality_aware_hbm_controller_ppa_recost_frontier`
+- proposal_outcome: `score32_integrated_frontier_best_precision_safe_throughput`
+- comparison_summary: `Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].`
+- baseline_ref: `None`
+- baseline_item_id: `None`
+
+## Checklist
+- [ ] Commit lightweight campaign artifacts only
+- [ ] Include metrics row references in result.metrics_rows
+- [ ] Keep committed result_path fields repo-portable
+- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing

--- a/control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/review_package.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/review_package.json
@@ -1,0 +1,236 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-10T10:45:33.317692Z",
+  "control_plane_source_commit": "3ee947a3dd8f67e932782ea1cd6b3a24f73bac44",
+  "review_metadata_source_commit": "3ee947a3dd8f67e932782ea1cd6b3a24f73bac44",
+  "item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+  "run_key": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1_run_44f9371d9a1b3d21",
+  "layer": "layer2",
+  "flow": "openroad",
+  "task_type": "l2_campaign",
+  "source_commit": "3ee947a3dd8f67e932782ea1cd6b3a24f73bac44",
+  "queue_snapshot": {
+    "path": "control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/evaluated.json",
+    "result": {
+      "branch": "eval/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/s20260710t104530z",
+      "completed_utc": "2026-07-10T10:45:29.426883Z",
+      "evaluator_id": "control_plane",
+      "executor": "@control_plane",
+      "host": "b7c2d9c80c1c",
+      "identity_block": "[role:evaluator][account:control_plane][session:s20260710t104530z][host:b7c2d9c80c1c][item:l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1]",
+      "metrics_rows": [],
+      "metrics_exempt_reason": "evidence_only_decoder_evidence",
+      "queue_item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+      "session_id": "s20260710t104530z",
+      "status": "ok",
+      "summary": "2/2 commands succeeded"
+    }
+  },
+  "review_artifact": {
+    "kind": "decision_proposal",
+    "path": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+    "storage_mode": "repo",
+    "sha256": "88d8650c2984978f68f60570a145d56b1773c954a5a83910f610cafdde6a67d6",
+    "payload": {
+      "version": 0.1,
+      "generated_utc": "2026-07-10T10:45:30.106124Z",
+      "item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+      "run_key": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1_run_44f9371d9a1b3d21",
+      "layer": "layer2",
+      "flow": "openroad",
+      "platform": "nangate45",
+      "task_type": "l2_campaign",
+      "source_commit": "3ee947a3dd8f67e932782ea1cd6b3a24f73bac44",
+      "review_metadata_source_commit": "3ee947a3dd8f67e932782ea1cd6b3a24f73bac44",
+      "objective": "Correct the recosted score32 Llama7B frontier with merged mixed/int8 quality invalidation and nested energy-component evidence.",
+      "input_manifest": {
+        "decoder_contract": {
+          "attention_integrated_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json",
+          "attention_mixed_int8_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+          "attention_score32_hbm_controller_replay": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json",
+          "attention_measured_compute_energy_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json",
+          "attention_mixed_int8_quality_backed_frontier": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+          "attention_score32_exp_lut_generation_quality": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json",
+          "attention_score32_hbm_controller_replay_ppa_json": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_hbm_replay_controller_ppa_v2.json",
+          "attention_score32_integrated_frontier_ranking_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+          "attention_score32_exp_lut_hbm_dram_service_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json",
+          "attention_score32_exp_lut_measured_command_control": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+          "attention_score32_integrated_frontier_ranking_scope": "Rank the closed score32 exp-LUT Llama7B attention row against prior integrated, measured-compute, and mixed/int8 energy evidence. Report latency, energy, area, precision status, promotability, and remaining abstractions without promoting planning-only or quality-unclosed rows.",
+          "attention_score32_integrated_frontier_ranking_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.md"
+        }
+      },
+      "recommendation": {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+        "arch_id": "decoder_attention_score32_integrated_frontier_ranking",
+        "macro_mode": "evidence_only",
+        "outcome": "score32_integrated_frontier_best_precision_safe_throughput"
+      },
+      "objective_profiles": [],
+      "evaluation_record": {
+        "proposal_id": "prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1",
+        "title": "Quality-aware score32 HBM-controller PPA recost frontier",
+        "primary_question": "Which measured Llama7B rows remain rankable after controller PPA recost and merged quality invalidation evidence?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "score32_quality_aware_hbm_controller_ppa_recost_frontier",
+        "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+        "expected_direction": "record_quality_aware_score32_hbm_controller_ppa_recost_frontier",
+        "expected_reason": "Use merged quality evidence to invalidate stale low-precision rows before ranking.",
+        "summary": "Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].",
+        "outcome": "score32_integrated_frontier_best_precision_safe_throughput",
+        "expectation_status": "unspecified"
+      },
+      "proposal_assessment": {
+        "proposal_id": "prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1",
+        "title": "Quality-aware score32 HBM-controller PPA recost frontier",
+        "kind": "architecture",
+        "primary_question": "Which measured Llama7B rows remain rankable after controller PPA recost and merged quality invalidation evidence?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "score32_quality_aware_hbm_controller_ppa_recost_frontier",
+        "outcome": "score32_integrated_frontier_best_precision_safe_throughput",
+        "summary": "Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].",
+        "baseline_ref": null,
+        "baseline_item_id": null,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+        "decoder_quality": {
+          "diagnosis": {
+            "best_energy_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+            "best_latency_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+            "best_precision_safe_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+            "best_precision_safe_energy_candidate": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+            "current_recommended_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+            "decision": "score32_integrated_frontier_best_precision_safe_throughput",
+            "excluded_fastest_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+            "mixed_int8_quality_status": "quality_invalidated_low_precision_score_softmax",
+            "remaining_abstractions": [
+              "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+              "does not include vendor HBM current signoff",
+              "profile_scaled_noc_sram_energy",
+              "source_backed_aggregate_hbm_energy_not_vendor_current_signoff"
+            ],
+            "score32_compute_plus_controller_area_mm2": 296.8263662009,
+            "score32_controller_area_mm2": 0.0289102009,
+            "score32_controller_clock_ok": true,
+            "score32_controller_energy_mj_per_token": 0.001396754106,
+            "score32_die_area_mm2": 800.0,
+            "score32_latency_us": 12814.257853,
+            "score32_quality_status": "mixed_int8_generation_quality_pass",
+            "score32_token_throughput_per_s": 78.038073798,
+            "score32_total_energy_mj_per_token": 467.191305313106,
+            "score32_vs_measured_fp16_energy_ratio": 5.720887555,
+            "score32_vs_measured_fp16_throughput_ratio": 5.661198874
+          },
+          "assumptions": [
+            "Rows are ranked by explicit metrics from merged evidence; no new PPA is synthesized in this audit.",
+            "The score32 row is quality-backed by the bounded generation-quality gate and measured through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing.",
+            "The old mixed-int8 energy row is retained only as measured historical evidence because the quality-backed frontier invalidated its low-precision score/softmax profile.",
+            "The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible."
+          ],
+          "next_step": {
+            "mixed_int8_old_candidate_quality_invalidated": true,
+            "mixed_int8_requires_quality_closure": false,
+            "recommended_next_step": "Use score32 as the current precision-safe throughput frontier and measured exact-FP16 as the energy reference; next reduce score32 compute energy or build a quality-backed q8/k8/v8 path with high-precision score/softmax.",
+            "score32_energy_reduction_required_for_energy_best": true
+          }
+        }
+      },
+      "source_refs": {
+        "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+        "decoder_attention_score32_integrated_frontier_ranking_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json",
+        "decoder_attention_score32_integrated_frontier_ranking_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.md"
+      },
+      "decoder_quality": {
+        "diagnosis": {
+          "best_energy_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+          "best_latency_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+          "best_precision_safe_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+          "best_precision_safe_energy_candidate": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+          "current_recommended_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+          "decision": "score32_integrated_frontier_best_precision_safe_throughput",
+          "excluded_fastest_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+          "mixed_int8_quality_status": "quality_invalidated_low_precision_score_softmax",
+          "remaining_abstractions": [
+            "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+            "does not include vendor HBM current signoff",
+            "profile_scaled_noc_sram_energy",
+            "source_backed_aggregate_hbm_energy_not_vendor_current_signoff"
+          ],
+          "score32_compute_plus_controller_area_mm2": 296.8263662009,
+          "score32_controller_area_mm2": 0.0289102009,
+          "score32_controller_clock_ok": true,
+          "score32_controller_energy_mj_per_token": 0.001396754106,
+          "score32_die_area_mm2": 800.0,
+          "score32_latency_us": 12814.257853,
+          "score32_quality_status": "mixed_int8_generation_quality_pass",
+          "score32_token_throughput_per_s": 78.038073798,
+          "score32_total_energy_mj_per_token": 467.191305313106,
+          "score32_vs_measured_fp16_energy_ratio": 5.720887555,
+          "score32_vs_measured_fp16_throughput_ratio": 5.661198874
+        },
+        "assumptions": [
+          "Rows are ranked by explicit metrics from merged evidence; no new PPA is synthesized in this audit.",
+          "The score32 row is quality-backed by the bounded generation-quality gate and measured through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing.",
+          "The old mixed-int8 energy row is retained only as measured historical evidence because the quality-backed frontier invalidated its low-precision score/softmax profile.",
+          "The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible."
+        ],
+        "next_step": {
+          "mixed_int8_old_candidate_quality_invalidated": true,
+          "mixed_int8_requires_quality_closure": false,
+          "recommended_next_step": "Use score32 as the current precision-safe throughput frontier and measured exact-FP16 as the energy reference; next reduce score32 compute energy or build a quality-backed q8/k8/v8 path with high-precision score/softmax.",
+          "score32_energy_reduction_required_for_energy_best": true
+        }
+      }
+    }
+  },
+  "developer_loop": {
+    "comparison": {
+      "role": "score32_quality_aware_hbm_controller_ppa_recost_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1"
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "Use merged quality evidence to invalidate stale low-precision rows before ranking.",
+      "expected_direction": "record_quality_aware_score32_hbm_controller_ppa_recost_frontier"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_score32_integrated_frontier_ranking"
+    },
+    "proposal_id": "prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_recost_integrated_frontier_ranking_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+        "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json"
+  },
+  "submission_history": null,
+  "pr_payload": {
+    "branch": "eval/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/s20260710t104530z",
+    "title": "eval: run quality-aware score32 hbm-controller ppa recost frontier",
+    "body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260710t104530z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1"
+    },
+    "body_md": "## Summary\n- item_id: `l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1`\n- run_key: `l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1_run_44f9371d9a1b3d21`\n- layer: `layer2`\n- task_type: `l2_campaign`\n- status: `ok`\n- summary: `2/2 commands succeeded`\n- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/evaluated.json`\n- metrics_rows_count: `0`\n- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json`\n\n## Developer Context\n- proposal_id: `prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1`\n- proposal_path: `docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json`\n- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`\n- execution_source_commit: `3ee947a3dd8f67e932782ea1cd6b3a24f73bac44`\n- review_metadata_source_commit: `3ee947a3dd8f67e932782ea1cd6b3a24f73bac44`\n\n## Evaluation Mode\n- evaluation_mode: `frontier_detail`\n- abstraction_layer: `decoder_attention_score32_integrated_frontier_ranking`\n- comparison_role: `score32_quality_aware_hbm_controller_ppa_recost_frontier`\n- expected_direction: `record_quality_aware_score32_hbm_controller_ppa_recost_frontier`\n- expected_reason: `Use merged quality evidence to invalidate stale low-precision rows before ranking.`\n- expectation_status: `unspecified`\n- evaluation_summary: `Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].`\n\n## Focused Comparison\n- primary_question: `Which measured Llama7B rows remain rankable after controller PPA recost and merged quality invalidation evidence?`\n- comparison_role: `score32_quality_aware_hbm_controller_ppa_recost_frontier`\n- proposal_outcome: `score32_integrated_frontier_best_precision_safe_throughput`\n- comparison_summary: `Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].`\n- baseline_ref: `None`\n- baseline_item_id: `None`\n\n## Checklist\n- [ ] Commit lightweight campaign artifacts only\n- [ ] Include metrics row references in result.metrics_rows\n- [ ] Keep committed result_path fields repo-portable\n- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing\n",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ]
+  }
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json
@@ -1,0 +1,541 @@
+{
+  "assumptions": [
+    "Rows are ranked by explicit metrics from merged evidence; no new PPA is synthesized in this audit.",
+    "The score32 row is quality-backed by the bounded generation-quality gate and measured through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing.",
+    "The old mixed-int8 energy row is retained only as measured historical evidence because the quality-backed frontier invalidated its low-precision score/softmax profile.",
+    "The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible."
+  ],
+  "decision": "score32_integrated_frontier_best_precision_safe_throughput",
+  "diagnosis": {
+    "best_energy_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+    "best_latency_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+    "best_precision_safe_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+    "best_precision_safe_energy_candidate": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+    "current_recommended_candidate": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+    "decision": "score32_integrated_frontier_best_precision_safe_throughput",
+    "excluded_fastest_candidate": "physical_hbm_gqa8_kv8_service_frontier",
+    "mixed_int8_quality_status": "quality_invalidated_low_precision_score_softmax",
+    "remaining_abstractions": [
+      "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+      "does not include vendor HBM current signoff",
+      "profile_scaled_noc_sram_energy",
+      "source_backed_aggregate_hbm_energy_not_vendor_current_signoff"
+    ],
+    "score32_compute_plus_controller_area_mm2": 296.8263662009,
+    "score32_controller_area_mm2": 0.0289102009,
+    "score32_controller_clock_ok": true,
+    "score32_controller_energy_mj_per_token": 0.001396754106,
+    "score32_die_area_mm2": 800.0,
+    "score32_latency_us": 12814.257853,
+    "score32_quality_status": "mixed_int8_generation_quality_pass",
+    "score32_token_throughput_per_s": 78.038073798,
+    "score32_total_energy_mj_per_token": 467.191305313106,
+    "score32_vs_measured_fp16_energy_ratio": 5.720887555,
+    "score32_vs_measured_fp16_throughput_ratio": 5.661198874
+  },
+  "energy_rank": [
+    {
+      "abstraction_status": "abstract_compute_target_infeasible_after_measured_compute_closure",
+      "candidate_id": "physical_hbm_gqa8_kv8_service_frontier",
+      "compute_area_mm2": 0.0,
+      "compute_energy_mj_per_token": 0.0,
+      "die_area_mm2": 100.0,
+      "energy_mj_per_token": 8.14357724928343,
+      "family": "abstract_integrated_gqa8_kv8",
+      "hbm_energy_mj_per_token": 0.0,
+      "latency_us": 30.944,
+      "macs_per_cycle": 524288.0,
+      "precision_status": "planning_only_native_gqa8_kv8",
+      "promotable": false,
+      "quality_backed": false,
+      "remaining_abstractions": [
+        "abstract_compute_capacity",
+        "parameterized_energy"
+      ],
+      "source_artifact": "integrated_energy_closure_r2",
+      "token_throughput_per_s": 32316.442605997934
+    },
+    {
+      "abstraction_status": "measured_compute_with_source_backed_hbm_energy",
+      "candidate_id": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+      "compute_area_mm2": 479.60213,
+      "compute_energy_mj_per_token": 18.095420734855,
+      "die_area_mm2": 1200.0,
+      "energy_mj_per_token": 81.66413005453946,
+      "family": "measured_exact_fp16_gqa8_kv8",
+      "hbm_energy_mj_per_token": 63.520046663430314,
+      "latency_us": 72544.06213406654,
+      "macs_per_cycle": 132736.0,
+      "precision_status": "conservative_native_gqa8_kv8",
+      "promotable": true,
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "source_backed_aggregate_hbm_energy_not_vendor_current_signoff",
+        "profile_scaled_noc_sram_energy"
+      ],
+      "source_artifact": "measured_compute_energy_closure",
+      "token_throughput_per_s": 13.784725731954872
+    },
+    {
+      "abstraction_status": "measured_int8_compute_quality_invalidated",
+      "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+      "compute_area_mm2": 179.09856,
+      "compute_energy_mj_per_token": 1.5372362316073815,
+      "die_area_mm2": 800.0,
+      "energy_mj_per_token": 135.75588466251537,
+      "family": "mixed_int8_compute",
+      "hbm_energy_mj_per_token": 134.14461348516411,
+      "latency_us": 1575.373891,
+      "macs_per_cycle": 109440.0,
+      "precision_status": "quality_invalidated_low_precision_score_softmax",
+      "promotable": false,
+      "quality_backed": false,
+      "quality_invalidation": {
+        "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+        "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+        "reason": "energy row uses score/softmax quantization or reciprocal-LUT softmax evidence, while broad native quality only passed qkv8_float_exact",
+        "source_decision": "mixed_int8_quality_backed_frontier_recost_required",
+        "source_model": "llm_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"
+      },
+      "remaining_abstractions": [
+        "quality_invalidated_by_broad_native_attention_shadow",
+        "energy row uses score/softmax quantization or reciprocal-LUT softmax evidence, while broad native quality only passed qkv8_float_exact"
+      ],
+      "source_artifact": "mixed_int8_energy_closure_r2",
+      "token_throughput_per_s": 634.7699461778119
+    },
+    {
+      "abstraction_status": "measured_schedule_wrapper_sram_envelope_hbm_controller_replay_ppa_recost",
+      "candidate_id": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+      "compute_area_mm2": 296.8263662009,
+      "compute_energy_mj_per_token": 332.910690072106,
+      "die_area_mm2": 800.0,
+      "energy_mj_per_token": 467.191305313106,
+      "family": "score32_exp_lut_div",
+      "hbm_energy_mj_per_token": 134.280615241,
+      "latency_us": 12814.257853,
+      "macs_per_cycle": 109568.0,
+      "precision_status": "mixed_int8_generation_quality_pass",
+      "promotable": true,
+      "quality": {
+        "candidate_id": "score32_exp_lut_div",
+        "candidate_probability_assigned_to_reference_token_mean": 0.44889021134685153,
+        "free_running_match_rate": 0.890625,
+        "quality_backed": true,
+        "status": "mixed_int8_generation_quality_pass",
+        "teacher_forced_nll_delta_mean": 0.0008945953623444368
+      },
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+        "does not include vendor HBM current signoff"
+      ],
+      "score32_hbm_controller_replay_ppa": {
+        "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "controller_area_mm2": 0.0289102009,
+        "controller_clock_margin_ns": 3.7724,
+        "controller_clock_ok": true,
+        "controller_energy_mj_per_token": 0.001396754106,
+        "controller_power_mw": 0.109,
+        "critical_path_ns_best": 2.2087,
+        "die_area_best": 28910.2009,
+        "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+        "schedule_clock_ns": 5.9811,
+        "source": "proposals",
+        "total_power_mw_best": 0.109
+      },
+      "source_artifact": "score32_schedule_wrapper_hbm_controller_replay",
+      "token_throughput_per_s": 78.038073798
+    }
+  ],
+  "inputs": {
+    "integrated_energy_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_integrated_energy_closure__l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2.json",
+    "measured_compute_energy_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_measured_compute_energy_closure__l2_decoder_attention_measured_compute_energy_closure_llama7b_v1.json",
+    "mixed_int8_energy_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_energy_closure__l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2.json",
+    "mixed_int8_quality_backed_frontier_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_quality_backed_frontier__l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1.json",
+    "score32_hbm_controller_replay_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json",
+    "score32_hbm_controller_replay_ppa_json": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_hbm_replay_controller_ppa_v2.json",
+    "score32_hbm_controller_replay_ppa_metrics": {
+      "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+      "critical_path_ns_best": 2.2087,
+      "die_area_best": 28910.2009,
+      "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+      "source": "proposals",
+      "total_power_mw_best": 0.109
+    },
+    "score32_hbm_dram_service_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json",
+    "score32_measured_command_control_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_measured_command_control_llama7b_v1.json",
+    "score32_physical_feasibility_json": null,
+    "score32_quality_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+  },
+  "latency_rank": [
+    {
+      "abstraction_status": "abstract_compute_target_infeasible_after_measured_compute_closure",
+      "candidate_id": "physical_hbm_gqa8_kv8_service_frontier",
+      "compute_area_mm2": 0.0,
+      "compute_energy_mj_per_token": 0.0,
+      "die_area_mm2": 100.0,
+      "energy_mj_per_token": 8.14357724928343,
+      "family": "abstract_integrated_gqa8_kv8",
+      "hbm_energy_mj_per_token": 0.0,
+      "latency_us": 30.944,
+      "macs_per_cycle": 524288.0,
+      "precision_status": "planning_only_native_gqa8_kv8",
+      "promotable": false,
+      "quality_backed": false,
+      "remaining_abstractions": [
+        "abstract_compute_capacity",
+        "parameterized_energy"
+      ],
+      "source_artifact": "integrated_energy_closure_r2",
+      "token_throughput_per_s": 32316.442605997934
+    },
+    {
+      "abstraction_status": "measured_int8_compute_quality_invalidated",
+      "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+      "compute_area_mm2": 179.09856,
+      "compute_energy_mj_per_token": 1.5372362316073815,
+      "die_area_mm2": 800.0,
+      "energy_mj_per_token": 135.75588466251537,
+      "family": "mixed_int8_compute",
+      "hbm_energy_mj_per_token": 134.14461348516411,
+      "latency_us": 1575.373891,
+      "macs_per_cycle": 109440.0,
+      "precision_status": "quality_invalidated_low_precision_score_softmax",
+      "promotable": false,
+      "quality_backed": false,
+      "quality_invalidation": {
+        "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+        "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+        "reason": "energy row uses score/softmax quantization or reciprocal-LUT softmax evidence, while broad native quality only passed qkv8_float_exact",
+        "source_decision": "mixed_int8_quality_backed_frontier_recost_required",
+        "source_model": "llm_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"
+      },
+      "remaining_abstractions": [
+        "quality_invalidated_by_broad_native_attention_shadow",
+        "energy row uses score/softmax quantization or reciprocal-LUT softmax evidence, while broad native quality only passed qkv8_float_exact"
+      ],
+      "source_artifact": "mixed_int8_energy_closure_r2",
+      "token_throughput_per_s": 634.7699461778119
+    },
+    {
+      "abstraction_status": "measured_schedule_wrapper_sram_envelope_hbm_controller_replay_ppa_recost",
+      "candidate_id": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+      "compute_area_mm2": 296.8263662009,
+      "compute_energy_mj_per_token": 332.910690072106,
+      "die_area_mm2": 800.0,
+      "energy_mj_per_token": 467.191305313106,
+      "family": "score32_exp_lut_div",
+      "hbm_energy_mj_per_token": 134.280615241,
+      "latency_us": 12814.257853,
+      "macs_per_cycle": 109568.0,
+      "precision_status": "mixed_int8_generation_quality_pass",
+      "promotable": true,
+      "quality": {
+        "candidate_id": "score32_exp_lut_div",
+        "candidate_probability_assigned_to_reference_token_mean": 0.44889021134685153,
+        "free_running_match_rate": 0.890625,
+        "quality_backed": true,
+        "status": "mixed_int8_generation_quality_pass",
+        "teacher_forced_nll_delta_mean": 0.0008945953623444368
+      },
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+        "does not include vendor HBM current signoff"
+      ],
+      "score32_hbm_controller_replay_ppa": {
+        "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "controller_area_mm2": 0.0289102009,
+        "controller_clock_margin_ns": 3.7724,
+        "controller_clock_ok": true,
+        "controller_energy_mj_per_token": 0.001396754106,
+        "controller_power_mw": 0.109,
+        "critical_path_ns_best": 2.2087,
+        "die_area_best": 28910.2009,
+        "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+        "schedule_clock_ns": 5.9811,
+        "source": "proposals",
+        "total_power_mw_best": 0.109
+      },
+      "source_artifact": "score32_schedule_wrapper_hbm_controller_replay",
+      "token_throughput_per_s": 78.038073798
+    },
+    {
+      "abstraction_status": "measured_compute_with_source_backed_hbm_energy",
+      "candidate_id": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+      "compute_area_mm2": 479.60213,
+      "compute_energy_mj_per_token": 18.095420734855,
+      "die_area_mm2": 1200.0,
+      "energy_mj_per_token": 81.66413005453946,
+      "family": "measured_exact_fp16_gqa8_kv8",
+      "hbm_energy_mj_per_token": 63.520046663430314,
+      "latency_us": 72544.06213406654,
+      "macs_per_cycle": 132736.0,
+      "precision_status": "conservative_native_gqa8_kv8",
+      "promotable": true,
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "source_backed_aggregate_hbm_energy_not_vendor_current_signoff",
+        "profile_scaled_noc_sram_energy"
+      ],
+      "source_artifact": "measured_compute_energy_closure",
+      "token_throughput_per_s": 13.784725731954872
+    }
+  ],
+  "model": "llm_decoder_attention_score32_integrated_frontier_ranking_v1",
+  "next_step": {
+    "mixed_int8_old_candidate_quality_invalidated": true,
+    "mixed_int8_requires_quality_closure": false,
+    "recommended_next_step": "Use score32 as the current precision-safe throughput frontier and measured exact-FP16 as the energy reference; next reduce score32 compute energy or build a quality-backed q8/k8/v8 path with high-precision score/softmax.",
+    "score32_energy_reduction_required_for_energy_best": true
+  },
+  "promotable_energy_rank": [
+    {
+      "abstraction_status": "measured_compute_with_source_backed_hbm_energy",
+      "candidate_id": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+      "compute_area_mm2": 479.60213,
+      "compute_energy_mj_per_token": 18.095420734855,
+      "die_area_mm2": 1200.0,
+      "energy_mj_per_token": 81.66413005453946,
+      "family": "measured_exact_fp16_gqa8_kv8",
+      "hbm_energy_mj_per_token": 63.520046663430314,
+      "latency_us": 72544.06213406654,
+      "macs_per_cycle": 132736.0,
+      "precision_status": "conservative_native_gqa8_kv8",
+      "promotable": true,
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "source_backed_aggregate_hbm_energy_not_vendor_current_signoff",
+        "profile_scaled_noc_sram_energy"
+      ],
+      "source_artifact": "measured_compute_energy_closure",
+      "token_throughput_per_s": 13.784725731954872
+    },
+    {
+      "abstraction_status": "measured_schedule_wrapper_sram_envelope_hbm_controller_replay_ppa_recost",
+      "candidate_id": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+      "compute_area_mm2": 296.8263662009,
+      "compute_energy_mj_per_token": 332.910690072106,
+      "die_area_mm2": 800.0,
+      "energy_mj_per_token": 467.191305313106,
+      "family": "score32_exp_lut_div",
+      "hbm_energy_mj_per_token": 134.280615241,
+      "latency_us": 12814.257853,
+      "macs_per_cycle": 109568.0,
+      "precision_status": "mixed_int8_generation_quality_pass",
+      "promotable": true,
+      "quality": {
+        "candidate_id": "score32_exp_lut_div",
+        "candidate_probability_assigned_to_reference_token_mean": 0.44889021134685153,
+        "free_running_match_rate": 0.890625,
+        "quality_backed": true,
+        "status": "mixed_int8_generation_quality_pass",
+        "teacher_forced_nll_delta_mean": 0.0008945953623444368
+      },
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+        "does not include vendor HBM current signoff"
+      ],
+      "score32_hbm_controller_replay_ppa": {
+        "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "controller_area_mm2": 0.0289102009,
+        "controller_clock_margin_ns": 3.7724,
+        "controller_clock_ok": true,
+        "controller_energy_mj_per_token": 0.001396754106,
+        "controller_power_mw": 0.109,
+        "critical_path_ns_best": 2.2087,
+        "die_area_best": 28910.2009,
+        "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+        "schedule_clock_ns": 5.9811,
+        "source": "proposals",
+        "total_power_mw_best": 0.109
+      },
+      "source_artifact": "score32_schedule_wrapper_hbm_controller_replay",
+      "token_throughput_per_s": 78.038073798
+    }
+  ],
+  "promotable_latency_rank": [
+    {
+      "abstraction_status": "measured_schedule_wrapper_sram_envelope_hbm_controller_replay_ppa_recost",
+      "candidate_id": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+      "compute_area_mm2": 296.8263662009,
+      "compute_energy_mj_per_token": 332.910690072106,
+      "die_area_mm2": 800.0,
+      "energy_mj_per_token": 467.191305313106,
+      "family": "score32_exp_lut_div",
+      "hbm_energy_mj_per_token": 134.280615241,
+      "latency_us": 12814.257853,
+      "macs_per_cycle": 109568.0,
+      "precision_status": "mixed_int8_generation_quality_pass",
+      "promotable": true,
+      "quality": {
+        "candidate_id": "score32_exp_lut_div",
+        "candidate_probability_assigned_to_reference_token_mean": 0.44889021134685153,
+        "free_running_match_rate": 0.890625,
+        "quality_backed": true,
+        "status": "mixed_int8_generation_quality_pass",
+        "teacher_forced_nll_delta_mean": 0.0008945953623444368
+      },
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+        "does not include vendor HBM current signoff"
+      ],
+      "score32_hbm_controller_replay_ppa": {
+        "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "controller_area_mm2": 0.0289102009,
+        "controller_clock_margin_ns": 3.7724,
+        "controller_clock_ok": true,
+        "controller_energy_mj_per_token": 0.001396754106,
+        "controller_power_mw": 0.109,
+        "critical_path_ns_best": 2.2087,
+        "die_area_best": 28910.2009,
+        "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+        "schedule_clock_ns": 5.9811,
+        "source": "proposals",
+        "total_power_mw_best": 0.109
+      },
+      "source_artifact": "score32_schedule_wrapper_hbm_controller_replay",
+      "token_throughput_per_s": 78.038073798
+    },
+    {
+      "abstraction_status": "measured_compute_with_source_backed_hbm_energy",
+      "candidate_id": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+      "compute_area_mm2": 479.60213,
+      "compute_energy_mj_per_token": 18.095420734855,
+      "die_area_mm2": 1200.0,
+      "energy_mj_per_token": 81.66413005453946,
+      "family": "measured_exact_fp16_gqa8_kv8",
+      "hbm_energy_mj_per_token": 63.520046663430314,
+      "latency_us": 72544.06213406654,
+      "macs_per_cycle": 132736.0,
+      "precision_status": "conservative_native_gqa8_kv8",
+      "promotable": true,
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "source_backed_aggregate_hbm_energy_not_vendor_current_signoff",
+        "profile_scaled_noc_sram_energy"
+      ],
+      "source_artifact": "measured_compute_energy_closure",
+      "token_throughput_per_s": 13.784725731954872
+    }
+  ],
+  "rows": [
+    {
+      "abstraction_status": "measured_schedule_wrapper_sram_envelope_hbm_controller_replay_ppa_recost",
+      "candidate_id": "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best",
+      "compute_area_mm2": 296.8263662009,
+      "compute_energy_mj_per_token": 332.910690072106,
+      "die_area_mm2": 800.0,
+      "energy_mj_per_token": 467.191305313106,
+      "family": "score32_exp_lut_div",
+      "hbm_energy_mj_per_token": 134.280615241,
+      "latency_us": 12814.257853,
+      "macs_per_cycle": 109568.0,
+      "precision_status": "mixed_int8_generation_quality_pass",
+      "promotable": true,
+      "quality": {
+        "candidate_id": "score32_exp_lut_div",
+        "candidate_probability_assigned_to_reference_token_mean": 0.44889021134685153,
+        "free_running_match_rate": 0.890625,
+        "quality_backed": true,
+        "status": "mixed_int8_generation_quality_pass",
+        "teacher_forced_nll_delta_mean": 0.0008945953623444368
+      },
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.",
+        "does not include vendor HBM current signoff"
+      ],
+      "score32_hbm_controller_replay_ppa": {
+        "artifact_item_id": "l1_decoder_attention_hbm_replay_controller_ppa_v2",
+        "controller_area_mm2": 0.0289102009,
+        "controller_clock_margin_ns": 3.7724,
+        "controller_clock_ok": true,
+        "controller_energy_mj_per_token": 0.001396754106,
+        "controller_power_mw": 0.109,
+        "critical_path_ns_best": 2.2087,
+        "die_area_best": 28910.2009,
+        "metrics_csv": "runs/designs/npu_blocks/attention_hbm_replay_controller_c4/metrics.csv",
+        "schedule_clock_ns": 5.9811,
+        "source": "proposals",
+        "total_power_mw_best": 0.109
+      },
+      "source_artifact": "score32_schedule_wrapper_hbm_controller_replay",
+      "token_throughput_per_s": 78.038073798
+    },
+    {
+      "abstraction_status": "measured_compute_with_source_backed_hbm_energy",
+      "candidate_id": "die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512",
+      "compute_area_mm2": 479.60213,
+      "compute_energy_mj_per_token": 18.095420734855,
+      "die_area_mm2": 1200.0,
+      "energy_mj_per_token": 81.66413005453946,
+      "family": "measured_exact_fp16_gqa8_kv8",
+      "hbm_energy_mj_per_token": 63.520046663430314,
+      "latency_us": 72544.06213406654,
+      "macs_per_cycle": 132736.0,
+      "precision_status": "conservative_native_gqa8_kv8",
+      "promotable": true,
+      "quality_backed": true,
+      "remaining_abstractions": [
+        "source_backed_aggregate_hbm_energy_not_vendor_current_signoff",
+        "profile_scaled_noc_sram_energy"
+      ],
+      "source_artifact": "measured_compute_energy_closure",
+      "token_throughput_per_s": 13.784725731954872
+    },
+    {
+      "abstraction_status": "measured_int8_compute_quality_invalidated",
+      "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+      "compute_area_mm2": 179.09856,
+      "compute_energy_mj_per_token": 1.5372362316073815,
+      "die_area_mm2": 800.0,
+      "energy_mj_per_token": 135.75588466251537,
+      "family": "mixed_int8_compute",
+      "hbm_energy_mj_per_token": 134.14461348516411,
+      "latency_us": 1575.373891,
+      "macs_per_cycle": 109440.0,
+      "precision_status": "quality_invalidated_low_precision_score_softmax",
+      "promotable": false,
+      "quality_backed": false,
+      "quality_invalidation": {
+        "candidate_id": "die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024",
+        "precision_profile": "q8_k8_v6_a24_s8_w8_recip_lut_q10_int8_compute",
+        "reason": "energy row uses score/softmax quantization or reciprocal-LUT softmax evidence, while broad native quality only passed qkv8_float_exact",
+        "source_decision": "mixed_int8_quality_backed_frontier_recost_required",
+        "source_model": "llm_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1"
+      },
+      "remaining_abstractions": [
+        "quality_invalidated_by_broad_native_attention_shadow",
+        "energy row uses score/softmax quantization or reciprocal-LUT softmax evidence, while broad native quality only passed qkv8_float_exact"
+      ],
+      "source_artifact": "mixed_int8_energy_closure_r2",
+      "token_throughput_per_s": 634.7699461778119
+    },
+    {
+      "abstraction_status": "abstract_compute_target_infeasible_after_measured_compute_closure",
+      "candidate_id": "physical_hbm_gqa8_kv8_service_frontier",
+      "compute_area_mm2": 0.0,
+      "compute_energy_mj_per_token": 0.0,
+      "die_area_mm2": 100.0,
+      "energy_mj_per_token": 8.14357724928343,
+      "family": "abstract_integrated_gqa8_kv8",
+      "hbm_energy_mj_per_token": 0.0,
+      "latency_us": 30.944,
+      "macs_per_cycle": 524288.0,
+      "precision_status": "planning_only_native_gqa8_kv8",
+      "promotable": false,
+      "quality_backed": false,
+      "remaining_abstractions": [
+        "abstract_compute_capacity",
+        "parameterized_energy"
+      ],
+      "source_artifact": "integrated_energy_closure_r2",
+      "token_throughput_per_s": 32316.442605997934
+    }
+  ],
+  "version": 1
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.md
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.md
@@ -1,0 +1,34 @@
+# Score32 Integrated Frontier Ranking
+
+- decision: `score32_integrated_frontier_best_precision_safe_throughput`
+- best latency candidate: `physical_hbm_gqa8_kv8_service_frontier`
+- best energy candidate: `physical_hbm_gqa8_kv8_service_frontier`
+- best precision-safe throughput candidate: `score32_exp_lut_schedule_wrapper_hbm_controller_replay_best`
+- current recommended candidate: `score32_exp_lut_schedule_wrapper_hbm_controller_replay_best`
+- score32 latency us: `12814.257853`
+- score32 total energy mJ/token: `467.191305313106`
+- score32 die area mm2: `800.0`
+- score32 quality status: `mixed_int8_generation_quality_pass`
+
+## Promotable Latency Rank
+
+| candidate | latency us | token/s | energy mJ/token | area mm2 | precision |
+|---|---:|---:|---:|---:|---|
+| score32_exp_lut_schedule_wrapper_hbm_controller_replay_best | 12814.257853 | 78.038073798 | 467.191305313106 | 800.0 | mixed_int8_generation_quality_pass |
+| die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512 | 72544.06213406654 | 13.784725731954872 | 81.66413005453946 | 1200.0 | conservative_native_gqa8_kv8 |
+
+## All Rows
+
+| candidate | promotable | latency us | energy mJ/token | status |
+|---|---:|---:|---:|---|
+| physical_hbm_gqa8_kv8_service_frontier | False | 30.944 | 8.14357724928343 | abstract_compute_target_infeasible_after_measured_compute_closure |
+| die800_dense_gemm_int8_16x8_k1_p1_rep855_lat1575.37_hbm0.983398_tt1024 | False | 1575.373891 | 135.75588466251537 | measured_int8_compute_quality_invalidated |
+| score32_exp_lut_schedule_wrapper_hbm_controller_replay_best | True | 12814.257853 | 467.191305313106 | measured_schedule_wrapper_sram_envelope_hbm_controller_replay_ppa_recost |
+| die1200_dense_gemm_16x8_k1_p1_mac132736_lat1872.29_hbm0.465654_tt512 | True | 72544.06213406654 | 81.66413005453946 | measured_compute_with_source_backed_hbm_energy |
+
+## Assumptions
+
+- Rows are ranked by explicit metrics from merged evidence; no new PPA is synthesized in this audit.
+- The score32 row is quality-backed by the bounded generation-quality gate and measured through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing.
+- The old mixed-int8 energy row is retained only as measured historical evidence because the quality-backed frontier invalidated its low-precision score/softmax profile.
+- The older integrated-energy row is retained as planning-only because measured-compute closure made its abstract compute target infeasible.


### PR DESCRIPTION
## Summary
- item_id: `l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1`
- run_key: `l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1_run_44f9371d9a1b3d21`
- layer: `layer2`
- task_type: `l2_campaign`
- status: `ok`
- summary: `2/2 commands succeeded`
- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1/evaluated.json`
- metrics_rows_count: `0`
- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json`

## Developer Context
- proposal_id: `prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1`
- proposal_path: `docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json`
- reviewer_first_read: `docs/proposals/prop_l2_decoder_attention_score32_quality_aware_hbm_controller_ppa_recost_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
- execution_source_commit: `3ee947a3dd8f67e932782ea1cd6b3a24f73bac44`
- review_metadata_source_commit: `3ee947a3dd8f67e932782ea1cd6b3a24f73bac44`

## Evaluation Mode
- evaluation_mode: `frontier_detail`
- abstraction_layer: `decoder_attention_score32_integrated_frontier_ranking`
- comparison_role: `score32_quality_aware_hbm_controller_ppa_recost_frontier`
- expected_direction: `record_quality_aware_score32_hbm_controller_ppa_recost_frontier`
- expected_reason: `Use merged quality evidence to invalidate stale low-precision rows before ranking.`
- expectation_status: `unspecified`
- evaluation_summary: `Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].`

## Focused Comparison
- primary_question: `Which measured Llama7B rows remain rankable after controller PPA recost and merged quality invalidation evidence?`
- comparison_role: `score32_quality_aware_hbm_controller_ppa_recost_frontier`
- proposal_outcome: `score32_integrated_frontier_best_precision_safe_throughput`
- comparison_summary: `Decoder score32 integrated frontier ranking recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json: decision=score32_integrated_frontier_best_precision_safe_throughput; best_latency_candidate=physical_hbm_gqa8_kv8_service_frontier; best_energy_candidate=physical_hbm_gqa8_kv8_service_frontier; best_precision_safe_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; score32_latency_us=12814.257853; score32_total_energy_mj_per_token=467.191305313106; score32_die_area_mm2=800.0; score32_quality_status=mixed_int8_generation_quality_pass; current_recommended_candidate=score32_exp_lut_schedule_wrapper_hbm_controller_replay_best; remaining_abstractions=['HBM replay controller area, active energy, and control timing are backed by measured Nangate45 RTL PPA.', 'does not include vendor HBM current signoff', 'profile_scaled_noc_sram_energy', 'source_backed_aggregate_hbm_energy_not_vendor_current_signoff'].`
- baseline_ref: `None`
- baseline_item_id: `None`

## Checklist
- [ ] Commit lightweight campaign artifacts only
- [ ] Include metrics row references in result.metrics_rows
- [ ] Keep committed result_path fields repo-portable
- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing
