### PR TITLE
eval: run layer2 campaign npu_e2e_eval_llm_attention_tail_stress_v1 on nangate45

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json
@@ -1,0 +1,67 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-15T02:26:13.229895Z",
+  "item_id": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1",
+  "run_key": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1_run_e48bf396c0f803b6",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "500e5fd8f51f51ca7014d9fa74c00a80528fe84f",
+  "review_metadata_source_commit": "500e5fd8f51f51ca7014d9fa74c00a80528fe84f",
+  "objective": "LLM-oriented attention-tail stress campaign for larger sequence lengths and more repeated non-terminal Softmax paths.",
+  "input_manifest": {
+    "decoder_contract": {
+      "decode_score_tile_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+      "decode_score_tile_equivalence_scope": "Prove exact signed-int8 M=1,N=8 decoder QK accumulation, final-beat inclusion, packed score-row lane order, clear/reuse, and ready/valid backpressure behavior against the dot-product reference.",
+      "decode_score_tile_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.md"
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+    "arch_id": "decoder_attention_decode_score_tile_equivalence",
+    "macro_mode": "evidence_only",
+    "outcome": "attention_decode_score_tile_int8_1x8_equivalence_pass"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1",
+    "title": "Decode-shaped M1x8 score tile for the Llama7B attention frontier",
+    "primary_question": "How do scalar-drain and packed-row M1x8 score tiles change measured area, delay, and the precision-aligned Llama7B token frontier relative to the semantically mismatched M16x8 recost?",
+    "evaluation_mode": "equivalence_gate",
+    "comparison_role": "decode_score_compute_semantic_gate",
+    "abstraction_layer": "decoder_attention_decode_score_tile_equivalence",
+    "expected_direction": "prove_decode_shaped_score_equivalence",
+    "expected_reason": "PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode.",
+    "summary": "RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.",
+    "outcome": "attention_decode_score_tile_int8_1x8_equivalence_pass",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1",
+    "title": "Decode-shaped M1x8 score tile for the Llama7B attention frontier",
+    "kind": "architecture",
+    "primary_question": "How do scalar-drain and packed-row M1x8 score tiles change measured area, delay, and the precision-aligned Llama7B token frontier relative to the semantically mismatched M16x8 recost?",
+    "evaluation_mode": "equivalence_gate",
+    "comparison_role": "decode_score_compute_semantic_gate",
+    "outcome": "attention_decode_score_tile_int8_1x8_equivalence_pass",
+    "summary": "RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+    "decoder_quality": {
+      "diagnosis": {}
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+    "decoder_decode_score_tile_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+    "decoder_decode_score_tile_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {}
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/evaluated.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/evaluated.json
@@ -1,0 +1,104 @@
+{
+  "flow": "openroad",
+  "task": {
+    "inputs": {
+      "decoder_contract": {
+        "decode_score_tile_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+        "decode_score_tile_equivalence_scope": "Prove exact signed-int8 M=1,N=8 decoder QK accumulation, final-beat inclusion, packed score-row lane order, clear/reuse, and ready/valid backpressure behavior against the dot-product reference.",
+        "decode_score_tile_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.md"
+      }
+    },
+    "commands": [
+      {
+        "run": "python3 npu/eval/audit_rtl_component_equivalence.py --component attention_decode_score_tile_int8_1x8 --semantic-profile llama_decode_qk_score_row_m1_n8_s8_s8_acc32 --test-target tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol --reference python_signed_m1_n8_dot_products --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.md",
+        "name": "audit_decode_score_tile_equivalence"
+      },
+      {
+        "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+        "name": "validate_runs"
+      }
+    ],
+    "objective": "LLM-oriented attention-tail stress campaign for larger sequence lengths and more repeated non-terminal Softmax paths.",
+    "acceptance": [
+      "Write all declared decoder evidence artifacts",
+      "Keep evidence artifact paths repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "source_mode": "src_verilog",
+    "expected_outputs": [
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.md"
+    ]
+  },
+  "layer": "layer2",
+  "state": "evaluated",
+  "title": "Layer2 campaign npu_e2e_eval_llm_attention_tail_stress_v1 on nangate45",
+  "result": {
+    "branch": "eval/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/s20260715t022613z",
+    "completed_utc": "2026-07-15T02:26:12.179234Z",
+    "evaluator_id": "control_plane",
+    "executor": "@control_plane",
+    "host": "b7c2d9c80c1c",
+    "identity_block": "[role:evaluator][account:control_plane][session:s20260715t022613z][host:b7c2d9c80c1c][item:l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1]",
+    "metrics_rows": [],
+    "metrics_exempt_reason": "evidence_only_decoder_evidence",
+    "queue_item_id": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1",
+    "session_id": "s20260715t022613z",
+    "status": "ok",
+    "summary": "2/2 commands succeeded"
+  },
+  "handoff": {
+    "branch": "eval/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/s20260715t022613z",
+    "pr_title": "eval: run layer2 campaign npu_e2e_eval_llm_attention_tail_stress_v1 on nangate45",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "pr_body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260715t022613z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1"
+    },
+    "identity_block_format": "[role:evaluator][account:<evaluator_id>][session:<session_id>][host:<host>][item:<queue_item_id>]"
+  },
+  "item_id": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1",
+  "version": 0.1,
+  "platform": "nangate45",
+  "priority": 1,
+  "created_utc": "2026-07-15T02:25:47.411228Z",
+  "requested_by": "control_plane",
+  "developer_loop": {
+    "comparison": {
+      "role": "decode_score_compute_semantic_gate",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "equivalence_gate",
+      "expected_reason": "PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode.",
+      "expected_direction": "prove_decode_shaped_score_equivalence"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_decode_score_tile_equivalence"
+    },
+    "proposal_id": "prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_operational_dense_tile_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json"
+  },
+  "source_requirement": {
+    "repo": "",
+    "reason": "evaluator runtime must contain the queued job source commit",
+    "version": 1,
+    "required_ref": "origin/master",
+    "required_sha": "500e5fd8f51f51ca7014d9fa74c00a80528fe84f",
+    "requires_daemon_restart": true
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/pr_body.md
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/pr_body.md
@@ -1,0 +1,40 @@
+## Summary
+- item_id: `l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1`
+- run_key: `l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1_run_e48bf396c0f803b6`
+- layer: `layer2`
+- task_type: `l2_campaign`
+- status: `ok`
+- summary: `2/2 commands succeeded`
+- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/evaluated.json`
+- metrics_rows_count: `0`
+- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json`
+
+## Developer Context
+- proposal_id: `prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1`
+- proposal_path: `docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json`
+- reviewer_first_read: `docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
+- execution_source_commit: `500e5fd8f51f51ca7014d9fa74c00a80528fe84f`
+- review_metadata_source_commit: `500e5fd8f51f51ca7014d9fa74c00a80528fe84f`
+
+## Evaluation Mode
+- evaluation_mode: `equivalence_gate`
+- abstraction_layer: `decoder_attention_decode_score_tile_equivalence`
+- comparison_role: `decode_score_compute_semantic_gate`
+- expected_direction: `prove_decode_shaped_score_equivalence`
+- expected_reason: `PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode.`
+- expectation_status: `unspecified`
+- evaluation_summary: `RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.`
+
+## Focused Comparison
+- primary_question: `How do scalar-drain and packed-row M1x8 score tiles change measured area, delay, and the precision-aligned Llama7B token frontier relative to the semantically mismatched M16x8 recost?`
+- comparison_role: `decode_score_compute_semantic_gate`
+- proposal_outcome: `attention_decode_score_tile_int8_1x8_equivalence_pass`
+- comparison_summary: `RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.`
+- baseline_ref: `None`
+- baseline_item_id: `None`
+
+## Checklist
+- [ ] Commit lightweight campaign artifacts only
+- [ ] Include metrics row references in result.metrics_rows
+- [ ] Keep committed result_path fields repo-portable
+- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing

--- a/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/review_package.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/review_package.json
@@ -1,0 +1,143 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-15T02:26:16.762323Z",
+  "control_plane_source_commit": "500e5fd8f51f51ca7014d9fa74c00a80528fe84f",
+  "review_metadata_source_commit": "500e5fd8f51f51ca7014d9fa74c00a80528fe84f",
+  "item_id": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1",
+  "run_key": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1_run_e48bf396c0f803b6",
+  "layer": "layer2",
+  "flow": "openroad",
+  "task_type": "l2_campaign",
+  "source_commit": "500e5fd8f51f51ca7014d9fa74c00a80528fe84f",
+  "queue_snapshot": {
+    "path": "control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/evaluated.json",
+    "result": {
+      "branch": "eval/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/s20260715t022613z",
+      "completed_utc": "2026-07-15T02:26:12.179234Z",
+      "evaluator_id": "control_plane",
+      "executor": "@control_plane",
+      "host": "b7c2d9c80c1c",
+      "identity_block": "[role:evaluator][account:control_plane][session:s20260715t022613z][host:b7c2d9c80c1c][item:l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1]",
+      "metrics_rows": [],
+      "metrics_exempt_reason": "evidence_only_decoder_evidence",
+      "queue_item_id": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1",
+      "session_id": "s20260715t022613z",
+      "status": "ok",
+      "summary": "2/2 commands succeeded"
+    }
+  },
+  "review_artifact": {
+    "kind": "decision_proposal",
+    "path": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+    "storage_mode": "repo",
+    "sha256": "3e3e7f32d8056b94b7650f72c0e61d7ba416a648f9140c0adf8f68b248ec88ca",
+    "payload": {
+      "version": 0.1,
+      "generated_utc": "2026-07-15T02:26:13.229895Z",
+      "item_id": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1",
+      "run_key": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1_run_e48bf396c0f803b6",
+      "layer": "layer2",
+      "flow": "openroad",
+      "platform": "nangate45",
+      "task_type": "l2_campaign",
+      "source_commit": "500e5fd8f51f51ca7014d9fa74c00a80528fe84f",
+      "review_metadata_source_commit": "500e5fd8f51f51ca7014d9fa74c00a80528fe84f",
+      "objective": "LLM-oriented attention-tail stress campaign for larger sequence lengths and more repeated non-terminal Softmax paths.",
+      "input_manifest": {
+        "decoder_contract": {
+          "decode_score_tile_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+          "decode_score_tile_equivalence_scope": "Prove exact signed-int8 M=1,N=8 decoder QK accumulation, final-beat inclusion, packed score-row lane order, clear/reuse, and ready/valid backpressure behavior against the dot-product reference.",
+          "decode_score_tile_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.md"
+        }
+      },
+      "recommendation": {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+        "arch_id": "decoder_attention_decode_score_tile_equivalence",
+        "macro_mode": "evidence_only",
+        "outcome": "attention_decode_score_tile_int8_1x8_equivalence_pass"
+      },
+      "objective_profiles": [],
+      "evaluation_record": {
+        "proposal_id": "prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1",
+        "title": "Decode-shaped M1x8 score tile for the Llama7B attention frontier",
+        "primary_question": "How do scalar-drain and packed-row M1x8 score tiles change measured area, delay, and the precision-aligned Llama7B token frontier relative to the semantically mismatched M16x8 recost?",
+        "evaluation_mode": "equivalence_gate",
+        "comparison_role": "decode_score_compute_semantic_gate",
+        "abstraction_layer": "decoder_attention_decode_score_tile_equivalence",
+        "expected_direction": "prove_decode_shaped_score_equivalence",
+        "expected_reason": "PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode.",
+        "summary": "RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.",
+        "outcome": "attention_decode_score_tile_int8_1x8_equivalence_pass",
+        "expectation_status": "unspecified"
+      },
+      "proposal_assessment": {
+        "proposal_id": "prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1",
+        "title": "Decode-shaped M1x8 score tile for the Llama7B attention frontier",
+        "kind": "architecture",
+        "primary_question": "How do scalar-drain and packed-row M1x8 score tiles change measured area, delay, and the precision-aligned Llama7B token frontier relative to the semantically mismatched M16x8 recost?",
+        "evaluation_mode": "equivalence_gate",
+        "comparison_role": "decode_score_compute_semantic_gate",
+        "outcome": "attention_decode_score_tile_int8_1x8_equivalence_pass",
+        "summary": "RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.",
+        "baseline_ref": null,
+        "baseline_item_id": null,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+        "decoder_quality": {
+          "diagnosis": {}
+        }
+      },
+      "source_refs": {
+        "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+        "decoder_decode_score_tile_equivalence_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json",
+        "decoder_decode_score_tile_equivalence_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.md"
+      },
+      "decoder_quality": {
+        "diagnosis": {}
+      }
+    }
+  },
+  "developer_loop": {
+    "comparison": {
+      "role": "decode_score_compute_semantic_gate",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "equivalence_gate",
+      "expected_reason": "PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode.",
+      "expected_direction": "prove_decode_shaped_score_equivalence"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_decode_score_tile_equivalence"
+    },
+    "proposal_id": "prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l2_decoder_attention_operational_dense_tile_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json"
+  },
+  "submission_history": null,
+  "pr_payload": {
+    "branch": "eval/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/s20260715t022613z",
+    "title": "eval: run layer2 campaign npu_e2e_eval_llm_attention_tail_stress_v1 on nangate45",
+    "body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260715t022613z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1"
+    },
+    "body_md": "## Summary\n- item_id: `l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1`\n- run_key: `l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1_run_e48bf396c0f803b6`\n- layer: `layer2`\n- task_type: `l2_campaign`\n- status: `ok`\n- summary: `2/2 commands succeeded`\n- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/evaluated.json`\n- metrics_rows_count: `0`\n- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json`\n\n## Developer Context\n- proposal_id: `prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1`\n- proposal_path: `docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json`\n- reviewer_first_read: `docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`\n- execution_source_commit: `500e5fd8f51f51ca7014d9fa74c00a80528fe84f`\n- review_metadata_source_commit: `500e5fd8f51f51ca7014d9fa74c00a80528fe84f`\n\n## Evaluation Mode\n- evaluation_mode: `equivalence_gate`\n- abstraction_layer: `decoder_attention_decode_score_tile_equivalence`\n- comparison_role: `decode_score_compute_semantic_gate`\n- expected_direction: `prove_decode_shaped_score_equivalence`\n- expected_reason: `PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode.`\n- expectation_status: `unspecified`\n- evaluation_summary: `RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.`\n\n## Focused Comparison\n- primary_question: `How do scalar-drain and packed-row M1x8 score tiles change measured area, delay, and the precision-aligned Llama7B token frontier relative to the semantically mismatched M16x8 recost?`\n- comparison_role: `decode_score_compute_semantic_gate`\n- proposal_outcome: `attention_decode_score_tile_int8_1x8_equivalence_pass`\n- comparison_summary: `RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.`\n- baseline_ref: `None`\n- baseline_item_id: `None`\n\n## Checklist\n- [ ] Commit lightweight campaign artifacts only\n- [ ] Include metrics row references in result.metrics_rows\n- [ ] Keep committed result_path fields repo-portable\n- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing\n",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ]
+  }
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json
@@ -1,0 +1,24 @@
+{
+  "command": [
+    "python3",
+    "-m",
+    "pytest",
+    "-q",
+    "tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol"
+  ],
+  "component": "attention_decode_score_tile_int8_1x8",
+  "decision": "attention_decode_score_tile_int8_1x8_equivalence_pass",
+  "equivalence_pass": true,
+  "generated_utc": "2026-07-15T02:26:08.497846Z",
+  "model": "rtl_component_reference_equivalence_v1",
+  "passed_test_count": 1,
+  "reference": "python_signed_m1_n8_dot_products",
+  "returncode": 0,
+  "semantic_profile": "llama_decode_qk_score_row_m1_n8_s8_s8_acc32",
+  "test_output_sha256": "774412243a4dd9109d74cac1e88830db06a136051bbdbb28f78f1755be3ed12a",
+  "test_output_tail": ".                                                                        [100%]\n1 passed in 0.04s",
+  "test_target": "tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol",
+  "timed_out": false,
+  "timeout_seconds": 300.0,
+  "version": 1
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.md
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.md
@@ -1,0 +1,8 @@
+# attention_decode_score_tile_int8_1x8 Equivalence
+
+- decision: `attention_decode_score_tile_int8_1x8_equivalence_pass`
+- equivalence pass: `True`
+- semantic profile: `llama_decode_qk_score_row_m1_n8_s8_s8_acc32`
+- reference: `python_signed_m1_n8_dot_products`
+- focused tests passed: `1`
+- test target: `tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol`


### PR DESCRIPTION
## Summary
- item_id: `l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1`
- run_key: `l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1_run_e48bf396c0f803b6`
- layer: `layer2`
- task_type: `l2_campaign`
- status: `ok`
- summary: `2/2 commands succeeded`
- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1/evaluated.json`
- metrics_rows_count: `0`
- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json`

## Developer Context
- proposal_id: `prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1`
- proposal_path: `docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json`
- reviewer_first_read: `docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json` plus `docs/developer_agent_review.md`
- execution_source_commit: `500e5fd8f51f51ca7014d9fa74c00a80528fe84f`
- review_metadata_source_commit: `500e5fd8f51f51ca7014d9fa74c00a80528fe84f`

## Evaluation Mode
- evaluation_mode: `equivalence_gate`
- abstraction_layer: `decoder_attention_decode_score_tile_equivalence`
- comparison_role: `decode_score_compute_semantic_gate`
- expected_direction: `prove_decode_shaped_score_equivalence`
- expected_reason: `PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode.`
- expectation_status: `unspecified`
- evaluation_summary: `RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.`

## Focused Comparison
- primary_question: `How do scalar-drain and packed-row M1x8 score tiles change measured area, delay, and the precision-aligned Llama7B token frontier relative to the semantically mismatched M16x8 recost?`
- comparison_role: `decode_score_compute_semantic_gate`
- proposal_outcome: `attention_decode_score_tile_int8_1x8_equivalence_pass`
- comparison_summary: `RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.`
- baseline_ref: `None`
- baseline_item_id: `None`

## Checklist
- [ ] Commit lightweight campaign artifacts only
- [ ] Include metrics row references in result.metrics_rows
- [ ] Keep committed result_path fields repo-portable
- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing
