### PR TITLE
control_plane: preserve current proposal state in submissions

### DIFF
--- a/control_plane/control_plane/services/submission_bridge.py
+++ b/control_plane/control_plane/services/submission_bridge.py
@@ -117,30 +117,54 @@ def _collect_existing_file_refs(*, repo_root: Path, value: Any, files: list[str]
     files.append(rel_path)
 
 
-def _collect_proposal_files(*, repo_root: Path, package_payload: dict[str, Any], files: list[str], seen: set[str]) -> None:
+def _proposal_file(*, repo_root: Path, package_payload: dict[str, Any]) -> Path | None:
     developer_loop = package_payload.get("developer_loop")
     if not isinstance(developer_loop, dict):
-        return
+        return None
     proposal_id = str(developer_loop.get("proposal_id", "")).strip() or None
     proposal_path = str(developer_loop.get("proposal_path", "")).strip() or None
     proposal_file = resolve_proposal_file(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
     if proposal_file is None or not proposal_file.exists() or proposal_file.name != "proposal.json":
         if proposal_id or proposal_path:
             raise SubmissionPrepareError("developer_loop proposal linkage does not resolve to a proposal")
-        return
+        return None
     placeholder_reason = proposal_placeholder_reason(proposal_file)
     if placeholder_reason is not None:
         raise SubmissionPrepareError(placeholder_reason)
+    return proposal_file
+
+
+def _proposal_context_files(*, repo_root: Path, package_payload: dict[str, Any]) -> list[str]:
+    proposal_file = _proposal_file(repo_root=repo_root, package_payload=package_payload)
+    if proposal_file is None:
+        return []
     proposal_dir = proposal_file.parent
+    files: list[str] = []
     for candidate in sorted(path for path in proposal_dir.rglob("*") if path.is_file()):
         try:
             rel_path = str(candidate.resolve().relative_to(repo_root.resolve()))
         except ValueError:
             continue
-        if rel_path in seen:
-            continue
-        seen.add(rel_path)
         files.append(rel_path)
+    return files
+
+
+def _path_exists_at_ref(repo_root: Path, ref: str, rel_path: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "cat-file", "-e", f"{ref}:{rel_path}"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _path_tracked_at_head(repo_root: Path, rel_path: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "--error-unmatch", rel_path],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
 
 
 def _review_linked_supporting_files(*, repo_root: Path, package_payload: dict[str, Any]) -> list[str]:
@@ -148,14 +172,12 @@ def _review_linked_supporting_files(*, repo_root: Path, package_payload: dict[st
     seen: set[str] = set()
     review_artifact = package_payload.get("review_artifact")
     if not isinstance(review_artifact, dict):
-        _collect_proposal_files(repo_root=repo_root, package_payload=package_payload, files=files, seen=seen)
         return files
     payload = review_artifact.get("payload")
     if isinstance(payload, dict):
         source_refs = payload.get("source_refs")
         if isinstance(source_refs, dict):
             _collect_existing_file_refs(repo_root=repo_root, value=source_refs, files=files, seen=seen)
-    _collect_proposal_files(repo_root=repo_root, package_payload=package_payload, files=files, seen=seen)
     return files
 
 
@@ -370,6 +392,23 @@ def prepare_submission_branch(session: Session, request: SubmissionPrepareReques
             existing=[*evidence_files, *supporting_files],
         )
     )
+    source_proposal_file = _proposal_file(repo_root=repo_root, package_payload=package_payload)
+    source_proposal_context = _proposal_context_files(repo_root=repo_root, package_payload=package_payload)
+    submission_base_ref, submission_base_commit = _resolve_submission_base(repo_root, request.pr_base)
+    proposal_files_to_copy: list[str] = []
+    if source_proposal_file is not None:
+        proposal_rel = str(source_proposal_file.resolve().relative_to(repo_root.resolve()))
+        if not _path_exists_at_ref(repo_root, submission_base_ref, proposal_rel):
+            if _path_tracked_at_head(repo_root, proposal_rel):
+                raise SubmissionPrepareError(
+                    f"developer_loop proposal was removed from current submission base: {proposal_rel}"
+                )
+            # Preserve legacy scaffolding that has not been committed anywhere
+            # yet. Once tracked, mutable proposal state always comes from base.
+            proposal_files_to_copy = source_proposal_context
+            for rel_path in proposal_files_to_copy:
+                if rel_path not in supporting_files:
+                    supporting_files.append(rel_path)
     files_to_copy = [snapshot_rel, package_rel]
     if review_rel:
         files_to_copy.append(review_rel)
@@ -396,7 +435,6 @@ def prepare_submission_branch(session: Session, request: SubmissionPrepareReques
 
     worktree_root = _worktree_root(work_item.item_id, request.worktree_root)
     worktree_path = worktree_root / "repo"
-    submission_base_ref, submission_base_commit = _resolve_submission_base(repo_root, request.pr_base)
     if _branch_exists(repo_root, branch_name):
         raise SubmissionPrepareError(f"branch already exists: {branch_name}")
     _run_git(repo_root, "worktree", "add", "-b", branch_name, str(worktree_path), submission_base_ref)
@@ -409,6 +447,13 @@ def prepare_submission_branch(session: Session, request: SubmissionPrepareReques
                 rel_path=frozen_file_map[rel_path],
                 target_rel_path=rel_path,
             )
+
+        # Validate against the materialized current base. Tracked proposal files
+        # were intentionally not copied from the pinned execution checkout.
+        proposal_context_files = _proposal_context_files(
+            repo_root=worktree_path,
+            package_payload=package_payload,
+        )
 
         _copy_into_worktree(
             repo_root=repo_root,
@@ -467,6 +512,7 @@ def prepare_submission_branch(session: Session, request: SubmissionPrepareReques
         "review_artifact_path": review_rel or None,
         "evidence_paths": evidence_files,
         "supporting_paths": supporting_files,
+        "proposal_context_paths": proposal_context_files,
         "canonical_diff_paths": canonical_diff_paths,
         "frozen_file_map": frozen_file_map,
         "pr_title": pr_title,

--- a/control_plane/control_plane/tests/test_submission_bridge.py
+++ b/control_plane/control_plane/tests/test_submission_bridge.py
@@ -37,6 +37,23 @@ def _git(repo_root: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
+def _commit(repo_root: Path, message: str, *paths: str) -> None:
+    _git(repo_root, "add", *paths)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "commit", "-m", message],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **__import__("os").environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    )
+
+
 def _init_repo(repo_root: Path) -> None:
     subprocess.run(["git", "-C", str(repo_root), "init", "-b", "master"], check=True, capture_output=True, text=True)
     _write(repo_root / "README.md", "demo\n")
@@ -506,11 +523,68 @@ def test_prepare_submission_branch_packages_only_specific_proposal_file_parent()
             manifest = json.loads(
                 (repo_root / "control_plane" / "shadow_exports" / "review" / item_id / "submission_manifest.json").read_text()
             )
+            assert "docs/proposals/prop_l2_submit_demo/proposal.json" in manifest["proposal_context_paths"]
+            assert "docs/proposals/prop_l2_submit_demo/evaluation_requests.json" in manifest["proposal_context_paths"]
+            assert "docs/proposals/prop_unrelated/proposal.json" not in manifest["proposal_context_paths"]
             assert "docs/proposals/prop_l2_submit_demo/proposal.json" in manifest["supporting_paths"]
             assert "docs/proposals/prop_l2_submit_demo/evaluation_requests.json" in manifest["supporting_paths"]
             assert "docs/proposals/prop_unrelated/proposal.json" not in manifest["supporting_paths"]
             assert (Path(result.worktree_path) / "docs/proposals/prop_l2_submit_demo/proposal.json").exists()
             assert not (Path(result.worktree_path) / "docs/proposals/prop_unrelated/proposal.json").exists()
+
+
+def test_prepare_submission_branch_preserves_newer_proposal_state_from_current_base() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, _run_key = _seed_l2_reviewable(session, repo_root)
+            _commit(repo_root, "add proposal", "docs/proposals/prop_l2_submit_demo")
+            source_commit = _git(repo_root, "rev-parse", "HEAD")
+            requests_path = repo_root / "docs/proposals/prop_l2_submit_demo/evaluation_requests.json"
+            requests = json.loads(requests_path.read_text(encoding="utf-8"))
+            requests["requested_items"][0]["status"] = "merged"
+            requests["requested_items"].append(
+                {
+                    "item_id": "l2_newer_sibling",
+                    "task_type": "l2_campaign",
+                    "status": "pending_implementation_merge",
+                }
+            )
+            _write(requests_path, json.dumps(requests, indent=2) + "\n")
+            _commit(
+                repo_root,
+                "advance proposal state",
+                "docs/proposals/prop_l2_submit_demo/evaluation_requests.json",
+            )
+            master_head = _git(repo_root, "rev-parse", "master")
+            _git(repo_root, "checkout", source_commit)
+
+            result = prepare_submission_branch(
+                session,
+                SubmissionPrepareRequest(
+                    repo_root=str(repo_root),
+                    item_id=item_id,
+                    evaluator_id="cpbot",
+                    session_id="s20260310t080013z",
+                    host="cp-host",
+                    worktree_root=str(repo_root / "tmp_submit"),
+                ),
+            )
+
+            branch_requests = json.loads(
+                (Path(result.worktree_path) / "docs/proposals/prop_l2_submit_demo/evaluation_requests.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert branch_requests == requests
+            assert _git(repo_root, "rev-parse", f"{result.branch_name}^") == master_head
+            changed_paths = _git(repo_root, "diff", "--name-only", f"master...{result.branch_name}").splitlines()
+            assert not any(path.startswith("docs/proposals/prop_l2_submit_demo/") for path in changed_paths)
 
 
 def test_prepare_submission_branch_rejects_broad_proposal_path() -> None:

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -608,7 +608,7 @@ def test_worker_daemon_syncs_expected_outputs_before_immediate_completion() -> N
             report_path = repo_root / "runs" / "campaigns" / "daemon_item_sync_before_completion" / "report.md"
             assert metrics_path.exists(), metrics_path
             assert report_path.exists(), report_path
-            assert Path(request.repo_root).resolve() != repo_root.resolve()
+            assert Path(request.repo_root).resolve() == repo_root.resolve()
 
             review_path = Path(request.repo_root) / "control_plane" / "shadow_exports" / "review" / "daemon_item_sync_before_completion" / "evaluated.json"
             review_path.parent.mkdir(parents=True, exist_ok=True)

--- a/control_plane/control_plane/workers/executor.py
+++ b/control_plane/control_plane/workers/executor.py
@@ -1173,7 +1173,7 @@ def execute_one_work_item(session_factory: sessionmaker, *, config: WorkerConfig
             config=config,
             work_item=work_item,
             run_key=run_key,
-            completion_repo_root=checkout_info.work_dir,
+            completion_repo_root=config.repo_root,
         )
 
     cleanup_checkout(checkout_info)

--- a/docs/developer_agent_review.md
+++ b/docs/developer_agent_review.md
@@ -54,6 +54,15 @@ The artifact PR must also include the proposal workspace files referenced by
 points to files absent from the PR branch, the evidence package is incomplete;
 fix packaging before reviewing or merging the PR.
 
+Tracked proposal files are mutable control-plane state owned by the artifact
+PR's current base branch. A pinned evaluator checkout supplies reproducible run
+evidence, but must not overwrite, delete, or regress proposal files that changed
+while the job was running. Submission preparation validates proposal linkage in
+the current-base worktree and copies proposal files from the execution checkout
+only for a new, still-untracked scaffold. Reviewers should block any artifact PR
+that changes sibling request entries or regresses merged/queued statuses without
+an explicit revision operation.
+
 ## Review Questions
 
 The reviewer must answer:


### PR DESCRIPTION
## Summary
- process immediate completion from the synchronized service repository instead of the pinned run checkout
- treat tracked proposal workspaces as mutable state owned by the current PR base
- retain legacy packaging only for new, untracked proposal scaffolds and reject tracked proposals removed from the base
- record proposal context separately in the submission manifest
- document the ownership and review rule

## Root cause
The evaluator correctly ran from a pinned source commit, but completion recursively copied that checkout's proposal directory into a submission branch based on newer `master`. This regressed statuses and deleted sibling requests added while the job was running.

## Validation
- `12 passed`: submission-bridge coverage plus immediate-completion regression
- `24 passed`: complete worker-daemon test module
- regression simulates a detached execution commit while `master` advances proposal status and adds a sibling request; the generated branch preserves current-base proposal contents and has no proposal diff
- `git diff --check`