### PR TITLE
Keep operational frontier evidence portable

### DIFF
--- a/npu/eval/audit_llm_decoder_attention_operational_component_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_operational_component_frontier.py
@@ -14,6 +14,29 @@ from typing import Any
 JsonDict = dict[str, Any]
 
 
+_MEASUREMENT_PROVENANCE_FIELDS = (
+    "metrics_csv",
+    "design",
+    "platform",
+    "tag",
+    "status",
+    "param_hash",
+    "config_hash",
+    "params_json",
+    "critical_path_ns",
+    "instance_area_um2",
+    "stdcell_area_um2",
+    "stdcell_count",
+    "core_area_um2",
+    "die_area",
+    "utilization_pct",
+    "total_power_mw",
+    "flow_elapsed_seconds",
+    "stage_elapsed_seconds",
+    "synth_script_sha1",
+)
+
+
 def _load(path: Path) -> JsonDict:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -57,6 +80,12 @@ def _select_row(rows: list[JsonDict], *, clock_ns: float) -> JsonDict:
             _float(row.get("total_power_mw"), 1.0e99),
         ),
     )
+
+
+def _measurement_provenance(row: JsonDict | None) -> JsonDict | None:
+    if row is None:
+        return None
+    return {key: row[key] for key in _MEASUREMENT_PROVENANCE_FIELDS if key in row}
 
 
 def _dense_component(row: JsonDict) -> JsonDict:
@@ -252,9 +281,9 @@ def build_report(
             "energy": "retain activity-backed frontier energy; never substitute vectorless OpenROAD power",
             "precision": "inherit the already-passed mixed-int8 Llama7B quality gate unchanged",
         },
-        "selected_operational_tile": operational_tile,
-        "selected_old_tile": old_tile,
-        "selected_score_bank": score_bank,
+        "selected_operational_tile": _measurement_provenance(operational_tile),
+        "selected_old_tile": _measurement_provenance(old_tile),
+        "selected_score_bank": _measurement_provenance(score_bank),
         "rows": updated_rows,
         "latency_rank": latency_rank,
         "area_rank": area_rank,

--- a/tests/test_audit_llm_decoder_attention_operational_component_frontier.py
+++ b/tests/test_audit_llm_decoder_attention_operational_component_frontier.py
@@ -65,12 +65,16 @@ def test_build_report_recosts_dense_area_and_timing_but_retains_energy_and_power
                 "instance_area_um2": 880.0,
                 "critical_path_ns": 6.0,
                 "total_power_mw": 0.06,
+                "result_path": "",
+                "synth_script_path": "",
             },
             {
                 "status": "ok",
                 "instance_area_um2": 900.0,
                 "critical_path_ns": 4.0,
                 "total_power_mw": 0.07,
+                "result_path": "/orfs/flow/reports/demo/6_finish.rpt",
+                "synth_script_path": "/tmp/rtlcp-worktree-demo/synth.tcl",
             },
         ],
     )
@@ -97,6 +101,8 @@ def test_build_report_recosts_dense_area_and_timing_but_retains_energy_and_power
 
     assert report["model"] == "llm_decoder_attention_operational_component_frontier_v1"
     assert report["selected_operational_tile"]["critical_path_ns"] == "4.0"
+    assert "result_path" not in report["selected_operational_tile"]
+    assert "synth_script_path" not in report["selected_operational_tile"]
     assert report["selected_old_tile"]["instance_area_um2"] == "1000.0"
     assert dense["component"] == "operational_dense_int8_gemm_fabric"
     assert dense["area_replica_count"] == 1710


### PR DESCRIPTION
## Summary
- project selected PPA rows onto a bounded measurement-provenance schema
- retain source CSV, design/tag/hash/parameter identity, and PPA quantities
- exclude evaluator-local report and temporary synthesis-script paths from committed recost evidence

## Root cause
The recost auditor copied complete metrics CSV rows into its JSON. Those rows contain `/orfs` and temporary evaluator worktree paths, violating the review package's repo-portability contract.

## Validation
- focused operational-frontier auditor/consumer tests (4 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`