### PR TITLE
Preserve immutable L1 retry accounting

### DIFF
--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -92,7 +92,14 @@ def _failed_acceptance_run_has_metrics(run: Run) -> bool:
         return False
     queue_result = dict(payload.get("queue_result") or {})
     metrics_rows = queue_result.get("metrics_rows")
-    return isinstance(metrics_rows, list) and bool(metrics_rows)
+    if not isinstance(metrics_rows, list) or not metrics_rows:
+        return False
+    metrics_csvs = {
+        str(ref).split(":", 1)[0].strip()
+        for ref in metrics_rows
+        if str(ref).split(":", 1)[0].strip().endswith("metrics.csv")
+    }
+    return any(_inline_metrics_text(run, metrics_csv) is not None for metrics_csv in metrics_csvs)
 
 
 def _run_can_contribute_l1_metrics(run: Run) -> bool:
@@ -157,10 +164,9 @@ def _objective_name(work_item: WorkItem) -> str:
     return str(work_item.task_request.description or "").strip()
 
 
-def _load_metrics_rows(path: Path) -> list[dict[str, str]]:
+def _load_metrics_rows_text(text: str) -> list[dict[str, str]]:
     # Match the tolerant parsing used by scripts/build_runs_index.py because
     # historical metrics.csv rows may carry unquoted JSON in params_json.
-    text = path.read_text(encoding="utf-8", errors="ignore")
     text = re.sub(r"result\.json(?=[A-Za-z0-9_])", "result.json\n", text)
     lines = text.splitlines()
     if not lines:
@@ -195,6 +201,10 @@ def _load_metrics_rows(path: Path) -> list[dict[str, str]]:
             continue
         rows.append(dict(zip(header, values)))
     return rows
+
+
+def _load_metrics_rows(path: Path) -> list[dict[str, str]]:
+    return _load_metrics_rows_text(path.read_text(encoding="utf-8", errors="ignore"))
 
 
 def _current_sweep_tag_prefixes(repo_root: Path, work_item: WorkItem) -> tuple[str, ...]:
@@ -498,10 +508,32 @@ def _proposal_entry(*, metrics_csv: str, best_row: dict[str, Any], evaluation_re
 def _completed_trial_runs(work_item: WorkItem) -> list[Run]:
     completed: list[Run] = []
     for run in sorted(work_item.runs, key=lambda row: (row.attempt, row.created_at or utcnow())):
-        if run.status not in {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.CANCELED, RunStatus.TIMED_OUT}:
+        if run.status not in {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.TIMED_OUT}:
             continue
         completed.append(run)
     return completed
+
+
+def _inline_metrics_text(run: Run, metrics_csv: str) -> str | None:
+    for artifact in run.artifacts:
+        if artifact.kind != "expected_output" or str(artifact.path).strip() != metrics_csv:
+            continue
+        inline_text = dict(artifact.metadata_ or {}).get("inline_utf8")
+        if isinstance(inline_text, str):
+            return inline_text
+    return None
+
+
+def _metrics_rows_for_run(repo_root: Path, run: Run, metrics_csv: str) -> list[dict[str, str]]:
+    inline_text = _inline_metrics_text(run, metrics_csv)
+    if inline_text is not None:
+        return _load_metrics_rows_text(inline_text)
+    if run.status != RunStatus.SUCCEEDED:
+        return []
+    metrics_path = _resolve_path(repo_root=repo_root, path_text=metrics_csv)
+    if not metrics_path.exists():
+        return []
+    return _load_metrics_rows(metrics_path)
 
 
 def _metrics_csvs_from_run(run: Run, *, work_item: WorkItem | None = None) -> list[str]:
@@ -554,15 +586,15 @@ def _best_trial_row(repo_root: Path, run: Run) -> tuple[str, dict[str, Any]] | N
     candidates: list[tuple[str, dict[str, Any]]] = []
     tag_prefixes = _current_sweep_tag_prefixes(repo_root, run.work_item)
     for metrics_csv in _metrics_csvs_from_run(run, work_item=run.work_item):
-        best_row = _best_metrics_row(
-            repo_root=repo_root,
-            metrics_csv=metrics_csv,
-            tag_prefixes=tag_prefixes,
-            require_timing_feasible=False,
-        )
-        if best_row is None:
+        rows = [
+            dict(row)
+            for row in _metrics_rows_for_run(repo_root, run, metrics_csv)
+            if str(row.get("status", "")).strip() == "ok"
+            and _row_in_current_sweep_scope(row, tag_prefixes=tag_prefixes)
+        ]
+        if not rows:
             continue
-        candidates.append((metrics_csv, best_row))
+        candidates.append((metrics_csv, sorted(rows, key=_row_sort_key)[0]))
     if not candidates:
         return None
     candidates.sort(key=lambda item: _row_sort_key(item[1]))
@@ -573,10 +605,7 @@ def _ok_trial_rows(repo_root: Path, run: Run) -> list[tuple[str, dict[str, Any]]
     candidates: list[tuple[str, dict[str, Any]]] = []
     tag_prefixes = _current_sweep_tag_prefixes(repo_root, run.work_item)
     for metrics_csv in _metrics_csvs_from_run(run, work_item=run.work_item):
-        metrics_path = _resolve_path(repo_root=repo_root, path_text=metrics_csv)
-        if not metrics_path.exists():
-            continue
-        for row in _load_metrics_rows(metrics_path):
+        for row in _metrics_rows_for_run(repo_root, run, metrics_csv):
             if str(row.get("status", "")).strip() != "ok":
                 continue
             if not _row_in_current_sweep_scope(row, tag_prefixes=tag_prefixes):

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -467,6 +467,22 @@ def test_consume_l1_result_accepts_failed_acceptance_run_with_mixed_metrics() ->
                 },
             )
             session.add(run)
+            session.flush()
+            session.add_all(
+                [
+                    Artifact(
+                        run_id=run.id,
+                        kind="expected_output",
+                        storage_mode="repo",
+                        path=metrics_path,
+                        metadata_={
+                            "transport_policy": "inline_text_evidence",
+                            "inline_utf8": (repo_root / metrics_path).read_text(encoding="utf-8"),
+                        },
+                    )
+                    for metrics_path in (metrics_ok, metrics_failed)
+                ]
+            )
             session.commit()
 
             result = consume_l1_result(
@@ -556,10 +572,24 @@ def test_consume_l1_result_keeps_single_trial_metrics_without_trials_subdir() ->
             session.add(work_item)
             session.flush()
 
-            run = Run(
+            canceled_run = Run(
                 run_key="l1_test_single_trial_plain_metrics_run_1",
                 work_item_id=work_item.id,
                 attempt=1,
+                trial_index=1,
+                seed=0,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.CANCELED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                result_summary="operator canceled before execution",
+                result_payload={"trial": {"trial_index": 1, "seed": 0}},
+            )
+            run = Run(
+                run_key="l1_test_single_trial_plain_metrics_run_2",
+                work_item_id=work_item.id,
+                attempt=2,
                 trial_index=1,
                 seed=0,
                 executor_type=ExecutorType.INTERNAL_WORKER,
@@ -573,7 +603,7 @@ def test_consume_l1_result_keeps_single_trial_metrics_without_trials_subdir() ->
                     "queue_result": {"status": "ok", "metrics_rows": [f"{metrics_rel}:2"]},
                 },
             )
-            session.add(run)
+            session.add_all([canceled_run, run])
             session.flush()
 
             result = consume_l1_result(
@@ -588,6 +618,14 @@ def test_consume_l1_result_keeps_single_trial_metrics_without_trials_subdir() ->
             proposal_path = repo_root / "control_plane" / "shadow_exports" / "l1_promotions" / f"{work_item.item_id}.json"
             payload = json.loads(proposal_path.read_text(encoding="utf-8"))
             assert payload["proposals"][0]["metrics_ref"]["metrics_csv"] == metrics_rel
+            assert payload["trial_summary"]["completed_trials"] == 1
+            assert payload["trial_summary"]["success_count"] == 1
+            assert payload["trial_summary"]["failure_count"] == 0
+
+            trial_table_path = (
+                repo_root / "control_plane" / "shadow_exports" / "l1_trials" / work_item.item_id / "trial_table.csv"
+            )
+            assert "l1_test_single_trial_plain_metrics_run_1" not in trial_table_path.read_text(encoding="utf-8")
 
 
 def test_consume_l1_result_filters_historical_rows_by_current_sweep_tag_prefix() -> None:
@@ -1099,15 +1137,21 @@ def test_consume_l1_result_counts_requeued_failures_in_trial_history() -> None:
                 checkout_commit="deadbeef",
                 trial_index=1,
                 seed=101,
-                result_summary="checkout failed",
+                result_summary="acceptance failed before retry",
                 result_payload={
                     "trial": {"trial_index": 1, "seed": 101},
                     "retry_decision": {"requeue": True},
-                    "failure_classification": {"category": "checkout_error", "stage": "checkout", "signature": "git fetch origin"},
+                    "queue_result": {"status": "fail", "metrics_rows": [f"{metrics_trial_1}:2"]},
+                    "failure_classification": {
+                        "category": "validation_error",
+                        "stage": "acceptance",
+                        "failed_command_name": "acceptance",
+                        "signature": "no accepted rows",
+                    },
                 },
-                failure_category="checkout_error",
-                failure_stage="checkout",
-                failure_signature="git fetch origin",
+                failure_category="validation_error",
+                failure_stage="acceptance",
+                failure_signature="no accepted rows",
             )
             run_2 = Run(
                 run_key="l1_test_requeued_failure_history_run_2",
@@ -1156,13 +1200,13 @@ def test_consume_l1_result_counts_requeued_failures_in_trial_history() -> None:
 
             failure_path = repo_root / "control_plane" / "shadow_exports" / "l1_trials" / work_item.item_id / "failure_stats.json"
             failure_stats = json.loads(failure_path.read_text(encoding="utf-8"))
-            assert failure_stats["by_category"] == {"checkout_error": 1}
-            assert failure_stats["by_stage"] == {"checkout": 1}
+            assert failure_stats["by_category"] == {"validation_error": 1}
+            assert failure_stats["by_stage"] == {"acceptance": 1}
 
             trial_table_path = repo_root / "control_plane" / "shadow_exports" / "l1_trials" / work_item.item_id / "trial_table.csv"
             trial_table = trial_table_path.read_text(encoding="utf-8")
             assert "l1_test_requeued_failure_history_run_1,1,1,101,failed" in trial_table
-            assert "checkout_error,checkout,git fetch origin" in trial_table
+            assert "validation_error,acceptance,no accepted rows" in trial_table
             assert metrics_trial_1 in trial_table
             assert metrics_trial_2 in trial_table
 


### PR DESCRIPTION
## Summary
- exclude operator-canceled attempts from completed trial statistics
- require failed-acceptance runs to have their own inline expected-output metrics snapshot before contributing measurements
- prefer per-run inline metrics snapshots during trial and seed-variance aggregation
- retain repository-path fallback only for successful legacy runs
- add regressions for canceled retries and shared `metrics.csv` overwrite

## Root cause
Historical attempts stored references to shared metrics paths. Aggregation reopened those paths after retries had overwritten them, so a failed score-bank attempt was falsely counted as successful. Canceled dense-tile attempts were also counted as failed trials.

## Validation
- L1 result consumer suite: 14 passed
- repository run validation passed
- live DB replay with this code gives dense tile `1/1` and score-bank proxy `1/2`, matching the actual attempt histories
- `git diff --check`