### PR TITLE
npu: make separated equivalence probe executable

### DIFF
--- a/npu/eval/probe_attention_separated_equivalence.py
+++ b/npu/eval/probe_attention_separated_equivalence.py
@@ -9,8 +9,13 @@ from pathlib import Path
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 from npu.rtlgen.gen_attention_separated_cluster import _validate, _write_top
 from npu.sim.perf.attention_separated import (

--- a/tests/test_attention_separated_equivalence.py
+++ b/tests/test_attention_separated_equivalence.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+import subprocess
+import sys
+
 from npu.eval.probe_attention_separated_equivalence import build_report
 from npu.eval.evaluate_llm_decoder_model_native_mixed_int8_attention import _exp_lut_div_softmax
 from npu.sim.perf.attention_separated import default_commands, exact_reference, simulate
@@ -55,3 +59,25 @@ def test_attention_separated_rtl_matches_perf_for_physical_sweep() -> None:
     assert report["equivalence_pass"] is True
     assert len(report["rows"]) == 24
     assert all(row["equivalence_pass"] for row in report["rows"])
+
+
+def test_attention_separated_probe_runs_directly_without_pythonpath(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/probe_attention_separated_equivalence.py",
+            "--ratios",
+            "1:1",
+            "--command-count",
+            "1",
+            "--out",
+            str(tmp_path / "equivalence.json"),
+            "--out-md",
+            str(tmp_path / "equivalence.md"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr


### PR DESCRIPTION
## Summary

- bootstrap the repository root before importing `npu.*` modules in the separated-attention equivalence CLI
- add a subprocess regression test that invokes the exact direct-script form used by evaluator jobs without `PYTHONPATH`

## Root cause

The initial remote equivalence item failed before simulation because direct script execution placed `npu/eval` rather than the repository root on `sys.path`. Pytest used `PYTHONPATH=.` and therefore masked the packaging error.

## Validation

- direct `python3 npu/eval/probe_attention_separated_equivalence.py` invocation: passed
- `tests/test_attention_separated_equivalence.py`: 5 passed
- `git diff --check`: passed