### PR TITLE
Reactivate latest retry review after stale PR close

### DIFF
--- a/control_plane/control_plane/services/github_bridge.py
+++ b/control_plane/control_plane/services/github_bridge.py
@@ -110,13 +110,29 @@ def _other_active_review_prs(session: Session, link: GitHubLink) -> list[int]:
     return sorted(int(row.pr_number) for row in query.all() if row.pr_number is not None)
 
 
+def _link_targets_latest_run(session: Session, link: GitHubLink) -> bool:
+    if link.run_id is None:
+        return False
+    latest_run_id = (
+        session.query(Run.id)
+        .filter(Run.work_item_id == link.work_item_id)
+        .order_by(Run.attempt.desc(), Run.created_at.desc())
+        .limit(1)
+        .scalar()
+    )
+    return latest_run_id == link.run_id
+
+
 def _advance_work_item_state(
     work_item: WorkItem,
     state: GitHubLinkState,
     *,
     close_is_terminal: bool = True,
+    reopen_superseded: bool = False,
 ) -> None:
-    if state == GitHubLinkState.PR_OPEN and work_item.state not in {WorkItemState.MERGED, WorkItemState.SUPERSEDED}:
+    if state == GitHubLinkState.PR_OPEN and work_item.state != WorkItemState.MERGED:
+        if work_item.state == WorkItemState.SUPERSEDED and not reopen_superseded:
+            return
         if work_item.state not in {WorkItemState.AWAITING_REVIEW, WorkItemState.MERGED}:
             work_item.state = WorkItemState.AWAITING_REVIEW
     elif state == GitHubLinkState.PR_MERGED:
@@ -187,7 +203,14 @@ def reconcile_github_link(session: Session, request: GitHubReconcileRequest) -> 
     session.flush()
     other_active_prs = _other_active_review_prs(session, link) if state == GitHubLinkState.PR_CLOSED else []
     close_is_terminal = not other_active_prs
-    _advance_work_item_state(work_item, state, close_is_terminal=close_is_terminal)
+    prior_work_item_state = work_item.state
+    reopen_superseded = state == GitHubLinkState.PR_OPEN and _link_targets_latest_run(session, link)
+    _advance_work_item_state(
+        work_item,
+        state,
+        close_is_terminal=close_is_terminal,
+        reopen_superseded=reopen_superseded,
+    )
 
     event_payload = {
         "repo": request.repo,
@@ -232,6 +255,16 @@ def reconcile_github_link(session: Session, request: GitHubReconcileRequest) -> 
                     "other_active_pr_numbers": other_active_prs,
                 },
             )
+    elif prior_work_item_state == WorkItemState.SUPERSEDED and work_item.state == WorkItemState.AWAITING_REVIEW:
+        _emit_run_event(
+            session,
+            run,
+            "work_item_review_reactivated",
+            {
+                **event_payload,
+                "reason": "latest_run_review_pr_active",
+            },
+        )
     else:
         _emit_run_event(session, run, "pr_linked", event_payload)
 

--- a/control_plane/control_plane/tests/test_reconciliation.py
+++ b/control_plane/control_plane/tests/test_reconciliation.py
@@ -428,3 +428,56 @@ def test_reconcile_stale_closed_pr_preserves_newer_open_review() -> None:
         assert "work_item_superseded" not in [event.event_type for event in events]
         nonterminal = next(event for event in events if event.event_type == "nonterminal_pr_closed")
         assert nonterminal.event_payload["other_active_pr_numbers"] == [43]
+
+
+def test_reconcile_latest_run_open_pr_recovers_stale_supersession() -> None:
+    with make_session() as session:
+        first_run = seed_reviewable_run(session)
+        second_run = Run(
+            run_key="run-review-2",
+            work_item_id=first_run.work_item_id,
+            lease_id=first_run.lease_id,
+            attempt=2,
+            executor_type="internal_worker",
+            machine_id=first_run.machine_id,
+            branch_name="eval/item_review/s20260308t010000z",
+            status="succeeded",
+            started_at=utcnow(),
+            completed_at=utcnow(),
+            result_summary="retry review ok",
+            result_payload={"queue_result": {"status": "ok", "metrics_rows": []}},
+        )
+        session.add(second_run)
+        session.commit()
+
+        reconcile_github_link(
+            session,
+            GitHubReconcileRequest(
+                repo="yhmtmt/RTLGen",
+                item_id="item_review",
+                branch_name="eval/item_review/s20260308t010000z",
+                pr_number=43,
+                state="pr_open",
+                run_key=second_run.run_key,
+            ),
+        )
+        work_item = session.query(WorkItem).filter_by(item_id="item_review").one()
+        work_item.state = WorkItemState.SUPERSEDED
+        session.commit()
+
+        result = reconcile_github_link(
+            session,
+            GitHubReconcileRequest(
+                repo="yhmtmt/RTLGen",
+                item_id="item_review",
+                branch_name="eval/item_review/s20260308t010000z",
+                pr_number=43,
+                state="pr_open",
+                run_key=second_run.run_key,
+            ),
+        )
+
+        events = session.query(RunEvent).filter_by(run_id=second_run.id).all()
+        assert result.work_item_state == WorkItemState.AWAITING_REVIEW.value
+        assert work_item.state == WorkItemState.AWAITING_REVIEW
+        assert "work_item_review_reactivated" in [event.event_type for event in events]


### PR DESCRIPTION
## What changed
- allow an open review PR to recover a superseded work item only when it belongs to the item's latest run
- emit an explicit `work_item_review_reactivated` event
- cover the stale older-PR close race while preserving normal closed-PR supersession

## Root cause
A GitHub poll cycle can close an older result PR after a retry PR has been linked. If that stale close marks the item `SUPERSEDED`, later polls of the retry PR cannot restore `AWAITING_REVIEW` because open-PR reconciliation previously treated supersession as irreversible. This occurred with #1298 and #1300.

## Validation
- focused reconciliation and GitHub poller coverage: 8 passed
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

A pre-existing unrelated full-file test attempts proposal finalization in a non-git temporary directory; it is outside this transition change.