### PR TITLE
control_plane: invoke decode recost auditor as module

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6675,7 +6675,7 @@ def _decoder_attention_decode_score_tile_frontier_evidence(*, item_id: str) -> d
             {
                 "name": "audit_decode_score_tile_frontier",
                 "run": (
-                    "python3 npu/eval/audit_llm_decoder_attention_decode_score_tile_frontier.py "
+                    "python3 -m npu.eval.audit_llm_decoder_attention_decode_score_tile_frontier "
                     f"--operational-frontier-json {operational} "
                     f"--subtile-schedule-json {schedule} "
                     f"--scalar-metrics-csv {scalar} --packed-metrics-csv {packed} "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7790,7 +7790,9 @@ def test_generate_l2_campaign_task_adds_decode_score_tile_frontier() -> None:
             decoder_inputs = work_item.input_manifest["decoder_contract"]
 
             assert command["name"] == "audit_decode_score_tile_frontier"
-            assert "audit_llm_decoder_attention_decode_score_tile_frontier.py" in command["run"]
+            assert command["run"].startswith(
+                "python3 -m npu.eval.audit_llm_decoder_attention_decode_score_tile_frontier "
+            )
             assert "--scalar-metrics-csv" in command["run"]
             assert "--packed-metrics-csv" in command["run"]
             assert decoder_inputs["decode_score_tile_frontier_out"] in work_item.expected_outputs


### PR DESCRIPTION
## Summary
- invoke the decode-score frontier auditor through Python module execution
- preserve repository-root package resolution on evaluator workers
- assert the executable command form in the task-generator regression

## Root cause
The generated worker command executed the script by path. Its `npu.eval` imports then failed because Python placed `npu/eval` rather than the repository root on `sys.path`.

## Verification
- `pytest control_plane/control_plane/tests/test_l2_task_generator.py -k decode_score_tile_frontier -q`
- exact generated auditor command reproduced successfully with `python3 -m`