### PR TITLE
npu: reserve measured SRAM for two-pass scores

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6397,6 +6397,28 @@ def _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(*, item_
     }
 
 
+def _decoder_attention_two_pass_score_sram_reservation_evidence(*, item_id: str) -> dict[str, Any]:
+    evidence = _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(item_id=item_id)
+    inputs = evidence["inputs"]
+    score_sram_metrics = "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json"
+    inputs["attention_two_pass_score_sram_metrics"] = score_sram_metrics
+    inputs["attention_score32_exp_lut_sram_hierarchy_envelope_scope"] = (
+        "Reserve one measured 512 KiB x 256-bit score SRAM macro per Llama7B attention head before "
+        "packing remaining KV SRAM capacity; account score write/replay energy and propagate reduced "
+        "KV residency into HBM share and token latency."
+    )
+    command = evidence["commands"][0]
+    command["name"] = "audit_decoder_attention_two_pass_score_sram_reservation"
+    command["run"] = command["run"].replace(
+        "--placement-efficiency",
+        f"--score-buffer-sram-metrics-json {score_sram_metrics} "
+        "--score-buffer-macro-name kv_tile_read_buffer "
+        "--score-buffer-bytes 16777216 --attention-heads 32 --score-block-bytes 32 "
+        "--clock-period-ns 10 --placement-efficiency",
+    )
+    return evidence
+
+
 def _decoder_attention_integrated_abstraction_closure_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_integrated_abstraction_closure__{item_id}.json"
@@ -9853,6 +9875,7 @@ def _build_payload(
         "decoder_attention_score32_exp_lut_measured_wrapper_promotion",
         "decoder_attention_score32_exp_lut_service_closure",
         "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
+        "decoder_attention_two_pass_score_sram_reservation",
         "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
         "decoder_attention_score32_hbm_controller_replay",
         "decoder_attention_score32_integrated_frontier_ranking",
@@ -10063,6 +10086,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_score32_exp_lut_service_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_exp_lut_sram_hierarchy_envelope":
             decoder_evidence = _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_two_pass_score_sram_reservation":
+            decoder_evidence = _decoder_attention_two_pass_score_sram_reservation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_exp_lut_hbm_dram_service_closure":
             decoder_evidence = _decoder_attention_score32_exp_lut_hbm_dram_service_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_hbm_controller_replay":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7522,6 +7522,47 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy
             )
 
 
+def test_generate_l2_campaign_task_adds_two_pass_score_sram_reservation() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_two_pass_score_sram_reservation",
+                    evaluation_mode="frontier_recost",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert commands[0]["name"] == "audit_decoder_attention_two_pass_score_sram_reservation"
+            assert "--score-buffer-sram-metrics-json" in run
+            assert "llama7b_attention_tile_buffers_v1/sram_metrics.json" in run
+            assert "--score-buffer-macro-name kv_tile_read_buffer" in run
+            assert "--score-buffer-bytes 16777216" in run
+            assert "--attention-heads 32" in run
+            assert "--score-block-bytes 32" in run
+            assert decoder_inputs["attention_two_pass_score_sram_metrics"].endswith(
+                "llama7b_attention_tile_buffers_v1/sram_metrics.json"
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
@@ -142,6 +142,24 @@
       },
       "status": "ready_to_queue",
       "notes": "Prerequisites are merged; item is ready to queue."
+    },
+    {
+      "item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Reserve a measured 16 MiB score SRAM before KV packing and recost Llama7B latency, area, and energy.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_two_pass_score_sram_reservation",
+      "comparison_role": "measured_score_memory_recost",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "reserve_measured_score_sram_before_kv",
+        "reason": "The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "source_commit": "d34ba91f06cc149de6ab71b5bd5f783586c629c4"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
@@ -152,11 +152,29 @@
         "reason": "A 480-cycle final divide adds less than one percent to a 131072-token two-pass row while removing the 42.7 ns path."
       },
       "status": "blocked_on_iterdiv_equivalence_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Reserve a measured 16 MiB score SRAM before KV packing and recost Llama7B latency, area, and energy.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_two_pass_score_sram_reservation",
+      "comparison_role": "measured_score_memory_recost",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "reserve_measured_score_sram_before_kv",
+        "reason": "The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "remaining_abstractions_after_this_step": [
     "The exact iterative divider still requires remote equivalence and PPA measurement.",
-    "The score buffer must be mapped to measured SRAM ports and scheduled with QK and V traffic.",
+    "The measured score-SRAM macro reservation still requires a placed macro floorplan and composed QK/KV schedule recost.",
     "The resulting arithmetic profile requires model-native Llama quality evaluation before promotion."
   ]
 }

--- a/npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py
@@ -80,6 +80,79 @@ def _macro_library(capacity_payload: JsonDict) -> list[JsonDict]:
     return sorted(macros, key=lambda item: (float(item["bytes_per_um2"]), int(item["size_bytes"])), reverse=True)
 
 
+def _score_buffer_profile(
+    *,
+    metrics_path: Path,
+    macro_name: str,
+    score_buffer_bytes: int,
+    attention_heads: int,
+    score_block_bytes: int,
+) -> JsonDict:
+    metrics = _load_json(metrics_path)
+    selected: JsonDict | None = None
+    for entry in metrics.get("instances", []):
+        if not isinstance(entry, dict):
+            continue
+        instance = _as_dict(entry.get("instance"))
+        metric = _as_dict(entry.get("metrics"))
+        if str(instance.get("name", "")) != macro_name:
+            continue
+        selected = {"instance": instance, "metrics": metric}
+        break
+    if selected is None:
+        raise ValueError(f"score-buffer macro {macro_name!r} not found in {metrics_path}")
+
+    instance = selected["instance"]
+    metric = selected["metrics"]
+    macro_bytes = int(instance.get("size_bytes", 0) or 0)
+    width_bits = int(instance.get("width", 0) or 0)
+    area_um2 = float(metric.get("area_um2", 0.0) or 0.0)
+    access_time_ns = float(metric.get("access_time_ns", 0.0) or 0.0)
+    read_energy_pj = float(metric.get("read_energy_pj", 0.0) or 0.0)
+    write_energy_pj = float(metric.get("write_energy_pj", 0.0) or 0.0)
+    if min(macro_bytes, width_bits, area_um2, access_time_ns, read_energy_pj, write_energy_pj) <= 0:
+        raise ValueError(f"score-buffer macro {macro_name!r} has incomplete measured metrics")
+    if score_buffer_bytes <= 0 or attention_heads <= 0 or score_block_bytes <= 0:
+        raise ValueError("score-buffer capacity, attention heads, and block bytes must be positive")
+    if score_buffer_bytes % attention_heads:
+        raise ValueError("score-buffer bytes must divide evenly across attention heads")
+    if width_bits != score_block_bytes * 8:
+        raise ValueError(
+            f"score-buffer macro width {width_bits} does not match stream block width {score_block_bytes * 8}"
+        )
+
+    bytes_per_head = score_buffer_bytes // attention_heads
+    macros_per_head = _ceil_div(bytes_per_head, macro_bytes)
+    macro_count = macros_per_head * attention_heads
+    access_count_per_token = score_buffer_bytes // score_block_bytes
+    return {
+        "source_metrics_json": str(metrics_path),
+        "macro_name": macro_name,
+        "attention_heads": attention_heads,
+        "score_buffer_bytes": score_buffer_bytes,
+        "score_buffer_mib": round(score_buffer_bytes / (1024 * 1024), 6),
+        "bytes_per_head": bytes_per_head,
+        "score_block_bytes": score_block_bytes,
+        "macro_width_bits": width_bits,
+        "macro_size_bytes": macro_bytes,
+        "macros_per_head": macros_per_head,
+        "macro_count": macro_count,
+        "allocated_capacity_bytes": macro_count * macro_bytes,
+        "macro_area_um2": round(macro_count * area_um2, 6),
+        "access_time_ns": access_time_ns,
+        "read_energy_pj_per_access": read_energy_pj,
+        "write_energy_pj_per_access": write_energy_pj,
+        "read_accesses_per_token": access_count_per_token,
+        "write_accesses_per_token": access_count_per_token,
+        "read_energy_mj_per_token": round(access_count_per_token * read_energy_pj / 1.0e9, 12),
+        "write_energy_mj_per_token": round(access_count_per_token * write_energy_pj / 1.0e9, 12),
+        "total_energy_mj_per_token": round(
+            access_count_per_token * (read_energy_pj + write_energy_pj) / 1.0e9,
+            12,
+        ),
+    }
+
+
 def _pack_capacity(*, macro_area_budget_um2: float, macros: list[JsonDict]) -> JsonDict:
     remaining = max(0.0, float(macro_area_budget_um2))
     selected: list[JsonDict] = []
@@ -139,13 +212,17 @@ def _build_row(
     composition_quantities: JsonDict,
     local_capacity_payload: JsonDict,
     macros: list[JsonDict],
+    score_buffer: JsonDict | None = None,
+    clock_period_ns: float = 10.0,
 ) -> JsonDict:
     sram_budget_um2 = float(composition_quantities["sram_budget_area_um2"])
     tile_area_um2 = float(composition_quantities["tile_sram_total_area_um2_for_active_clusters"])
     service_area_um2 = float(composition_quantities.get("scaled_local_service_area_all_clusters_um2", 0.0) or 0.0)
     shared_envelope_budget_um2 = max(0.0, sram_budget_um2 - tile_area_um2 - service_area_um2)
     macro_area_budget_um2 = shared_envelope_budget_um2 * efficiency * (1.0 - placement_overhead_fraction)
-    pack = _pack_capacity(macro_area_budget_um2=macro_area_budget_um2, macros=macros)
+    score_buffer_area_um2 = float(_as_dict(score_buffer).get("macro_area_um2", 0.0) or 0.0)
+    kv_macro_area_budget_um2 = max(0.0, macro_area_budget_um2 - score_buffer_area_um2)
+    pack = _pack_capacity(macro_area_budget_um2=kv_macro_area_budget_um2, macros=macros)
     kv_cache_bytes = int(round(float(measured_sram_row["kv_cache_mib"]) * 1024.0 * 1024.0))
     shared_byte_share = min(kv_cache_bytes, int(pack["capacity_bytes"])) / kv_cache_bytes if kv_cache_bytes else 0.0
     hbm_byte_share = max(0.0, 1.0 - shared_byte_share)
@@ -163,6 +240,17 @@ def _build_row(
         "endpoint_router_fifo_area_um2": round(service_area_um2, 6),
         "shared_sram_envelope_budget_um2": round(shared_envelope_budget_um2, 6),
         "shared_sram_macro_area_budget_um2": round(macro_area_budget_um2, 6),
+        "score_buffer_macro_area_um2": round(score_buffer_area_um2, 6),
+        "score_buffer_envelope_area_um2": round(score_buffer_area_um2 / efficiency if efficiency else 0.0, 6),
+        "score_buffer_fits_macro_budget": score_buffer_area_um2 <= macro_area_budget_um2 + 1e-6,
+        "score_buffer_access_time_ns": _as_dict(score_buffer).get("access_time_ns"),
+        "score_buffer_meets_clock": (
+            float(_as_dict(score_buffer).get("access_time_ns", 0.0) or 0.0) <= clock_period_ns
+            if score_buffer
+            else None
+        ),
+        "score_buffer_energy_mj_per_token": _as_dict(score_buffer).get("total_energy_mj_per_token", 0.0),
+        "kv_shared_sram_macro_area_budget_um2": round(kv_macro_area_budget_um2, 6),
         "shared_sram_capacity_mib": pack["capacity_mib"],
         "shared_sram_macro_area_um2": pack["macro_area_um2"],
         "shared_sram_envelope_area_um2": round(pack["macro_area_um2"] / efficiency if efficiency else 0.0, 6),
@@ -179,7 +267,7 @@ def _build_row(
             measured_sram_row.get("abstract_local_capacity_bytes_per_cluster_replaced", 0)
             or _as_dict(local_capacity_payload.get("selected_frontier")).get("local_capacity_bytes_per_cluster", 0)
         ),
-        "fits_sram_area_budget": (pack["macro_area_um2"] / efficiency if efficiency else 0.0)
+        "fits_sram_area_budget": ((pack["macro_area_um2"] + score_buffer_area_um2) / efficiency if efficiency else 0.0)
         + tile_area_um2
         + service_area_um2
         <= sram_budget_um2 + 1e-6,
@@ -195,6 +283,15 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     measured_sram_row = _best_measured_sram_row(measured_sram)
     quantities = _as_dict(composition.get("composition_quantities"))
     macros = _macro_library(local_capacity)
+    score_buffer = None
+    if args.score_buffer_sram_metrics_json:
+        score_buffer = _score_buffer_profile(
+            metrics_path=args.score_buffer_sram_metrics_json,
+            macro_name=args.score_buffer_macro_name,
+            score_buffer_bytes=args.score_buffer_bytes,
+            attention_heads=args.attention_heads,
+            score_block_bytes=args.score_block_bytes,
+        )
 
     rows = [
         _build_row(
@@ -205,6 +302,8 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             composition_quantities=quantities,
             local_capacity_payload=local_capacity,
             macros=macros,
+            score_buffer=score_buffer,
+            clock_period_ns=args.clock_period_ns,
         )
         for efficiency in args.placement_efficiency
     ]
@@ -212,9 +311,13 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     conservative = min(rows_sorted, key=lambda item: float(item["placement_efficiency"]))
     nominal = min(rows_sorted, key=lambda item: abs(float(item["placement_efficiency"]) - args.nominal_efficiency))
     hbm_share_delta = float(conservative["hbm_byte_share"]) - float(measured_sram_row["hbm_byte_share"])
+    score_buffer_feasible = all(
+        bool(row["score_buffer_fits_macro_budget"]) and bool(row["score_buffer_meets_clock"])
+        for row in rows_sorted
+    ) if score_buffer else True
     decision = (
         "score32_exp_lut_sram_hierarchy_envelope_stable"
-        if hbm_share_delta <= args.max_hbm_share_delta_for_stable
+        if hbm_share_delta <= args.max_hbm_share_delta_for_stable and score_buffer_feasible
         else "score32_exp_lut_sram_hierarchy_envelope_changes_frontier"
     )
     return {
@@ -226,6 +329,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "measured_sram_rebalance_json": str(args.measured_sram_rebalance_json),
             "local_sram_capacity_json": str(args.local_sram_capacity_json),
             "endpoint_router_sram_composition_json": str(args.endpoint_router_sram_composition_json),
+            "score_buffer_sram_metrics_json": str(args.score_buffer_sram_metrics_json)
+            if args.score_buffer_sram_metrics_json
+            else None,
         },
         "diagnosis": {
             "score32_supported": _as_dict(service_closure.get("diagnosis")).get("score32_supported"),
@@ -245,9 +351,16 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             ],
             "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr",
             "remaining_abstractions": ["hbm_dram_service", "sram_macro_floorplan_pnr"],
+            "score_buffer_reserved": score_buffer is not None,
+            "score_buffer_macro_name": _as_dict(score_buffer).get("macro_name"),
+            "score_buffer_macro_count": _as_dict(score_buffer).get("macro_count", 0),
+            "score_buffer_area_mm2": round(float(_as_dict(score_buffer).get("macro_area_um2", 0.0)) / 1.0e6, 6),
+            "score_buffer_energy_mj_per_token": _as_dict(score_buffer).get("total_energy_mj_per_token", 0.0),
+            "score_buffer_feasible_across_envelope": score_buffer_feasible,
         },
         "rows": rows_sorted,
         "sram_macro_library": macros,
+        "score_buffer": score_buffer,
         "next_step": {
             "recommended_next_step": (
                 "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope "
@@ -260,6 +373,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
             "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
             "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+            "When supplied, the measured score-buffer macro set is reserved before packing remaining KV SRAM capacity.",
             "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited.",
         ],
     }
@@ -279,15 +393,20 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
         f"- conservative efficiency: `{diagnosis.get('conservative_efficiency')}`",
         f"- conservative shared MiB: `{diagnosis.get('conservative_shared_sram_capacity_mib')}`",
         f"- conservative hbm share delta: `{diagnosis.get('conservative_hbm_share_delta')}`",
+        f"- score buffer reserved: `{diagnosis.get('score_buffer_reserved')}`",
+        f"- score buffer macro: `{diagnosis.get('score_buffer_macro_name')}`",
+        f"- score buffer macro count: `{diagnosis.get('score_buffer_macro_count')}`",
+        f"- score buffer area mm2: `{diagnosis.get('score_buffer_area_mm2')}`",
+        f"- score buffer energy mJ/token: `{diagnosis.get('score_buffer_energy_mj_per_token')}`",
         "",
         "## Sweep",
         "",
-        "| efficiency | shared MiB | hbm share | projected latency us | shared envelope um2 | fits |",
-        "|---:|---:|---:|---:|---:|---|",
+        "| efficiency | KV shared MiB | score area um2 | hbm share | projected latency us | shared envelope um2 | fits |",
+        "|---:|---:|---:|---:|---:|---:|---|",
     ]
     for row in payload["rows"]:
         lines.append(
-            "| {placement_efficiency} | {shared_sram_capacity_mib} | {hbm_byte_share} | "
+            "| {placement_efficiency} | {shared_sram_capacity_mib} | {score_buffer_macro_area_um2} | {hbm_byte_share} | "
             "{projected_latency_us_hbm_share_scaled} | {shared_sram_envelope_area_um2} | "
             "{fits_sram_area_budget} |".format(**row)
         )
@@ -304,6 +423,12 @@ def main() -> int:
     parser.add_argument("--measured-sram-rebalance-json", type=Path, required=True)
     parser.add_argument("--local-sram-capacity-json", type=Path, required=True)
     parser.add_argument("--endpoint-router-sram-composition-json", type=Path, required=True)
+    parser.add_argument("--score-buffer-sram-metrics-json", type=Path)
+    parser.add_argument("--score-buffer-macro-name", default="kv_tile_read_buffer")
+    parser.add_argument("--score-buffer-bytes", type=int, default=16 * 1024 * 1024)
+    parser.add_argument("--attention-heads", type=int, default=32)
+    parser.add_argument("--score-block-bytes", type=int, default=32)
+    parser.add_argument("--clock-period-ns", type=float, default=10.0)
     parser.add_argument("--placement-efficiency", type=_float_list, default=[1.0, 0.85, 0.75, 0.65, 0.55])
     parser.add_argument("--nominal-efficiency", type=float, default=0.75)
     parser.add_argument("--placement-overhead-fraction", type=float, default=0.05)

--- a/tests/test_attention_score_sram_reservation.py
+++ b/tests/test_attention_score_sram_reservation.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+
+from npu.eval.audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope import (
+    _build_row,
+    _macro_library,
+    _score_buffer_profile,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DATASET = ROOT / "runs" / "datasets" / "llm_decoder_eval_gpt2_prompt_stress_v1"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_measured_score_sram_reservation_matches_llama7b_stream() -> None:
+    profile = _score_buffer_profile(
+        metrics_path=ROOT / "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json",
+        macro_name="kv_tile_read_buffer",
+        score_buffer_bytes=16 * 1024 * 1024,
+        attention_heads=32,
+        score_block_bytes=32,
+    )
+
+    assert profile["macro_width_bits"] == 256
+    assert profile["macros_per_head"] == 1
+    assert profile["macro_count"] == 32
+    assert profile["allocated_capacity_bytes"] == 16 * 1024 * 1024
+    assert profile["macro_area_um2"] == 66_636_897.2928
+    assert profile["access_time_ns"] == 1.4124
+    assert profile["read_accesses_per_token"] == 32 * 16384
+    assert profile["write_accesses_per_token"] == 32 * 16384
+    assert profile["total_energy_mj_per_token"] == 0.277849571328
+
+
+def test_score_sram_is_reserved_before_nominal_kv_packing() -> None:
+    local_capacity = _load(
+        DATASET
+        / "decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json"
+    )
+    measured_sram = _load(
+        DATASET
+        / "decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1.json"
+    )
+    composition = _load(
+        DATASET
+        / "decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json"
+    )
+    service_closure = _load(
+        DATASET
+        / "decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json"
+    )
+    score_buffer = _score_buffer_profile(
+        metrics_path=ROOT / "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json",
+        macro_name="kv_tile_read_buffer",
+        score_buffer_bytes=16 * 1024 * 1024,
+        attention_heads=32,
+        score_block_bytes=32,
+    )
+
+    row = _build_row(
+        efficiency=0.75,
+        placement_overhead_fraction=0.05,
+        score32_row=service_closure["selected_score32_row"],
+        measured_sram_row=measured_sram["best"],
+        composition_quantities=composition["composition_quantities"],
+        local_capacity_payload=local_capacity,
+        macros=_macro_library(local_capacity),
+        score_buffer=score_buffer,
+        clock_period_ns=10.0,
+    )
+
+    assert row["score_buffer_fits_macro_budget"] is True
+    assert row["score_buffer_meets_clock"] is True
+    assert row["shared_sram_capacity_mib"] == 29.015625
+    assert row["hbm_byte_share"] == 0.992916107
+    assert row["projected_latency_us_hbm_share_scaled"] == 12640.508864
+
+    baseline = _build_row(
+        efficiency=0.75,
+        placement_overhead_fraction=0.05,
+        score32_row=service_closure["selected_score32_row"],
+        measured_sram_row=measured_sram["best"],
+        composition_quantities=composition["composition_quantities"],
+        local_capacity_payload=local_capacity,
+        macros=_macro_library(local_capacity),
+    )
+    assert baseline["shared_sram_capacity_mib"] == 47.8125
+    assert baseline["hbm_byte_share"] == 0.988327026


### PR DESCRIPTION
## Summary
- reserve a measured 16 MiB score store before packing remaining shared KV SRAM
- map one measured 512 KiB x 256-bit macro to each of 32 Llama7B attention heads
- account score write/replay energy and access timing
- propagate reduced KV residency into HBM share and projected token latency
- add a control-plane evaluation path and proposal item

## Measured mapping
- 32 macros, 16 MiB allocated capacity
- 66.636897 mm2 macro area
- 1.4124 ns access time
- 0.277849571328 mJ/token score read+write energy
- nominal KV shared capacity changes from 47.8125 to 29.015625 MiB
- nominal projected latency becomes 12640.508864 us

## Validation
- `pytest -q tests/test_attention_score_sram_reservation.py` (2 passed)
- focused L2 task-generator test passed
- legacy no-score-reservation envelope behavior is covered
- `python3 scripts/validate_runs.py --skip_eval_queue`
