### PR TITLE
npu: replace two-pass final divide iteratively

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1582,6 +1582,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "kv_replay",
             "block_counts",
             "div_lanes_per_cycle",
+            "divider_impl",
             "scenarios",
         ):
             if key in evidence_payload:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6322,6 +6322,27 @@ def _decoder_attention_two_pass_stream_equivalence_evidence(*, item_id: str) -> 
     }
 
 
+def _decoder_attention_two_pass_stream_iterdiv_equivalence_evidence(*, item_id: str) -> dict[str, Any]:
+    evidence = _decoder_attention_two_pass_stream_equivalence_evidence(item_id=item_id)
+    inputs = evidence["inputs"]
+    inputs["attention_two_pass_stream_equivalence_scope"] = (
+        "Prove the exact single-unit restoring divider preserves the external score-SRAM/KV-replay "
+        "stream arithmetic and schedule under independent memory/result backpressure."
+    )
+    evidence["commands"] = [
+        {
+            "name": "probe_attention_two_pass_stream_iterdiv_equivalence",
+            "run": (
+                "python3 npu/eval/probe_attention_two_pass_stream_equivalence.py "
+                "--block-counts 4,8 --div-lanes 1 --divider-impl iterative_restoring "
+                f"--out {inputs['attention_two_pass_stream_equivalence_out']} "
+                f"--out-md {inputs['attention_two_pass_stream_equivalence_report']}"
+            ),
+        }
+    ]
+    return evidence
+
+
 def _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__{item_id}.json"
@@ -9841,6 +9862,7 @@ def _build_payload(
         "decoder_attention_hierarchical_softmax_architecture",
         "decoder_attention_two_pass_global_max_equivalence",
         "decoder_attention_two_pass_stream_equivalence",
+        "decoder_attention_two_pass_stream_iterdiv_equivalence",
         "decoder_attention_hbm_dram_service_energy",
         "decoder_attention_hbm_energy_calibration",
         "decoder_attention_hbm_command_calibrated_service",
@@ -10065,6 +10087,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_two_pass_global_max_equivalence_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_two_pass_stream_equivalence":
             decoder_evidence = _decoder_attention_two_pass_stream_equivalence_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_two_pass_stream_iterdiv_equivalence":
+            decoder_evidence = _decoder_attention_two_pass_stream_iterdiv_equivalence_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_dram_service_energy":
             decoder_evidence = _decoder_attention_hbm_dram_service_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hbm_energy_calibration":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -59,6 +59,7 @@ def test_decoder_evidence_summary_recognizes_two_pass_stream_equivalence() -> No
             "kv_replay": "external_ready_valid_stream",
             "block_counts": [4, 8],
             "div_lanes_per_cycle": [1, 2, 4, 8],
+            "divider_impl": "iterative_restoring",
             "scenarios": ["always_ready", "memory_stalls", "result_backpressure"],
         },
     )
@@ -66,6 +67,7 @@ def test_decoder_evidence_summary_recognizes_two_pass_stream_equivalence() -> No
     assert outcome == "attention_two_pass_stream_equivalence_pass"
     assert "external_ready_valid_sram" in summary
     assert "memory_stalls" in summary
+    assert "iterative_restoring" in summary
 
 
 def test_decoder_evidence_summary_recognizes_mixed_precision_int8_compute_physical_feasibility() -> None:

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7423,6 +7423,45 @@ def test_generate_l2_campaign_task_adds_attention_two_pass_stream_equivalence() 
             ]
 
 
+def test_generate_l2_campaign_task_adds_attention_two_pass_stream_iterdiv_equivalence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_two_pass_stream_iterdiv_equivalence",
+                    evaluation_mode="equivalence_gate",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "probe_attention_two_pass_stream_iterdiv_equivalence",
+                "validate_runs",
+            ]
+            command = work_item.command_manifest[0]["run"]
+            assert "--divider-impl iterative_restoring" in command
+            assert "--div-lanes 1" in command
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.expected_outputs == [
+                decoder_inputs["attention_two_pass_stream_equivalence_out"],
+                decoder_inputs["attention_two_pass_stream_equivalence_report"],
+            ]
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy_envelope_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/analysis_report.md
@@ -22,9 +22,18 @@
 - summary: No timing-feasible Layer 1 rows were produced; completed flows that miss their declared clock period are retained as explicit timing-boundary evidence.
 
 ## Failures and Caveats
-- no additional caveats recorded during automatic finalization
+- every 10 ns point completed place-and-route but failed timing; the best
+  critical paths were 42.7317/45.2992/47.3708/48.9200 ns for 1/2/4/8
+  combinational divider lanes
+- each longest path runs from divider control into `result_value`, so the
+  external score-SRAM and KV-replay interfaces are not the timing cause
+- the one-lane combinational point is also smallest and lowest power
+  (138432 um2 standard-cell area and 7.35 mW at density 0.4), but is not a
+  feasible clocked architecture
 
 ## Recommendation
 - `iterate`
 - reason: Accepted Layer 1 evidence merged, but no concrete promotion proposal entries were present.
-- next_action: inspect the next dependent item
+- next_action: prove and measure one exact shared restoring divider; its 480
+  finalization cycles add less than one percent to the 131072-token two-pass
+  fill/replay schedule while removing the combinational divide path

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
@@ -97,6 +97,46 @@
       "merged_pr_number": 1256,
       "merge_commit": "2431b5500e8700b573d6a18215619e0ac2b99eb5",
       "merged_utc": "2026-07-12T09:59:34.180012Z"
+    },
+    {
+      "item_id": "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove exact two-pass stream behavior after replacing the timing-infeasible combinational divider with one restoring divider.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_two_pass_stream_iterdiv_equivalence",
+      "comparison_role": "timing_repair_equivalence_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_two_pass_stream_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_exact_iterative_divider_replacement",
+        "reason": "The replacement must preserve every final value bit and ready/valid schedule before physical promotion."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure whether the exact shared restoring divider closes 10 ns and quantify its area and power.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_two_pass_stream_iterdiv",
+      "comparison_role": "timing_repair_ppa",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_two_pass_stream_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_two_pass_stream_iterdiv_v1/sweeps/nangate45_attention_two_pass_stream_iterdiv.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_exact_two_pass_stream_timing",
+        "reason": "A 480-cycle final divide adds less than one percent to a 131072-token two-pass row while removing the 42.7 ns path."
+      },
+      "status": "blocked_on_iterdiv_equivalence_merge"
     }
   ],
   "source_commit": "636d3d67ff149b5fa9066750d26240d7723c11b0"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
@@ -112,10 +112,50 @@
         "reason": "Choose the minimum-area divider width that remains hidden by full-context replay service."
       },
       "status": "blocked_on_stream_equivalence_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove exact two-pass stream behavior after replacing the timing-infeasible combinational divider with one restoring divider.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_two_pass_stream_iterdiv_equivalence",
+      "comparison_role": "timing_repair_equivalence_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_two_pass_stream_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_exact_iterative_divider_replacement",
+        "reason": "The replacement must preserve every final value bit and ready/valid schedule before physical promotion."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure whether the exact shared restoring divider closes 10 ns and quantify its area and power.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_two_pass_stream_iterdiv",
+      "comparison_role": "timing_repair_ppa",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_two_pass_stream_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_two_pass_stream_iterdiv_v1/sweeps/nangate45_attention_two_pass_stream_iterdiv.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_exact_two_pass_stream_timing",
+        "reason": "A 480-cycle final divide adds less than one percent to a 131072-token two-pass row while removing the 42.7 ns path."
+      },
+      "status": "blocked_on_iterdiv_equivalence_merge"
     }
   ],
   "remaining_abstractions_after_this_step": [
-    "The selected two-pass datapath still requires RTL and PPA measurement.",
+    "The exact iterative divider still requires remote equivalence and PPA measurement.",
     "The score buffer must be mapped to measured SRAM ports and scheduled with QK and V traffic.",
     "The resulting arithmetic profile requires model-native Llama quality evaluation before promotion."
   ]

--- a/npu/eval/check_attention_two_pass_stream_guard.py
+++ b/npu/eval/check_attention_two_pass_stream_guard.py
@@ -32,6 +32,9 @@ def main() -> int:
     for key in ("max_blocks", "div_lanes_per_cycle"):
         if int(manifest.get(key, 0)) != int(body.get(key, 0)):
             raise SystemExit(f"manifest {key} does not match config")
+    divider_impl = str(body.get("divider_impl", "combinational"))
+    if manifest.get("divider_impl") != divider_impl:
+        raise SystemExit("manifest divider_impl does not match config")
     if manifest.get("score_storage") != "external_ready_valid_sram":
         raise SystemExit("score storage must use external ready/valid SRAM")
     text = paths["top"].read_text(encoding="utf-8")
@@ -47,9 +50,13 @@ def main() -> int:
         "replay_ready",
         "default: exp_lut = 16'd0",
         "numerator_accum",
-        "final_magnitude / exp_sum_accum",
-        "DIV_LANES",
     )
+    if divider_impl == "iterative_restoring":
+        required += ("DIV_ITER", "div_remainder", "div_bit_count", "div_trial_remainder")
+        if "final_magnitude / exp_sum_accum" in text:
+            raise SystemExit("iterative stream RTL must not contain a combinational final divider")
+    else:
+        required += ("final_magnitude / exp_sum_accum", "DIV_LANES")
     for token in required:
         if token not in text:
             raise SystemExit(f"stream RTL missing semantic token: {token}")

--- a/npu/eval/probe_attention_two_pass_stream_equivalence.py
+++ b/npu/eval/probe_attention_two_pass_stream_equivalence.py
@@ -56,10 +56,14 @@ def _pack_values(matrix: list[list[int]]) -> int:
     return _pack([value for row in matrix for value in row], 8)
 
 
-def _config(*, top_name: str, div_lanes: int) -> JsonDict:
+def _config(*, top_name: str, div_lanes: int, divider_impl: str = "combinational") -> JsonDict:
     return {
         "top_name": top_name,
-        "attention_two_pass_stream": {"max_blocks": 16384, "div_lanes_per_cycle": div_lanes},
+        "attention_two_pass_stream": {
+            "max_blocks": 16384,
+            "div_lanes_per_cycle": div_lanes,
+            "divider_impl": divider_impl,
+        },
     }
 
 
@@ -74,9 +78,10 @@ def _ready(kind: str, scenario: str, cycle: int) -> bool:
     return True
 
 
-def _expected_cycle(*, block_count: int, div_lanes: int, scenario: str) -> int:
+def _expected_cycle(*, block_count: int, div_lanes: int, divider_impl: str, scenario: str) -> int:
     state = "idle"
     fill_index = read_index = div_index = 0
+    div_bit_index = 0
     pending = False
     for cycle in range(10000):
         old = state
@@ -97,9 +102,23 @@ def _expected_cycle(*, block_count: int, div_lanes: int, scenario: str) -> int:
             else:
                 state = "read_req"
         elif old == "divide":
-            div_index += div_lanes
-            if div_index >= 8:
-                state = "hold"
+            if divider_impl == "iterative_restoring":
+                state = "div_load"
+            else:
+                div_index += div_lanes
+                if div_index >= 8:
+                    state = "hold"
+        elif old == "div_load":
+            div_bit_index = 0
+            state = "div_iter"
+        elif old == "div_iter":
+            div_bit_index += 1
+            if div_bit_index == 58:
+                div_index += 1
+                if div_index == 8:
+                    state = "hold"
+                else:
+                    state = "divide"
         elif old == "hold" and _ready("result", scenario, cycle):
             return cycle
     raise RuntimeError("expected-cycle model timed out")
@@ -215,12 +234,13 @@ endmodule
 _RESULT = re.compile(r"RESULT cycle=(\d+) id=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+)")
 
 
-def _run_rtl(*, block_count: int, div_lanes: int, scenario: str) -> JsonDict:
-    top_name = f"attention_two_pass_stream_d{div_lanes}"
+def _run_rtl(*, block_count: int, div_lanes: int, divider_impl: str, scenario: str) -> JsonDict:
+    suffix = "iterdiv" if divider_impl == "iterative_restoring" else f"d{div_lanes}"
+    top_name = f"attention_two_pass_stream_{suffix}"
     with tempfile.TemporaryDirectory(prefix="attention-two-pass-stream-") as tmp_text:
         tmp = Path(tmp_text)
         rtl = tmp / "rtl"
-        generate(_config(top_name=top_name, div_lanes=div_lanes), rtl)
+        generate(_config(top_name=top_name, div_lanes=div_lanes, divider_impl=divider_impl), rtl)
         tb = tmp / "tb.sv"
         tb.write_text(
             _testbench(top_name=top_name, block_count=block_count, div_lanes=div_lanes, scenario=scenario),
@@ -246,15 +266,30 @@ def _run_rtl(*, block_count: int, div_lanes: int, scenario: str) -> JsonDict:
         }
 
 
-def build_report(*, block_counts: list[int], div_lanes: list[int]) -> JsonDict:
+def build_report(
+    *,
+    block_counts: list[int],
+    div_lanes: list[int],
+    divider_impl: str = "combinational",
+) -> JsonDict:
     command = default_commands(1)[0]
     rows: list[JsonDict] = []
     for block_count in block_counts:
         expected = two_pass_command(command, block_count=block_count)
         for lanes in div_lanes:
             for scenario in ("always_ready", "memory_stalls", "result_backpressure"):
-                rtl = _run_rtl(block_count=block_count, div_lanes=lanes, scenario=scenario)
-                expected_cycle = _expected_cycle(block_count=block_count, div_lanes=lanes, scenario=scenario)
+                rtl = _run_rtl(
+                    block_count=block_count,
+                    div_lanes=lanes,
+                    divider_impl=divider_impl,
+                    scenario=scenario,
+                )
+                expected_cycle = _expected_cycle(
+                    block_count=block_count,
+                    div_lanes=lanes,
+                    divider_impl=divider_impl,
+                    scenario=scenario,
+                )
                 functional = all(
                     rtl[key] == expected[key] for key in ("command_id", "global_max", "exp_sum", "value")
                 )
@@ -263,6 +298,7 @@ def build_report(*, block_counts: list[int], div_lanes: list[int]) -> JsonDict:
                     {
                         "block_count": block_count,
                         "div_lanes_per_cycle": lanes,
+                        "divider_impl": divider_impl,
                         "scenario": scenario,
                         "functional_pass": functional,
                         "schedule_pass": schedule,
@@ -282,6 +318,7 @@ def build_report(*, block_counts: list[int], div_lanes: list[int]) -> JsonDict:
         "kv_replay": "external_ready_valid_stream",
         "block_counts": block_counts,
         "div_lanes_per_cycle": div_lanes,
+        "divider_impl": divider_impl,
         "scenarios": ["always_ready", "memory_stalls", "result_backpressure"],
         "rows": rows,
     }
@@ -291,12 +328,14 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--block-counts", default="4,8")
     parser.add_argument("--div-lanes", default="1,2,4,8")
+    parser.add_argument("--divider-impl", choices=("combinational", "iterative_restoring"), default="combinational")
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
     args = parser.parse_args()
     payload = build_report(
         block_counts=[int(value) for value in args.block_counts.split(",") if value],
         div_lanes=[int(value) for value in args.div_lanes.split(",") if value],
+        divider_impl=args.divider_impl,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/npu/rtlgen/gen_attention_two_pass_stream.py
+++ b/npu/rtlgen/gen_attention_two_pass_stream.py
@@ -14,7 +14,7 @@ def _load(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _validate(config: dict[str, Any]) -> dict[str, int]:
+def _validate(config: dict[str, Any]) -> dict[str, int | str]:
     if not str(config.get("top_name") or "").strip():
         raise SystemExit("config top_name must not be empty")
     body = config.get("attention_two_pass_stream")
@@ -22,11 +22,22 @@ def _validate(config: dict[str, Any]) -> dict[str, int]:
         raise SystemExit("config must contain attention_two_pass_stream object")
     max_blocks = int(body.get("max_blocks", 16384))
     div_lanes = int(body.get("div_lanes_per_cycle", 1))
+    divider_impl = str(body.get("divider_impl", "combinational")).strip()
     if max_blocks < 8 or max_blocks > 16384 or max_blocks & (max_blocks - 1):
         raise SystemExit("attention_two_pass_stream.max_blocks must be a power of two in [8, 16384]")
     if div_lanes not in {1, 2, 4, 8}:
         raise SystemExit("attention_two_pass_stream.div_lanes_per_cycle must be one of 1,2,4,8")
-    params = {"max_blocks": max_blocks, "div_lanes_per_cycle": div_lanes}
+    if divider_impl not in {"combinational", "iterative_restoring"}:
+        raise SystemExit(
+            "attention_two_pass_stream.divider_impl must be combinational or iterative_restoring"
+        )
+    if divider_impl == "iterative_restoring" and div_lanes != 1:
+        raise SystemExit("iterative_restoring uses one shared divider; div_lanes_per_cycle must be 1")
+    params: dict[str, int | str] = {
+        "max_blocks": max_blocks,
+        "div_lanes_per_cycle": div_lanes,
+        "divider_impl": divider_impl,
+    }
     body.update(params)
     return params
 
@@ -42,11 +53,12 @@ def _exp_cases() -> str:
     )
 
 
-def _top(*, top_name: str, params: dict[str, int]) -> str:
-    max_blocks = params["max_blocks"]
+def _top(*, top_name: str, params: dict[str, int | str]) -> str:
+    max_blocks = int(params["max_blocks"])
     addr_bits = _clog2(max_blocks)
     count_bits = _clog2(max_blocks + 1)
-    div_lanes = params["div_lanes_per_cycle"]
+    div_lanes = int(params["div_lanes_per_cycle"])
+    divider_impl = str(params["divider_impl"])
     reset_num = "\n".join(f"      numerator_accum[{lane}] <= 41'sd0;" for lane in range(8))
     clear_num = "\n".join(f"        numerator_accum[{lane}] <= 41'sd0;" for lane in range(8))
     init_block = "\n".join(f"        block_numerator[{lane}] = 41'sd0;" for lane in range(8))
@@ -54,6 +66,106 @@ def _top(*, top_name: str, params: dict[str, int]) -> str:
         f"        numerator_next[{lane}] = numerator_accum[{lane}] + block_numerator[{lane}];" for lane in range(8)
     )
     store_num = "\n".join(f"        numerator_accum[{lane}] <= numerator_next[{lane}];" for lane in range(8))
+    if divider_impl == "iterative_restoring":
+        state_params = (
+            "  localparam [2:0] IDLE = 3'd0, FILL = 3'd1, READ_REQ = 3'd2,\n"
+            "      READ_DATA = 3'd3, DIVIDE = 3'd4, DIV_LOAD = 3'd5,\n"
+            "      DIV_ITER = 3'd6, HOLD = 3'd7;"
+        )
+        divider_regs = """
+  reg div_negative;
+  reg [6:0] div_bit_count;
+  reg [57:0] div_quotient;
+  reg [33:0] div_remainder;
+  reg [33:0] div_trial_remainder;
+  reg [57:0] div_next_quotient;
+"""
+        divider_reset = """
+      div_negative <= 1'b0;
+      div_bit_count <= 7'd0;
+      div_quotient <= 58'd0;
+      div_remainder <= 34'd0;
+"""
+        divider_logic = """
+      if (state == DIVIDE) begin
+        div_negative <= numerator_accum[div_index] < 0;
+        if (numerator_accum[div_index] < 0)
+          numerator_magnitude <= (~numerator_accum[div_index]) + 1'b1;
+        else
+          numerator_magnitude <= numerator_accum[div_index];
+        state <= DIV_LOAD;
+      end
+
+      if (state == DIV_LOAD) begin
+        final_magnitude <= ({17'd0, numerator_magnitude} << 16)
+            - {17'd0, numerator_magnitude} + (exp_sum_accum >> 1);
+        div_quotient <= 58'd0;
+        div_remainder <= 34'd0;
+        div_bit_count <= 7'd58;
+        state <= DIV_ITER;
+      end
+
+      if (state == DIV_ITER) begin
+        div_trial_remainder = {div_remainder[32:0], final_magnitude[57]};
+        div_next_quotient = {div_quotient[56:0], 1'b0};
+        if (div_trial_remainder >= {1'b0, exp_sum_accum}) begin
+          div_remainder <= div_trial_remainder - {1'b0, exp_sum_accum};
+          div_next_quotient[0] = 1'b1;
+        end else begin
+          div_remainder <= div_trial_remainder;
+        end
+        final_magnitude <= {final_magnitude[56:0], 1'b0};
+        div_quotient <= div_next_quotient;
+        if (div_bit_count == 1) begin
+          if (div_negative)
+            result_value[(div_index * 40) +: 40] <= (~div_next_quotient[39:0]) + 1'b1;
+          else
+            result_value[(div_index * 40) +: 40] <= div_next_quotient[39:0];
+          if (div_index == 7) begin
+            state <= HOLD;
+            result_valid <= 1'b1;
+          end else begin
+            div_index <= div_index + 1'b1;
+            state <= DIVIDE;
+          end
+        end else begin
+          div_bit_count <= div_bit_count - 1'b1;
+        end
+      end
+"""
+    else:
+        state_params = (
+            "  localparam [2:0] IDLE = 3'd0, FILL = 3'd1, READ_REQ = 3'd2,\n"
+            "      READ_DATA = 3'd3, DIVIDE = 3'd4, HOLD = 3'd5;"
+        )
+        divider_regs = ""
+        divider_reset = ""
+        divider_logic = """
+      if (state == DIVIDE) begin
+        for (lane_iter = 0; lane_iter < DIV_LANES; lane_iter = lane_iter + 1) begin
+          lane_index = div_index + lane_iter;
+          if (lane_index < 8) begin
+            if (numerator_accum[lane_index] < 0) begin
+              numerator_magnitude = (~numerator_accum[lane_index]) + 1'b1;
+              final_magnitude = (numerator_magnitude * 17'd65535) + (exp_sum_accum >> 1);
+              final_quotient = final_magnitude / exp_sum_accum;
+              result_value[(lane_index * 40) +: 40] <= (~final_quotient) + 1'b1;
+            end else begin
+              numerator_magnitude = numerator_accum[lane_index];
+              final_magnitude = (numerator_magnitude * 17'd65535) + (exp_sum_accum >> 1);
+              final_quotient = final_magnitude / exp_sum_accum;
+              result_value[(lane_index * 40) +: 40] <= final_quotient;
+            end
+          end
+        end
+        if (div_index + DIV_LANES >= 8) begin
+          state <= HOLD;
+          result_valid <= 1'b1;
+        end else begin
+          div_index <= div_index + DIV_LANES;
+        end
+      end
+"""
     return f"""module {top_name} (
     input  wire         clk,
     input  wire         rst_n,
@@ -92,8 +204,7 @@ def _top(*, top_name: str, params: dict[str, int]) -> str:
   localparam integer ADDR_W = {addr_bits};
   localparam integer COUNT_W = {count_bits};
   localparam integer DIV_LANES = {div_lanes};
-  localparam [2:0] IDLE = 3'd0, FILL = 3'd1, READ_REQ = 3'd2,
-      READ_DATA = 3'd3, DIVIDE = 3'd4, HOLD = 3'd5;
+{state_params}
 
   reg [2:0] state;
   reg [15:0] active_command_id;
@@ -122,6 +233,7 @@ def _top(*, top_name: str, params: dict[str, int]) -> str:
   reg [40:0] numerator_magnitude;
   reg [57:0] final_magnitude;
   reg [39:0] final_quotient;
+{divider_regs}
 
   assign command_ready = state == IDLE;
   assign fill_ready = state == FILL && score_write_ready;
@@ -160,6 +272,7 @@ def _top(*, top_name: str, params: dict[str, int]) -> str:
       accepted_count <= 32'd0;
       completed_count <= 32'd0;
       cycle_count <= 32'd0;
+{divider_reset}
 {reset_num}
     end else begin
       cycle_count <= cycle_count + 1'b1;
@@ -224,30 +337,7 @@ def _top(*, top_name: str, params: dict[str, int]) -> str:
         end
       end
 
-      if (state == DIVIDE) begin
-        for (lane_iter = 0; lane_iter < DIV_LANES; lane_iter = lane_iter + 1) begin
-          lane_index = div_index + lane_iter;
-          if (lane_index < 8) begin
-            if (numerator_accum[lane_index] < 0) begin
-              numerator_magnitude = (~numerator_accum[lane_index]) + 1'b1;
-              final_magnitude = (numerator_magnitude * 17'd65535) + (exp_sum_accum >> 1);
-              final_quotient = final_magnitude / exp_sum_accum;
-              result_value[(lane_index * 40) +: 40] <= (~final_quotient) + 1'b1;
-            end else begin
-              numerator_magnitude = numerator_accum[lane_index];
-              final_magnitude = (numerator_magnitude * 17'd65535) + (exp_sum_accum >> 1);
-              final_quotient = final_magnitude / exp_sum_accum;
-              result_value[(lane_index * 40) +: 40] <= final_quotient;
-            end
-          end
-        end
-        if (div_index + DIV_LANES >= 8) begin
-          state <= HOLD;
-          result_valid <= 1'b1;
-        end else begin
-          div_index <= div_index + DIV_LANES;
-        end
-      end
+{divider_logic}
 
       if (state == HOLD && result_valid && result_ready) begin
         result_valid <= 1'b0;
@@ -271,8 +361,16 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
         "top_name": top_name,
         "semantic_profile": "q8_k8_v8_a32_s32_exp_lut_b20_zero_tail_two_pass_global_max",
         "max_blocks": params["max_blocks"],
-        "max_context_tokens": params["max_blocks"] * 8,
+        "max_context_tokens": int(params["max_blocks"]) * 8,
         "div_lanes_per_cycle": params["div_lanes_per_cycle"],
+        "divider_impl": params["divider_impl"],
+        "divider_units": 1 if params["divider_impl"] == "iterative_restoring" else params["div_lanes_per_cycle"],
+        "divider_bits_per_cycle": 1 if params["divider_impl"] == "iterative_restoring" else None,
+        "divider_cycles_per_command": (
+            8 * (1 + 1 + 58)
+            if params["divider_impl"] == "iterative_restoring"
+            else math.ceil(8 / int(params["div_lanes_per_cycle"]))
+        ),
         "score_storage": "external_ready_valid_sram",
         "kv_replay": "external_ready_valid_stream",
         "read_outstanding": 1,

--- a/runs/campaigns/npu/attention_two_pass_stream_iterdiv_v1/sweeps/nangate45_attention_two_pass_stream_iterdiv.json
+++ b/runs/campaigns/npu/attention_two_pass_stream_iterdiv_v1/sweeps/nangate45_attention_two_pass_stream_iterdiv.json
@@ -1,0 +1,13 @@
+{
+  "tag_prefix": "attention_two_pass_stream_iterdiv_v1",
+  "flow_params": {
+    "TAG": ["attention_two_pass_stream_iterdiv_v1"],
+    "FLOW_VARIANT": ["attention_two_pass_stream_iterdiv_v1"],
+    "CLOCK_PERIOD": [10],
+    "DIE_AREA": ["0 0 2500 2500"],
+    "CORE_AREA": ["50 50 2450 2450"],
+    "PLACE_DENSITY": [0.3, 0.4],
+    "SYNTH_HIERARCHICAL": [1],
+    "SYNTH_MEMORY_MAX_BITS": [65536]
+  }
+}

--- a/runs/designs/npu_blocks/attention_two_pass_stream_iterdiv/config.json
+++ b/runs/designs/npu_blocks/attention_two_pass_stream_iterdiv/config.json
@@ -1,0 +1,8 @@
+{
+  "top_name": "attention_two_pass_stream_iterdiv",
+  "attention_two_pass_stream": {
+    "max_blocks": 16384,
+    "div_lanes_per_cycle": 1,
+    "divider_impl": "iterative_restoring"
+  }
+}

--- a/tests/test_attention_two_pass_stream.py
+++ b/tests/test_attention_two_pass_stream.py
@@ -10,10 +10,14 @@ from npu.eval.probe_attention_two_pass_stream_equivalence import build_report
 from npu.rtlgen.gen_attention_two_pass_stream import generate
 
 
-def _config(div_lanes: int = 2) -> dict:
+def _config(div_lanes: int = 2, divider_impl: str = "combinational") -> dict:
     return {
         "top_name": f"attention_two_pass_stream_d{div_lanes}",
-        "attention_two_pass_stream": {"max_blocks": 16384, "div_lanes_per_cycle": div_lanes},
+        "attention_two_pass_stream": {
+            "max_blocks": 16384,
+            "div_lanes_per_cycle": div_lanes,
+            "divider_impl": divider_impl,
+        },
     }
 
 
@@ -26,6 +30,7 @@ def test_attention_two_pass_stream_generator_has_external_memory_ports(tmp_path:
     assert manifest["max_context_tokens"] == 131072
     assert manifest["score_storage"] == "external_ready_valid_sram"
     assert manifest["div_lanes_per_cycle"] == 2
+    assert manifest["divider_impl"] == "combinational"
     assert "score_write_valid" in text
     assert "score_read_req_valid" in text
     assert "score_mem" not in text
@@ -64,3 +69,35 @@ def test_attention_two_pass_stream_perf_rtl_equivalence() -> None:
     assert report["equivalence_pass"] is True
     assert len(report["rows"]) == 24
     assert all(row["equivalence_pass"] for row in report["rows"])
+
+
+def test_attention_two_pass_stream_iterative_divider_is_exact_and_division_free(tmp_path: Path) -> None:
+    config = _config(div_lanes=1, divider_impl="iterative_restoring")
+    config["top_name"] = "attention_two_pass_stream_iterdiv"
+    design_dir = tmp_path / "design"
+    design_dir.mkdir()
+    (design_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    generate(config, design_dir / "verilog")
+
+    manifest = json.loads((design_dir / "verilog" / "attention_two_pass_stream_manifest.json").read_text())
+    text = (design_dir / "verilog" / "top.v").read_text()
+    assert manifest["divider_impl"] == "iterative_restoring"
+    assert manifest["divider_units"] == 1
+    assert manifest["divider_cycles_per_command"] == 480
+    assert "DIV_ITER" in text
+    assert "final_magnitude / exp_sum_accum" not in text
+    subprocess.run(
+        [sys.executable, "npu/eval/check_attention_two_pass_stream_guard.py", "--design-dir", str(design_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    report = build_report(
+        block_counts=[4, 8],
+        div_lanes=[1],
+        divider_impl="iterative_restoring",
+    )
+    assert report["equivalence_pass"] is True
+    assert len(report["rows"]) == 6
+    assert {row["final_cycle"] for row in report["rows"] if row["scenario"] == "always_ready"} == {493, 505}


### PR DESCRIPTION
## Summary
- add an exact single-unit restoring divider to the external-memory two-pass attention engine
- preserve the existing combinational divider configurations for measured boundary comparison
- extend perf/RTL equivalence to cover iterative scheduling and independent stalls
- add the Nangate45 iterative-divider design and sweep
- gate PPA behind a dedicated remote equivalence item
- record the combinational timing boundary and concrete next action in the proposal

## Architecture
The 58-bit rounded dividend is processed one quotient bit per cycle by one shared 34-bit compare/subtract datapath. Sign/magnitude capture and dividend formation are separate states. Eight output lanes require 480 cycles, about 0.98% of the 49,152-cycle full-context fill/replay schedule for 131,072 tokens.

## Validation
- iterative perf/RTL: 6/6 cases pass for block counts 4/8 and always-ready, memory-stall, and result-backpressure scenarios
- existing combinational perf/RTL: 24/24 cases still pass
- `pytest -q tests/test_attention_two_pass_stream.py` (5 passed)
- focused L1/L2 control-plane tests (3 passed)
- Icarus compile for combinational and iterative generated RTL
- Yosys `proc; opt; check` passes and reports no `$div` cell for the iterative design
- iterative stream guard passes
- `python3 scripts/validate_runs.py --skip_eval_queue`
