### PR TITLE
control_plane: classify timing-infeasible L1 results

### DIFF
--- a/.github/workflows/validate-runs.yml
+++ b/.github/workflows/validate-runs.yml
@@ -34,9 +34,11 @@ jobs:
         run: python scripts/validate_runs.py
 
       - name: Regenerate index
+        if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'eval/')
         run: python scripts/build_runs_index.py
 
       - name: Check index is up to date
+        if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'eval/')
         run: |
           if git diff --ignore-cr-at-eol --exit-code runs/index.csv; then
             echo "Index is up to date"
@@ -44,3 +46,7 @@ jobs:
             echo "::error::runs/index.csv is out of date. Run 'python scripts/build_runs_index.py' and commit the result."
             exit 1
           fi
+
+      - name: Confirm central index ownership for evaluator PR
+        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'eval/')
+        run: echo "Evaluator PR validated without regenerating runs/index.csv; the post-merge finalizer owns the shared index."

--- a/.github/workflows/validate-runs.yml
+++ b/.github/workflows/validate-runs.yml
@@ -8,12 +8,14 @@ on:
       - 'scripts/validate_runs.py'
       - 'scripts/build_runs_index.py'
       - 'tests/test_runs_parsers.py'
+      - '.github/workflows/validate-runs.yml'
   pull_request:
     paths:
       - 'runs/**'
       - 'scripts/validate_runs.py'
       - 'scripts/build_runs_index.py'
       - 'tests/test_runs_parsers.py'
+      - '.github/workflows/validate-runs.yml'
   workflow_dispatch:
 
 jobs:

--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -108,6 +108,34 @@ def _safe_float(value: str | None) -> float | None:
         return None
 
 
+def _row_timing_assessment(row: dict[str, Any]) -> dict[str, Any]:
+    critical_path_ns = _safe_float(row.get("critical_path_ns"))
+    clock_period_ns = _safe_float(row.get("clock_period_ns"))
+    if clock_period_ns is None:
+        params_text = str(row.get("params_json", "")).strip()
+        if params_text:
+            try:
+                params = json.loads(params_text)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                params = {}
+            if isinstance(params, dict):
+                clock_period_ns = _safe_float(params.get("CLOCK_PERIOD"))
+
+    if critical_path_ns is None or clock_period_ns is None or clock_period_ns <= 0:
+        return {
+            "timing_feasible": None,
+            "clock_period_ns": clock_period_ns,
+            "timing_slack_ns": None,
+        }
+
+    slack_ns = clock_period_ns - critical_path_ns
+    return {
+        "timing_feasible": slack_ns >= 0.0,
+        "clock_period_ns": clock_period_ns,
+        "timing_slack_ns": slack_ns,
+    }
+
+
 def _row_sort_key(row: dict[str, Any]) -> tuple[float, float, float, str, str]:
     cp = _safe_float(row.get("critical_path_ns"))
     area = _safe_float(row.get("die_area"))
@@ -329,14 +357,18 @@ def _effective_evaluation_record(*, repo_root: Path, work_item: WorkItem, best_r
             + "; no physical metrics are recorded yet."
         )
     else:
-        summary = "Physical metrics recorded from an accepted status=ok Layer 1 row."
-    return {
+        summary = "Physical metrics recorded from a completed, timing-feasible Layer 1 row."
+    record = {
         "evaluation_mode": mode,
         "abstraction_layer": _developer_loop_abstraction_layer(repo_root, work_item),
         "result_kind": result_kind,
         "physical_metrics_present": has_physical_metrics,
         "summary": summary,
     }
+    timing = _row_timing_assessment(best_row)
+    if timing["timing_feasible"] is not None:
+        record.update(timing)
+    return record
 
 
 def _best_metrics_row(
@@ -344,6 +376,7 @@ def _best_metrics_row(
     repo_root: Path,
     metrics_csv: str,
     tag_prefixes: tuple[str, ...] = (),
+    require_timing_feasible: bool = True,
 ) -> dict[str, Any] | None:
     path = _resolve_path(repo_root=repo_root, path_text=metrics_csv)
     if not path.exists():
@@ -353,6 +386,8 @@ def _best_metrics_row(
         if str(row.get("status", "")).strip() != "ok":
             continue
         if not _row_in_current_sweep_scope(row, tag_prefixes=tag_prefixes):
+            continue
+        if require_timing_feasible and _row_timing_assessment(row)["timing_feasible"] is False:
             continue
         rows.append(dict(row))
     if not rows:
@@ -372,15 +407,21 @@ def _boundary_metrics_rows(
         if not path.exists():
             continue
         for raw_row in _load_metrics_rows(path):
-            status = str(raw_row.get("status", "")).strip()
-            if status == "ok":
+            flow_status = str(raw_row.get("status", "")).strip()
+            timing = _row_timing_assessment(raw_row)
+            timing_infeasible = flow_status == "ok" and timing["timing_feasible"] is False
+            if flow_status == "ok" and not timing_infeasible:
                 continue
             if not _row_in_current_sweep_scope(raw_row, tag_prefixes=tag_prefixes):
                 continue
+            status = "timing_infeasible" if timing_infeasible else flow_status
             evidence: dict[str, Any] = {
                 "metrics_csv": metrics_csv,
                 "status": status,
             }
+            if timing_infeasible:
+                evidence["flow_status"] = flow_status
+                evidence.update(timing)
             for key in (
                 "design",
                 "platform",
@@ -403,12 +444,21 @@ def _boundary_metrics_rows(
 
 def _boundary_evaluation_record(*, repo_root: Path, work_item: WorkItem, boundary_rows: list[dict[str, Any]]) -> dict[str, Any]:
     status_counts = Counter(str(row.get("status", "")).strip() or "unknown" for row in boundary_rows)
+    timing_infeasible_count = status_counts.get("timing_infeasible", 0)
+    if timing_infeasible_count:
+        summary = (
+            "No timing-feasible Layer 1 rows were produced; completed flows that miss their "
+            "declared clock period are retained as explicit timing-boundary evidence."
+        )
+    else:
+        summary = "No status=ok Layer 1 rows were produced; non-ok metrics rows are recorded as explicit boundary evidence."
     return {
         "evaluation_mode": "measurement_only",
         "abstraction_layer": _developer_loop_abstraction_layer(repo_root, work_item),
         "result_kind": "boundary_evidence",
-        "physical_metrics_present": False,
-        "summary": "No status=ok Layer 1 rows were produced; non-ok metrics rows are recorded as explicit boundary evidence.",
+        "physical_metrics_present": bool(timing_infeasible_count),
+        "timing_feasible": False if timing_infeasible_count else None,
+        "summary": summary,
         "boundary_status_counts": dict(status_counts),
     }
 
@@ -501,7 +551,12 @@ def _best_trial_row(repo_root: Path, run: Run) -> tuple[str, dict[str, Any]] | N
     candidates: list[tuple[str, dict[str, Any]]] = []
     tag_prefixes = _current_sweep_tag_prefixes(repo_root, run.work_item)
     for metrics_csv in _metrics_csvs_from_run(run, work_item=run.work_item):
-        best_row = _best_metrics_row(repo_root=repo_root, metrics_csv=metrics_csv, tag_prefixes=tag_prefixes)
+        best_row = _best_metrics_row(
+            repo_root=repo_root,
+            metrics_csv=metrics_csv,
+            tag_prefixes=tag_prefixes,
+            require_timing_feasible=False,
+        )
         if best_row is None:
             continue
         candidates.append((metrics_csv, best_row))
@@ -898,9 +953,22 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
     payload["trial_summary"] = summary_stats
     if boundary_rows:
         if not proposals:
+            timing_infeasible_count = sum(
+                1 for row in boundary_rows if str(row.get("status", "")).strip() == "timing_infeasible"
+            )
+            if timing_infeasible_count:
+                assessment_summary = (
+                    "All completed physical rows miss their declared clock period; retain them as "
+                    "timing-boundary evidence and do not promote a feasible design point."
+                )
+            else:
+                assessment_summary = (
+                    "All current Layer 1 metrics rows are non-ok; this is accepted as frontier "
+                    "boundary evidence, not a promotable design point."
+                )
             payload["proposal_assessment"] = {
                 "outcome": "boundary_no_feasible_points",
-                "summary": "All current Layer 1 metrics rows are non-ok; this is accepted as frontier boundary evidence, not a promotable design point.",
+                "summary": assessment_summary,
                 "failure_row_count": len(boundary_rows),
             }
         payload["boundary_evidence"] = {

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 from pathlib import Path
 import tempfile
@@ -29,12 +30,14 @@ def _write_metrics(path: Path, rows: list[dict[str, str]]) -> None:
         "critical_path_ns",
         "die_area",
         "total_power_mw",
+        "params_json",
         "result_path",
     ]
     with path.open("w", encoding="utf-8", newline="") as handle:
-        handle.write(",".join(headers) + "\n")
+        writer = csv.DictWriter(handle, fieldnames=headers)
+        writer.writeheader()
         for row in rows:
-            handle.write(",".join(row.get(key, "") for key in headers) + "\n")
+            writer.writerow({key: row.get(key, "") for key in headers})
 
 
 def _seed_succeeded_l1_sweep(session: Session, repo_root: Path) -> tuple[str, str]:
@@ -182,6 +185,53 @@ def test_consume_l1_result_writes_promotion_proposal() -> None:
 
             artifact = session.query(Artifact).filter_by(kind="promotion_proposal").one()
             assert artifact.path == f"control_plane/shadow_exports/l1_promotions/{item_id}.json"
+
+
+def test_consume_l1_result_records_completed_timing_misses_as_boundary_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            item_id, _run_key = _seed_succeeded_l1_sweep(session, repo_root)
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            metrics_paths = [Path(path) for path in work_item.expected_outputs if str(path).endswith("metrics.csv")]
+            for index, metrics_path in enumerate(metrics_paths):
+                _write_metrics(
+                    repo_root / metrics_path,
+                    [{
+                        "platform": "nangate45",
+                        "status": "ok",
+                        "param_hash": f"timingmiss{index}",
+                        "tag": f"tag_timing_miss_{index}",
+                        "critical_path_ns": str(42.0 + index),
+                        "die_area": str(100000 + index),
+                        "total_power_mw": str(7.0 + index),
+                        "params_json": json.dumps({"CLOCK_PERIOD": 10}),
+                        "result_path": f"runs/timing_miss_{index}/result.json",
+                    }],
+                )
+
+            result = consume_l1_result(
+                session,
+                Layer1ConsumeRequest(repo_root=str(repo_root), item_id=item_id),
+            )
+
+            assert result.proposal_count == 0
+            proposal_path = repo_root / "control_plane" / "shadow_exports" / "l1_promotions" / f"{item_id}.json"
+            payload = json.loads(proposal_path.read_text(encoding="utf-8"))
+            assert payload["proposal_assessment"]["outcome"] == "boundary_no_feasible_points"
+            assert payload["evaluation_record"]["timing_feasible"] is False
+            assert payload["evaluation_record"]["physical_metrics_present"] is True
+            assert payload["evaluation_record"]["boundary_status_counts"] == {"timing_infeasible": 2}
+            assert payload["boundary_evidence"]["row_count"] == 2
+            first = payload["boundary_evidence"]["rows"][0]
+            assert first["status"] == "timing_infeasible"
+            assert first["flow_status"] == "ok"
+            assert first["clock_period_ns"] == 10.0
+            assert first["timing_slack_ns"] == -32.0
 
 
 def test_consume_l1_result_records_failure_only_boundary_evidence() -> None:

--- a/docs/developer_agent_review.md
+++ b/docs/developer_agent_review.md
@@ -168,9 +168,15 @@ When preparing or reviewing a boundary job:
 - the report must distinguish a useful boundary failure from an infrastructure,
   checkout, or validation failure
 
+Treat `metrics.csv status=ok` as flow completion, not proof that the requested
+clock closed. When `critical_path_ns` and the declared `CLOCK_PERIOD` are both
+available, a row is promotable only if `critical_path_ns <= CLOCK_PERIOD`.
+Completed rows that miss the period must retain `flow_status=ok` but be reported
+as `timing_infeasible` boundary evidence with the clock period and signed slack.
+
 Do not use relaxed boundary acceptance for ordinary winner-selection sweeps.
-Those should continue to require at least one `status=ok` row for each expected
-metrics file.
+Those should continue to require at least one completed, timing-feasible row for
+each expected metrics file.
 
 ## Semantic Equivalence And Proxy Rule
 
@@ -203,6 +209,9 @@ Evaluation PR merge rule:
 - do not hold merge until after notebook-side analysis artifacts are updated
 - a flat or negative result can still be merge-worthy if the evidence is
   correct
+- evaluator branches commit per-design metrics but do not update the shared
+  `runs/index.csv`; CI validates their artifacts without enforcing index
+  freshness, and the post-merge finalizer rebuilds the index from tracked files
 
 Post-merge rule:
 


### PR DESCRIPTION
## Summary
- distinguish completed OpenROAD flows from timing-feasible physical points
- retain negative-slack rows as explicit `timing_infeasible` boundary evidence
- prevent timing misses from entering L1 promotion proposals
- exempt evaluator result branches from the pre-finalizer shared-index freshness check
- document timing and central-index review semantics

## Root cause
The L1 consumer treated every `status=ok` row as promotable even when `critical_path_ns` exceeded the sweep's `CLOCK_PERIOD`. Separately, evaluator PRs followed the central-index ownership policy while CI still required them to regenerate `runs/index.csv` before merge.

## Validation
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l1_result_consumer.py` (14 passed)
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_run_index_exporter.py` (passed as part of focused suite)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `python3 scripts/build_runs_index.py --tracked-only` with clean `runs/index.csv`
- workflow YAML parsed successfully

A pre-existing `test_review_publisher.py::test_publish_review_package_for_l1` expectation fails identically on `master` (`control_plane_source_commit` is `deadbeef`, test expects `None`).
