### PR TITLE
control_plane: preserve boundary evaluation mode

### DIFF
--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -445,6 +445,9 @@ def _boundary_metrics_rows(
 def _boundary_evaluation_record(*, repo_root: Path, work_item: WorkItem, boundary_rows: list[dict[str, Any]]) -> dict[str, Any]:
     status_counts = Counter(str(row.get("status", "")).strip() or "unknown" for row in boundary_rows)
     timing_infeasible_count = status_counts.get("timing_infeasible", 0)
+    developer_loop = _developer_loop_payload(work_item)
+    evaluation = developer_loop.get("evaluation") if isinstance(developer_loop.get("evaluation"), dict) else {}
+    evaluation_mode = str(evaluation.get("mode", "")).strip() or "measurement_only"
     if timing_infeasible_count:
         summary = (
             "No timing-feasible Layer 1 rows were produced; completed flows that miss their "
@@ -453,7 +456,7 @@ def _boundary_evaluation_record(*, repo_root: Path, work_item: WorkItem, boundar
     else:
         summary = "No status=ok Layer 1 rows were produced; non-ok metrics rows are recorded as explicit boundary evidence."
     return {
-        "evaluation_mode": "measurement_only",
+        "evaluation_mode": evaluation_mode,
         "abstraction_layer": _developer_loop_abstraction_layer(repo_root, work_item),
         "result_kind": "boundary_evidence",
         "physical_metrics_present": bool(timing_infeasible_count),

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -197,6 +197,10 @@ def test_consume_l1_result_records_completed_timing_misses_as_boundary_evidence(
         with Session(engine) as session:
             item_id, _run_key = _seed_succeeded_l1_sweep(session, repo_root)
             work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            request_payload = dict(work_item.task_request.request_payload or {})
+            request_payload["developer_loop"] = {"evaluation": {"mode": "frontier_followup"}}
+            work_item.task_request.request_payload = request_payload
+            session.flush()
             metrics_paths = [Path(path) for path in work_item.expected_outputs if str(path).endswith("metrics.csv")]
             for index, metrics_path in enumerate(metrics_paths):
                 _write_metrics(
@@ -223,6 +227,7 @@ def test_consume_l1_result_records_completed_timing_misses_as_boundary_evidence(
             proposal_path = repo_root / "control_plane" / "shadow_exports" / "l1_promotions" / f"{item_id}.json"
             payload = json.loads(proposal_path.read_text(encoding="utf-8"))
             assert payload["proposal_assessment"]["outcome"] == "boundary_no_feasible_points"
+            assert payload["evaluation_record"]["evaluation_mode"] == "frontier_followup"
             assert payload["evaluation_record"]["timing_feasible"] is False
             assert payload["evaluation_record"]["physical_metrics_present"] is True
             assert payload["evaluation_record"]["boundary_status_counts"] == {"timing_infeasible": 2}


### PR DESCRIPTION
## Summary
- preserve the developer-loop evaluation mode when an L1 sweep yields only boundary evidence
- retain `measurement_only` as the fallback for legacy jobs without an explicit mode
- cover a timing-infeasible `frontier_followup` result

## Root cause
The boundary result path hard-coded `measurement_only`, so regenerating PR #1256 after timing classification discarded its requested `frontier_followup` semantics.

## Validation
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l1_result_consumer.py` (14 passed)
