### PR TITLE
Make cluster frontier evidence portable

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/evaluation_requests.json
@@ -107,7 +107,7 @@
     {
       "item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v1",
       "task_type": "l2_campaign",
-      "status": "ready_to_queue",
+      "status": "superseded",
       "objective": "Retract the bare-M1x8 frontier and recompute a no-stall Llama7B bound from measured composed-cluster area, timing, fill, replay, divider, and value-slice service.",
       "evaluation_mode": "frontier_recost",
       "abstraction_layer": "decoder_attention_decode_score_local_cluster_frontier",
@@ -127,6 +127,32 @@
       "expected_result": {
         "direction": "reprice_with_composed_cluster_lower_bound",
         "reason": "The active frontier must charge the measured 512 KiB score bank and all 16 eight-dimensional value slices per head."
+      },
+      "notes": "Superseded after review found evaluator-local result_path and synth_script_path values in the committed metric provenance."
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+      "task_type": "l2_campaign",
+      "status": "ready_to_queue",
+      "objective": "Repeat the composed-cluster corrective recost with repo-portable metric provenance.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_local_cluster_frontier",
+      "comparison_role": "decode_composed_cluster_corrective_recost",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_local_cluster_pnr_v1",
+        "l2_decoder_attention_decode_score_local_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "remove_evaluator_local_paths_from_cluster_metric_provenance",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "reprice_with_composed_cluster_lower_bound",
+        "reason": "The corrected evidence must preserve the composed result while removing evaluator-local paths."
       }
     }
   ],

--- a/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_tile_m1x8_llama7b_v1/proposal.json
@@ -8,7 +8,7 @@
   "abstraction_layer": "decoder_attention_decode_score_tile_m1x8",
   "hypothesis": "A decode-shaped signed-int8 M1x8 score tile with a packed 256-bit result row will preserve exact Llama7B QK score semantics while materially reducing compute area and result-drain service relative to scaling the measured M16x8 operational GEMM tile.",
   "direct_comparison": {
-    "primary_question": "How do scalar-drain and packed-row M1x8 score tiles change measured area, delay, and the precision-aligned Llama7B token frontier relative to the semantically mismatched M16x8 recost?",
+    "primary_question": "How does the measured composed M1x8 score cluster change the precision-aligned Llama7B frontier once score storage, replay, division, and all 16 value slices per head are charged?",
     "baseline": "l2_decoder_attention_operational_component_frontier_llama7b_v1",
     "include": [
       "one signed query scalar by eight signed key scalars per accepted head-dimension beat",
@@ -170,6 +170,31 @@
       "expected_result": {
         "direction": "reprice_with_composed_cluster_lower_bound",
         "reason": "A full Llama7B head requires 16 eight-dimensional value commands at the measured cluster boundary."
+      },
+      "status": "superseded"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+      "task_type": "l2_campaign",
+      "objective": "Recompute the Llama7B bound from the measured composed cluster with repo-portable physical provenance.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_local_cluster_frontier",
+      "comparison_role": "decode_composed_cluster_corrective_recost",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_local_cluster_pnr_v1",
+        "l2_decoder_attention_decode_score_local_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "remove_evaluator_local_paths_from_cluster_metric_provenance",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "reprice_with_composed_cluster_lower_bound",
+        "reason": "The corrected evidence must retain the composed cycle accounting without evaluator-local artifact paths."
       },
       "status": "ready_to_queue"
     }

--- a/npu/eval/audit_llm_decoder_attention_decode_score_local_cluster_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_decode_score_local_cluster_frontier.py
@@ -34,6 +34,28 @@ def _selected_metric(path: Path) -> JsonDict:
     return min(rows, key=lambda row: (float(row["critical_path_ns"]), float(row["instance_area_um2"])))
 
 
+def _metric_provenance(row: JsonDict, *, metrics_csv: Path) -> JsonDict:
+    keys = (
+        "design",
+        "platform",
+        "config_hash",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "total_power_mw",
+        "instance_area_um2",
+        "stdcell_area_um2",
+        "stdcell_count",
+        "core_area_um2",
+        "utilization_pct",
+        "flow_elapsed_seconds",
+        "params_json",
+    )
+    return {"metrics_csv": str(metrics_csv), **{key: row[key] for key in keys if key in row}}
+
+
 def _source_schedule(frontier: JsonDict) -> JsonDict:
     schedule = frontier.get("source_schedule")
     if not isinstance(schedule, dict):
@@ -213,7 +235,7 @@ def build_report(
             "cluster_metrics_csv": str(cluster_metrics_csv),
             "equivalence_json": str(equivalence_json),
         },
-        "selected_cluster_metric": metric,
+        "selected_cluster_metric": _metric_provenance(metric, metrics_csv=cluster_metrics_csv),
         "dense_qkv_tile": {
             "source": source_tile,
             "area_um2": dense_tile_area_um2,

--- a/tests/test_attention_decode_score_local_cluster_frontier.py
+++ b/tests/test_attention_decode_score_local_cluster_frontier.py
@@ -60,3 +60,6 @@ def test_composed_cluster_frontier_charges_value_slices_and_retracts_prior(tmp_p
     assert report["decision"].startswith("prior_decode_score_tile_frontier_retracted")
     assert report["diagnosis"]["best_no_stall_token_throughput_upper_bound_per_s"] < 1.0
     assert report["diagnosis"]["promotion_blocked"] is True
+    assert report["selected_cluster_metric"]["metrics_csv"] == str(metrics_path)
+    assert "result_path" not in report["selected_cluster_metric"]
+    assert "synth_script_path" not in report["selected_cluster_metric"]


### PR DESCRIPTION
## Summary
- filter composed-cluster PPA provenance to repo-portable fields
- revise the proposal comparison question to the measured cluster boundary
- supersede the non-portable v1 evaluation and define a v2 replacement

## Root cause
The audit copied the complete metrics CSV row into evidence, including evaluator-local `result_path` and `synth_script_path` values. The run was numerically valid but its review artifact violated the portable-path contract.

## Validation
- focused audit test passes
- generated JSON contains no `/tmp` or `/orfs` paths
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`