### PR TITLE
npu: select scalable hierarchical softmax

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -591,6 +591,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_separated_cluster_equivalence_report",
     ),
     (
+        "attention_hierarchical_softmax_architecture_out",
+        "attention_hierarchical_softmax_architecture_report",
+    ),
+    (
         "attention_score32_exp_lut_sram_hierarchy_envelope_out",
         "attention_score32_exp_lut_sram_hierarchy_envelope_report",
     ),
@@ -1517,6 +1521,25 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "scenarios",
             "gates",
             "remaining_abstractions",
+            "next_step",
+        ):
+            if key in evidence_payload:
+                parts.append(f"{key}={evidence_payload.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "attention_hierarchical_softmax_architecture_probe_v1":
+        outcome = str(evidence_payload.get("decision") or "hierarchical_softmax_architecture_recorded")
+        parts = [
+            f"Hierarchical attention composition evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "online_pass",
+            "online_error_bound_q16",
+            "lengths",
+            "distributions",
+            "llama7b_score_buffer",
+            "width_bounds",
             "next_step",
         ):
             if key in evidence_payload:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6235,6 +6235,35 @@ def _decoder_attention_separated_cluster_equivalence_evidence(*, item_id: str) -
     }
 
 
+def _decoder_attention_hierarchical_softmax_architecture_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_hierarchical_softmax_architecture__{item_id}.json"
+    report = f"{base}/decoder_attention_hierarchical_softmax_architecture__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_hierarchical_softmax_architecture_out": out,
+            "attention_hierarchical_softmax_architecture_report": report,
+            "attention_hierarchical_softmax_architecture_scope": (
+                "Stress scalable score32 attention composition at 128, 4096, and 131072 tokens across normal, "
+                "wide, and monotonic-max score distributions. Compare streaming and balanced online merges "
+                "against an exact two-pass global-max/score-replay reference."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_attention_hierarchical_softmax_architecture",
+                "run": (
+                    "python3 npu/eval/probe_attention_hierarchical_softmax.py "
+                    "--lengths 128,4096,131072 "
+                    f"--out {out} --out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__{item_id}.json"
@@ -9751,6 +9780,7 @@ def _build_payload(
         "decoder_attention_score32_compute_activity_energy",
         "decoder_attention_score32_separated_compute_recost",
         "decoder_attention_separated_cluster_equivalence",
+        "decoder_attention_hierarchical_softmax_architecture",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -9969,6 +9999,8 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_separated_cluster_equivalence":
             decoder_evidence = _decoder_attention_separated_cluster_equivalence_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_hierarchical_softmax_architecture":
+            decoder_evidence = _decoder_attention_hierarchical_softmax_architecture_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -6096,6 +6096,90 @@ def test_consume_l2_result_attention_separated_cluster_equivalence_uses_decoder_
             assert decision_payload["source_refs"]["decoder_attention_separated_cluster_equivalence_out"] == evidence_rel
 
 
+def test_consume_l2_result_hierarchical_softmax_architecture_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = repo_root / "docs" / "proposals" / "prop_hierarchical_softmax_v1"
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_hierarchical_softmax_v1",
+                        "kind": "architecture",
+                        "title": "Hierarchical softmax",
+                        "direct_comparison": {"primary_question": "Which composition is scalable?"},
+                    }
+                ),
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_hierarchical_softmax_architecture__item.json"
+            )
+            report_rel = evidence_rel.removesuffix(".json") + ".md"
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "attention_hierarchical_softmax_architecture_probe_v1",
+                        "decision": "two_pass_exact_selected",
+                        "online_pass": False,
+                        "online_error_bound_q16": 655,
+                        "lengths": [128, 4096, 131072],
+                        "distributions": ["normal_std1", "normal_std4", "monotonic_ramp16"],
+                        "llama7b_score_buffer": {"mib": 16, "fits_current_shared_sram": True},
+                        "width_bounds": {"exp_sum_bits": 33, "weighted_numerator_bits": 41},
+                        "next_step": "Implement exact two-pass RTL.",
+                    }
+                ),
+            )
+            _write(repo_root / report_rel, "# hierarchy\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="item",
+                campaign_dir_rel="runs/campaigns/npu/attention_hierarchical_softmax",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,attention,flat_nomacro,1,0.1,0.1,1,1,1,1\n"
+                ),
+                proposal_path="docs/proposals/prop_hierarchical_softmax_v1",
+                comparison={"role": "hierarchical_composition_gate"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_hierarchical_softmax_architecture"
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "attention_hierarchical_softmax_architecture_out": evidence_rel,
+                    "attention_hierarchical_softmax_architecture_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / "item.json").read_text()
+            )
+            assessment = decision_payload["proposal_assessment"]
+            assert assessment["outcome"] == "two_pass_exact_selected"
+            assert "online_pass=False" in assessment["summary"]
+            assert "fits_current_shared_sram" in assessment["summary"]
+            assert (
+                decision_payload["source_refs"]["decoder_attention_hierarchical_softmax_architecture_out"]
+                == evidence_rel
+            )
+
+
 def test_consume_l2_result_score32_exp_lut_sram_hierarchy_envelope_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7305,6 +7305,48 @@ def test_generate_l2_campaign_task_adds_attention_separated_cluster_equivalence(
             ]
 
 
+def test_generate_l2_campaign_task_adds_attention_hierarchical_softmax_architecture() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_hierarchical_softmax_architecture_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_hierarchical_softmax_architecture",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "probe_attention_hierarchical_softmax_architecture",
+                "validate_runs",
+            ]
+            assert "probe_attention_hierarchical_softmax.py" in work_item.command_manifest[0]["run"]
+            assert "--lengths 128,4096,131072" in work_item.command_manifest[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert decoder_inputs["attention_hierarchical_softmax_architecture_out"].endswith(
+                "decoder_attention_hierarchical_softmax_architecture__"
+                "l2_decoder_attention_hierarchical_softmax_architecture_llama7b_v1.json"
+            )
+            assert work_item.expected_outputs == [
+                decoder_inputs["attention_hierarchical_softmax_architecture_out"],
+                decoder_inputs["attention_hierarchical_softmax_architecture_report"],
+            ]
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy_envelope_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/README.md
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/README.md
@@ -1,0 +1,5 @@
+# Hierarchical Softmax Frontier
+
+This proposal removes the assumption that independently normalized 8-token attention blocks can be composed into a Llama7B context row.
+
+The first gate compares one-pass online merges with an exact two-pass global-max/score-replay reference at the full 131072-token target. The selected architecture must then expose real score-buffer, max-reduction, exponent accumulation, weighted-value accumulation, final division, and ready/valid behavior in RTL before full-model recost.

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,43 @@
+{
+  "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+  "source_commit_note": "Dispatch the architecture probe after implementation merge; keep scalable RTL equivalence blocked until its implementation is merged.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_hierarchical_softmax_architecture_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Stress long-context hierarchical score32 attention composition and select the scalable arithmetic architecture.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_hierarchical_softmax_architecture",
+      "comparison_role": "hierarchical_composition_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "select_scalable_softmax_composition",
+        "reason": "Do not extrapolate locally normalized 8-token outputs into a full Llama7B row."
+      },
+      "status": "pending"
+    },
+    {
+      "item_id": "l2_decoder_attention_two_pass_global_max_rtl_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove score-buffer, global-max, exp-sum, weighted-numerator, final-divider, and backpressure equivalence for the selected scalable architecture.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_two_pass_global_max_equivalence",
+      "comparison_role": "semantic_equivalence_gate",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_hierarchical_softmax_architecture_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_two_pass_attention_equivalence",
+        "reason": "Full-model PPA recost remains ineligible until the scalable normalization path is embodied and exact."
+      },
+      "status": "blocked_on_implementation"
+    }
+  ]
+}

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
@@ -1,0 +1,79 @@
+{
+  "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+  "created_utc": "2026-07-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Scalable exact hierarchical softmax for Llama7B",
+  "abstraction_layer": "decoder_attention_hierarchical_softmax_architecture",
+  "hypothesis": "The quality-approved score32 exp-LUT attention path requires either a precision-qualified online max-rescale merge or a two-pass global-max/score-replay datapath; locally normalized 8-token values are not compositionally valid at 131072 tokens.",
+  "direct_comparison": {
+    "primary_question": "Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?",
+    "baseline": "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1",
+    "include": [
+      "131072-token context",
+      "32 attention heads",
+      "score32 Q28 inputs",
+      "q16 exp-LUT values",
+      "streaming and balanced online max-rescale merges",
+      "two-pass global-max score replay",
+      "signed weighted-V accumulation",
+      "explicit score-buffer capacity"
+    ],
+    "exclude": [
+      "HBM vendor-current signoff",
+      "full-die clock and reset distribution"
+    ],
+    "metrics": [
+      "max_abs_value_error_q16",
+      "exp_sum_relative_error",
+      "score_buffer_bytes",
+      "required_accumulator_bits",
+      "arithmetic_exactness"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_hierarchical_softmax_architecture_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Stress long-context hierarchical score32 attention composition and select the scalable arithmetic architecture.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_hierarchical_softmax_architecture",
+      "comparison_role": "hierarchical_composition_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_separated_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "select_scalable_softmax_composition",
+        "reason": "Do not extrapolate locally normalized 8-token outputs into a full Llama7B row."
+      },
+      "status": "pending"
+    },
+    {
+      "item_id": "l2_decoder_attention_two_pass_global_max_rtl_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove score-buffer, global-max, exp-sum, weighted-numerator, final-divider, and backpressure equivalence for the selected scalable architecture.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_two_pass_global_max_equivalence",
+      "comparison_role": "semantic_equivalence_gate",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_hierarchical_softmax_architecture_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_two_pass_attention_equivalence",
+        "reason": "Full-model PPA recost remains ineligible until the scalable normalization path is embodied and exact."
+      },
+      "status": "blocked_on_implementation"
+    }
+  ],
+  "remaining_abstractions_after_this_step": [
+    "The selected two-pass datapath still requires RTL and PPA measurement.",
+    "The score buffer must be mapped to measured SRAM ports and scheduled with QK and V traffic.",
+    "The resulting arithmetic profile requires model-native Llama quality evaluation before promotion."
+  ]
+}

--- a/npu/eval/probe_attention_hierarchical_softmax.py
+++ b/npu/eval/probe_attention_hierarchical_softmax.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Compare scalable online and two-pass score32 attention composition."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import random
+import sys
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.sim.perf.attention_online import (
+    block_stats,
+    finalize_value,
+    merge_balanced,
+    merge_sequence,
+    score_buffer_bytes,
+    two_pass_stats,
+    width_bounds,
+)
+from npu.sim.perf.attention_separated import ROW_ELEMS, VALUE_DIM
+
+JsonDict = dict[str, Any]
+
+
+def _scores(*, length: int, distribution: str, seed: int) -> list[int]:
+    rng = random.Random(seed)
+    scale = 1 << 28
+    if distribution == "normal_std1":
+        return [round(rng.gauss(0.0, 1.0) * scale) for _ in range(length)]
+    if distribution == "normal_std4":
+        return [round(rng.gauss(0.0, 4.0) * scale) for _ in range(length)]
+    if distribution == "monotonic_ramp16":
+        return [round((-8.0 + 16.0 * index / max(1, length - 1)) * scale) for index in range(length)]
+    raise ValueError(f"unknown distribution: {distribution}")
+
+
+def _values(*, length: int, seed: int) -> list[list[int]]:
+    rng = random.Random(seed ^ 0x5A17C9E3)
+    return [[rng.randint(-128, 127) for _ in range(VALUE_DIM)] for _ in range(length)]
+
+
+def _blocks(scores: list[int], values: list[list[int]]) -> tuple[list[list[int]], list[list[list[int]]]]:
+    if len(scores) % ROW_ELEMS:
+        raise ValueError(f"length must be divisible by {ROW_ELEMS}")
+    return (
+        [scores[index : index + ROW_ELEMS] for index in range(0, len(scores), ROW_ELEMS)],
+        [values[index : index + ROW_ELEMS] for index in range(0, len(values), ROW_ELEMS)],
+    )
+
+
+def _error(candidate, reference) -> JsonDict:
+    candidate_value = finalize_value(candidate)
+    reference_value = finalize_value(reference)
+    errors = [abs(left - right) for left, right in zip(candidate_value, reference_value)]
+    return {
+        "exp_sum_relative_error": abs(candidate.exp_sum - reference.exp_sum) / max(1, reference.exp_sum),
+        "max_abs_value_error_q16": max(errors),
+        "mean_abs_value_error_q16": sum(errors) / len(errors),
+        "max_abs_value_error": max(errors) / 65535.0,
+    }
+
+
+def build_report(*, lengths: list[int], distributions: list[str], seed: int) -> JsonDict:
+    rows: list[JsonDict] = []
+    for length in lengths:
+        for distribution in distributions:
+            scores = _scores(length=length, distribution=distribution, seed=seed)
+            values = _values(length=length, seed=seed)
+            score_blocks, value_blocks = _blocks(scores, values)
+            leaves = [
+                block_stats(score_row, value_matrix)
+                for score_row, value_matrix in zip(score_blocks, value_blocks)
+            ]
+            reference = two_pass_stats(score_blocks, value_blocks)
+            for architecture, candidate in (
+                ("online_streaming", merge_sequence(leaves)),
+                ("online_balanced", merge_balanced(leaves)),
+            ):
+                error = _error(candidate, reference)
+                rows.append(
+                    {
+                        "length": length,
+                        "distribution": distribution,
+                        "architecture": architecture,
+                        "block_count": len(leaves),
+                        "passes": 1,
+                        "score_buffer_bytes_32_heads": 0,
+                        "arithmetic_exact_vs_two_pass": all(value == 0 for value in error.values()),
+                        **error,
+                    }
+                )
+            rows.append(
+                {
+                    "length": length,
+                    "distribution": distribution,
+                    "architecture": "two_pass_global_max",
+                    "block_count": len(leaves),
+                    "passes": 2,
+                    "score_buffer_bytes_32_heads": score_buffer_bytes(
+                        context_tokens=length, attention_heads=32, score_bits=32
+                    ),
+                    "arithmetic_exact_vs_two_pass": True,
+                    "exp_sum_relative_error": 0.0,
+                    "max_abs_value_error_q16": 0,
+                    "mean_abs_value_error_q16": 0.0,
+                    "max_abs_value_error": 0.0,
+                }
+            )
+
+    online_rows = [row for row in rows if str(row["architecture"]).startswith("online_")]
+    online_error_bound_q16 = 655
+    online_pass = bool(online_rows) and all(
+        int(row["max_abs_value_error_q16"]) <= online_error_bound_q16 for row in online_rows
+    )
+    return {
+        "version": 1,
+        "model": "attention_hierarchical_softmax_architecture_probe_v1",
+        "decision": "online_candidate_retained" if online_pass else "two_pass_exact_selected",
+        "seed": seed,
+        "lengths": lengths,
+        "distributions": distributions,
+        "online_error_bound_q16": online_error_bound_q16,
+        "online_pass": online_pass,
+        "width_bounds": width_bounds(),
+        "llama7b_score_buffer": {
+            "bytes": score_buffer_bytes(context_tokens=131072, attention_heads=32, score_bits=32),
+            "mib": score_buffer_bytes(context_tokens=131072, attention_heads=32, score_bits=32) / (1024 * 1024),
+            "current_shared_sram_mib": 68,
+            "fits_current_shared_sram": True,
+        },
+        "rows": rows,
+        "next_step": (
+            "Implement and quality-test both online and two-pass RTL."
+            if online_pass
+            else "Implement the two-pass global-max/score-replay datapath and retain online merge only as an approximate comparison."
+        ),
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    lines = [
+        "# Hierarchical Attention Composition Probe",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- online pass: `{payload['online_pass']}`",
+        f"- Llama7B score buffer MiB: `{payload['llama7b_score_buffer']['mib']}`",
+        "",
+        "| length | distribution | architecture | max value error q16 | exp-sum relative error |",
+        "|---:|---|---|---:|---:|",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            f"| {row['length']} | {row['distribution']} | {row['architecture']} | "
+            f"{row['max_abs_value_error_q16']} | {row['exp_sum_relative_error']:.9g} |"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _int_list(value: str) -> list[int]:
+    values = [int(item) for item in value.split(",") if item.strip()]
+    if not values or any(item <= 0 or item % ROW_ELEMS for item in values):
+        raise argparse.ArgumentTypeError(f"lengths must be positive multiples of {ROW_ELEMS}")
+    return values
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lengths", type=_int_list, default=[128, 4096, 131072])
+    parser.add_argument("--distributions", default="normal_std1,normal_std4,monotonic_ramp16")
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        lengths=args.lengths,
+        distributions=[item for item in args.distributions.split(",") if item],
+        seed=args.seed,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"decision": payload["decision"], "online_pass": payload["online_pass"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/perf/attention_online.py
+++ b/npu/sim/perf/attention_online.py
@@ -1,0 +1,257 @@
+"""Fixed-point online-softmax composition for scalable separated attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Iterable
+
+from npu.sim.perf.attention_separated import (
+    EXP_BUCKET_SHIFT,
+    MAX_EXP_BUCKET,
+    ROW_ELEMS,
+    VALUE_DIM,
+    WEIGHT_SCALE,
+    _exp_lut,
+)
+
+MAX_CONTEXT_TOKENS = 131072
+MAX_BLOCK_COUNT = MAX_CONTEXT_TOKENS // ROW_ELEMS
+EXP_SUM_BITS = 33
+WEIGHTED_NUMERATOR_BITS = 41
+FINAL_VALUE_BITS = 40
+MERGE_SCALE_BITS = 24
+MERGE_SCALE = (1 << MERGE_SCALE_BITS) - 1
+
+
+@dataclass(frozen=True)
+class AttentionOnlineStats:
+    max_score: int
+    exp_sum: int
+    weighted_numerator: tuple[int, ...]
+    block_count: int
+
+    def __post_init__(self) -> None:
+        if len(self.weighted_numerator) != VALUE_DIM:
+            raise ValueError(f"weighted_numerator must have {VALUE_DIM} lanes")
+        if not 1 <= self.block_count <= MAX_BLOCK_COUNT:
+            raise ValueError(f"block_count must be in [1, {MAX_BLOCK_COUNT}]")
+        if not 0 <= self.exp_sum < (1 << EXP_SUM_BITS):
+            raise ValueError(f"exp_sum does not fit {EXP_SUM_BITS} bits")
+        limit = 1 << (WEIGHTED_NUMERATOR_BITS - 1)
+        if any(not -limit <= value < limit for value in self.weighted_numerator):
+            raise ValueError(f"weighted numerator does not fit {WEIGHTED_NUMERATOR_BITS} signed bits")
+
+
+def _bucket(delta: int) -> int:
+    return max(0, (int(delta) + (1 << (EXP_BUCKET_SHIFT - 1))) >> EXP_BUCKET_SHIFT)
+
+
+def _online_exp_lut(bucket: int, *, output_scale: int = WEIGHT_SCALE) -> int:
+    if bucket > MAX_EXP_BUCKET:
+        return 0
+    if output_scale == WEIGHT_SCALE:
+        return _exp_lut(bucket)
+    step = float(1 << EXP_BUCKET_SHIFT) / float(1 << 28)
+    return max(1, int(math.exp(-(bucket * step)) * output_scale + 0.5))
+
+
+def _round_div_signed(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        raise ValueError("denominator must be positive")
+    magnitude = (abs(numerator) + denominator // 2) // denominator
+    return -magnitude if numerator < 0 else magnitude
+
+
+def _scale_unsigned(value: int, scale: int, *, scale_one: int) -> int:
+    return (int(value) * int(scale) + scale_one // 2) // scale_one
+
+
+def _scale_signed(value: int, scale: int, *, scale_one: int) -> int:
+    return _round_div_signed(int(value) * int(scale), scale_one)
+
+
+def block_stats(score_row: Iterable[int], value_matrix: Iterable[Iterable[int]]) -> AttentionOnlineStats:
+    scores = [int(value) for value in score_row]
+    values = [[int(value) for value in row] for row in value_matrix]
+    if len(scores) != ROW_ELEMS or len(values) != ROW_ELEMS:
+        raise ValueError(f"block must contain {ROW_ELEMS} score/value rows")
+    if any(len(row) != VALUE_DIM for row in values):
+        raise ValueError(f"each value row must contain {VALUE_DIM} lanes")
+
+    maximum = max(scores)
+    exponents = [_online_exp_lut(_bucket(maximum - score)) for score in scores]
+    numerators = tuple(
+        sum(exponents[row] * values[row][lane] for row in range(ROW_ELEMS))
+        for lane in range(VALUE_DIM)
+    )
+    return AttentionOnlineStats(
+        max_score=maximum,
+        exp_sum=sum(exponents),
+        weighted_numerator=numerators,
+        block_count=1,
+    )
+
+
+def block_stats_with_global_max(
+    score_row: Iterable[int],
+    value_matrix: Iterable[Iterable[int]],
+    *,
+    global_max: int,
+) -> AttentionOnlineStats:
+    scores = [int(value) for value in score_row]
+    values = [[int(value) for value in row] for row in value_matrix]
+    if len(scores) != ROW_ELEMS or len(values) != ROW_ELEMS:
+        raise ValueError(f"block must contain {ROW_ELEMS} score/value rows")
+    if any(len(row) != VALUE_DIM for row in values):
+        raise ValueError(f"each value row must contain {VALUE_DIM} lanes")
+    if any(score > global_max for score in scores):
+        raise ValueError("global_max must cover every score")
+    exponents = [_online_exp_lut(_bucket(global_max - score)) for score in scores]
+    return AttentionOnlineStats(
+        max_score=global_max,
+        exp_sum=sum(exponents),
+        weighted_numerator=tuple(
+            sum(exponents[row] * values[row][lane] for row in range(ROW_ELEMS))
+            for lane in range(VALUE_DIM)
+        ),
+        block_count=1,
+    )
+
+
+def merge_stats(left: AttentionOnlineStats, right: AttentionOnlineStats) -> AttentionOnlineStats:
+    block_count = left.block_count + right.block_count
+    if block_count > MAX_BLOCK_COUNT:
+        raise ValueError(f"merged block_count exceeds {MAX_BLOCK_COUNT}")
+    maximum = max(left.max_score, right.max_score)
+    left_scale = _online_exp_lut(_bucket(maximum - left.max_score), output_scale=MERGE_SCALE)
+    right_scale = _online_exp_lut(_bucket(maximum - right.max_score), output_scale=MERGE_SCALE)
+    exp_sum = _scale_unsigned(left.exp_sum, left_scale, scale_one=MERGE_SCALE) + _scale_unsigned(
+        right.exp_sum, right_scale, scale_one=MERGE_SCALE
+    )
+    numerators = tuple(
+        _scale_signed(left.weighted_numerator[lane], left_scale, scale_one=MERGE_SCALE)
+        + _scale_signed(right.weighted_numerator[lane], right_scale, scale_one=MERGE_SCALE)
+        for lane in range(VALUE_DIM)
+    )
+    return AttentionOnlineStats(
+        max_score=maximum,
+        exp_sum=exp_sum,
+        weighted_numerator=numerators,
+        block_count=block_count,
+    )
+
+
+def merge_sequence(blocks: Iterable[AttentionOnlineStats]) -> AttentionOnlineStats:
+    iterator = iter(blocks)
+    try:
+        merged = next(iterator)
+    except StopIteration as exc:
+        raise ValueError("expected at least one block") from exc
+    for block in iterator:
+        merged = merge_stats(merged, block)
+    return merged
+
+
+def merge_balanced(blocks: Iterable[AttentionOnlineStats]) -> AttentionOnlineStats:
+    level = list(blocks)
+    if not level:
+        raise ValueError("expected at least one block")
+    while len(level) > 1:
+        next_level: list[AttentionOnlineStats] = []
+        for index in range(0, len(level), 2):
+            if index + 1 == len(level):
+                next_level.append(level[index])
+            else:
+                next_level.append(merge_stats(level[index], level[index + 1]))
+        level = next_level
+    return level[0]
+
+
+def sum_same_max(blocks: Iterable[AttentionOnlineStats]) -> AttentionOnlineStats:
+    values = list(blocks)
+    if not values:
+        raise ValueError("expected at least one block")
+    maximum = values[0].max_score
+    if any(block.max_score != maximum for block in values):
+        raise ValueError("all blocks must use the same global max")
+    return AttentionOnlineStats(
+        max_score=maximum,
+        exp_sum=sum(block.exp_sum for block in values),
+        weighted_numerator=tuple(
+            sum(block.weighted_numerator[lane] for block in values)
+            for lane in range(VALUE_DIM)
+        ),
+        block_count=sum(block.block_count for block in values),
+    )
+
+
+def two_pass_stats(
+    score_rows: Iterable[Iterable[int]],
+    value_matrices: Iterable[Iterable[Iterable[int]]],
+) -> AttentionOnlineStats:
+    score_blocks = [[int(value) for value in row] for row in score_rows]
+    value_blocks = [[[int(value) for value in lane_row] for lane_row in block] for block in value_matrices]
+    if not score_blocks or len(score_blocks) != len(value_blocks):
+        raise ValueError("score_rows and value_matrices must contain the same nonzero block count")
+    maximum = max(max(row) for row in score_blocks)
+    return sum_same_max(
+        block_stats_with_global_max(scores, values, global_max=maximum)
+        for scores, values in zip(score_blocks, value_blocks)
+    )
+
+
+def score_buffer_bytes(*, context_tokens: int, attention_heads: int, score_bits: int = 32) -> int:
+    if context_tokens <= 0 or attention_heads <= 0 or score_bits <= 0 or score_bits % 8:
+        raise ValueError("context_tokens, attention_heads, and byte-aligned score_bits must be positive")
+    return context_tokens * attention_heads * (score_bits // 8)
+
+
+def finalize_value(stats: AttentionOnlineStats) -> tuple[int, ...]:
+    if stats.exp_sum <= 0:
+        raise ValueError("cannot finalize an empty exponent sum")
+    limit = 1 << (FINAL_VALUE_BITS - 1)
+    values = tuple(
+        _round_div_signed(numerator * WEIGHT_SCALE, stats.exp_sum)
+        for numerator in stats.weighted_numerator
+    )
+    if any(not -limit <= value < limit for value in values):
+        raise ValueError(f"final value does not fit {FINAL_VALUE_BITS} signed bits")
+    return values
+
+
+def width_bounds() -> dict[str, int]:
+    max_exp_sum = MAX_CONTEXT_TOKENS * WEIGHT_SCALE
+    max_weighted_numerator = MAX_CONTEXT_TOKENS * 128 * WEIGHT_SCALE
+    return {
+        "max_context_tokens": MAX_CONTEXT_TOKENS,
+        "max_block_count": MAX_BLOCK_COUNT,
+        "max_exp_sum": max_exp_sum,
+        "exp_sum_bits_required": max_exp_sum.bit_length(),
+        "exp_sum_bits": EXP_SUM_BITS,
+        "max_weighted_numerator_magnitude": max_weighted_numerator,
+        "weighted_numerator_signed_bits_required": max_weighted_numerator.bit_length() + 1,
+        "weighted_numerator_bits": WEIGHTED_NUMERATOR_BITS,
+        "merge_scale_bits": MERGE_SCALE_BITS,
+    }
+
+
+__all__ = [
+    "AttentionOnlineStats",
+    "EXP_SUM_BITS",
+    "FINAL_VALUE_BITS",
+    "MAX_BLOCK_COUNT",
+    "MAX_CONTEXT_TOKENS",
+    "MERGE_SCALE_BITS",
+    "WEIGHTED_NUMERATOR_BITS",
+    "block_stats",
+    "block_stats_with_global_max",
+    "finalize_value",
+    "merge_sequence",
+    "merge_balanced",
+    "merge_stats",
+    "score_buffer_bytes",
+    "sum_same_max",
+    "two_pass_stats",
+    "width_bounds",
+]

--- a/tests/test_attention_hierarchical_softmax_probe.py
+++ b/tests/test_attention_hierarchical_softmax_probe.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import subprocess
+import sys
+
+from npu.eval.probe_attention_hierarchical_softmax import build_report
+
+
+def test_hierarchical_softmax_probe_selects_exact_two_pass() -> None:
+    report = build_report(
+        lengths=[128],
+        distributions=["normal_std1", "normal_std4", "monotonic_ramp16"],
+        seed=1,
+    )
+
+    assert report["decision"] == "two_pass_exact_selected"
+    assert report["online_pass"] is False
+    assert report["llama7b_score_buffer"]["mib"] == 16.0
+    assert all(
+        row["arithmetic_exact_vs_two_pass"]
+        for row in report["rows"]
+        if row["architecture"] == "two_pass_global_max"
+    )
+
+
+def test_hierarchical_softmax_probe_runs_directly(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/probe_attention_hierarchical_softmax.py",
+            "--lengths",
+            "128",
+            "--out",
+            str(tmp_path / "report.json"),
+            "--out-md",
+            str(tmp_path / "report.md"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert (tmp_path / "report.json").is_file()
+    assert (tmp_path / "report.md").is_file()

--- a/tests/test_attention_online.py
+++ b/tests/test_attention_online.py
@@ -1,0 +1,111 @@
+from dataclasses import replace
+
+import pytest
+
+from npu.sim.perf.attention_online import (
+    AttentionOnlineStats,
+    block_stats,
+    finalize_value,
+    merge_sequence,
+    merge_stats,
+    score_buffer_bytes,
+    two_pass_stats,
+    width_bounds,
+)
+from npu.sim.perf.attention_separated import command_tensors, default_commands, producer_result
+
+
+def _stats(index: int) -> AttentionOnlineStats:
+    command = default_commands(index + 1)[index]
+    payload = producer_result(command)
+    return block_stats(payload["score_row"], payload["value_matrix"])
+
+
+def test_attention_online_widths_cover_llama7b_context() -> None:
+    bounds = width_bounds()
+
+    assert bounds["max_context_tokens"] == 131072
+    assert bounds["max_block_count"] == 16384
+    assert bounds["exp_sum_bits_required"] <= bounds["exp_sum_bits"]
+    assert bounds["weighted_numerator_signed_bits_required"] <= bounds["weighted_numerator_bits"]
+
+
+def test_attention_online_identity_scale_preserves_left_stats() -> None:
+    left = _stats(0)
+    zero_right = replace(
+        _stats(1),
+        max_score=left.max_score,
+        exp_sum=1,
+        weighted_numerator=(0,) * 8,
+    )
+
+    merged = merge_stats(left, zero_right)
+
+    assert merged.max_score == left.max_score
+    assert merged.exp_sum == left.exp_sum + 1
+    assert merged.weighted_numerator == left.weighted_numerator
+
+
+def test_attention_online_zeroes_blocks_beyond_lut_range() -> None:
+    left = _stats(0)
+    low = replace(_stats(1), max_score=left.max_score - (9 << 28))
+
+    merged = merge_stats(left, low)
+
+    assert merged.exp_sum == left.exp_sum
+    assert merged.weighted_numerator == left.weighted_numerator
+
+
+def test_attention_online_merge_is_deterministic_and_finalizable() -> None:
+    blocks = [_stats(index) for index in range(8)]
+
+    first = merge_sequence(blocks)
+    second = merge_sequence(blocks)
+
+    assert first == second
+    assert first.block_count == 8
+    assert len(finalize_value(first)) == 8
+
+
+def test_attention_online_rejects_context_overflow() -> None:
+    block = _stats(0)
+    full = replace(block, block_count=16384)
+
+    with pytest.raises(ValueError, match="exceeds"):
+        merge_stats(full, block)
+
+
+def test_attention_online_block_stats_use_complete_value_matrix() -> None:
+    command = default_commands(1)[0]
+    tensors = command_tensors(command)
+    payload = producer_result(command)
+    baseline = block_stats(payload["score_row"], payload["value_matrix"])
+    changed_values = [list(row) for row in tensors["v"]]
+    changed_values[-1][-1] += 1
+
+    changed = block_stats(payload["score_row"], changed_values)
+
+    assert changed.weighted_numerator[:-1] == baseline.weighted_numerator[:-1]
+    assert changed.weighted_numerator[-1] != baseline.weighted_numerator[-1]
+
+
+def test_attention_two_pass_is_order_invariant() -> None:
+    payloads = [producer_result(command) for command in default_commands(8)]
+    forward = two_pass_stats(
+        [payload["score_row"] for payload in payloads],
+        [payload["value_matrix"] for payload in payloads],
+    )
+    reverse = two_pass_stats(
+        [payload["score_row"] for payload in reversed(payloads)],
+        [payload["value_matrix"] for payload in reversed(payloads)],
+    )
+
+    assert forward == reverse
+    assert finalize_value(forward) == finalize_value(reverse)
+
+
+def test_attention_two_pass_score_buffer_fits_current_shared_sram() -> None:
+    required = score_buffer_bytes(context_tokens=131072, attention_heads=32, score_bits=32)
+
+    assert required == 16 * 1024 * 1024
+    assert required < 68 * 1024 * 1024


### PR DESCRIPTION
## Summary

- model score32 online-softmax block statistics through the full 131072-token Llama7B context
- compare streaming and balanced max-rescaled merges against a two-pass global-max/score-replay reference across normal, wide, and monotonic score distributions
- derive the required 33-bit exp-sum and 41-bit signed weighted-numerator widths
- quantify the exact two-pass score buffer as 16 MiB for 32 heads, fitting the current 68 MiB shared-SRAM point
- add an L2 evidence contract and proposal that blocks full-model recost until scalable RTL equivalence is implemented

## Result

The online candidates fail the 0.01 output-value bound. The worst full-context streaming case has `max_abs_value_error_q16=67531` and `exp_sum_relative_error=15.0053`; the probe therefore selects exact two-pass global-max/score replay.

## Validation

- focused perf/probe/control-plane tests: 19 passed
- direct full 131072-token probe: `two_pass_exact_selected`
- `scripts/validate_runs.py --skip_eval_queue`: passed
- `git diff --check`: passed