### PR TITLE
control_plane: preserve sibling reviews while iterating

### DIFF
--- a/control_plane/control_plane/services/proposal_finalizer.py
+++ b/control_plane/control_plane/services/proposal_finalizer.py
@@ -326,7 +326,7 @@ def _supersede_stale_sibling_reviews(
     current_item_id: str,
     decision: str,
 ) -> list[str]:
-    if not _is_terminal_decision(decision):
+    if not _closes_proposal(decision):
         return []
     superseded: list[str] = []
     reason = f"proposal finalized with decision={decision}"
@@ -383,6 +383,11 @@ def _is_merged_status(status: str) -> bool:
 def _is_terminal_decision(decision: str) -> bool:
     normalized = str(decision or "").strip().lower()
     return normalized in {"promote", "promoted", "iterate", "reject", "rejected", "close", "closed", "superseded"}
+
+
+def _closes_proposal(decision: str) -> bool:
+    normalized = str(decision or "").strip().lower()
+    return normalized in {"promote", "promoted", "reject", "rejected", "close", "closed", "superseded"}
 
 
 def _revision_payload_from_entry(entry: dict[str, Any]) -> dict[str, Any]:

--- a/control_plane/control_plane/tests/test_proposal_finalizer.py
+++ b/control_plane/control_plane/tests/test_proposal_finalizer.py
@@ -197,6 +197,8 @@ def test_finalize_accepts_directory_style_proposal_path() -> None:
 
 def test_iterate_decision_is_terminal_for_idempotent_finalize() -> None:
     assert proposal_finalizer._is_terminal_decision("iterate")
+    assert not proposal_finalizer._closes_proposal("iterate")
+    assert proposal_finalizer._closes_proposal("promote")
 
 
 


### PR DESCRIPTION
## Summary
- keep `iterate` terminal for idempotent finalization bookkeeping
- stop treating `iterate` as proposal closure when superseding sibling review PRs
- retain sibling cleanup for actual closing decisions such as promote, reject, close, and superseded

## Root cause
Independent follow-up results can be open concurrently under one proposal. Finalizing the first as `iterate` previously marked the other review as superseded even though iteration explicitly means more evidence remains.

## Validation
- idempotent iterate classification test passes
- closing-decision stale-sibling cleanup test passes
- `git diff --check`