### PR TITLE
Fix macro fixed-floorplan sweeps

### DIFF
--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -61,6 +61,27 @@ def parse_boolish(value: object, default: bool = False) -> bool:
     return bool(text)
 
 
+def fixed_floorplan_make_overrides(sweep_params: Dict[str, object]) -> List[str]:
+    """Disable the template utilization initializer for explicit floorplans."""
+    has_fixed_area = any(
+        str(sweep_params.get(key, "")).strip()
+        for key in ("DIE_AREA", "CORE_AREA")
+    )
+    if has_fixed_area and "CORE_UTILIZATION" not in sweep_params:
+        return ["CORE_UTILIZATION="]
+    return []
+
+
+def macro_synth_make_overrides(sweep_params: Dict[str, object]) -> List[str]:
+    overrides: List[str] = []
+    if parse_boolish(sweep_params.get("SYNTH_HIERARCHICAL")):
+        # Macro Liberty is deliberately absent in this pass, so Yosys cannot
+        # calculate the cost used by threshold-based hierarchy selection.
+        overrides.append("SYNTH_MINIMUM_KEEP_SIZE=")
+    overrides.append("ADDITIONAL_LIBS=")
+    return overrides
+
+
 def synth_keep_module_names(value: object) -> List[str]:
     if value is None:
         return []
@@ -1737,6 +1758,7 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
     ]
     for k, v in sweep_params.items():
         make_cmd.append(f"{k.upper()}={v}")
+    make_cmd.extend(fixed_floorplan_make_overrides(sweep_params))
 
     blackboxes = []
     synth_script_override: Optional[Path] = None
@@ -1758,7 +1780,7 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
     )
     if use_macro_synth_workaround:
         synth_cmd = list(make_cmd)
-        synth_cmd.append("ADDITIONAL_LIBS=")
+        synth_cmd.extend(macro_synth_make_overrides(sweep_params))
         synth_cmd.append("synth")
         print(f"[INFO] Running OpenROAD flow: {' '.join(synth_cmd)}")
         try:

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -44,6 +44,40 @@ class ModeCompareRegressionTest(unittest.TestCase):
         self.assertEqual("hier_macro", cfg["modes"][1]["name"])
         self.assertTrue(cfg["modes"][1]["use_macro"])
 
+    def test_fixed_floorplan_clears_template_core_utilization(self):
+        self.assertEqual(
+            ["CORE_UTILIZATION="],
+            self.run_block_sweep.fixed_floorplan_make_overrides(
+                {"DIE_AREA": "0 0 2500 2500", "CORE_AREA": "50 50 2450 2450"}
+            ),
+        )
+        self.assertEqual(
+            [],
+            self.run_block_sweep.fixed_floorplan_make_overrides(
+                {"CORE_AREA": "0 0 100 100", "CORE_UTILIZATION": 40}
+            ),
+        )
+        self.assertEqual(
+            [],
+            self.run_block_sweep.fixed_floorplan_make_overrides(
+                {"CORE_UTILIZATION": 40}
+            ),
+        )
+
+    def test_hierarchical_macro_synth_disables_cost_threshold_without_macro_liberty(self):
+        self.assertEqual(
+            ["SYNTH_MINIMUM_KEEP_SIZE=", "ADDITIONAL_LIBS="],
+            self.run_block_sweep.macro_synth_make_overrides(
+                {"SYNTH_HIERARCHICAL": 1}
+            ),
+        )
+        self.assertEqual(
+            ["ADDITIONAL_LIBS="],
+            self.run_block_sweep.macro_synth_make_overrides(
+                {"SYNTH_HIERARCHICAL": 0}
+            ),
+        )
+
     def test_parse_mode_compare_custom_modes(self):
         raw = {
             "mode_compare": {


### PR DESCRIPTION
## Summary
- clear the template core-utilization initializer when a sweep supplies explicit die/core geometry
- disable threshold-based hierarchy costing only during the Liberty-free macro preservation synthesis pass
- add regressions for both implicit make overrides

## Root cause
The score-bank proxy combined explicit `DIE_AREA`/`CORE_AREA` with the generated config's `CORE_UTILIZATION`, and hierarchical synthesis attempted cost-based hierarchy selection after the macro Liberty was deliberately removed. OpenROAD rejected the first combination and Yosys could not cost the opaque SRAM blackbox in the second.

## Validation
- `python3 -m pytest -q tests/test_run_block_sweep_mode_compare.py control_plane/control_plane/tests/test_run_block_sweep.py` (21 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- exact local diagnostic advanced through synthesis, floorplan, and placement of all 56 SRAM macros before being stopped so PPA remains on the remote evaluator

Broad baseline suites retain unrelated existing failures (9/421 root tests; 36/627 control-plane tests).