### PR TITLE
Recognize operational component frontier evidence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -611,6 +611,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "separated_two_pass_frontier_report",
     ),
     (
+        "operational_component_frontier_out",
+        "operational_component_frontier_report",
+    ),
+    (
         "operational_dense_tile_equivalence_out",
         "operational_dense_tile_equivalence_report",
     ),
@@ -1505,6 +1509,34 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "quality_status",
             "precision_status",
             "remaining_abstractions",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if (
+        model == "llm_decoder_attention_operational_component_frontier_v1"
+        or evidence_payload.get("decision")
+        == "operational_component_area_timing_recosted_energy_retained"
+    ):
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            evidence_payload.get("decision")
+            or "operational_component_frontier_recorded"
+        )
+        parts = [
+            f"Decoder operational-component frontier recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "recommended_candidate",
+            "recommended_latency_us",
+            "recommended_token_throughput_per_s",
+            "recommended_energy_mj_per_token",
+            "recommended_embodied_area_mm2",
+            "energy_promotion_blocked",
+            "next_step",
         ):
             if key in diagnosis_dict:
                 parts.append(f"{key}={diagnosis_dict.get(key)}")

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -6,6 +6,7 @@ import copy
 import json
 from pathlib import Path
 import tempfile
+from types import SimpleNamespace
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -17,7 +18,12 @@ from control_plane.models.enums import ExecutorType, FlowName, LayerName, RunSta
 from control_plane.models.runs import Run
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
-from control_plane.services.l2_result_consumer import Layer2ConsumeRequest, _decoder_evidence_summary, consume_l2_result
+from control_plane.services.l2_result_consumer import (
+    Layer2ConsumeRequest,
+    _decoder_evidence_paths,
+    _decoder_evidence_summary,
+    consume_l2_result,
+)
 
 
 def _write(path: Path, text: str) -> None:
@@ -87,6 +93,67 @@ def test_decoder_evidence_summary_recognizes_separated_two_pass_frontier() -> No
     assert outcome == "precision_aligned_separated_two_pass_frontier_ranked"
     assert "recommended_token_throughput_per_s=626.8" in summary
     assert "sram_macro_floorplan_pnr" in summary
+
+
+def test_decoder_evidence_summary_recognizes_operational_component_frontier() -> None:
+    payload = {
+        "model": "llm_decoder_attention_operational_component_frontier_v1",
+        "decision": "operational_component_area_timing_recosted_energy_retained",
+        "diagnosis": {
+            "recommended_candidate": "separated_two_pass_operational_components",
+            "recommended_latency_us": 1595.4,
+            "recommended_token_throughput_per_s": 626.8,
+            "recommended_energy_mj_per_token": 137.3,
+            "recommended_embodied_area_mm2": 325.5,
+            "energy_promotion_blocked": True,
+            "next_step": "measure activity-backed operational tile power",
+        },
+    }
+
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/operational_component_frontier.json",
+        evidence_payload=payload,
+    )
+
+    assert outcome == "operational_component_area_timing_recosted_energy_retained"
+    assert "recommended_token_throughput_per_s=626.8" in summary
+    assert "recommended_embodied_area_mm2=325.5" in summary
+    assert "energy_promotion_blocked=True" in summary
+
+    payload.pop("model")
+    legacy_outcome, legacy_summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/legacy_operational_component_frontier.json",
+        evidence_payload=payload,
+    )
+
+    assert legacy_outcome == outcome
+    assert "recommended_candidate=separated_two_pass_operational_components" in legacy_summary
+
+
+def test_decoder_evidence_paths_recognizes_operational_component_frontier(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/operational_component_frontier.json"
+    report_rel = "runs/datasets/demo/operational_component_frontier.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Operational component frontier\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "operational_component_frontier_out": evidence_rel,
+                "operational_component_frontier_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(
+        repo_root=tmp_path,
+        work_item=work_item,
+    )
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_operational_component_frontier_out": evidence_rel,
+        "decoder_operational_component_frontier_report": report_rel,
+    }
 
 
 def test_decoder_evidence_summary_recognizes_rtl_component_equivalence() -> None:

--- a/npu/eval/audit_llm_decoder_attention_operational_component_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_operational_component_frontier.py
@@ -238,6 +238,7 @@ def build_report(
     )
     return {
         "version": 1,
+        "model": "llm_decoder_attention_operational_component_frontier_v1",
         "decision": "operational_component_area_timing_recosted_energy_retained",
         "inputs": {
             "frontier_json": str(frontier_json),

--- a/tests/test_audit_llm_decoder_attention_operational_component_frontier.py
+++ b/tests/test_audit_llm_decoder_attention_operational_component_frontier.py
@@ -95,6 +95,7 @@ def test_build_report_recosts_dense_area_and_timing_but_retains_energy_and_power
     row = report["rows"][0]
     dense = row["components"][0]
 
+    assert report["model"] == "llm_decoder_attention_operational_component_frontier_v1"
     assert report["selected_operational_tile"]["critical_path_ns"] == "4.0"
     assert report["selected_old_tile"]["instance_area_um2"] == "1000.0"
     assert dense["component"] == "operational_dense_int8_gemm_fabric"


### PR DESCRIPTION
## Summary
- register the operational-component frontier JSON/report pair as decoder evidence
- emit a stable model identifier from the recost auditor
- retain compatibility with the already-completed model-less artifact by recognizing its decision
- add output-resolution and summary regressions

## Root cause
The L2 result consumer did not know the new decoder-contract output keys, so completion fell through to the generic campaign path and required a nonexistent `best_point.json`.

## Validation
- `PYTHONPATH="$PWD/control_plane:$PWD" ... pytest -q tests/test_audit_llm_decoder_attention_operational_component_frontier.py control_plane/control_plane/tests/test_l2_result_consumer.py` (90 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`