### PR TITLE
npu: prove two-pass attention equivalence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -595,6 +595,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_hierarchical_softmax_architecture_report",
     ),
     (
+        "attention_two_pass_global_max_equivalence_out",
+        "attention_two_pass_global_max_equivalence_report",
+    ),
+    (
         "attention_score32_exp_lut_sram_hierarchy_envelope_out",
         "attention_score32_exp_lut_sram_hierarchy_envelope_report",
     ),
@@ -1541,6 +1545,23 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "llama7b_score_buffer",
             "width_bounds",
             "next_step",
+        ):
+            if key in evidence_payload:
+                parts.append(f"{key}={evidence_payload.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "attention_two_pass_perf_rtl_equivalence_v1":
+        outcome = str(evidence_payload.get("decision") or "two_pass_attention_equivalence_recorded")
+        parts = [f"Two-pass attention perf/RTL equivalence recorded from {evidence_ref}: decision={outcome}"]
+        for key in (
+            "equivalence_pass",
+            "semantic_profile",
+            "block_counts",
+            "command_count",
+            "scenarios",
+            "gates",
+            "remaining_abstractions",
         ):
             if key in evidence_payload:
                 parts.append(f"{key}={evidence_payload.get(key)}")

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6264,6 +6264,35 @@ def _decoder_attention_hierarchical_softmax_architecture_evidence(*, item_id: st
     }
 
 
+def _decoder_attention_two_pass_global_max_equivalence_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_two_pass_global_max_equivalence__{item_id}.json"
+    report = f"{base}/decoder_attention_two_pass_global_max_equivalence__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_two_pass_global_max_equivalence_out": out,
+            "attention_two_pass_global_max_equivalence_report": report,
+            "attention_two_pass_global_max_equivalence_scope": (
+                "Prove exact q8 QK block generation, complete score/value storage, global-max reduction, "
+                "zero-tail score32 exp accumulation, signed weighted-value accumulation, one final divide, "
+                "and ready/valid behavior for bounded 4- and 8-block engines."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_attention_two_pass_global_max_equivalence",
+                "run": (
+                    "python3 npu/eval/probe_attention_two_pass_equivalence.py "
+                    "--block-counts 4,8 --command-count 3 "
+                    f"--out {out} --out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__{item_id}.json"
@@ -9781,6 +9810,7 @@ def _build_payload(
         "decoder_attention_score32_separated_compute_recost",
         "decoder_attention_separated_cluster_equivalence",
         "decoder_attention_hierarchical_softmax_architecture",
+        "decoder_attention_two_pass_global_max_equivalence",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -10001,6 +10031,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_separated_cluster_equivalence_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hierarchical_softmax_architecture":
             decoder_evidence = _decoder_attention_hierarchical_softmax_architecture_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_two_pass_global_max_equivalence":
+            decoder_evidence = _decoder_attention_two_pass_global_max_equivalence_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -25,6 +25,28 @@ def _write(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def test_decoder_evidence_summary_recognizes_two_pass_attention_equivalence() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/two_pass.json",
+        evidence_payload={
+            "model": "attention_two_pass_perf_rtl_equivalence_v1",
+            "decision": "attention_two_pass_equivalence_pass",
+            "equivalence_pass": True,
+            "semantic_profile": "q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max",
+            "block_counts": [4, 8],
+            "command_count": 3,
+            "scenarios": ["always_ready", "result_backpressure"],
+            "gates": {"exact_global_max": True, "exact_weighted_value": True},
+            "remaining_abstractions": ["external score SRAM"],
+        },
+    )
+
+    assert outcome == "attention_two_pass_equivalence_pass"
+    assert "equivalence_pass=True" in summary
+    assert "exact_global_max" in summary
+    assert "external score SRAM" in summary
+
+
 def test_decoder_evidence_summary_recognizes_mixed_precision_int8_compute_physical_feasibility() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/int8_compute.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7347,6 +7347,44 @@ def test_generate_l2_campaign_task_adds_attention_hierarchical_softmax_architect
             ]
 
 
+def test_generate_l2_campaign_task_adds_attention_two_pass_global_max_equivalence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_two_pass_global_max_rtl_equivalence_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_two_pass_global_max_equivalence",
+                    evaluation_mode="equivalence_gate",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "probe_attention_two_pass_global_max_equivalence",
+                "validate_runs",
+            ]
+            assert "probe_attention_two_pass_equivalence.py" in work_item.command_manifest[0]["run"]
+            assert "--block-counts 4,8" in work_item.command_manifest[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.expected_outputs == [
+                decoder_inputs["attention_two_pass_global_max_equivalence_out"],
+                decoder_inputs["attention_two_pass_global_max_equivalence_report"],
+            ]
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy_envelope_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
@@ -41,8 +41,7 @@
         "direction": "prove_two_pass_attention_equivalence",
         "reason": "Full-model PPA recost remains ineligible until the scalable normalization path is embodied and exact."
       },
-      "status": "ready_to_queue",
-      "notes": "Prerequisites are merged; item is ready to queue."
+      "status": "pending_implementation_merge"
     }
   ],
   "source_commit": "7dd3b32a12c2dcc4acc528aa88dd71fd3d88ad12"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
@@ -68,7 +68,7 @@
         "direction": "prove_two_pass_attention_equivalence",
         "reason": "Full-model PPA recost remains ineligible until the scalable normalization path is embodied and exact."
       },
-      "status": "blocked_on_implementation"
+      "status": "pending_implementation_merge"
     }
   ],
   "remaining_abstractions_after_this_step": [

--- a/npu/eval/check_attention_two_pass_guard.py
+++ b/npu/eval/check_attention_two_pass_guard.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Guard bounded two-pass attention RTL semantics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    args = parser.parse_args()
+    config_path = args.design_dir / "config.json"
+    generated_config = args.design_dir / "verilog" / "config.json"
+    manifest_path = args.design_dir / "verilog" / "attention_two_pass_manifest.json"
+    top_path = args.design_dir / "verilog" / "top.v"
+    for path in (config_path, generated_config, manifest_path, top_path):
+        if not path.is_file():
+            raise SystemExit(f"missing two-pass artifact: {path}")
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    if config != json.loads(generated_config.read_text(encoding="utf-8")):
+        raise SystemExit("generated config does not match source config")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("semantic_profile") != "q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max":
+        raise SystemExit("unexpected two-pass semantic profile")
+    body = config.get("attention_two_pass") or {}
+    if int(manifest.get("block_count", 0)) != int(body.get("block_count", 0)):
+        raise SystemExit("manifest block_count does not match config")
+    if int(manifest.get("exp_sum_bits", 0)) != 33:
+        raise SystemExit("two-pass exp sum must be 33 bits")
+    if int(manifest.get("weighted_numerator_bits", 0)) != 41:
+        raise SystemExit("two-pass weighted numerator must be 41 bits")
+    text = top_path.read_text(encoding="utf-8")
+    top_name = str(config.get("top_name") or "")
+    if not re.search(rf"^module\s+{re.escape(top_name)}\b", text, re.MULTILINE):
+        raise SystemExit(f"missing top module {top_name}")
+    required = (
+        "score_mem",
+        "value_mem",
+        "global_max",
+        "exp_sum_accum",
+        "numerator_accum",
+        "default: exp_lut = 16'd0",
+        "state == REPLAY",
+        "final_magnitude / sum_next",
+        "result_valid && result_ready",
+    )
+    for token in required:
+        if token not in text:
+            raise SystemExit(f"two-pass RTL missing semantic token: {token}")
+    for forbidden in ("result_hash", "result_weights", "default: exp_lut = 16'd1"):
+        if forbidden in text:
+            raise SystemExit(f"two-pass RTL contains forbidden local-normalization token: {forbidden}")
+    print(f"OK: two-pass guard passed for {args.design_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/probe_attention_two_pass_equivalence.py
+++ b/npu/eval/probe_attention_two_pass_equivalence.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Prove bounded two-pass attention perf/RTL equivalence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.rtlgen.gen_attention_two_pass import generate
+from npu.sim.perf.attention_online import simulate_two_pass
+from npu.sim.perf.attention_separated import default_commands, unpack_signed
+
+JsonDict = dict[str, Any]
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool is unavailable: {name}")
+
+
+def _config(*, top_name: str, block_count: int) -> JsonDict:
+    return {
+        "top_name": top_name,
+        "attention_two_pass": {
+            "block_count": block_count,
+            "row_elems": 8,
+            "head_dim": 8,
+            "value_dim": 8,
+            "score_bits": 32,
+            "weight_bits": 16,
+            "input_frac_bits": 28,
+            "exp_bucket_shift": 20,
+        },
+    }
+
+
+def _testbench(*, top_name: str, command_count: int, scenario: str) -> str:
+    commands = default_commands(command_count)
+    init = "\n".join(
+        f"    command_ids[{index}] = 16'h{command.command_id:04x}; command_seeds[{index}] = 32'h{command.seed:08x};"
+        for index, command in enumerate(commands)
+    )
+    ready = (
+        "result_ready = !(((cycle >= 9) && (cycle < 13)) || ((cycle % 6) == 4));"
+        if scenario == "result_backpressure"
+        else "result_ready = 1'b1;"
+    )
+    return f"""`timescale 1ns/1ps
+module tb;
+  localparam integer COMMAND_COUNT = {command_count};
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  reg command_valid;
+  wire command_ready;
+  reg [15:0] command_id;
+  reg [31:0] command_seed;
+  wire result_valid;
+  reg result_ready;
+  wire [15:0] result_command_id;
+  wire signed [31:0] result_global_max;
+  wire [32:0] result_exp_sum;
+  wire [319:0] result_value;
+  wire [31:0] accepted_count;
+  wire [31:0] completed_count;
+  wire [31:0] cycle_count;
+  reg [15:0] command_ids [0:COMMAND_COUNT-1];
+  reg [31:0] command_seeds [0:COMMAND_COUNT-1];
+  integer send_index;
+  integer cycle;
+
+  always #5 clk = ~clk;
+  {top_name} dut (
+    .clk(clk), .rst_n(rst_n),
+    .command_valid(command_valid), .command_ready(command_ready),
+    .command_id(command_id), .command_seed(command_seed),
+    .result_valid(result_valid), .result_ready(result_ready),
+    .result_command_id(result_command_id), .result_global_max(result_global_max),
+    .result_exp_sum(result_exp_sum), .result_value(result_value),
+    .accepted_count(accepted_count), .completed_count(completed_count), .cycle_count(cycle_count)
+  );
+
+  always @* begin
+    command_valid = rst_n && send_index < COMMAND_COUNT;
+    command_id = send_index < COMMAND_COUNT ? command_ids[send_index] : 16'd0;
+    command_seed = send_index < COMMAND_COUNT ? command_seeds[send_index] : 32'd0;
+    {ready}
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      send_index <= 0;
+      cycle <= 0;
+    end else begin
+      if (command_valid && command_ready) begin
+        $display("ACCEPT cycle=%0d id=%0d seed=%08x", cycle, command_id, command_seed);
+        send_index <= send_index + 1;
+      end
+      if (result_valid && result_ready) begin
+        $display("RESULT cycle=%0d id=%0d max=%0d sum=%0d value=%080x", cycle, result_command_id, $signed(result_global_max), result_exp_sum, result_value);
+        if (completed_count + 1 == COMMAND_COUNT) begin
+          $display("SUMMARY accepted=%0d completed=%0d final_cycle=%0d", accepted_count, completed_count + 1, cycle);
+          #1 $finish;
+        end
+      end
+      cycle <= cycle + 1;
+      if (cycle > 1000) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+{init}
+    repeat (2) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+"""
+
+
+_ACCEPT = re.compile(r"ACCEPT cycle=(\d+) id=(\d+) seed=([0-9a-fA-F]+)")
+_RESULT = re.compile(r"RESULT cycle=(\d+) id=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+)")
+_SUMMARY = re.compile(r"SUMMARY accepted=(\d+) completed=(\d+) final_cycle=(\d+)")
+
+
+def _parse(text: str) -> JsonDict:
+    accepts: list[JsonDict] = []
+    results: list[JsonDict] = []
+    summary: JsonDict | None = None
+    for line in text.splitlines():
+        match = _ACCEPT.fullmatch(line.strip())
+        if match:
+            accepts.append(
+                {"cycle": int(match.group(1)), "command_id": int(match.group(2)), "seed": int(match.group(3), 16)}
+            )
+            continue
+        match = _RESULT.fullmatch(line.strip())
+        if match:
+            results.append(
+                {
+                    "cycle": int(match.group(1)),
+                    "command_id": int(match.group(2)),
+                    "global_max": int(match.group(3)),
+                    "exp_sum": int(match.group(4)),
+                    "value": unpack_signed(int(match.group(5), 16), lanes=8, bits=40),
+                    "block_count": 4,
+                    "seed": 0,
+                }
+            )
+            continue
+        match = _SUMMARY.fullmatch(line.strip())
+        if match:
+            summary = {
+                "accepted_count": int(match.group(1)),
+                "completed_count": int(match.group(2)),
+                "final_cycle": int(match.group(3)),
+            }
+    if summary is None:
+        raise RuntimeError(f"missing RTL summary:\n{text[-4000:]}")
+    return {"accept_events": accepts, "result_events": results, **summary}
+
+
+def _run_rtl(*, block_count: int, command_count: int, scenario: str) -> JsonDict:
+    top_name = f"attention_two_pass_b{block_count}"
+    with tempfile.TemporaryDirectory(prefix="attention-two-pass-") as tmp_text:
+        tmp = Path(tmp_text)
+        rtl = tmp / "rtl"
+        generate(_config(top_name=top_name, block_count=block_count), rtl)
+        tb = tmp / "tb.sv"
+        tb.write_text(_testbench(top_name=top_name, command_count=command_count, scenario=scenario), encoding="utf-8")
+        sim = tmp / "simv"
+        subprocess.run(
+            [_tool("iverilog"), "-g2012", "-s", "tb", "-o", str(sim), str(rtl / "top.v"), str(tb)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        completed = subprocess.run([_tool("vvp"), str(sim)], check=True, capture_output=True, text=True)
+        return _parse(completed.stdout)
+
+
+def build_report(*, block_counts: list[int], command_count: int) -> JsonDict:
+    commands = default_commands(command_count)
+    rows: list[JsonDict] = []
+    for block_count in block_counts:
+        for scenario in ("always_ready", "result_backpressure"):
+            perf = simulate_two_pass(commands, block_count=block_count, scenario=scenario)
+            rtl = _run_rtl(block_count=block_count, command_count=command_count, scenario=scenario)
+            functional_failures: list[str] = []
+            schedule_failures: list[str] = []
+            for index, (expected, actual) in enumerate(zip(perf["result_events"], rtl["result_events"])):
+                for key in ("command_id", "global_max", "exp_sum", "value"):
+                    if expected[key] != actual[key]:
+                        functional_failures.append(f"result[{index}].{key}: perf={expected[key]} rtl={actual[key]}")
+                if expected["cycle"] != actual["cycle"]:
+                    schedule_failures.append(
+                        f"result[{index}].cycle: perf={expected['cycle']} rtl={actual['cycle']}"
+                    )
+            if len(perf["result_events"]) != len(rtl["result_events"]):
+                functional_failures.append("result count mismatch")
+            if perf["accept_events"] != rtl["accept_events"]:
+                schedule_failures.append("accept event mismatch")
+            for key in ("accepted_count", "completed_count", "final_cycle"):
+                if perf[key] != rtl[key]:
+                    schedule_failures.append(f"{key} mismatch: perf={perf[key]} rtl={rtl[key]}")
+            rows.append(
+                {
+                    "block_count": block_count,
+                    "context_tokens": block_count * 8,
+                    "scenario": scenario,
+                    "functional_pass": not functional_failures,
+                    "schedule_pass": not schedule_failures,
+                    "equivalence_pass": not functional_failures and not schedule_failures,
+                    "functional_failures": functional_failures,
+                    "schedule_failures": schedule_failures,
+                    "final_cycle": rtl["final_cycle"],
+                }
+            )
+    passed = bool(rows) and all(row["equivalence_pass"] for row in rows)
+    return {
+        "version": 1,
+        "model": "attention_two_pass_perf_rtl_equivalence_v1",
+        "decision": "attention_two_pass_equivalence_pass" if passed else "attention_two_pass_equivalence_fail",
+        "equivalence_pass": passed,
+        "semantic_profile": "q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max",
+        "block_counts": block_counts,
+        "command_count": command_count,
+        "scenarios": ["always_ready", "result_backpressure"],
+        "rows": rows,
+        "gates": {
+            "exact_global_max": all(row["functional_pass"] for row in rows),
+            "exact_exp_sum": all(row["functional_pass"] for row in rows),
+            "exact_weighted_value": all(row["functional_pass"] for row in rows),
+            "exact_ready_valid_schedule": all(row["schedule_pass"] for row in rows),
+        },
+        "remaining_abstractions": [
+            "bounded internal score/value registers must be replaced with measured score-SRAM and KV replay ports",
+            "final divider lane folding and full 16384-block scheduling require physical exploration",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--block-counts", default="4")
+    parser.add_argument("--command-count", type=int, default=3)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        block_counts=[int(value) for value in args.block_counts.split(",") if value],
+        command_count=args.command_count,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out_md.write_text(
+        "# Two-Pass Attention Equivalence\n\n"
+        f"- decision: `{payload['decision']}`\n"
+        f"- equivalence pass: `{payload['equivalence_pass']}`\n",
+        encoding="utf-8",
+    )
+    print(json.dumps({"decision": payload["decision"], "ok": payload["equivalence_pass"]}, sort_keys=True))
+    return 0 if payload["equivalence_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_two_pass.py
+++ b/npu/rtlgen/gen_attention_two_pass.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Generate a bounded exact two-pass score32 attention engine."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import sys
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.rtlgen.gen_attention_separated_cluster import _producer_module
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate(config: dict[str, Any]) -> dict[str, int]:
+    if not str(config.get("top_name") or "").strip():
+        raise SystemExit("config top_name must not be empty")
+    body = config.get("attention_two_pass")
+    if not isinstance(body, dict):
+        raise SystemExit("config must contain attention_two_pass object")
+    expected = {
+        "row_elems": 8,
+        "head_dim": 8,
+        "value_dim": 8,
+        "score_bits": 32,
+        "weight_bits": 16,
+        "input_frac_bits": 28,
+        "exp_bucket_shift": 20,
+    }
+    params = {key: int(body.get(key, value)) for key, value in expected.items()}
+    for key, value in expected.items():
+        if params[key] != value:
+            raise SystemExit(f"attention_two_pass.{key} must be {value}")
+    block_count = int(body.get("block_count", 4))
+    if block_count < 2 or block_count > 16 or block_count & (block_count - 1):
+        raise SystemExit("attention_two_pass.block_count must be a power of two in [2, 16]")
+    params["block_count"] = block_count
+    body.update(params)
+    return params
+
+
+def _clog2(value: int) -> int:
+    return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _top(*, top_name: str, params: dict[str, int]) -> str:
+    block_count = params["block_count"]
+    index_bits = _clog2(block_count + 1)
+    max_bucket = 8 << (params["input_frac_bits"] - params["exp_bucket_shift"])
+    bucket_scale = float(1 << params["exp_bucket_shift"]) / float(1 << params["input_frac_bits"])
+    exp_cases = "\n".join(
+        f"      32'd{bucket}: exp_lut = 16'd{max(1, int(math.exp(-(bucket * bucket_scale)) * 65535 + 0.5))};"
+        for bucket in range(max_bucket + 1)
+    )
+    producer_name = f"{top_name}_producer"
+    producer = _producer_module(
+        module_name=producer_name,
+        row_elems=8,
+        head_dim=8,
+        value_dim=8,
+        score_bits=32,
+        score_frac_bits=20,
+    )
+    reset_numerators = "\n".join(f"      numerator_accum[{lane}] <= 41'sd0;" for lane in range(8))
+    clear_numerators = "\n".join(f"          numerator_accum[{lane}] <= 41'sd0;" for lane in range(8))
+    replay_lane_init = "\n".join(f"        block_numerator[{lane}] = 41'sd0;" for lane in range(8))
+    numerator_next = "\n".join(
+        f"        numerator_next[{lane}] = numerator_accum[{lane}] + block_numerator[{lane}];" for lane in range(8)
+    )
+    numerator_store = "\n".join(f"          numerator_accum[{lane}] <= numerator_next[{lane}];" for lane in range(8))
+    final_values = "\n".join(
+        f"""          if (numerator_next[{lane}] < 0) begin
+            numerator_magnitude = (~numerator_next[{lane}]) + 1'b1;
+            final_magnitude = (numerator_magnitude * 17'd65535) + (sum_next >> 1);
+            final_quotient = final_magnitude / sum_next;
+            result_value[({lane} * 40) +: 40] <= (~final_quotient) + 1'b1;
+          end else begin
+            numerator_magnitude = numerator_next[{lane}];
+            final_magnitude = (numerator_magnitude * 17'd65535) + (sum_next >> 1);
+            final_quotient = final_magnitude / sum_next;
+            result_value[({lane} * 40) +: 40] <= final_quotient;
+          end"""
+        for lane in range(8)
+    )
+    return producer + f"""
+module {top_name} (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire         command_valid,
+    output wire         command_ready,
+    input  wire [15:0]  command_id,
+    input  wire [31:0]  command_seed,
+    output reg          result_valid,
+    input  wire         result_ready,
+    output reg  [15:0]  result_command_id,
+    output reg signed [31:0] result_global_max,
+    output reg  [32:0]  result_exp_sum,
+    output reg  [319:0] result_value,
+    output reg  [31:0]  accepted_count,
+    output reg  [31:0]  completed_count,
+    output reg  [31:0]  cycle_count
+);
+  localparam integer BLOCK_COUNT = {block_count};
+  localparam integer INDEX_W = {index_bits};
+  localparam [1:0] IDLE = 2'd0, FILL = 2'd1, REPLAY = 2'd2, HOLD = 2'd3;
+
+  reg [1:0] state;
+  reg [15:0] active_command_id;
+  reg [31:0] active_seed;
+  reg [INDEX_W-1:0] issue_index;
+  reg [INDEX_W-1:0] stored_count;
+  reg [INDEX_W-1:0] replay_index;
+  reg signed [31:0] global_max;
+  reg [32:0] exp_sum_accum;
+  reg signed [40:0] numerator_accum [0:7];
+  reg signed [31:0] score_mem [0:(BLOCK_COUNT*8)-1];
+  reg signed [7:0] value_mem [0:(BLOCK_COUNT*64)-1];
+
+  wire producer_payload_valid;
+  wire [15:0] producer_payload_command_id;
+  wire [255:0] producer_payload_score_row;
+  wire [511:0] producer_payload_value_matrix;
+  wire producer_load = state == FILL && issue_index < BLOCK_COUNT && !producer_payload_valid;
+  wire producer_pop = state == FILL && producer_payload_valid;
+  wire [15:0] producer_command_id = active_command_id + issue_index;
+  wire [31:0] producer_seed = active_seed ^ (issue_index * 32'h9e37_79b9);
+
+  integer row_idx;
+  integer dim_idx;
+  integer mem_idx;
+  reg signed [31:0] block_max;
+  reg signed [31:0] score_lane;
+  reg signed [31:0] delta_score;
+  reg [31:0] exp_bucket;
+  reg [15:0] exp_weight;
+  reg signed [7:0] value_lane;
+  reg [19:0] block_sum;
+  reg signed [40:0] block_numerator [0:7];
+  reg [32:0] sum_next;
+  reg signed [40:0] numerator_next [0:7];
+  reg [40:0] numerator_magnitude;
+  reg [57:0] final_magnitude;
+  reg [39:0] final_quotient;
+
+  assign command_ready = state == IDLE;
+
+  function automatic [15:0] exp_lut;
+    input [31:0] bucket;
+    begin
+      case (bucket)
+{exp_cases}
+      default: exp_lut = 16'd0;
+      endcase
+    end
+  endfunction
+
+  {producer_name} u_producer (
+    .clk(clk), .rst_n(rst_n),
+    .load_valid(producer_load),
+    .load_command_id(producer_command_id),
+    .load_seed(producer_seed),
+    .pop_valid(producer_pop),
+    .payload_valid(producer_payload_valid),
+    .payload_command_id(producer_payload_command_id),
+    .payload_score_row(producer_payload_score_row),
+    .payload_value_matrix(producer_payload_value_matrix)
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      state <= IDLE;
+      active_command_id <= 16'd0;
+      active_seed <= 32'd0;
+      issue_index <= {{INDEX_W{{1'b0}}}};
+      stored_count <= {{INDEX_W{{1'b0}}}};
+      replay_index <= {{INDEX_W{{1'b0}}}};
+      global_max <= -32'sh8000_0000;
+      exp_sum_accum <= 33'd0;
+      result_valid <= 1'b0;
+      result_command_id <= 16'd0;
+      result_global_max <= 32'sd0;
+      result_exp_sum <= 33'd0;
+      result_value <= 320'd0;
+      accepted_count <= 32'd0;
+      completed_count <= 32'd0;
+      cycle_count <= 32'd0;
+{reset_numerators}
+    end else begin
+      cycle_count <= cycle_count + 1'b1;
+      if (state == IDLE && command_valid) begin
+        state <= FILL;
+        active_command_id <= command_id;
+        active_seed <= command_seed;
+        issue_index <= {{INDEX_W{{1'b0}}}};
+        stored_count <= {{INDEX_W{{1'b0}}}};
+        global_max <= -32'sh8000_0000;
+        accepted_count <= accepted_count + 1'b1;
+      end
+
+      if (producer_load) begin
+        issue_index <= issue_index + 1'b1;
+      end
+
+      if (producer_pop) begin
+        block_max = $signed(producer_payload_score_row[0 +: 32]);
+        for (row_idx = 0; row_idx < 8; row_idx = row_idx + 1) begin
+          score_lane = $signed(producer_payload_score_row[(row_idx * 32) +: 32]);
+          score_mem[(stored_count * 8) + row_idx] <= score_lane;
+          if (score_lane > block_max) block_max = score_lane;
+          for (dim_idx = 0; dim_idx < 8; dim_idx = dim_idx + 1) begin
+            value_mem[(stored_count * 64) + (row_idx * 8) + dim_idx]
+                <= $signed(producer_payload_value_matrix[((row_idx * 8 + dim_idx) * 8) +: 8]);
+          end
+        end
+        if (stored_count == 0 || block_max > global_max) global_max <= block_max;
+        if (stored_count + 1'b1 == BLOCK_COUNT) begin
+          state <= REPLAY;
+          replay_index <= {{INDEX_W{{1'b0}}}};
+          exp_sum_accum <= 33'd0;
+{clear_numerators}
+        end
+        stored_count <= stored_count + 1'b1;
+      end
+
+      if (state == REPLAY) begin
+        block_sum = 20'd0;
+{replay_lane_init}
+        for (row_idx = 0; row_idx < 8; row_idx = row_idx + 1) begin
+          score_lane = score_mem[(replay_index * 8) + row_idx];
+          delta_score = global_max - score_lane;
+          if (delta_score < 0) delta_score = 32'sd0;
+          exp_bucket = (delta_score + 32'd524288) >> 20;
+          exp_weight = exp_lut(exp_bucket);
+          block_sum = block_sum + exp_weight;
+          for (dim_idx = 0; dim_idx < 8; dim_idx = dim_idx + 1) begin
+            value_lane = value_mem[(replay_index * 64) + (row_idx * 8) + dim_idx];
+            block_numerator[dim_idx] = block_numerator[dim_idx]
+                + ($signed(value_lane) * $signed({{1'b0, exp_weight}}));
+          end
+        end
+        sum_next = exp_sum_accum + block_sum;
+{numerator_next}
+        if (replay_index + 1'b1 == BLOCK_COUNT) begin
+          state <= HOLD;
+          result_valid <= 1'b1;
+          result_command_id <= active_command_id;
+          result_global_max <= global_max;
+          result_exp_sum <= sum_next;
+{final_values}
+        end else begin
+          replay_index <= replay_index + 1'b1;
+          exp_sum_accum <= sum_next;
+{numerator_store}
+        end
+      end
+
+      if (state == HOLD && result_valid && result_ready) begin
+        result_valid <= 1'b0;
+        completed_count <= completed_count + 1'b1;
+        state <= IDLE;
+      end
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: dict[str, Any], out_dir: Path) -> None:
+    params = _validate(config)
+    top_name = str(config["top_name"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "top.v").write_text(_top(top_name=top_name, params=params), encoding="utf-8")
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    manifest = {
+        "version": 1,
+        "top_name": top_name,
+        "semantic_profile": "q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max",
+        "block_count": params["block_count"],
+        "row_elems": 8,
+        "context_tokens_bounded": params["block_count"] * 8,
+        "exp_sum_bits": 33,
+        "weighted_numerator_bits": 41,
+        "result_value_bits": 40,
+        "score_store": "bounded_internal_register_reference",
+        "passes": ["qk_score_store_global_max", "score_value_replay_exp_sum_weighted_numerator_final_divide"],
+        "remaining_physical_abstraction": "replace bounded register store with measured score-SRAM ports",
+    }
+    (out_dir / "attention_two_pass_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/perf/attention_online.py
+++ b/npu/sim/perf/attention_online.py
@@ -7,12 +7,15 @@ import math
 from typing import Iterable
 
 from npu.sim.perf.attention_separated import (
+    AttentionSeparatedCommand,
     EXP_BUCKET_SHIFT,
     MAX_EXP_BUCKET,
     ROW_ELEMS,
     VALUE_DIM,
     WEIGHT_SCALE,
     _exp_lut,
+    producer_result,
+    result_ready,
 )
 
 MAX_CONTEXT_TOKENS = 131072
@@ -207,6 +210,105 @@ def score_buffer_bytes(*, context_tokens: int, attention_heads: int, score_bits:
     return context_tokens * attention_heads * (score_bits // 8)
 
 
+def two_pass_command(command: AttentionSeparatedCommand, *, block_count: int) -> dict[str, object]:
+    if block_count < 2 or block_count > MAX_BLOCK_COUNT:
+        raise ValueError(f"block_count must be in [2, {MAX_BLOCK_COUNT}]")
+    command = command.normalized()
+    payloads = [
+        producer_result(
+            AttentionSeparatedCommand(
+                command_id=(command.command_id + index) & 0xFFFF,
+                seed=(command.seed ^ ((index * 0x9E3779B9) & 0xFFFFFFFF)) & 0xFFFFFFFF,
+            )
+        )
+        for index in range(block_count)
+    ]
+    stats = two_pass_stats(
+        [payload["score_row"] for payload in payloads],
+        [payload["value_matrix"] for payload in payloads],
+    )
+    return {
+        "command_id": command.command_id,
+        "seed": command.seed,
+        "block_count": block_count,
+        "global_max": stats.max_score,
+        "exp_sum": stats.exp_sum,
+        "value": list(finalize_value(stats)),
+        "stats": stats,
+    }
+
+
+def simulate_two_pass(
+    commands: Iterable[AttentionSeparatedCommand],
+    *,
+    block_count: int,
+    scenario: str,
+    max_cycles: int = 10000,
+) -> dict[str, object]:
+    command_list = [command.normalized() for command in commands]
+    if scenario not in {"always_ready", "result_backpressure"}:
+        raise ValueError(f"unsupported scenario: {scenario}")
+    state = "idle"
+    command_index = 0
+    issue_index = stored_count = replay_index = 0
+    producer_payload: dict[str, object] | None = None
+    active: AttentionSeparatedCommand | None = None
+    pending_result: dict[str, object] | None = None
+    accept_events: list[dict[str, int]] = []
+    result_events: list[dict[str, object]] = []
+
+    for cycle in range(max_cycles):
+        if len(result_events) == len(command_list):
+            break
+        old_state = state
+        if old_state == "hold" and pending_result is not None and result_ready(scenario, cycle=cycle):
+            result_events.append({"cycle": cycle, **pending_result})
+            pending_result = None
+            state = "idle"
+        if old_state == "idle" and command_index < len(command_list):
+            active = command_list[command_index]
+            accept_events.append(
+                {"cycle": cycle, "command_id": active.command_id, "seed": active.seed}
+            )
+            command_index += 1
+            issue_index = stored_count = replay_index = 0
+            state = "fill"
+        elif old_state == "fill":
+            if producer_payload is not None:
+                producer_payload = None
+                stored_count += 1
+                if stored_count == block_count:
+                    replay_index = 0
+                    state = "replay"
+            elif issue_index < block_count:
+                assert active is not None
+                producer_payload = producer_result(
+                    AttentionSeparatedCommand(
+                        command_id=(active.command_id + issue_index) & 0xFFFF,
+                        seed=(active.seed ^ ((issue_index * 0x9E3779B9) & 0xFFFFFFFF)) & 0xFFFFFFFF,
+                    )
+                )
+                issue_index += 1
+        elif old_state == "replay":
+            replay_index += 1
+            if replay_index == block_count:
+                assert active is not None
+                pending_result = two_pass_command(active, block_count=block_count)
+                pending_result.pop("stats")
+                state = "hold"
+    else:
+        raise RuntimeError(f"two-pass scenario {scenario} exceeded {max_cycles} cycles")
+    return {
+        "scenario": scenario,
+        "block_count": block_count,
+        "accepted_count": len(accept_events),
+        "completed_count": len(result_events),
+        "accept_events": accept_events,
+        "result_events": result_events,
+        "final_cycle": result_events[-1]["cycle"] if result_events else -1,
+    }
+
+
 def finalize_value(stats: AttentionOnlineStats) -> tuple[int, ...]:
     if stats.exp_sum <= 0:
         raise ValueError("cannot finalize an empty exponent sum")
@@ -252,6 +354,8 @@ __all__ = [
     "merge_stats",
     "score_buffer_bytes",
     "sum_same_max",
+    "simulate_two_pass",
+    "two_pass_command",
     "two_pass_stats",
     "width_bounds",
 ]

--- a/runs/designs/npu_blocks/attention_two_pass_b4/config.json
+++ b/runs/designs/npu_blocks/attention_two_pass_b4/config.json
@@ -1,0 +1,13 @@
+{
+  "top_name": "attention_two_pass_b4",
+  "attention_two_pass": {
+    "block_count": 4,
+    "row_elems": 8,
+    "head_dim": 8,
+    "value_dim": 8,
+    "score_bits": 32,
+    "weight_bits": 16,
+    "input_frac_bits": 28,
+    "exp_bucket_shift": 20
+  }
+}

--- a/tests/test_attention_online.py
+++ b/tests/test_attention_online.py
@@ -9,6 +9,8 @@ from npu.sim.perf.attention_online import (
     merge_sequence,
     merge_stats,
     score_buffer_bytes,
+    simulate_two_pass,
+    two_pass_command,
     two_pass_stats,
     width_bounds,
 )
@@ -109,3 +111,28 @@ def test_attention_two_pass_score_buffer_fits_current_shared_sram() -> None:
 
     assert required == 16 * 1024 * 1024
     assert required < 68 * 1024 * 1024
+
+
+def test_attention_two_pass_command_covers_all_blocks() -> None:
+    command = default_commands(1)[0]
+
+    result = two_pass_command(command, block_count=4)
+
+    assert result["command_id"] == command.command_id
+    assert result["block_count"] == 4
+    assert result["exp_sum"] > 0
+    assert len(result["value"]) == 8
+
+
+def test_attention_two_pass_cycle_model_preserves_backpressured_commands() -> None:
+    result = simulate_two_pass(
+        default_commands(3),
+        block_count=4,
+        scenario="result_backpressure",
+    )
+
+    assert result["accepted_count"] == 3
+    assert result["completed_count"] == 3
+    assert [event["command_id"] for event in result["result_events"]] == [
+        command.command_id for command in default_commands(3)
+    ]

--- a/tests/test_attention_two_pass.py
+++ b/tests/test_attention_two_pass.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from npu.eval.probe_attention_two_pass_equivalence import build_report
+from npu.rtlgen.gen_attention_two_pass import generate
+
+
+def _config(block_count: int = 4) -> dict:
+    return {
+        "top_name": f"attention_two_pass_b{block_count}",
+        "attention_two_pass": {
+            "block_count": block_count,
+            "row_elems": 8,
+            "head_dim": 8,
+            "value_dim": 8,
+            "score_bits": 32,
+            "weight_bits": 16,
+            "input_frac_bits": 28,
+            "exp_bucket_shift": 20,
+        },
+    }
+
+
+def test_attention_two_pass_generator_emits_semantic_manifest(tmp_path: Path) -> None:
+    config = _config()
+    generate(config, tmp_path)
+
+    manifest = json.loads((tmp_path / "attention_two_pass_manifest.json").read_text())
+    text = (tmp_path / "top.v").read_text()
+    assert manifest["block_count"] == 4
+    assert manifest["exp_sum_bits"] == 33
+    assert manifest["weighted_numerator_bits"] == 41
+    assert "default: exp_lut = 16'd0" in text
+    assert "result_weights" not in text
+
+
+def test_attention_two_pass_generator_compiles(tmp_path: Path) -> None:
+    iverilog = shutil.which("iverilog")
+    if not iverilog:
+        pytest.skip("iverilog unavailable")
+    config = _config()
+    generate(config, tmp_path)
+
+    subprocess.run(
+        [iverilog, "-g2012", "-s", config["top_name"], "-o", str(tmp_path / "simv"), str(tmp_path / "top.v")],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_attention_two_pass_perf_rtl_equivalence() -> None:
+    report = build_report(block_counts=[4, 8], command_count=3)
+
+    assert report["decision"] == "attention_two_pass_equivalence_pass"
+    assert report["equivalence_pass"] is True
+    assert len(report["rows"]) == 4
+    assert all(row["equivalence_pass"] for row in report["rows"])
+
+
+def test_attention_two_pass_guard_accepts_generated_design(tmp_path: Path) -> None:
+    config = _config()
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    generate(config, tmp_path / "verilog")
+
+    subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_two_pass_guard.py",
+            "--design-dir",
+            str(tmp_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary

- add a bounded two-pass attention RTL engine using the real signed q8 QK producer
- store complete score and V blocks, reduce one global maximum, replay with a zero-tail score32 exp LUT, accumulate a 33-bit denominator and eight signed 41-bit numerators, and normalize once
- model the exact cycle schedule and output backpressure in the perf simulator
- prove exact global-max, exp-sum, weighted-value, ordering, and ready/valid equivalence for 4- and 8-block engines
- add semantic guards and the remote L2 equivalence contract

## Scope

This closes bounded arithmetic and control semantics for the scalable two-pass choice. The internal register store is intentionally identified as a reference implementation; measured score-SRAM ports, divider lane folding, and the full 16384-block schedule remain the next physical integration step.

## Validation

- focused two-pass/hierarchical control-plane tests: 12 passed
- broader focused attention suite: 20 passed
- direct 4/8-block perf/RTL probe: all four block-count/scenario rows passed
- generated RTL compiles with Icarus Verilog
- `scripts/validate_runs.py --skip_eval_queue`: passed
- `git diff --check`: passed