### PR TITLE
Recompute Llama7B frontier for decode-shaped M1x8 tiles

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -623,6 +623,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "decode_score_tile_equivalence_report",
     ),
     (
+        "decode_score_tile_frontier_out",
+        "decode_score_tile_frontier_report",
+    ),
+    (
         "score_bank_proxy_equivalence_out",
         "score_bank_proxy_equivalence_report",
     ),
@@ -1539,6 +1543,31 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "recommended_token_throughput_per_s",
             "recommended_energy_mj_per_token",
             "recommended_embodied_area_mm2",
+            "energy_promotion_blocked",
+            "next_step",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_decode_score_tile_frontier_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(
+            evidence_payload.get("decision")
+            or "decode_score_tile_frontier_recorded"
+        )
+        parts = [
+            f"Decoder M1x8 score-tile frontier recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "best_throughput_candidate",
+            "best_throughput_token_per_s",
+            "best_throughput_area_mm2",
+            "best_area_candidate",
+            "best_area_mm2",
+            "best_area_token_per_s",
             "energy_promotion_blocked",
             "next_step",
         ):

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6644,6 +6644,50 @@ def _decoder_attention_decode_score_tile_equivalence_evidence(*, item_id: str) -
     }
 
 
+def _decoder_attention_decode_score_tile_frontier_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    operational = (
+        f"{base}/decoder_attention_operational_component_frontier__"
+        "l2_decoder_attention_operational_component_frontier_llama7b_v1.json"
+    )
+    schedule = (
+        f"{base}/decoder_attention_kv_subtile_pipeline_schedule__"
+        "l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1.json"
+    )
+    scalar = "runs/designs/npu_blocks/dense_gemm_tile_stream_int8_1x8/metrics.csv"
+    packed = "runs/designs/npu_blocks/attention_decode_score_tile_int8_1x8/metrics.csv"
+    out = f"{base}/decoder_attention_decode_score_tile_frontier__{item_id}.json"
+    report = f"{base}/decoder_attention_decode_score_tile_frontier__{item_id}.md"
+    return {
+        "inputs": {
+            "decode_score_tile_operational_frontier_source": operational,
+            "decode_score_tile_subtile_schedule_source": schedule,
+            "decode_score_tile_scalar_metrics": scalar,
+            "decode_score_tile_packed_metrics": packed,
+            "decode_score_tile_frontier_out": out,
+            "decode_score_tile_frontier_report": report,
+            "decode_score_tile_frontier_scope": (
+                "Replace the M16x8 decode mismatch with measured M1x8 scalar and packed interfaces, then "
+                "recompute stage service, subtile scheduling, HBM-share latency, area feasibility, and Pareto rank."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decode_score_tile_frontier",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_decode_score_tile_frontier.py "
+                    f"--operational-frontier-json {operational} "
+                    f"--subtile-schedule-json {schedule} "
+                    f"--scalar-metrics-csv {scalar} --packed-metrics-csv {packed} "
+                    f"--out-json {out} --out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score_bank_proxy_equivalence_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score_bank_proxy_equivalence__{item_id}.json"
@@ -10180,6 +10224,7 @@ def _build_payload(
         "decoder_attention_operational_component_frontier",
         "decoder_attention_operational_dense_tile_equivalence",
         "decoder_attention_decode_score_tile_equivalence",
+        "decoder_attention_decode_score_tile_frontier",
         "decoder_attention_score_bank_proxy_equivalence",
         "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
         "decoder_attention_score32_hbm_controller_replay",
@@ -10410,6 +10455,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_operational_dense_tile_equivalence_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_decode_score_tile_equivalence":
             decoder_evidence = _decoder_attention_decode_score_tile_equivalence_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_decode_score_tile_frontier":
+            decoder_evidence = _decoder_attention_decode_score_tile_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score_bank_proxy_equivalence":
             decoder_evidence = _decoder_attention_score_bank_proxy_equivalence_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_exp_lut_hbm_dram_service_closure":

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -182,6 +182,29 @@ def test_decoder_evidence_paths_recognizes_decode_score_tile_equivalence(tmp_pat
     }
 
 
+def test_decoder_evidence_paths_recognizes_decode_score_tile_frontier(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/decode_score_tile_frontier.json"
+    report_rel = "runs/datasets/demo/decode_score_tile_frontier.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Decode score tile frontier\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "decode_score_tile_frontier_out": evidence_rel,
+                "decode_score_tile_frontier_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=tmp_path, work_item=work_item)
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_decode_score_tile_frontier_out": evidence_rel,
+        "decoder_decode_score_tile_frontier_report": report_rel,
+    }
+
+
 def test_decoder_evidence_summary_recognizes_rtl_component_equivalence() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/operational_tile_equivalence.json",
@@ -200,6 +223,30 @@ def test_decoder_evidence_summary_recognizes_rtl_component_equivalence() -> None
     assert outcome == "operational_dense_gemm_tile_int8_16x8_equivalence_pass"
     assert "equivalence_pass=True" in summary
     assert "python_signed_outer_product_gemm" in summary
+
+
+def test_decoder_evidence_summary_recognizes_decode_score_tile_frontier() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/decode_score_tile_frontier.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_decode_score_tile_frontier_v1",
+            "decision": "decode_shaped_m1x8_schedule_and_area_recosted_energy_retained",
+            "diagnosis": {
+                "best_throughput_candidate": "packed_area_budget",
+                "best_throughput_token_per_s": 700.0,
+                "best_throughput_area_mm2": 410.0,
+                "best_area_candidate": "packed_nominal",
+                "best_area_mm2": 350.0,
+                "best_area_token_per_s": 620.0,
+                "energy_promotion_blocked": True,
+            },
+        },
+    )
+
+    assert outcome == "decode_shaped_m1x8_schedule_and_area_recosted_energy_retained"
+    assert "best_throughput_candidate=packed_area_budget" in summary
+    assert "best_area_mm2=350.0" in summary
+    assert "energy_promotion_blocked=True" in summary
 
 
 def test_decoder_evidence_summary_recognizes_two_pass_stream_equivalence() -> None:

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7761,6 +7761,41 @@ def test_generate_l2_campaign_task_adds_decode_score_tile_equivalence() -> None:
             )
 
 
+def test_generate_l2_campaign_task_adds_decode_score_tile_frontier() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_decode_score_tile_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_tile_frontier",
+                    evaluation_mode="frontier_recost",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command = work_item.task_request.request_payload["task"]["commands"][0]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert command["name"] == "audit_decode_score_tile_frontier"
+            assert "audit_llm_decoder_attention_decode_score_tile_frontier.py" in command["run"]
+            assert "--scalar-metrics-csv" in command["run"]
+            assert "--packed-metrics-csv" in command["run"]
+            assert decoder_inputs["decode_score_tile_frontier_out"] in work_item.expected_outputs
+
+
 def test_generate_l2_campaign_task_adds_score_bank_proxy_equivalence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/analysis_report.md
@@ -29,4 +29,9 @@
 ## Recommendation
 - `iterate`
 - reason: RTL component/reference equivalence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_tile_equivalence__l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1.json: decision=attention_decode_score_tile_int8_1x8_equivalence_pass; component=attention_decode_score_tile_int8_1x8; semantic_profile=llama_decode_qk_score_row_m1_n8_s8_s8_acc32; reference=python_signed_m1_n8_dot_products; equivalence_pass=True; passed_test_count=1; test_target=tests/test_dense_gemm_tile_stream.py::test_packed_decode_score_tile_matches_reference_and_protocol.
-- next_action: inspect follow-on work after l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1
+- next_action: merge comparative scalar/packed M1x8 PPA, then recompute the stage-service frontier
+
+## Current Progress
+- exact packed M1x8 equivalence is merged via PR #1300
+- comparative Nangate45 scalar/packed PPA is running on the remote evaluator
+- the corrective recost must recompute QKV, QK, value, subtile, layer, and token cycles rather than scale aggregate latency

--- a/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/evaluation_requests.json
@@ -26,15 +26,24 @@
     {
       "item_id": "l1_decoder_attention_decode_score_tile_m1x8_ppa_v1",
       "task_type": "l1_sweep",
-      "status": "ready_to_queue",
+      "status": "running",
       "objective": "Compare scalar and packed M1x8 PPA under identical physical constraints.",
-      "notes": "Prerequisites are merged; item is ready to queue."
+      "notes": "Exact M1x8 equivalence is merged; comparative scalar/packed PPA is running."
     },
     {
       "item_id": "l2_decoder_attention_decode_score_tile_frontier_recost_llama7b_v1",
       "task_type": "l2_campaign",
-      "status": "ready_to_queue",
+      "status": "blocked_on_ppa",
       "objective": "Correct the Llama7B frontier with the decode-exact compute shape.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_tile_frontier",
+      "comparison_role": "decode_shape_corrective_recost",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_tile_m1x8_ppa_v1",
+        "l1_decoder_attention_score_bank_proxy_pnr_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
       "revision": {
         "reason": "wrong_compute_shape_for_autoregressive_decode",
         "invalidates_item_ids": [
@@ -46,14 +55,18 @@
           ]
         }
       },
-      "notes": "Prerequisites are merged; item is ready to queue."
+      "expected_result": {
+        "direction": "reprice_frontier_with_decode_exact_compute_shape",
+        "reason": "The active Llama7B decision path must recompute stage service instead of scaling an M16 tile as if all rows were useful during M1 decode."
+      },
+      "notes": "Exact M1x8 equivalence is merged; comparative scalar/packed PPA is running."
     },
     {
       "item_id": "l1_decoder_attention_decode_score_local_cluster_pnr_v1",
       "task_type": "l1_sweep",
-      "status": "ready_to_queue",
+      "status": "blocked_on_corrective_recost",
       "objective": "Measure the semantically valid local score producer/store/replay composition.",
-      "notes": "Prerequisites are merged; item is ready to queue."
+      "notes": "Wait for the decode-shaped PPA and corrective schedule recost before composing the cluster."
     }
   ],
   "source_commit": "500e5fd8f51f51ca7014d9fa74c00a80528fe84f"

--- a/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json
@@ -53,7 +53,7 @@
         "direction": "prove_decode_shaped_score_equivalence",
         "reason": "PPA and cluster composition must use the single-query score shape exercised by autoregressive Llama7B decode."
       },
-      "status": "pending_equivalence_rerun"
+      "status": "merged"
     },
     {
       "item_id": "l1_decoder_attention_decode_score_tile_m1x8_ppa_v1",
@@ -76,7 +76,7 @@
         "direction": "select_decode_score_result_interface",
         "reason": "The packed interface removes eight scalar drain cycles but its 256-bit physical interface must be charged."
       },
-      "status": "blocked_on_equivalence"
+      "status": "running"
     },
     {
       "item_id": "l2_decoder_attention_decode_score_tile_frontier_recost_llama7b_v1",

--- a/npu/eval/audit_llm_decoder_attention_decode_score_tile_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_decode_score_tile_frontier.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Recompute the Llama7B attention frontier with decode-shaped M1x8 tiles."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from npu.eval.estimate_llm_decoder_attention_kv_dual_stream_physical_feasibility import (
+    _scheduled_subtile_pipeline,
+)
+
+
+JsonDict = dict[str, Any]
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _positive(value: Any, label: str) -> float:
+    result = float(value)
+    if result <= 0.0:
+        raise ValueError(f"{label} must be positive")
+    return result
+
+
+def _metrics_rows(path: Path) -> list[JsonDict]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = [dict(row) for row in csv.DictReader(handle) if row.get("status") == "ok"]
+    if not rows:
+        raise ValueError(f"no status=ok metrics rows: {path}")
+    for row in rows:
+        row["metrics_csv"] = str(path)
+    return rows
+
+
+def _select_metric(path: Path, *, schedule_clock_ns: float) -> JsonDict:
+    rows = _metrics_rows(path)
+    feasible = [row for row in rows if float(row["critical_path_ns"]) <= schedule_clock_ns]
+    candidates = feasible or rows
+    return min(
+        candidates,
+        key=lambda row: (
+            float(row.get("instance_area_um2") or "inf"),
+            float(row.get("critical_path_ns") or "inf"),
+            float(row.get("total_power_mw") or "inf"),
+        ),
+    )
+
+
+def _metric_provenance(row: JsonDict) -> JsonDict:
+    keys = (
+        "metrics_csv",
+        "design",
+        "platform",
+        "tag",
+        "status",
+        "param_hash",
+        "config_hash",
+        "params_json",
+        "critical_path_ns",
+        "instance_area_um2",
+        "stdcell_area_um2",
+        "stdcell_count",
+        "core_area_um2",
+        "die_area",
+        "utilization_pct",
+        "total_power_mw",
+    )
+    return {key: row[key] for key in keys if key in row}
+
+
+def _source_schedule(payload: JsonDict, *, latency_us: float) -> JsonDict:
+    candidates: list[JsonDict] = []
+    best = payload.get("best")
+    if isinstance(best, dict):
+        candidates.append(best)
+    candidates.extend(row for row in payload.get("top_rows", []) if isinstance(row, dict))
+    matches = [row for row in candidates if math.isclose(float(row.get("latency_us", -1.0)), latency_us, abs_tol=1e-6)]
+    if not matches:
+        raise ValueError(f"no schedule row matches baseline latency {latency_us}")
+    return deepcopy(matches[0])
+
+
+def _dense_component(row: JsonDict) -> JsonDict:
+    for component in row.get("components", []):
+        if isinstance(component, dict) and component.get("component") == "operational_dense_int8_gemm_fabric":
+            return component
+    raise ValueError(f"frontier row {row.get('candidate_id')} lacks operational dense component")
+
+
+def _effective_macs(*, k_length: int, result_cycles: int) -> tuple[int, float]:
+    service_cycles = 1 + k_length + result_cycles
+    return service_cycles, (8.0 * k_length) / service_cycles
+
+
+def _stage_service(*, schedule: JsonDict, result_cycles: int) -> JsonDict:
+    hidden = int(schedule["hidden_size"])
+    attention_heads = int(schedule["attention_heads"])
+    kv_heads = int(schedule["kv_heads"])
+    head_dim = hidden // attention_heads
+    tile_tokens = int(schedule["tile_tokens"])
+    qkv_k = hidden
+    qk_k = head_dim
+    value_k = tile_tokens
+    qkv_cycles, qkv_macs = _effective_macs(k_length=qkv_k, result_cycles=result_cycles)
+    qk_cycles, qk_macs = _effective_macs(k_length=qk_k, result_cycles=result_cycles)
+    value_cycles, value_macs = _effective_macs(k_length=value_k, result_cycles=result_cycles)
+    return {
+        "command_cycles": 1,
+        "result_cycles": result_cycles,
+        "qkv": {"k_length": qkv_k, "service_cycles": qkv_cycles, "effective_macs_per_cycle": qkv_macs},
+        "qk": {"k_length": qk_k, "service_cycles": qk_cycles, "effective_macs_per_cycle": qk_macs},
+        "value": {"k_length": value_k, "service_cycles": value_cycles, "effective_macs_per_cycle": value_macs},
+        "qkv_work_macs": hidden * hidden + 2 * hidden * kv_heads * head_dim,
+        "tile_qk_work_macs": tile_tokens * hidden,
+        "tile_value_work_macs": tile_tokens * hidden,
+    }
+
+
+def _replica_policies(
+    *,
+    schedule: JsonDict,
+    tile_area_um2: float,
+    service: JsonDict,
+) -> list[tuple[str, int]]:
+    cluster_count = int(schedule["cluster_count"])
+    source_per_cluster_macs = _positive(
+        schedule.get("per_cluster_macs_per_cycle")
+        or math.floor(int(schedule["compute_replica_count"]) / cluster_count)
+        * _positive(schedule["measured_block_macs_per_cycle"], "source block MACs"),
+        "source per-cluster MACs per cycle",
+    )
+    nominal = cluster_count * math.ceil(source_per_cluster_macs / 8.0)
+    throughput = cluster_count * math.ceil(
+        source_per_cluster_macs / float(service["qk"]["effective_macs_per_cycle"])
+    )
+    multiplier = _positive(schedule.get("compute_area_multiplier", 1.0), "compute area multiplier")
+    noncompute_area = _positive(schedule["logic_area_used_um2"], "logic area used") - _positive(
+        schedule["compute_area_um2"], "compute area"
+    )
+    available = max(0.0, _positive(schedule["compute_budget_um2"], "compute budget") - noncompute_area)
+    area_budget = max(1, int(available // (tile_area_um2 * multiplier)))
+    ordered = [("nominal_peak", nominal), ("throughput_matched", throughput), ("area_budget", area_budget)]
+    seen: set[int] = set()
+    result: list[tuple[str, int]] = []
+    for name, count in ordered:
+        if count in seen:
+            continue
+        seen.add(count)
+        result.append((name, count))
+    return result
+
+
+def _recompute_schedule(
+    source: JsonDict,
+    *,
+    active_replicas: int,
+    tile_delay_ns: float,
+    tile_area_um2: float,
+    service: JsonDict,
+) -> JsonDict:
+    updated = deepcopy(source)
+    multiplier = _positive(source.get("compute_area_multiplier", 1.0), "compute area multiplier")
+    clock_ns = max(_positive(source["clock_ns"], "source clock"), tile_delay_ns)
+    qkv_macs = active_replicas * float(service["qkv"]["effective_macs_per_cycle"])
+    cluster_count = int(source["cluster_count"])
+    replicas_per_cluster = max(1, active_replicas // cluster_count)
+    qk_macs = replicas_per_cluster * float(service["qk"]["effective_macs_per_cycle"])
+    value_macs = replicas_per_cluster * float(service["value"]["effective_macs_per_cycle"])
+    updated.update(
+        {
+            "clock_ns": clock_ns,
+            "qkv_cycles": math.ceil(float(service["qkv_work_macs"]) / qkv_macs),
+            "tile_qk_cycles": math.ceil(float(service["tile_qk_work_macs"]) / qk_macs),
+            "tile_value_cycles": math.ceil(float(service["tile_value_work_macs"]) / value_macs),
+        }
+    )
+    scheduled = _scheduled_subtile_pipeline(updated)
+    compute_area = active_replicas * tile_area_um2 * multiplier
+    noncompute_area = _positive(source["logic_area_used_um2"], "logic area used") - _positive(
+        source["compute_area_um2"], "compute area"
+    )
+    logic_area = noncompute_area + compute_area
+    return {
+        **scheduled,
+        "clock_ns": clock_ns,
+        "active_replica_count": active_replicas,
+        "area_replica_count": int(round(active_replicas * multiplier)),
+        "compute_area_um2": compute_area,
+        "logic_area_used_um2": logic_area,
+        "logic_area_slack_um2": _positive(source["compute_budget_um2"], "compute budget") - logic_area,
+        "area_fit": logic_area <= _positive(source["compute_budget_um2"], "compute budget"),
+        "effective_qkv_macs_per_cycle": qkv_macs,
+        "effective_qk_macs_per_cycle_per_cluster": qk_macs,
+        "effective_value_macs_per_cycle_per_cluster": value_macs,
+        "replicas_per_cluster_floor": replicas_per_cluster,
+        "qkv_cycles": updated["qkv_cycles"],
+        "tile_qk_cycles": updated["tile_qk_cycles"],
+        "tile_value_cycles": updated["tile_value_cycles"],
+    }
+
+
+def _replace_frontier_row(
+    source: JsonDict,
+    *,
+    interface: str,
+    policy: str,
+    metric: JsonDict,
+    schedule: JsonDict,
+    service: JsonDict,
+) -> JsonDict:
+    updated = deepcopy(source)
+    dense = _dense_component(updated)
+    old_dense_area = _positive(dense["area_um2"], "old dense area")
+    new_dense_area = float(schedule["compute_area_um2"])
+    area_delta_mm2 = (new_dense_area - old_dense_area) / 1.0e6
+    metric_path = str(metric["metrics_csv"])
+    dense.update(
+        {
+            "component": "decode_shaped_m1x8_score_fabric",
+            "interface": interface,
+            "deployment_policy": policy,
+            "source": metric_path,
+            "area_um2": round(new_dense_area, 6),
+            "per_tile_area_um2": float(metric["instance_area_um2"]),
+            "critical_path_ns": float(metric["critical_path_ns"]),
+            "clock_ok": float(metric["critical_path_ns"]) <= float(schedule["clock_ns"]),
+            "active_replica_count": schedule["active_replica_count"],
+            "area_replica_count": schedule["area_replica_count"],
+            "vectorless_power_mw_per_tile": float(metric["total_power_mw"]),
+            "vectorless_power_mw_scaled_active": round(
+                float(metric["total_power_mw"]) * int(schedule["active_replica_count"]), 12
+            ),
+            "power_accounting": "retained_activity_backed_frontier_energy",
+        }
+    )
+    for key in ("logic_plus_service_area_mm2", "retained_logic_area_mm2", "embodied_logic_plus_score_macro_area_mm2"):
+        updated[key] = round(_positive(updated[key], key) + area_delta_mm2, 12)
+    base_latency = float(schedule["latency_us"])
+    scaled_latency = base_latency * _positive(updated["hbm_share_scale"], "HBM share scale")
+    latency = scaled_latency + float(updated.get("divider_latency_us") or 0.0)
+    updated.update(
+        {
+            "candidate_id": f"{source['candidate_id']}_decode_m1x8_{interface}_{policy}",
+            "family": "score32_separated_two_pass_decode_shaped_m1x8",
+            "baseline_source_latency_us": base_latency,
+            "hbm_share_scaled_latency_us": round(scaled_latency, 12),
+            "latency_us": round(latency, 12),
+            "token_throughput_per_s": round(1.0e6 / latency, 12),
+            "decode_score_tile_interface": interface,
+            "decode_score_tile_deployment_policy": policy,
+            "decode_score_tile_service": service,
+            "decode_score_tile_schedule": schedule,
+            "decode_score_tile_metrics": _metric_provenance(metric),
+            "decode_score_tile_area_delta_mm2": round(area_delta_mm2, 12),
+            "timing_ok": bool(updated.get("timing_ok", True)) and bool(dense["clock_ok"]),
+            "energy_recost_status": "retained_activity_backed_energy_pending_decode_tile_activity",
+        }
+    )
+    abstractions = [
+        item
+        for item in (str(value) for value in updated.get("remaining_abstractions", []))
+        if "inherited dense-int8 schedule" not in item.lower()
+    ]
+    abstractions.extend(
+        [
+            "decode-shaped tile token energy is retained from prior activity evidence pending VCD/SAIF calibration",
+            "QKV and value-stage reuse of the selected M1x8 result interface is schedule-modeled pending composed routing and quantization RTL",
+            "tile replicas, score banks, divider service, and local routing remain physically uncomposed",
+        ]
+    )
+    updated["remaining_abstractions"] = list(dict.fromkeys(abstractions))
+    return updated
+
+
+def _pareto(rows: list[JsonDict]) -> list[JsonDict]:
+    feasible = [row for row in rows if row["timing_ok"] and row["decode_score_tile_schedule"]["area_fit"]]
+    frontier = []
+    for row in feasible:
+        area = float(row["embodied_logic_plus_score_macro_area_mm2"])
+        latency = float(row["latency_us"])
+        dominated = any(
+            float(other["embodied_logic_plus_score_macro_area_mm2"]) <= area
+            and float(other["latency_us"]) <= latency
+            and (
+                float(other["embodied_logic_plus_score_macro_area_mm2"]) < area
+                or float(other["latency_us"]) < latency
+            )
+            for other in feasible
+        )
+        if not dominated:
+            frontier.append(row)
+    return sorted(frontier, key=lambda row: (float(row["latency_us"]), float(row["embodied_logic_plus_score_macro_area_mm2"])))
+
+
+def build_report(
+    *,
+    operational_frontier_json: Path,
+    subtile_schedule_json: Path,
+    scalar_metrics_csv: Path,
+    packed_metrics_csv: Path,
+) -> JsonDict:
+    frontier = _load(operational_frontier_json)
+    source_rows = [row for row in frontier.get("rows", []) if isinstance(row, dict)]
+    if not source_rows:
+        raise ValueError("operational frontier has no rows")
+    baseline_latency = _positive(source_rows[0]["baseline_source_latency_us"], "baseline source latency")
+    source_schedule = _source_schedule(_load(subtile_schedule_json), latency_us=baseline_latency)
+    schedule_clock = _positive(source_schedule["clock_ns"], "schedule clock")
+    metrics = {
+        "scalar": _select_metric(scalar_metrics_csv, schedule_clock_ns=schedule_clock),
+        "packed": _select_metric(packed_metrics_csv, schedule_clock_ns=schedule_clock),
+    }
+    result_cycles = {"scalar": 8, "packed": 1}
+    rows: list[JsonDict] = []
+    for interface, metric in metrics.items():
+        service = _stage_service(schedule=source_schedule, result_cycles=result_cycles[interface])
+        policies = _replica_policies(
+            schedule=source_schedule,
+            tile_area_um2=_positive(metric["instance_area_um2"], "tile area"),
+            service=service,
+        )
+        for policy, active_replicas in policies:
+            schedule = _recompute_schedule(
+                source_schedule,
+                active_replicas=active_replicas,
+                tile_delay_ns=_positive(metric["critical_path_ns"], "tile delay"),
+                tile_area_um2=_positive(metric["instance_area_um2"], "tile area"),
+                service=service,
+            )
+            for source in source_rows:
+                rows.append(
+                    _replace_frontier_row(
+                        source,
+                        interface=interface,
+                        policy=policy,
+                        metric=metric,
+                        schedule=schedule,
+                        service=service,
+                    )
+                )
+    pareto = _pareto(rows)
+    if not pareto:
+        raise ValueError("no timing- and area-feasible decode-shaped rows")
+    best_throughput = min(pareto, key=lambda row: float(row["latency_us"]))
+    best_area = min(pareto, key=lambda row: float(row["embodied_logic_plus_score_macro_area_mm2"]))
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_decode_score_tile_frontier_v1",
+        "decision": "decode_shaped_m1x8_schedule_and_area_recosted_energy_retained",
+        "inputs": {
+            "operational_frontier_json": str(operational_frontier_json),
+            "subtile_schedule_json": str(subtile_schedule_json),
+            "scalar_metrics_csv": str(scalar_metrics_csv),
+            "packed_metrics_csv": str(packed_metrics_csv),
+        },
+        "measurement_policy": {
+            "schedule": "recompute QKV, QK, value, subtile pipeline, layer, and token cycles from exact M1x8 service",
+            "area": "replace M16x8 fabric scaling with measured M1x8 area and explicit active/area replica counts",
+            "energy": "retain prior activity-backed token energy; vectorless tile power is diagnostic only",
+            "precision": "inherit the merged mixed-int8 Llama7B generation-quality gate",
+            "cross_stage_interface": "model the same selected M1x8 drain mode for QKV, QK, and value until composed routing is measured",
+        },
+        "source_schedule": source_schedule,
+        "selected_scalar_tile": _metric_provenance(metrics["scalar"]),
+        "selected_packed_tile": _metric_provenance(metrics["packed"]),
+        "rows": rows,
+        "pareto_rows": pareto,
+        "diagnosis": {
+            "best_throughput_candidate": best_throughput["candidate_id"],
+            "best_throughput_token_per_s": best_throughput["token_throughput_per_s"],
+            "best_throughput_area_mm2": best_throughput["embodied_logic_plus_score_macro_area_mm2"],
+            "best_area_candidate": best_area["candidate_id"],
+            "best_area_mm2": best_area["embodied_logic_plus_score_macro_area_mm2"],
+            "best_area_token_per_s": best_area["token_throughput_per_s"],
+            "energy_promotion_blocked": True,
+            "next_step": "physically compose one selected M1x8 tile, score bank, and two-pass service cluster with activity",
+        },
+    }
+
+
+def _write_markdown(payload: JsonDict, path: Path) -> None:
+    diagnosis = payload["diagnosis"]
+    lines = [
+        "# Llama7B decode-shaped M1x8 score-tile frontier",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- best throughput: `{diagnosis['best_throughput_token_per_s']}` token/s",
+        f"- best throughput area: `{diagnosis['best_throughput_area_mm2']}` mm2",
+        f"- best area: `{diagnosis['best_area_mm2']}` mm2",
+        f"- best-area throughput: `{diagnosis['best_area_token_per_s']}` token/s",
+        "- activity-backed decode-tile energy promotion: `blocked`",
+        "",
+        "| candidate | token/s | latency us | energy mJ/token | area mm2 | area fit |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["pareto_rows"]:
+        lines.append(
+            f"| {row['candidate_id']} | {row['token_throughput_per_s']} | {row['latency_us']} | "
+            f"{row['energy_mj_per_token']} | {row['embodied_logic_plus_score_macro_area_mm2']} | "
+            f"{row['decode_score_tile_schedule']['area_fit']} |"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--operational-frontier-json", type=Path, required=True)
+    parser.add_argument("--subtile-schedule-json", type=Path, required=True)
+    parser.add_argument("--scalar-metrics-csv", type=Path, required=True)
+    parser.add_argument("--packed-metrics-csv", type=Path, required=True)
+    parser.add_argument("--out-json", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        operational_frontier_json=args.operational_frontier_json,
+        subtile_schedule_json=args.subtile_schedule_json,
+        scalar_metrics_csv=args.scalar_metrics_csv,
+        packed_metrics_csv=args.packed_metrics_csv,
+    )
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_llm_decoder_attention_decode_score_tile_frontier.py
+++ b/tests/test_audit_llm_decoder_attention_decode_score_tile_frontier.py
@@ -1,0 +1,170 @@
+import csv
+import json
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_decode_score_tile_frontier import build_report
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_metrics(path: Path, *, area: float, delay: float, power: float, design: str) -> None:
+    fields = ["status", "design", "instance_area_um2", "critical_path_ns", "total_power_mw"]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "status": "ok",
+                "design": design,
+                "instance_area_um2": area,
+                "critical_path_ns": delay,
+                "total_power_mw": power,
+            }
+        )
+
+
+def _source_schedule() -> dict:
+    return {
+        "latency_us": 1.0,
+        "hidden_size": 16,
+        "attention_heads": 2,
+        "kv_heads": 1,
+        "tile_tokens": 8,
+        "macs_per_cycle": 16,
+        "compute_replica_count": 1,
+        "cluster_count": 2,
+        "per_cluster_macs_per_cycle": 8,
+        "measured_block_macs_per_cycle": 8,
+        "compute_area_multiplier": 2,
+        "compute_area_um2": 80,
+        "compute_budget_um2": 200,
+        "logic_area_used_um2": 100,
+        "clock_ns": 5,
+        "subtile_count": 2,
+        "prefetch_distance": 0,
+        "normalize_strategy": "online_correction",
+        "compute_mode": "dual_mac",
+        "qkv_cycles": 20,
+        "tile_qk_cycles": 8,
+        "tile_value_cycles": 8,
+        "tile_stats_cycles": 4,
+        "subtile_stats_cycles": 2,
+        "tile_hbm_cycles": 4,
+        "subtile_hbm_cycles": 2,
+        "subtile_aux_memory_cycles": 1,
+        "tile_local_sram_cycles": 2,
+        "tile_shared_path_cycles": 2,
+        "tile_waves": 2,
+        "command_dispatch_cycles": 0,
+        "cross_tile_reduction_cycles": 2,
+        "kv_write_cycles": 1,
+        "layers": 2,
+    }
+
+
+def _frontier_row() -> dict:
+    return {
+        "candidate_id": "operational_source",
+        "family": "operational",
+        "baseline_source_latency_us": 1.0,
+        "hbm_share_scale": 1.1,
+        "hbm_share_scaled_latency_us": 1.1,
+        "divider_latency_us": 0.2,
+        "latency_us": 1.3,
+        "token_throughput_per_s": 769230.0,
+        "energy_mj_per_token": 3.5,
+        "logic_plus_service_area_mm2": 0.001,
+        "retained_logic_area_mm2": 0.001,
+        "embodied_logic_plus_score_macro_area_mm2": 0.002,
+        "timing_ok": True,
+        "remaining_abstractions": ["the inherited dense-int8 schedule has not yet been replayed against the separated score32 consumer"],
+        "components": [
+            {
+                "component": "operational_dense_int8_gemm_fabric",
+                "area_um2": 80,
+                "critical_path_ns": 4,
+                "power_mw": 2,
+                "energy_mj_per_token": 0.5,
+            }
+        ],
+    }
+
+
+def test_build_report_recomputes_stage_service_and_exposes_area_throughput_pareto(tmp_path: Path) -> None:
+    operational = tmp_path / "operational.json"
+    schedule = tmp_path / "schedule.json"
+    scalar = tmp_path / "scalar.csv"
+    packed = tmp_path / "packed.csv"
+    _write_json(operational, {"rows": [_frontier_row()]})
+    _write_json(schedule, {"best": _source_schedule(), "top_rows": []})
+    _write_metrics(scalar, area=10, delay=4, power=0.1, design="scalar_m1x8")
+    _write_metrics(packed, area=12, delay=4.5, power=0.12, design="packed_m1x8")
+
+    report = build_report(
+        operational_frontier_json=operational,
+        subtile_schedule_json=schedule,
+        scalar_metrics_csv=scalar,
+        packed_metrics_csv=packed,
+    )
+
+    assert report["model"] == "llm_decoder_attention_decode_score_tile_frontier_v1"
+    assert report["diagnosis"]["energy_promotion_blocked"] is True
+    assert len(report["rows"]) == 6
+    by_key = {
+        (row["decode_score_tile_interface"], row["decode_score_tile_deployment_policy"]): row
+        for row in report["rows"]
+    }
+    scalar_throughput = by_key[("scalar", "throughput_matched")]
+    packed_throughput = by_key[("packed", "throughput_matched")]
+    assert scalar_throughput["decode_score_tile_service"]["result_cycles"] == 8
+    assert packed_throughput["decode_score_tile_service"]["result_cycles"] == 1
+    assert scalar_throughput["decode_score_tile_schedule"]["active_replica_count"] == 6
+    assert packed_throughput["decode_score_tile_schedule"]["active_replica_count"] == 4
+    assert by_key[("packed", "nominal_peak")]["decode_score_tile_schedule"]["tile_qk_cycles"] < by_key[
+        ("scalar", "nominal_peak")
+    ][
+        "decode_score_tile_schedule"
+    ]["tile_qk_cycles"]
+    assert all(row["energy_mj_per_token"] == 3.5 for row in report["rows"])
+    assert all(row["decode_score_tile_schedule"]["area_fit"] for row in report["pareto_rows"])
+    assert all(
+        "inherited dense-int8 schedule" not in " ".join(row["remaining_abstractions"]).lower()
+        for row in report["rows"]
+    )
+
+
+def test_metric_selection_prefers_area_minimum_that_meets_schedule_clock(tmp_path: Path) -> None:
+    operational = tmp_path / "operational.json"
+    schedule = tmp_path / "schedule.json"
+    scalar = tmp_path / "scalar.csv"
+    packed = tmp_path / "packed.csv"
+    _write_json(operational, {"rows": [_frontier_row()]})
+    _write_json(schedule, {"best": _source_schedule(), "top_rows": []})
+    fields = ["status", "design", "instance_area_um2", "critical_path_ns", "total_power_mw"]
+    with scalar.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(
+            [
+                {"status": "ok", "design": "too_slow", "instance_area_um2": 5, "critical_path_ns": 6, "total_power_mw": 0.1},
+                {"status": "ok", "design": "feasible", "instance_area_um2": 10, "critical_path_ns": 4, "total_power_mw": 0.2},
+            ]
+        )
+    _write_metrics(packed, area=12, delay=4.5, power=0.12, design="packed")
+
+    report = build_report(
+        operational_frontier_json=operational,
+        subtile_schedule_json=schedule,
+        scalar_metrics_csv=scalar,
+        packed_metrics_csv=packed,
+    )
+
+    assert report["selected_scalar_tile"]["design"] == "feasible"


### PR DESCRIPTION
## What changed
- add a schedule-aware corrective auditor for measured scalar and packed M1x8 score tiles
- recompute stage-specific QKV, QK, and value service from command, accumulation, and result-drain cycles
- preserve per-cluster replica distribution through the existing subtile pipeline model
- evaluate nominal, throughput-matched, and area-budget deployment policies
- replace M16x8 area scaling, reapply HBM-share/divider latency, and emit an area/throughput Pareto frontier
- retain activity-backed energy explicitly pending M1x8 VCD/SAIF measurement
- add L2 generation, result consumption, proposal, and regression coverage

## Root cause
The prior operational frontier substituted M16x8 area and timing into an inherited 1.575 ms schedule. During M1 decode, its 16 rows cannot represent independent heads with different key matrices, and aggregate-latency scaling would not account for command/result service or per-cluster scheduling.

## Validation
- model tests: 2 passed
- full affected L2 generator/consumer suites: 293 passed
- end-to-end smoke recost against checked-in schedule/frontier artifacts
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`