### PR TITLE
Transport operational component frontier evidence

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -27,6 +27,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_kv_",
     "decoder_attention_mixed_int8_",
     "decoder_attention_noc_profile__",
+    "decoder_attention_operational_component_frontier__",
     "decoder_attention_sram_profile__",
 }
 

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -115,3 +115,14 @@ def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> 
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
         "decoder_attention_noc_profile__l2_decoder_attention_noc_profile_v1.md"
     )
+
+
+def test_transportable_expected_output_allows_operational_component_frontier() -> None:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    stem = (
+        "decoder_attention_operational_component_frontier__"
+        "l2_decoder_attention_operational_component_frontier_llama7b_v1"
+    )
+
+    assert is_transportable_expected_output(f"{base}{stem}.json")
+    assert is_transportable_expected_output(f"{base}{stem}.md")

--- a/control_plane/control_plane/tests/test_artifact_stage.py
+++ b/control_plane/control_plane/tests/test_artifact_stage.py
@@ -104,6 +104,32 @@ def test_collect_expected_output_artifacts_includes_attention_kv_dataset(tmp_pat
     assert all("inline_utf8" in artifact.metadata for artifact in artifacts)
 
 
+def test_collect_expected_output_artifacts_includes_operational_component_frontier(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    stem = (
+        "decoder_attention_operational_component_frontier__"
+        "l2_decoder_attention_operational_component_frontier_llama7b_v1"
+    )
+    json_rel = f"{base}{stem}.json"
+    report_rel = f"{base}{stem}.md"
+    _write_json(repo_root / json_rel, {"decision": "operational_component_area_timing_recosted_energy_retained"})
+    (repo_root / report_rel).write_text("# Operational component frontier\n", encoding="utf-8")
+
+    artifacts = collect_expected_output_artifacts(
+        repo_root=str(repo_root),
+        expected_outputs=[json_rel, report_rel],
+    )
+
+    assert [artifact.path for artifact in artifacts] == [json_rel, report_rel]
+    assert all(artifact.kind == "expected_output" for artifact in artifacts)
+    assert all(artifact.metadata["transport_policy"] == "inline_text_evidence" for artifact in artifacts)
+    assert all("inline_utf8" in artifact.metadata for artifact in artifacts)
+
+
 def test_collect_expected_output_artifacts_includes_large_attention_schedule_dataset(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()


### PR DESCRIPTION
## Summary
- allow the operational-component frontier JSON and Markdown through the remote artifact transport policy
- verify the exact output family is accepted and staged as inline expected-output evidence

## Root cause
The remote job completed successfully, but the dataset filename prefix was absent from the strict artifact allowlist. The worker therefore recorded only command logs, leaving completion without the generated evidence files.

## Validation
- `PYTHONPATH="$PWD/control_plane:$PWD" ... pytest -q control_plane/control_plane/tests/test_artifact_policy.py control_plane/control_plane/tests/test_artifact_stage.py` (8 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`