### PR TITLE
Recost separated exact two-pass Llama7B frontier

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -607,6 +607,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "two_pass_integrated_frontier_ranking_report",
     ),
     (
+        "separated_two_pass_frontier_out",
+        "separated_two_pass_frontier_report",
+    ),
+    (
         "attention_score32_exp_lut_sram_hierarchy_envelope_out",
         "attention_score32_exp_lut_sram_hierarchy_envelope_report",
     ),
@@ -1465,6 +1469,33 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "shared_divider_latency_penalty_us",
             "per_head_divider_area_premium_mm2",
             "quality_status",
+            "remaining_abstractions",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_separated_two_pass_frontier_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            evidence_payload.get("decision")
+            or diagnosis_dict.get("decision")
+            or "separated_two_pass_frontier_recorded"
+        )
+        parts = [
+            f"Decoder separated-producer two-pass frontier recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "recommended_candidate",
+            "recommended_latency_us",
+            "recommended_token_throughput_per_s",
+            "recommended_total_energy_mj_per_token",
+            "recommended_embodied_area_mm2",
+            "minimum_area_candidate",
+            "quality_status",
+            "precision_status",
             "remaining_abstractions",
         ):
             if key in diagnosis_dict:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6479,6 +6479,66 @@ def _decoder_attention_two_pass_integrated_frontier_ranking_evidence(
     }
 
 
+def _decoder_attention_separated_two_pass_frontier_evidence(
+    *, item_id: str, depends_on_item_ids: list[str] | None = None
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    separated_compute = (
+        f"{base}/decoder_attention_score32_separated_compute_recost__"
+        "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1.json"
+    )
+    score_sram = (
+        f"{base}/decoder_attention_score32_exp_lut_sram_hierarchy_envelope__"
+        "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json"
+    )
+    zero_tail_quality = (
+        f"{base}/decoder_attention_mixed_int8_score32_zero_tail_two_pass_generation_quality__"
+        "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1.json"
+    )
+    iterdiv_item_id = next(
+        (
+            str(dep)
+            for dep in (depends_on_item_ids or [])
+            if str(dep).startswith("l1_decoder_attention_two_pass_stream_iterdiv_ppa_v")
+        ),
+        "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1",
+    )
+    iterdiv_ppa = f"control_plane/shadow_exports/l1_promotions/{iterdiv_item_id}.json"
+    out = f"{base}/decoder_attention_separated_two_pass_frontier__{item_id}.json"
+    report = f"{base}/decoder_attention_separated_two_pass_frontier__{item_id}.md"
+    return {
+        "inputs": {
+            "separated_two_pass_compute_recost": separated_compute,
+            "separated_two_pass_score_sram_recost": score_sram,
+            "separated_two_pass_zero_tail_quality": zero_tail_quality,
+            "separated_two_pass_iterdiv_ppa": iterdiv_ppa,
+            "separated_two_pass_frontier_out": out,
+            "separated_two_pass_frontier_report": report,
+            "separated_two_pass_frontier_scope": (
+                "Replace the slow replicated score32 wrapper with the measured dense-int8 producer and "
+                "exact global two-pass iterative service. Transfer measured score-SRAM HBM-share deltas "
+                "and rank per-head/shared service deployments without attributing old local softmax cost."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_separated_two_pass_frontier",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_separated_two_pass_frontier.py "
+                    f"--separated-compute-recost-json {separated_compute} "
+                    f"--score-sram-recost-json {score_sram} "
+                    f"--zero-tail-quality-json {zero_tail_quality} "
+                    f"--iterdiv-ppa-json {iterdiv_ppa} "
+                    "--head-count 32 --divide-cycles-per-head 480 --clock-ns 10 "
+                    f"--out {out} --out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_integrated_abstraction_closure_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_integrated_abstraction_closure__{item_id}.json"
@@ -9980,6 +10040,7 @@ def _build_payload(
         "decoder_attention_score32_exp_lut_sram_hierarchy_envelope",
         "decoder_attention_two_pass_score_sram_reservation",
         "decoder_attention_two_pass_integrated_frontier_ranking",
+        "decoder_attention_separated_two_pass_frontier",
         "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
         "decoder_attention_score32_hbm_controller_replay",
         "decoder_attention_score32_integrated_frontier_ranking",
@@ -10195,6 +10256,11 @@ def _build_payload(
             decoder_evidence = _decoder_attention_two_pass_score_sram_reservation_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_two_pass_integrated_frontier_ranking":
             decoder_evidence = _decoder_attention_two_pass_integrated_frontier_ranking_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+            )
+        elif abstraction_layer_name == "decoder_attention_separated_two_pass_frontier":
+            decoder_evidence = _decoder_attention_separated_two_pass_frontier_evidence(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
             )

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -67,6 +67,28 @@ def test_decoder_evidence_summary_recognizes_two_pass_integrated_frontier() -> N
     assert "sram_macro_floorplan_pnr" in summary
 
 
+def test_decoder_evidence_summary_recognizes_separated_two_pass_frontier() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/separated_two_pass_frontier.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_separated_two_pass_frontier_v1",
+            "decision": "precision_aligned_separated_two_pass_frontier_ranked",
+            "diagnosis": {
+                "recommended_candidate": "separated_two_pass_nominal_per_head_iterdiv",
+                "recommended_latency_us": 1595.4,
+                "recommended_token_throughput_per_s": 626.8,
+                "recommended_embodied_area_mm2": 249.4,
+                "quality_status": "zero_tail_quality_pass",
+                "remaining_abstractions": ["hbm_dram_service", "sram_macro_floorplan_pnr"],
+            },
+        },
+    )
+
+    assert outcome == "precision_aligned_separated_two_pass_frontier_ranked"
+    assert "recommended_token_throughput_per_s=626.8" in summary
+    assert "sram_macro_floorplan_pnr" in summary
+
+
 def test_decoder_evidence_summary_recognizes_two_pass_stream_equivalence() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/two_pass_stream.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7603,6 +7603,49 @@ def test_generate_l2_campaign_task_adds_two_pass_integrated_frontier_ranking() -
             )
 
 
+def test_generate_l2_campaign_task_adds_separated_two_pass_frontier() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_separated_two_pass_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_separated_two_pass_frontier",
+                    evaluation_mode="frontier_recost",
+                    depends_on_item_ids=["l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1"],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command = work_item.task_request.request_payload["task"]["commands"][0]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert command["name"] == "audit_decoder_attention_separated_two_pass_frontier"
+            assert "--head-count 32 --divide-cycles-per-head 480 --clock-ns 10" in command["run"]
+            assert "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1.json" in command["run"]
+            assert decoder_inputs["separated_two_pass_compute_recost"].endswith(
+                "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1.json"
+            )
+            assert decoder_inputs["separated_two_pass_score_sram_recost"].endswith(
+                "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1.json"
+            )
+            assert decoder_inputs["separated_two_pass_zero_tail_quality"].endswith(
+                "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1.json"
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_reduced_replica_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/evaluation_requests.json
@@ -213,6 +213,28 @@
       "merge_commit": "daea1186cc1a11d78c5d97015f30b72066d375a6",
       "merged_utc": "2026-07-13T12:14:48.219668Z",
       "notes": "Merged via PR #1277 and merge daea1186cc1a11d78c5d97015f30b72066d375a6 at 2026-07-13T12:14:48.219668Z."
+    },
+    {
+      "item_id": "l2_decoder_attention_separated_two_pass_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replace the slow replicated score32 wrapper with the measured dense producer plus exact global two-pass service and rerank Llama7B.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_separated_two_pass_frontier",
+      "comparison_role": "precision_aligned_separated_two_pass_frontier",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1",
+        "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1",
+        "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+        "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1",
+        "l2_decoder_attention_two_pass_integrated_frontier_ranking_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_precision_aligned_separated_two_pass_frontier",
+        "reason": "Transfer the measured score-SRAM bandwidth share into the fast dense-producer baseline while replacing, rather than double-counting, the old local vector-softmax component."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "source_commit": "8f41146c030f8f3324eac52250932983a5ff75f9"

--- a/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_hierarchical_softmax_frontier_llama7b_v1/proposal.json
@@ -208,10 +208,33 @@
         "reason": "The frontier must charge divider latency, area, and energy together with score SRAM and the implemented zero-tail quality result."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_separated_two_pass_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replace the slow replicated score32 wrapper with the measured dense producer plus exact global two-pass service and rerank Llama7B.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_separated_two_pass_frontier",
+      "comparison_role": "precision_aligned_separated_two_pass_frontier",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_separated_compute_recost_llama7b_v1",
+        "l1_decoder_attention_two_pass_stream_iterdiv_ppa_v1",
+        "l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
+        "l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1",
+        "l2_decoder_attention_two_pass_integrated_frontier_ranking_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_precision_aligned_separated_two_pass_frontier",
+        "reason": "Transfer the measured score-SRAM bandwidth share into the fast dense-producer baseline while replacing, rather than double-counting, the old local vector-softmax component."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "remaining_abstractions_after_this_step": [
-    "The measured score-SRAM macros still require composed floorplan and PNR evidence.",
+    "The separated dense producer, exact two-pass service, and score-SRAM macros still require composed scheduling, floorplan, and PNR evidence.",
+    "Toggle-accurate composed energy remains unmeasured.",
     "HBM/DRAM service and vendor-current signoff remain external to the current measured datapath."
   ]
 }

--- a/npu/eval/audit_llm_decoder_attention_separated_two_pass_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_separated_two_pass_frontier.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Recost the separated score32 Llama7B row with measured two-pass service."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+def _load(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _arg_value(args: argparse.Namespace, primary: str, legacy: str) -> Any:
+    value = getattr(args, primary, None)
+    if value is not None:
+        return value
+    return getattr(args, legacy)
+
+
+def _dict(value: Any) -> JsonDict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _require_positive(value: Any, label: str) -> float:
+    result = _float(value)
+    if result <= 0.0:
+        raise ValueError(f"{label} must be positive")
+    return result
+
+
+def _quality_evidence(payload: JsonDict) -> JsonDict:
+    decision = _dict(payload.get("decision"))
+    best = _dict(payload.get("best_candidate"))
+    status = str(decision.get("status") or best.get("decision_status") or "unknown")
+    quality_backed = status.endswith("_pass")
+    return {
+        "status": status,
+        "candidate_id": best.get("candidate_id"),
+        "teacher_forced_nll_delta_mean": best.get("teacher_forced_nll_delta_mean"),
+        "free_running_match_rate": best.get("free_running_match_rate"),
+        "candidate_probability_assigned_to_reference_token_mean": best.get(
+            "candidate_probability_assigned_to_reference_token_mean"
+        ),
+        "precision": _dict(payload.get("precision")),
+        "quality_backed": quality_backed,
+        "precision_aligned": quality_backed,
+    }
+
+
+def _metrics_csv_row(metrics_csv: str, ppa_path: Path) -> JsonDict:
+    relative = Path(metrics_csv)
+    candidates = [relative] if relative.is_absolute() else [Path.cwd() / relative]
+    if not relative.is_absolute():
+        candidates.extend(parent / relative for parent in ppa_path.resolve().parents)
+    path = next((candidate for candidate in candidates if candidate.is_file()), None)
+    if path is None:
+        return {}
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = [dict(row) for row in csv.DictReader(handle) if str(row.get("status") or "").strip() == "ok"]
+    if not rows:
+        return {}
+    return min(
+        rows,
+        key=lambda row: (
+            _float(row.get("critical_path_ns"), 1.0e99),
+            _float(row.get("instance_area_um2"), 1.0e99),
+        ),
+    )
+
+
+def _iterdiv_metrics(payload: JsonDict, ppa_path: Path) -> JsonDict:
+    candidates: list[JsonDict] = []
+    for proposal in payload.get("proposals", []):
+        proposal_dict = _dict(proposal)
+        metrics_ref = _dict(proposal_dict.get("metrics_ref"))
+        summary = _dict(proposal_dict.get("metric_summary"))
+        if str(metrics_ref.get("status") or "") != "ok" or not summary:
+            continue
+        metrics_csv = str(metrics_ref.get("metrics_csv") or "")
+        csv_row = _metrics_csv_row(metrics_csv, ppa_path) if metrics_csv else {}
+        candidates.append(
+            {
+                "critical_path_ns": _require_positive(summary.get("critical_path_ns"), "iterdiv critical_path_ns"),
+                "area_um2": _require_positive(
+                    csv_row.get("instance_area_um2", summary.get("die_area")),
+                    "iterdiv instance_area_um2",
+                ),
+                "area_metric": "instance_area_um2" if csv_row else "die_area_fallback",
+                "power_mw": _require_positive(summary.get("total_power_mw"), "iterdiv total_power_mw"),
+                "metrics_csv": metrics_csv,
+            }
+        )
+    if not candidates:
+        raise ValueError("iterative-divider PPA has no successful proposal metrics")
+    return min(candidates, key=lambda row: (row["critical_path_ns"], row["area_um2"]))
+
+
+def _component_map(source_candidate: JsonDict) -> JsonDict:
+    components = [
+        _dict(component)
+        for component in source_candidate.get("components", [])
+        if isinstance(component, dict)
+    ]
+    indexed = {str(component.get("component")): component for component in components}
+    controller = next(
+        (component for component in components if str(component.get("component", "")).startswith("hbm_replay_controller")),
+        None,
+    )
+    required = {
+        "dense_int8_gemm_fabric": indexed.get("dense_int8_gemm_fabric"),
+        "shared_score32_vector_softmax_overhead": indexed.get("shared_score32_vector_softmax_overhead"),
+        "command_dispatch_control": indexed.get("command_dispatch_control"),
+        "hbm_replay_controller": controller,
+    }
+    missing = [name for name, component in required.items() if component is None]
+    if missing:
+        raise ValueError(f"source separated recost is missing components: {', '.join(sorted(missing))}")
+    return required
+
+
+def _select_scenarios(payload: JsonDict) -> list[JsonDict]:
+    rows = [_dict(row) for row in payload.get("rows", []) if isinstance(row, dict)]
+    if not rows:
+        raise ValueError("frontier input must contain rows")
+
+    if any("score_sram_latency_delta_us" in row for row in rows):
+        by_name: dict[str, JsonDict] = {}
+        for row in rows:
+            name = str(row.get("placement_scenario") or "")
+            if name in ("nominal", "conservative") and name not in by_name:
+                score_source_latency_us = _require_positive(
+                    row.get("score_sram_source_latency_us"),
+                    f"{name} integrated frontier score_sram_source_latency_us",
+                )
+                score_latency_delta_us = _float(row.get("score_sram_latency_delta_us"))
+                projected_latency_us = score_source_latency_us + score_latency_delta_us
+                by_name[name] = {
+                    "name": name,
+                    "placement_efficiency": _float(row.get("placement_efficiency")),
+                    "shared_sram_capacity_mib": _float(row.get("shared_sram_capacity_mib")),
+                    "hbm_byte_share": _float(row.get("hbm_byte_share")),
+                    "hbm_share_scale": projected_latency_us / score_source_latency_us,
+                    "source_score32_latency_us": score_source_latency_us,
+                    "projected_latency_us_hbm_share_scaled": projected_latency_us,
+                    "score_sram_energy_mj_per_token": _float(row.get("score_sram_energy_mj_per_token")),
+                    "score_sram_macro_area_mm2": _float(row.get("score_sram_macro_area_mm2")),
+                    "score_sram_envelope_area_mm2": _float(row.get("score_sram_envelope_area_mm2")),
+                }
+        missing = [name for name in ("nominal", "conservative") if name not in by_name]
+        if missing:
+            raise ValueError(f"integrated frontier is missing scenarios: {', '.join(missing)}")
+        return [by_name["nominal"], by_name["conservative"]]
+
+    diagnosis = _dict(payload.get("diagnosis"))
+    wanted = {0.75: "nominal", 0.55: "conservative"}
+    selected: list[JsonDict] = []
+    for efficiency, name in wanted.items():
+        row = next(
+            (candidate for candidate in rows if abs(_float(candidate.get("placement_efficiency")) - efficiency) < 1.0e-9),
+            None,
+        )
+        if row is None:
+            raise ValueError(f"score-SRAM recost is missing placement efficiency {efficiency}")
+        source_score32_latency_us = _require_positive(
+            row.get("source_score32_latency_us"),
+            f"{name} score-SRAM source_score32_latency_us",
+        )
+        projected_latency_us = _require_positive(
+            row.get("projected_latency_us_hbm_share_scaled"),
+            f"{name} score-SRAM projected_latency_us_hbm_share_scaled",
+        )
+        selected.append(
+            {
+                "name": name,
+                "placement_efficiency": efficiency,
+                "shared_sram_capacity_mib": _float(row.get("shared_sram_capacity_mib")),
+                "hbm_byte_share": _float(row.get("hbm_byte_share")),
+                "hbm_share_scale": _float(
+                    row.get("hbm_share_scale_vs_measured_sram"),
+                    projected_latency_us / source_score32_latency_us,
+                ),
+                "source_score32_latency_us": source_score32_latency_us,
+                "projected_latency_us_hbm_share_scaled": projected_latency_us,
+                "score_sram_energy_mj_per_token": _float(
+                    row.get("score_buffer_energy_mj_per_token"),
+                    diagnosis.get("score_buffer_energy_mj_per_token"),
+                ),
+                "score_sram_macro_area_mm2": _float(
+                    diagnosis.get("score_buffer_area_mm2"),
+                    _float(row.get("score_buffer_macro_area_um2")) / 1.0e6,
+                ),
+                "score_sram_envelope_area_mm2": _float(row.get("score_buffer_envelope_area_um2")) / 1.0e6,
+            }
+        )
+    return selected
+
+
+def _source_remaining_abstractions(source_candidate: JsonDict) -> list[str]:
+    filtered: list[str] = []
+    for item in source_candidate.get("remaining_abstractions", []):
+        text = str(item)
+        lower = text.lower()
+        if "precision-aligned" in lower or "precision aligned" in lower:
+            continue
+        filtered.append(text)
+    return filtered
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    separated_compute_recost_json = _arg_value(
+        args,
+        "separated_compute_recost_json",
+        "score32_separated_compute_recost_json",
+    )
+    score_sram_recost_json = _arg_value(
+        args,
+        "score_sram_recost_json",
+        "two_pass_frontier_or_score_sram_json",
+    )
+    source_payload = _load(separated_compute_recost_json)
+    frontier_payload = _load(score_sram_recost_json)
+    quality_payload = _load(args.zero_tail_quality_json)
+    iterdiv_payload = _load(args.iterdiv_ppa_json)
+
+    source_candidate = _dict(source_payload.get("candidate"))
+    if not source_candidate:
+        raise ValueError("source separated recost must provide candidate")
+    components = _component_map(source_candidate)
+    scenarios = _select_scenarios(frontier_payload)
+    quality = _quality_evidence(quality_payload)
+    iterdiv = _iterdiv_metrics(iterdiv_payload, args.iterdiv_ppa_json)
+
+    source_latency_us = _require_positive(source_candidate.get("latency_us"), "source candidate latency_us")
+    source_hbm_energy_mj = _require_positive(
+        source_candidate.get("hbm_energy_mj_per_token"),
+        "source candidate hbm_energy_mj_per_token",
+    )
+    source_noc_energy_mj = _require_positive(
+        source_candidate.get("noc_energy_mj_per_token"),
+        "source candidate noc_energy_mj_per_token",
+    )
+    source_sram_energy_mj = _require_positive(
+        source_candidate.get("sram_energy_mj_per_token"),
+        "source candidate sram_energy_mj_per_token",
+    )
+    source_schedule_clock_ns = _require_positive(
+        source_candidate.get("schedule_clock_ns", args.clock_ns),
+        "source candidate schedule_clock_ns",
+    )
+    source_logic_area_mm2 = _require_positive(source_candidate.get("logic_area_mm2"), "source candidate logic_area_mm2")
+    source_compute_control_energy_mj = _require_positive(
+        source_candidate.get("compute_control_energy_mj_per_token"),
+        "source candidate compute_control_energy_mj_per_token",
+    )
+
+    dense = components["dense_int8_gemm_fabric"]
+    old_shared = components["shared_score32_vector_softmax_overhead"]
+    dispatch = components["command_dispatch_control"]
+    controller = components["hbm_replay_controller"]
+    retained_components = [dense, dispatch, controller]
+    retained_logic_area_mm2 = round(
+        sum(_require_positive(component.get("area_um2"), f"{component.get('component')} area_um2") for component in retained_components)
+        / 1.0e6,
+        12,
+    )
+    retained_logic_power_mw = round(
+        sum(_require_positive(component.get("power_mw"), f"{component.get('component')} power_mw") for component in retained_components),
+        12,
+    )
+    removed_shared_energy_mj = round(
+        _require_positive(old_shared.get("power_mw"), "shared score32 power_mw") * source_latency_us * 1.0e-6,
+        12,
+    )
+    retained_logic_energy_mj = round(source_compute_control_energy_mj - removed_shared_energy_mj, 12)
+    if retained_logic_energy_mj <= 0.0:
+        raise ValueError("replacing the shared score32 overhead produced non-positive retained logic energy")
+
+    clock_ns = _float(args.clock_ns)
+    divide_cycles_per_head = int(args.divide_cycles_per_head)
+    head_count = int(args.head_count)
+    per_head_divider_latency_us = divide_cycles_per_head * clock_ns / 1000.0
+    divider_energy_total_mj = round(iterdiv["power_mw"] * per_head_divider_latency_us * head_count * 1.0e-6, 12)
+    deployments = (
+        ("per_head", head_count, 1),
+        ("shared", 1, head_count),
+    )
+
+    source_remaining_abstractions = _source_remaining_abstractions(source_candidate)
+    rows: list[JsonDict] = []
+    for scenario in scenarios:
+        score_sram_energy_mj = _require_positive(
+            scenario.get("score_sram_energy_mj_per_token"),
+            f"{scenario['name']} score SRAM energy",
+        )
+        score_sram_macro_area_mm2 = _require_positive(
+            scenario.get("score_sram_macro_area_mm2"),
+            f"{scenario['name']} score SRAM macro area",
+        )
+        score_sram_envelope_area_mm2 = _require_positive(
+            scenario.get("score_sram_envelope_area_mm2"),
+            f"{scenario['name']} score SRAM envelope area",
+        )
+        hbm_share_scale = _require_positive(scenario.get("hbm_share_scale"), f"{scenario['name']} hbm share scale")
+        projected_latency_us = round(source_latency_us * hbm_share_scale, 12)
+        scaled_hbm_energy_mj = round(source_hbm_energy_mj * hbm_share_scale, 12)
+
+        for deployment, instances, serial_head_groups in deployments:
+            divider_latency_us = round(per_head_divider_latency_us * serial_head_groups, 12)
+            divider_area_mm2 = round(iterdiv["area_um2"] * instances / 1.0e6, 12)
+            logic_plus_service_area_mm2 = round(retained_logic_area_mm2 + divider_area_mm2, 12)
+            active_power_mw = round(retained_logic_power_mw + iterdiv["power_mw"] * instances, 12)
+            compute_control_service_energy_mj = round(retained_logic_energy_mj + divider_energy_total_mj, 12)
+            total_energy_mj = round(
+                compute_control_service_energy_mj
+                + scaled_hbm_energy_mj
+                + source_noc_energy_mj
+                + source_sram_energy_mj
+                + score_sram_energy_mj,
+                12,
+            )
+            component_rows = []
+            for component in retained_components:
+                component_rows.append(
+                    {
+                        "component": component.get("component"),
+                        "area_um2": _float(component.get("area_um2")),
+                        "power_mw": _float(component.get("power_mw")),
+                        "critical_path_ns": _float(component.get("critical_path_ns")),
+                        "clock_ok": bool(component.get("clock_ok", True)),
+                        "source": component.get("source"),
+                        "energy_mj_per_token": round(_float(component.get("power_mw")) * source_latency_us * 1.0e-6, 12),
+                    }
+                )
+            component_rows.append(
+                {
+                    "component": f"two_pass_iterdiv_service_{deployment}",
+                    "area_um2": round(iterdiv["area_um2"] * instances, 6),
+                    "power_mw": round(iterdiv["power_mw"] * instances, 12),
+                    "critical_path_ns": iterdiv["critical_path_ns"],
+                    "clock_ok": iterdiv["critical_path_ns"] <= clock_ns,
+                    "source": iterdiv.get("metrics_csv"),
+                    "energy_mj_per_token": divider_energy_total_mj,
+                    "deployment": deployment,
+                    "instances": instances,
+                    "serial_head_groups": serial_head_groups,
+                }
+            )
+            row_remaining_abstractions = sorted(
+                set(
+                    source_remaining_abstractions
+                    + [
+                        "Schedule latency is inherited from the separated compute recost and scaled only by the score-SRAM HBM-share ratio.",
+                        "HBM/DRAM service latency and energy are inherited from the separated compute recost and scaled only by the score-SRAM HBM-share ratio.",
+                        "sram_macro_floorplan_pnr",
+                    ]
+                )
+            )
+            timing_ok = all(bool(component["clock_ok"]) for component in component_rows)
+            total_latency_us = round(projected_latency_us + divider_latency_us, 12)
+            rows.append(
+                {
+                    "candidate_id": f"score32_separated_zero_tail_two_pass_{scenario['name']}_{deployment}_iterdiv",
+                    "family": "score32_separated_zero_tail_two_pass_iterdiv",
+                    "placement_scenario": scenario["name"],
+                    "placement_efficiency": scenario["placement_efficiency"],
+                    "divider_deployment": deployment,
+                    "divider_instances": instances,
+                    "serial_head_groups": serial_head_groups,
+                    "head_count": head_count,
+                    "source_candidate_id": source_candidate.get("candidate_id"),
+                    "precision_profile": source_candidate.get("precision_profile"),
+                    "precision_aligned": quality["precision_aligned"],
+                    "quality_status": quality["status"],
+                    "quality_backed": quality["quality_backed"],
+                    "free_running_match_rate": quality.get("free_running_match_rate"),
+                    "teacher_forced_nll_delta_mean": quality.get("teacher_forced_nll_delta_mean"),
+                    "candidate_probability_assigned_to_reference_token_mean": quality.get(
+                        "candidate_probability_assigned_to_reference_token_mean"
+                    ),
+                    "latency_us": total_latency_us,
+                    "token_throughput_per_s": round(1_000_000.0 / total_latency_us, 12),
+                    "source_logic_area_mm2": source_logic_area_mm2,
+                    "baseline_source_latency_us": source_latency_us,
+                    "baseline_source_score32_latency_us": scenario["source_score32_latency_us"],
+                    "hbm_share_scaled_latency_us": projected_latency_us,
+                    "hbm_share_scale": round(hbm_share_scale, 12),
+                    "divider_latency_us": divider_latency_us,
+                    "divider_critical_path_ns": iterdiv["critical_path_ns"],
+                    "divider_schedule_clock_ns": clock_ns,
+                    "divider_meets_clock": iterdiv["critical_path_ns"] <= clock_ns,
+                    "source_schedule_clock_ns": source_schedule_clock_ns,
+                    "source_timing_ok": bool(source_candidate.get("timing_ok", True)),
+                    "timing_ok": timing_ok,
+                    "energy_mj_per_token": total_energy_mj,
+                    "compute_control_service_energy_mj_per_token": compute_control_service_energy_mj,
+                    "retained_logic_energy_mj_per_token": retained_logic_energy_mj,
+                    "removed_shared_score32_energy_mj_per_token": removed_shared_energy_mj,
+                    "divider_energy_mj_per_token": divider_energy_total_mj,
+                    "hbm_energy_mj_per_token": scaled_hbm_energy_mj,
+                    "noc_energy_mj_per_token": source_noc_energy_mj,
+                    "base_sram_energy_mj_per_token": source_sram_energy_mj,
+                    "score_sram_energy_mj_per_token": score_sram_energy_mj,
+                    "logic_plus_service_area_mm2": logic_plus_service_area_mm2,
+                    "retained_logic_area_mm2": retained_logic_area_mm2,
+                    "removed_shared_score32_area_mm2": round(_float(old_shared.get("area_um2")) / 1.0e6, 12),
+                    "divider_area_mm2": divider_area_mm2,
+                    "score_sram_macro_area_mm2": score_sram_macro_area_mm2,
+                    "score_sram_envelope_area_mm2": score_sram_envelope_area_mm2,
+                    "embodied_logic_plus_score_macro_area_mm2": round(
+                        logic_plus_service_area_mm2 + score_sram_macro_area_mm2,
+                        12,
+                    ),
+                    "die_area_mm2": _float(source_candidate.get("die_area_mm2")),
+                    "shared_sram_capacity_mib": scenario["shared_sram_capacity_mib"],
+                    "hbm_byte_share": scenario["hbm_byte_share"],
+                    "active_power_mw": active_power_mw,
+                    "active_power_accounting_note": (
+                        "Instantaneous active power reports retained logic plus deployed divider instances; "
+                        "token energy preserves identical divider work across deployments."
+                    ),
+                    "components": component_rows,
+                    "remaining_abstractions": row_remaining_abstractions,
+                    "inherited_schedule_abstraction": {
+                        "source_candidate_id": source_candidate.get("candidate_id"),
+                        "baseline_latency_us": source_latency_us,
+                        "source_score_sram_latency_us": scenario["source_score32_latency_us"],
+                        "hbm_share_scale": round(hbm_share_scale, 12),
+                        "scaled_latency_us_before_divider": projected_latency_us,
+                    },
+                    "inherited_hbm_service_abstraction": {
+                        "source_hbm_energy_mj_per_token": source_hbm_energy_mj,
+                        "scaled_hbm_energy_mj_per_token": scaled_hbm_energy_mj,
+                        "hbm_share_scale": round(hbm_share_scale, 12),
+                        "hbm_byte_share": scenario["hbm_byte_share"],
+                    },
+                }
+            )
+
+    latency_rank = sorted(rows, key=lambda row: (row["latency_us"], row["embodied_logic_plus_score_macro_area_mm2"]))
+    area_rank = sorted(rows, key=lambda row: (row["embodied_logic_plus_score_macro_area_mm2"], row["latency_us"]))
+    recommended = latency_rank[0]
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_separated_two_pass_frontier_v1",
+        "decision": "score32_separated_two_pass_frontier_ranked",
+        "inputs": {
+            "separated_compute_recost_json": str(separated_compute_recost_json),
+            "score_sram_recost_json": str(score_sram_recost_json),
+            "zero_tail_quality_json": str(args.zero_tail_quality_json),
+            "iterdiv_ppa_json": str(args.iterdiv_ppa_json),
+        },
+        "iterdiv_metrics": iterdiv,
+        "schedule": {
+            "source_schedule_clock_ns": source_schedule_clock_ns,
+            "divider_schedule_clock_ns": clock_ns,
+            "divide_cycles_per_head": divide_cycles_per_head,
+            "head_count": head_count,
+            "per_head_divider_latency_us": per_head_divider_latency_us,
+            "shared_divider_latency_us": per_head_divider_latency_us * head_count,
+            "note": "Separated candidate latency is inherited as the baseline; divider service is a measured 10ns two-pass abstraction.",
+        },
+        "rows": rows,
+        "latency_rank": latency_rank,
+        "area_rank": area_rank,
+        "diagnosis": {
+            "recommended_candidate": recommended["candidate_id"],
+            "recommended_latency_us": recommended["latency_us"],
+            "recommended_token_throughput_per_s": recommended["token_throughput_per_s"],
+            "recommended_total_energy_mj_per_token": recommended["energy_mj_per_token"],
+            "recommended_embodied_area_mm2": recommended["embodied_logic_plus_score_macro_area_mm2"],
+            "minimum_area_candidate": area_rank[0]["candidate_id"],
+            "shared_divider_latency_penalty_us": round(per_head_divider_latency_us * (head_count - 1), 12),
+            "per_head_divider_area_premium_mm2": round(iterdiv["area_um2"] * (head_count - 1) / 1.0e6, 12),
+            "quality_status": quality["status"],
+            "precision_status": quality["status"],
+            "precision_aligned": quality["precision_aligned"],
+            "inherited_schedule_abstraction": "score32_separated_compute_recost_scaled_by_hbm_share_ratio",
+            "inherited_hbm_service_abstraction": "score32_separated_compute_recost_scaled_by_hbm_share_ratio",
+            "remaining_abstractions": [
+                "score32_separated_compute_schedule_inheritance",
+                "hbm_dram_service",
+                "sram_macro_floorplan_pnr",
+            ],
+        },
+        "assumptions": [
+            "The separated score32 recost supplies the baseline dense producer, dispatch, controller, NoC, and tile-SRAM costs.",
+            "Score-SRAM integration transfers only the HBM-share scale ratio onto inherited latency and HBM energy; it does not reuse the slow wrapper's absolute latency.",
+            "The old shared_score32_vector_softmax_overhead component is replaced by measured iterative two-pass service rather than stacked on top of it.",
+            "Divider total active work energy is identical across per-head and shared deployments; only area, instantaneous power, and serialized latency change.",
+            "Score SRAM raw macro area is reported separately from its placement envelope so the envelope is not double-counted as embodied silicon.",
+            "Zero-tail quality pass is treated as the precision-aligned quality witness for the two-pass recost.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    diagnosis = payload["diagnosis"]
+    lines = [
+        "# Separated Two-Pass Frontier",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- recommended candidate: `{diagnosis['recommended_candidate']}`",
+        f"- recommended latency us: `{diagnosis['recommended_latency_us']}`",
+        f"- minimum-area candidate: `{diagnosis['minimum_area_candidate']}`",
+        f"- quality status: `{diagnosis['quality_status']}`",
+        "",
+        "| candidate | latency us | token/s | energy mJ/token | embodied logic + score macro mm2 |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for row in payload["latency_rank"]:
+        lines.append(
+            f"| {row['candidate_id']} | {row['latency_us']} | {row['token_throughput_per_s']} | "
+            f"{row['energy_mj_per_token']} | {row['embodied_logic_plus_score_macro_area_mm2']} |"
+        )
+    lines.extend(["", "## Assumptions", ""])
+    lines.extend(f"- {item}" for item in payload["assumptions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--separated-compute-recost-json",
+        "--score32-separated-compute-recost-json",
+        dest="separated_compute_recost_json",
+        type=Path,
+        required=True,
+    )
+    parser.add_argument(
+        "--score-sram-recost-json",
+        "--two-pass-frontier-or-score-sram-json",
+        dest="score_sram_recost_json",
+        type=Path,
+        required=True,
+    )
+    parser.add_argument("--zero-tail-quality-json", type=Path, required=True)
+    parser.add_argument("--iterdiv-ppa-json", type=Path, required=True)
+    parser.add_argument("--head-count", type=int, default=32)
+    parser.add_argument("--divide-cycles-per-head", type=int, default=480)
+    parser.add_argument("--clock-ns", type=float, default=10.0)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "decision": payload["decision"], "out": str(args.out)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_llm_decoder_attention_separated_two_pass_frontier.py
+++ b/tests/test_audit_llm_decoder_attention_separated_two_pass_frontier.py
@@ -1,0 +1,282 @@
+from argparse import Namespace
+import csv
+import json
+from pathlib import Path
+
+from npu.eval.audit_llm_decoder_attention_separated_two_pass_frontier import build_report
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_metrics_csv(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["status", "critical_path_ns", "instance_area_um2"])
+        writer.writeheader()
+        writer.writerow({"status": "ok", "critical_path_ns": "7.5", "instance_area_um2": "100000"})
+
+
+def _separated_source_json(path: Path) -> Path:
+    return _write_json(
+        path,
+        {
+            "candidate": {
+                "candidate_id": "score32_separated_dense_int8_shared_vector_softmax_c16_hbm_c4",
+                "precision_profile": "q8_k8_v8_score32",
+                "latency_us": 1000.0,
+                "compute_control_energy_mj_per_token": 0.0135,
+                "hbm_energy_mj_per_token": 2.0,
+                "noc_energy_mj_per_token": 0.2,
+                "sram_energy_mj_per_token": 0.1,
+                "logic_area_mm2": 5.0,
+                "die_area_mm2": 20.0,
+                "active_power_mw": 13.5,
+                "schedule_clock_ns": 5.0,
+                "timing_ok": True,
+                "remaining_abstractions": [
+                    "the inherited row was not precision-aligned with the score32 zero-tail target",
+                    "producer-to-consumer ready/valid composition remains abstract",
+                ],
+                "components": [
+                    {
+                        "component": "dense_int8_gemm_fabric",
+                        "area_um2": 4_000_000.0,
+                        "power_mw": 10.0,
+                        "critical_path_ns": 2.0,
+                        "clock_ok": True,
+                        "source": "dense/metrics.csv",
+                    },
+                    {
+                        "component": "shared_score32_vector_softmax_overhead",
+                        "area_um2": 200_000.0,
+                        "power_mw": 2.0,
+                        "critical_path_ns": 4.0,
+                        "clock_ok": True,
+                        "source": "softmax/metrics.csv",
+                    },
+                    {
+                        "component": "command_dispatch_control",
+                        "area_um2": 100_000.0,
+                        "power_mw": 1.0,
+                        "critical_path_ns": 1.0,
+                        "clock_ok": True,
+                        "source": "dispatch/metrics.csv",
+                    },
+                    {
+                        "component": "hbm_replay_controller_c4",
+                        "area_um2": 700_000.0,
+                        "power_mw": 0.5,
+                        "critical_path_ns": 3.0,
+                        "clock_ok": True,
+                        "source": "controller/metrics.csv",
+                    },
+                ],
+            }
+        },
+    )
+
+
+def _quality_json(path: Path) -> Path:
+    return _write_json(
+        path,
+        {
+            "decision": {"status": "mixed_int8_generation_quality_pass"},
+            "best_candidate": {
+                "candidate_id": "score32_zero_tail_two_pass",
+                "free_running_match_rate": 0.91,
+                "teacher_forced_nll_delta_mean": 0.005,
+            },
+        },
+    )
+
+
+def _iterdiv_json(path: Path, metrics_csv: str) -> Path:
+    return _write_json(
+        path,
+        {
+            "proposals": [
+                {
+                    "metrics_ref": {"status": "ok", "metrics_csv": metrics_csv},
+                    "metric_summary": {
+                        "critical_path_ns": 7.5,
+                        "die_area": 999999.0,
+                        "total_power_mw": 2.0,
+                    },
+                }
+            ]
+        },
+    )
+
+
+def _build_args(tmp_path: Path, frontier_input: Path) -> Namespace:
+    return Namespace(
+        separated_compute_recost_json=tmp_path / "source.json",
+        score_sram_recost_json=frontier_input,
+        zero_tail_quality_json=tmp_path / "quality.json",
+        iterdiv_ppa_json=tmp_path / "iterdiv.json",
+        head_count=32,
+        divide_cycles_per_head=480,
+        clock_ns=10.0,
+    )
+
+
+def test_separated_two_pass_frontier_recosts_from_score_sram_ratio(tmp_path: Path) -> None:
+    _separated_source_json(tmp_path / "source.json")
+    _quality_json(tmp_path / "quality.json")
+    _write_metrics_csv(tmp_path / "iterdiv" / "metrics.csv")
+    _iterdiv_json(tmp_path / "iterdiv.json", "iterdiv/metrics.csv")
+    frontier_input = _write_json(
+        tmp_path / "score_sram.json",
+        {
+            "diagnosis": {
+                "score_buffer_energy_mj_per_token": 0.25,
+                "score_buffer_area_mm2": 8.0,
+            },
+            "rows": [
+                {
+                    "placement_efficiency": 0.75,
+                    "source_score32_latency_us": 5000.0,
+                    "projected_latency_us_hbm_share_scaled": 5500.0,
+                    "score_buffer_envelope_area_um2": 10_000_000.0,
+                    "shared_sram_capacity_mib": 30.0,
+                    "hbm_byte_share": 0.90,
+                    "hbm_share_scale_vs_measured_sram": 1.1,
+                },
+                {
+                    "placement_efficiency": 0.55,
+                    "source_score32_latency_us": 5000.0,
+                    "projected_latency_us_hbm_share_scaled": 5750.0,
+                    "score_buffer_envelope_area_um2": 14_000_000.0,
+                    "shared_sram_capacity_mib": 16.0,
+                    "hbm_byte_share": 0.95,
+                    "hbm_share_scale_vs_measured_sram": 1.15,
+                },
+            ],
+        },
+    )
+
+    report = build_report(_build_args(tmp_path, frontier_input))
+
+    assert report["decision"] == "score32_separated_two_pass_frontier_ranked"
+    assert report["iterdiv_metrics"]["area_metric"] == "instance_area_um2"
+    assert report["schedule"]["per_head_divider_latency_us"] == 4.8
+    assert report["schedule"]["shared_divider_latency_us"] == 153.6
+
+    nominal_per_head = report["latency_rank"][0]
+    nominal_shared = next(
+        row
+        for row in report["rows"]
+        if row["placement_scenario"] == "nominal" and row["divider_deployment"] == "shared"
+    )
+    conservative_shared = next(
+        row
+        for row in report["rows"]
+        if row["placement_scenario"] == "conservative" and row["divider_deployment"] == "shared"
+    )
+
+    assert nominal_per_head["candidate_id"] == "score32_separated_zero_tail_two_pass_nominal_per_head_iterdiv"
+    assert nominal_per_head["latency_us"] == 1104.8
+    assert nominal_shared["latency_us"] == 1253.6
+    assert conservative_shared["latency_us"] == 1303.6
+    assert nominal_per_head["hbm_share_scaled_latency_us"] == 1100.0
+    assert nominal_per_head["hbm_energy_mj_per_token"] == 2.2
+    assert nominal_per_head["energy_mj_per_token"] == 2.7618072
+    assert conservative_shared["energy_mj_per_token"] == 2.8618072
+    assert nominal_per_head["compute_control_service_energy_mj_per_token"] == 0.0118072
+    assert nominal_per_head["removed_shared_score32_energy_mj_per_token"] == 0.002
+    assert nominal_per_head["divider_energy_mj_per_token"] == nominal_shared["divider_energy_mj_per_token"] == 0.0003072
+    assert nominal_per_head["logic_plus_service_area_mm2"] == 8.0
+    assert nominal_shared["logic_plus_service_area_mm2"] == 4.9
+    assert nominal_per_head["score_sram_macro_area_mm2"] == 8.0
+    assert nominal_per_head["score_sram_envelope_area_mm2"] == 10.0
+    assert nominal_per_head["embodied_logic_plus_score_macro_area_mm2"] == 16.0
+    assert nominal_shared["embodied_logic_plus_score_macro_area_mm2"] == 12.9
+    assert nominal_per_head["active_power_mw"] == 75.5
+    assert nominal_shared["active_power_mw"] == 13.5
+    assert nominal_per_head["precision_aligned"] is True
+    assert nominal_per_head["quality_backed"] is True
+    assert "precision-aligned" not in " ".join(nominal_per_head["remaining_abstractions"]).lower()
+    assert report["diagnosis"]["shared_divider_latency_penalty_us"] == 148.8
+    assert report["diagnosis"]["per_head_divider_area_premium_mm2"] == 3.1
+    assert report["diagnosis"]["recommended_total_energy_mj_per_token"] == 2.7618072
+    assert report["diagnosis"]["recommended_embodied_area_mm2"] == 16.0
+    assert report["diagnosis"]["precision_status"] == "mixed_int8_generation_quality_pass"
+    assert report["diagnosis"]["precision_aligned"] is True
+
+
+def test_separated_two_pass_frontier_accepts_integrated_frontier_rows(tmp_path: Path) -> None:
+    _separated_source_json(tmp_path / "source.json")
+    _quality_json(tmp_path / "quality.json")
+    _write_metrics_csv(tmp_path / "iterdiv" / "metrics.csv")
+    _iterdiv_json(tmp_path / "iterdiv.json", "iterdiv/metrics.csv")
+    frontier_input = _write_json(
+        tmp_path / "integrated_frontier.json",
+        {
+            "rows": [
+                {
+                    "candidate_id": "score32_zero_tail_two_pass_nominal_per_head_iterdiv",
+                    "placement_scenario": "nominal",
+                    "placement_efficiency": 0.75,
+                    "divider_deployment": "per_head",
+                    "score_sram_source_latency_us": 5000.0,
+                    "score_sram_latency_delta_us": 500.0,
+                    "score_sram_energy_mj_per_token": 0.25,
+                    "score_sram_macro_area_mm2": 8.0,
+                    "score_sram_envelope_area_mm2": 10.0,
+                    "shared_sram_capacity_mib": 30.0,
+                    "hbm_byte_share": 0.90,
+                },
+                {
+                    "candidate_id": "score32_zero_tail_two_pass_nominal_shared_iterdiv",
+                    "placement_scenario": "nominal",
+                    "placement_efficiency": 0.75,
+                    "divider_deployment": "shared",
+                    "score_sram_source_latency_us": 5000.0,
+                    "score_sram_latency_delta_us": 500.0,
+                    "score_sram_energy_mj_per_token": 0.25,
+                    "score_sram_macro_area_mm2": 8.0,
+                    "score_sram_envelope_area_mm2": 10.0,
+                    "shared_sram_capacity_mib": 30.0,
+                    "hbm_byte_share": 0.90,
+                },
+                {
+                    "candidate_id": "score32_zero_tail_two_pass_conservative_per_head_iterdiv",
+                    "placement_scenario": "conservative",
+                    "placement_efficiency": 0.55,
+                    "divider_deployment": "per_head",
+                    "score_sram_source_latency_us": 5000.0,
+                    "score_sram_latency_delta_us": 750.0,
+                    "score_sram_energy_mj_per_token": 0.25,
+                    "score_sram_macro_area_mm2": 8.0,
+                    "score_sram_envelope_area_mm2": 14.0,
+                    "shared_sram_capacity_mib": 16.0,
+                    "hbm_byte_share": 0.95,
+                },
+                {
+                    "candidate_id": "score32_zero_tail_two_pass_conservative_shared_iterdiv",
+                    "placement_scenario": "conservative",
+                    "placement_efficiency": 0.55,
+                    "divider_deployment": "shared",
+                    "score_sram_source_latency_us": 5000.0,
+                    "score_sram_latency_delta_us": 750.0,
+                    "score_sram_energy_mj_per_token": 0.25,
+                    "score_sram_macro_area_mm2": 8.0,
+                    "score_sram_envelope_area_mm2": 14.0,
+                    "shared_sram_capacity_mib": 16.0,
+                    "hbm_byte_share": 0.95,
+                },
+            ]
+        },
+    )
+
+    report = build_report(_build_args(tmp_path, frontier_input))
+
+    assert report["rows"][0]["family"] == "score32_separated_zero_tail_two_pass_iterdiv"
+    assert report["diagnosis"]["recommended_candidate"] == "score32_separated_zero_tail_two_pass_nominal_per_head_iterdiv"
+    assert report["rows"][0]["inherited_schedule_abstraction"]["hbm_share_scale"] == 1.1
+    assert report["rows"][0]["inherited_hbm_service_abstraction"]["scaled_hbm_energy_mj_per_token"] == 2.2
+    assert report["inputs"]["separated_compute_recost_json"] == str(tmp_path / "source.json")
+    assert report["inputs"]["score_sram_recost_json"] == str(frontier_input)


### PR DESCRIPTION
## Summary
- replace the slow replicated score32 wrapper in frontier accounting with the measured dense producer and exact global two-pass service
- transfer only measured score-SRAM HBM-share deltas; keep SRAM macro and placement-envelope area separate
- add generator, result-consumer, proposal contract, and focused numerical coverage

## Verification
- `282 passed` across the auditor, L2 task generator, and L2 result consumer suites
- real-artifact preview: nominal per-head 1595.42 us, 626.79 token/s, 137.33 mJ/token, 249.43 mm2 embodied logic plus score macro