### PR TITLE
npu: gate zero-tail two-pass generation quality

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7653,6 +7653,49 @@ def _decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_evidenc
     }
 
 
+def _decoder_attention_mixed_int8_score32_zero_tail_generation_quality_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    evidence = _decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_evidence(item_id=item_id)
+    inputs = evidence["inputs"]
+    old_out = inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality_out"]
+    old_report = inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality_report"]
+    out = old_out.replace(
+        "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__",
+        "decoder_attention_mixed_int8_score32_zero_tail_two_pass_generation_quality__",
+    )
+    report = old_report.replace(
+        "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__",
+        "decoder_attention_mixed_int8_score32_zero_tail_two_pass_generation_quality__",
+    )
+    inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality_out"] = out
+    inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality_report"] = report
+    inputs.pop("attention_score32_exp_lut_div_composed_config", None)
+    inputs["attention_two_pass_stream_iterdiv_config"] = (
+        "runs/designs/npu_blocks/attention_two_pass_stream_iterdiv/config.json"
+    )
+    inputs["attention_mixed_int8_score32_exp_lut_div_generation_quality_scope"] = (
+        "Run the native-checkpoint generation/NLL gate for the exact two-pass score32 profile: "
+        "global row max, bucket20 q16 exp LUT, zero weight beyond the exp(-8) LUT boundary, "
+        "signed weighted-value accumulation, and one final exact divide."
+    )
+    command = evidence["commands"][0]
+    command["name"] = "evaluate_decoder_attention_mixed_int8_score32_zero_tail_generation_quality"
+    command["run"] = (
+        command["run"]
+        .replace(old_out, out)
+        .replace(old_report, report)
+        .replace(
+            "score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20",
+            "score32_zero_tail_two_pass:q8,k8,v8,s32,w16,exp_lut_div_zero_tail_bucket20",
+        )
+        .replace("--primary-candidate-id score32_exp_lut_div", "--primary-candidate-id score32_zero_tail_two_pass")
+    )
+    evidence["expected_outputs"] = [out, report]
+    return evidence
+
+
 def _decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality_evidence(
     *,
     item_id: str,
@@ -9906,6 +9949,7 @@ def _build_payload(
         "decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality",
         "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality",
+        "decoder_attention_mixed_int8_score32_zero_tail_generation_quality",
         "decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality",
         "decoder_attention_mixed_int8_score32_w16_rtl_recip_precision_generation_quality",
         "decoder_attention_mixed_int8_softmax_replacement_generation_quality",
@@ -10160,6 +10204,10 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality":
             decoder_evidence = _decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_evidence(
+                item_id=item_id,
+            )
+        elif abstraction_layer_name == "decoder_attention_mixed_int8_score32_zero_tail_generation_quality":
+            decoder_evidence = _decoder_attention_mixed_int8_score32_zero_tail_generation_quality_evidence(
                 item_id=item_id,
             )
         elif abstraction_layer_name == "decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -9518,6 +9518,48 @@ def test_generate_l2_campaign_task_adds_score32_exp_lut_div_generation_quality_e
             }
 
 
+def test_generate_l2_campaign_task_adds_score32_zero_tail_generation_quality_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_mixed_int8_score32_zero_tail_generation_quality",
+                    evaluation_mode="quality_gate",
+                    comparison_role="two_pass_zero_tail_generation_quality",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command = work_item.command_manifest[0]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert command["name"] == "evaluate_decoder_attention_mixed_int8_score32_zero_tail_generation_quality"
+            assert (
+                "--candidate score32_zero_tail_two_pass:q8,k8,v8,s32,w16,"
+                "exp_lut_div_zero_tail_bucket20"
+            ) in command["run"]
+            assert "--primary-candidate-id score32_zero_tail_two_pass" in command["run"]
+            assert decoder_inputs["attention_two_pass_stream_iterdiv_config"].endswith(
+                "attention_two_pass_stream_iterdiv/config.json"
+            )
+            assert "zero weight beyond the exp(-8) LUT boundary" in decoder_inputs[
+                "attention_mixed_int8_score32_exp_lut_div_generation_quality_scope"
+            ]
+
+
 def test_generate_l2_campaign_task_adds_score24_w16_rtl_exact_generation_quality_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
@@ -160,6 +160,24 @@
         "reason": "The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure native-checkpoint generation quality for the exact zero-tail two-pass score32 arithmetic.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_zero_tail_generation_quality",
+      "comparison_role": "two_pass_zero_tail_generation_quality",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "qualify_zero_tail_two_pass_precision",
+        "reason": "The earlier score32 quality pass clamps out-of-range LUT deltas to exp(-8) and cannot be transferred to the implemented zero-tail profile."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "source_commit": "d34ba91f06cc149de6ab71b5bd5f783586c629c4"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
@@ -170,6 +170,24 @@
         "reason": "The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure native-checkpoint generation quality for the exact zero-tail two-pass score32 arithmetic.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_mixed_int8_score32_zero_tail_generation_quality",
+      "comparison_role": "two_pass_zero_tail_generation_quality",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "qualify_zero_tail_two_pass_precision",
+        "reason": "The earlier score32 quality pass clamps out-of-range LUT deltas to exp(-8) and cannot be transferred to the implemented zero-tail profile."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "remaining_abstractions_after_this_step": [

--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_attention.py
@@ -142,6 +142,19 @@ def _exp_lut_div_mode(mode: str) -> int:
     return bucket_shift
 
 
+def _exp_lut_div_zero_tail_mode(mode: str) -> int:
+    prefix = "exp_lut_div_zero_tail_bucket"
+    if not mode.startswith(prefix):
+        return -1
+    try:
+        bucket_shift = int(mode[len(prefix) :])
+    except ValueError as exc:
+        raise ValueError(f"unsupported softmax mode: {mode}") from exc
+    if bucket_shift < 0 or bucket_shift > 24:
+        raise ValueError(f"unsupported softmax mode: {mode}")
+    return bucket_shift
+
+
 def _quantize_symmetric_list(values: list[float], bits: int) -> tuple[list[int], float]:
     if bits >= 24:
         return [int(round(value * 1024.0)) for value in values], 1.0 / 1024.0
@@ -262,6 +275,7 @@ def _exp_lut_div_softmax(
     weight_bits: int,
     bucket_shift: int,
     input_frac_bits: int | None = None,
+    zero_tail: bool = False,
 ) -> list[float]:
     if score_bits < 5 or score_bits > 32:
         raise ValueError("exp_lut_div softmax expects score_bits in [5, 32]")
@@ -289,8 +303,12 @@ def _exp_lut_div_softmax(
 
     exp_weights: list[int] = []
     for value in q_logits:
-        delta = max(0, min(max_delta, row_max - value))
-        bucket = min(max_bucket, (delta + (bucket_step >> 1)) >> bucket_shift)
+        delta = max(0, row_max - value)
+        bucket = (delta + (bucket_step >> 1)) >> bucket_shift
+        if zero_tail and bucket > max_bucket:
+            exp_weights.append(0)
+            continue
+        bucket = min(max_bucket, bucket)
         exp_arg = (bucket * bucket_step) / float(input_scale)
         exp_weights.append(int(math.exp(-exp_arg) * output_scale + 0.5))
 
@@ -444,6 +462,7 @@ def _parse_candidate_spec(spec: Any) -> CandidateConfig:
                     or part.startswith("rtl_recip_lut_q")
                     or part.startswith("pwl_recip_lut_q")
                     or part.startswith("exp_lut_div_bucket")
+                    or part.startswith("exp_lut_div_zero_tail_bucket")
                 ):
                     if softmax_mode:
                         raise ValueError(f"candidate spec {spec!r} has duplicate softmax mode tokens")
@@ -516,6 +535,11 @@ def _parse_softmax_mode(value: str) -> str:
     supported = {"float_quantized", "float_exact", "rtl_exact", "rtl_pow2sum", "rtl_recip_lut_q8"}
     if value.startswith("exp_lut_div_bucket"):
         bucket_shift = _exp_lut_div_mode(value)
+        if bucket_shift < 0:
+            raise argparse.ArgumentTypeError(f"unsupported softmax mode: {value}")
+        return value
+    if value.startswith("exp_lut_div_zero_tail_bucket"):
+        bucket_shift = _exp_lut_div_zero_tail_mode(value)
         if bucket_shift < 0:
             raise argparse.ArgumentTypeError(f"unsupported softmax mode: {value}")
         return value
@@ -809,6 +833,15 @@ def _softmax_patch(score_bits: int, weight_bits: int, softmax_mode: str):
         if softmax_mode == "float_exact":
             out = _safe_exp_softmax(values)
             return torch.tensor(out, dtype=torch.float32, device=row.device).reshape(row.shape)
+        if softmax_mode.startswith("exp_lut_div_zero_tail_bucket"):
+            out = _exp_lut_div_softmax(
+                values,
+                score_bits=score_bits,
+                weight_bits=weight_bits,
+                bucket_shift=_exp_lut_div_zero_tail_mode(softmax_mode),
+                zero_tail=True,
+            )
+            return torch.tensor(out, dtype=row.dtype if row.dtype.is_floating_point else torch.float32, device=row.device).reshape(row.shape)
         if softmax_mode.startswith("exp_lut_div_bucket"):
             out = _exp_lut_div_softmax(
                 values,

--- a/tests/test_llm_decoder_model_native_mixed_int8_attention.py
+++ b/tests/test_llm_decoder_model_native_mixed_int8_attention.py
@@ -157,6 +157,32 @@ def test_exp_lut_div_softmax_mode_matches_range_and_precision() -> None:
     assert q24 != q32
 
 
+def test_exp_lut_div_zero_tail_matches_two_pass_lut_boundary() -> None:
+    logits = [1.0, -7.0, -7.01, -8.0]
+
+    clamped = _exp_lut_div_softmax(
+        logits,
+        score_bits=32,
+        weight_bits=16,
+        bucket_shift=20,
+        input_frac_bits=28,
+    )
+    zero_tail = _exp_lut_div_softmax(
+        logits,
+        score_bits=32,
+        weight_bits=16,
+        bucket_shift=20,
+        input_frac_bits=28,
+        zero_tail=True,
+    )
+
+    assert clamped[2] > 0.0
+    assert clamped[3] > 0.0
+    assert zero_tail[1] > 0.0
+    assert zero_tail[2] == 0.0
+    assert zero_tail[3] == 0.0
+
+
 def test_fake_attention_patch_quantizes_qkv_once_and_restores() -> None:
     torch = pytest.importorskip("torch")
 
@@ -296,6 +322,12 @@ def test_parse_candidate_spec_and_list_compatibility() -> None:
     assert exp_lut.score_bits == 32
     assert exp_lut.weight_bits == 16
     assert exp_lut.softmax_mode == "exp_lut_div_bucket20"
+
+    zero_tail = _parse_candidate_spec(
+        "score32_exp_lut_zero_tail_two_pass:q8,k8,v8,s32,w16,exp_lut_div_zero_tail_bucket20"
+    )
+    assert zero_tail.candidate_id == "score32_exp_lut_zero_tail_two_pass"
+    assert zero_tail.softmax_mode == "exp_lut_div_zero_tail_bucket20"
 
     with pytest.raises(ValueError):
         _parse_candidate_spec("qkv8_score8:r8")


### PR DESCRIPTION
## Summary
- add a distinct score32 exp-LUT softmax mode that returns zero beyond the bucket-2048 boundary
- preserve the previous exp(-8)-clamped mode for its existing quality records
- add native-checkpoint generation/NLL evaluation for the exact two-pass profile
- prevent the earlier clamped-tail quality pass from being inherited by the new architecture

## Root cause
The implemented two-pass RTL uses a zero LUT default for deltas whose rounded bucket exceeds 2048. Existing `score32_exp_lut_div` quality evaluation clamps every larger delta to bucket 2048, assigning exp(-8), so its quality pass is not evidence for the implemented arithmetic.

## Validation
- `pytest -q tests/test_llm_decoder_model_native_mixed_int8_attention.py` (13 passed, 1 skipped)
- focused L2 task-generator test passed
- boundary test proves bucket 2048 remains nonzero and larger rounded buckets become zero
- `python3 scripts/validate_runs.py --skip_eval_queue`
