### PR TITLE
control_plane: consume two-pass frontier evidence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -603,6 +603,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_two_pass_stream_equivalence_report",
     ),
     (
+        "two_pass_integrated_frontier_ranking_out",
+        "two_pass_integrated_frontier_ranking_report",
+    ),
+    (
         "attention_score32_exp_lut_sram_hierarchy_envelope_out",
         "attention_score32_exp_lut_sram_hierarchy_envelope_report",
     ),
@@ -1436,6 +1440,31 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "score32_die_area_mm2",
             "score32_quality_status",
             "current_recommended_candidate",
+            "remaining_abstractions",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_two_pass_integrated_frontier_ranking_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            evidence_payload.get("decision")
+            or "two_pass_integrated_frontier_ranking_recorded"
+        )
+        parts = [
+            f"Decoder two-pass integrated frontier ranking recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "recommended_candidate",
+            "recommended_latency_us",
+            "recommended_token_throughput_per_s",
+            "minimum_area_candidate",
+            "shared_divider_latency_penalty_us",
+            "per_head_divider_area_premium_mm2",
+            "quality_status",
             "remaining_abstractions",
         ):
             if key in diagnosis_dict:

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -47,6 +47,26 @@ def test_decoder_evidence_summary_recognizes_two_pass_attention_equivalence() ->
     assert "external score SRAM" in summary
 
 
+def test_decoder_evidence_summary_recognizes_two_pass_integrated_frontier() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/two_pass_frontier.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_two_pass_integrated_frontier_ranking_v1",
+            "decision": "two_pass_measured_components_integrated_frontier_ranked",
+            "diagnosis": {
+                "recommended_candidate": "score32_zero_tail_two_pass_nominal_per_head_iterdiv",
+                "recommended_latency_us": 12940.2,
+                "minimum_area_candidate": "score32_zero_tail_two_pass_nominal_shared_iterdiv",
+                "remaining_abstractions": ["hbm_dram_service", "sram_macro_floorplan_pnr"],
+            },
+        },
+    )
+
+    assert outcome == "two_pass_measured_components_integrated_frontier_ranked"
+    assert "recommended_latency_us=12940.2" in summary
+    assert "sram_macro_floorplan_pnr" in summary
+
+
 def test_decoder_evidence_summary_recognizes_two_pass_stream_equivalence() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/two_pass_stream.json",


### PR DESCRIPTION
Registers the integrated two-pass output contract with the L2 evidence consumer and summarizes its frontier diagnosis. This rescues the already-successful remote run without rerunning evaluation.\n\nVerification: focused result-consumer tests passed.