### PR TITLE
Measure multivalue cluster phase activity

### DIFF
--- a/docs/developer_agent_loop.md
+++ b/docs/developer_agent_loop.md
@@ -218,6 +218,19 @@ The quality precheck must also:
 - keep hashes and trace-only observability disabled outside explicit equivalence runs so they do not contaminate PPA
 - record any externally supplied quantization metadata or scale derivation as a remaining abstraction
 
+For energy claims, vectorless OpenROAD power is not workload energy. An
+activity-backed promotion must:
+- generate VCD/SAIF only through an explicit activity-evaluation command, never in normal PPA RTL or tests
+- use the same ready/valid transaction and numeric inputs already covered by end-to-end equivalence
+- partition traces by architectural phase when a short representative run has a different phase mix from the full workload
+- record measured phase cycles and an exact, reviewable scaling formula to the target context length
+- load the routed netlist, final SDC, and final SPEF used by the cited PPA point
+- require the trace clock period to equal the routed design clock period
+- report and gate VCD/SAIF annotation coverage; reject missing, low-coverage, or `NaN` power instead of falling back to vectorless power
+- require explicit activity on accessed SRAM proxy pins when SRAM proxy energy is included
+- keep evaluator-local VCD, ODB, and SPEF files out of Git while preserving their hashes and portable source identifiers in the result
+- state separately which memory, NoC, HBM, and SRAM-compiler energy terms remain outside the measurement
+
 This is not an extra human approval gate by default.
 It is a mandatory technical gate for numerically sensitive proposals.
 

--- a/npu/eval/generate_attention_decode_score_multivalue_cluster_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_cluster_activity.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Generate phase-specific VCD activity for the shared-score multivalue cluster."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.probe_attention_decode_score_multivalue_cluster_equivalence import (  # noqa: E402
+    _FAKERAM_MODEL,
+    _pack,
+    _signed_literal,
+    _tool,
+    _vectors,
+)
+from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate  # noqa: E402
+
+JsonDict = dict[str, Any]
+
+_PHASES = ("score_fill", "replay_value", "finalize_result")
+_PHASE_DONE_PREFIX = "PHASE_DONE"
+_DEFAULT_HEAD_DIM = 128
+_DEFAULT_BLOCK_COUNT = 2
+_DEFAULT_SCORE_MULTIPLIER = 1 << 20
+_DEFAULT_SCORE_SHIFT = 0
+_DEFAULT_CLOCK_PERIOD_NS = 10.0
+_TARGET_MAX_BLOCKS = 16384
+_VALUE_SLICES = 16
+_VALUE_DIMS = _VALUE_SLICES * 8
+_COMMAND_SETUP_CYCLES = 1
+_REPLAY_CLEAR_CYCLES = _VALUE_SLICES
+_FINALIZE_DIVIDE_CYCLES_PER_DIM = 60
+_FINALIZE_RESULT_EMIT_CYCLES = _VALUE_SLICES
+
+
+def _load(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _cluster_body(config: JsonDict) -> JsonDict:
+    body = config.get("attention_decode_score_multivalue_cluster")
+    if not isinstance(body, dict):
+        raise ValueError("config requires attention_decode_score_multivalue_cluster")
+    return body
+
+
+def _validate_request(*, config: JsonDict, block_count: int, head_dim: int) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    if not top_name:
+        raise ValueError("config requires top_name")
+    body = _cluster_body(config)
+    max_blocks = int(body.get("max_blocks", 0))
+    if max_blocks != _TARGET_MAX_BLOCKS:
+        raise ValueError(f"activity generation requires max_blocks={_TARGET_MAX_BLOCKS}")
+    if block_count < 1:
+        raise ValueError("block_count must be >= 1")
+    if head_dim not in {3, 128}:
+        raise ValueError("head_dim must be 3 or 128")
+    beats, values = _vectors(head_dim=head_dim)
+    if block_count > len(beats):
+        raise ValueError(f"block_count must be <= available representative blocks ({len(beats)})")
+    score_scale_lanes = int(body.get("score_scale_lanes_per_cycle", 1))
+    return {
+        "top_name": top_name,
+        "max_blocks": max_blocks,
+        "score_scale_lanes_per_cycle": score_scale_lanes,
+        "beats": beats[:block_count],
+        "values": values[:block_count],
+    }
+
+
+def _phase_expr(phase: str) -> str:
+    if phase == "score_fill":
+        return "(dut.state_q == 3'd0 && command_valid && command_ready) || dut.state_q == 3'd1 || dut.state_q == 3'd2 || dut.state_q == 3'd3 || dut.state_q == 3'd4 || dut.state_q == 3'd5"
+    if phase == "replay_value":
+        return "dut.reducer.state == 4'd2 || dut.reducer.state == 4'd3 || dut.reducer.state == 4'd4 || dut.reducer.state == 4'd5 || dut.reducer.state == 4'd6"
+    if phase == "finalize_result":
+        return "dut.reducer.state == 4'd7 || dut.reducer.state == 4'd8 || dut.reducer.state == 4'd9 || dut.reducer.state == 4'd10"
+    raise ValueError(f"unknown phase: {phase}")
+
+
+def _testbench(
+    *,
+    top_name: str,
+    beats: list[list[tuple[int, list[int]]]],
+    values: list[list[list[list[int]]]],
+    block_count: int,
+    head_dim: int,
+    score_multiplier: int,
+    score_shift: int,
+    phase: str,
+    vcd_path: Path,
+    clock_period_ns: float,
+) -> str:
+    flat_beats = [beat for block in beats for beat in block]
+    beat_init = "\n".join(
+        f"    q_mem[{index}] = {_signed_literal(q, 8)}; k_mem[{index}] = 64'h{_pack(keys, 8):016x};"
+        for index, (q, keys) in enumerate(flat_beats)
+    )
+    last_indices = {sum(len(block) for block in beats[: index + 1]) - 1 for index in range(len(beats))}
+    last_cases = "\n".join(f"      {index}: input_last = 1'b1;" for index in sorted(last_indices))
+    value_init = "\n".join(
+        f"    value_mem[{block * _VALUE_SLICES + value_slice}] = 512'h"
+        f"{_pack([lane for row in values[block][value_slice] for lane in row], 8):0128x};"
+        for block in range(block_count)
+        for value_slice in range(_VALUE_SLICES)
+    )
+    phase_active = _phase_expr(phase)
+    clock_half_period = clock_period_ns / 2.0
+    return f"""`timescale 1ns/1ps
+{_FAKERAM_MODEL}
+module tb;
+  localparam integer BLOCK_COUNT = {block_count};
+  localparam integer HEAD_DIM = {head_dim};
+  localparam integer TOTAL_BEATS = {len(flat_beats)};
+  reg clk = 0, rst_n = 0;
+  reg command_valid, input_valid, input_last;
+  wire command_ready, input_ready;
+  reg signed [7:0] input_a;
+  reg signed [63:0] input_b;
+  wire value_read_req_valid, value_response_ready;
+  reg value_read_req_ready, value_response_valid;
+  wire [13:0] value_read_req_address;
+  wire [3:0] value_read_req_slice;
+  reg [13:0] value_response_address;
+  reg [3:0] value_response_slice;
+  reg [511:0] value_response_matrix;
+  wire result_valid, result_last;
+  reg result_ready;
+  wire [15:0] result_command_id;
+  wire signed [31:0] result_global_max;
+  wire [32:0] result_exp_sum;
+  wire [3:0] result_slice;
+  wire [319:0] result_value;
+  wire [31:0] accepted_count, completed_count, cycle_count;
+  wire protocol_error;
+  reg signed [7:0] q_mem [0:TOTAL_BEATS-1];
+  reg [63:0] k_mem [0:TOTAL_BEATS-1];
+  reg [511:0] value_mem [0:BLOCK_COUNT*{_VALUE_SLICES}-1];
+  integer input_index = 0;
+  integer phase_cycles = 0;
+  reg value_pending = 0;
+  reg [13:0] pending_addr = 0;
+  reg [3:0] pending_slice = 0;
+  integer pending_delay = 0;
+  reg phase_started = 0;
+
+  always #{clock_half_period:g} clk = ~clk;
+
+  {top_name} dut (
+      .clk(clk), .rst_n(rst_n), .command_valid(command_valid), .command_ready(command_ready),
+      .command_id(16'h4a21), .command_block_count(BLOCK_COUNT),
+      .command_score_multiplier(32'd{score_multiplier}), .command_score_shift(6'd{score_shift}),
+      .input_valid(input_valid), .input_ready(input_ready), .input_last(input_last),
+      .input_a(input_a), .input_b(input_b),
+      .value_read_req_valid(value_read_req_valid), .value_read_req_ready(value_read_req_ready),
+      .value_read_req_address(value_read_req_address), .value_read_req_slice(value_read_req_slice),
+      .value_response_valid(value_response_valid), .value_response_ready(value_response_ready),
+      .value_response_address(value_response_address), .value_response_slice(value_response_slice),
+      .value_response_matrix(value_response_matrix), .result_valid(result_valid), .result_ready(result_ready),
+      .result_command_id(result_command_id), .result_global_max(result_global_max),
+      .result_exp_sum(result_exp_sum), .result_slice(result_slice), .result_last(result_last),
+      .result_value(result_value), .accepted_count(accepted_count), .completed_count(completed_count),
+      .cycle_count(cycle_count), .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    command_valid = rst_n && accepted_count == 0;
+    input_valid = rst_n && input_index < TOTAL_BEATS;
+    input_a = input_index < TOTAL_BEATS ? q_mem[input_index] : 0;
+    input_b = input_index < TOTAL_BEATS ? k_mem[input_index] : 0;
+    input_last = 0;
+    case (input_index)
+{last_cases}
+      default: input_last = 0;
+    endcase
+    value_read_req_ready = 1'b1;
+    result_ready = 1'b1;
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      input_index <= 0;
+      phase_cycles <= 0;
+      value_pending <= 0;
+      value_response_valid <= 0;
+      pending_delay <= 0;
+      value_response_address <= 0;
+      value_response_slice <= 0;
+      value_response_matrix <= 0;
+      phase_started <= 0;
+    end else begin
+      if (input_valid && input_ready) input_index <= input_index + 1;
+      if (value_read_req_valid && value_read_req_ready) begin
+        if (value_pending || value_response_valid) $fatal(1, "multiple outstanding value requests");
+        value_pending <= 1;
+        pending_addr <= value_read_req_address;
+        pending_slice <= value_read_req_slice;
+        pending_delay <= 1;
+      end
+      if (value_pending) begin
+        if (pending_delay == 0) begin
+          value_pending <= 0;
+          value_response_valid <= 1;
+          value_response_address <= pending_addr;
+          value_response_slice <= pending_slice;
+          value_response_matrix <= value_mem[pending_addr * {_VALUE_SLICES} + pending_slice];
+        end else pending_delay <= pending_delay - 1;
+      end
+      if (value_response_valid && value_response_ready) value_response_valid <= 0;
+      if (!phase_started && ({phase_active})) begin
+        phase_started <= 1;
+        phase_cycles <= 1;
+        $dumpon;
+      end else if (phase_started && ({phase_active})) begin
+        phase_cycles <= phase_cycles + 1;
+      end else if (phase_started && !({phase_active})) begin
+        if (protocol_error) $fatal(1, "protocol_error raised during {phase}");
+        $display("{_PHASE_DONE_PREFIX} phase={phase} cycles=%0d service_cycles=%0d accepted=%0d completed=%0d", phase_cycles, cycle_count, accepted_count, completed_count);
+        $dumpoff;
+        #1 $finish;
+      end
+      if (cycle_count > 40000) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+    $dumpfile("{vcd_path.as_posix()}");
+    $dumpvars(0, dut);
+    $dumpoff;
+{beat_init}
+{value_init}
+    value_response_valid = 0; value_response_address = 0; value_response_slice = 0; value_response_matrix = 0;
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1;
+  end
+endmodule
+"""
+
+
+def _parse_phase_cycles(stdout: str, phase: str) -> tuple[int, int]:
+    prefix = f"{_PHASE_DONE_PREFIX} phase={phase} cycles="
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if line.startswith(prefix):
+            fields = line[len(prefix) :].split()
+            phase_cycles = int(fields[0])
+            service_field = next(field for field in fields[1:] if field.startswith("service_cycles="))
+            return phase_cycles, int(service_field.split("=", 1)[1])
+    raise RuntimeError(f"simulation output missing phase completion for {phase}")
+
+
+def _run_phase(
+    *,
+    config: JsonDict,
+    phase: str,
+    out_dir: Path,
+    block_count: int,
+    head_dim: int,
+    clock_period_ns: float,
+    score_multiplier: int,
+    score_shift: int,
+) -> tuple[int, int, Path]:
+    validated = _validate_request(config=config, block_count=block_count, head_dim=head_dim)
+    with tempfile.TemporaryDirectory(prefix=f"decode-score-multivalue-{phase}-") as tmp_text:
+        tmp = Path(tmp_text)
+        rtl_dir = tmp / "rtl"
+        generate(json.loads(json.dumps(config)), rtl_dir)
+        vcd_path = tmp / f"{phase}.vcd"
+        tb_path = tmp / "tb.sv"
+        tb_path.write_text(
+            _testbench(
+                top_name=str(validated["top_name"]),
+                beats=validated["beats"],
+                values=validated["values"],
+                block_count=block_count,
+                head_dim=head_dim,
+                score_multiplier=score_multiplier,
+                score_shift=score_shift,
+                phase=phase,
+                vcd_path=vcd_path,
+                clock_period_ns=clock_period_ns,
+            ),
+            encoding="utf-8",
+        )
+        simv = tmp / "simv"
+        compiled = subprocess.run(
+            [_tool("iverilog"), "-g2012", "-s", "tb", "-o", str(simv), str(rtl_dir / "top.v"), str(tb_path)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"iverilog failed for {phase}:\n{compiled.stderr}")
+        run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=120)
+        if run.returncode:
+            raise RuntimeError(f"simulation failed for {phase}:\n{run.stdout}\n{run.stderr}")
+        cycle_count, service_cycles = _parse_phase_cycles(run.stdout, phase)
+        phase_out = out_dir / f"{phase}.vcd"
+        phase_out.write_bytes(vcd_path.read_bytes())
+        return cycle_count, service_cycles, phase_out
+
+
+def _score_fill_scaling(*, cycle_count: int, block_count: int) -> JsonDict:
+    variable_cycles = cycle_count - _COMMAND_SETUP_CYCLES
+    if variable_cycles < 0 or variable_cycles % block_count != 0:
+        raise RuntimeError("score_fill cycles do not match command-setup plus linear block contract")
+    cycles_per_block = variable_cycles // block_count
+    return {
+        "kind": "fixed_setup_plus_linear_by_block_count",
+        "command_setup_cycles": _COMMAND_SETUP_CYCLES,
+        "representative_block_count": block_count,
+        "cycles_per_block": cycles_per_block,
+        "target_max_blocks": _TARGET_MAX_BLOCKS,
+        "full_context_cycles": _COMMAND_SETUP_CYCLES + cycles_per_block * _TARGET_MAX_BLOCKS,
+        "formula": "command_setup_cycles + cycles_per_block * target_max_blocks",
+    }
+
+
+def _replay_value_scaling(*, cycle_count: int, block_count: int) -> JsonDict:
+    variable_cycles = cycle_count - _REPLAY_CLEAR_CYCLES
+    if variable_cycles < 0 or variable_cycles % block_count != 0:
+        raise RuntimeError("replay_value cycles do not match fixed-clear plus linear replay contract")
+    replay_cycles_per_block = variable_cycles // block_count
+    return {
+        "kind": "fixed_clear_plus_linear_by_block_count",
+        "clear_cycles": _REPLAY_CLEAR_CYCLES,
+        "replay_cycles_per_block": replay_cycles_per_block,
+        "representative_block_count": block_count,
+        "target_max_blocks": _TARGET_MAX_BLOCKS,
+        "full_context_cycles": _REPLAY_CLEAR_CYCLES + replay_cycles_per_block * _TARGET_MAX_BLOCKS,
+        "formula": "clear_cycles + replay_cycles_per_block * target_max_blocks",
+    }
+
+
+def _finalize_result_scaling(*, cycle_count: int) -> JsonDict:
+    expected_cycles = _VALUE_DIMS * _FINALIZE_DIVIDE_CYCLES_PER_DIM + _FINALIZE_RESULT_EMIT_CYCLES
+    if cycle_count != expected_cycles:
+        raise RuntimeError("finalize_result cycles diverged from expected fixed per-command contract")
+    return {
+        "kind": "fixed_per_command",
+        "value_dimensions": _VALUE_DIMS,
+        "divide_cycles_per_dimension": _FINALIZE_DIVIDE_CYCLES_PER_DIM,
+        "result_emit_cycles": _FINALIZE_RESULT_EMIT_CYCLES,
+        "target_max_blocks": _TARGET_MAX_BLOCKS,
+        "full_context_cycles": cycle_count,
+        "formula": "value_dimensions * divide_cycles_per_dimension + result_emit_cycles",
+    }
+
+
+def generate_phase_activity(
+    config: JsonDict,
+    out_dir: Path,
+    *,
+    block_count: int = _DEFAULT_BLOCK_COUNT,
+    head_dim: int = _DEFAULT_HEAD_DIM,
+    clock_period_ns: float = _DEFAULT_CLOCK_PERIOD_NS,
+    score_multiplier: int = _DEFAULT_SCORE_MULTIPLIER,
+    score_shift: int = _DEFAULT_SCORE_SHIFT,
+) -> JsonDict:
+    if clock_period_ns <= 0.0:
+        raise ValueError("clock_period_ns must be > 0")
+    validated = _validate_request(config=config, block_count=block_count, head_dim=head_dim)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    phases: list[JsonDict] = []
+    full_service_cycles = 0
+    for phase in _PHASES:
+        cycle_count, service_cycles, vcd_path = _run_phase(
+            config=config,
+            phase=phase,
+            out_dir=out_dir,
+            block_count=block_count,
+            head_dim=head_dim,
+            clock_period_ns=clock_period_ns,
+            score_multiplier=score_multiplier,
+            score_shift=score_shift,
+        )
+        if phase == "score_fill":
+            scaling = _score_fill_scaling(cycle_count=cycle_count, block_count=block_count)
+        elif phase == "replay_value":
+            scaling = _replay_value_scaling(cycle_count=cycle_count, block_count=block_count)
+        else:
+            scaling = _finalize_result_scaling(cycle_count=cycle_count)
+            full_service_cycles = service_cycles
+        phases.append({
+            "phase": phase,
+            "measured_cycles": cycle_count,
+            "full_context_cycles": scaling["full_context_cycles"],
+            "vcd": vcd_path.name,
+            "vcd_sha256": _sha256_file(vcd_path),
+            "requires_macro_activity": phase in {"score_fill", "replay_value"},
+            "scaling": scaling,
+        })
+
+    partition_cycles = sum(int(row["measured_cycles"]) for row in phases)
+    if partition_cycles != full_service_cycles:
+        raise RuntimeError(
+            "phase activity does not partition the representative full transaction: "
+            f"phases={partition_cycles}, service={full_service_cycles}"
+        )
+
+    manifest = {
+        "version": 1,
+        "model": "decode_score_multivalue_cluster_phase_activity_v1",
+        "generator": "npu/eval/generate_attention_decode_score_multivalue_cluster_activity.py",
+        "top_name": validated["top_name"],
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_activity_v1",
+        "activity_generation": "explicit_script_only",
+        "clock_period_ns": clock_period_ns,
+        "block_count": block_count,
+        "head_dim": head_dim,
+        "beats_per_block": head_dim,
+        "max_blocks": validated["max_blocks"],
+        "target_max_blocks": _TARGET_MAX_BLOCKS,
+        "score_multiplier": score_multiplier,
+        "score_shift": score_shift,
+        "score_scale_lanes_per_cycle": validated["score_scale_lanes_per_cycle"],
+        "value_slices": _VALUE_SLICES,
+        "value_dimensions": _VALUE_DIMS,
+        "representative_full_transaction_cycles": full_service_cycles,
+        "phase_partition_cycle_sum": partition_cycles,
+        "phases": phases,
+    }
+    manifest_path = out_dir / "attention_decode_score_multivalue_cluster_activity_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--block-count", type=int, default=_DEFAULT_BLOCK_COUNT)
+    parser.add_argument("--head-dim", type=int, default=_DEFAULT_HEAD_DIM, choices=[3, 128])
+    parser.add_argument("--clock-period-ns", type=float, default=_DEFAULT_CLOCK_PERIOD_NS)
+    args = parser.parse_args()
+    generate_phase_activity(
+        _load(args.config),
+        args.out,
+        block_count=args.block_count,
+        head_dim=args.head_dim,
+        clock_period_ns=args.clock_period_ns,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -192,10 +192,15 @@ def _run_openroad_phase(
     result: Path,
     timeout_seconds: int,
 ) -> JsonDict:
+    resolved_config = design_config.resolve()
+    if not resolved_config.is_file():
+        raise FileNotFoundError(f"ORFS design config does not exist: {resolved_config}")
     try:
-        config_rel = design_config.resolve().relative_to(ORFS_FLOW.resolve())
-    except ValueError as exc:
-        raise ValueError(f"design config must be below {ORFS_FLOW}: {design_config}") from exc
+        config_arg = str(resolved_config.relative_to(ORFS_FLOW.resolve()))
+    except ValueError:
+        # ORFS includes DESIGN_CONFIG directly, so an absolute out-of-tree
+        # config is valid and useful for isolated workspaces.
+        config_arg = str(resolved_config)
     recipe = (
         ".PHONY: rtlgen_activity_power\n"
         "rtlgen_activity_power:\n"
@@ -207,7 +212,7 @@ def _run_openroad_phase(
     command = [
         "make",
         "--no-print-directory",
-        f"DESIGN_CONFIG={config_rel}",
+        f"DESIGN_CONFIG={config_arg}",
         f"FLOW_VARIANT={flow_variant}",
         "--eval",
         recipe,
@@ -252,7 +257,10 @@ def _orfs_relative_path(path: Path) -> str:
     try:
         return str(path.resolve().relative_to(ORFS_FLOW.resolve()))
     except ValueError:
-        return path.name
+        try:
+            return str(path.resolve().relative_to(Path.cwd().resolve()))
+        except ValueError:
+            return path.name
 
 
 def build_report(
@@ -264,6 +272,8 @@ def build_report(
     scope: str,
     min_vcd_coverage: float,
     min_vcd_pins: int,
+    min_macro_active_coverage: float,
+    min_macro_active_pins: int,
     timeout_seconds: int,
 ) -> JsonDict:
     clock_period_ns = float(manifest.get("clock_period_ns", 0.0))
@@ -290,8 +300,13 @@ def build_report(
             annotated = int(power.get("vcd_annotated_pin_count", 0))
             coverage = annotated / annotatable if annotatable else 0.0
             macro_active = int(power.get("macro_trace_active_pin_count", 0))
+            macro_annotatable = int(power.get("macro_annotatable_pin_count", 0))
+            macro_coverage = macro_active / macro_annotatable if macro_annotatable else 0.0
             coverage_pass = annotated >= min_vcd_pins and coverage >= min_vcd_coverage
-            macro_pass = not phase["requires_macro_activity"] or macro_active > 0
+            macro_pass = not phase["requires_macro_activity"] or (
+                macro_active >= min_macro_active_pins
+                and macro_coverage >= min_macro_active_coverage
+            )
             sdc_period_value = power.get("sdc_clock_period_ns")
             sdc_period_ns = float(sdc_period_value) if sdc_period_value is not None else 0.0
             clock_period_pass = abs(sdc_period_ns - clock_period_ns) <= 1e-6
@@ -313,6 +328,7 @@ def build_report(
                     "vcd_annotation_coverage": coverage,
                     "annotation_gate_pass": coverage_pass,
                     "macro_activity_gate_pass": macro_pass,
+                    "macro_trace_active_coverage": macro_coverage,
                     "clock_period_gate_pass": clock_period_pass,
                     "power_numeric_gate_pass": power_numeric_pass,
                     "phase_gate_pass": coverage_pass and macro_pass and clock_period_pass and power_numeric_pass,
@@ -333,11 +349,15 @@ def build_report(
         "orfs_design_config": _orfs_relative_path(design_config),
         "min_vcd_annotation_coverage": min_vcd_coverage,
         "min_vcd_annotated_pins": min_vcd_pins,
+        "min_macro_trace_active_coverage": min_macro_active_coverage,
+        "min_macro_trace_active_pins": min_macro_active_pins,
         "full_context_cycles": total_cycles,
         "full_context_latency_s": total_cycles * clock_period_ns * 1e-9,
         "full_context_energy_j": total_energy_j if gate_pass else None,
         "phases": measured,
         "source_activity_manifest": _portable_repo_path(manifest_path),
+        "source_activity_manifest_sha256": _sha256(manifest_path),
+        "orfs_design_config_sha256": _sha256(design_config),
         "remaining_abstractions": [
             "FakeRAM power uses the Nangate45 proxy Liberty model, not SRAM compiler signoff.",
             "RTL-generated VCD is mapped onto the post-route netlist; annotation coverage is explicit and gated.",
@@ -389,6 +409,8 @@ def main() -> int:
     parser.add_argument("--scope", default="tb/dut")
     parser.add_argument("--min-vcd-coverage", type=float, default=0.05)
     parser.add_argument("--min-vcd-pins", type=int, default=32)
+    parser.add_argument("--min-macro-active-coverage", type=float, default=0.01)
+    parser.add_argument("--min-macro-active-pins", type=int, default=16)
     parser.add_argument("--timeout-seconds", type=int, default=1800)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path)
@@ -397,6 +419,10 @@ def main() -> int:
         parser.error("--min-vcd-coverage must be in (0, 1]")
     if args.min_vcd_pins <= 0:
         parser.error("--min-vcd-pins must be positive")
+    if not 0.0 < args.min_macro_active_coverage <= 1.0:
+        parser.error("--min-macro-active-coverage must be in (0, 1]")
+    if args.min_macro_active_pins <= 0:
+        parser.error("--min-macro-active-pins must be positive")
     manifest = _load_json(args.activity_manifest)
     payload = build_report(
         manifest=manifest,
@@ -406,6 +432,8 @@ def main() -> int:
         scope=args.scope,
         min_vcd_coverage=args.min_vcd_coverage,
         min_vcd_pins=args.min_vcd_pins,
+        min_macro_active_coverage=args.min_macro_active_coverage,
+        min_macro_active_pins=args.min_macro_active_pins,
         timeout_seconds=args.timeout_seconds,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Measure post-route power from explicit phase VCD activity.
+
+This utility intentionally lives outside the normal PPA sweep.  A regular
+``run_block_sweep.py`` result remains vectorless; only this command may turn a
+functional simulation trace into activity-backed power evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+ORFS_FLOW = Path(os.environ.get("ORFS_FLOW", "/orfs/flow"))
+
+
+def _load_json(path: Path) -> JsonDict:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return raw
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _activity_annotation_counts(stdout: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for line in stdout.splitlines():
+        match = re.fullmatch(r"\s*(vcd|saif|input|unannotated)\s+(\d+)\s*", line)
+        if match:
+            counts[match.group(1)] = int(match.group(2))
+    return counts
+
+
+def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
+    raw_phases = manifest.get("phases")
+    if not isinstance(raw_phases, list) or not raw_phases:
+        raise ValueError("activity manifest requires a non-empty phases[]")
+    rows: list[JsonDict] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(raw_phases):
+        if not isinstance(raw, dict):
+            raise ValueError(f"phases[{index}] must be an object")
+        phase = str(raw.get("phase", raw.get("name", ""))).strip()
+        if not phase or phase in seen:
+            raise ValueError(f"invalid or duplicate phase name at phases[{index}]")
+        seen.add(phase)
+        vcd_value = str(raw.get("vcd", raw.get("vcd_path", ""))).strip()
+        if not vcd_value:
+            raise ValueError(f"phase {phase} is missing vcd/vcd_path")
+        vcd = Path(vcd_value)
+        if not vcd.is_absolute():
+            vcd = (manifest_path.parent / vcd).resolve()
+        if not vcd.is_file():
+            raise FileNotFoundError(f"phase VCD does not exist: {vcd}")
+        expected_hash = str(raw.get("vcd_sha256", "")).strip().lower()
+        actual_hash = _sha256(vcd)
+        if expected_hash and expected_hash != actual_hash:
+            raise ValueError(
+                f"phase {phase} VCD hash mismatch: expected {expected_hash}, got {actual_hash}"
+            )
+        measured_cycles = int(raw.get("measured_cycles", raw.get("trace_cycles", 0)))
+        scaling = raw.get("scaling") if isinstance(raw.get("scaling"), dict) else {}
+        full_context_cycles = int(
+            raw.get("full_context_cycles", scaling.get("full_context_cycles", 0))
+        )
+        if measured_cycles <= 0 or full_context_cycles <= 0:
+            raise ValueError(
+                f"phase {phase} requires positive measured_cycles and full_context_cycles"
+            )
+        rows.append(
+            {
+                **raw,
+                "phase": phase,
+                "vcd": vcd_value,
+                "_resolved_vcd": str(vcd),
+                "vcd_sha256": actual_hash,
+                "measured_cycles": measured_cycles,
+                "full_context_cycles": full_context_cycles,
+                "requires_macro_activity": bool(
+                    raw.get("requires_macro_activity", phase in {"score_fill", "replay_value"})
+                ),
+            }
+        )
+    return rows
+
+
+def _tcl_script() -> str:
+    return r'''source $::env(SCRIPTS_DIR)/load.tcl
+load_design 6_final.odb 6_final.sdc
+read_spef $::env(RESULTS_DIR)/6_final.spef
+log_cmd read_vcd -scope $::env(RTLGEN_ACTIVITY_SCOPE) $::env(RTLGEN_ACTIVITY_VCD)
+
+set annotatable 0
+set vcd_count 0
+set constant_count 0
+set clock_count 0
+set macro_annotatable 0
+set macro_trace_active_count 0
+foreach pin [get_pins -hierarchical *] {
+  if {[get_property $pin is_hierarchical]} {
+    continue
+  }
+  set direction [get_property $pin direction]
+  if {$direction == "internal"} {
+    continue
+  }
+  incr annotatable
+  set activity [get_property $pin activity]
+  set origin [lindex $activity 2]
+  if {$origin == "vcd"} {
+    incr vcd_count
+  } elseif {$origin == "constant"} {
+    incr constant_count
+  } elseif {$origin == "clock"} {
+    incr clock_count
+  }
+  set full_name [get_property $pin full_name]
+  if {[string match "*u_group_*" $full_name]} {
+    incr macro_annotatable
+    set toggle_rate [lindex $activity 0]
+    if {($origin == "vcd" || $origin == "propagated") && $toggle_rate > 0.0} {
+      incr macro_trace_active_count
+    }
+  }
+}
+
+proc rtlgen_json_number {value} {
+  if {[string match -nocase "*nan*" "$value"] ||
+      [string match -nocase "*inf*" "$value"]} {
+    return "null"
+  }
+  if {[catch {format "%.12g" $value} formatted]} {
+    return "null"
+  }
+  return $formatted
+}
+set totals [sta::design_power [sta::corners]]
+set clocks [get_clocks *]
+set sdc_clock_period_ns "null"
+if {[llength $clocks] > 0} {
+  set sdc_clock_period_ns [rtlgen_json_number [get_property [lindex $clocks 0] period]]
+}
+set internal_w [rtlgen_json_number [lindex $totals 0]]
+set switching_w [rtlgen_json_number [lindex $totals 1]]
+set leakage_w [rtlgen_json_number [lindex $totals 2]]
+set total_w [rtlgen_json_number [lindex $totals 3]]
+set fp [open $::env(RTLGEN_ACTIVITY_RESULT) w]
+puts $fp "{"
+puts $fp "  \"internal_w\": $internal_w,"
+puts $fp "  \"switching_w\": $switching_w,"
+puts $fp "  \"leakage_w\": $leakage_w,"
+puts $fp "  \"total_w\": $total_w,"
+puts $fp "  \"sdc_clock_period_ns\": $sdc_clock_period_ns,"
+puts $fp "  \"annotatable_pin_count\": $annotatable,"
+puts $fp "  \"vcd_annotated_pin_count\": $vcd_count,"
+puts $fp "  \"constant_pin_count\": $constant_count,"
+puts $fp "  \"clock_pin_count\": $clock_count,"
+puts $fp "  \"macro_annotatable_pin_count\": $macro_annotatable,"
+puts $fp "  \"macro_trace_active_pin_count\": $macro_trace_active_count"
+puts $fp "}"
+close $fp
+
+report_activity_annotation
+report_power
+'''
+
+
+def _run_openroad_phase(
+    *,
+    design_config: Path,
+    flow_variant: str,
+    vcd: Path,
+    scope: str,
+    tcl: Path,
+    result: Path,
+    timeout_seconds: int,
+) -> JsonDict:
+    try:
+        config_rel = design_config.resolve().relative_to(ORFS_FLOW.resolve())
+    except ValueError as exc:
+        raise ValueError(f"design config must be below {ORFS_FLOW}: {design_config}") from exc
+    recipe = (
+        ".PHONY: rtlgen_activity_power\n"
+        "rtlgen_activity_power:\n"
+        f"\t@RTLGEN_ACTIVITY_VCD='{vcd}' "
+        f"RTLGEN_ACTIVITY_SCOPE='{scope}' "
+        f"RTLGEN_ACTIVITY_RESULT='{result}' "
+        f"$(OPENROAD_CMD) '{tcl}'\n"
+    )
+    command = [
+        "make",
+        "--no-print-directory",
+        f"DESIGN_CONFIG={config_rel}",
+        f"FLOW_VARIANT={flow_variant}",
+        "--eval",
+        recipe,
+        "rtlgen_activity_power",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=ORFS_FLOW,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+    if completed.returncode:
+        raise RuntimeError(
+            "post-route VCD power failed:\n"
+            f"command: {' '.join(command[:4])} ...\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
+        )
+    if not result.is_file():
+        raise RuntimeError("OpenROAD completed without writing the activity power result")
+    payload = _load_json(result)
+    annotation_counts = _activity_annotation_counts(completed.stdout)
+    if "vcd" in annotation_counts and "unannotated" in annotation_counts:
+        payload["leaf_vcd_annotated_pin_count"] = payload.get("vcd_annotated_pin_count", 0)
+        payload["leaf_annotatable_pin_count"] = payload.get("annotatable_pin_count", 0)
+        payload["vcd_annotated_pin_count"] = annotation_counts["vcd"]
+        payload["annotatable_pin_count"] = sum(annotation_counts.values())
+        payload["activity_annotation_counts"] = annotation_counts
+    return payload
+
+
+def _portable_repo_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(Path.cwd().resolve()))
+    except ValueError:
+        return path.name
+
+
+def _orfs_relative_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ORFS_FLOW.resolve()))
+    except ValueError:
+        return path.name
+
+
+def build_report(
+    *,
+    manifest: JsonDict,
+    manifest_path: Path,
+    design_config: Path,
+    flow_variant: str,
+    scope: str,
+    min_vcd_coverage: float,
+    min_vcd_pins: int,
+    timeout_seconds: int,
+) -> JsonDict:
+    clock_period_ns = float(manifest.get("clock_period_ns", 0.0))
+    if clock_period_ns <= 0.0:
+        raise ValueError("activity manifest requires positive clock_period_ns")
+    phases = _phase_rows(manifest, manifest_path)
+    measured: list[JsonDict] = []
+    with tempfile.TemporaryDirectory(prefix="rtlgen-vcd-power-") as temp_text:
+        temp = Path(temp_text)
+        tcl = temp / "activity_power.tcl"
+        tcl.write_text(_tcl_script(), encoding="utf-8")
+        for phase in phases:
+            result = temp / f"{phase['phase']}.json"
+            power = _run_openroad_phase(
+                design_config=design_config,
+                flow_variant=flow_variant,
+                vcd=Path(str(phase["_resolved_vcd"])),
+                scope=scope,
+                tcl=tcl,
+                result=result,
+                timeout_seconds=timeout_seconds,
+            )
+            annotatable = int(power.get("annotatable_pin_count", 0))
+            annotated = int(power.get("vcd_annotated_pin_count", 0))
+            coverage = annotated / annotatable if annotatable else 0.0
+            macro_active = int(power.get("macro_trace_active_pin_count", 0))
+            coverage_pass = annotated >= min_vcd_pins and coverage >= min_vcd_coverage
+            macro_pass = not phase["requires_macro_activity"] or macro_active > 0
+            sdc_period_value = power.get("sdc_clock_period_ns")
+            sdc_period_ns = float(sdc_period_value) if sdc_period_value is not None else 0.0
+            clock_period_pass = abs(sdc_period_ns - clock_period_ns) <= 1e-6
+            component_names = ("internal_w", "switching_w", "leakage_w", "total_w")
+            component_values = [power.get(name) for name in component_names]
+            power_numeric_pass = all(
+                value is not None and math.isfinite(float(value)) and float(value) >= 0.0
+                for value in component_values
+            )
+            total_value = power.get("total_w")
+            total_w = float(total_value) if total_value is not None else 0.0
+            power_numeric_pass = power_numeric_pass and total_w > 0.0
+            full_cycles = int(phase["full_context_cycles"])
+            energy_j = total_w * full_cycles * clock_period_ns * 1e-9
+            measured.append(
+                {
+                    **{key: value for key, value in phase.items() if not key.startswith("_")},
+                    "power": power,
+                    "vcd_annotation_coverage": coverage,
+                    "annotation_gate_pass": coverage_pass,
+                    "macro_activity_gate_pass": macro_pass,
+                    "clock_period_gate_pass": clock_period_pass,
+                    "power_numeric_gate_pass": power_numeric_pass,
+                    "phase_gate_pass": coverage_pass and macro_pass and clock_period_pass and power_numeric_pass,
+                    "full_context_energy_j": energy_j,
+                }
+            )
+    gate_pass = all(bool(row["phase_gate_pass"]) for row in measured)
+    total_cycles = sum(int(row["full_context_cycles"]) for row in measured)
+    total_energy_j = sum(float(row["full_context_energy_j"]) for row in measured)
+    return {
+        "version": 1,
+        "model": "postroute_phase_vcd_power_v1",
+        "status": "activity_backed" if gate_pass else "rejected_annotation_gate",
+        "promotion_gate_pass": gate_pass,
+        "clock_period_ns": clock_period_ns,
+        "scope": scope,
+        "flow_variant": flow_variant,
+        "orfs_design_config": _orfs_relative_path(design_config),
+        "min_vcd_annotation_coverage": min_vcd_coverage,
+        "min_vcd_annotated_pins": min_vcd_pins,
+        "full_context_cycles": total_cycles,
+        "full_context_latency_s": total_cycles * clock_period_ns * 1e-9,
+        "full_context_energy_j": total_energy_j if gate_pass else None,
+        "phases": measured,
+        "source_activity_manifest": _portable_repo_path(manifest_path),
+        "remaining_abstractions": [
+            "FakeRAM power uses the Nangate45 proxy Liberty model, not SRAM compiler signoff.",
+            "RTL-generated VCD is mapped onto the post-route netlist; annotation coverage is explicit and gated.",
+            "Off-cluster value-memory, NoC, and HBM energy are outside this cluster power result.",
+        ],
+    }
+
+
+def write_markdown(payload: JsonDict, path: Path) -> None:
+    lines = [
+        "# Post-route Phase VCD Power",
+        "",
+        f"- status: `{payload['status']}`",
+        f"- promotion_gate_pass: `{payload['promotion_gate_pass']}`",
+        f"- clock_period_ns: `{payload['clock_period_ns']}`",
+        f"- full_context_cycles: `{payload['full_context_cycles']}`",
+        f"- full_context_latency_s: `{payload['full_context_latency_s']}`",
+        f"- full_context_energy_j: `{payload['full_context_energy_j']}`",
+        "",
+        "| phase | measured cycles | full cycles | total W | VCD coverage | macro active pins | energy J | gate |",
+        "|---|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in payload["phases"]:
+        power = row["power"]
+        lines.append(
+            "| {phase} | {measured_cycles} | {full_context_cycles} | {total_w} | "
+            "{coverage:.6f} | {macro_pins} | {energy} | {gate} |".format(
+                phase=row["phase"],
+                measured_cycles=row["measured_cycles"],
+                full_context_cycles=row["full_context_cycles"],
+                total_w=power.get("total_w"),
+                coverage=row["vcd_annotation_coverage"],
+                macro_pins=power.get("macro_trace_active_pin_count", 0),
+                energy=row["full_context_energy_j"],
+                gate=row["phase_gate_pass"],
+            )
+        )
+    lines.extend(["", "## Remaining Abstractions", ""])
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--activity-manifest", type=Path, required=True)
+    parser.add_argument("--design-config", type=Path, required=True)
+    parser.add_argument("--flow-variant", required=True)
+    parser.add_argument("--scope", default="tb/dut")
+    parser.add_argument("--min-vcd-coverage", type=float, default=0.05)
+    parser.add_argument("--min-vcd-pins", type=int, default=32)
+    parser.add_argument("--timeout-seconds", type=int, default=1800)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path)
+    args = parser.parse_args()
+    if not 0.0 < args.min_vcd_coverage <= 1.0:
+        parser.error("--min-vcd-coverage must be in (0, 1]")
+    if args.min_vcd_pins <= 0:
+        parser.error("--min-vcd-pins must be positive")
+    manifest = _load_json(args.activity_manifest)
+    payload = build_report(
+        manifest=manifest,
+        manifest_path=args.activity_manifest,
+        design_config=args.design_config,
+        flow_variant=args.flow_variant,
+        scope=args.scope,
+        min_vcd_coverage=args.min_vcd_coverage,
+        min_vcd_pins=args.min_vcd_pins,
+        timeout_seconds=args.timeout_seconds,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.out_md:
+        write_markdown(payload, args.out_md)
+    return 0 if payload["promotion_gate_pass"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_attention_decode_score_multivalue_cluster_activity.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity.py
@@ -1,0 +1,109 @@
+import hashlib
+import json
+from pathlib import Path
+import shutil
+
+import pytest
+
+from npu.eval.generate_attention_decode_score_multivalue_cluster_activity import generate_phase_activity
+
+
+def _tool_available(name: str) -> bool:
+    return shutil.which(name) is not None or (Path("/oss-cad-suite/bin") / name).exists()
+
+
+def _config() -> dict:
+    return {
+        "top_name": "attention_decode_score_multivalue_cluster_activity",
+        "attention_decode_score_multivalue_cluster": {
+            "max_blocks": 16384,
+            "array_n": 8,
+            "value_slices": 16,
+            "divider_impl": "iterative_restoring",
+            "score_scale_lanes_per_cycle": 1,
+        },
+    }
+
+
+def test_multivalue_cluster_activity_generates_phase_vcds_and_manifest(tmp_path: Path) -> None:
+    if not _tool_available("iverilog") or not _tool_available("vvp"):
+        pytest.skip("iverilog/vvp unavailable")
+
+    manifest = generate_phase_activity(_config(), tmp_path, block_count=2, head_dim=128, clock_period_ns=10.0)
+    manifest_path = tmp_path / "attention_decode_score_multivalue_cluster_activity_manifest.json"
+    assert manifest_path.exists()
+    on_disk = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert on_disk == manifest
+
+    assert manifest["activity_generation"] == "explicit_script_only"
+    assert manifest["block_count"] == 2
+    assert manifest["head_dim"] == 128
+    assert manifest["clock_period_ns"] == 10.0
+    assert manifest["max_blocks"] == 16384
+    assert manifest["target_max_blocks"] == 16384
+    assert manifest["phase_partition_cycle_sum"] == manifest["representative_full_transaction_cycles"]
+
+    phases = {row["phase"]: row for row in manifest["phases"]}
+    assert set(phases) == {"score_fill", "replay_value", "finalize_result"}
+
+    for phase_name, phase in phases.items():
+        vcd_path = tmp_path / phase["vcd"]
+        assert vcd_path.exists()
+        raw = vcd_path.read_bytes()
+        assert raw
+        assert phase["vcd_sha256"] == hashlib.sha256(raw).hexdigest()
+        text = raw.decode("utf-8", errors="ignore")
+        assert "$timescale" in text
+        assert "$scope module tb $end" in text
+        assert phase["measured_cycles"] > 0
+
+    score_fill = phases["score_fill"]
+    assert (score_fill["measured_cycles"] - 1) % manifest["block_count"] == 0
+    assert score_fill["scaling"]["kind"] == "fixed_setup_plus_linear_by_block_count"
+    assert score_fill["scaling"]["cycles_per_block"] == (score_fill["measured_cycles"] - 1) // manifest["block_count"]
+    assert score_fill["full_context_cycles"] == (
+        1 + score_fill["scaling"]["cycles_per_block"] * manifest["target_max_blocks"]
+    )
+
+    replay_value = phases["replay_value"]
+    assert replay_value["measured_cycles"] > 16
+    assert replay_value["scaling"]["kind"] == "fixed_clear_plus_linear_by_block_count"
+    assert replay_value["scaling"]["clear_cycles"] == 16
+    assert replay_value["scaling"]["representative_block_count"] == 2
+    assert replay_value["scaling"]["replay_cycles_per_block"] == (
+        replay_value["measured_cycles"] - 16
+    ) // manifest["block_count"]
+    assert replay_value["full_context_cycles"] == (
+        16 + replay_value["scaling"]["replay_cycles_per_block"] * 16384
+    )
+    assert replay_value["scaling"]["formula"] == "clear_cycles + replay_cycles_per_block * target_max_blocks"
+
+    finalize_result = phases["finalize_result"]
+    assert finalize_result["measured_cycles"] == 128 * 60 + 16
+    assert finalize_result["scaling"] == {
+        "kind": "fixed_per_command",
+        "value_dimensions": 128,
+        "divide_cycles_per_dimension": 60,
+        "result_emit_cycles": 16,
+        "target_max_blocks": 16384,
+        "full_context_cycles": 128 * 60 + 16,
+        "formula": "value_dimensions * divide_cycles_per_dimension + result_emit_cycles",
+    }
+
+
+@pytest.mark.parametrize("block_count", [1, 3])
+def test_phase_scaling_is_invariant_across_representative_block_counts(
+    tmp_path: Path, block_count: int
+) -> None:
+    if not _tool_available("iverilog") or not _tool_available("vvp"):
+        pytest.skip("iverilog/vvp unavailable")
+    manifest = generate_phase_activity(
+        _config(), tmp_path, block_count=block_count, head_dim=128, clock_period_ns=8.0
+    )
+    phases = {row["phase"]: row for row in manifest["phases"]}
+    assert phases["score_fill"]["scaling"]["cycles_per_block"] == 139
+    assert phases["replay_value"]["scaling"]["replay_cycles_per_block"] == 68
+    assert phases["score_fill"]["full_context_cycles"] == 1 + 139 * 16384
+    assert phases["replay_value"]["full_context_cycles"] == 16 + 68 * 16384
+    assert phases["finalize_result"]["full_context_cycles"] == 7696
+    assert manifest["phase_partition_cycle_sum"] == manifest["representative_full_transaction_cycles"]

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 from pathlib import Path
 import tempfile
+from types import SimpleNamespace
 import unittest
 from unittest import mock
 
@@ -30,6 +31,49 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             {"vcd": 35, "saif": 2, "input": 3, "unannotated": 664519},
         )
 
+    def test_openroad_phase_accepts_absolute_out_of_tree_design_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            orfs = root / "orfs"
+            orfs.mkdir()
+            config = root / "external" / "config.mk"
+            config.parent.mkdir()
+            config.write_text("", encoding="utf-8")
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            tcl = root / "power.tcl"
+            tcl.write_text("", encoding="utf-8")
+            result = root / "result.json"
+            result.write_text(
+                json.dumps(
+                    {
+                        "total_w": 1.0,
+                        "internal_w": 0.5,
+                        "switching_w": 0.4,
+                        "leakage_w": 0.1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            completed = SimpleNamespace(
+                returncode=0,
+                stdout="vcd 2\nunannotated 8\n",
+                stderr="",
+            )
+            with mock.patch.object(MODULE, "ORFS_FLOW", orfs), mock.patch.object(
+                MODULE.subprocess, "run", return_value=completed
+            ) as run:
+                MODULE._run_openroad_phase(
+                    design_config=config,
+                    flow_variant="test",
+                    vcd=vcd,
+                    scope="tb/dut",
+                    tcl=tcl,
+                    result=result,
+                    timeout_seconds=10,
+                )
+            command = run.call_args.args[0]
+            self.assertIn(f"DESIGN_CONFIG={config.resolve()}", command)
     def _fixture(self, root: Path) -> tuple[dict, Path]:
         phases = []
         for name, measured, full in (
@@ -78,6 +122,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                         "annotatable_pin_count": 1000,
                         "vcd_annotated_pin_count": 500,
                         "macro_trace_active_pin_count": 10,
+                        "macro_annotatable_pin_count": 100,
                     },
                     {
                         "total_w": 3.0,
@@ -88,6 +133,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                         "annotatable_pin_count": 1000,
                         "vcd_annotated_pin_count": 400,
                         "macro_trace_active_pin_count": 8,
+                        "macro_annotatable_pin_count": 100,
                     },
                     {
                         "total_w": 1.0,
@@ -98,6 +144,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                         "annotatable_pin_count": 1000,
                         "vcd_annotated_pin_count": 300,
                         "macro_trace_active_pin_count": 0,
+                        "macro_annotatable_pin_count": 100,
                     },
                 ]
             )
@@ -110,6 +157,8 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                     scope="tb/dut",
                     min_vcd_coverage=0.25,
                     min_vcd_pins=32,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
                     timeout_seconds=10,
                 )
             self.assertTrue(report["promotion_gate_pass"])
@@ -128,7 +177,8 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "sdc_clock_period_ns": 8.0,
                 "annotatable_pin_count": 100,
                 "vcd_annotated_pin_count": 80,
-                "macro_trace_active_pin_count": 0,
+                "macro_trace_active_pin_count": 1,
+                "macro_annotatable_pin_count": 100,
             }
             with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
                 report = MODULE.build_report(
@@ -139,10 +189,13 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                     scope="tb/dut",
                     min_vcd_coverage=0.05,
                     min_vcd_pins=2,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
                     timeout_seconds=10,
                 )
             self.assertFalse(report["promotion_gate_pass"])
             self.assertIsNone(report["full_context_energy_j"])
+            self.assertLess(report["phases"][0]["macro_trace_active_coverage"], 0.05)
 
     def test_nan_or_missing_power_component_cannot_promote(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:
@@ -159,6 +212,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "annotatable_pin_count": 100,
                 "vcd_annotated_pin_count": 80,
                 "macro_trace_active_pin_count": 10,
+                "macro_annotatable_pin_count": 100,
             }
             with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
                 report = MODULE.build_report(
@@ -169,6 +223,8 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                     scope="tb/dut",
                     min_vcd_coverage=0.05,
                     min_vcd_pins=2,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
                     timeout_seconds=10,
                 )
             self.assertFalse(report["promotion_gate_pass"])

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Unit tests for activity-backed post-route power accounting."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "run_postroute_vcd_power", ROOT / "npu/synth/run_postroute_vcd_power.py"
+)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class PostrouteVcdPowerTests(unittest.TestCase):
+    def test_activity_annotation_counts_parse_openroad_report(self) -> None:
+        counts = MODULE._activity_annotation_counts(
+            "vcd            35\nsaif 2\ninput 3\nunannotated 664519\n"
+        )
+        self.assertEqual(
+            counts,
+            {"vcd": 35, "saif": 2, "input": 3, "unannotated": 664519},
+        )
+
+    def _fixture(self, root: Path) -> tuple[dict, Path]:
+        phases = []
+        for name, measured, full in (
+            ("score_fill", 20, 200),
+            ("replay_value", 30, 300),
+            ("finalize_result", 40, 40),
+        ):
+            vcd = root / f"{name}.vcd"
+            vcd.write_text(f"$comment {name} $end\n", encoding="utf-8")
+            phases.append(
+                {
+                    "phase": name,
+                    "vcd": vcd.name,
+                    "vcd_sha256": MODULE._sha256(vcd),
+                    "measured_cycles": measured,
+                    "full_context_cycles": full,
+                }
+            )
+        manifest = {"clock_period_ns": 8.0, "phases": phases}
+        path = root / "manifest.json"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        return manifest, path
+
+    def test_phase_manifest_rejects_hash_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, path = self._fixture(root)
+            manifest["phases"][0]["vcd_sha256"] = "0" * 64
+            with self.assertRaisesRegex(ValueError, "hash mismatch"):
+                MODULE._phase_rows(manifest, path)
+
+    def test_build_report_accounts_phase_energy_and_gates_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, manifest_path = self._fixture(root)
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power_rows = iter(
+                [
+                    {
+                        "total_w": 2.0,
+                        "internal_w": 1.0,
+                        "switching_w": 0.8,
+                        "leakage_w": 0.2,
+                        "sdc_clock_period_ns": 8.0,
+                        "annotatable_pin_count": 1000,
+                        "vcd_annotated_pin_count": 500,
+                        "macro_trace_active_pin_count": 10,
+                    },
+                    {
+                        "total_w": 3.0,
+                        "internal_w": 1.5,
+                        "switching_w": 1.2,
+                        "leakage_w": 0.3,
+                        "sdc_clock_period_ns": 8.0,
+                        "annotatable_pin_count": 1000,
+                        "vcd_annotated_pin_count": 400,
+                        "macro_trace_active_pin_count": 8,
+                    },
+                    {
+                        "total_w": 1.0,
+                        "internal_w": 0.5,
+                        "switching_w": 0.4,
+                        "leakage_w": 0.1,
+                        "sdc_clock_period_ns": 8.0,
+                        "annotatable_pin_count": 1000,
+                        "vcd_annotated_pin_count": 300,
+                        "macro_trace_active_pin_count": 0,
+                    },
+                ]
+            )
+            with mock.patch.object(MODULE, "_run_openroad_phase", side_effect=lambda **_: next(power_rows)):
+                report = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.25,
+                    min_vcd_pins=32,
+                    timeout_seconds=10,
+                )
+            self.assertTrue(report["promotion_gate_pass"])
+            self.assertEqual(report["full_context_cycles"], 540)
+            expected = (2.0 * 200 + 3.0 * 300 + 1.0 * 40) * 8.0e-9
+            self.assertAlmostEqual(report["full_context_energy_j"], expected)
+
+    def test_required_macro_phase_cannot_promote_without_macro_activity(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, manifest_path = self._fixture(root)
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = {
+                "total_w": 1.0,
+                "sdc_clock_period_ns": 8.0,
+                "annotatable_pin_count": 100,
+                "vcd_annotated_pin_count": 80,
+                "macro_trace_active_pin_count": 0,
+            }
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                report = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.05,
+                    min_vcd_pins=2,
+                    timeout_seconds=10,
+                )
+            self.assertFalse(report["promotion_gate_pass"])
+            self.assertIsNone(report["full_context_energy_j"])
+
+    def test_nan_or_missing_power_component_cannot_promote(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, manifest_path = self._fixture(root)
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = {
+                "total_w": 1.0,
+                "internal_w": None,
+                "switching_w": 0.8,
+                "leakage_w": 0.2,
+                "sdc_clock_period_ns": 8.0,
+                "annotatable_pin_count": 100,
+                "vcd_annotated_pin_count": 80,
+                "macro_trace_active_pin_count": 10,
+            }
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                report = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.05,
+                    min_vcd_pins=2,
+                    timeout_seconds=10,
+                )
+            self.assertFalse(report["promotion_gate_pass"])
+            self.assertFalse(report["phases"][0]["power_numeric_gate_pass"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- generate explicit score-fill, replay/value, and finalize/result VCD traces from the end-to-end multivalue-cluster transaction
- prove representative 1/2/3-block traces scale to the exact 16K-token phase cycle contract without gaps
- load routed ODB/SDC/SPEF in OpenROAD, apply each phase VCD, and gate annotation coverage, clock agreement, SRAM-proxy activity, and finite power
- keep VCD/ODB/SPEF evaluator-local while emitting portable JSON/Markdown evidence
- document the activity-backed energy requirements for developer agents

## Why

The existing PPA result reports vectorless power, which cannot support token-energy ranking. Phase traces avoid distorting full-context energy with the fixed 7,696-cycle divider tail present in short representative simulations.

## Validation

- `python3 -m pytest -q tests/test_attention_decode_score_multivalue_cluster.py tests/test_attention_decode_score_multivalue_cluster_activity.py tests/test_postroute_vcd_power.py` (12 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- real ORFS smoke test against a routed Nangate45 ODB/SDC/SPEF, including clean rejection of unannotated/NaN power
