### PR TITLE
npu: add exact separated attention cluster

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -516,6 +516,53 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "attention_separated_cluster" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                f"separated attention config must live under repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": "generate_attention_separated_cluster_rtl",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/rtlgen/gen_attention_separated_cluster.py "
+                        f"--config {config_rel} --out {design_dir}/verilog"
+                    ),
+                },
+                {
+                    "name": "check_attention_separated_cluster_guard",
+                    "run": f"python3 npu/eval/check_attention_separated_cluster_guard.py --design-dir {design_dir}",
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/synth/run_block_sweep.py "
+                        f"--design_dir {design_dir} --platform {{platform}} --top {top_name} "
+                        f"--sweep {{sweep_path}} --out_root {out_root} "
+                        + (f"--make_target {make_target} " if make_target else "")
+                        + "--skip_existing"
+                    ),
+                },
+                {
+                    "name": "extract_attention_separated_cluster_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} --out {design_dir}/timing_debug_report.md --max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "attention_dual_stream_composed" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -587,6 +587,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_separated_compute_recost_report",
     ),
     (
+        "attention_separated_cluster_equivalence_out",
+        "attention_separated_cluster_equivalence_report",
+    ),
+    (
         "attention_score32_exp_lut_sram_hierarchy_envelope_out",
         "attention_score32_exp_lut_sram_hierarchy_envelope_report",
     ),
@@ -1495,6 +1499,28 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         ):
             if key in diagnosis_dict:
                 parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "attention_separated_cluster_perf_rtl_equivalence_v1":
+        outcome = str(
+            evidence_payload.get("decision") or "attention_separated_cluster_equivalence_recorded"
+        )
+        parts = [
+            f"Separated attention perf/RTL equivalence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "equivalence_pass",
+            "semantic_profile",
+            "ratios",
+            "command_count",
+            "scenarios",
+            "gates",
+            "remaining_abstractions",
+            "next_step",
+        ):
+            if key in evidence_payload:
+                parts.append(f"{key}={evidence_payload.get(key)}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6216,7 +6216,8 @@ def _decoder_attention_separated_cluster_equivalence_evidence(*, item_id: str) -
             "attention_separated_cluster_equivalence_report": report,
             "attention_separated_cluster_equivalence_scope": (
                 "Compare exact QK score rows, score32 exp-LUT/div weights, weighted-V vectors, and ready/valid "
-                "schedules between the bounded separated-cluster perf model and RTL for 1:1 and 4:1 sharing."
+                "schedules between the bounded separated-cluster perf model and RTL for 1:1, 2:1, 4:1, "
+                "8:1, 4:2, and 8:2 producer-to-consumer sharing."
             ),
         },
         "commands": [

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6206,6 +6206,34 @@ def _decoder_attention_score32_separated_compute_recost_evidence(
     }
 
 
+def _decoder_attention_separated_cluster_equivalence_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_separated_cluster_equivalence__{item_id}.json"
+    report = f"{base}/decoder_attention_separated_cluster_equivalence__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_separated_cluster_equivalence_out": out,
+            "attention_separated_cluster_equivalence_report": report,
+            "attention_separated_cluster_equivalence_scope": (
+                "Compare exact QK score rows, score32 exp-LUT/div weights, weighted-V vectors, and ready/valid "
+                "schedules between the bounded separated-cluster perf model and RTL for 1:1 and 4:1 sharing."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_attention_separated_cluster_equivalence",
+                "run": (
+                    "python3 npu/eval/probe_attention_separated_equivalence.py "
+                    "--ratios 1:1,2:1,4:1,8:1,4:2,8:2 --command-count 8 "
+                    f"--out {out} --out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__{item_id}.json"
@@ -9721,6 +9749,7 @@ def _build_payload(
         "decoder_attention_score32_integrated_frontier_ranking",
         "decoder_attention_score32_compute_activity_energy",
         "decoder_attention_score32_separated_compute_recost",
+        "decoder_attention_separated_cluster_equivalence",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -9937,6 +9966,8 @@ def _build_payload(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
             )
+        elif abstraction_layer_name == "decoder_attention_separated_cluster_equivalence":
+            decoder_evidence = _decoder_attention_separated_cluster_equivalence_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -606,6 +606,55 @@ def _write_example_attention_schedule_wrapper_repo(repo_root: Path) -> tuple[str
     )
 
 
+def _write_example_attention_separated_cluster_repo(repo_root: Path) -> tuple[str, str]:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_separated_cluster_p4_c1"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_separated_cluster_p4_c1",
+                "attention_separated_cluster": {
+                    "producer_count": 4,
+                    "consumer_count": 1,
+                    "row_elems": 8,
+                    "head_dim": 8,
+                    "value_dim": 8,
+                    "score_bits": 32,
+                    "weight_bits": 16,
+                    "input_frac_bits": 28,
+                    "exp_bucket_shift": 20,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_separated_cluster_v1"
+        / "sweeps"
+        / "nangate45_attention_separated_cluster.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "flow_params": {"CLOCK_PERIOD": [10.0], "PLACE_DENSITY": [0.35]},
+                "tag_prefix": "attention_separated_cluster",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
 def _write_example_attention_hbm_replay_controller_repo(repo_root: Path) -> tuple[str, str]:
     design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_hbm_replay_controller_smoke"
     design_dir.mkdir(parents=True, exist_ok=True)
@@ -1830,6 +1879,49 @@ def test_generate_l1_sweep_task_supports_attention_schedule_wrapper_configs() ->
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "decoder_attention_dual_stream_schedule_wrapper"
             }
+
+
+def test_generate_l1_sweep_task_supports_attention_separated_cluster_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_separated_cluster_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_separated_cluster",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_separated_cluster_rtl",
+                "check_attention_separated_cluster_guard",
+                "run_block_sweep",
+                "extract_attention_separated_cluster_timing_paths",
+                "build_runs_index",
+                "validate",
+            ]
+            assert "gen_attention_separated_cluster.py" in work_item.command_manifest[0]["run"]
+            assert "check_attention_separated_cluster_guard.py" in work_item.command_manifest[1]["run"]
+            assert "--top attention_separated_cluster_p4_c1" in work_item.command_manifest[2]["run"]
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_separated_cluster_p4_c1/metrics.csv",
+                "runs/designs/npu_blocks/attention_separated_cluster_p4_c1/timing_debug_report.md",
+            ]
 
 
 def test_generate_l1_sweep_task_supports_multi_attention_command_dispatch_configs() -> None:

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -6008,6 +6008,94 @@ def test_consume_l2_result_score32_separated_compute_recost_uses_decoder_evidenc
             )
 
 
+def test_consume_l2_result_attention_separated_cluster_equivalence_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_attention_separated_cluster_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_attention_separated_cluster_v1",
+                        "kind": "architecture",
+                        "title": "Separated attention cluster",
+                        "direct_comparison": {"primary_question": "Does exact perf/RTL equivalence pass?"},
+                    }
+                ),
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_separated_cluster_equivalence__item.json"
+            )
+            report_rel = evidence_rel.removesuffix(".json") + ".md"
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "attention_separated_cluster_perf_rtl_equivalence_v1",
+                        "decision": "attention_separated_cluster_equivalence_pass",
+                        "equivalence_pass": True,
+                        "semantic_profile": "q8_k8_v8_a32_s32_w16_exp_lut_div_b20",
+                        "ratios": ["1:1", "4:1", "4:2", "8:2"],
+                        "command_count": 8,
+                        "scenarios": ["always_ready", "result_backpressure"],
+                        "gates": {
+                            "exact_score_rows": True,
+                            "exact_softmax_weights": True,
+                            "exact_weighted_value_vectors": True,
+                            "exact_ready_valid_schedule": True,
+                            "loss_or_duplication": False,
+                        },
+                        "remaining_abstractions": ["full Llama7B scaling"],
+                        "next_step": "Measure producer-to-consumer ratio PPA.",
+                    }
+                ),
+            )
+            _write(repo_root / report_rel, "# equivalence\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="item",
+                campaign_dir_rel="runs/campaigns/npu/attention_separated_equivalence",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,attention,flat_nomacro,1,0.1,0.1,1,1,1,1\n"
+                ),
+                proposal_path="docs/proposals/prop_attention_separated_cluster_v1",
+                comparison={"role": "equivalence_gate"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_separated_cluster_equivalence"
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_separated_cluster_equivalence_out": evidence_rel,
+                    "attention_separated_cluster_equivalence_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / "item.json").read_text()
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "attention_separated_cluster_equivalence_pass"
+            assert "equivalence_pass=True" in assessment["summary"]
+            assert "exact_ready_valid_schedule" in assessment["summary"]
+            assert decision_payload["source_refs"]["decoder_attention_separated_cluster_equivalence_out"] == evidence_rel
+
+
 def test_consume_l2_result_score32_exp_lut_sram_hierarchy_envelope_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7262,6 +7262,49 @@ def test_generate_l2_campaign_task_adds_attention_score32_separated_compute_reco
             }
 
 
+def test_generate_l2_campaign_task_adds_attention_separated_cluster_equivalence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_separated_cluster_equivalence_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_separated_cluster_equivalence",
+                    evaluation_mode="equivalence_gate",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.command_manifest
+            assert [command["name"] for command in commands] == [
+                "probe_attention_separated_cluster_equivalence",
+                "validate_runs",
+            ]
+            assert "probe_attention_separated_equivalence.py" in commands[0]["run"]
+            assert "--ratios 1:1,2:1,4:1,8:1,4:2,8:2" in commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["attention_separated_cluster_equivalence_out"].endswith(
+                "decoder_attention_separated_cluster_equivalence__"
+                "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1.json"
+            )
+            assert work_item.expected_outputs == [
+                decoder_inputs["attention_separated_cluster_equivalence_out"],
+                decoder_inputs["attention_separated_cluster_equivalence_report"],
+            ]
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy_envelope_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/developer_agent_review.md
+++ b/docs/developer_agent_review.md
@@ -172,6 +172,28 @@ Do not use relaxed boundary acceptance for ordinary winner-selection sweeps.
 Those should continue to require at least one `status=ok` row for each expected
 metrics file.
 
+## Semantic Equivalence And Proxy Rule
+
+Do not treat generator syntax checks, a folded result hash, or agreement on
+independent single operations as proof of composed datapath equivalence.
+
+For a producer-consumer datapath claim, the evidence must cover:
+
+- the producer's complete architectural output, not an XOR/fold proxy
+- every stateful intermediate consumed by the next stage
+- the final architectural output vector
+- sequential visibility: a consumer cannot observe data before producer
+  completion
+- ready/valid ordering, backpressure, loss, and duplication behavior
+- the same precision profile and rounding rules on both perf and RTL sides
+
+A hash is acceptable as secondary compression after exact stage traces have
+established the contract. Hash-only evidence is not sufficient for first
+promotion of a composed path. PPA stimulus generation must also be separated
+from the claimed datapath cost, or its hardware overhead must be identified
+explicitly; expensive pseudo-random or modulo logic is not a valid substitute
+for ordinary input registers.
+
 ## Merge Policy
 
 Evaluation PR merge rule:

--- a/docs/proposals/prop_decoder_attention_separated_cluster_frontier_llama7b_v1/README.md
+++ b/docs/proposals/prop_decoder_attention_separated_cluster_frontier_llama7b_v1/README.md
@@ -1,0 +1,5 @@
+# Precision-Aligned Separated Attention Cluster Frontier
+
+This proposal replaces the replicated synthetic attention wrapper with a bounded semantic tile that computes real q8 QK scores, score32 exp-LUT/div weights, and every weighted-V output lane. Exact perf/RTL stage and ready/valid equivalence is the mandatory gate before Nangate45 PPA.
+
+The physical sweep measures `1:1`, `2:1`, `4:1`, `8:1`, `4:2`, and `8:2` producer-to-consumer points. These rows quantify both consumer sharing and the wide payload/arbitration cost; they do not by themselves claim full Llama7B performance.

--- a/docs/proposals/prop_decoder_attention_separated_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_separated_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_decoder_attention_separated_cluster_frontier_llama7b_v1",
+  "source_commit_note": "Dispatch equivalence after implementation merge; dispatch PPA only after equivalence result merges.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove exact stage-tensor and ready/valid schedule equivalence for every bounded separated-attention ratio in the physical sweep.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_separated_cluster_equivalence",
+      "comparison_role": "semantic_equivalence_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_attention_separated_cluster_equivalence",
+        "reason": "Physical evaluation is ineligible until exact QK, softmax, weighted-V, ordering, and backpressure behavior match the perf model."
+      },
+      "status": "pending"
+    },
+    {
+      "item_id": "l1_decoder_attention_separated_cluster_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for precision-aligned separated attention producer-to-consumer ratios.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_separated_cluster",
+      "comparison_role": "producer_consumer_ratio_ppa",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_separated_cluster_p1_c1/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p2_c1/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c1/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c1/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c2/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_separated_cluster_v1/sweeps/nangate45_attention_separated_cluster.json",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_separated_cluster_p1_c1/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p1_c1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p2_c1/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p2_c1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c1/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c1/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c2/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c2/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c2/timing_debug_report.md"
+      ],
+      "depends_on_item_ids": [
+        "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1",
+        "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_attention_separated_cluster_ratio_frontier",
+        "reason": "Replace analytical producer/consumer sharing area and timing with measured macro PPA before Llama7B recost."
+      },
+      "status": "blocked_on_equivalence_merge"
+    }
+  ]
+}

--- a/docs/proposals/prop_decoder_attention_separated_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_separated_cluster_frontier_llama7b_v1/proposal.json
@@ -1,0 +1,110 @@
+{
+  "proposal_id": "prop_decoder_attention_separated_cluster_frontier_llama7b_v1",
+  "created_utc": "2026-07-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1_layer2",
+  "kind": "architecture",
+  "title": "Precision-aligned separated attention cluster frontier",
+  "abstraction_layer": "decoder_attention_separated_cluster",
+  "hypothesis": "A semantically exact q8/k8/v8 score32 exp-LUT/div cluster can share expensive softmax/value consumers across multiple QK producers, reducing area and active power relative to full-wrapper replication while preserving the burst service required by the Llama7B schedule.",
+  "direct_comparison": {
+    "primary_question": "After exact perf/RTL equivalence, how do producer:consumer ratios 1:1, 2:1, 4:1, 8:1, 4:2, and 8:2 trade Nangate45 area, power, clock, peak score-row service, and burst buffering?",
+    "baseline": "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1",
+    "include": [
+      "real signed q8 QK dot products",
+      "score32 Q28 bucketed-exp LUT with bucket shift 20",
+      "exact w16 normalized divide",
+      "all eight signed weighted-V output lanes",
+      "one-entry producer and consumer buffers",
+      "round-robin ready/valid arbitration",
+      "consumer and result backpressure",
+      "bounded 8-token by 8-dimension semantic tile"
+    ],
+    "exclude": [
+      "vendor HBM current signoff",
+      "full 4096-dimension and 131072-context physical replication",
+      "new model-quality run because the arithmetic profile is unchanged from the passing target"
+    ],
+    "metrics": [
+      "exact_score_equivalence",
+      "exact_weight_equivalence",
+      "exact_value_equivalence",
+      "exact_schedule_equivalence",
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "producer_count",
+      "consumer_count",
+      "peak_result_rows_per_cycle"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove exact stage-tensor and ready/valid schedule equivalence for every bounded separated-attention ratio in the physical sweep.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_separated_cluster_equivalence",
+      "comparison_role": "semantic_equivalence_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_attention_separated_cluster_equivalence",
+        "reason": "Physical evaluation is ineligible until exact QK, softmax, weighted-V, ordering, and backpressure behavior match the perf model."
+      },
+      "status": "pending"
+    },
+    {
+      "item_id": "l1_decoder_attention_separated_cluster_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for precision-aligned separated attention producer-to-consumer ratios.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_separated_cluster",
+      "comparison_role": "producer_consumer_ratio_ppa",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_separated_cluster_p1_c1/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p2_c1/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c1/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c1/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c2/config.json",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_separated_cluster_v1/sweeps/nangate45_attention_separated_cluster.json",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_separated_cluster_p1_c1/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p1_c1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p2_c1/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p2_c1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c1/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c1/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c2/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p4_c2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c2/metrics.csv",
+        "runs/designs/npu_blocks/attention_separated_cluster_p8_c2/timing_debug_report.md"
+      ],
+      "depends_on_item_ids": [
+        "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1",
+        "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_attention_separated_cluster_ratio_frontier",
+        "reason": "Replace analytical producer/consumer sharing area and timing with measured macro PPA before Llama7B recost."
+      },
+      "status": "blocked_on_equivalence_merge"
+    }
+  ],
+  "remaining_abstractions_after_this_step": [
+    "The bounded semantic tile must be composed into the full Llama7B clustered schedule.",
+    "NoC/SRAM toggle power and HBM vendor-current signoff remain separate closure items.",
+    "Full-die replication, clock/reset distribution, and macro placement require a later integration run."
+  ]
+}

--- a/npu/eval/check_attention_separated_cluster_guard.py
+++ b/npu/eval/check_attention_separated_cluster_guard.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Guard semantic separated-attention RTL before physical evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", required=True)
+    args = parser.parse_args(argv)
+    design_dir = Path(args.design_dir)
+    config_path = design_dir / "config.json"
+    generated_config_path = design_dir / "verilog" / "config.json"
+    manifest_path = design_dir / "verilog" / "attention_separated_cluster_manifest.json"
+    top_path = design_dir / "verilog" / "top.v"
+    for path in (config_path, generated_config_path, manifest_path, top_path):
+        if not path.exists():
+            raise SystemExit(f"missing separated-attention artifact: {path}")
+
+    config = _load(config_path)
+    if config != _load(generated_config_path):
+        raise SystemExit("generated config does not match source config")
+    manifest = _load(manifest_path)
+    cluster = config.get("attention_separated_cluster")
+    if not isinstance(cluster, dict):
+        raise SystemExit("config must contain attention_separated_cluster object")
+    producer_count = int(cluster.get("producer_count", 0))
+    consumer_count = int(cluster.get("consumer_count", 0))
+    if manifest.get("semantic_profile") != "q8_k8_v8_a32_s32_w16_exp_lut_div_b20":
+        raise SystemExit("unexpected separated-attention semantic profile")
+    if int(manifest.get("producer_count", 0)) != producer_count:
+        raise SystemExit("manifest producer_count does not match config")
+    if int(manifest.get("consumer_count", 0)) != consumer_count:
+        raise SystemExit("manifest consumer_count does not match config")
+    if manifest.get("producer_to_consumer_ratio") != f"{producer_count}:{consumer_count}":
+        raise SystemExit("manifest producer-to-consumer ratio does not match config")
+    if int(manifest.get("producer_payload_width", 0)) != 784:
+        raise SystemExit("producer payload must contain command id, full score row, and full V matrix")
+    if int(manifest.get("consumer_result_width", 0)) != 720:
+        raise SystemExit("consumer result must contain command id and exact score, weight, and V outputs")
+
+    text = top_path.read_text(encoding="utf-8", errors="replace")
+    top_name = str(config.get("top_name") or "")
+    if not re.search(rf"^\s*module\s+{re.escape(top_name)}\b", text, re.MULTILINE):
+        raise SystemExit(f"generated RTL does not define top module {top_name}")
+    required = (
+        "payload_score_row",
+        "payload_value_matrix",
+        "result_score_row",
+        "result_weights",
+        "result_value",
+        "dispatch_fire",
+        "result_fire",
+        "consumer_enable",
+        "score_accum <<< 20",
+        "32'd2048",
+        "17'd65535",
+        "weight_numer / sum_exp",
+        "$signed(value_lane) * $signed({1'b0, weight_lane[row_idx]})",
+    )
+    for token in required:
+        if token not in text:
+            raise SystemExit(f"separated-attention RTL missing semantic token: {token}")
+    forbidden = ("result_hash", "equivalence_hash", "PRODUCER_INDEX *")
+    for token in forbidden:
+        if token in text:
+            raise SystemExit(f"separated-attention RTL contains forbidden proxy token: {token}")
+    for index in range(producer_count):
+        if f"u_producer_{index}" not in text:
+            raise SystemExit(f"missing producer instance {index}")
+    for index in range(consumer_count):
+        if f"u_consumer_{index}" not in text:
+            raise SystemExit(f"missing consumer instance {index}")
+
+    print(f"OK: separated-attention guard passed for {design_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/check_attention_separated_cluster_guard.py
+++ b/npu/eval/check_attention_separated_cluster_guard.py
@@ -62,6 +62,7 @@ def main(argv: list[str] | None = None) -> int:
         "result_fire",
         "consumer_enable",
         "score_accum <<< 20",
+        "delta_score + 32'd524288",
         "32'd2048",
         "17'd65535",
         "weight_numer / sum_exp",

--- a/npu/eval/probe_attention_separated_equivalence.py
+++ b/npu/eval/probe_attention_separated_equivalence.py
@@ -369,7 +369,7 @@ def build_report(*, ratios: list[tuple[int, int]], command_count: int) -> JsonDi
             "PPA and toggle-based power for each producer-to-consumer ratio are not measured by this equivalence probe",
         ],
         "next_step": (
-            "Measure Nangate45 PPA for 1:1, 2:1, 4:1, and 8:1 producer-to-consumer ratios."
+            "Measure Nangate45 PPA for 1:1, 2:1, 4:1, 8:1, 4:2, and 8:2 producer-to-consumer ratios."
             if passed
             else "Fix exact stage or schedule mismatches before physical evaluation."
         ),

--- a/npu/eval/probe_attention_separated_equivalence.py
+++ b/npu/eval/probe_attention_separated_equivalence.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Prove exact functional and schedule equivalence for separated attention RTL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+from typing import Any
+
+from npu.rtlgen.gen_attention_separated_cluster import _validate, _write_top
+from npu.sim.perf.attention_separated import (
+    AttentionSeparatedCommand,
+    default_commands,
+    scenario_names,
+    simulate,
+    unpack_signed,
+    unpack_unsigned,
+)
+
+JsonDict = dict[str, Any]
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required RTL simulation tool is unavailable: {name}")
+
+
+def _config(*, top_name: str, producer_count: int, consumer_count: int) -> JsonDict:
+    return {
+        "top_name": top_name,
+        "attention_separated_cluster": {
+            "producer_count": producer_count,
+            "consumer_count": consumer_count,
+            "row_elems": 8,
+            "head_dim": 8,
+            "value_dim": 8,
+            "score_bits": 32,
+            "weight_bits": 16,
+            "input_frac_bits": 28,
+            "exp_bucket_shift": 20,
+        },
+    }
+
+
+def _testbench(
+    *, top_name: str, producer_count: int, consumer_count: int, commands: list[AttentionSeparatedCommand], scenario: str
+) -> str:
+    command_init = "\n".join(
+        f"    command_ids[{index}] = 16'h{command.command_id & 0xFFFF:04x};\n"
+        f"    command_seeds[{index}] = 32'h{command.seed & 0xFFFFFFFF:08x};"
+        for index, command in enumerate(commands)
+    )
+    dispatch_id_cases = "\n".join(
+        f"      {index}: dispatch_command_id = dut.producer_{index}_payload_command_id;"
+        for index in range(producer_count)
+    )
+    full_mask = (1 << consumer_count) - 1
+    enable_logic = {
+        "always_ready": f"consumer_enable = {consumer_count}'h{full_mask:x};",
+        "result_backpressure": f"consumer_enable = {consumer_count}'h{full_mask:x};",
+        "all_consumers_blocked_temporarily": (
+            f"consumer_enable = ((cycle >= 6) && (cycle < 10)) ? {consumer_count}'h0 : "
+            f"{consumer_count}'h{full_mask:x};"
+        ),
+        "intermittent_consumer_stall": "\n".join(
+            [f"consumer_enable = {consumer_count}'h0;"]
+            + [f"if (((cycle + {index}) % 4) != 1) consumer_enable[{index}] = 1'b1;" for index in range(consumer_count)]
+        ),
+    }[scenario]
+    ready_logic = (
+        "result_ready = !(((cycle >= 9) && (cycle < 13)) || ((cycle % 6) == 4));"
+        if scenario == "result_backpressure"
+        else "result_ready = 1'b1;"
+    )
+    return f"""`timescale 1ns/1ps
+module tb;
+  localparam integer COMMAND_COUNT = {len(commands)};
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  reg command_valid;
+  wire command_ready;
+  reg [15:0] command_id;
+  reg [31:0] command_seed;
+  reg [{consumer_count - 1}:0] consumer_enable;
+  wire result_valid;
+  reg result_ready;
+  wire [15:0] result_command_id;
+  wire [255:0] result_score_row;
+  wire [127:0] result_weights;
+  wire [319:0] result_value;
+  wire [31:0] accepted_count;
+  wire [31:0] completed_count;
+  reg [15:0] command_ids [0:COMMAND_COUNT-1];
+  reg [31:0] command_seeds [0:COMMAND_COUNT-1];
+  integer send_index;
+  integer cycle;
+  reg [15:0] dispatch_command_id;
+
+  always #5 clk = ~clk;
+
+  {top_name} dut (
+    .clk(clk), .rst_n(rst_n),
+    .command_valid(command_valid), .command_ready(command_ready),
+    .command_id(command_id), .command_seed(command_seed),
+    .consumer_enable(consumer_enable),
+    .result_valid(result_valid), .result_ready(result_ready),
+    .result_command_id(result_command_id), .result_score_row(result_score_row),
+    .result_weights(result_weights), .result_value(result_value),
+    .accepted_count(accepted_count), .completed_count(completed_count)
+  );
+
+  always @* begin
+    command_valid = rst_n && (send_index < COMMAND_COUNT);
+    command_id = 16'h0;
+    command_seed = 32'h0;
+    if (send_index < COMMAND_COUNT) begin
+      command_id = command_ids[send_index];
+      command_seed = command_seeds[send_index];
+    end
+    {enable_logic}
+    {ready_logic}
+    dispatch_command_id = 16'h0;
+    case (dut.dispatch_producer_idx)
+{dispatch_id_cases}
+      default: dispatch_command_id = 16'h0;
+    endcase
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      send_index <= 0;
+      cycle <= 0;
+    end else begin
+      if (command_valid && command_ready) begin
+        $display("ACCEPT cycle=%0d producer=%0d id=%0d seed=%08x", cycle, dut.issue_target_idx, command_id, command_seed);
+        send_index <= send_index + 1;
+      end
+      if (dut.dispatch_fire) begin
+        $display("DISPATCH cycle=%0d producer=%0d consumer=%0d id=%0d", cycle, dut.dispatch_producer_idx, dut.dispatch_consumer_idx, dispatch_command_id);
+      end
+      if (result_valid && result_ready) begin
+        $display("RESULT cycle=%0d id=%0d score=%064x weights=%032x value=%080x", cycle, result_command_id, result_score_row, result_weights, result_value);
+        if (completed_count + 1 == COMMAND_COUNT) begin
+          $display("SUMMARY accepted=%0d completed=%0d final_cycle=%0d", accepted_count, completed_count + 1, cycle);
+          #1 $finish;
+        end
+      end
+      cycle <= cycle + 1;
+      if (cycle > 500) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+{command_init}
+    repeat (2) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+"""
+
+
+_ACCEPT_RE = re.compile(r"ACCEPT cycle=(\d+) producer=(\d+) id=(\d+) seed=([0-9a-fA-F]+)")
+_DISPATCH_RE = re.compile(r"DISPATCH cycle=(\d+) producer=(\d+) consumer=(\d+) id=(\d+)")
+_RESULT_RE = re.compile(
+    r"RESULT cycle=(\d+) id=(\d+) score=([0-9a-fA-F]+) weights=([0-9a-fA-F]+) value=([0-9a-fA-F]+)"
+)
+_SUMMARY_RE = re.compile(r"SUMMARY accepted=(\d+) completed=(\d+) final_cycle=(\d+)")
+
+
+def _parse_log(text: str) -> JsonDict:
+    accepts: list[JsonDict] = []
+    dispatches: list[JsonDict] = []
+    results: list[JsonDict] = []
+    summary: JsonDict | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        match = _ACCEPT_RE.fullmatch(line)
+        if match:
+            accepts.append(
+                {
+                    "cycle": int(match.group(1)),
+                    "producer": int(match.group(2)),
+                    "command_id": int(match.group(3)),
+                    "seed": int(match.group(4), 16),
+                }
+            )
+            continue
+        match = _DISPATCH_RE.fullmatch(line)
+        if match:
+            dispatches.append(
+                {
+                    "cycle": int(match.group(1)),
+                    "producer": int(match.group(2)),
+                    "consumer": int(match.group(3)),
+                    "command_id": int(match.group(4)),
+                }
+            )
+            continue
+        match = _RESULT_RE.fullmatch(line)
+        if match:
+            results.append(
+                {
+                    "cycle": int(match.group(1)),
+                    "command_id": int(match.group(2)),
+                    "score_row": unpack_signed(int(match.group(3), 16), lanes=8, bits=32),
+                    "weights": unpack_unsigned(int(match.group(4), 16), lanes=8, bits=16),
+                    "value": unpack_signed(int(match.group(5), 16), lanes=8, bits=40),
+                }
+            )
+            continue
+        match = _SUMMARY_RE.fullmatch(line)
+        if match:
+            summary = {
+                "accepted_count": int(match.group(1)),
+                "completed_count": int(match.group(2)),
+                "final_cycle": int(match.group(3)),
+            }
+    if summary is None:
+        raise RuntimeError(f"RTL simulation did not emit SUMMARY:\n{text[-4000:]}")
+    return {"accept_events": accepts, "dispatch_events": dispatches, "result_events": results, **summary}
+
+
+def _run_rtl(
+    *, producer_count: int, consumer_count: int, commands: list[AttentionSeparatedCommand], scenario: str
+) -> JsonDict:
+    top_name = f"attention_separated_cluster_p{producer_count}_c{consumer_count}"
+    with tempfile.TemporaryDirectory(prefix="attention-separated-equivalence-") as tmp_text:
+        tmp = Path(tmp_text)
+        cfg = _config(top_name=top_name, producer_count=producer_count, consumer_count=consumer_count)
+        params = _validate(cfg)
+        rtl_dir = tmp / "rtl"
+        _write_top(cfg=cfg, comp=params, out_path=rtl_dir)
+        tb_path = tmp / "tb.sv"
+        tb_path.write_text(
+            _testbench(
+                top_name=top_name,
+                producer_count=producer_count,
+                consumer_count=consumer_count,
+                commands=commands,
+                scenario=scenario,
+            ),
+            encoding="utf-8",
+        )
+        sim_path = tmp / "simv"
+        subprocess.run(
+            [_tool("iverilog"), "-g2012", "-s", "tb", "-o", str(sim_path), str(rtl_dir / "top.v"), str(tb_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        completed = subprocess.run([_tool("vvp"), str(sim_path)], check=True, capture_output=True, text=True)
+        return _parse_log(completed.stdout)
+
+
+def _compare(perf: JsonDict, rtl: JsonDict) -> JsonDict:
+    schedule_failures: list[str] = []
+    functional_failures: list[str] = []
+    for key in ("accept_events", "dispatch_events"):
+        if perf[key] != rtl[key]:
+            schedule_failures.append(f"{key} mismatch: perf={perf[key]} rtl={rtl[key]}")
+    perf_results = perf["result_events"]
+    rtl_results = rtl["result_events"]
+    if len(perf_results) != len(rtl_results):
+        functional_failures.append(f"result count mismatch: perf={len(perf_results)} rtl={len(rtl_results)}")
+    for index, (expected, actual) in enumerate(zip(perf_results, rtl_results)):
+        expected_functional = {
+            "command_id": expected["command_id"],
+            "score_row": expected["score_row"],
+            "weights": expected["weights"],
+            "value": expected["value"],
+        }
+        actual_functional = {key: actual[key] for key in expected_functional}
+        if expected_functional != actual_functional:
+            functional_failures.append(
+                f"result[{index}] mismatch: perf={expected_functional} rtl={actual_functional}"
+            )
+        if expected["cycle"] != actual["cycle"]:
+            schedule_failures.append(
+                f"result[{index}] cycle mismatch: perf={expected['cycle']} rtl={actual['cycle']}"
+            )
+    for key in ("accepted_count", "completed_count", "final_cycle"):
+        if perf[key] != rtl[key]:
+            schedule_failures.append(f"{key} mismatch: perf={perf[key]} rtl={rtl[key]}")
+    return {
+        "functional_failures": functional_failures,
+        "schedule_failures": schedule_failures,
+        "functional_pass": not functional_failures,
+        "schedule_pass": not schedule_failures,
+    }
+
+
+def build_report(*, ratios: list[tuple[int, int]], command_count: int) -> JsonDict:
+    commands = default_commands(command_count)
+    rows: list[JsonDict] = []
+    for producer_count, consumer_count in ratios:
+        for scenario in scenario_names():
+            perf = simulate(
+                commands,
+                producer_count=producer_count,
+                consumer_count=consumer_count,
+                scenario=scenario,
+            )
+            rtl = _run_rtl(
+                producer_count=producer_count,
+                consumer_count=consumer_count,
+                commands=commands,
+                scenario=scenario,
+            )
+            comparison = _compare(perf, rtl)
+            expected_ids = sorted(command.command_id for command in commands)
+            actual_ids = sorted(row["command_id"] for row in rtl["result_events"])
+            loss_or_duplication = (
+                rtl["accepted_count"] != len(commands)
+                or rtl["completed_count"] != len(commands)
+                or actual_ids != expected_ids
+            )
+            rows.append(
+                {
+                    "producer_count": producer_count,
+                    "consumer_count": consumer_count,
+                    "ratio": f"{producer_count}:{consumer_count}",
+                    "scenario": scenario,
+                    "equivalence_pass": bool(
+                        comparison["functional_pass"] and comparison["schedule_pass"] and not loss_or_duplication
+                    ),
+                    **comparison,
+                    "loss_or_duplication": loss_or_duplication,
+                    "accepted_count": rtl["accepted_count"],
+                    "completed_count": rtl["completed_count"],
+                    "final_cycle": rtl["final_cycle"],
+                    "completed_order": [row["command_id"] for row in rtl["result_events"]],
+                    "perf_sha256": perf["sha256"],
+                }
+            )
+    passed = bool(rows) and all(row["equivalence_pass"] for row in rows)
+    functional_pass = bool(rows) and all(row["functional_pass"] for row in rows)
+    schedule_pass = bool(rows) and all(row["schedule_pass"] for row in rows)
+    loss_or_duplication = any(row["loss_or_duplication"] for row in rows)
+    return {
+        "version": 1,
+        "model": "attention_separated_cluster_perf_rtl_equivalence_v1",
+        "decision": "attention_separated_cluster_equivalence_pass" if passed else "attention_separated_cluster_equivalence_fail",
+        "equivalence_pass": passed,
+        "semantic_profile": "q8_k8_v8_a32_s32_w16_exp_lut_div_b20",
+        "ratios": [f"{producer_count}:{consumer_count}" for producer_count, consumer_count in ratios],
+        "command_count": command_count,
+        "scenarios": list(scenario_names()),
+        "rows": rows,
+        "gates": {
+            "exact_score_rows": functional_pass,
+            "exact_softmax_weights": functional_pass,
+            "exact_weighted_value_vectors": functional_pass,
+            "exact_ready_valid_schedule": schedule_pass,
+            "loss_or_duplication": loss_or_duplication,
+        },
+        "remaining_abstractions": [
+            "the bounded 8x8 attention tile must be replicated and scheduled across the full Llama7B dimensions",
+            "PPA and toggle-based power for each producer-to-consumer ratio are not measured by this equivalence probe",
+        ],
+        "next_step": (
+            "Measure Nangate45 PPA for 1:1, 2:1, 4:1, and 8:1 producer-to-consumer ratios."
+            if passed
+            else "Fix exact stage or schedule mismatches before physical evaluation."
+        ),
+    }
+
+
+def _ratios(text: str) -> list[tuple[int, int]]:
+    values: list[tuple[int, int]] = []
+    for item in text.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            producer_text, consumer_text = item.split(":", 1)
+            producer_count = int(producer_text)
+            consumer_count = int(consumer_text)
+        except (TypeError, ValueError) as exc:
+            raise argparse.ArgumentTypeError(f"invalid producer:consumer ratio: {item}") from exc
+        if not 1 <= consumer_count <= producer_count <= 8:
+            raise argparse.ArgumentTypeError(f"ratio must satisfy 1 <= consumer <= producer <= 8: {item}")
+        values.append((producer_count, consumer_count))
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one producer:consumer ratio")
+    return values
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Separated Attention Perf/RTL Equivalence",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- equivalence pass: `{payload['equivalence_pass']}`",
+        f"- semantic profile: `{payload['semantic_profile']}`",
+        "",
+        "| ratio | scenario | pass | completed | final cycle |",
+        "|---|---|---:|---:|---:|",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            f"| {row['ratio']} | {row['scenario']} | {row['equivalence_pass']} | "
+            f"{row['completed_count']} | {row['final_cycle']} |"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ratios",
+        type=_ratios,
+        default=[(1, 1), (2, 1), (4, 1), (8, 1), (4, 2), (8, 2)],
+    )
+    parser.add_argument("--command-count", type=int, default=8)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        ratios=args.ratios,
+        command_count=args.command_count,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": payload["equivalence_pass"], "decision": payload["decision"]}, sort_keys=True))
+    return 0 if payload["equivalence_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_separated_cluster.py
+++ b/npu/rtlgen/gen_attention_separated_cluster.py
@@ -1,0 +1,815 @@
+#!/usr/bin/env python3
+"""Generate a bounded producer/consumer attention cluster with semantic outputs.
+
+Each accepted command occupies one producer slot. A producer derives q8 query,
+key, and value payloads from the command seed and id, computes an 8-lane score
+row as exact signed sums of q*k products, and holds the payload until a shared
+consumer selects it. Consumers apply a bucketed-exp LUT plus exact rowwise
+normalization, accumulate weighted q8 values into signed 40-bit outputs, and
+hold one result entry until the external result channel accepts it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+SEMANTIC_PROFILE = "q8_k8_v8_a32_s32_w16_exp_lut_div_b20"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_int(config: dict[str, Any], key: str, default: int) -> int:
+    return int(config.get(key, default))
+
+
+def _clog2(value: int) -> int:
+    return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
+    top_name = str(cfg.get("top_name", "")).strip()
+    if not top_name:
+        raise SystemExit("config top_name must not be empty")
+
+    cluster = cfg.get("attention_separated_cluster")
+    if not isinstance(cluster, dict):
+        raise SystemExit("config must contain attention_separated_cluster object")
+
+    producer_count = _as_int(cluster, "producer_count", 1)
+    consumer_count = _as_int(cluster, "consumer_count", 1)
+    row_elems = _as_int(cluster, "row_elems", 8)
+    head_dim = _as_int(cluster, "head_dim", 8)
+    value_dim = _as_int(cluster, "value_dim", 8)
+    score_bits = _as_int(cluster, "score_bits", 32)
+    weight_bits = _as_int(cluster, "weight_bits", 16)
+    input_frac_bits = _as_int(cluster, "input_frac_bits", 28)
+    exp_bucket_shift = _as_int(cluster, "exp_bucket_shift", 20)
+
+    if producer_count < 1 or producer_count > 8:
+        raise SystemExit("attention_separated_cluster.producer_count must be in [1, 8]")
+    if consumer_count < 1 or consumer_count > 8:
+        raise SystemExit("attention_separated_cluster.consumer_count must be in [1, 8]")
+    if consumer_count > producer_count:
+        raise SystemExit(
+            "attention_separated_cluster.consumer_count must be less than or equal to producer_count"
+        )
+    if row_elems != 8:
+        raise SystemExit("attention_separated_cluster.row_elems must be 8")
+    if head_dim != 8:
+        raise SystemExit("attention_separated_cluster.head_dim must be 8")
+    if value_dim != 8:
+        raise SystemExit("attention_separated_cluster.value_dim must be 8")
+    if score_bits != 32:
+        raise SystemExit("attention_separated_cluster.score_bits must be 32")
+    if weight_bits != 16:
+        raise SystemExit("attention_separated_cluster.weight_bits must be 16")
+    if input_frac_bits != 28:
+        raise SystemExit("attention_separated_cluster.input_frac_bits must be 28")
+    if exp_bucket_shift != 20:
+        raise SystemExit("attention_separated_cluster.exp_bucket_shift must be 20")
+
+    cluster["producer_count"] = producer_count
+    cluster["consumer_count"] = consumer_count
+    cluster["row_elems"] = row_elems
+    cluster["head_dim"] = head_dim
+    cluster["value_dim"] = value_dim
+    cluster["score_bits"] = score_bits
+    cluster["weight_bits"] = weight_bits
+    cluster["input_frac_bits"] = input_frac_bits
+    cluster["exp_bucket_shift"] = exp_bucket_shift
+    return cluster
+
+
+def _producer_module(*, module_name: str, row_elems: int, head_dim: int, value_dim: int, score_bits: int) -> str:
+    score_width = row_elems * score_bits
+    value_matrix_width = row_elems * value_dim * 8
+    return f"""module {module_name} #(parameter integer PRODUCER_INDEX = 0) (
+    input  wire                         clk,
+    input  wire                         rst_n,
+    input  wire                         load_valid,
+    input  wire [15:0]                  load_command_id,
+    input  wire [31:0]                  load_seed,
+    input  wire                         pop_valid,
+    output reg                          payload_valid,
+    output reg  [15:0]                  payload_command_id,
+    output reg  [{score_width - 1}:0]   payload_score_row,
+    output reg  [{value_matrix_width - 1}:0] payload_value_matrix
+);
+  integer row_idx;
+  integer dim_idx;
+  reg signed [31:0] score_accum;
+
+  function automatic signed [7:0] derive_q8;
+    input [31:0] seed;
+    input [15:0] command_id;
+    input integer producer_idx;
+    input integer tag;
+    input integer lane_a;
+    input integer lane_b;
+    reg [31:0] mixed;
+    begin
+      mixed = seed ^ {{16'h0, command_id}};
+      mixed = mixed ^ (producer_idx * 32'h45d9_f3b1);
+      mixed = mixed ^ (tag * 32'h119d_e1f3);
+      mixed = mixed ^ (lane_a * 32'h344b_5409);
+      mixed = mixed ^ (lane_b * 32'h27d4_eb2d);
+      mixed = mixed ^ (mixed >> 16);
+      mixed = mixed ^ (mixed >> 8);
+      derive_q8 = mixed[7:0];
+    end
+  endfunction
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      payload_valid <= 1'b0;
+      payload_command_id <= 16'h0;
+      payload_score_row <= {{{score_width}{{1'b0}}}};
+      payload_value_matrix <= {{{value_matrix_width}{{1'b0}}}};
+    end else begin
+      if (load_valid) begin
+        payload_valid <= 1'b1;
+        payload_command_id <= load_command_id;
+        for (row_idx = 0; row_idx < {row_elems}; row_idx = row_idx + 1) begin
+          score_accum = 32'sd0;
+          for (dim_idx = 0; dim_idx < {head_dim}; dim_idx = dim_idx + 1) begin
+            score_accum = score_accum
+                + $signed(derive_q8(load_seed, load_command_id, PRODUCER_INDEX, 17, 0, dim_idx))
+                * $signed(derive_q8(load_seed, load_command_id, PRODUCER_INDEX, 51, row_idx, dim_idx));
+            payload_value_matrix[(((row_idx * {value_dim}) + dim_idx) * 8) +: 8]
+                <= derive_q8(load_seed, load_command_id, PRODUCER_INDEX, 85, row_idx, dim_idx);
+          end
+          payload_score_row[(row_idx * {score_bits}) +: {score_bits}] <= score_accum;
+        end
+      end
+      if (pop_valid) begin
+        payload_valid <= 1'b0;
+      end
+    end
+  end
+endmodule
+"""
+
+
+def _consumer_module(
+    *,
+    module_name: str,
+    row_elems: int,
+    value_dim: int,
+    score_bits: int,
+    weight_bits: int,
+    exp_bucket_shift: int,
+) -> str:
+    score_width = row_elems * score_bits
+    weight_width = row_elems * weight_bits
+    value_matrix_width = row_elems * value_dim * 8
+    result_value_width = value_dim * 40
+    exp_entries = [
+        (bucket, max(1, int(round(math.exp(-float(bucket)) * ((1 << weight_bits) - 1)))))
+        for bucket in range(8)
+    ]
+    exp_cases = "\n".join(
+        f"      32'd{bucket}: exp_lut = 16'd{value};" for bucket, value in exp_entries
+    )
+    return f"""module {module_name} (
+    input  wire                         clk,
+    input  wire                         rst_n,
+    input  wire                         load_valid,
+    input  wire [15:0]                  load_command_id,
+    input  wire [{score_width - 1}:0]   load_score_row,
+    input  wire [{value_matrix_width - 1}:0] load_value_matrix,
+    input  wire                         pop_valid,
+    output reg                          result_valid,
+    output reg  [15:0]                  result_command_id,
+    output reg  [{score_width - 1}:0]   result_score_row,
+    output reg  [{weight_width - 1}:0]  result_weights,
+    output reg  [{result_value_width - 1}:0] result_value
+);
+  integer row_idx;
+  integer dim_idx;
+  integer sum_exp;
+  reg signed [31:0] max_score;
+  reg signed [31:0] score_lane;
+  reg signed [31:0] delta_score;
+  reg [31:0] exp_bucket;
+  reg [31:0] weight_numer;
+  reg [15:0] exp_weight [0:{row_elems - 1}];
+  reg [15:0] weight_lane [0:{row_elems - 1}];
+  reg signed [7:0] value_lane;
+  reg signed [39:0] accum_lane;
+
+  function automatic [15:0] exp_lut;
+    input [31:0] bucket;
+    begin
+      case (bucket)
+{exp_cases}
+      default: exp_lut = 16'd1;
+      endcase
+    end
+  endfunction
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      result_valid <= 1'b0;
+      result_command_id <= 16'h0;
+      result_score_row <= {{{score_width}{{1'b0}}}};
+      result_weights <= {{{weight_width}{{1'b0}}}};
+      result_value <= {{{result_value_width}{{1'b0}}}};
+    end else begin
+      if (load_valid) begin
+        result_valid <= 1'b1;
+        result_command_id <= load_command_id;
+        result_score_row <= load_score_row;
+
+        max_score = $signed(load_score_row[0 +: {score_bits}]);
+        for (row_idx = 1; row_idx < {row_elems}; row_idx = row_idx + 1) begin
+          score_lane = $signed(load_score_row[(row_idx * {score_bits}) +: {score_bits}]);
+          if (score_lane > max_score) begin
+            max_score = score_lane;
+          end
+        end
+
+        sum_exp = 0;
+        for (row_idx = 0; row_idx < {row_elems}; row_idx = row_idx + 1) begin
+          score_lane = $signed(load_score_row[(row_idx * {score_bits}) +: {score_bits}]);
+          delta_score = max_score - score_lane;
+          if (delta_score < 0) begin
+            delta_score = 32'sd0;
+          end
+          exp_bucket = delta_score >> {exp_bucket_shift};
+          exp_weight[row_idx] = exp_lut(exp_bucket);
+          sum_exp = sum_exp + exp_weight[row_idx];
+        end
+
+        for (row_idx = 0; row_idx < {row_elems}; row_idx = row_idx + 1) begin
+          if (sum_exp != 0) begin
+            weight_numer = (exp_weight[row_idx] * 16'd{(1 << weight_bits) - 1}) + (sum_exp >> 1);
+            weight_lane[row_idx] = weight_numer / sum_exp;
+          end else begin
+            weight_lane[row_idx] = 16'd0;
+          end
+          result_weights[(row_idx * {weight_bits}) +: {weight_bits}] <= weight_lane[row_idx];
+        end
+
+        for (dim_idx = 0; dim_idx < {value_dim}; dim_idx = dim_idx + 1) begin
+          accum_lane = 40'sd0;
+          for (row_idx = 0; row_idx < {row_elems}; row_idx = row_idx + 1) begin
+            value_lane = $signed(load_value_matrix[(((row_idx * {value_dim}) + dim_idx) * 8) +: 8]);
+            accum_lane = accum_lane + ($signed(value_lane) * $signed({{1'b0, weight_lane[row_idx]}}));
+          end
+          result_value[(dim_idx * 40) +: 40] <= accum_lane;
+        end
+      end
+
+      if (pop_valid) begin
+        result_valid <= 1'b0;
+      end
+    end
+  end
+endmodule
+"""
+
+
+def _top_module(*, top_name: str, params: dict[str, Any]) -> str:
+    producer_count = int(params["producer_count"])
+    consumer_count = int(params["consumer_count"])
+    row_elems = int(params["row_elems"])
+    value_dim = int(params["value_dim"])
+    score_bits = int(params["score_bits"])
+    weight_bits = int(params["weight_bits"])
+    producer_idx_bits = _clog2(producer_count)
+    consumer_idx_bits = _clog2(consumer_count)
+    score_width = row_elems * score_bits
+    weight_width = row_elems * weight_bits
+    value_matrix_width = row_elems * value_dim * 8
+    result_value_width = value_dim * 40
+    producer_module = f"{top_name}_producer"
+    consumer_module = f"{top_name}_consumer"
+
+    producer_wires: list[str] = []
+    producer_insts: list[str] = []
+    for idx in range(producer_count):
+        producer_wires.extend(
+            [
+                f"  wire                         producer_{idx}_payload_valid;",
+                f"  wire [15:0]                  producer_{idx}_payload_command_id;",
+                f"  wire [{score_width - 1}:0]   producer_{idx}_payload_score_row;",
+                f"  wire [{value_matrix_width - 1}:0] producer_{idx}_payload_value_matrix;",
+                f"  reg                          producer_{idx}_load_valid;",
+                f"  reg                          producer_{idx}_pop_valid;",
+            ]
+        )
+        producer_insts.append(
+            f"""  {producer_module} #(
+    .PRODUCER_INDEX({idx})
+  ) u_producer_{idx} (
+    .clk(clk),
+    .rst_n(rst_n),
+    .load_valid(producer_{idx}_load_valid),
+    .load_command_id(command_id),
+    .load_seed(command_seed),
+    .pop_valid(producer_{idx}_pop_valid),
+    .payload_valid(producer_{idx}_payload_valid),
+    .payload_command_id(producer_{idx}_payload_command_id),
+    .payload_score_row(producer_{idx}_payload_score_row),
+    .payload_value_matrix(producer_{idx}_payload_value_matrix)
+  );"""
+        )
+
+    consumer_wires: list[str] = []
+    consumer_insts: list[str] = []
+    for idx in range(consumer_count):
+        consumer_wires.extend(
+            [
+                f"  wire                         consumer_{idx}_result_valid;",
+                f"  wire [15:0]                  consumer_{idx}_result_command_id;",
+                f"  wire [{score_width - 1}:0]   consumer_{idx}_result_score_row;",
+                f"  wire [{weight_width - 1}:0]  consumer_{idx}_result_weights;",
+                f"  wire [{result_value_width - 1}:0] consumer_{idx}_result_value;",
+                f"  reg                          consumer_{idx}_load_valid;",
+                f"  reg                          consumer_{idx}_pop_valid;",
+                f"  reg  [15:0]                  consumer_{idx}_load_command_id;",
+                f"  reg  [{score_width - 1}:0]   consumer_{idx}_load_score_row;",
+                f"  reg  [{value_matrix_width - 1}:0] consumer_{idx}_load_value_matrix;",
+            ]
+        )
+        consumer_insts.append(
+            f"""  {consumer_module} u_consumer_{idx} (
+    .clk(clk),
+    .rst_n(rst_n),
+    .load_valid(consumer_{idx}_load_valid),
+    .load_command_id(consumer_{idx}_load_command_id),
+    .load_score_row(consumer_{idx}_load_score_row),
+    .load_value_matrix(consumer_{idx}_load_value_matrix),
+    .pop_valid(consumer_{idx}_pop_valid),
+    .result_valid(consumer_{idx}_result_valid),
+    .result_command_id(consumer_{idx}_result_command_id),
+    .result_score_row(consumer_{idx}_result_score_row),
+    .result_weights(consumer_{idx}_result_weights),
+    .result_value(consumer_{idx}_result_value)
+  );"""
+        )
+
+    return f"""// Auto-generated by npu/rtlgen/gen_attention_separated_cluster.py
+(* keep_hierarchy = 1 *)
+module {top_name} (
+    input  wire                         clk,
+    input  wire                         rst_n,
+    input  wire                         command_valid,
+    output wire                         command_ready,
+    input  wire [15:0]                  command_id,
+    input  wire [31:0]                  command_seed,
+    input  wire [{consumer_count - 1}:0] consumer_enable,
+    output reg                          result_valid,
+    input  wire                         result_ready,
+    output reg  [15:0]                  result_command_id,
+    output reg  [{score_width - 1}:0]   result_score_row,
+    output reg  [{weight_width - 1}:0]  result_weights,
+    output reg  [{result_value_width - 1}:0] result_value,
+    output reg  [31:0]                  accepted_count,
+    output reg  [31:0]                  completed_count
+);
+  localparam integer PRODUCER_COUNT = {producer_count};
+  localparam integer CONSUMER_COUNT = {consumer_count};
+  localparam integer SCORE_ROW_WIDTH = {score_width};
+  localparam integer WEIGHT_ROW_WIDTH = {weight_width};
+  localparam integer VALUE_MATRIX_WIDTH = {value_matrix_width};
+  localparam integer RESULT_VALUE_WIDTH = {result_value_width};
+
+  reg [{producer_idx_bits - 1}:0] issue_rr_ptr;
+  reg [{producer_idx_bits - 1}:0] dispatch_producer_rr_ptr;
+  reg [{consumer_idx_bits - 1}:0] dispatch_consumer_rr_ptr;
+  reg [{consumer_idx_bits - 1}:0] result_rr_ptr;
+  reg issue_target_valid;
+  reg [{producer_idx_bits - 1}:0] issue_target_idx;
+  reg dispatch_producer_valid;
+  reg [{producer_idx_bits - 1}:0] dispatch_producer_idx;
+  reg dispatch_consumer_valid;
+  reg [{consumer_idx_bits - 1}:0] dispatch_consumer_idx;
+  reg result_target_valid;
+  reg [{consumer_idx_bits - 1}:0] result_target_idx;
+  integer issue_scan_offset;
+  integer issue_scan_index;
+  integer dispatch_producer_scan_offset;
+  integer dispatch_producer_scan_index;
+  integer dispatch_consumer_scan_offset;
+  integer dispatch_consumer_scan_index;
+  integer result_scan_offset;
+  integer result_scan_index;
+
+  wire command_fire = command_valid && command_ready;
+  wire dispatch_fire = dispatch_producer_valid && dispatch_consumer_valid;
+  wire result_fire = result_target_valid && result_ready;
+
+{chr(10).join(producer_wires)}
+{chr(10).join(consumer_wires)}
+
+  assign command_ready = issue_target_valid;
+
+{chr(10).join(producer_insts)}
+
+{chr(10).join(consumer_insts)}
+
+  always @(*) begin
+    issue_target_valid = 1'b0;
+    issue_target_idx = {{{producer_idx_bits}{{1'b0}}}};
+    for (issue_scan_offset = 0; issue_scan_offset < PRODUCER_COUNT; issue_scan_offset = issue_scan_offset + 1) begin
+      issue_scan_index = issue_rr_ptr + issue_scan_offset;
+      if (issue_scan_index >= PRODUCER_COUNT) begin
+        issue_scan_index = issue_scan_index - PRODUCER_COUNT;
+      end
+      case (issue_scan_index)
+{_producer_issue_cases(producer_count)}
+      endcase
+    end
+  end
+
+  always @(*) begin
+    dispatch_producer_valid = 1'b0;
+    dispatch_producer_idx = {{{producer_idx_bits}{{1'b0}}}};
+    for (
+      dispatch_producer_scan_offset = 0;
+      dispatch_producer_scan_offset < PRODUCER_COUNT;
+      dispatch_producer_scan_offset = dispatch_producer_scan_offset + 1
+    ) begin
+      dispatch_producer_scan_index = dispatch_producer_rr_ptr + dispatch_producer_scan_offset;
+      if (dispatch_producer_scan_index >= PRODUCER_COUNT) begin
+        dispatch_producer_scan_index = dispatch_producer_scan_index - PRODUCER_COUNT;
+      end
+      case (dispatch_producer_scan_index)
+{_producer_dispatch_cases(producer_count)}
+      endcase
+    end
+  end
+
+  always @(*) begin
+    dispatch_consumer_valid = 1'b0;
+    dispatch_consumer_idx = {{{consumer_idx_bits}{{1'b0}}}};
+    for (
+      dispatch_consumer_scan_offset = 0;
+      dispatch_consumer_scan_offset < CONSUMER_COUNT;
+      dispatch_consumer_scan_offset = dispatch_consumer_scan_offset + 1
+    ) begin
+      dispatch_consumer_scan_index = dispatch_consumer_rr_ptr + dispatch_consumer_scan_offset;
+      if (dispatch_consumer_scan_index >= CONSUMER_COUNT) begin
+        dispatch_consumer_scan_index = dispatch_consumer_scan_index - CONSUMER_COUNT;
+      end
+      case (dispatch_consumer_scan_index)
+{_consumer_dispatch_cases(consumer_count)}
+      endcase
+    end
+  end
+
+  always @(*) begin
+    result_target_valid = 1'b0;
+    result_target_idx = {{{consumer_idx_bits}{{1'b0}}}};
+    for (result_scan_offset = 0; result_scan_offset < CONSUMER_COUNT; result_scan_offset = result_scan_offset + 1) begin
+      result_scan_index = result_rr_ptr + result_scan_offset;
+      if (result_scan_index >= CONSUMER_COUNT) begin
+        result_scan_index = result_scan_index - CONSUMER_COUNT;
+      end
+      case (result_scan_index)
+{_consumer_result_cases(consumer_count)}
+      endcase
+    end
+  end
+
+  always @(*) begin
+{_control_defaults(producer_count, consumer_count, score_width, value_matrix_width)}
+    if (command_fire) begin
+      case (issue_target_idx)
+{_producer_load_cases(producer_count)}
+      endcase
+    end
+    if (dispatch_fire) begin
+      case (dispatch_producer_idx)
+{_producer_pop_cases(producer_count)}
+      endcase
+      case (dispatch_consumer_idx)
+{_consumer_load_cases(producer_count, consumer_count)}
+      endcase
+    end
+    if (result_fire) begin
+      case (result_target_idx)
+{_consumer_pop_cases(consumer_count)}
+      endcase
+    end
+  end
+
+  always @(*) begin
+    result_valid = result_target_valid;
+    result_command_id = 16'h0;
+    result_score_row = {{SCORE_ROW_WIDTH{{1'b0}}}};
+    result_weights = {{WEIGHT_ROW_WIDTH{{1'b0}}}};
+    result_value = {{RESULT_VALUE_WIDTH{{1'b0}}}};
+    if (result_target_valid) begin
+      case (result_target_idx)
+{_result_mux_cases(consumer_count)}
+      endcase
+    end
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      issue_rr_ptr <= {{{producer_idx_bits}{{1'b0}}}};
+      dispatch_producer_rr_ptr <= {{{producer_idx_bits}{{1'b0}}}};
+      dispatch_consumer_rr_ptr <= {{{consumer_idx_bits}{{1'b0}}}};
+      result_rr_ptr <= {{{consumer_idx_bits}{{1'b0}}}};
+      accepted_count <= 32'h0;
+      completed_count <= 32'h0;
+    end else begin
+      if (command_fire) begin
+        accepted_count <= accepted_count + 32'h1;
+        if (issue_target_idx == PRODUCER_COUNT - 1) begin
+          issue_rr_ptr <= {{{producer_idx_bits}{{1'b0}}}};
+        end else begin
+          issue_rr_ptr <= issue_target_idx + 1'b1;
+        end
+      end
+      if (dispatch_fire) begin
+        if (dispatch_producer_idx == PRODUCER_COUNT - 1) begin
+          dispatch_producer_rr_ptr <= {{{producer_idx_bits}{{1'b0}}}};
+        end else begin
+          dispatch_producer_rr_ptr <= dispatch_producer_idx + 1'b1;
+        end
+        if (dispatch_consumer_idx == CONSUMER_COUNT - 1) begin
+          dispatch_consumer_rr_ptr <= {{{consumer_idx_bits}{{1'b0}}}};
+        end else begin
+          dispatch_consumer_rr_ptr <= dispatch_consumer_idx + 1'b1;
+        end
+      end
+      if (result_fire) begin
+        completed_count <= completed_count + 32'h1;
+        if (result_target_idx == CONSUMER_COUNT - 1) begin
+          result_rr_ptr <= {{{consumer_idx_bits}{{1'b0}}}};
+        end else begin
+          result_rr_ptr <= result_target_idx + 1'b1;
+        end
+      end
+    end
+  end
+endmodule
+"""
+
+
+def _producer_issue_cases(producer_count: int) -> str:
+    cases: list[str] = []
+    for idx in range(producer_count):
+        cases.append(
+            f"""        {idx}: begin
+          if (!issue_target_valid && !producer_{idx}_payload_valid) begin
+            issue_target_valid = 1'b1;
+            issue_target_idx = {idx};
+          end
+        end"""
+        )
+    cases.append("        default: begin end")
+    return "\n".join(cases)
+
+
+def _producer_dispatch_cases(producer_count: int) -> str:
+    cases: list[str] = []
+    for idx in range(producer_count):
+        cases.append(
+            f"""        {idx}: begin
+          if (!dispatch_producer_valid && producer_{idx}_payload_valid) begin
+            dispatch_producer_valid = 1'b1;
+            dispatch_producer_idx = {idx};
+          end
+        end"""
+        )
+    cases.append("        default: begin end")
+    return "\n".join(cases)
+
+
+def _consumer_dispatch_cases(consumer_count: int) -> str:
+    cases: list[str] = []
+    for idx in range(consumer_count):
+        cases.append(
+            f"""        {idx}: begin
+          if (!dispatch_consumer_valid && consumer_enable[{idx}] && !consumer_{idx}_result_valid) begin
+            dispatch_consumer_valid = 1'b1;
+            dispatch_consumer_idx = {idx};
+          end
+        end"""
+        )
+    cases.append("        default: begin end")
+    return "\n".join(cases)
+
+
+def _consumer_result_cases(consumer_count: int) -> str:
+    cases: list[str] = []
+    for idx in range(consumer_count):
+        cases.append(
+            f"""        {idx}: begin
+          if (!result_target_valid && consumer_{idx}_result_valid) begin
+            result_target_valid = 1'b1;
+            result_target_idx = {idx};
+          end
+        end"""
+        )
+    cases.append("        default: begin end")
+    return "\n".join(cases)
+
+
+def _control_defaults(
+    producer_count: int,
+    consumer_count: int,
+    score_width: int,
+    value_matrix_width: int,
+) -> str:
+    lines: list[str] = []
+    for idx in range(producer_count):
+        lines.append(f"    producer_{idx}_load_valid = 1'b0;")
+        lines.append(f"    producer_{idx}_pop_valid = 1'b0;")
+    for idx in range(consumer_count):
+        lines.extend(
+            [
+                f"    consumer_{idx}_load_valid = 1'b0;",
+                f"    consumer_{idx}_pop_valid = 1'b0;",
+                f"    consumer_{idx}_load_command_id = 16'h0;",
+                f"    consumer_{idx}_load_score_row = {score_width}'h0;",
+                f"    consumer_{idx}_load_value_matrix = {value_matrix_width}'h0;",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _producer_load_cases(producer_count: int) -> str:
+    cases: list[str] = []
+    for idx in range(producer_count):
+        cases.append(
+            f"""        {idx}: begin
+          producer_{idx}_load_valid = 1'b1;
+        end"""
+        )
+    cases.append("        default: begin end")
+    return "\n".join(cases)
+
+
+def _producer_pop_cases(producer_count: int) -> str:
+    cases: list[str] = []
+    for idx in range(producer_count):
+        cases.append(
+            f"""        {idx}: begin
+          producer_{idx}_pop_valid = 1'b1;
+        end"""
+        )
+    cases.append("        default: begin end")
+    return "\n".join(cases)
+
+
+def _consumer_load_cases(producer_count: int, consumer_count: int) -> str:
+    cases: list[str] = []
+    for c_idx in range(consumer_count):
+        cases.append(
+            f"""        {c_idx}: begin
+          consumer_{c_idx}_load_valid = 1'b1;
+          case (dispatch_producer_idx)
+{_consumer_load_from_producer_cases(producer_count, c_idx)}
+          endcase
+        end"""
+        )
+    cases.append("        default: begin end")
+    return "\n".join(cases)
+
+
+def _consumer_load_from_producer_cases(producer_count: int, c_idx: int) -> str:
+    cases: list[str] = []
+    for p_idx in range(producer_count):
+        cases.append(
+            f"""            {p_idx}: begin
+              consumer_{c_idx}_load_command_id = producer_{p_idx}_payload_command_id;
+              consumer_{c_idx}_load_score_row = producer_{p_idx}_payload_score_row;
+              consumer_{c_idx}_load_value_matrix = producer_{p_idx}_payload_value_matrix;
+            end"""
+        )
+    cases.append("            default: begin end")
+    return "\n".join(cases)
+
+
+def _consumer_pop_cases(consumer_count: int) -> str:
+    cases: list[str] = []
+    for idx in range(consumer_count):
+        cases.append(
+            f"""        {idx}: begin
+          consumer_{idx}_pop_valid = 1'b1;
+        end"""
+        )
+    cases.append("        default: begin end")
+    return "\n".join(cases)
+
+
+def _result_mux_cases(consumer_count: int) -> str:
+    cases: list[str] = []
+    for idx in range(consumer_count):
+        cases.append(
+            f"""        {idx}: begin
+          result_command_id = consumer_{idx}_result_command_id;
+          result_score_row = consumer_{idx}_result_score_row;
+          result_weights = consumer_{idx}_result_weights;
+          result_value = consumer_{idx}_result_value;
+        end"""
+        )
+    cases.append("        default: begin end")
+    return "\n".join(cases)
+
+
+def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> None:
+    top_name = str(cfg["top_name"]).strip()
+    score_width = int(comp["row_elems"]) * int(comp["score_bits"])
+    weight_width = int(comp["row_elems"]) * int(comp["weight_bits"])
+    value_matrix_width = int(comp["row_elems"]) * int(comp["value_dim"]) * 8
+    result_value_width = int(comp["value_dim"]) * 40
+    producer_module = _producer_module(
+        module_name=f"{top_name}_producer",
+        row_elems=int(comp["row_elems"]),
+        head_dim=int(comp["head_dim"]),
+        value_dim=int(comp["value_dim"]),
+        score_bits=int(comp["score_bits"]),
+    )
+    consumer_module = _consumer_module(
+        module_name=f"{top_name}_consumer",
+        row_elems=int(comp["row_elems"]),
+        value_dim=int(comp["value_dim"]),
+        score_bits=int(comp["score_bits"]),
+        weight_bits=int(comp["weight_bits"]),
+        exp_bucket_shift=int(comp["exp_bucket_shift"]),
+    )
+    top_module = _top_module(top_name=top_name, params=comp)
+
+    out_path.mkdir(parents=True, exist_ok=True)
+    (out_path / "top.v").write_text(
+        "\n\n".join([producer_module, consumer_module, top_module]) + "\n",
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "version": 0.1,
+        "generator": "npu/rtlgen/gen_attention_separated_cluster.py",
+        "top_name": top_name,
+        "semantic_profile": SEMANTIC_PROFILE,
+        "producer_count": int(comp["producer_count"]),
+        "consumer_count": int(comp["consumer_count"]),
+        "row_elems": int(comp["row_elems"]),
+        "head_dim": int(comp["head_dim"]),
+        "value_dim": int(comp["value_dim"]),
+        "score_bits": int(comp["score_bits"]),
+        "weight_bits": int(comp["weight_bits"]),
+        "input_frac_bits": int(comp["input_frac_bits"]),
+        "exp_bucket_shift": int(comp["exp_bucket_shift"]),
+        "producer_to_consumer_ratio": f"{int(comp['producer_count'])}:{int(comp['consumer_count'])}",
+        "producer_queue_depth": 1,
+        "consumer_queue_depth": 1,
+        "producer_payload_width": 16 + score_width + value_matrix_width,
+        "consumer_result_width": 16 + score_width + weight_width + result_value_width,
+        "payload_width_bits": {
+            "producer_score_row": score_width,
+            "producer_value_matrix": value_matrix_width,
+            "consumer_weights": weight_width,
+            "consumer_value": result_value_width,
+        },
+        "arbitration": {
+            "command_to_producer": "deterministic round-robin across free producers",
+            "producer_to_consumer": "deterministic round-robin producer scan and enabled-free consumer scan",
+            "consumer_to_result": "deterministic round-robin across valid consumers",
+        },
+        "stage_outputs": {
+            "producer": ["payload_command_id", "payload_score_row", "payload_value_matrix"],
+            "consumer": ["result_command_id", "result_score_row", "result_weights", "result_value"],
+            "top": ["result_command_id", "result_score_row", "result_weights", "result_value"],
+        },
+        "score_contract": {
+            "representation": "8 signed score lanes, each lane is an exact sum of 8 signed q8*k8 products",
+            "softmax": "bucketed exp LUT with exact normalized divide",
+            "value_accumulation": "8 signed q8 value dimensions accumulated with unsigned q16 weights into signed 40-bit sums",
+        },
+    }
+    (out_path / "attention_separated_cluster_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_path / "config.json").write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    cfg = _load_json(Path(args.config))
+    comp = _validate(cfg)
+    _write_top(cfg=cfg, comp=comp, out_path=Path(args.out))
+    print(f"attention-separated-cluster: wrote RTL to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_separated_cluster.py
+++ b/npu/rtlgen/gen_attention_separated_cluster.py
@@ -87,7 +87,9 @@ def _validate(cfg: dict[str, Any]) -> dict[str, Any]:
     return cluster
 
 
-def _producer_module(*, module_name: str, row_elems: int, head_dim: int, value_dim: int, score_bits: int) -> str:
+def _producer_module(
+    *, module_name: str, row_elems: int, head_dim: int, value_dim: int, score_bits: int, score_frac_bits: int
+) -> str:
     score_width = row_elems * score_bits
     value_matrix_width = row_elems * value_dim * 8
     return f"""module {module_name} #(parameter integer PRODUCER_INDEX = 0) (
@@ -109,20 +111,18 @@ def _producer_module(*, module_name: str, row_elems: int, head_dim: int, value_d
   function automatic signed [7:0] derive_q8;
     input [31:0] seed;
     input [15:0] command_id;
-    input integer producer_idx;
     input integer tag;
     input integer lane_a;
     input integer lane_b;
     reg [31:0] mixed;
     begin
       mixed = seed ^ {{16'h0, command_id}};
-      mixed = mixed ^ (producer_idx * 32'h45d9_f3b1);
       mixed = mixed ^ (tag * 32'h119d_e1f3);
       mixed = mixed ^ (lane_a * 32'h344b_5409);
       mixed = mixed ^ (lane_b * 32'h27d4_eb2d);
       mixed = mixed ^ (mixed >> 16);
       mixed = mixed ^ (mixed >> 8);
-      derive_q8 = mixed[7:0];
+      derive_q8 = {{{{4{{mixed[3]}}}}, mixed[3:0]}};
     end
   endfunction
 
@@ -140,12 +140,12 @@ def _producer_module(*, module_name: str, row_elems: int, head_dim: int, value_d
           score_accum = 32'sd0;
           for (dim_idx = 0; dim_idx < {head_dim}; dim_idx = dim_idx + 1) begin
             score_accum = score_accum
-                + $signed(derive_q8(load_seed, load_command_id, PRODUCER_INDEX, 17, 0, dim_idx))
-                * $signed(derive_q8(load_seed, load_command_id, PRODUCER_INDEX, 51, row_idx, dim_idx));
+                + $signed(derive_q8(load_seed, load_command_id, 17, 0, dim_idx))
+                * $signed(derive_q8(load_seed, load_command_id, 51, row_idx, dim_idx));
             payload_value_matrix[(((row_idx * {value_dim}) + dim_idx) * 8) +: 8]
-                <= derive_q8(load_seed, load_command_id, PRODUCER_INDEX, 85, row_idx, dim_idx);
+                <= derive_q8(load_seed, load_command_id, 85, row_idx, dim_idx);
           end
-          payload_score_row[(row_idx * {score_bits}) +: {score_bits}] <= score_accum;
+          payload_score_row[(row_idx * {score_bits}) +: {score_bits}] <= score_accum <<< {score_frac_bits};
         end
       end
       if (pop_valid) begin
@@ -164,15 +164,18 @@ def _consumer_module(
     value_dim: int,
     score_bits: int,
     weight_bits: int,
+    input_frac_bits: int,
     exp_bucket_shift: int,
 ) -> str:
     score_width = row_elems * score_bits
     weight_width = row_elems * weight_bits
     value_matrix_width = row_elems * value_dim * 8
     result_value_width = value_dim * 40
+    max_bucket = 8 << (input_frac_bits - exp_bucket_shift)
+    bucket_scale = float(1 << exp_bucket_shift) / float(1 << input_frac_bits)
     exp_entries = [
-        (bucket, max(1, int(round(math.exp(-float(bucket)) * ((1 << weight_bits) - 1)))))
-        for bucket in range(8)
+        (bucket, max(1, int(math.exp(-(bucket * bucket_scale)) * ((1 << weight_bits) - 1) + 0.5)))
+        for bucket in range(max_bucket + 1)
     ]
     exp_cases = "\n".join(
         f"      32'd{bucket}: exp_lut = 16'd{value};" for bucket, value in exp_entries
@@ -198,7 +201,7 @@ def _consumer_module(
   reg signed [31:0] score_lane;
   reg signed [31:0] delta_score;
   reg [31:0] exp_bucket;
-  reg [31:0] weight_numer;
+  reg [33:0] weight_numer;
   reg [15:0] exp_weight [0:{row_elems - 1}];
   reg [15:0] weight_lane [0:{row_elems - 1}];
   reg signed [7:0] value_lane;
@@ -243,13 +246,17 @@ def _consumer_module(
             delta_score = 32'sd0;
           end
           exp_bucket = delta_score >> {exp_bucket_shift};
+          if (exp_bucket > 32'd{max_bucket}) begin
+            exp_bucket = 32'd{max_bucket};
+          end
           exp_weight[row_idx] = exp_lut(exp_bucket);
           sum_exp = sum_exp + exp_weight[row_idx];
         end
 
         for (row_idx = 0; row_idx < {row_elems}; row_idx = row_idx + 1) begin
           if (sum_exp != 0) begin
-            weight_numer = (exp_weight[row_idx] * 16'd{(1 << weight_bits) - 1}) + (sum_exp >> 1);
+            weight_numer = ({{1'b0, exp_weight[row_idx]}} * 17'd{(1 << weight_bits) - 1})
+                + (sum_exp >> 1);
             weight_lane[row_idx] = weight_numer / sum_exp;
           end else begin
             weight_lane[row_idx] = 16'd0;
@@ -733,6 +740,7 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
         head_dim=int(comp["head_dim"]),
         value_dim=int(comp["value_dim"]),
         score_bits=int(comp["score_bits"]),
+        score_frac_bits=int(comp["exp_bucket_shift"]),
     )
     consumer_module = _consumer_module(
         module_name=f"{top_name}_consumer",
@@ -740,6 +748,7 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
         value_dim=int(comp["value_dim"]),
         score_bits=int(comp["score_bits"]),
         weight_bits=int(comp["weight_bits"]),
+        input_frac_bits=int(comp["input_frac_bits"]),
         exp_bucket_shift=int(comp["exp_bucket_shift"]),
     )
     top_module = _top_module(top_name=top_name, params=comp)
@@ -786,9 +795,14 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
             "top": ["result_command_id", "result_score_row", "result_weights", "result_value"],
         },
         "score_contract": {
-            "representation": "8 signed score lanes, each lane is an exact sum of 8 signed q8*k8 products",
+            "representation": "8 signed Q20 score lanes, each lane is an exact sum of 8 signed q8*k8 products",
             "softmax": "bucketed exp LUT with exact normalized divide",
             "value_accumulation": "8 signed q8 value dimensions accumulated with unsigned q16 weights into signed 40-bit sums",
+        },
+        "ppa_stimulus": {
+            "mode": "seeded_internal_input_expansion",
+            "purpose": "keep all QK and V lanes observable through a narrow registered macro boundary",
+            "cost_caveat": "small seed-mix XOR logic is harness overhead and must be reported separately from MAC/softmax/value scaling",
         },
     }
     (out_path / "attention_separated_cluster_manifest.json").write_text(

--- a/npu/rtlgen/gen_attention_separated_cluster.py
+++ b/npu/rtlgen/gen_attention_separated_cluster.py
@@ -245,7 +245,7 @@ def _consumer_module(
           if (delta_score < 0) begin
             delta_score = 32'sd0;
           end
-          exp_bucket = delta_score >> {exp_bucket_shift};
+          exp_bucket = (delta_score + 32'd{1 << (exp_bucket_shift - 1)}) >> {exp_bucket_shift};
           if (exp_bucket > 32'd{max_bucket}) begin
             exp_bucket = 32'd{max_bucket};
           end
@@ -795,7 +795,7 @@ def _write_top(*, cfg: dict[str, Any], comp: dict[str, Any], out_path: Path) -> 
             "top": ["result_command_id", "result_score_row", "result_weights", "result_value"],
         },
         "score_contract": {
-            "representation": "8 signed Q20 score lanes, each lane is an exact sum of 8 signed q8*k8 products",
+            "representation": "8 signed Q28 score lanes from exact 8-term q8*k8 dot products with fixed 1/256 dequantization scale",
             "softmax": "bucketed exp LUT with exact normalized divide",
             "value_accumulation": "8 signed q8 value dimensions accumulated with unsigned q16 weights into signed 40-bit sums",
         },

--- a/npu/sim/perf/attention_separated.py
+++ b/npu/sim/perf/attention_separated.py
@@ -99,7 +99,10 @@ def _exp_lut(bucket: int) -> int:
 def consumer_result(payload: JsonDict) -> JsonDict:
     scores = [int(value) for value in payload["score_row"]]
     row_max = max(scores)
-    exp_values = [_exp_lut((row_max - score) >> EXP_BUCKET_SHIFT) for score in scores]
+    exp_values = [
+        _exp_lut(((row_max - score) + (1 << (EXP_BUCKET_SHIFT - 1))) >> EXP_BUCKET_SHIFT)
+        for score in scores
+    ]
     exp_sum = sum(exp_values)
     weights = [(value * WEIGHT_SCALE + (exp_sum >> 1)) // exp_sum for value in exp_values]
     value_matrix = payload["value_matrix"]

--- a/npu/sim/perf/attention_separated.py
+++ b/npu/sim/perf/attention_separated.py
@@ -1,0 +1,280 @@
+"""Exact functional and cycle reference for the separated attention cluster."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+from typing import Any
+
+ROW_ELEMS = 8
+HEAD_DIM = 8
+VALUE_DIM = 8
+SCORE_BITS = 32
+WEIGHT_BITS = 16
+VALUE_BITS = 8
+VALUE_ACCUM_BITS = 40
+INPUT_FRAC_BITS = 28
+EXP_BUCKET_SHIFT = 20
+MAX_EXP_BUCKET = 8 << (INPUT_FRAC_BITS - EXP_BUCKET_SHIFT)
+WEIGHT_SCALE = (1 << WEIGHT_BITS) - 1
+
+JsonDict = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AttentionSeparatedCommand:
+    command_id: int
+    seed: int
+
+    def normalized(self) -> "AttentionSeparatedCommand":
+        return AttentionSeparatedCommand(self.command_id & 0xFFFF, self.seed & 0xFFFFFFFF)
+
+
+def default_commands(count: int = 8) -> list[AttentionSeparatedCommand]:
+    return [
+        AttentionSeparatedCommand(
+            command_id=(0x120 + index * 0x17) & 0xFFFF,
+            seed=(0x13579BDF * (index + 1) + 0x2468ACE0) & 0xFFFFFFFF,
+        )
+        for index in range(count)
+    ]
+
+
+def _u32(value: int) -> int:
+    return value & 0xFFFFFFFF
+
+
+def _signed(value: int, bits: int) -> int:
+    value &= (1 << bits) - 1
+    return value - (1 << bits) if value & (1 << (bits - 1)) else value
+
+
+def derive_q8(command: AttentionSeparatedCommand, *, tag: int, lane_a: int, lane_b: int) -> int:
+    command = command.normalized()
+    mixed = _u32(command.seed ^ command.command_id)
+    mixed = _u32(mixed ^ _u32(tag * 0x119DE1F3))
+    mixed = _u32(mixed ^ _u32(lane_a * 0x344B5409))
+    mixed = _u32(mixed ^ _u32(lane_b * 0x27D4EB2D))
+    mixed = _u32(mixed ^ (mixed >> 16))
+    mixed = _u32(mixed ^ (mixed >> 8))
+    return _signed(mixed & 0xF, 4)
+
+
+def command_tensors(command: AttentionSeparatedCommand) -> JsonDict:
+    q = [derive_q8(command, tag=17, lane_a=0, lane_b=dim) for dim in range(HEAD_DIM)]
+    keys = [
+        [derive_q8(command, tag=51, lane_a=row, lane_b=dim) for dim in range(HEAD_DIM)]
+        for row in range(ROW_ELEMS)
+    ]
+    values = [
+        [derive_q8(command, tag=85, lane_a=row, lane_b=dim) for dim in range(VALUE_DIM)]
+        for row in range(ROW_ELEMS)
+    ]
+    return {"q": q, "k": keys, "v": values}
+
+
+def producer_result(command: AttentionSeparatedCommand) -> JsonDict:
+    command = command.normalized()
+    tensors = command_tensors(command)
+    scores = [
+        _signed(sum(q * k for q, k in zip(tensors["q"], key_row)) << EXP_BUCKET_SHIFT, SCORE_BITS)
+        for key_row in tensors["k"]
+    ]
+    return {
+        "command_id": command.command_id,
+        "seed": command.seed,
+        "score_row": scores,
+        "value_matrix": tensors["v"],
+    }
+
+
+def _exp_lut(bucket: int) -> int:
+    bucket = min(max(0, int(bucket)), MAX_EXP_BUCKET)
+    scale = float(1 << EXP_BUCKET_SHIFT) / float(1 << INPUT_FRAC_BITS)
+    return max(1, int(math.exp(-(bucket * scale)) * WEIGHT_SCALE + 0.5))
+
+
+def consumer_result(payload: JsonDict) -> JsonDict:
+    scores = [int(value) for value in payload["score_row"]]
+    row_max = max(scores)
+    exp_values = [_exp_lut((row_max - score) >> EXP_BUCKET_SHIFT) for score in scores]
+    exp_sum = sum(exp_values)
+    weights = [(value * WEIGHT_SCALE + (exp_sum >> 1)) // exp_sum for value in exp_values]
+    value_matrix = payload["value_matrix"]
+    values = [
+        _signed(sum(weights[row] * int(value_matrix[row][dim]) for row in range(ROW_ELEMS)), VALUE_ACCUM_BITS)
+        for dim in range(VALUE_DIM)
+    ]
+    return {
+        "command_id": int(payload["command_id"]),
+        "score_row": scores,
+        "weights": weights,
+        "value": values,
+    }
+
+
+def exact_reference(command: AttentionSeparatedCommand) -> JsonDict:
+    producer = producer_result(command)
+    return {"producer": producer, "consumer": consumer_result(producer)}
+
+
+def scenario_names() -> tuple[str, ...]:
+    return (
+        "always_ready",
+        "intermittent_consumer_stall",
+        "all_consumers_blocked_temporarily",
+        "result_backpressure",
+    )
+
+
+def consumer_enable_mask(scenario: str, *, cycle: int, consumer_count: int) -> int:
+    full = (1 << consumer_count) - 1
+    if scenario in {"always_ready", "result_backpressure"}:
+        return full
+    if scenario == "intermittent_consumer_stall":
+        return sum(1 << idx for idx in range(consumer_count) if (cycle + idx) % 4 != 1)
+    if scenario == "all_consumers_blocked_temporarily":
+        return 0 if 6 <= cycle < 10 else full
+    raise ValueError(f"unknown scenario: {scenario}")
+
+
+def result_ready(scenario: str, *, cycle: int) -> bool:
+    if scenario in {"always_ready", "intermittent_consumer_stall", "all_consumers_blocked_temporarily"}:
+        return True
+    if scenario == "result_backpressure":
+        return not (9 <= cycle < 13 or cycle % 6 == 4)
+    raise ValueError(f"unknown scenario: {scenario}")
+
+
+def _first_rr(valid: list[bool], start: int) -> int | None:
+    for offset in range(len(valid)):
+        index = (start + offset) % len(valid)
+        if valid[index]:
+            return index
+    return None
+
+
+def simulate(
+    commands: list[AttentionSeparatedCommand],
+    *,
+    producer_count: int,
+    consumer_count: int,
+    scenario: str,
+    max_cycles: int = 1000,
+) -> JsonDict:
+    if not 1 <= producer_count <= 8:
+        raise ValueError("producer_count must be in [1, 8]")
+    if not 1 <= consumer_count <= producer_count:
+        raise ValueError("consumer_count must be in [1, producer_count]")
+    if scenario not in scenario_names():
+        raise ValueError(f"unknown scenario: {scenario}")
+
+    producer_slots: list[JsonDict | None] = [None] * producer_count
+    consumer_slots: list[JsonDict | None] = [None] * consumer_count
+    issue_rr = dispatch_producer_rr = dispatch_consumer_rr = result_rr = 0
+    command_index = accepted = completed = 0
+    accept_events: list[JsonDict] = []
+    dispatch_events: list[JsonDict] = []
+    result_events: list[JsonDict] = []
+
+    for cycle in range(max_cycles):
+        if completed == len(commands):
+            break
+        enable = consumer_enable_mask(scenario, cycle=cycle, consumer_count=consumer_count)
+        ready = result_ready(scenario, cycle=cycle)
+        issue_index = _first_rr([slot is None for slot in producer_slots], issue_rr)
+        producer_index = _first_rr([slot is not None for slot in producer_slots], dispatch_producer_rr)
+        consumer_index = _first_rr(
+            [slot is None and bool(enable & (1 << idx)) for idx, slot in enumerate(consumer_slots)],
+            dispatch_consumer_rr,
+        )
+        result_index = _first_rr([slot is not None for slot in consumer_slots], result_rr)
+
+        command_fire = command_index < len(commands) and issue_index is not None
+        dispatch_fire = producer_index is not None and consumer_index is not None
+        result_fire = result_index is not None and ready
+
+        if result_fire:
+            assert result_index is not None
+            result = consumer_slots[result_index]
+            assert result is not None
+            result_events.append({"cycle": cycle, "consumer": result_index, **result})
+            consumer_slots[result_index] = None
+            completed += 1
+            result_rr = (result_index + 1) % consumer_count
+
+        if dispatch_fire:
+            assert producer_index is not None and consumer_index is not None
+            payload = producer_slots[producer_index]
+            assert payload is not None
+            result = consumer_result(payload)
+            dispatch_events.append(
+                {
+                    "cycle": cycle,
+                    "producer": producer_index,
+                    "consumer": consumer_index,
+                    "command_id": payload["command_id"],
+                }
+            )
+            producer_slots[producer_index] = None
+            consumer_slots[consumer_index] = result
+            dispatch_producer_rr = (producer_index + 1) % producer_count
+            dispatch_consumer_rr = (consumer_index + 1) % consumer_count
+
+        if command_fire:
+            assert issue_index is not None
+            command = commands[command_index].normalized()
+            producer_slots[issue_index] = producer_result(command)
+            accept_events.append(
+                {"cycle": cycle, "producer": issue_index, "command_id": command.command_id, "seed": command.seed}
+            )
+            accepted += 1
+            command_index += 1
+            issue_rr = (issue_index + 1) % producer_count
+    else:
+        raise RuntimeError(f"scenario {scenario} exceeded {max_cycles} cycles")
+
+    summary = {
+        "scenario": scenario,
+        "producer_count": producer_count,
+        "consumer_count": consumer_count,
+        "accepted_count": accepted,
+        "completed_count": completed,
+        "accept_events": accept_events,
+        "dispatch_events": dispatch_events,
+        "result_events": result_events,
+        "accepted_order": [event["command_id"] for event in accept_events],
+        "completed_order": [event["command_id"] for event in result_events],
+        "final_cycle": result_events[-1]["cycle"] if result_events else -1,
+    }
+    summary["sha256"] = hashlib.sha256(
+        json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return summary
+
+
+def unpack_signed(packed: int, *, lanes: int, bits: int) -> list[int]:
+    return [_signed(packed >> (lane * bits), bits) for lane in range(lanes)]
+
+
+def unpack_unsigned(packed: int, *, lanes: int, bits: int) -> list[int]:
+    mask = (1 << bits) - 1
+    return [(packed >> (lane * bits)) & mask for lane in range(lanes)]
+
+
+__all__ = [
+    "AttentionSeparatedCommand",
+    "consumer_enable_mask",
+    "consumer_result",
+    "default_commands",
+    "derive_q8",
+    "exact_reference",
+    "producer_result",
+    "result_ready",
+    "scenario_names",
+    "simulate",
+    "unpack_signed",
+    "unpack_unsigned",
+]

--- a/runs/campaigns/npu/attention_separated_cluster_v1/sweeps/nangate45_attention_separated_cluster.json
+++ b/runs/campaigns/npu/attention_separated_cluster_v1/sweeps/nangate45_attention_separated_cluster.json
@@ -1,0 +1,30 @@
+{
+  "flow_params": {
+    "TAG": [
+      "attention_separated_cluster_v1"
+    ],
+    "FLOW_VARIANT": [
+      "attention_separated_cluster_v1"
+    ],
+    "CLOCK_PERIOD": [
+      10
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "tag_prefix": "attention_separated_cluster_v1"
+}

--- a/runs/designs/npu_blocks/attention_separated_cluster_p1_c1/config.json
+++ b/runs/designs/npu_blocks/attention_separated_cluster_p1_c1/config.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.1",
+  "top_name": "attention_separated_cluster_p1_c1",
+  "attention_separated_cluster": {
+    "producer_count": 1,
+    "consumer_count": 1,
+    "row_elems": 8,
+    "head_dim": 8,
+    "value_dim": 8,
+    "score_bits": 32,
+    "weight_bits": 16,
+    "input_frac_bits": 28,
+    "exp_bucket_shift": 20
+  }
+}

--- a/runs/designs/npu_blocks/attention_separated_cluster_p2_c1/config.json
+++ b/runs/designs/npu_blocks/attention_separated_cluster_p2_c1/config.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.1",
+  "top_name": "attention_separated_cluster_p2_c1",
+  "attention_separated_cluster": {
+    "producer_count": 2,
+    "consumer_count": 1,
+    "row_elems": 8,
+    "head_dim": 8,
+    "value_dim": 8,
+    "score_bits": 32,
+    "weight_bits": 16,
+    "input_frac_bits": 28,
+    "exp_bucket_shift": 20
+  }
+}

--- a/runs/designs/npu_blocks/attention_separated_cluster_p4_c1/config.json
+++ b/runs/designs/npu_blocks/attention_separated_cluster_p4_c1/config.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.1",
+  "top_name": "attention_separated_cluster_p4_c1",
+  "attention_separated_cluster": {
+    "producer_count": 4,
+    "consumer_count": 1,
+    "row_elems": 8,
+    "head_dim": 8,
+    "value_dim": 8,
+    "score_bits": 32,
+    "weight_bits": 16,
+    "input_frac_bits": 28,
+    "exp_bucket_shift": 20
+  }
+}

--- a/runs/designs/npu_blocks/attention_separated_cluster_p4_c2/config.json
+++ b/runs/designs/npu_blocks/attention_separated_cluster_p4_c2/config.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.1",
+  "top_name": "attention_separated_cluster_p4_c2",
+  "attention_separated_cluster": {
+    "producer_count": 4,
+    "consumer_count": 2,
+    "row_elems": 8,
+    "head_dim": 8,
+    "value_dim": 8,
+    "score_bits": 32,
+    "weight_bits": 16,
+    "input_frac_bits": 28,
+    "exp_bucket_shift": 20
+  }
+}

--- a/runs/designs/npu_blocks/attention_separated_cluster_p8_c1/config.json
+++ b/runs/designs/npu_blocks/attention_separated_cluster_p8_c1/config.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.1",
+  "top_name": "attention_separated_cluster_p8_c1",
+  "attention_separated_cluster": {
+    "producer_count": 8,
+    "consumer_count": 1,
+    "row_elems": 8,
+    "head_dim": 8,
+    "value_dim": 8,
+    "score_bits": 32,
+    "weight_bits": 16,
+    "input_frac_bits": 28,
+    "exp_bucket_shift": 20
+  }
+}

--- a/runs/designs/npu_blocks/attention_separated_cluster_p8_c2/config.json
+++ b/runs/designs/npu_blocks/attention_separated_cluster_p8_c2/config.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.1",
+  "top_name": "attention_separated_cluster_p8_c2",
+  "attention_separated_cluster": {
+    "producer_count": 8,
+    "consumer_count": 2,
+    "row_elems": 8,
+    "head_dim": 8,
+    "value_dim": 8,
+    "score_bits": 32,
+    "weight_bits": 16,
+    "input_frac_bits": 28,
+    "exp_bucket_shift": 20
+  }
+}

--- a/tests/test_attention_separated_cluster_generator.py
+++ b/tests/test_attention_separated_cluster_generator.py
@@ -120,7 +120,7 @@ def test_attention_separated_cluster_generator_configurations(
         "dispatch_consumer_rr_ptr",
         "result_rr_ptr",
         "exp_lut",
-        "weight_numer = (exp_weight[row_idx] * 16'd65535) + (sum_exp >> 1);",
+        "weight_numer = ({1'b0, exp_weight[row_idx]} * 17'd65535)",
         "accum_lane = accum_lane + ($signed(value_lane) * $signed({1'b0, weight_lane[row_idx]}));",
     ):
         assert token in top_text

--- a/tests/test_attention_separated_cluster_generator.py
+++ b/tests/test_attention_separated_cluster_generator.py
@@ -1,0 +1,175 @@
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_config(config_path: Path, *, producer_count: int, consumer_count: int, **overrides: int) -> None:
+    cluster = {
+        "producer_count": producer_count,
+        "consumer_count": consumer_count,
+        "row_elems": 8,
+        "head_dim": 8,
+        "value_dim": 8,
+        "score_bits": 32,
+        "weight_bits": 16,
+        "input_frac_bits": 28,
+        "exp_bucket_shift": 20,
+    }
+    cluster.update(overrides)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_separated_cluster_smoke",
+                "attention_separated_cluster": cluster,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _generate(design_dir: Path, config_path: Path) -> tuple[str, dict[str, object]]:
+    subprocess.run(
+        [
+            sys.executable,
+            "npu/rtlgen/gen_attention_separated_cluster.py",
+            "--config",
+            str(config_path),
+            "--out",
+            str(design_dir / "verilog"),
+        ],
+        cwd=str(REPO_ROOT),
+        check=True,
+    )
+    top_text = (design_dir / "verilog" / "top.v").read_text(encoding="utf-8")
+    manifest = json.loads(
+        (design_dir / "verilog" / "attention_separated_cluster_manifest.json").read_text(encoding="utf-8")
+    )
+    return top_text, manifest
+
+
+def _maybe_compile_with_iverilog(design_dir: Path) -> None:
+    iverilog = shutil.which("iverilog")
+    if iverilog is None:
+        fallback = Path("/oss-cad-suite/bin/iverilog")
+        if fallback.exists():
+            iverilog = str(fallback)
+    if iverilog is None:
+        return
+    subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-o",
+            str(design_dir / "simv"),
+            str(design_dir / "verilog" / "top.v"),
+        ],
+        cwd=str(REPO_ROOT),
+        check=True,
+    )
+
+
+@pytest.mark.parametrize(("producer_count", "consumer_count"), [(1, 1), (4, 1)])
+def test_attention_separated_cluster_generator_configurations(
+    tmp_path: Path, producer_count: int, consumer_count: int
+) -> None:
+    design_dir = tmp_path / f"attention_separated_cluster_p{producer_count}_c{consumer_count}"
+    config_path = design_dir / "config.json"
+    _write_config(config_path, producer_count=producer_count, consumer_count=consumer_count)
+
+    top_text, manifest = _generate(design_dir, config_path)
+
+    assert manifest["semantic_profile"] == "q8_k8_v8_a32_s32_w16_exp_lut_div_b20"
+    assert manifest["producer_count"] == producer_count
+    assert manifest["consumer_count"] == consumer_count
+    assert manifest["producer_to_consumer_ratio"] == f"{producer_count}:{consumer_count}"
+    assert manifest["producer_queue_depth"] == 1
+    assert manifest["consumer_queue_depth"] == 1
+    assert manifest["producer_payload_width"] == 784
+    assert manifest["consumer_result_width"] == 720
+    assert manifest["stage_outputs"]["top"] == [
+        "result_command_id",
+        "result_score_row",
+        "result_weights",
+        "result_value",
+    ]
+
+    for token in (
+        "command_valid",
+        "command_ready",
+        "command_id",
+        "command_seed",
+        "consumer_enable",
+        "result_valid",
+        "result_score_row",
+        "result_weights",
+        "result_value",
+        "accepted_count",
+        "completed_count",
+        "issue_rr_ptr",
+        "dispatch_producer_rr_ptr",
+        "dispatch_consumer_rr_ptr",
+        "result_rr_ptr",
+        "exp_lut",
+        "weight_numer = (exp_weight[row_idx] * 16'd65535) + (sum_exp >> 1);",
+        "accum_lane = accum_lane + ($signed(value_lane) * $signed({1'b0, weight_lane[row_idx]}));",
+    ):
+        assert token in top_text
+
+    assert "result_hash" not in top_text
+    assert "equivalence_hash" not in top_text
+    assert f"u_producer_{producer_count - 1}" in top_text
+    assert f"u_consumer_{consumer_count - 1}" in top_text
+
+    _maybe_compile_with_iverilog(design_dir)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"producer_count": 0}, "producer_count must be in [1, 8]"),
+        ({"consumer_count": 2, "producer_count": 1}, "consumer_count must be less than or equal to producer_count"),
+        ({"row_elems": 4}, "row_elems must be 8"),
+    ],
+)
+def test_attention_separated_cluster_generator_rejects_invalid_params(
+    tmp_path: Path, overrides: dict[str, int], message: str
+) -> None:
+    design_dir = tmp_path / "attention_separated_cluster_invalid"
+    config_path = design_dir / "config.json"
+    local_overrides = dict(overrides)
+    producer_count = local_overrides.pop("producer_count", 1)
+    consumer_count = local_overrides.pop("consumer_count", 1)
+    _write_config(
+        config_path,
+        producer_count=producer_count,
+        consumer_count=consumer_count,
+        **local_overrides,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/rtlgen/gen_attention_separated_cluster.py",
+            "--config",
+            str(config_path),
+            "--out",
+            str(design_dir / "verilog"),
+        ],
+        cwd=str(REPO_ROOT),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert message in (result.stderr + result.stdout)

--- a/tests/test_attention_separated_cluster_guard.py
+++ b/tests/test_attention_separated_cluster_guard.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_attention_separated_cluster_guard_accepts_semantic_rtl(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_separated_cluster_p4_c1"
+    config = {
+        "top_name": "attention_separated_cluster_p4_c1",
+        "attention_separated_cluster": {
+            "producer_count": 4,
+            "consumer_count": 1,
+            "row_elems": 8,
+            "head_dim": 8,
+            "value_dim": 8,
+            "score_bits": 32,
+            "weight_bits": 16,
+            "input_frac_bits": 28,
+            "exp_bucket_shift": 20,
+        },
+    }
+    design_dir.mkdir()
+    (design_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    subprocess.run(
+        [
+            sys.executable,
+            "npu/rtlgen/gen_attention_separated_cluster.py",
+            "--config",
+            str(design_dir / "config.json"),
+            "--out",
+            str(design_dir / "verilog"),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_separated_cluster_guard.py",
+            "--design-dir",
+            str(design_dir),
+        ],
+        check=True,
+    )
+
+
+def test_attention_separated_cluster_guard_rejects_hash_proxy(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_separated_cluster_p1_c1"
+    config = {
+        "top_name": "attention_separated_cluster_p1_c1",
+        "attention_separated_cluster": {
+            "producer_count": 1,
+            "consumer_count": 1,
+            "row_elems": 8,
+            "head_dim": 8,
+            "value_dim": 8,
+            "score_bits": 32,
+            "weight_bits": 16,
+            "input_frac_bits": 28,
+            "exp_bucket_shift": 20,
+        },
+    }
+    design_dir.mkdir()
+    (design_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    subprocess.run(
+        [
+            sys.executable,
+            "npu/rtlgen/gen_attention_separated_cluster.py",
+            "--config",
+            str(design_dir / "config.json"),
+            "--out",
+            str(design_dir / "verilog"),
+        ],
+        check=True,
+    )
+    with (design_dir / "verilog" / "top.v").open("a", encoding="utf-8") as handle:
+        handle.write("\n// result_hash proxy\n")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_separated_cluster_guard.py",
+            "--design-dir",
+            str(design_dir),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "forbidden proxy token" in result.stderr

--- a/tests/test_attention_separated_equivalence.py
+++ b/tests/test_attention_separated_equivalence.py
@@ -45,10 +45,13 @@ def test_attention_separated_perf_scheduler_preserves_commands_under_backpressur
     assert result["completed_order"] == expected_order
 
 
-def test_attention_separated_rtl_matches_perf_for_one_to_one_and_four_to_one() -> None:
-    report = build_report(ratios=[(1, 1), (4, 1), (4, 2), (8, 2)], command_count=8)
+def test_attention_separated_rtl_matches_perf_for_physical_sweep() -> None:
+    report = build_report(
+        ratios=[(1, 1), (2, 1), (4, 1), (8, 1), (4, 2), (8, 2)],
+        command_count=8,
+    )
 
     assert report["decision"] == "attention_separated_cluster_equivalence_pass"
     assert report["equivalence_pass"] is True
-    assert len(report["rows"]) == 16
+    assert len(report["rows"]) == 24
     assert all(row["equivalence_pass"] for row in report["rows"])

--- a/tests/test_attention_separated_equivalence.py
+++ b/tests/test_attention_separated_equivalence.py
@@ -1,0 +1,39 @@
+from npu.eval.probe_attention_separated_equivalence import build_report
+from npu.sim.perf.attention_separated import default_commands, exact_reference, simulate
+
+
+def test_attention_separated_reference_is_deterministic_and_semantic() -> None:
+    command = default_commands(1)[0]
+    first = exact_reference(command)
+    second = exact_reference(command)
+
+    assert first == second
+    assert len(first["consumer"]["score_row"]) == 8
+    assert len(first["consumer"]["weights"]) == 8
+    assert len(first["consumer"]["value"]) == 8
+    assert sum(first["consumer"]["weights"]) in range(65531, 65540)
+
+
+def test_attention_separated_perf_scheduler_preserves_commands_under_backpressure() -> None:
+    commands = default_commands(8)
+    result = simulate(
+        commands,
+        producer_count=4,
+        consumer_count=1,
+        scenario="result_backpressure",
+    )
+
+    expected_order = [command.command_id for command in commands]
+    assert result["accepted_count"] == 8
+    assert result["completed_count"] == 8
+    assert result["accepted_order"] == expected_order
+    assert result["completed_order"] == expected_order
+
+
+def test_attention_separated_rtl_matches_perf_for_one_to_one_and_four_to_one() -> None:
+    report = build_report(ratios=[(1, 1), (4, 1), (4, 2), (8, 2)], command_count=8)
+
+    assert report["decision"] == "attention_separated_cluster_equivalence_pass"
+    assert report["equivalence_pass"] is True
+    assert len(report["rows"]) == 16
+    assert all(row["equivalence_pass"] for row in report["rows"])

--- a/tests/test_attention_separated_equivalence.py
+++ b/tests/test_attention_separated_equivalence.py
@@ -1,4 +1,5 @@
 from npu.eval.probe_attention_separated_equivalence import build_report
+from npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention import _exp_lut_div_softmax
 from npu.sim.perf.attention_separated import default_commands, exact_reference, simulate
 
 
@@ -12,6 +13,20 @@ def test_attention_separated_reference_is_deterministic_and_semantic() -> None:
     assert len(first["consumer"]["weights"]) == 8
     assert len(first["consumer"]["value"]) == 8
     assert sum(first["consumer"]["weights"]) in range(65531, 65540)
+
+
+def test_attention_separated_softmax_matches_quality_model_profile() -> None:
+    reference = exact_reference(default_commands(1)[0])["consumer"]
+    logits = [score / float(1 << 28) for score in reference["score_row"]]
+    quality_probs = _exp_lut_div_softmax(
+        logits,
+        score_bits=32,
+        weight_bits=16,
+        bucket_shift=20,
+        input_frac_bits=28,
+    )
+
+    assert reference["weights"] == [round(probability * 65535) for probability in quality_probs]
 
 
 def test_attention_separated_perf_scheduler_preserves_commands_under_backpressure() -> None:


### PR DESCRIPTION
## Summary

- add a bounded separated attention cluster with independently parameterized QK/V producers and score32 exp-LUT/div consumers
- expose complete score rows, Q16 softmax weights, and signed weighted-V vectors as semantic outputs
- prove exact perf-model/RTL values and ready/valid behavior across six producer/consumer ratios and four backpressure scenarios
- add control-plane L1 PPA and L2 equivalence task support for the six physical configurations
- document the semantic-equivalence rule that prevents hash-only proxy promotion

## Scope

This PR closes functional and flow-control equivalence for the bounded 8x8 tile. It intentionally does not claim full Llama7B performance closure; producer arrival statistics, full schedule scaling, and measured PPA recost remain follow-up evaluation work.

## Validation

- `14 passed, 298 deselected` focused RTL/perf/control-plane tests
- `tests/test_eval_campaign_tools.py`: 13 passed
- `tests/test_run_campaign_mapper_notes.py`: 6 passed
- `scripts/validate_runs.py --skip_eval_queue`: passed
- `git diff --check origin/master...HEAD`: passed