### PR TITLE
Consume composed score cluster frontier

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -631,6 +631,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "decode_score_tile_frontier_report",
     ),
     (
+        "decode_score_local_cluster_frontier_out",
+        "decode_score_local_cluster_frontier_report",
+    ),
+    (
         "score_bank_proxy_equivalence_out",
         "score_bank_proxy_equivalence_report",
     ),
@@ -1574,6 +1578,27 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             "best_area_token_per_s",
             "energy_promotion_blocked",
             "next_step",
+        ):
+            if key in diagnosis_dict:
+                parts.append(f"{key}={diagnosis_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_decode_score_local_cluster_frontier_v1":
+        diagnosis = evidence_payload.get("diagnosis")
+        diagnosis_dict = dict(diagnosis) if isinstance(diagnosis, dict) else {}
+        outcome = str(evidence_payload.get("decision") or "decode_score_local_cluster_frontier_recorded")
+        parts = [
+            f"Decoder composed score-cluster frontier recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "prior_best_token_throughput_per_s_retracted",
+            "best_no_stall_candidate",
+            "best_no_stall_token_throughput_upper_bound_per_s",
+            "best_no_stall_latency_lower_bound_us",
+            "best_no_stall_area_mm2",
+            "promotion_blocked",
+            "next_architecture",
         ):
             if key in diagnosis_dict:
                 parts.append(f"{key}={diagnosis_dict.get(key)}")

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -231,6 +231,29 @@ def test_decoder_evidence_paths_recognizes_decode_score_tile_frontier(tmp_path: 
     }
 
 
+def test_decoder_evidence_paths_recognizes_decode_score_local_cluster_frontier(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/decode_score_local_cluster_frontier.json"
+    report_rel = "runs/datasets/demo/decode_score_local_cluster_frontier.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Decode score local-cluster frontier\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "decode_score_local_cluster_frontier_out": evidence_rel,
+                "decode_score_local_cluster_frontier_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=tmp_path, work_item=work_item)
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_decode_score_local_cluster_frontier_out": evidence_rel,
+        "decoder_decode_score_local_cluster_frontier_report": report_rel,
+    }
+
+
 def test_decoder_evidence_summary_recognizes_rtl_component_equivalence() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/operational_tile_equivalence.json",
@@ -273,6 +296,29 @@ def test_decoder_evidence_summary_recognizes_decode_score_tile_frontier() -> Non
     assert "best_throughput_candidate=packed_area_budget" in summary
     assert "best_area_mm2=350.0" in summary
     assert "energy_promotion_blocked=True" in summary
+
+
+def test_decoder_evidence_summary_recognizes_decode_score_local_cluster_frontier() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/decode_score_local_cluster_frontier.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_decode_score_local_cluster_frontier_v1",
+            "decision": "prior_decode_score_tile_frontier_retracted_composed_cluster_lower_bound_only",
+            "diagnosis": {
+                "prior_best_token_throughput_per_s_retracted": 669.8,
+                "best_no_stall_candidate": "decode_score_local_cluster_c128_vl1",
+                "best_no_stall_token_throughput_upper_bound_per_s": 0.521,
+                "best_no_stall_latency_lower_bound_us": 1_918_542.0,
+                "best_no_stall_area_mm2": 634.9,
+                "promotion_blocked": True,
+            },
+        },
+    )
+
+    assert outcome.startswith("prior_decode_score_tile_frontier_retracted")
+    assert "best_no_stall_candidate=decode_score_local_cluster_c128_vl1" in summary
+    assert "best_no_stall_token_throughput_upper_bound_per_s=0.521" in summary
+    assert "promotion_blocked=True" in summary
 
 
 def test_decoder_evidence_summary_recognizes_two_pass_stream_equivalence() -> None:


### PR DESCRIPTION
## Summary
- recognize composed score-cluster frontier JSON/Markdown as decoder evidence
- serialize its retraction, no-stall throughput bound, area, and next architecture in the decision summary
- preserve the already successful remote run for artifact consumption

## Root cause
The L2 task generator added the new abstraction layer, but the result consumer allowlist did not add its output/report keys. Consumption therefore fell through to the generic campaign contract and incorrectly required `best_point.json`.

## Validation
- `94 passed` in `control_plane/tests/test_l2_result_consumer.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`