### PR TITLE
Keep equivalence evidence commands repo-portable

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/evaluation_requests.json
@@ -4,8 +4,20 @@
     {
       "item_id": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1",
       "task_type": "l2_campaign",
-      "status": "pending_implementation_merge",
-      "objective": "Prove exact M1x8 packed score-row semantics before physical measurement."
+      "status": "pending_equivalence_rerun",
+      "objective": "Prove exact M1x8 packed score-row semantics before physical measurement.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_decode_score_tile_equivalence",
+      "comparison_role": "decode_score_compute_semantic_gate",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_operational_dense_tile_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_decode_shaped_score_equivalence",
+        "reason": "PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode."
+      }
     },
     {
       "item_id": "l1_decoder_attention_decode_score_tile_m1x8_ppa_v1",

--- a/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/promotion_decision.json
@@ -4,6 +4,6 @@
   "decision": "pending",
   "reason": "Await exact M1x8 equivalence and comparative Nangate45 PPA.",
   "evidence_refs": [],
-  "next_action": "merge implementation and dispatch equivalence gate",
+  "next_action": "merge portable evidence fix and rerun equivalence gate",
   "requires_human_approval": false
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json
@@ -53,7 +53,7 @@
         "direction": "prove_decode_shaped_score_equivalence",
         "reason": "PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode."
       },
-      "status": "pending_implementation_merge"
+      "status": "pending_equivalence_rerun"
     },
     {
       "item_id": "l1_decoder_attention_decode_score_tile_m1x8_ppa_v1",

--- a/npu/eval/audit_rtl_component_equivalence.py
+++ b/npu/eval/audit_rtl_component_equivalence.py
@@ -33,11 +33,12 @@ def main() -> int:
         parser.error("--timeout-seconds must be positive")
 
     repo_root = Path(__file__).resolve().parents[2]
-    command = [sys.executable, "-m", "pytest", "-q", args.test_target]
+    execution_command = [sys.executable, "-m", "pytest", "-q", args.test_target]
+    recorded_command = ["python3", "-m", "pytest", "-q", args.test_target]
     timed_out = False
     try:
         run = subprocess.run(
-            command,
+            execution_command,
             cwd=repo_root,
             capture_output=True,
             text=True,
@@ -61,7 +62,7 @@ def main() -> int:
         "semantic_profile": args.semantic_profile,
         "reference": args.reference,
         "test_target": args.test_target,
-        "command": command,
+        "command": recorded_command,
         "returncode": returncode,
         "timed_out": timed_out,
         "timeout_seconds": args.timeout_seconds,

--- a/tests/test_audit_rtl_component_equivalence.py
+++ b/tests/test_audit_rtl_component_equivalence.py
@@ -42,6 +42,14 @@ def test_audit_rtl_component_equivalence_records_passing_target(tmp_path: Path) 
     assert payload["equivalence_pass"] is True
     assert payload["timed_out"] is False
     assert payload["timeout_seconds"] == 300.0
+    assert payload["command"] == [
+        "python3",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_attention_score_bank_proxy.py",
+    ]
+    assert str(REPO_ROOT) not in json.dumps(payload["command"])
     assert payload["passed_test_count"] == 2
     assert payload["reference"] == "behavioral_synchronous_1rw_memory"
     assert "attention_score_bank_proxy_equivalence_pass" in out_md.read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed
- execute focused equivalence tests with the active interpreter but record a repo-portable `python3` command
- assert evaluator-local checkout paths cannot enter the recorded command
- complete the M1x8 equivalence request metadata and mark its portable rerun pending

## Root cause
The auditor serialized `sys.executable`, which is evaluator-specific. Result PR #1298 therefore contains `/workspaces/rtlgen-eval-clean/...` in committed evidence even though the evidence contract requires repo-portable paths.

## Validation
- focused audit and M1x8 RTL tests: 4 passed
- direct audit emits a portable command and equivalence pass
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`