### PR TITLE
eval: run prove external-memory two-pass attention rtl equivalence

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json
@@ -1,0 +1,67 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-10T13:02:07.989368Z",
+  "item_id": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1",
+  "run_key": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1_run_ecf327e57d2035b0",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "638989e3b2353bf1fe41c55c51fdc25246359cf2",
+  "review_metadata_source_commit": "638989e3b2353bf1fe41c55c51fdc25246359cf2",
+  "objective": "Prove exact score-SRAM and KV-replay stream behavior for divider lanes 1,2,4,8 under independent stalls.",
+  "input_manifest": {
+    "decoder_contract": {
+      "attention_two_pass_stream_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+      "attention_two_pass_stream_equivalence_scope": "Prove the external score-SRAM write/read boundary, KV replay stream, zero-tail score32 accumulation, divider folding at 1/2/4/8 lanes per cycle, and independent memory/result backpressure for 4- and 8-block semantic contexts.",
+      "attention_two_pass_stream_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.md"
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+    "arch_id": "decoder_attention_two_pass_stream_equivalence",
+    "macro_mode": "evidence_only",
+    "outcome": "attention_two_pass_stream_equivalence_pass"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+    "title": "Scalable exact hierarchical softmax for Llama7B",
+    "primary_question": "Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?",
+    "evaluation_mode": "equivalence_gate",
+    "comparison_role": "memory_interface_equivalence_gate",
+    "abstraction_layer": "decoder_attention_two_pass_stream_equivalence",
+    "expected_direction": "prove_two_pass_stream_equivalence",
+    "expected_reason": "Physical measurement is ineligible until score-SRAM and KV replay handshakes preserve the selected arithmetic under independent stalls.",
+    "summary": "Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].",
+    "outcome": "attention_two_pass_stream_equivalence_pass",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+    "title": "Scalable exact hierarchical softmax for Llama7B",
+    "kind": "architecture",
+    "primary_question": "Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?",
+    "evaluation_mode": "equivalence_gate",
+    "comparison_role": "memory_interface_equivalence_gate",
+    "outcome": "attention_two_pass_stream_equivalence_pass",
+    "summary": "Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+    "decoder_quality": {
+      "diagnosis": {}
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+    "decoder_attention_two_pass_stream_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+    "decoder_attention_two_pass_stream_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {}
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/evaluated.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/evaluated.json
@@ -1,0 +1,104 @@
+{
+  "flow": "openroad",
+  "task": {
+    "inputs": {
+      "decoder_contract": {
+        "attention_two_pass_stream_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+        "attention_two_pass_stream_equivalence_scope": "Prove the external score-SRAM write/read boundary, KV replay stream, zero-tail score32 accumulation, divider folding at 1/2/4/8 lanes per cycle, and independent memory/result backpressure for 4- and 8-block semantic contexts.",
+        "attention_two_pass_stream_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.md"
+      }
+    },
+    "commands": [
+      {
+        "run": "python3 npu/eval/probe_attention_two_pass_stream_equivalence.py --block-counts 4,8 --div-lanes 1,2,4,8 --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.md",
+        "name": "probe_attention_two_pass_stream_equivalence"
+      },
+      {
+        "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+        "name": "validate_runs"
+      }
+    ],
+    "objective": "Prove exact score-SRAM and KV-replay stream behavior for divider lanes 1,2,4,8 under independent stalls.",
+    "acceptance": [
+      "Write all declared decoder evidence artifacts",
+      "Keep evidence artifact paths repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "source_mode": "src_verilog",
+    "expected_outputs": [
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.md"
+    ]
+  },
+  "layer": "layer2",
+  "state": "evaluated",
+  "title": "Prove external-memory two-pass attention RTL equivalence",
+  "result": {
+    "branch": "eval/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/s20260710t130208z",
+    "completed_utc": "2026-07-10T13:02:07.378977Z",
+    "evaluator_id": "control_plane",
+    "executor": "@control_plane",
+    "host": "b7c2d9c80c1c",
+    "identity_block": "[role:evaluator][account:control_plane][session:s20260710t130208z][host:b7c2d9c80c1c][item:l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1]",
+    "metrics_rows": [],
+    "metrics_exempt_reason": "evidence_only_decoder_evidence",
+    "queue_item_id": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1",
+    "session_id": "s20260710t130208z",
+    "status": "ok",
+    "summary": "2/2 commands succeeded"
+  },
+  "handoff": {
+    "branch": "eval/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/s20260710t130208z",
+    "pr_title": "eval: run prove external-memory two-pass attention rtl equivalence",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "pr_body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260710t130208z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1"
+    },
+    "identity_block_format": "[role:evaluator][account:<evaluator_id>][session:<session_id>][host:<host>][item:<queue_item_id>]"
+  },
+  "item_id": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1",
+  "version": 0.1,
+  "platform": "nangate45",
+  "priority": 1,
+  "created_utc": "2026-07-10T13:01:44.815459Z",
+  "requested_by": "developer_agent",
+  "developer_loop": {
+    "comparison": {
+      "role": "memory_interface_equivalence_gate",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "equivalence_gate",
+      "expected_reason": "Physical measurement is ineligible until score-SRAM and KV replay handshakes preserve the selected arithmetic under independent stalls.",
+      "expected_direction": "prove_two_pass_stream_equivalence"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_two_pass_stream_equivalence"
+    },
+    "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_two_pass_global_max_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json"
+  },
+  "source_requirement": {
+    "repo": "",
+    "reason": "evaluator runtime must contain the queued job source commit",
+    "version": 1,
+    "required_ref": "origin/master",
+    "required_sha": "638989e3b2353bf1fe41c55c51fdc25246359cf2",
+    "requires_daemon_restart": true
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/pr_body.md
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/pr_body.md
@@ -1,0 +1,40 @@
+## Summary
+- item_id: `l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1`
+- run_key: `l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1_run_ecf327e57d2035b0`
+- layer: `layer2`
+- task_type: `l2_campaign`
+- status: `ok`
+- summary: `2/2 commands succeeded`
+- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/evaluated.json`
+- metrics_rows_count: `0`
+- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json`
+
+## Developer Context
+- proposal_id: `prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1`
+- proposal_path: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json`
+- reviewer_first_read: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
+- execution_source_commit: `638989e3b2353bf1fe41c55c51fdc25246359cf2`
+- review_metadata_source_commit: `638989e3b2353bf1fe41c55c51fdc25246359cf2`
+
+## Evaluation Mode
+- evaluation_mode: `equivalence_gate`
+- abstraction_layer: `decoder_attention_two_pass_stream_equivalence`
+- comparison_role: `memory_interface_equivalence_gate`
+- expected_direction: `prove_two_pass_stream_equivalence`
+- expected_reason: `Physical measurement is ineligible until score-SRAM and KV replay handshakes preserve the selected arithmetic under independent stalls.`
+- expectation_status: `unspecified`
+- evaluation_summary: `Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].`
+
+## Focused Comparison
+- primary_question: `Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?`
+- comparison_role: `memory_interface_equivalence_gate`
+- proposal_outcome: `attention_two_pass_stream_equivalence_pass`
+- comparison_summary: `Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].`
+- baseline_ref: `None`
+- baseline_item_id: `None`
+
+## Checklist
+- [ ] Commit lightweight campaign artifacts only
+- [ ] Include metrics row references in result.metrics_rows
+- [ ] Keep committed result_path fields repo-portable
+- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing

--- a/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/review_package.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/review_package.json
@@ -1,0 +1,143 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-10T13:02:10.191690Z",
+  "control_plane_source_commit": "638989e3b2353bf1fe41c55c51fdc25246359cf2",
+  "review_metadata_source_commit": "638989e3b2353bf1fe41c55c51fdc25246359cf2",
+  "item_id": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1",
+  "run_key": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1_run_ecf327e57d2035b0",
+  "layer": "layer2",
+  "flow": "openroad",
+  "task_type": "l2_campaign",
+  "source_commit": "638989e3b2353bf1fe41c55c51fdc25246359cf2",
+  "queue_snapshot": {
+    "path": "control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/evaluated.json",
+    "result": {
+      "branch": "eval/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/s20260710t130208z",
+      "completed_utc": "2026-07-10T13:02:07.378977Z",
+      "evaluator_id": "control_plane",
+      "executor": "@control_plane",
+      "host": "b7c2d9c80c1c",
+      "identity_block": "[role:evaluator][account:control_plane][session:s20260710t130208z][host:b7c2d9c80c1c][item:l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1]",
+      "metrics_rows": [],
+      "metrics_exempt_reason": "evidence_only_decoder_evidence",
+      "queue_item_id": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1",
+      "session_id": "s20260710t130208z",
+      "status": "ok",
+      "summary": "2/2 commands succeeded"
+    }
+  },
+  "review_artifact": {
+    "kind": "decision_proposal",
+    "path": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+    "storage_mode": "repo",
+    "sha256": "f88391650c774fb42b8093f4d7f1f64cb50f9e1abce08caf8dd6d4326310c748",
+    "payload": {
+      "version": 0.1,
+      "generated_utc": "2026-07-10T13:02:07.989368Z",
+      "item_id": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1",
+      "run_key": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1_run_ecf327e57d2035b0",
+      "layer": "layer2",
+      "flow": "openroad",
+      "platform": "nangate45",
+      "task_type": "l2_campaign",
+      "source_commit": "638989e3b2353bf1fe41c55c51fdc25246359cf2",
+      "review_metadata_source_commit": "638989e3b2353bf1fe41c55c51fdc25246359cf2",
+      "objective": "Prove exact score-SRAM and KV-replay stream behavior for divider lanes 1,2,4,8 under independent stalls.",
+      "input_manifest": {
+        "decoder_contract": {
+          "attention_two_pass_stream_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+          "attention_two_pass_stream_equivalence_scope": "Prove the external score-SRAM write/read boundary, KV replay stream, zero-tail score32 accumulation, divider folding at 1/2/4/8 lanes per cycle, and independent memory/result backpressure for 4- and 8-block semantic contexts.",
+          "attention_two_pass_stream_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.md"
+        }
+      },
+      "recommendation": {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+        "arch_id": "decoder_attention_two_pass_stream_equivalence",
+        "macro_mode": "evidence_only",
+        "outcome": "attention_two_pass_stream_equivalence_pass"
+      },
+      "objective_profiles": [],
+      "evaluation_record": {
+        "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+        "title": "Scalable exact hierarchical softmax for Llama7B",
+        "primary_question": "Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?",
+        "evaluation_mode": "equivalence_gate",
+        "comparison_role": "memory_interface_equivalence_gate",
+        "abstraction_layer": "decoder_attention_two_pass_stream_equivalence",
+        "expected_direction": "prove_two_pass_stream_equivalence",
+        "expected_reason": "Physical measurement is ineligible until score-SRAM and KV replay handshakes preserve the selected arithmetic under independent stalls.",
+        "summary": "Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].",
+        "outcome": "attention_two_pass_stream_equivalence_pass",
+        "expectation_status": "unspecified"
+      },
+      "proposal_assessment": {
+        "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+        "title": "Scalable exact hierarchical softmax for Llama7B",
+        "kind": "architecture",
+        "primary_question": "Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?",
+        "evaluation_mode": "equivalence_gate",
+        "comparison_role": "memory_interface_equivalence_gate",
+        "outcome": "attention_two_pass_stream_equivalence_pass",
+        "summary": "Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].",
+        "baseline_ref": null,
+        "baseline_item_id": null,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+        "decoder_quality": {
+          "diagnosis": {}
+        }
+      },
+      "source_refs": {
+        "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+        "decoder_attention_two_pass_stream_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json",
+        "decoder_attention_two_pass_stream_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.md"
+      },
+      "decoder_quality": {
+        "diagnosis": {}
+      }
+    }
+  },
+  "developer_loop": {
+    "comparison": {
+      "role": "memory_interface_equivalence_gate",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "equivalence_gate",
+      "expected_reason": "Physical measurement is ineligible until score-SRAM and KV replay handshakes preserve the selected arithmetic under independent stalls.",
+      "expected_direction": "prove_two_pass_stream_equivalence"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_two_pass_stream_equivalence"
+    },
+    "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_two_pass_global_max_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json"
+  },
+  "submission_history": null,
+  "pr_payload": {
+    "branch": "eval/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/s20260710t130208z",
+    "title": "eval: run prove external-memory two-pass attention rtl equivalence",
+    "body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260710t130208z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1"
+    },
+    "body_md": "## Summary\n- item_id: `l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1`\n- run_key: `l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1_run_ecf327e57d2035b0`\n- layer: `layer2`\n- task_type: `l2_campaign`\n- status: `ok`\n- summary: `2/2 commands succeeded`\n- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/evaluated.json`\n- metrics_rows_count: `0`\n- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json`\n\n## Developer Context\n- proposal_id: `prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1`\n- proposal_path: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json`\n- reviewer_first_read: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`\n- execution_source_commit: `638989e3b2353bf1fe41c55c51fdc25246359cf2`\n- review_metadata_source_commit: `638989e3b2353bf1fe41c55c51fdc25246359cf2`\n\n## Evaluation Mode\n- evaluation_mode: `equivalence_gate`\n- abstraction_layer: `decoder_attention_two_pass_stream_equivalence`\n- comparison_role: `memory_interface_equivalence_gate`\n- expected_direction: `prove_two_pass_stream_equivalence`\n- expected_reason: `Physical measurement is ineligible until score-SRAM and KV replay handshakes preserve the selected arithmetic under independent stalls.`\n- expectation_status: `unspecified`\n- evaluation_summary: `Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].`\n\n## Focused Comparison\n- primary_question: `Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?`\n- comparison_role: `memory_interface_equivalence_gate`\n- proposal_outcome: `attention_two_pass_stream_equivalence_pass`\n- comparison_summary: `Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].`\n- baseline_ref: `None`\n- baseline_item_id: `None`\n\n## Checklist\n- [ ] Commit lightweight campaign artifacts only\n- [ ] Include metrics row references in result.metrics_rows\n- [ ] Keep committed result_path fields repo-portable\n- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing\n",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ]
+  }
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json
@@ -1,0 +1,266 @@
+{
+  "block_counts": [
+    4,
+    8
+  ],
+  "decision": "attention_two_pass_stream_equivalence_pass",
+  "div_lanes_per_cycle": [
+    1,
+    2,
+    4,
+    8
+  ],
+  "equivalence_pass": true,
+  "kv_replay": "external_ready_valid_stream",
+  "model": "attention_two_pass_stream_perf_rtl_equivalence_v1",
+  "rows": [
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 1,
+      "equivalence_pass": true,
+      "expected_final_cycle": 21,
+      "final_cycle": 21,
+      "functional_pass": true,
+      "scenario": "always_ready",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 1,
+      "equivalence_pass": true,
+      "expected_final_cycle": 22,
+      "final_cycle": 22,
+      "functional_pass": true,
+      "scenario": "memory_stalls",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 1,
+      "equivalence_pass": true,
+      "expected_final_cycle": 23,
+      "final_cycle": 23,
+      "functional_pass": true,
+      "scenario": "result_backpressure",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 2,
+      "equivalence_pass": true,
+      "expected_final_cycle": 17,
+      "final_cycle": 17,
+      "functional_pass": true,
+      "scenario": "always_ready",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 2,
+      "equivalence_pass": true,
+      "expected_final_cycle": 18,
+      "final_cycle": 18,
+      "functional_pass": true,
+      "scenario": "memory_stalls",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 2,
+      "equivalence_pass": true,
+      "expected_final_cycle": 17,
+      "final_cycle": 17,
+      "functional_pass": true,
+      "scenario": "result_backpressure",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 4,
+      "equivalence_pass": true,
+      "expected_final_cycle": 15,
+      "final_cycle": 15,
+      "functional_pass": true,
+      "scenario": "always_ready",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 4,
+      "equivalence_pass": true,
+      "expected_final_cycle": 16,
+      "final_cycle": 16,
+      "functional_pass": true,
+      "scenario": "memory_stalls",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 4,
+      "equivalence_pass": true,
+      "expected_final_cycle": 17,
+      "final_cycle": 17,
+      "functional_pass": true,
+      "scenario": "result_backpressure",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 8,
+      "equivalence_pass": true,
+      "expected_final_cycle": 14,
+      "final_cycle": 14,
+      "functional_pass": true,
+      "scenario": "always_ready",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 8,
+      "equivalence_pass": true,
+      "expected_final_cycle": 15,
+      "final_cycle": 15,
+      "functional_pass": true,
+      "scenario": "memory_stalls",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 4,
+      "div_lanes_per_cycle": 8,
+      "equivalence_pass": true,
+      "expected_final_cycle": 14,
+      "final_cycle": 14,
+      "functional_pass": true,
+      "scenario": "result_backpressure",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 1,
+      "equivalence_pass": true,
+      "expected_final_cycle": 33,
+      "final_cycle": 33,
+      "functional_pass": true,
+      "scenario": "always_ready",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 1,
+      "equivalence_pass": true,
+      "expected_final_cycle": 36,
+      "final_cycle": 36,
+      "functional_pass": true,
+      "scenario": "memory_stalls",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 1,
+      "equivalence_pass": true,
+      "expected_final_cycle": 35,
+      "final_cycle": 35,
+      "functional_pass": true,
+      "scenario": "result_backpressure",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 2,
+      "equivalence_pass": true,
+      "expected_final_cycle": 29,
+      "final_cycle": 29,
+      "functional_pass": true,
+      "scenario": "always_ready",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 2,
+      "equivalence_pass": true,
+      "expected_final_cycle": 32,
+      "final_cycle": 32,
+      "functional_pass": true,
+      "scenario": "memory_stalls",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 2,
+      "equivalence_pass": true,
+      "expected_final_cycle": 29,
+      "final_cycle": 29,
+      "functional_pass": true,
+      "scenario": "result_backpressure",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 4,
+      "equivalence_pass": true,
+      "expected_final_cycle": 27,
+      "final_cycle": 27,
+      "functional_pass": true,
+      "scenario": "always_ready",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 4,
+      "equivalence_pass": true,
+      "expected_final_cycle": 30,
+      "final_cycle": 30,
+      "functional_pass": true,
+      "scenario": "memory_stalls",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 4,
+      "equivalence_pass": true,
+      "expected_final_cycle": 29,
+      "final_cycle": 29,
+      "functional_pass": true,
+      "scenario": "result_backpressure",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 8,
+      "equivalence_pass": true,
+      "expected_final_cycle": 26,
+      "final_cycle": 26,
+      "functional_pass": true,
+      "scenario": "always_ready",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 8,
+      "equivalence_pass": true,
+      "expected_final_cycle": 29,
+      "final_cycle": 29,
+      "functional_pass": true,
+      "scenario": "memory_stalls",
+      "schedule_pass": true
+    },
+    {
+      "block_count": 8,
+      "div_lanes_per_cycle": 8,
+      "equivalence_pass": true,
+      "expected_final_cycle": 26,
+      "final_cycle": 26,
+      "functional_pass": true,
+      "scenario": "result_backpressure",
+      "schedule_pass": true
+    }
+  ],
+  "scenarios": [
+    "always_ready",
+    "memory_stalls",
+    "result_backpressure"
+  ],
+  "score_storage": "external_ready_valid_sram",
+  "semantic_profile": "q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max",
+  "version": 1
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.md
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.md
@@ -1,0 +1,4 @@
+# Two-Pass Stream Equivalence
+
+- decision: `attention_two_pass_stream_equivalence_pass`
+- equivalence pass: `True`


### PR DESCRIPTION
## Summary
- item_id: `l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1`
- run_key: `l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1_run_ecf327e57d2035b0`
- layer: `layer2`
- task_type: `l2_campaign`
- status: `ok`
- summary: `2/2 commands succeeded`
- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1/evaluated.json`
- metrics_rows_count: `0`
- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json`

## Developer Context
- proposal_id: `prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1`
- proposal_path: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json`
- reviewer_first_read: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
- execution_source_commit: `638989e3b2353bf1fe41c55c51fdc25246359cf2`
- review_metadata_source_commit: `638989e3b2353bf1fe41c55c51fdc25246359cf2`

## Evaluation Mode
- evaluation_mode: `equivalence_gate`
- abstraction_layer: `decoder_attention_two_pass_stream_equivalence`
- comparison_role: `memory_interface_equivalence_gate`
- expected_direction: `prove_two_pass_stream_equivalence`
- expected_reason: `Physical measurement is ineligible until score-SRAM and KV replay handshakes preserve the selected arithmetic under independent stalls.`
- expectation_status: `unspecified`
- evaluation_summary: `Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].`

## Focused Comparison
- primary_question: `Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?`
- comparison_role: `memory_interface_equivalence_gate`
- proposal_outcome: `attention_two_pass_stream_equivalence_pass`
- comparison_summary: `Two-pass external-memory stream equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_two_pass_stream_equivalence__l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1.json: decision=attention_two_pass_stream_equivalence_pass; equivalence_pass=True; semantic_profile=q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max; score_storage=external_ready_valid_sram; kv_replay=external_ready_valid_stream; block_counts=[4, 8]; div_lanes_per_cycle=[1, 2, 4, 8]; scenarios=['always_ready', 'memory_stalls', 'result_backpressure'].`
- baseline_ref: `None`
- baseline_item_id: `None`

## Checklist
- [ ] Commit lightweight campaign artifacts only
- [ ] Include metrics row references in result.metrics_rows
- [ ] Keep committed result_path fields repo-portable
- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing
