### PR TITLE
Correct operational component retry summaries

### DIFF
--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -650,7 +650,7 @@ def _write_trial_table(path: Path, rows: list[dict[str, Any]]) -> None:
         "failure_category", "failure_stage", "failure_signature",
     ]
     with path.open("w", encoding="utf-8", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, lineterminator="\n")
         writer.writeheader()
         for row in rows:
             writer.writerow({key: row.get(key, "") for key in fieldnames})

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -1062,6 +1062,7 @@ def test_consume_l1_result_writes_trial_aggregate_artifacts() -> None:
             assert summary["success_rate"] == 2 / 3
             assert failure_stats["by_category"] == {"timing_unmet": 1}
             assert failure_stats["by_stage"] == {"route": 1}
+            assert "\r" not in trial_table
             assert "trial_index,seed,status" in trial_table
             assert "l1_test_trial_aggregate_run_3" in trial_table
 

--- a/control_plane/shadow_exports/l1_promotions/l1_decoder_attention_operational_dense_tile_ppa_v1.json
+++ b/control_plane/shadow_exports/l1_promotions/l1_decoder_attention_operational_dense_tile_ppa_v1.json
@@ -1,6 +1,6 @@
 {
   "version": 0.1,
-  "generated_utc": "2026-07-14T04:57:54.568492Z",
+  "generated_utc": "2026-07-15T02:03:49.230766Z",
   "item_id": "l1_decoder_attention_operational_dense_tile_ppa_v1",
   "run_key": "l1_decoder_attention_operational_dense_tile_ppa_v1_run_cb0b9acc6498034e",
   "layer": "layer1",
@@ -56,10 +56,10 @@
   ],
   "trial_summary": {
     "item_id": "l1_decoder_attention_operational_dense_tile_ppa_v1",
-    "completed_trials": 2,
+    "completed_trials": 1,
     "success_count": 1,
-    "failure_count": 1,
-    "success_rate": 0.5,
+    "failure_count": 0,
+    "success_rate": 1.0,
     "metrics": {
       "critical_path_ns": {
         "best": 4.3024,

--- a/control_plane/shadow_exports/l1_promotions/l1_decoder_attention_score_bank_proxy_pnr_v1.json
+++ b/control_plane/shadow_exports/l1_promotions/l1_decoder_attention_score_bank_proxy_pnr_v1.json
@@ -1,6 +1,6 @@
 {
   "version": 0.1,
-  "generated_utc": "2026-07-14T06:30:08.367457Z",
+  "generated_utc": "2026-07-15T02:03:49.255942Z",
   "item_id": "l1_decoder_attention_score_bank_proxy_pnr_v1",
   "run_key": "l1_decoder_attention_score_bank_proxy_pnr_v1_run_03f8a35ea97d7f03",
   "layer": "layer1",
@@ -57,9 +57,9 @@
   "trial_summary": {
     "item_id": "l1_decoder_attention_score_bank_proxy_pnr_v1",
     "completed_trials": 2,
-    "success_count": 2,
-    "failure_count": 0,
-    "success_rate": 1.0,
+    "success_count": 1,
+    "failure_count": 1,
+    "success_rate": 0.5,
     "metrics": {
       "critical_path_ns": {
         "best": 2.8162,

--- a/control_plane/shadow_exports/l1_trials/l1_decoder_attention_operational_dense_tile_ppa_v1/failure_stats.json
+++ b/control_plane/shadow_exports/l1_trials/l1_decoder_attention_operational_dense_tile_ppa_v1/failure_stats.json
@@ -1,12 +1,8 @@
 {
   "item_id": "l1_decoder_attention_operational_dense_tile_ppa_v1",
-  "completed_trials": 2,
+  "completed_trials": 1,
   "success_count": 1,
-  "failure_count": 1,
-  "by_category": {
-    "command_canceled": 1
-  },
-  "by_stage": {
-    "run_block_sweep": 1
-  }
+  "failure_count": 0,
+  "by_category": {},
+  "by_stage": {}
 }

--- a/control_plane/shadow_exports/l1_trials/l1_decoder_attention_operational_dense_tile_ppa_v1/summary_stats.json
+++ b/control_plane/shadow_exports/l1_trials/l1_decoder_attention_operational_dense_tile_ppa_v1/summary_stats.json
@@ -1,9 +1,9 @@
 {
   "item_id": "l1_decoder_attention_operational_dense_tile_ppa_v1",
-  "completed_trials": 2,
+  "completed_trials": 1,
   "success_count": 1,
-  "failure_count": 1,
-  "success_rate": 0.5,
+  "failure_count": 0,
+  "success_rate": 1.0,
   "metrics": {
     "critical_path_ns": {
       "best": 4.3024,

--- a/control_plane/shadow_exports/l1_trials/l1_decoder_attention_operational_dense_tile_ppa_v1/trial_table.csv
+++ b/control_plane/shadow_exports/l1_trials/l1_decoder_attention_operational_dense_tile_ppa_v1/trial_table.csv
@@ -1,3 +1,2 @@
 run_key,attempt,trial_index,seed,status,metrics_csv,critical_path_ns,die_area,total_power_mw,failure_category,failure_stage,failure_signature
-l1_decoder_attention_operational_dense_tile_ppa_v1_run_55224266af39cc58,1,1,0,canceled,,,,,command_canceled,run_block_sweep,exit_code=130
 l1_decoder_attention_operational_dense_tile_ppa_v1_run_cb0b9acc6498034e,2,2,1,succeeded,runs/designs/npu_blocks/dense_gemm_tile_stream_int8_16x8/metrics.csv,4.3024,2560000.0,0.25,none,,

--- a/control_plane/shadow_exports/l1_trials/l1_decoder_attention_score_bank_proxy_pnr_v1/failure_stats.json
+++ b/control_plane/shadow_exports/l1_trials/l1_decoder_attention_score_bank_proxy_pnr_v1/failure_stats.json
@@ -1,8 +1,12 @@
 {
   "item_id": "l1_decoder_attention_score_bank_proxy_pnr_v1",
   "completed_trials": 2,
-  "success_count": 2,
-  "failure_count": 0,
-  "by_category": {},
-  "by_stage": {}
+  "success_count": 1,
+  "failure_count": 1,
+  "by_category": {
+    "validation_error": 1
+  },
+  "by_stage": {
+    "acceptance": 1
+  }
 }

--- a/control_plane/shadow_exports/l1_trials/l1_decoder_attention_score_bank_proxy_pnr_v1/summary_stats.json
+++ b/control_plane/shadow_exports/l1_trials/l1_decoder_attention_score_bank_proxy_pnr_v1/summary_stats.json
@@ -1,9 +1,9 @@
 {
   "item_id": "l1_decoder_attention_score_bank_proxy_pnr_v1",
   "completed_trials": 2,
-  "success_count": 2,
-  "failure_count": 0,
-  "success_rate": 1.0,
+  "success_count": 1,
+  "failure_count": 1,
+  "success_rate": 0.5,
   "metrics": {
     "critical_path_ns": {
       "best": 2.8162,

--- a/control_plane/shadow_exports/l1_trials/l1_decoder_attention_score_bank_proxy_pnr_v1/trial_table.csv
+++ b/control_plane/shadow_exports/l1_trials/l1_decoder_attention_score_bank_proxy_pnr_v1/trial_table.csv
@@ -1,3 +1,3 @@
 run_key,attempt,trial_index,seed,status,metrics_csv,critical_path_ns,die_area,total_power_mw,failure_category,failure_stage,failure_signature
-l1_decoder_attention_score_bank_proxy_pnr_v1_run_8fd29ecf3ed8dbba,1,1,0,failed,runs/designs/npu_blocks/attention_score_bank_proxy_16kx256/metrics.csv,2.8162,9000000.0,0.19,validation_error,acceptance,runs/designs/npu_blocks/attention_score_bank_proxy_16kx256/metrics.csv: no status=ok rows (statuses=flow_failed)
+l1_decoder_attention_score_bank_proxy_pnr_v1_run_8fd29ecf3ed8dbba,1,1,0,failed,,,,,validation_error,acceptance,runs/designs/npu_blocks/attention_score_bank_proxy_16kx256/metrics.csv: no status=ok rows (statuses=flow_failed)
 l1_decoder_attention_score_bank_proxy_pnr_v1_run_03f8a35ea97d7f03,2,2,1,succeeded,runs/designs/npu_blocks/attention_score_bank_proxy_16kx256/metrics.csv,2.8162,9000000.0,0.19,none,,


### PR DESCRIPTION
## Summary
- correct the merged operational dense-tile trial history from `1/2` to `1/1` by excluding its operator-canceled attempt
- correct the merged score-bank proxy trial history from `2/2` to `1/2` by using the failed attempt's immutable metrics snapshot
- remove the falsely attributed successful PPA row from the failed score-bank trial
- emit trial-table CSV with repository-standard LF line endings

## Evidence
The correction was generated by the merged immutable retry-accounting consumer against the existing control-plane run/artifact records. The underlying PPA measurements and selected rows are unchanged.

## Validation
- L1 result consumer suite: 14 passed
- repository run validation passed
- `git diff --check`