### PR TITLE
Cancel runs atomically when leases expire

### DIFF
--- a/control_plane/control_plane/services/lease_service.py
+++ b/control_plane/control_plane/services/lease_service.py
@@ -285,6 +285,7 @@ def expire_stale_leases(session: Session) -> LeaseExpiryResult:
     )
     expired_count = 0
     requeued_count = 0
+    cleaned_run_count = 0
     for lease in leases:
         lease.status = LeaseStatus.EXPIRED
         clear_worker_progress_for_item(lease.machine, item_id=lease.work_item.item_id)
@@ -303,7 +304,15 @@ def expire_stale_leases(session: Session) -> LeaseExpiryResult:
             work_item.state = WorkItemState.READY if work_item.assigned_machine_key else WorkItemState.DISPATCH_PENDING
             requeued_count += 1
 
-    cleaned_run_count = 0
+        # Close attached runs in the same transaction as the lease expiry.
+        # Querying them only after changing the lease leaves a race window in
+        # which the item is requeued while its previous run still reads RUNNING.
+        for run in lease.runs:
+            if run.status in {RunStatus.STARTING, RunStatus.RUNNING}:
+                _mark_run_abandoned(session, run=run, now=now)
+                cleaned_run_count += 1
+
+    session.flush()
     dangling_runs = (
         session.query(__import__('control_plane.models.runs', fromlist=['Run']).Run)
         .join(WorkerLease, __import__('control_plane.models.runs', fromlist=['Run']).Run.lease_id == WorkerLease.id)

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -287,6 +287,8 @@ def test_expire_stale_leases_requeues_assigned_nonterminal_work_as_ready() -> No
         assert "last_progress" not in lease.machine.capabilities
         assert run.completed_at is not None
         assert run.failure_category == "lease_expired"
+        assert run.result_payload["stale_lease_cleanup"] is True
+        assert any(event.event_type == "run_abandoned" for event in run.events)
 
         reacquired = acquire_next_lease(
             session,


### PR DESCRIPTION
## Summary
- cancel STARTING/RUNNING runs through the stale lease relationship in the same transaction that requeues work
- flush before the historical dangling-run cleanup query
- strengthen stale-lease regression assertions for cleanup payload and event

## Validation
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_leases.py control_plane/control_plane/tests/test_worker_daemon.py control_plane/control_plane/tests/test_resolver_dev_daemon.py` (46 passed)
- `git diff --check`