### PR TITLE
eval: run recost llama7b with measured two-pass score sram

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json
@@ -1,0 +1,144 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-13T11:21:26.099051Z",
+  "item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+  "run_key": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1_run_b95116cc4c39841a",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "275673eb674626455a988b848941edbf28fd02cd",
+  "review_metadata_source_commit": "98812adafb0c9fa81aaf526f38ed790ed84cdf52",
+  "objective": "Reserve one measured 512 KiB x 256-bit score SRAM macro per attention head before KV packing and recost latency, area, and energy.",
+  "input_manifest": {
+    "decoder_contract": {
+      "attention_local_sram_capacity": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json",
+      "attention_kv_measured_sram_rebalance": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json",
+      "attention_two_pass_score_sram_metrics": "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json",
+      "attention_score32_exp_lut_service_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json",
+      "attention_kv_endpoint_router_sram_composition": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+      "attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+      "attention_score32_exp_lut_sram_hierarchy_envelope_scope": "Reserve one measured 512 KiB x 256-bit score SRAM macro per Llama7B attention head before packing remaining KV SRAM capacity; account score write/replay energy and propagate reduced KV residency into HBM share and token latency.",
+      "attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.md"
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+    "arch_id": "decoder_attention_two_pass_score_sram_reservation",
+    "macro_mode": "evidence_only",
+    "outcome": "score32_exp_lut_sram_hierarchy_envelope_changes_frontier"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+    "title": "Scalable exact hierarchical softmax for Llama7B",
+    "primary_question": "Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?",
+    "evaluation_mode": "frontier_recost",
+    "comparison_role": "measured_score_memory_recost",
+    "abstraction_layer": "decoder_attention_two_pass_score_sram_reservation",
+    "expected_direction": "reserve_measured_score_sram_before_kv",
+    "expected_reason": "The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope.",
+    "summary": "Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.",
+    "outcome": "score32_exp_lut_sram_hierarchy_envelope_changes_frontier",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+    "title": "Scalable exact hierarchical softmax for Llama7B",
+    "kind": "architecture",
+    "primary_question": "Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?",
+    "evaluation_mode": "frontier_recost",
+    "comparison_role": "measured_score_memory_recost",
+    "outcome": "score32_exp_lut_sram_hierarchy_envelope_changes_frontier",
+    "summary": "Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+    "decoder_quality": {
+      "diagnosis": {
+        "conservative_efficiency": 0.55,
+        "conservative_hbm_byte_share": 0.9960289,
+        "conservative_hbm_share_delta": 0.012630462,
+        "conservative_projected_latency_us_hbm_share_scaled": 12680.136872,
+        "conservative_shared_sram_capacity_mib": 16.265625,
+        "nominal_efficiency": 0.75,
+        "nominal_hbm_byte_share": 0.992916107,
+        "nominal_shared_sram_capacity_mib": 29.015625,
+        "remaining_abstractions": [
+          "hbm_dram_service",
+          "sram_macro_floorplan_pnr"
+        ],
+        "score32_supported": true,
+        "score_buffer_area_mm2": 66.636897,
+        "score_buffer_energy_mj_per_token": 0.277849571328,
+        "score_buffer_feasible_across_envelope": true,
+        "score_buffer_macro_count": 32,
+        "score_buffer_macro_name": "kv_tile_read_buffer",
+        "score_buffer_reserved": true,
+        "selected_semantic_profile": "score32_exp_lut_div",
+        "source_hbm_byte_share": 0.983398438,
+        "source_score32_latency_us": 12519.342352,
+        "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+      },
+      "assumptions": [
+        "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+        "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+        "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+        "When supplied, the measured score-buffer macro set is reserved before packing remaining KV SRAM capacity.",
+        "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+      ],
+      "next_step": {
+        "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+        "requires_full_sram_macro_floorplan": true,
+        "requires_hbm_dram_closure": true
+      }
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+    "decoder_attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+    "decoder_attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {
+      "conservative_efficiency": 0.55,
+      "conservative_hbm_byte_share": 0.9960289,
+      "conservative_hbm_share_delta": 0.012630462,
+      "conservative_projected_latency_us_hbm_share_scaled": 12680.136872,
+      "conservative_shared_sram_capacity_mib": 16.265625,
+      "nominal_efficiency": 0.75,
+      "nominal_hbm_byte_share": 0.992916107,
+      "nominal_shared_sram_capacity_mib": 29.015625,
+      "remaining_abstractions": [
+        "hbm_dram_service",
+        "sram_macro_floorplan_pnr"
+      ],
+      "score32_supported": true,
+      "score_buffer_area_mm2": 66.636897,
+      "score_buffer_energy_mj_per_token": 0.277849571328,
+      "score_buffer_feasible_across_envelope": true,
+      "score_buffer_macro_count": 32,
+      "score_buffer_macro_name": "kv_tile_read_buffer",
+      "score_buffer_reserved": true,
+      "selected_semantic_profile": "score32_exp_lut_div",
+      "source_hbm_byte_share": 0.983398438,
+      "source_score32_latency_us": 12519.342352,
+      "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+    },
+    "assumptions": [
+      "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+      "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+      "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+      "When supplied, the measured score-buffer macro set is reserved before packing remaining KV SRAM capacity.",
+      "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+    ],
+    "next_step": {
+      "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+      "requires_full_sram_macro_floorplan": true,
+      "requires_hbm_dram_closure": true
+    }
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/evaluated.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/evaluated.json
@@ -1,0 +1,109 @@
+{
+  "flow": "openroad",
+  "task": {
+    "inputs": {
+      "decoder_contract": {
+        "attention_local_sram_capacity": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json",
+        "attention_kv_measured_sram_rebalance": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json",
+        "attention_two_pass_score_sram_metrics": "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json",
+        "attention_score32_exp_lut_service_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json",
+        "attention_kv_endpoint_router_sram_composition": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+        "attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+        "attention_score32_exp_lut_sram_hierarchy_envelope_scope": "Reserve one measured 512 KiB x 256-bit score SRAM macro per Llama7B attention head before packing remaining KV SRAM capacity; account score write/replay energy and propagate reduced KV residency into HBM share and token latency.",
+        "attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.md"
+      }
+    },
+    "commands": [
+      {
+        "run": "python3 npu/eval/audit_llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope.py --service-closure-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json --measured-sram-rebalance-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json --local-sram-capacity-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json --endpoint-router-sram-composition-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json --score-buffer-sram-metrics-json runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json --score-buffer-macro-name kv_tile_read_buffer --score-buffer-bytes 16777216 --attention-heads 32 --score-block-bytes 32 --clock-period-ns 10 --placement-efficiency 1.0,0.85,0.75,0.65,0.55 --nominal-efficiency 0.75 --placement-overhead-fraction 0.05 --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.md",
+        "name": "audit_decoder_attention_two_pass_score_sram_reservation"
+      },
+      {
+        "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+        "name": "validate_runs"
+      }
+    ],
+    "objective": "Reserve one measured 512 KiB x 256-bit score SRAM macro per attention head before KV packing and recost latency, area, and energy.",
+    "acceptance": [
+      "Write all declared decoder evidence artifacts",
+      "Keep evidence artifact paths repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "source_mode": "src_verilog",
+    "expected_outputs": [
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.md"
+    ]
+  },
+  "layer": "layer2",
+  "state": "evaluated",
+  "title": "Recost Llama7B with measured two-pass score SRAM",
+  "result": {
+    "branch": "eval/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/s20260713t112126z",
+    "completed_utc": "2026-07-13T11:09:48.226437Z",
+    "evaluator_id": "control_plane",
+    "executor": "@control_plane",
+    "host": "b7c2d9c80c1c",
+    "identity_block": "[role:evaluator][account:control_plane][session:s20260713t112126z][host:b7c2d9c80c1c][item:l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1]",
+    "metrics_rows": [],
+    "metrics_exempt_reason": "evidence_only_decoder_evidence",
+    "queue_item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+    "session_id": "s20260713t112126z",
+    "status": "ok",
+    "summary": "2/2 commands succeeded"
+  },
+  "handoff": {
+    "branch": "eval/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/s20260713t112126z",
+    "pr_title": "eval: run recost llama7b with measured two-pass score sram",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "pr_body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260713t112126z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1"
+    },
+    "identity_block_format": "[role:evaluator][account:<evaluator_id>][session:<session_id>][host:<host>][item:<queue_item_id>]"
+  },
+  "item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+  "version": 0.1,
+  "platform": "nangate45",
+  "priority": 1,
+  "created_utc": "2026-07-12T10:26:36.279879Z",
+  "requested_by": "developer_agent",
+  "developer_loop": {
+    "comparison": {
+      "role": "measured_score_memory_recost",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "frontier_recost",
+      "expected_reason": "The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope.",
+      "expected_direction": "reserve_measured_score_sram_before_kv"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_two_pass_score_sram_reservation"
+    },
+    "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json"
+  },
+  "source_requirement": {
+    "repo": "",
+    "reason": "evaluator runtime must contain the queued job source commit",
+    "version": 1,
+    "required_ref": "origin/master",
+    "required_sha": "275673eb674626455a988b848941edbf28fd02cd",
+    "requires_daemon_restart": true
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/pr_body.md
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/pr_body.md
@@ -1,0 +1,47 @@
+## Summary
+- item_id: `l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1`
+- run_key: `l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1_run_b95116cc4c39841a`
+- layer: `layer2`
+- task_type: `l2_campaign`
+- status: `ok`
+- summary: `2/2 commands succeeded`
+- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/evaluated.json`
+- metrics_rows_count: `0`
+- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json`
+
+## Developer Context
+- proposal_id: `prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1`
+- proposal_path: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json`
+- reviewer_first_read: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
+- execution_source_commit: `275673eb674626455a988b848941edbf28fd02cd`
+- review_metadata_source_commit: `98812adafb0c9fa81aaf526f38ed790ed84cdf52`
+
+## Evaluation Mode
+- evaluation_mode: `frontier_recost`
+- abstraction_layer: `decoder_attention_two_pass_score_sram_reservation`
+- comparison_role: `measured_score_memory_recost`
+- expected_direction: `reserve_measured_score_sram_before_kv`
+- expected_reason: `The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope.`
+- expectation_status: `unspecified`
+- evaluation_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`
+
+## Focused Comparison
+- primary_question: `Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?`
+- comparison_role: `measured_score_memory_recost`
+- proposal_outcome: `score32_exp_lut_sram_hierarchy_envelope_changes_frontier`
+- comparison_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`
+- baseline_ref: `None`
+- baseline_item_id: `None`
+
+## Submission Recovery
+- resolver_retry_path: `true`
+- submission_failure_count: `1`
+- retry_request_count: `1`
+- last_submission_failure: `work item l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1 is not eligible for submission: proposal already finalized with decision=promote`
+- retry_request_id: `resume_8845fde13a7f0626`
+
+## Checklist
+- [ ] Commit lightweight campaign artifacts only
+- [ ] Include metrics row references in result.metrics_rows
+- [ ] Keep committed result_path fields repo-portable
+- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing

--- a/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/review_package.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/review_package.json
@@ -1,0 +1,254 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-13T11:21:28.879047Z",
+  "control_plane_source_commit": "98812adafb0c9fa81aaf526f38ed790ed84cdf52",
+  "review_metadata_source_commit": "98812adafb0c9fa81aaf526f38ed790ed84cdf52",
+  "item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+  "run_key": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1_run_b95116cc4c39841a",
+  "layer": "layer2",
+  "flow": "openroad",
+  "task_type": "l2_campaign",
+  "source_commit": "275673eb674626455a988b848941edbf28fd02cd",
+  "queue_snapshot": {
+    "path": "control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/evaluated.json",
+    "result": {
+      "branch": "eval/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/s20260713t112126z",
+      "completed_utc": "2026-07-13T11:09:48.226437Z",
+      "evaluator_id": "control_plane",
+      "executor": "@control_plane",
+      "host": "b7c2d9c80c1c",
+      "identity_block": "[role:evaluator][account:control_plane][session:s20260713t112126z][host:b7c2d9c80c1c][item:l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1]",
+      "metrics_rows": [],
+      "metrics_exempt_reason": "evidence_only_decoder_evidence",
+      "queue_item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+      "session_id": "s20260713t112126z",
+      "status": "ok",
+      "summary": "2/2 commands succeeded"
+    }
+  },
+  "review_artifact": {
+    "kind": "decision_proposal",
+    "path": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+    "storage_mode": "repo",
+    "sha256": "ffacd398128fb2cf1148a7af6c92c423bf4ed36963730b3c86d6eccb04cbcd0a",
+    "payload": {
+      "version": 0.1,
+      "generated_utc": "2026-07-13T11:21:26.099051Z",
+      "item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+      "run_key": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1_run_b95116cc4c39841a",
+      "layer": "layer2",
+      "flow": "openroad",
+      "platform": "nangate45",
+      "task_type": "l2_campaign",
+      "source_commit": "275673eb674626455a988b848941edbf28fd02cd",
+      "review_metadata_source_commit": "98812adafb0c9fa81aaf526f38ed790ed84cdf52",
+      "objective": "Reserve one measured 512 KiB x 256-bit score SRAM macro per attention head before KV packing and recost latency, area, and energy.",
+      "input_manifest": {
+        "decoder_contract": {
+          "attention_local_sram_capacity": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json",
+          "attention_kv_measured_sram_rebalance": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json",
+          "attention_two_pass_score_sram_metrics": "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json",
+          "attention_score32_exp_lut_service_closure": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json",
+          "attention_kv_endpoint_router_sram_composition": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+          "attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+          "attention_score32_exp_lut_sram_hierarchy_envelope_scope": "Reserve one measured 512 KiB x 256-bit score SRAM macro per Llama7B attention head before packing remaining KV SRAM capacity; account score write/replay energy and propagate reduced KV residency into HBM share and token latency.",
+          "attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.md"
+        }
+      },
+      "recommendation": {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+        "arch_id": "decoder_attention_two_pass_score_sram_reservation",
+        "macro_mode": "evidence_only",
+        "outcome": "score32_exp_lut_sram_hierarchy_envelope_changes_frontier"
+      },
+      "objective_profiles": [],
+      "evaluation_record": {
+        "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+        "title": "Scalable exact hierarchical softmax for Llama7B",
+        "primary_question": "Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?",
+        "evaluation_mode": "frontier_recost",
+        "comparison_role": "measured_score_memory_recost",
+        "abstraction_layer": "decoder_attention_two_pass_score_sram_reservation",
+        "expected_direction": "reserve_measured_score_sram_before_kv",
+        "expected_reason": "The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope.",
+        "summary": "Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.",
+        "outcome": "score32_exp_lut_sram_hierarchy_envelope_changes_frontier",
+        "expectation_status": "unspecified"
+      },
+      "proposal_assessment": {
+        "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+        "title": "Scalable exact hierarchical softmax for Llama7B",
+        "kind": "architecture",
+        "primary_question": "Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?",
+        "evaluation_mode": "frontier_recost",
+        "comparison_role": "measured_score_memory_recost",
+        "outcome": "score32_exp_lut_sram_hierarchy_envelope_changes_frontier",
+        "summary": "Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.",
+        "baseline_ref": null,
+        "baseline_item_id": null,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+        "decoder_quality": {
+          "diagnosis": {
+            "conservative_efficiency": 0.55,
+            "conservative_hbm_byte_share": 0.9960289,
+            "conservative_hbm_share_delta": 0.012630462,
+            "conservative_projected_latency_us_hbm_share_scaled": 12680.136872,
+            "conservative_shared_sram_capacity_mib": 16.265625,
+            "nominal_efficiency": 0.75,
+            "nominal_hbm_byte_share": 0.992916107,
+            "nominal_shared_sram_capacity_mib": 29.015625,
+            "remaining_abstractions": [
+              "hbm_dram_service",
+              "sram_macro_floorplan_pnr"
+            ],
+            "score32_supported": true,
+            "score_buffer_area_mm2": 66.636897,
+            "score_buffer_energy_mj_per_token": 0.277849571328,
+            "score_buffer_feasible_across_envelope": true,
+            "score_buffer_macro_count": 32,
+            "score_buffer_macro_name": "kv_tile_read_buffer",
+            "score_buffer_reserved": true,
+            "selected_semantic_profile": "score32_exp_lut_div",
+            "source_hbm_byte_share": 0.983398438,
+            "source_score32_latency_us": 12519.342352,
+            "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+          },
+          "assumptions": [
+            "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+            "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+            "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+            "When supplied, the measured score-buffer macro set is reserved before packing remaining KV SRAM capacity.",
+            "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+          ],
+          "next_step": {
+            "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+            "requires_full_sram_macro_floorplan": true,
+            "requires_hbm_dram_closure": true
+          }
+        }
+      },
+      "source_refs": {
+        "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+        "decoder_attention_score32_exp_lut_sram_hierarchy_envelope_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json",
+        "decoder_attention_score32_exp_lut_sram_hierarchy_envelope_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.md"
+      },
+      "decoder_quality": {
+        "diagnosis": {
+          "conservative_efficiency": 0.55,
+          "conservative_hbm_byte_share": 0.9960289,
+          "conservative_hbm_share_delta": 0.012630462,
+          "conservative_projected_latency_us_hbm_share_scaled": 12680.136872,
+          "conservative_shared_sram_capacity_mib": 16.265625,
+          "nominal_efficiency": 0.75,
+          "nominal_hbm_byte_share": 0.992916107,
+          "nominal_shared_sram_capacity_mib": 29.015625,
+          "remaining_abstractions": [
+            "hbm_dram_service",
+            "sram_macro_floorplan_pnr"
+          ],
+          "score32_supported": true,
+          "score_buffer_area_mm2": 66.636897,
+          "score_buffer_energy_mj_per_token": 0.277849571328,
+          "score_buffer_feasible_across_envelope": true,
+          "score_buffer_macro_count": 32,
+          "score_buffer_macro_name": "kv_tile_read_buffer",
+          "score_buffer_reserved": true,
+          "selected_semantic_profile": "score32_exp_lut_div",
+          "source_hbm_byte_share": 0.983398438,
+          "source_score32_latency_us": 12519.342352,
+          "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+        },
+        "assumptions": [
+          "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+          "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+          "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+          "When supplied, the measured score-buffer macro set is reserved before packing remaining KV SRAM capacity.",
+          "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+        ],
+        "next_step": {
+          "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+          "requires_full_sram_macro_floorplan": true,
+          "requires_hbm_dram_closure": true
+        }
+      }
+    }
+  },
+  "developer_loop": {
+    "comparison": {
+      "role": "measured_score_memory_recost",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "frontier_recost",
+      "expected_reason": "The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope.",
+      "expected_direction": "reserve_measured_score_sram_before_kv"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_two_pass_score_sram_reservation"
+    },
+    "proposal_id": "prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json"
+  },
+  "submission_history": {
+    "event_count": 3,
+    "failure_count": 1,
+    "retry_request_count": 1,
+    "retry_processed_count": 0,
+    "retry_failed_count": 0,
+    "had_retry": true,
+    "events": [
+      {
+        "event_time": "2026-07-13T11:09:49.666988Z",
+        "event_type": "submission_failed",
+        "error": "work item l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1 is not eligible for submission: proposal already finalized with decision=promote"
+      },
+      {
+        "event_time": "2026-07-13T11:21:12.997428Z",
+        "event_type": "submission_retry_requested",
+        "request_id": "resume_8845fde13a7f0626"
+      },
+      {
+        "event_time": "2026-07-13T11:21:25.047311Z",
+        "event_type": "submission_retry_started",
+        "request_id": "resume_8845fde13a7f0626"
+      }
+    ],
+    "last_failure": {
+      "event_time": "2026-07-13T11:09:49.666988Z",
+      "event_type": "submission_failed",
+      "error": "work item l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1 is not eligible for submission: proposal already finalized with decision=promote"
+    },
+    "last_retry_request": {
+      "event_time": "2026-07-13T11:21:12.997428Z",
+      "event_type": "submission_retry_requested",
+      "request_id": "resume_8845fde13a7f0626"
+    }
+  },
+  "pr_payload": {
+    "branch": "eval/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/s20260713t112126z",
+    "title": "eval: run recost llama7b with measured two-pass score sram",
+    "body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260713t112126z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1"
+    },
+    "body_md": "## Summary\n- item_id: `l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1`\n- run_key: `l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1_run_b95116cc4c39841a`\n- layer: `layer2`\n- task_type: `l2_campaign`\n- status: `ok`\n- summary: `2/2 commands succeeded`\n- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/evaluated.json`\n- metrics_rows_count: `0`\n- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json`\n\n## Developer Context\n- proposal_id: `prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1`\n- proposal_path: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json`\n- reviewer_first_read: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`\n- execution_source_commit: `275673eb674626455a988b848941edbf28fd02cd`\n- review_metadata_source_commit: `98812adafb0c9fa81aaf526f38ed790ed84cdf52`\n\n## Evaluation Mode\n- evaluation_mode: `frontier_recost`\n- abstraction_layer: `decoder_attention_two_pass_score_sram_reservation`\n- comparison_role: `measured_score_memory_recost`\n- expected_direction: `reserve_measured_score_sram_before_kv`\n- expected_reason: `The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope.`\n- expectation_status: `unspecified`\n- evaluation_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`\n\n## Focused Comparison\n- primary_question: `Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?`\n- comparison_role: `measured_score_memory_recost`\n- proposal_outcome: `score32_exp_lut_sram_hierarchy_envelope_changes_frontier`\n- comparison_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`\n- baseline_ref: `None`\n- baseline_item_id: `None`\n\n## Submission Recovery\n- resolver_retry_path: `true`\n- submission_failure_count: `1`\n- retry_request_count: `1`\n- last_submission_failure: `work item l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1 is not eligible for submission: proposal already finalized with decision=promote`\n- retry_request_id: `resume_8845fde13a7f0626`\n\n## Checklist\n- [ ] Commit lightweight campaign artifacts only\n- [ ] Include metrics row references in result.metrics_rows\n- [ ] Keep committed result_path fields repo-portable\n- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing\n",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ]
+  }
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json
@@ -1,0 +1,392 @@
+{
+  "assumptions": [
+    "SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.",
+    "Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.",
+    "Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.",
+    "When supplied, the measured score-buffer macro set is reserved before packing remaining KV SRAM capacity.",
+    "Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited."
+  ],
+  "decision": "score32_exp_lut_sram_hierarchy_envelope_changes_frontier",
+  "diagnosis": {
+    "conservative_efficiency": 0.55,
+    "conservative_hbm_byte_share": 0.9960289,
+    "conservative_hbm_share_delta": 0.012630462,
+    "conservative_projected_latency_us_hbm_share_scaled": 12680.136872,
+    "conservative_shared_sram_capacity_mib": 16.265625,
+    "nominal_efficiency": 0.75,
+    "nominal_hbm_byte_share": 0.992916107,
+    "nominal_shared_sram_capacity_mib": 29.015625,
+    "remaining_abstractions": [
+      "hbm_dram_service",
+      "sram_macro_floorplan_pnr"
+    ],
+    "score32_supported": true,
+    "score_buffer_area_mm2": 66.636897,
+    "score_buffer_energy_mj_per_token": 0.277849571328,
+    "score_buffer_feasible_across_envelope": true,
+    "score_buffer_macro_count": 32,
+    "score_buffer_macro_name": "kv_tile_read_buffer",
+    "score_buffer_reserved": true,
+    "selected_semantic_profile": "score32_exp_lut_div",
+    "source_hbm_byte_share": 0.983398438,
+    "source_score32_latency_us": 12519.342352,
+    "sram_hierarchy_status": "placement_envelope_not_full_sram_pnr"
+  },
+  "inputs": {
+    "endpoint_router_sram_composition_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_endpoint_router_sram_composition__l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1_r4.json",
+    "local_sram_capacity_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_local_sram_capacity__l2_decoder_attention_local_sram_capacity_llama7b_v1.json",
+    "measured_sram_rebalance_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_measured_sram_rebalance__l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1.json",
+    "score_buffer_sram_metrics_json": "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json",
+    "service_closure_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_service_closure__l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1.json"
+  },
+  "model": "llm_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_v1",
+  "next_step": {
+    "recommended_next_step": "Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.",
+    "requires_full_sram_macro_floorplan": true,
+    "requires_hbm_dram_closure": true
+  },
+  "rows": [
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.989009857,
+      "hbm_share_scale_vs_measured_sram": 1.00570615,
+      "kv_shared_sram_macro_area_budget_um2": 159176399.061803,
+      "placement_efficiency": 1.0,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12590.7796,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "score_buffer_access_time_ns": 1.4124,
+      "score_buffer_energy_mj_per_token": 0.277849571328,
+      "score_buffer_envelope_area_um2": 66636897.2928,
+      "score_buffer_fits_macro_budget": true,
+      "score_buffer_macro_area_um2": 66636897.2928,
+      "score_buffer_meets_clock": true,
+      "shared_byte_share": 0.010990143,
+      "shared_sram_capacity_mib": 45.015625,
+      "shared_sram_envelope_area_um2": 159039885.568626,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 225813296.354603,
+      "shared_sram_macro_area_um2": 159039885.568626,
+      "shared_sram_pack": {
+        "capacity_bytes": 47202304,
+        "capacity_mib": 45.015625,
+        "macro_area_um2": 159039885.568626,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 32053.223,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 180,
+            "macro_area_um2_total": 158867230.2984,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 47185920
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 1,
+            "macro_area_um2_total": 172655.270226,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 16384
+          }
+        ],
+        "unused_macro_area_budget_um2": 136513.493177,
+        "write_energy_pj": 112279.822
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    },
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.991378784,
+      "hbm_share_scale_vs_measured_sram": 1.008115069,
+      "kv_shared_sram_macro_area_budget_um2": 125304404.608613,
+      "placement_efficiency": 0.85,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12620.937679,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "score_buffer_access_time_ns": 1.4124,
+      "score_buffer_energy_mj_per_token": 0.277849571328,
+      "score_buffer_envelope_area_um2": 78396349.756235,
+      "score_buffer_fits_macro_budget": true,
+      "score_buffer_macro_area_um2": 66636897.2928,
+      "score_buffer_meets_clock": true,
+      "shared_byte_share": 0.008621216,
+      "shared_sram_capacity_mib": 35.3125,
+      "shared_sram_envelope_area_um2": 147219550.762334,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 191941301.901413,
+      "shared_sram_macro_area_um2": 125136618.147984,
+      "shared_sram_pack": {
+        "capacity_bytes": 37027840,
+        "capacity_mib": 35.3125,
+        "macro_area_um2": 125136618.147984,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 25427.075,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 141,
+            "macro_area_um2_total": 124445997.06708,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 36962304
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 4,
+            "macro_area_um2_total": 690621.080904,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 65536
+          }
+        ],
+        "unused_macro_area_budget_um2": 167786.460629,
+        "write_energy_pj": 88344.388
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    },
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.992916107,
+      "hbm_share_scale_vs_measured_sram": 1.009678345,
+      "kv_shared_sram_macro_area_budget_um2": 102723074.973152,
+      "placement_efficiency": 0.75,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12640.508864,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "score_buffer_access_time_ns": 1.4124,
+      "score_buffer_energy_mj_per_token": 0.277849571328,
+      "score_buffer_envelope_area_um2": 88849196.3904,
+      "score_buffer_fits_macro_budget": true,
+      "score_buffer_macro_area_um2": 66636897.2928,
+      "score_buffer_meets_clock": true,
+      "shared_byte_share": 0.007083893,
+      "shared_sram_capacity_mib": 29.015625,
+      "shared_sram_envelope_area_um2": 136738345.653741,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 169359972.265952,
+      "shared_sram_macro_area_um2": 102553759.240306,
+      "shared_sram_pack": {
+        "capacity_bytes": 30425088,
+        "capacity_mib": 29.015625,
+        "macro_area_um2": 102553759.240306,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 20691.751,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 116,
+            "macro_area_um2_total": 102381103.97008,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 30408704
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 1,
+            "macro_area_um2_total": 172655.270226,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 16384
+          }
+        ],
+        "unused_macro_area_budget_um2": 169315.732846,
+        "write_energy_pj": 72401.422
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    },
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.994491577,
+      "hbm_share_scale_vs_measured_sram": 1.011280412,
+      "kv_shared_sram_macro_area_budget_um2": 80141745.337692,
+      "placement_efficiency": 0.65,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12660.565687,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "score_buffer_access_time_ns": 1.4124,
+      "score_buffer_energy_mj_per_token": 0.277849571328,
+      "score_buffer_envelope_area_um2": 102518303.527385,
+      "score_buffer_fits_macro_budget": true,
+      "score_buffer_macro_area_um2": 66636897.2928,
+      "score_buffer_meets_clock": true,
+      "shared_byte_share": 0.005508423,
+      "shared_sram_capacity_mib": 22.5625,
+      "shared_sram_envelope_area_um2": 123268055.738622,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 146778642.630492,
+      "shared_sram_macro_area_um2": 80124236.230104,
+      "shared_sram_pack": {
+        "capacity_bytes": 23658496,
+        "capacity_mib": 22.5625,
+        "macro_area_um2": 80124236.230104,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 16373.402,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 90,
+            "macro_area_um2_total": 79433615.1492,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 23592960
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 4,
+            "macro_area_um2_total": 690621.080904,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 65536
+          }
+        ],
+        "unused_macro_area_budget_um2": 17509.107588,
+        "write_energy_pj": 56566.288
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    },
+    {
+      "endpoint_router_fifo_area_um2": 2498020.394,
+      "fits_sram_area_budget": true,
+      "hbm_byte_share": 0.9960289,
+      "hbm_share_scale_vs_measured_sram": 1.012843687,
+      "kv_shared_sram_macro_area_budget_um2": 57560415.702232,
+      "placement_efficiency": 0.55,
+      "placement_overhead_fraction": 0.05,
+      "projected_latency_us_hbm_share_scaled": 12680.136872,
+      "projected_tile_hbm_cycles": null,
+      "replaced_abstract_local_capacity_bytes_per_cluster": 19140624,
+      "score_buffer_access_time_ns": 1.4124,
+      "score_buffer_energy_mj_per_token": 0.277849571328,
+      "score_buffer_envelope_area_um2": 121157995.077818,
+      "score_buffer_fits_macro_budget": true,
+      "score_buffer_macro_area_um2": 66636897.2928,
+      "score_buffer_meets_clock": true,
+      "shared_byte_share": 0.0039711,
+      "shared_sram_capacity_mib": 16.265625,
+      "shared_sram_envelope_area_um2": 104620686.040775,
+      "shared_sram_envelope_budget_um2": 237698206.689056,
+      "shared_sram_macro_area_budget_um2": 124197312.995032,
+      "shared_sram_macro_area_um2": 57541377.322426,
+      "shared_sram_pack": {
+        "capacity_bytes": 17055744,
+        "capacity_mib": 16.265625,
+        "macro_area_um2": 57541377.322426,
+        "max_access_time_ns": 1.22148,
+        "read_energy_pj": 11638.078,
+        "selected_macros": [
+          {
+            "area_um2_each": 882595.72388,
+            "count": 65,
+            "macro_area_um2_total": 57368722.0522,
+            "name": "local_capacity_chunk_02_256kib",
+            "size_bytes_each": 262144,
+            "size_bytes_total": 17039360
+          },
+          {
+            "area_um2_each": 172655.270226,
+            "count": 1,
+            "macro_area_um2_total": 172655.270226,
+            "name": "local_capacity_chunk_03_16kib",
+            "size_bytes_each": 16384,
+            "size_bytes_total": 16384
+          }
+        ],
+        "unused_macro_area_budget_um2": 19038.379806,
+        "write_energy_pj": 40623.322
+      },
+      "source_score32_latency_us": 12519.342352,
+      "source_tile_hbm_cycles": 0,
+      "sram_budget_area_um2": 280000000.0,
+      "tile_local_capacity_bytes_per_cluster": 614656,
+      "tile_local_sram_area_um2": 39803772.916944
+    }
+  ],
+  "score_buffer": {
+    "access_time_ns": 1.4124,
+    "allocated_capacity_bytes": 16777216,
+    "attention_heads": 32,
+    "bytes_per_head": 524288,
+    "macro_area_um2": 66636897.2928,
+    "macro_count": 32,
+    "macro_name": "kv_tile_read_buffer",
+    "macro_size_bytes": 524288,
+    "macro_width_bits": 256,
+    "macros_per_head": 1,
+    "read_accesses_per_token": 524288,
+    "read_energy_mj_per_token": 0.12664438784,
+    "read_energy_pj_per_access": 241.55499999999998,
+    "score_block_bytes": 32,
+    "score_buffer_bytes": 16777216,
+    "score_buffer_mib": 16.0,
+    "source_metrics_json": "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json",
+    "total_energy_mj_per_token": 0.277849571328,
+    "write_accesses_per_token": 524288,
+    "write_energy_mj_per_token": 0.151205183488,
+    "write_energy_pj_per_access": 288.401
+  },
+  "sram_macro_library": [
+    {
+      "access_time_ns": 1.22148,
+      "area_um2": 882595.7238800001,
+      "bytes_per_um2": 0.2970148086006836,
+      "name": "local_capacity_chunk_02_256kib",
+      "read_energy_pj": 177.523,
+      "size_bytes": 262144,
+      "write_energy_pj": 623.1
+    },
+    {
+      "access_time_ns": 6.39009,
+      "area_um2": 71282253.00800002,
+      "bytes_per_um2": 0.23536315551245401,
+      "name": "local_capacity_chunk_00_16384kib",
+      "read_energy_pj": 3403.82,
+      "size_bytes": 16777216,
+      "write_energy_pj": 4126.839999999999
+    },
+    {
+      "access_time_ns": 2.80412,
+      "area_um2": 9338999.8472,
+      "bytes_per_um2": 0.22455852171673005,
+      "name": "local_capacity_chunk_01_2048kib",
+      "read_energy_pj": 1001.04,
+      "size_bytes": 2097152,
+      "write_energy_pj": 1361.25
+    },
+    {
+      "access_time_ns": 0.389435,
+      "area_um2": 172655.270226,
+      "bytes_per_um2": 0.09489429415362699,
+      "name": "local_capacity_chunk_03_16kib",
+      "read_energy_pj": 99.083,
+      "size_bytes": 16384,
+      "write_energy_pj": 121.822
+    }
+  ],
+  "version": 1
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.md
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.md
@@ -1,0 +1,38 @@
+# Score32 exp-LUT SRAM Hierarchy Envelope
+
+- decision: `score32_exp_lut_sram_hierarchy_envelope_changes_frontier`
+- source score32 latency us: `12519.342352`
+- source hbm share: `0.983398438`
+- nominal efficiency: `0.75`
+- nominal shared MiB: `29.015625`
+- nominal hbm share: `0.992916107`
+- conservative efficiency: `0.55`
+- conservative shared MiB: `16.265625`
+- conservative hbm share delta: `0.012630462`
+- score buffer reserved: `True`
+- score buffer macro: `kv_tile_read_buffer`
+- score buffer macro count: `32`
+- score buffer area mm2: `66.636897`
+- score buffer energy mJ/token: `0.277849571328`
+
+## Sweep
+
+| efficiency | KV shared MiB | score area um2 | hbm share | projected latency us | shared envelope um2 | fits |
+|---:|---:|---:|---:|---:|---:|---|
+| 1.0 | 45.015625 | 66636897.2928 | 0.989009857 | 12590.7796 | 159039885.568626 | True |
+| 0.85 | 35.3125 | 66636897.2928 | 0.991378784 | 12620.937679 | 147219550.762334 | True |
+| 0.75 | 29.015625 | 66636897.2928 | 0.992916107 | 12640.508864 | 136738345.653741 | True |
+| 0.65 | 22.5625 | 66636897.2928 | 0.994491577 | 12660.565687 | 123268055.738622 | True |
+| 0.55 | 16.265625 | 66636897.2928 | 0.9960289 | 12680.136872 | 104620686.040775 | True |
+
+## Assumptions
+
+- SRAM macro placement efficiency is modeled as macro_area/envelope_area and swept explicitly.
+- Tile-local SRAM area and endpoint/router/FIFO area are reserved before packing shared SRAM.
+- Shared SRAM capacity uses the existing CACTI macro library; this is a placement envelope, not a placed memory compiler floorplan.
+- When supplied, the measured score-buffer macro set is reserved before packing remaining KV SRAM capacity.
+- Latency sensitivity scales the score32 baseline by HBM byte-share change only; HBM/DRAM service remains inherited.
+
+## Next Step
+
+- Prioritize HBM/DRAM service closure if the conservative SRAM placement envelope does not materially change hbm_byte_share; otherwise revisit SRAM hierarchy capacity.


### PR DESCRIPTION
## Summary
- item_id: `l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1`
- run_key: `l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1_run_b95116cc4c39841a`
- layer: `layer2`
- task_type: `l2_campaign`
- status: `ok`
- summary: `2/2 commands succeeded`
- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1/evaluated.json`
- metrics_rows_count: `0`
- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json`

## Developer Context
- proposal_id: `prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1`
- proposal_path: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json`
- reviewer_first_read: `docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
- execution_source_commit: `275673eb674626455a988b848941edbf28fd02cd`
- review_metadata_source_commit: `98812adafb0c9fa81aaf526f38ed790ed84cdf52`

## Evaluation Mode
- evaluation_mode: `frontier_recost`
- abstraction_layer: `decoder_attention_two_pass_score_sram_reservation`
- comparison_role: `measured_score_memory_recost`
- expected_direction: `reserve_measured_score_sram_before_kv`
- expected_reason: `The two-pass score store must consume concrete SRAM area, ports, and energy instead of borrowing the full shared-KV capacity envelope.`
- expectation_status: `unspecified`
- evaluation_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`

## Focused Comparison
- primary_question: `Can one-pass online composition remain within a 0.01 output-value error bound across long-context score distributions, or should the scalable RTL use exact two-pass global-max score replay?`
- comparison_role: `measured_score_memory_recost`
- proposal_outcome: `score32_exp_lut_sram_hierarchy_envelope_changes_frontier`
- comparison_summary: `Decoder score32 exp-LUT SRAM hierarchy envelope evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json: decision=score32_exp_lut_sram_hierarchy_envelope_changes_frontier; score32_supported=True; source_score32_latency_us=12519.342352; source_hbm_byte_share=0.983398438; nominal_efficiency=0.75; nominal_shared_sram_capacity_mib=29.015625; nominal_hbm_byte_share=0.992916107; conservative_efficiency=0.55; conservative_shared_sram_capacity_mib=16.265625; conservative_hbm_byte_share=0.9960289; conservative_hbm_share_delta=0.012630462; conservative_projected_latency_us_hbm_share_scaled=12680.136872; remaining_abstractions=['hbm_dram_service', 'sram_macro_floorplan_pnr']; requires_hbm_dram_closure=True.`
- baseline_ref: `None`
- baseline_item_id: `None`

## Submission Recovery
- resolver_retry_path: `true`
- submission_failure_count: `1`
- retry_request_count: `1`
- last_submission_failure: `work item l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1 is not eligible for submission: proposal already finalized with decision=promote`
- retry_request_id: `resume_8845fde13a7f0626`

## Checklist
- [ ] Commit lightweight campaign artifacts only
- [ ] Include metrics row references in result.metrics_rows
- [ ] Keep committed result_path fields repo-portable
- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing
