### PR TITLE
Queue multivalue cluster activity power

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6708,6 +6708,69 @@ def _decoder_attention_decode_score_multivalue_cluster_equivalence_evidence(*, i
     }
 
 
+def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    config = (
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+        "config.json"
+    )
+    cluster_metrics_csv = (
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+        "metrics.csv"
+    )
+    equivalence_json = (
+        f"{base}/decoder_attention_decode_score_multivalue_cluster_equivalence__"
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json"
+    )
+    orfs_design_config = (
+        "/orfs/flow/designs/nangate45/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+        "config.mk"
+    )
+    activity_dir = "/tmp/rtlgen_multivalue_cluster_activity"
+    out = f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__{item_id}.json"
+    report = f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__{item_id}.md"
+    return {
+        "inputs": {
+            "decode_score_multivalue_cluster_config": config,
+            "decode_score_multivalue_cluster_pnr_metrics_csv": cluster_metrics_csv,
+            "decode_score_multivalue_cluster_equivalence_json": equivalence_json,
+            "decode_score_multivalue_cluster_orfs_design_config": orfs_design_config,
+            "decode_score_multivalue_cluster_activity_dir": activity_dir,
+            "decode_score_multivalue_cluster_activity_power_out": out,
+            "decode_score_multivalue_cluster_activity_power_report": report,
+            "decode_score_multivalue_cluster_activity_power_scope": (
+                "Audit the shared-score multivalue cluster with activity-backed power evidence after merged "
+                "equivalence and PNR. Keep VCD/ODB/SPEF evaluator-local, commit only repo-portable JSON/MD "
+                "artifacts, preserve the FakeRAM proxy qualification, and reject vectorless power as a "
+                "substitute for annotated power or token-energy claims."
+            ),
+            "decode_score_multivalue_cluster_activity_power_promotion_gate": (
+                "Promotion requires explicit annotation coverage, declared clock assumptions, macro activity "
+                "attribution, and finite power-gate accounting."
+            ),
+            "decode_score_multivalue_cluster_activity_power_local_only_artifacts": ["VCD", "ODB", "SPEF"],
+        },
+        "commands": [
+            {
+                "name": "audit_decode_score_multivalue_cluster_activity_power",
+                "run": (
+                    "python3 -m npu.eval.audit_attention_decode_score_multivalue_cluster_activity_power "
+                    f"--config {config} "
+                    f"--cluster-metrics-csv {cluster_metrics_csv} "
+                    f"--equivalence-json {equivalence_json} "
+                    f"--orfs-design-config {orfs_design_config} "
+                    "--clock-period-ns 8 "
+                    f"--activity-dir {activity_dir} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_decode_score_tile_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     operational = (
@@ -10330,6 +10393,7 @@ def _build_payload(
         "decoder_attention_decode_score_tile_equivalence",
         "decoder_attention_decode_score_local_cluster_equivalence",
         "decoder_attention_decode_score_multivalue_cluster_equivalence",
+        "decoder_attention_decode_score_multivalue_cluster_activity_power",
         "decoder_attention_decode_score_tile_frontier",
         "decoder_attention_decode_score_local_cluster_frontier",
         "decoder_attention_score_bank_proxy_equivalence",
@@ -10566,6 +10630,10 @@ def _build_payload(
             decoder_evidence = _decoder_attention_decode_score_local_cluster_equivalence_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_cluster_equivalence":
             decoder_evidence = _decoder_attention_decode_score_multivalue_cluster_equivalence_evidence(
+                item_id=item_id
+            )
+        elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_cluster_activity_power":
+            decoder_evidence = _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(
                 item_id=item_id
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_tile_frontier":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7833,6 +7833,86 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_equivale
             )
 
 
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity_power() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_cluster_activity_power",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:2]] == [
+                "audit_decode_score_multivalue_cluster_activity_power",
+                "validate_runs",
+            ]
+            assert "-m npu.eval.audit_attention_decode_score_multivalue_cluster_activity_power" in run
+            assert "--config runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json" in run
+            assert (
+                "--cluster-metrics-csv "
+                "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv"
+            ) in run
+            assert (
+                "--equivalence-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_equivalence__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json"
+            ) in run
+            assert (
+                "--orfs-design-config "
+                "/orfs/flow/designs/nangate45/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.mk"
+            ) in run
+            assert "--clock-period-ns 8" in run
+            assert "--activity-dir /tmp/rtlgen_multivalue_cluster_activity" in run
+            assert decoder_inputs["decode_score_multivalue_cluster_equivalence_json"].endswith(
+                "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json"
+            )
+            assert decoder_inputs["decode_score_multivalue_cluster_activity_power_local_only_artifacts"] == [
+                "VCD",
+                "ODB",
+                "SPEF",
+            ]
+            assert "vectorless power as a substitute" in decoder_inputs[
+                "decode_score_multivalue_cluster_activity_power_scope"
+            ]
+            assert "annotation coverage" in decoder_inputs[
+                "decode_score_multivalue_cluster_activity_power_promotion_gate"
+            ]
+            assert (
+                decoder_inputs["decode_score_multivalue_cluster_activity_power_out"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.md"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_adds_decode_score_tile_frontier() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/README.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/README.md
@@ -1,0 +1,15 @@
+# Shared-Score Multivalue Cluster Activity-Power Gate
+
+This proposal wires the activity-backed power audit for
+`l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1`.
+It is an evidence-only remote-evaluator job for the shared-score multivalue
+decode cluster.
+
+The evaluator may generate VCD/ODB/SPEF and temporary activity artifacts
+locally, but only repo-portable JSON and Markdown summaries may be committed
+under `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/`.
+
+Promotion remains blocked until the audit names annotation coverage, clock
+assumptions, macro activity attribution, and finite power-gate assumptions.
+OpenROAD vectorless power remains diagnostic only, and the installed FakeRAM
+score-store views remain physical proxies.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,14 @@
+# Evaluation Gate
+
+1. Queue only after merged
+   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1` and
+   `l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1`
+   evidence is available.
+2. Run the activity-power audit on the remote evaluator with evaluator-local
+   VCD/ODB/SPEF and temporary activity files; commit only portable JSON/MD.
+3. Require the result to spell out annotation coverage, clock assumptions,
+   macro activity attribution, and finite power-gate assumptions.
+4. Keep the FakeRAM score-store qualification explicit; no SRAM signoff or
+   silicon-current claim is allowed from LEF/LIB proxy views.
+5. Treat vectorless OpenROAD power as structural diagnostics only. It cannot
+   substitute for activity-backed power or token-energy claims.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+  "source_commit_note": "Queue this audit only after the activity-power hook merges; it depends on already-merged shared-score multivalue-cluster PNR and equivalence evidence.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit shared-score multivalue-cluster activity-backed power using merged PNR, merged equivalence, evaluator-local switching artifacts, and portable JSON/MD outputs.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "Promotion requires explicit annotation, clock, macro activity, and finite power-gate evidence; vectorless power cannot substitute."
+      },
+      "status": "pending_implementation_merge"
+    }
+  ]
+}

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -1,0 +1,88 @@
+{
+  "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+  "created_utc": "2026-07-15T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Activity-backed power gate for the shared-score multivalue decode cluster",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+  "hypothesis": "The shared-score multivalue decode cluster can only become promotable if activity-annotated power remains coherent after the merged equivalence proof and merged Nangate45 PNR row are combined with evaluator-local switching evidence; vectorless power alone is insufficient.",
+  "direct_comparison": {
+    "primary_question": "Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?",
+    "baseline": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+    "include": [
+      "merged shared-score multivalue-cluster equivalence evidence",
+      "merged Nangate45 PNR metrics at the committed 8 ns point",
+      "evaluator-local VCD, ODB, and SPEF used only to derive portable JSON/MD outputs",
+      "annotation, clock, macro activity, and finite power-gate assumptions called out explicitly",
+      "repo-portable evidence outputs under runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    ],
+    "exclude": [
+      "do not commit raw VCD, ODB, SPEF, or temporary activity directories",
+      "do not treat OpenROAD vectorless power as a substitute for activity-backed power",
+      "do not claim SRAM signoff or silicon-current accuracy from FakeRAM proxy views alone",
+      "do not promote token-energy claims without the explicit activity-power gate"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "instance_area_um2",
+      "vectorless_total_power_mw",
+      "phase_internal_power_w",
+      "phase_switching_power_w",
+      "phase_leakage_power_w",
+      "phase_total_power_w",
+      "macro_trace_active_coverage",
+      "vcd_annotation_coverage",
+      "full_context_head_energy_j",
+      "promotion_ready"
+    ]
+  },
+  "expected_benefit": [
+    "replaces a vectorless-only power placeholder with an activity-backed audit",
+    "preserves evaluator-local heavy artifacts while keeping committed evidence portable",
+    "states exactly what remains blocked before promotion or token-energy reuse"
+  ],
+  "risks": [
+    "annotation coverage may be partial or require explicit caveats",
+    "FakeRAM macro power remains a proxy rather than final SRAM signoff",
+    "the audit may prove the current cluster is still not promotable even after activity accounting"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit shared-score multivalue-cluster activity-backed power using merged PNR, merged equivalence, evaluator-local switching artifacts, and portable JSON/MD outputs.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "Promotion requires explicit annotation, clock, macro activity, and finite power-gate evidence; vectorless power cannot substitute."
+      },
+      "status": "pending_implementation_merge"
+    }
+  ],
+  "baseline_refs": [
+    "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json",
+    "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json",
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py",
+    "npu/synth/run_postroute_vcd_power.py",
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_gate.md"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "VCD, ODB, SPEF, and temporary activity directories remain evaluator-local and must be summarized into portable JSON/MD rather than committed verbatim.",
+    "Promotion still requires explicit annotation coverage, named clock assumptions, macro activity attribution, and finite power-gate accounting.",
+    "The installed FakeRAM views remain LEF/LIB physical proxies without SRAM GDS or signoff current models.",
+    "Vectorless OpenROAD power remains diagnostic only and cannot substitute for activity-backed power or token-energy claims."
+  ]
+}

--- a/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Measure activity-backed power across feasible multivalue-cluster PPA rows."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from npu.eval.generate_attention_decode_score_multivalue_cluster_activity import (
+    generate_phase_activity,
+)
+from npu.synth.run_postroute_vcd_power import build_report as build_power_report
+
+
+JsonDict = dict[str, Any]
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return payload
+
+
+def _params(row: JsonDict) -> JsonDict:
+    try:
+        payload = json.loads(str(row.get("params_json", "{}")))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid params_json for PPA row {row.get('param_hash')}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"params_json is not an object for PPA row {row.get('param_hash')}")
+    return payload
+
+
+def _metric_provenance(row: JsonDict, metrics_csv: Path) -> JsonDict:
+    fields = (
+        "design",
+        "platform",
+        "config_hash",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "total_power_mw",
+        "instance_area_um2",
+        "stdcell_area_um2",
+        "stdcell_count",
+        "core_area_um2",
+        "utilization_pct",
+        "flow_elapsed_seconds",
+        "stage_elapsed_seconds",
+        "params_json",
+    )
+    return {
+        "metrics_csv": str(metrics_csv),
+        **{field: row[field] for field in fields if str(row.get(field, "")).strip()},
+    }
+
+
+def _feasible_metrics(metrics_csv: Path, clock_period_ns: float) -> list[JsonDict]:
+    with metrics_csv.open(newline="", encoding="utf-8") as handle:
+        raw_rows = [dict(row) for row in csv.DictReader(handle)]
+    selected: dict[str, JsonDict] = {}
+    for row in raw_rows:
+        if str(row.get("status", "")) != "ok":
+            continue
+        params = _params(row)
+        row_clock = float(params.get("CLOCK_PERIOD", 0.0))
+        critical_path = float(row.get("critical_path_ns") or math.inf)
+        flow_variant = str(params.get("FLOW_VARIANT", "")).strip()
+        if not flow_variant or abs(row_clock - clock_period_ns) > 1e-9:
+            continue
+        if not math.isfinite(critical_path) or critical_path > clock_period_ns:
+            continue
+        previous = selected.get(flow_variant)
+        if previous is None or float(row.get("instance_area_um2") or math.inf) < float(
+            previous.get("instance_area_um2") or math.inf
+        ):
+            selected[flow_variant] = row
+    if not selected:
+        raise ValueError(
+            f"no status=ok timing-feasible {clock_period_ns:g} ns rows in {metrics_csv}"
+        )
+    return sorted(
+        selected.values(),
+        key=lambda row: (
+            float(row.get("die_area") or math.inf),
+            float(row.get("instance_area_um2") or math.inf),
+            float(row.get("critical_path_ns") or math.inf),
+        ),
+    )
+
+
+def _sanitized_failure(exc: Exception) -> JsonDict:
+    message = str(exc).splitlines()[0].strip()
+    if "/" in message:
+        message = f"evaluator-local path failure during {type(exc).__name__}"
+    return {"error_type": type(exc).__name__, "error_summary": message[:240]}
+
+
+def _write_markdown(payload: JsonDict, path: Path) -> None:
+    lines = [
+        "# Shared-score multivalue cluster activity power",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- promoted candidates: `{payload['promoted_candidate_count']}`",
+        f"- measured candidates: `{payload['candidate_count']}`",
+        "",
+        "| variant | path ns | instance mm2 | status | head cycles | head latency ms | energy mJ |",
+        "|---|---:|---:|---|---:|---:|---:|",
+    ]
+    for row in payload["candidates"]:
+        metric = row["ppa_metric"]
+        activity = row.get("activity_power", {})
+        energy = activity.get("full_context_energy_j")
+        lines.append(
+            "| {variant} | {path_ns} | {area_mm2:.6f} | {status} | {cycles} | {latency_ms} | {energy_mj} |".format(
+                variant=row["flow_variant"],
+                path_ns=metric.get("critical_path_ns"),
+                area_mm2=float(metric.get("instance_area_um2", 0.0)) / 1.0e6,
+                status=row["status"],
+                cycles=activity.get("full_context_cycles"),
+                latency_ms=(
+                    float(activity["full_context_latency_s"]) * 1.0e3
+                    if activity.get("full_context_latency_s") is not None
+                    else None
+                ),
+                energy_mj=float(energy) * 1.0e3 if energy is not None else None,
+            )
+        )
+    lines.extend(["", "## Remaining Abstractions", ""])
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_report(
+    *,
+    config: Path,
+    cluster_metrics_csv: Path,
+    equivalence_json: Path,
+    orfs_design_config: Path,
+    clock_period_ns: float,
+    activity_dir: Path,
+) -> JsonDict:
+    equivalence = _load(equivalence_json)
+    if not equivalence.get("equivalence_pass"):
+        raise ValueError("multivalue-cluster end-to-end equivalence did not pass")
+    activity_dir.mkdir(parents=True, exist_ok=True)
+    for name in (
+        "score_fill.vcd",
+        "replay_value.vcd",
+        "finalize_result.vcd",
+        "attention_decode_score_multivalue_cluster_activity_manifest.json",
+    ):
+        path = activity_dir / name
+        if path.is_file():
+            path.unlink()
+    activity_manifest = generate_phase_activity(
+        _load(config),
+        activity_dir,
+        block_count=3,
+        head_dim=128,
+        clock_period_ns=clock_period_ns,
+    )
+    activity_manifest_path = (
+        activity_dir / "attention_decode_score_multivalue_cluster_activity_manifest.json"
+    )
+    rows: list[JsonDict] = []
+    for metric in _feasible_metrics(cluster_metrics_csv, clock_period_ns):
+        params = _params(metric)
+        flow_variant = str(params["FLOW_VARIANT"])
+        candidate: JsonDict = {
+            "candidate_id": f"multivalue_cluster_activity_{flow_variant}",
+            "flow_variant": flow_variant,
+            "ppa_metric": _metric_provenance(metric, cluster_metrics_csv),
+        }
+        try:
+            activity_power = build_power_report(
+                manifest=activity_manifest,
+                manifest_path=activity_manifest_path,
+                design_config=orfs_design_config,
+                flow_variant=flow_variant,
+                scope="tb/dut",
+                min_vcd_coverage=0.05,
+                min_vcd_pins=32,
+                min_macro_active_coverage=0.01,
+                min_macro_active_pins=16,
+                timeout_seconds=1800,
+            )
+            candidate["activity_power"] = activity_power
+            candidate["status"] = (
+                "activity_backed" if activity_power.get("promotion_gate_pass") else "rejected_gate"
+            )
+        except Exception as exc:  # preserve an explicit negative row for physical-tool failures
+            candidate["status"] = "measurement_failed"
+            candidate["failure"] = _sanitized_failure(exc)
+        rows.append(candidate)
+    promoted = [row for row in rows if row["status"] == "activity_backed"]
+    best = None
+    if promoted:
+        best = min(
+            promoted,
+            key=lambda row: (
+                float(row["activity_power"]["full_context_energy_j"]),
+                float(row["ppa_metric"]["instance_area_um2"]),
+                float(row["ppa_metric"]["critical_path_ns"]),
+            ),
+        )
+    return {
+        "version": 1,
+        "model": "decoder_attention_decode_score_multivalue_cluster_activity_power_v1",
+        "decision": (
+            "activity_backed_cluster_power_measured"
+            if best is not None
+            else "activity_power_rejected_no_gated_candidate"
+        ),
+        "promotion_gate_pass": best is not None,
+        "candidate_count": len(rows),
+        "promoted_candidate_count": len(promoted),
+        "best_candidate_id": best["candidate_id"] if best is not None else None,
+        "best": best,
+        "candidates": rows,
+        "activity_contract": {
+            "clock_period_ns": activity_manifest["clock_period_ns"],
+            "representative_block_count": activity_manifest["block_count"],
+            "representative_full_transaction_cycles": activity_manifest[
+                "representative_full_transaction_cycles"
+            ],
+            "phase_partition_cycle_sum": activity_manifest["phase_partition_cycle_sum"],
+            "phases": activity_manifest["phases"],
+        },
+        "precision_status": "unchanged_integer_contract_from_merged_multivalue_equivalence",
+        "equivalence": {
+            "equivalence_pass": True,
+            "decision": equivalence.get("decision"),
+            "score_tensor_hash": equivalence.get("score_tensor_hash"),
+            "final_tensor_hash": equivalence.get("final_tensor_hash"),
+        },
+        "source_dependencies": [
+            "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+            "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+        ],
+        "remaining_abstractions": [
+            "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
+            "Value-memory, NoC, HBM/DRAM, command-distribution, and clock-tree composition outside the cluster are not included.",
+            "RTL VCD is mapped to the routed netlist; each candidate records and gates direct annotation coverage.",
+            "Score multiplier and shift derivation remain external to the cluster boundary.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--cluster-metrics-csv", type=Path, required=True)
+    parser.add_argument("--equivalence-json", type=Path, required=True)
+    parser.add_argument("--orfs-design-config", type=Path, required=True)
+    parser.add_argument("--clock-period-ns", type=float, default=8.0)
+    parser.add_argument("--activity-dir", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        config=args.config,
+        cluster_metrics_csv=args.cluster_metrics_csv,
+        equivalence_json=args.equivalence_json,
+        orfs_design_config=args.orfs_design_config,
+        clock_period_ns=args.clock_period_ns,
+        activity_dir=args.activity_dir,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Tests for the multivalue-cluster activity power frontier audit."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from unittest import mock
+
+from npu.eval import audit_attention_decode_score_multivalue_cluster_activity_power as audit
+
+
+def _write_metrics(path: Path) -> None:
+    fields = [
+        "design",
+        "platform",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "instance_area_um2",
+        "params_json",
+    ]
+    rows = [
+        {
+            "design": "cluster",
+            "platform": "nangate45",
+            "param_hash": "p10",
+            "tag": "die2500",
+            "status": "ok",
+            "critical_path_ns": "7.0",
+            "die_area": "6250000",
+            "instance_area_um2": "3000000",
+            "params_json": json.dumps(
+                {"CLOCK_PERIOD": 10, "FLOW_VARIANT": "cluster_die2500"}
+            ),
+        },
+        {
+            "design": "cluster",
+            "platform": "nangate45",
+            "param_hash": "p8a",
+            "tag": "die2500",
+            "status": "ok",
+            "critical_path_ns": "7.5",
+            "die_area": "6250000",
+            "instance_area_um2": "3100000",
+            "params_json": json.dumps(
+                {"CLOCK_PERIOD": 8, "FLOW_VARIANT": "cluster_die2500"}
+            ),
+        },
+        {
+            "design": "cluster",
+            "platform": "nangate45",
+            "param_hash": "p8b",
+            "tag": "die3000",
+            "status": "ok",
+            "critical_path_ns": "8.1",
+            "die_area": "9000000",
+            "instance_area_um2": "3050000",
+            "params_json": json.dumps(
+                {"CLOCK_PERIOD": 8, "FLOW_VARIANT": "cluster_die3000"}
+            ),
+        },
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_feasible_metrics_selects_exact_clock_and_timing(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics)
+    rows = audit._feasible_metrics(metrics, 8.0)
+    assert [audit._params(row)["FLOW_VARIANT"] for row in rows] == ["cluster_die2500"]
+
+
+def test_build_report_rejects_unproven_equivalence(tmp_path: Path) -> None:
+    equivalence = tmp_path / "equivalence.json"
+    equivalence.write_text('{"equivalence_pass": false}', encoding="utf-8")
+    with mock.patch.object(audit, "generate_phase_activity") as generate:
+        try:
+            audit.build_report(
+                config=tmp_path / "config.json",
+                cluster_metrics_csv=tmp_path / "metrics.csv",
+                equivalence_json=equivalence,
+                orfs_design_config=tmp_path / "config.mk",
+                clock_period_ns=8.0,
+                activity_dir=tmp_path / "activity",
+            )
+        except ValueError as exc:
+            assert "equivalence did not pass" in str(exc)
+        else:
+            raise AssertionError("unproven equivalence was accepted")
+    generate.assert_not_called()
+
+
+def test_build_report_records_promoted_and_failed_variants(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    config.write_text("{}", encoding="utf-8")
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics)
+    # Make the second 8 ns row feasible so both physical variants are attempted.
+    rows = list(csv.DictReader(metrics.open(encoding="utf-8")))
+    rows[-1]["critical_path_ns"] = "7.9"
+    with metrics.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+    manifest = {
+        "clock_period_ns": 8.0,
+        "block_count": 3,
+        "representative_full_transaction_cycles": 8334,
+        "phase_partition_cycle_sum": 8334,
+        "phases": [],
+    }
+    power_ok = {
+        "promotion_gate_pass": True,
+        "full_context_energy_j": 0.002,
+        "full_context_cycles": 3399201,
+        "full_context_latency_s": 0.027193608,
+    }
+    equivalence = tmp_path / "equivalence.json"
+    equivalence.write_text(
+        json.dumps(
+            {
+                "equivalence_pass": True,
+                "decision": "shared_score_multivalue_cluster_equivalent",
+                "score_tensor_hash": "score-hash",
+                "final_tensor_hash": "final-hash",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with mock.patch.object(audit, "generate_phase_activity", return_value=manifest), mock.patch.object(
+        audit,
+        "build_power_report",
+        side_effect=[power_ok, RuntimeError("/orfs/missing result")],
+    ):
+        payload = audit.build_report(
+            config=config,
+            cluster_metrics_csv=metrics,
+            equivalence_json=equivalence,
+            orfs_design_config=tmp_path / "config.mk",
+            clock_period_ns=8.0,
+            activity_dir=tmp_path / "activity",
+        )
+    assert payload["decision"] == "activity_backed_cluster_power_measured"
+    assert payload["promoted_candidate_count"] == 1
+    assert payload["best_candidate_id"] == "multivalue_cluster_activity_cluster_die2500"
+    assert payload["equivalence"]["final_tensor_hash"] == "final-hash"
+    assert payload["candidates"][1]["status"] == "measurement_failed"
+    assert "/orfs/" not in json.dumps(payload)


### PR DESCRIPTION
## What changed

- add an evidence-only L2 activity-power audit for the shared-score multivalue cluster
- measure every timing-feasible 8 ns routed floorplan variant with the phase VCD power gate
- require merged end-to-end equivalence before activity evidence is accepted
- retain failed variants as explicit negative rows and select a best candidate only from fully gated rows
- add proposal, evaluator command generation, portability contract, and focused/full generator tests

## Why

The cluster PPA sweep reports vectorless power. It cannot support the Llama7B energy frontier until routed activity, phase scaling, clock agreement, SRAM-proxy activity, and finite-power checks are recorded together.

## Validation

- 16 cluster/activity tests passed
- all 204 `test_l2_task_generator.py` tests passed
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
