### PR TITLE
npu: integrate measured two-pass frontier costs

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6419,6 +6419,66 @@ def _decoder_attention_two_pass_score_sram_reservation_evidence(*, item_id: str)
     return evidence
 
 
+def _decoder_attention_two_pass_integrated_frontier_ranking_evidence(
+    *, item_id: str, depends_on_item_ids: list[str] | None = None
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    source_frontier = (
+        f"{base}/decoder_attention_score32_integrated_frontier_ranking__"
+        "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json"
+    )
+    score_sram = (
+        f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__"
+        "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json"
+    )
+    zero_tail_quality = (
+        f"{base}/decoder_attention_mixed_int8_score32_zero_tail_two_pass_generation_quality__"
+        "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1.json"
+    )
+    iterdiv_item_id = next(
+        (
+            str(dep)
+            for dep in (depends_on_item_ids or [])
+            if str(dep).startswith("l1_decoder_attention_two_pass_stream_iterdiv_ppa_v")
+        ),
+        "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1",
+    )
+    iterdiv_ppa = f"control_plane/shadow_exports/l1_promotions/{iterdiv_item_id}.json"
+    out = f"{base}/decoder_attention_two_pass_integrated_frontier_ranking__{item_id}.json"
+    report = f"{base}/decoder_attention_two_pass_integrated_frontier_ranking__{item_id}.md"
+    return {
+        "inputs": {
+            "source_score32_frontier_ranking": source_frontier,
+            "two_pass_score_sram_recost": score_sram,
+            "two_pass_zero_tail_quality": zero_tail_quality,
+            "two_pass_iterdiv_ppa": iterdiv_ppa,
+            "two_pass_integrated_frontier_ranking_out": out,
+            "two_pass_integrated_frontier_ranking_report": report,
+            "two_pass_integrated_frontier_ranking_scope": (
+                "Recost the current Llama7B score32 frontier with measured iterative-divider PPA, "
+                "measured 16 MiB score SRAM, and zero-tail generation quality. Compare one divider "
+                "per head against a shared divider under nominal and conservative SRAM packing."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_two_pass_integrated_frontier_ranking",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_two_pass_integrated_frontier_ranking.py "
+                    f"--source-frontier-ranking-json {source_frontier} "
+                    f"--score-sram-recost-json {score_sram} "
+                    f"--zero-tail-quality-json {zero_tail_quality} "
+                    f"--iterdiv-ppa-json {iterdiv_ppa} "
+                    "--head-count 32 --divide-cycles-per-head 480 --clock-ns 10 "
+                    f"--out {out} --out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_integrated_abstraction_closure_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_integrated_abstraction_closure__{item_id}.json"
@@ -9919,6 +9979,7 @@ def _build_payload(
         "decoder_attention_score32_exp_lut_service_closure",
         "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
         "decoder_attention_two_pass_score_sram_reservation",
+        "decoder_attention_two_pass_integrated_frontier_ranking",
         "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
         "decoder_attention_score32_hbm_controller_replay",
         "decoder_attention_score32_integrated_frontier_ranking",
@@ -10132,6 +10193,11 @@ def _build_payload(
             decoder_evidence = _decoder_attention_score32_exp_lut_sram_hierarchy_envelope_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_two_pass_score_sram_reservation":
             decoder_evidence = _decoder_attention_two_pass_score_sram_reservation_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_two_pass_integrated_frontier_ranking":
+            decoder_evidence = _decoder_attention_two_pass_integrated_frontier_ranking_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+            )
         elif abstraction_layer_name == "decoder_attention_score32_exp_lut_hbm_dram_service_closure":
             decoder_evidence = _decoder_attention_score32_exp_lut_hbm_dram_service_closure_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_hbm_controller_replay":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7563,6 +7563,46 @@ def test_generate_l2_campaign_task_adds_two_pass_score_sram_reservation() -> Non
             )
 
 
+def test_generate_l2_campaign_task_adds_two_pass_integrated_frontier_ranking() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_two_pass_integrated_frontier_ranking_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_two_pass_integrated_frontier_ranking",
+                    evaluation_mode="frontier_recost",
+                    depends_on_item_ids=["l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1"],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command = work_item.task_request.request_payload["task"]["commands"][0]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert command["name"] == "audit_decoder_attention_two_pass_integrated_frontier_ranking"
+            assert "--head-count 32 --divide-cycles-per-head 480 --clock-ns 10" in command["run"]
+            assert "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1.json" in command["run"]
+            assert decoder_inputs["two_pass_score_sram_recost"].endswith(
+                "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json"
+            )
+            assert decoder_inputs["two_pass_zero_tail_quality"].endswith(
+                "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1.json"
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
@@ -189,6 +189,26 @@
       "merge_commit": "3862bc198ff013db559fa64f0710a55a7cfd4a9d",
       "merged_utc": "2026-07-13T11:27:09.946354Z",
       "notes": "Merged via PR #1272 and merge 3862bc198ff013db559fa64f0710a55a7cfd4a9d at 2026-07-13T11:27:09.946354Z."
+    },
+    {
+      "item_id": "l2_decoder_attention_two_pass_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Integrate measured iterative-divider PPA, score-SRAM cost, and zero-tail quality into the Llama7B frontier.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_two_pass_integrated_frontier_ranking",
+      "comparison_role": "measured_two_pass_frontier_ranking",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1",
+        "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+        "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_measured_two_pass_deployments",
+        "reason": "The frontier must charge divider latency, area, and energy together with score SRAM and the implemented zero-tail quality result."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "source_commit": "0f76c959af3d547b55491546970268d88586e85c"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
@@ -188,11 +188,30 @@
         "reason": "The earlier score32 quality pass clamps out-of-range LUT deltas to exp(-8) and cannot be transferred to the implemented zero-tail profile."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_two_pass_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Integrate measured iterative-divider PPA, score-SRAM cost, and zero-tail quality into the Llama7B frontier.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_two_pass_integrated_frontier_ranking",
+      "comparison_role": "measured_two_pass_frontier_ranking",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1",
+        "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+        "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_measured_two_pass_deployments",
+        "reason": "The frontier must charge divider latency, area, and energy together with score SRAM and the implemented zero-tail quality result."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "remaining_abstractions_after_this_step": [
-    "The exact iterative divider still requires remote equivalence and PPA measurement.",
-    "The measured score-SRAM macro reservation still requires a placed macro floorplan and composed QK/KV schedule recost.",
-    "The resulting arithmetic profile requires model-native Llama quality evaluation before promotion."
+    "The measured score-SRAM macros still require composed floorplan and PNR evidence.",
+    "HBM/DRAM service and vendor-current signoff remain external to the current measured datapath."
   ]
 }

--- a/npu/eval/audit_llm_decoder_attention_two_pass_integrated_frontier_ranking.py
+++ b/npu/eval/audit_llm_decoder_attention_two_pass_integrated_frontier_ranking.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Recost the Llama7B score32 frontier with the measured two-pass service."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> JsonDict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _metrics_csv_row(metrics_csv: str, ppa_path: Path) -> JsonDict:
+    relative = Path(metrics_csv)
+    candidates = [relative] if relative.is_absolute() else [Path.cwd() / relative]
+    if not relative.is_absolute():
+        candidates.extend(parent / relative for parent in ppa_path.resolve().parents)
+    path = next((candidate for candidate in candidates if candidate.is_file()), None)
+    if path is None:
+        return {}
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = [dict(row) for row in csv.DictReader(handle) if row.get("status") == "ok"]
+    if not rows:
+        return {}
+    return min(rows, key=lambda row: (_float(row.get("critical_path_ns"), 1.0e99), _float(row.get("instance_area_um2"), 1.0e99)))
+
+
+def _iterdiv_metrics(payload: JsonDict, ppa_path: Path) -> JsonDict:
+    candidates: list[JsonDict] = []
+    for proposal in payload.get("proposals", []):
+        if not isinstance(proposal, dict):
+            continue
+        metrics_ref = _dict(proposal.get("metrics_ref"))
+        summary = _dict(proposal.get("metric_summary"))
+        if metrics_ref.get("status") != "ok" or not summary:
+            continue
+        metrics_csv = str(metrics_ref.get("metrics_csv") or "")
+        csv_row = _metrics_csv_row(metrics_csv, ppa_path) if metrics_csv else {}
+        candidates.append(
+            {
+                "critical_path_ns": _float(summary.get("critical_path_ns")),
+                "area_um2": _float(csv_row.get("instance_area_um2"), _float(summary.get("die_area"))),
+                "area_metric": "instance_area_um2" if csv_row else "die_area_fallback",
+                "power_mw": _float(summary.get("total_power_mw")),
+                "metrics_csv": metrics_csv,
+            }
+        )
+    if not candidates:
+        raise ValueError("iterative-divider PPA has no successful proposal metrics")
+    return min(candidates, key=lambda row: (row["critical_path_ns"], row["area_um2"]))
+
+
+def _source_frontier_row(payload: JsonDict) -> JsonDict:
+    rows = [row for row in payload.get("rows", []) if isinstance(row, dict)]
+    for row in rows:
+        if str(row.get("candidate_id", "")).startswith("score32_"):
+            return dict(row)
+    raise ValueError("source ranking has no score32 frontier row")
+
+
+def _sram_scenarios(payload: JsonDict) -> list[JsonDict]:
+    rows = [row for row in payload.get("rows", []) if isinstance(row, dict)]
+    wanted = {0.75: "nominal", 0.55: "conservative"}
+    selected = []
+    for efficiency, name in wanted.items():
+        match = next(
+            (row for row in rows if abs(_float(row.get("placement_efficiency")) - efficiency) < 1e-9),
+            None,
+        )
+        if match is None:
+            raise ValueError(f"score-SRAM recost is missing placement efficiency {efficiency}")
+        selected.append({"name": name, **match})
+    return selected
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    source_payload = _load(args.source_frontier_ranking_json)
+    sram_payload = _load(args.score_sram_recost_json)
+    quality_payload = _load(args.zero_tail_quality_json)
+    iterdiv_payload = _load(args.iterdiv_ppa_json)
+
+    source = _source_frontier_row(source_payload)
+    sram_diagnosis = _dict(sram_payload.get("diagnosis"))
+    quality = _dict(quality_payload.get("best_candidate"))
+    quality_decision = _dict(quality_payload.get("decision"))
+    iterdiv = _iterdiv_metrics(iterdiv_payload, args.iterdiv_ppa_json)
+    clock_ns = _float(args.clock_ns)
+    divide_cycles_per_head = int(args.divide_cycles_per_head)
+    head_count = int(args.head_count)
+    per_head_latency_us = divide_cycles_per_head * clock_ns / 1000.0
+    divider_energy_per_head_mj = iterdiv["power_mw"] * per_head_latency_us * 1.0e-6
+    score_sram_energy_mj = _float(sram_diagnosis.get("score_buffer_energy_mj_per_token"))
+    score_sram_macro_area_mm2 = _float(sram_diagnosis.get("score_buffer_area_mm2"))
+    source_frontier_latency_us = _float(source.get("latency_us"))
+
+    rows: list[JsonDict] = []
+    deployments = (
+        ("per_head", head_count, 1),
+        ("shared", 1, head_count),
+    )
+    for scenario in _sram_scenarios(sram_payload):
+        for deployment, instances, serial_head_groups in deployments:
+            divider_latency_us = per_head_latency_us * serial_head_groups
+            sram_source_latency_us = _float(scenario.get("source_score32_latency_us"))
+            sram_latency_delta_us = (
+                _float(scenario.get("projected_latency_us_hbm_share_scaled")) - sram_source_latency_us
+            )
+            latency_us = source_frontier_latency_us + sram_latency_delta_us + divider_latency_us
+            divider_area_mm2 = iterdiv["area_um2"] * instances / 1.0e6
+            divider_energy_mj = divider_energy_per_head_mj * head_count
+            total_energy_mj = _float(source.get("energy_mj_per_token")) + score_sram_energy_mj + divider_energy_mj
+            logic_area_mm2 = _float(source.get("compute_area_mm2")) + divider_area_mm2
+            rows.append(
+                {
+                    "candidate_id": f"score32_zero_tail_two_pass_{scenario['name']}_{deployment}_iterdiv",
+                    "family": "score32_zero_tail_two_pass_iterdiv",
+                    "placement_scenario": scenario["name"],
+                    "placement_efficiency": _float(scenario.get("placement_efficiency")),
+                    "divider_deployment": deployment,
+                    "divider_instances": instances,
+                    "serial_head_groups": serial_head_groups,
+                    "head_count": head_count,
+                    "latency_us": round(latency_us, 12),
+                    "source_frontier_latency_us": source_frontier_latency_us,
+                    "score_sram_source_latency_us": sram_source_latency_us,
+                    "score_sram_latency_delta_us": round(sram_latency_delta_us, 12),
+                    "token_throughput_per_s": round(1_000_000.0 / latency_us, 12),
+                    "energy_mj_per_token": round(total_energy_mj, 12),
+                    "base_energy_mj_per_token": _float(source.get("energy_mj_per_token")),
+                    "score_sram_energy_mj_per_token": score_sram_energy_mj,
+                    "divider_energy_mj_per_token": round(divider_energy_mj, 12),
+                    "compute_plus_service_logic_area_mm2": round(logic_area_mm2, 12),
+                    "score_sram_macro_area_mm2": score_sram_macro_area_mm2,
+                    "score_sram_envelope_area_mm2": round(
+                        _float(scenario.get("score_buffer_envelope_area_um2")) / 1.0e6, 12
+                    ),
+                    "embodied_logic_plus_score_macro_area_mm2": round(
+                        logic_area_mm2 + score_sram_macro_area_mm2, 12
+                    ),
+                    "die_area_mm2": _float(source.get("die_area_mm2")),
+                    "shared_sram_capacity_mib": _float(scenario.get("shared_sram_capacity_mib")),
+                    "hbm_byte_share": _float(scenario.get("hbm_byte_share")),
+                    "divider_latency_us": round(divider_latency_us, 12),
+                    "divider_critical_path_ns": iterdiv["critical_path_ns"],
+                    "divider_meets_clock": iterdiv["critical_path_ns"] <= clock_ns,
+                    "quality_status": quality_decision.get("status"),
+                    "free_running_match_rate": quality.get("free_running_match_rate"),
+                    "teacher_forced_nll_delta_mean": quality.get("teacher_forced_nll_delta_mean"),
+                    "quality_backed": str(quality_decision.get("status", "")).endswith("_pass"),
+                    "remaining_abstractions": ["hbm_dram_service", "sram_macro_floorplan_pnr"],
+                }
+            )
+
+    latency_rank = sorted(rows, key=lambda row: (row["latency_us"], row["embodied_logic_plus_score_macro_area_mm2"]))
+    area_rank = sorted(rows, key=lambda row: (row["embodied_logic_plus_score_macro_area_mm2"], row["latency_us"]))
+    recommended = latency_rank[0]
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_two_pass_integrated_frontier_ranking_v1",
+        "decision": "two_pass_measured_components_integrated_frontier_ranked",
+        "inputs": {
+            "source_frontier_ranking_json": str(args.source_frontier_ranking_json),
+            "score_sram_recost_json": str(args.score_sram_recost_json),
+            "zero_tail_quality_json": str(args.zero_tail_quality_json),
+            "iterdiv_ppa_json": str(args.iterdiv_ppa_json),
+        },
+        "iterdiv_metrics": iterdiv,
+        "schedule": {
+            "head_count": head_count,
+            "divide_cycles_per_head": divide_cycles_per_head,
+            "clock_ns": clock_ns,
+            "per_head_divide_latency_us": per_head_latency_us,
+            "note": "Each measured block normalizes one attention head with eight value lanes.",
+        },
+        "rows": rows,
+        "latency_rank": latency_rank,
+        "area_rank": area_rank,
+        "diagnosis": {
+            "recommended_candidate": recommended["candidate_id"],
+            "recommended_latency_us": recommended["latency_us"],
+            "recommended_token_throughput_per_s": recommended["token_throughput_per_s"],
+            "minimum_area_candidate": area_rank[0]["candidate_id"],
+            "shared_divider_latency_penalty_us": round(per_head_latency_us * (head_count - 1), 12),
+            "per_head_divider_area_premium_mm2": round(
+                iterdiv["area_um2"] * (head_count - 1) / 1.0e6, 12
+            ),
+            "quality_status": quality_decision.get("status"),
+            "remaining_abstractions": ["hbm_dram_service", "sram_macro_floorplan_pnr"],
+        },
+        "assumptions": [
+            "The source compute/controller row remains measured evidence; the two-pass service is added rather than silently replacing unseparated logic area.",
+            "Only the score-SRAM recost latency delta is transferred onto the current controller-replay frontier, preserving measured controller overhead.",
+            "Divider active energy is charged once per head, so sharing changes latency and area but not total divider work energy.",
+            "The score SRAM macro area is reported separately from its placement envelope to avoid double counting the fixed die budget.",
+            "HBM service and score-SRAM floorplan PNR remain explicit abstractions.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    d = payload["diagnosis"]
+    lines = [
+        "# Two-Pass Integrated Frontier Ranking",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- recommended candidate: `{d['recommended_candidate']}`",
+        f"- recommended latency us: `{d['recommended_latency_us']}`",
+        f"- minimum-area candidate: `{d['minimum_area_candidate']}`",
+        f"- quality status: `{d['quality_status']}`",
+        "",
+        "| candidate | latency us | token/s | energy mJ/token | logic + score macro mm2 |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for row in payload["latency_rank"]:
+        lines.append(
+            f"| {row['candidate_id']} | {row['latency_us']} | {row['token_throughput_per_s']} | "
+            f"{row['energy_mj_per_token']} | {row['embodied_logic_plus_score_macro_area_mm2']} |"
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-frontier-ranking-json", type=Path, required=True)
+    parser.add_argument("--score-sram-recost-json", type=Path, required=True)
+    parser.add_argument("--zero-tail-quality-json", type=Path, required=True)
+    parser.add_argument("--iterdiv-ppa-json", type=Path, required=True)
+    parser.add_argument("--head-count", type=int, default=32)
+    parser.add_argument("--divide-cycles-per-head", type=int, default=480)
+    parser.add_argument("--clock-ns", type=float, default=10.0)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "decision": payload["decision"], "out": str(args.out)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_llm_decoder_attention_two_pass_integrated_frontier_ranking.py
+++ b/tests/test_audit_llm_decoder_attention_two_pass_integrated_frontier_ranking.py
@@ -1,0 +1,93 @@
+from argparse import Namespace
+import json
+from pathlib import Path
+
+from npu.eval.audit_llm_decoder_attention_two_pass_integrated_frontier_ranking import build_report
+
+
+def _write(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_two_pass_recost_exposes_shared_and_per_head_tradeoff(tmp_path: Path) -> None:
+    source = _write(
+        tmp_path / "source.json",
+        {
+            "rows": [
+                {
+                    "candidate_id": "score32_old",
+                    "latency_us": 1000.0,
+                    "energy_mj_per_token": 10.0,
+                    "compute_area_mm2": 20.0,
+                    "die_area_mm2": 100.0,
+                }
+            ]
+        },
+    )
+    sram = _write(
+        tmp_path / "sram.json",
+        {
+            "diagnosis": {
+                "score_buffer_energy_mj_per_token": 0.25,
+                "score_buffer_area_mm2": 8.0,
+            },
+            "rows": [
+                {
+                    "placement_efficiency": efficiency,
+                    "source_score32_latency_us": 1000.0,
+                    "projected_latency_us_hbm_share_scaled": latency,
+                    "score_buffer_envelope_area_um2": envelope,
+                    "shared_sram_capacity_mib": capacity,
+                    "hbm_byte_share": share,
+                }
+                for efficiency, latency, envelope, capacity, share in (
+                    (0.75, 1010.0, 10_000_000, 30.0, 0.99),
+                    (0.55, 1020.0, 14_000_000, 16.0, 0.995),
+                )
+            ],
+        },
+    )
+    quality = _write(
+        tmp_path / "quality.json",
+        {
+            "decision": {"status": "mixed_int8_generation_quality_pass"},
+            "best_candidate": {"free_running_match_rate": 0.875, "teacher_forced_nll_delta_mean": 0.01},
+        },
+    )
+    ppa = _write(
+        tmp_path / "ppa.json",
+        {
+            "proposals": [
+                {
+                    "metrics_ref": {"status": "ok", "metrics_csv": "iterdiv/metrics.csv"},
+                    "metric_summary": {"critical_path_ns": 7.5, "die_area": 100_000, "total_power_mw": 2.0},
+                }
+            ]
+        },
+    )
+
+    report = build_report(
+        Namespace(
+            source_frontier_ranking_json=source,
+            score_sram_recost_json=sram,
+            zero_tail_quality_json=quality,
+            iterdiv_ppa_json=ppa,
+            head_count=32,
+            divide_cycles_per_head=480,
+            clock_ns=10.0,
+        )
+    )
+
+    per_head = report["latency_rank"][0]
+    shared = next(row for row in report["rows"] if row["placement_scenario"] == "nominal" and row["divider_deployment"] == "shared")
+    assert per_head["latency_us"] == 1014.8
+    assert shared["latency_us"] == 1163.6
+    assert per_head["score_sram_latency_delta_us"] == 10.0
+    assert per_head["divider_instances"] == 32
+    assert shared["divider_instances"] == 1
+    assert per_head["divider_energy_mj_per_token"] == shared["divider_energy_mj_per_token"]
+    assert per_head["compute_plus_service_logic_area_mm2"] == 23.2
+    assert shared["compute_plus_service_logic_area_mm2"] == 20.1
+    assert per_head["quality_backed"] is True
+    assert report["diagnosis"]["shared_divider_latency_penalty_us"] == 148.8


### PR DESCRIPTION
## Summary
- add a dedicated Llama7B two-pass integrated frontier recost
- compare per-head and shared iterative-divider deployment across nominal/conservative SRAM packing
- schedule the evidence job after measured divider, score SRAM, and zero-tail quality dependencies

## Verification
- 14 focused tests passed
- actual merged-artifact preview resolves instance area from metrics.csv and emits four ranked rows