### PR TITLE
Ignore stale PR closures during active review

### DIFF
--- a/control_plane/control_plane/services/github_bridge.py
+++ b/control_plane/control_plane/services/github_bridge.py
@@ -99,13 +99,33 @@ def _select_existing_link(session: Session, work_item_id: str, request: GitHubRe
     return None
 
 
-def _advance_work_item_state(work_item: WorkItem, state: GitHubLinkState) -> None:
+def _other_active_review_prs(session: Session, link: GitHubLink) -> list[int]:
+    query = session.query(GitHubLink).filter(
+        GitHubLink.work_item_id == link.work_item_id,
+        GitHubLink.repo == link.repo,
+        GitHubLink.state.in_((GitHubLinkState.PR_OPEN, GitHubLinkState.PR_MERGED)),
+    )
+    if link.id is not None:
+        query = query.filter(GitHubLink.id != link.id)
+    return sorted(int(row.pr_number) for row in query.all() if row.pr_number is not None)
+
+
+def _advance_work_item_state(
+    work_item: WorkItem,
+    state: GitHubLinkState,
+    *,
+    close_is_terminal: bool = True,
+) -> None:
     if state == GitHubLinkState.PR_OPEN and work_item.state not in {WorkItemState.MERGED, WorkItemState.SUPERSEDED}:
         if work_item.state not in {WorkItemState.AWAITING_REVIEW, WorkItemState.MERGED}:
             work_item.state = WorkItemState.AWAITING_REVIEW
     elif state == GitHubLinkState.PR_MERGED:
         work_item.state = WorkItemState.MERGED
-    elif state == GitHubLinkState.PR_CLOSED and work_item.state not in {WorkItemState.MERGED, WorkItemState.SUPERSEDED}:
+    elif (
+        state == GitHubLinkState.PR_CLOSED
+        and close_is_terminal
+        and work_item.state not in {WorkItemState.MERGED, WorkItemState.SUPERSEDED}
+    ):
         work_item.state = WorkItemState.SUPERSEDED
 
 
@@ -164,7 +184,10 @@ def reconcile_github_link(session: Session, request: GitHubReconcileRequest) -> 
     if run is not None and request.branch_name and run.branch_name != request.branch_name:
         run.branch_name = request.branch_name
 
-    _advance_work_item_state(work_item, state)
+    session.flush()
+    other_active_prs = _other_active_review_prs(session, link) if state == GitHubLinkState.PR_CLOSED else []
+    close_is_terminal = not other_active_prs
+    _advance_work_item_state(work_item, state, close_is_terminal=close_is_terminal)
 
     event_payload = {
         "repo": request.repo,
@@ -183,17 +206,32 @@ def reconcile_github_link(session: Session, request: GitHubReconcileRequest) -> 
                 event_payload["released_dependent_items"] = released
         _emit_run_event(session, run, "pr_merged", event_payload)
     elif state == GitHubLinkState.PR_CLOSED:
+        if other_active_prs:
+            event_payload["other_active_pr_numbers"] = other_active_prs
         _emit_run_event(session, run, "pr_closed", event_payload)
-        _emit_run_event(
-            session,
-            run,
-            "work_item_superseded",
-            {
-                "reason": "review_pr_closed",
-                "actor": "github_reconcile",
-                "pr_number": request.pr_number,
-            },
-        )
+        if close_is_terminal:
+            _emit_run_event(
+                session,
+                run,
+                "work_item_superseded",
+                {
+                    "reason": "review_pr_closed",
+                    "actor": "github_reconcile",
+                    "pr_number": request.pr_number,
+                },
+            )
+        else:
+            _emit_run_event(
+                session,
+                run,
+                "nonterminal_pr_closed",
+                {
+                    "reason": "newer_review_pr_active",
+                    "actor": "github_reconcile",
+                    "pr_number": request.pr_number,
+                    "other_active_pr_numbers": other_active_prs,
+                },
+            )
     else:
         _emit_run_event(session, run, "pr_linked", event_payload)
 

--- a/control_plane/control_plane/tests/test_reconciliation.py
+++ b/control_plane/control_plane/tests/test_reconciliation.py
@@ -375,3 +375,56 @@ def test_reconcile_github_link_closed_supersedes_item() -> None:
         event_types = [row.event_type for row in session.query(RunEvent).filter_by(run_id=run.id).all()]
         assert "pr_closed" in event_types
         assert "work_item_superseded" in event_types
+
+
+def test_reconcile_stale_closed_pr_preserves_newer_open_review() -> None:
+    with make_session() as session:
+        run = seed_reviewable_run(session)
+        reconcile_github_link(
+            session,
+            GitHubReconcileRequest(
+                repo="yhmtmt/RTLGen",
+                item_id="item_review",
+                branch_name="eval/item_review/s20260308t000000z",
+                pr_number=42,
+                state="pr_open",
+                run_key=run.run_key,
+            ),
+        )
+        reconcile_github_link(
+            session,
+            GitHubReconcileRequest(
+                repo="yhmtmt/RTLGen",
+                item_id="item_review",
+                branch_name="eval/item_review/s20260308t010000z",
+                pr_number=43,
+                state="pr_open",
+                run_key=run.run_key,
+            ),
+        )
+
+        result = reconcile_github_link(
+            session,
+            GitHubReconcileRequest(
+                repo="yhmtmt/RTLGen",
+                item_id="item_review",
+                branch_name="eval/item_review/s20260308t000000z",
+                pr_number=42,
+                state="pr_closed",
+                run_key=run.run_key,
+            ),
+        )
+
+        work_item = session.query(WorkItem).filter_by(item_id="item_review").one()
+        old_link = session.query(GitHubLink).filter_by(pr_number=42).one()
+        new_link = session.query(GitHubLink).filter_by(pr_number=43).one()
+        events = session.query(RunEvent).filter_by(run_id=run.id).all()
+
+        assert result.work_item_state == WorkItemState.AWAITING_REVIEW.value
+        assert work_item.state == WorkItemState.AWAITING_REVIEW
+        assert old_link.state.value == "pr_closed"
+        assert new_link.state.value == "pr_open"
+        assert "nonterminal_pr_closed" in [event.event_type for event in events]
+        assert "work_item_superseded" not in [event.event_type for event in events]
+        nonterminal = next(event for event in events if event.event_type == "nonterminal_pr_closed")
+        assert nonterminal.event_payload["other_active_pr_numbers"] == [43]


### PR DESCRIPTION
## Summary
- make a closed review PR terminal only when no other PR for the item/repository remains open or merged
- retain the closed link for history while preserving the work item state
- record `nonterminal_pr_closed` with the active replacement PR numbers
- add a two-PR regression matching the #1291/#1293 race

## Root cause
The GitHub poller reconciles every historical open link. Closing an older retry PR after a replacement PR was linked caused the old link's `PR_CLOSED` event to supersede the whole work item, even though the replacement review was active.

## Validation
- focused terminal and stale-close regressions (2 passed)
- reconciliation/poller suite excluding one pre-existing fixture failure (12 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

## Existing test issue
`test_reconcile_merge_releases_blocked_dependent_when_materialized` invokes proposal finalization against a temporary directory that is not a Git repository and fails at `git fetch origin`; this patch does not touch that path.