### PR TITLE
Add GQA8 shared-KV equivalence boundary

### DIFF
--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_group_equivalence.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_group_equivalence.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Audit Llama7B GQA8 arithmetic by composing cluster and wrapper proofs.
+
+This audit deliberately does not simulate a flat eight-cluster design. It runs
+the real generated single-cluster RTL once for each query head, with one shared
+key tensor and one shared value tensor, and compares every head against the
+performance/reference math. A separate wrapper protocol test proves shared key
+broadcast, shared external value replay, and serialized head/slice result order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.probe_attention_decode_score_multivalue_cluster_equivalence import (
+    _RESULT_RE,
+    _SREQ_RE,
+    _VREQ_RE,
+    _WRITE_RE,
+    _testbench,
+    _tool,
+)
+from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate as generate_cluster
+from npu.sim.perf.attention_online import finalize_value, requantize_score_row, two_pass_stats
+from npu.sim.perf.attention_separated import unpack_signed
+
+JsonDict = dict[str, Any]
+HEAD_COUNT = 8
+VALUE_SLICES = 16
+HEAD_DIM = 128
+COMMAND_ID = 0x4A21
+DEFAULT_PROTOCOL_TEST = (
+    "tests/test_attention_decode_score_multivalue_gqa_group.py::"
+    "test_multivalue_gqa_group_atomic_replay_and_result_order"
+)
+
+
+def _hash(value: object) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _shared_vectors() -> tuple[list[list[list[int]]], list[list[list[int]]], list[list[list[list[int]]]]]:
+    """Return distinct Q heads and shared K/V tensors for three KV blocks."""
+    block_count = 3
+    queries = [
+        [
+            [((block * 29 + dim * 17 + head * 31 + head * dim * 3) % 255) - 127 for dim in range(HEAD_DIM)]
+            for block in range(block_count)
+        ]
+        for head in range(HEAD_COUNT)
+    ]
+    keys = [
+        [
+            [((block * 37 + dim * 11 + lane * 19 + dim * lane) % 255) - 127 for lane in range(8)]
+            for dim in range(HEAD_DIM)
+        ]
+        for block in range(block_count)
+    ]
+    values = [
+        [
+            [
+                [((block * 41 + value_slice * 23 + row * 7 + lane * 13) % 255) - 127 for lane in range(8)]
+                for row in range(8)
+            ]
+            for value_slice in range(VALUE_SLICES)
+        ]
+        for block in range(block_count)
+    ]
+    return queries, keys, values
+
+
+def _raw_scores(query: list[int], keys: list[list[int]]) -> list[int]:
+    return [sum(query[dim] * keys[dim][lane] for dim in range(HEAD_DIM)) for lane in range(8)]
+
+
+def _cluster_config(config: JsonDict) -> JsonDict:
+    body = config.get("attention_decode_score_multivalue_gqa_group")
+    if not isinstance(body, dict):
+        raise ValueError("config requires attention_decode_score_multivalue_gqa_group")
+    if int(body.get("query_heads_per_kv", HEAD_COUNT)) != HEAD_COUNT:
+        raise ValueError("arithmetic audit requires query_heads_per_kv=8")
+    return {
+        "top_name": f"{config.get('top_name', 'gqa8')}__arithmetic_cluster",
+        "attention_decode_score_multivalue_cluster": {
+            "max_blocks": int(body.get("max_blocks", 16384)),
+            "array_n": int(body.get("array_n", 8)),
+            "value_slices": int(body.get("value_slices", VALUE_SLICES)),
+            "divider_impl": str(body.get("divider_impl", "iterative_restoring")),
+            "score_scale_lanes_per_cycle": int(body.get("score_scale_lanes_per_cycle", 1)),
+        },
+    }
+
+
+def _parse_rtl_output(output: str) -> tuple[list[tuple[int, list[int]]], list[int], list[tuple[int, int]], list[JsonDict]]:
+    writes: list[tuple[int, list[int]]] = []
+    score_requests: list[int] = []
+    value_requests: list[tuple[int, int]] = []
+    results: list[JsonDict] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if match := _WRITE_RE.fullmatch(line):
+            writes.append((int(match.group(1)), unpack_signed(int(match.group(2), 16), lanes=8, bits=32)))
+        elif match := _SREQ_RE.fullmatch(line):
+            score_requests.append(int(match.group(1)))
+        elif match := _VREQ_RE.fullmatch(line):
+            value_requests.append((int(match.group(1)), int(match.group(2))))
+        elif match := _RESULT_RE.fullmatch(line):
+            results.append(
+                {
+                    "slice": int(match.group(1)),
+                    "last": bool(int(match.group(2))),
+                    "command_id": int(match.group(3)),
+                    "global_max": int(match.group(4)),
+                    "exp_sum": int(match.group(5)),
+                    "value": unpack_signed(int(match.group(6), 16), lanes=8, bits=40),
+                    "protocol_error": bool(int(match.group(7))),
+                }
+            )
+    return writes, score_requests, value_requests, results
+
+
+def _expected_results(
+    score_rows: list[list[int]], values: list[list[list[list[int]]]]
+) -> list[JsonDict]:
+    rows: list[JsonDict] = []
+    for value_slice in range(VALUE_SLICES):
+        stats = two_pass_stats(score_rows, [block[value_slice] for block in values])
+        rows.append(
+            {
+                "slice": value_slice,
+                "last": value_slice == VALUE_SLICES - 1,
+                "command_id": COMMAND_ID,
+                "global_max": stats.max_score,
+                "exp_sum": stats.exp_sum,
+                "value": list(finalize_value(stats)),
+            }
+        )
+    return rows
+
+
+def _run_head(
+    *,
+    head: int,
+    rtl_path: Path,
+    top_name: str,
+    work_dir: Path,
+    queries: list[list[list[int]]],
+    keys: list[list[list[int]]],
+    values: list[list[list[list[int]]]],
+    multiplier: int,
+    shift: int,
+) -> JsonDict:
+    beats = [
+        [(queries[head][block][dim], keys[block][dim]) for dim in range(HEAD_DIM)]
+        for block in range(len(keys))
+    ]
+    tb_path = work_dir / f"head_{head}_tb.sv"
+    tb_path.write_text(
+        _testbench(
+            top_name=top_name,
+            scenario="always_ready",
+            beats=beats,
+            values=values,
+            multiplier=multiplier,
+            shift=shift,
+        ),
+        encoding="utf-8",
+    )
+    simv = work_dir / f"head_{head}_simv"
+    compiled = subprocess.run(
+        [_tool("iverilog"), "-g2012", "-s", "tb", "-o", str(simv), str(rtl_path), str(tb_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if compiled.returncode:
+        raise RuntimeError(f"head {head} iverilog failed:\n{compiled.stderr}")
+    run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=60)
+    if run.returncode:
+        raise RuntimeError(f"head {head} simulation failed:\n{run.stdout}\n{run.stderr}")
+
+    writes, score_requests, value_requests, observed = _parse_rtl_output(run.stdout)
+    expected_scores = [
+        list(requantize_score_row(_raw_scores(queries[head][block], keys[block]), multiplier=multiplier, shift=shift))
+        for block in range(len(keys))
+    ]
+    expected = _expected_results(expected_scores, values)
+    observed_results = [{key: value for key, value in row.items() if key != "protocol_error"} for row in observed]
+    expected_requests = [(block, value_slice) for block in range(len(keys)) for value_slice in range(VALUE_SLICES)]
+    passed = (
+        [address for address, _ in writes] == list(range(len(keys)))
+        and [row for _, row in writes] == expected_scores
+        and score_requests == list(range(len(keys)))
+        and value_requests == expected_requests
+        and observed_results == expected
+        and not any(row["protocol_error"] for row in observed)
+    )
+    return {
+        "head": head,
+        "arithmetic_equivalence_pass": passed,
+        "query_sha256": _hash(queries[head]),
+        "shared_key_sha256": _hash(keys),
+        "shared_value_sha256": _hash(values),
+        "expected_score_sha256": _hash(expected_scores),
+        "observed_score_sha256": _hash([row for _, row in writes]),
+        "expected_result_sha256": _hash(expected),
+        "observed_result_sha256": _hash(observed_results),
+        "score_read_addresses": score_requests,
+        "value_read_requests": [list(request) for request in value_requests],
+        "expected_results": expected,
+        "observed_results": observed_results,
+    }
+
+
+def _ordered_group_hash(heads: list[JsonDict], field: str) -> str:
+    ordered = sorted(heads, key=lambda row: int(row["head"]))
+    return _hash([{"head": row["head"], "result_sha256": row[field]} for row in ordered])
+
+
+def _ordered_group_results(heads: list[JsonDict], field: str) -> list[JsonDict]:
+    ordered = sorted(heads, key=lambda row: int(row["head"]))
+    return [{"head": row["head"], **result} for row in ordered for result in row[field]]
+
+
+def _run_protocol_test(repo_root: Path, target: str) -> JsonDict:
+    command = [sys.executable, "-m", "pytest", "-q", target]
+    run = subprocess.run(command, cwd=repo_root, capture_output=True, text=True, timeout=120)
+    output = (run.stdout + "\n" + run.stderr).strip()
+    passed_count = sum(int(value) for value in re.findall(r"(\d+) passed", output))
+    return {
+        "test_target": target,
+        "command": ["python3", "-m", "pytest", "-q", target],
+        "returncode": run.returncode,
+        "passed_test_count": passed_count,
+        "sharing_and_order_pass": run.returncode == 0 and passed_count == 1,
+    }
+
+
+def build_report(config: JsonDict, *, protocol_test_target: str = DEFAULT_PROTOCOL_TEST) -> JsonDict:
+    cluster_config = _cluster_config(config)
+    queries, keys, values = _shared_vectors()
+    multiplier = 1
+    shift = 0
+    with tempfile.TemporaryDirectory(prefix="gqa8-arithmetic-audit-") as tmp_text:
+        tmp = Path(tmp_text)
+        rtl_dir = tmp / "rtl"
+        generate_cluster(cluster_config, rtl_dir)
+        heads = [
+            _run_head(
+                head=head,
+                rtl_path=rtl_dir / "top.v",
+                top_name=str(cluster_config["top_name"]),
+                work_dir=tmp,
+                queries=queries,
+                keys=keys,
+                values=values,
+                multiplier=multiplier,
+                shift=shift,
+            )
+            for head in range(HEAD_COUNT)
+        ]
+    protocol = _run_protocol_test(REPO_ROOT, protocol_test_target)
+    query_hashes = [row["query_sha256"] for row in heads]
+    shared_inputs_pass = (
+        {row["shared_key_sha256"] for row in heads} == {_hash(keys)}
+        and {row["shared_value_sha256"] for row in heads} == {_hash(values)}
+    )
+    arithmetic_pass = all(row["arithmetic_equivalence_pass"] for row in heads)
+    distinct_queries_pass = len(set(query_hashes)) == HEAD_COUNT
+    expected_group_hash = _ordered_group_hash(heads, "expected_result_sha256")
+    observed_group_hash = _ordered_group_hash(heads, "observed_result_sha256")
+    expected_group_results = _ordered_group_results(heads, "expected_results")
+    observed_group_results = _ordered_group_results(heads, "observed_results")
+    passed = (
+        arithmetic_pass
+        and distinct_queries_pass
+        and shared_inputs_pass
+        and expected_group_hash == observed_group_hash
+        and expected_group_results == observed_group_results
+        and protocol["sharing_and_order_pass"]
+    )
+    return {
+        "version": 1,
+        "model": "llama7b_gqa8_shared_kv_compositional_arithmetic_equivalence_v1",
+        "decision": "llama7b_gqa8_shared_kv_equivalence_pass" if passed else "llama7b_gqa8_shared_kv_equivalence_fail",
+        "equivalence_pass": passed,
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_v1",
+        "query_heads_per_kv": HEAD_COUNT,
+        "head_dim": HEAD_DIM,
+        "value_slices": VALUE_SLICES,
+        "shared_key_sha256": _hash(keys),
+        "shared_value_sha256": _hash(values),
+        "distinct_query_heads_pass": distinct_queries_pass,
+        "shared_inputs_pass": shared_inputs_pass,
+        "per_head_result_sha256": [row["observed_result_sha256"] for row in heads],
+        "expected_group_result_sha256": expected_group_hash,
+        "observed_group_result_sha256": observed_group_hash,
+        "group_result_sha256": observed_group_hash,
+        "expected_group_results": expected_group_results,
+        "observed_group_results": observed_group_results,
+        "arithmetic_equivalence_pass": arithmetic_pass,
+        "wrapper_protocol": protocol,
+        "heads": heads,
+        "compositional_proof": {
+            "method": "single_cluster_arithmetic_plus_wrapper_protocol",
+            "arithmetic_claim": (
+                "The real generated single-cluster RTL is simulated independently for each of eight distinct "
+                "query heads against the perf/reference math, while every run uses identical key and value tensors."
+            ),
+            "wrapper_claim": (
+                "The focused wrapper protocol test verifies atomic shared-key broadcast, one shared external "
+                "value replay, and deterministic head-major then slice-major result order."
+            ),
+            "composition_claim": (
+                "Because the wrapper only broadcasts shared keys and shared value responses to "
+                "arithmetic-equivalent children and serializes their unchanged results in the tested order, "
+                "the two checks compose to the GQA8 claim."
+            ),
+            "flat_8_cluster_rtl_simulation_run": False,
+            "scope_limit": (
+                "This is a compositional proof; it does not claim that a flat eight-cluster RTL simulation was run."
+            ),
+        },
+    }
+
+
+def _render_markdown(payload: JsonDict) -> str:
+    proof = payload["compositional_proof"]
+    lines = [
+        "# Llama7B GQA8 Shared-K/V Arithmetic Equivalence",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- equivalence pass: `{payload['equivalence_pass']}`",
+        f"- real single-cluster arithmetic pass: `{payload['arithmetic_equivalence_pass']}`",
+        f"- wrapper sharing/order protocol pass: `{payload['wrapper_protocol']['sharing_and_order_pass']}`",
+        f"- expected group result hash: `{payload['expected_group_result_sha256']}`",
+        f"- observed group result hash: `{payload['observed_group_result_sha256']}`",
+        "",
+        "## Compositional Proof",
+        "",
+        proof["arithmetic_claim"],
+        "",
+        proof["wrapper_claim"],
+        "",
+        proof["composition_claim"],
+        "",
+        f"**Scope:** {proof['scope_limit']}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    parser.add_argument("--protocol-test-target", default=DEFAULT_PROTOCOL_TEST)
+    args = parser.parse_args()
+    payload = build_report(
+        json.loads(args.config.read_text(encoding="utf-8")),
+        protocol_test_target=args.protocol_test_target,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.write_text(_render_markdown(payload), encoding="utf-8")
+    print(json.dumps({"decision": payload["decision"], "ok": payload["equivalence_pass"]}, sort_keys=True))
+    return 0 if payload["equivalence_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_decode_score_multivalue_gqa_group.py
+++ b/npu/rtlgen/gen_attention_decode_score_multivalue_gqa_group.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Generate an 8-head GQA wrapper around the shared-score multivalue cluster."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate as generate_cluster
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _clog2(value: int) -> int:
+    return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _validate(config: dict[str, Any]) -> dict[str, int | str]:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get("attention_decode_score_multivalue_gqa_group")
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit("config requires top_name and attention_decode_score_multivalue_gqa_group")
+
+    max_blocks = int(body.get("max_blocks", 16384))
+    array_n = int(body.get("array_n", 8))
+    value_slices = int(body.get("value_slices", 16))
+    scale_lanes = int(body.get("score_scale_lanes_per_cycle", 1))
+    divider_impl = str(body.get("divider_impl", "iterative_restoring")).strip()
+    query_heads_per_kv = int(body.get("query_heads_per_kv", 8))
+
+    if max_blocks < 8 or max_blocks > 16384 or max_blocks & (max_blocks - 1):
+        raise SystemExit("max_blocks must be a power of two in [8, 16384]")
+    if array_n != 8:
+        raise SystemExit("array_n must be 8")
+    if value_slices != 16:
+        raise SystemExit("value_slices must be 16")
+    if scale_lanes not in {1, 2, 4, 8}:
+        raise SystemExit("score_scale_lanes_per_cycle must be one of 1,2,4,8")
+    if divider_impl != "iterative_restoring":
+        raise SystemExit("divider_impl must be iterative_restoring")
+    if query_heads_per_kv != 8:
+        raise SystemExit("query_heads_per_kv must be 8 for Llama7B GQA8")
+
+    body.update(
+        {
+            "max_blocks": max_blocks,
+            "array_n": array_n,
+            "value_slices": value_slices,
+            "score_scale_lanes_per_cycle": scale_lanes,
+            "divider_impl": divider_impl,
+            "query_heads_per_kv": query_heads_per_kv,
+        }
+    )
+    return {
+        "top_name": top_name,
+        "max_blocks": max_blocks,
+        "array_n": array_n,
+        "value_slices": value_slices,
+        "score_scale_lanes_per_cycle": scale_lanes,
+        "divider_impl": divider_impl,
+        "query_heads_per_kv": query_heads_per_kv,
+    }
+
+
+def _bus_slice(name: str, index: int, width: int) -> str:
+    lo = index * width
+    hi = lo + width - 1
+    return f"{name}[{hi}:{lo}]"
+
+
+def _match_expr(name: str, width: int, count: int) -> str:
+    base = _bus_slice(name, 0, width)
+    return " && ".join(f"({_bus_slice(name, idx, width)} == {base})" for idx in range(1, count))
+
+
+def _result_mux_cases(query_heads_per_kv: int) -> str:
+    cases: list[str] = []
+    for head in range(query_heads_per_kv):
+        cases.append(
+            f"""      3'd{head}: begin
+        result_command_id = {_bus_slice("child_result_command_id_bus", head, 16)};
+        result_global_max = $signed({_bus_slice("child_result_global_max_bus", head, 32)});
+        result_exp_sum = {_bus_slice("child_result_exp_sum_bus", head, 33)};
+        result_slice = {_bus_slice("child_result_slice_bus", head, 4)};
+        result_last = child_result_last[{head}];
+        result_value = {_bus_slice("child_result_value_bus", head, 320)};
+      end"""
+        )
+    return "\n".join(cases)
+
+
+def _result_ready_assigns(query_heads_per_kv: int) -> str:
+    assigns = []
+    for head in range(query_heads_per_kv):
+        assigns.append(f"  assign child_result_ready[{head}] = result_ready && (result_head_q == 3'd{head});")
+    return "\n".join(assigns)
+
+
+def _cluster_instances(cluster_top: str, query_heads_per_kv: int) -> str:
+    instances: list[str] = []
+    for head in range(query_heads_per_kv):
+        instances.append(
+            f"""  {cluster_top} u_head_{head} (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(command_valid && command_ready),
+      .command_ready(child_command_ready[{head}]),
+      .command_id(command_id),
+      .command_block_count(command_block_count),
+      .command_score_multiplier(command_score_multiplier),
+      .command_score_shift(command_score_shift),
+      .input_valid(input_valid && input_ready),
+      .input_ready(child_input_ready[{head}]),
+      .input_last(input_last),
+      .input_a(input_query[{head * 8 + 7}:{head * 8}]),
+      .input_b(input_key),
+      .value_read_req_valid(child_value_read_req_valid[{head}]),
+      .value_read_req_ready(child_value_read_req_ready[{head}]),
+      .value_read_req_address({_bus_slice("child_value_read_req_address_bus", head, 14)}),
+      .value_read_req_slice({_bus_slice("child_value_read_req_slice_bus", head, 4)}),
+      .value_response_valid(child_value_response_valid[{head}]),
+      .value_response_ready(child_value_response_ready[{head}]),
+      .value_response_address(value_response_address),
+      .value_response_slice(value_response_slice),
+      .value_response_matrix(value_response_matrix),
+      .result_valid(child_result_valid[{head}]),
+      .result_ready(child_result_ready[{head}]),
+      .result_command_id({_bus_slice("child_result_command_id_bus", head, 16)}),
+      .result_global_max({_bus_slice("child_result_global_max_bus", head, 32)}),
+      .result_exp_sum({_bus_slice("child_result_exp_sum_bus", head, 33)}),
+      .result_slice({_bus_slice("child_result_slice_bus", head, 4)}),
+      .result_last(child_result_last[{head}]),
+      .result_value({_bus_slice("child_result_value_bus", head, 320)}),
+      .accepted_count({_bus_slice("child_accepted_count_bus", head, 32)}),
+      .completed_count({_bus_slice("child_completed_count_bus", head, 32)}),
+      .cycle_count({_bus_slice("child_cycle_count_bus", head, 32)}),
+      .protocol_error(child_protocol_error[{head}])
+  );"""
+        )
+    return "\n\n".join(instances)
+
+
+def _wrapper(*, top_name: str, params: dict[str, int | str], cluster_top: str) -> str:
+    max_blocks = int(params["max_blocks"])
+    value_slices = int(params["value_slices"])
+    query_heads_per_kv = int(params["query_heads_per_kv"])
+    addr_bits = 14
+    slice_bits = _clog2(value_slices)
+    head_bits = _clog2(query_heads_per_kv)
+    addr_match = _match_expr("child_value_read_req_address_bus", addr_bits, query_heads_per_kv)
+    slice_match = _match_expr("child_value_read_req_slice_bus", slice_bits, query_heads_per_kv)
+    return f"""// Auto-generated by npu/rtlgen/gen_attention_decode_score_multivalue_gqa_group.py
+module {top_name} (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire         command_valid,
+    output wire         command_ready,
+    input  wire [15:0]  command_id,
+    input  wire [14:0]  command_block_count,
+    input  wire [31:0]  command_score_multiplier,
+    input  wire [5:0]   command_score_shift,
+    input  wire         input_valid,
+    output wire         input_ready,
+    input  wire         input_last,
+    input  wire signed [63:0] input_query,
+    input  wire signed [63:0] input_key,
+    output wire         value_read_req_valid,
+    input  wire         value_read_req_ready,
+    output wire [13:0]  value_read_req_address,
+    output wire [{slice_bits - 1}:0] value_read_req_slice,
+    input  wire         value_response_valid,
+    output wire         value_response_ready,
+    input  wire [13:0]  value_response_address,
+    input  wire [{slice_bits - 1}:0] value_response_slice,
+    input  wire [511:0] value_response_matrix,
+    output wire         result_valid,
+    input  wire         result_ready,
+    output wire [{head_bits - 1}:0] result_head,
+    output reg  [15:0]  result_command_id,
+    output reg  signed [31:0] result_global_max,
+    output reg  [32:0]  result_exp_sum,
+    output reg  [{slice_bits - 1}:0] result_slice,
+    output reg          result_last,
+    output reg  [319:0] result_value,
+    output reg  [31:0]  accepted_count,
+    output reg  [31:0]  completed_count,
+    output reg  [31:0]  cycle_count,
+    output wire         protocol_error
+);
+  localparam integer MAX_BLOCKS = {max_blocks};
+  localparam integer VALUE_SLICES = {value_slices};
+  localparam integer QUERY_HEADS_PER_KV = {query_heads_per_kv};
+
+  reg command_active_q;
+  reg [{head_bits - 1}:0] result_head_q;
+  reg [{slice_bits - 1}:0] expected_slice_q;
+  reg protocol_error_q;
+
+  wire [QUERY_HEADS_PER_KV-1:0] child_command_ready;
+  wire [QUERY_HEADS_PER_KV-1:0] child_input_ready;
+  wire [QUERY_HEADS_PER_KV-1:0] child_value_read_req_valid;
+  wire [QUERY_HEADS_PER_KV-1:0] child_value_read_req_ready;
+  wire [QUERY_HEADS_PER_KV-1:0] child_value_response_valid;
+  wire [QUERY_HEADS_PER_KV-1:0] child_value_response_ready;
+  wire [QUERY_HEADS_PER_KV-1:0] child_result_valid;
+  wire [QUERY_HEADS_PER_KV-1:0] child_result_ready;
+  wire [QUERY_HEADS_PER_KV-1:0] child_result_last;
+  wire [QUERY_HEADS_PER_KV-1:0] child_protocol_error;
+  wire [QUERY_HEADS_PER_KV*{addr_bits}-1:0] child_value_read_req_address_bus;
+  wire [QUERY_HEADS_PER_KV*{slice_bits}-1:0] child_value_read_req_slice_bus;
+  wire [QUERY_HEADS_PER_KV*16-1:0] child_result_command_id_bus;
+  wire [QUERY_HEADS_PER_KV*32-1:0] child_result_global_max_bus;
+  wire [QUERY_HEADS_PER_KV*33-1:0] child_result_exp_sum_bus;
+  wire [QUERY_HEADS_PER_KV*{slice_bits}-1:0] child_result_slice_bus;
+  wire [QUERY_HEADS_PER_KV*320-1:0] child_result_value_bus;
+  wire [QUERY_HEADS_PER_KV*32-1:0] child_accepted_count_bus;
+  wire [QUERY_HEADS_PER_KV*32-1:0] child_completed_count_bus;
+  wire [QUERY_HEADS_PER_KV*32-1:0] child_cycle_count_bus;
+
+  wire command_block_count_valid = command_block_count != 0 && command_block_count <= MAX_BLOCKS;
+  wire command_ready_all = &child_command_ready;
+  wire input_ready_all = &child_input_ready;
+  wire any_value_req_valid = |child_value_read_req_valid;
+  wire all_value_req_valid = &child_value_read_req_valid;
+  wire value_req_addr_match = {addr_match};
+  wire value_req_slice_match = {slice_match};
+  wire value_req_consistent = all_value_req_valid && value_req_addr_match && value_req_slice_match;
+  wire value_req_divergent = any_value_req_valid && (!all_value_req_valid || !value_req_addr_match || !value_req_slice_match);
+  wire any_value_rsp_ready = |child_value_response_ready;
+  wire value_rsp_ready_all = &child_value_response_ready;
+  wire value_rsp_divergent = any_value_rsp_ready && !value_rsp_ready_all;
+  wire any_child_protocol_error = |child_protocol_error;
+
+  assign command_ready = !command_active_q && command_block_count_valid && command_ready_all;
+  assign input_ready = command_active_q && input_ready_all;
+
+  assign value_read_req_valid = value_req_consistent;
+  assign value_read_req_address = child_value_read_req_address_bus[{addr_bits - 1}:0];
+  assign value_read_req_slice = child_value_read_req_slice_bus[{slice_bits - 1}:0];
+  assign child_value_read_req_ready = {{QUERY_HEADS_PER_KV{{value_read_req_valid && value_read_req_ready}}}};
+
+  assign value_response_ready = value_rsp_ready_all;
+  assign child_value_response_valid = {{QUERY_HEADS_PER_KV{{value_response_valid && value_response_ready}}}};
+
+  assign result_valid = child_result_valid[result_head_q];
+  assign result_head = result_head_q;
+{_result_ready_assigns(query_heads_per_kv)}
+  assign protocol_error = protocol_error_q || any_child_protocol_error;
+
+  always @(*) begin
+    result_command_id = 16'd0;
+    result_global_max = 32'sd0;
+    result_exp_sum = 33'd0;
+    result_slice = {slice_bits}'d0;
+    result_last = 1'b0;
+    result_value = 320'd0;
+    case (result_head_q)
+{_result_mux_cases(query_heads_per_kv)}
+      default: begin
+        result_command_id = 16'd0;
+        result_global_max = 32'sd0;
+        result_exp_sum = 33'd0;
+        result_slice = {slice_bits}'d0;
+        result_last = 1'b0;
+        result_value = 320'd0;
+      end
+    endcase
+  end
+
+{_cluster_instances(cluster_top, query_heads_per_kv)}
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      command_active_q <= 1'b0;
+      result_head_q <= {head_bits}'d0;
+      expected_slice_q <= {slice_bits}'d0;
+      protocol_error_q <= 1'b0;
+      accepted_count <= 32'd0;
+      completed_count <= 32'd0;
+      cycle_count <= 32'd0;
+    end else begin
+      cycle_count <= cycle_count + 1'b1;
+
+      if (value_req_divergent || value_rsp_divergent) begin
+        protocol_error_q <= 1'b1;
+      end
+
+      if (command_valid && command_ready) begin
+        command_active_q <= 1'b1;
+        result_head_q <= {head_bits}'d0;
+        expected_slice_q <= {slice_bits}'d0;
+        accepted_count <= accepted_count + 1'b1;
+      end
+
+      if (result_valid && result_ready) begin
+        if (result_slice != expected_slice_q) begin
+          protocol_error_q <= 1'b1;
+        end
+        if (expected_slice_q == VALUE_SLICES - 1) begin
+          if (!result_last) begin
+            protocol_error_q <= 1'b1;
+          end
+          expected_slice_q <= {slice_bits}'d0;
+          if (result_head_q == QUERY_HEADS_PER_KV - 1) begin
+            command_active_q <= 1'b0;
+            completed_count <= completed_count + 1'b1;
+          end else begin
+            result_head_q <= result_head_q + 1'b1;
+          end
+        end else begin
+          if (result_last) begin
+            protocol_error_q <= 1'b1;
+          end
+          expected_slice_q <= expected_slice_q + 1'b1;
+        end
+      end
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: dict[str, Any], out_dir: Path) -> None:
+    params = _validate(config)
+    top_name = str(params["top_name"])
+    cluster_top = f"{top_name}__cluster"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmp_text:
+        tmp_dir = Path(tmp_text)
+        cluster_dir = tmp_dir / "cluster"
+        generate_cluster(
+            {
+                "top_name": cluster_top,
+                "attention_decode_score_multivalue_cluster": {
+                    "max_blocks": int(params["max_blocks"]),
+                    "array_n": int(params["array_n"]),
+                    "value_slices": int(params["value_slices"]),
+                    "divider_impl": str(params["divider_impl"]),
+                    "score_scale_lanes_per_cycle": int(params["score_scale_lanes_per_cycle"]),
+                },
+            },
+            cluster_dir,
+        )
+        cluster_rtl = (cluster_dir / "top.v").read_text(encoding="utf-8")
+        cluster_manifest = json.loads(
+            (cluster_dir / "attention_decode_score_multivalue_cluster_manifest.json").read_text(encoding="utf-8")
+        )
+
+    rtl = cluster_rtl + "\n\n" + _wrapper(top_name=top_name, params=params, cluster_top=cluster_top) + "\n"
+    (out_dir / "top.v").write_text(rtl, encoding="utf-8")
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    manifest = {
+        "version": 1,
+        "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_group.py",
+        "top_name": top_name,
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_v1",
+        "query_heads_per_kv": int(params["query_heads_per_kv"]),
+        "max_blocks": int(params["max_blocks"]),
+        "score_tile_array_n": int(params["array_n"]),
+        "score_scale_lanes_per_cycle": int(params["score_scale_lanes_per_cycle"]),
+        "value_slices": int(params["value_slices"]),
+        "value_dimensions_per_head": int(params["value_slices"]) * int(params["array_n"]),
+        "parallel_query_head_clusters": int(params["query_heads_per_kv"]),
+        "query_head_score_computations_per_command": int(params["query_heads_per_kv"]),
+        "score_passes_per_query_head": 1,
+        "shared_external_value_reads_per_block": int(params["value_slices"]),
+        "internal_value_reads_per_block_per_head": int(params["value_slices"]),
+        "result_beats_per_command": int(params["query_heads_per_kv"]) * int(params["value_slices"]),
+        "result_value_bits_per_beat": 320,
+        "submodule_manifests": {
+            "multivalue_cluster": cluster_manifest,
+        },
+    }
+    (out_dir / "attention_decode_score_multivalue_gqa_group_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_attention_decode_score_multivalue_gqa_group.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group.py
@@ -1,0 +1,459 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_gqa_group import generate
+
+
+def _config(*, scale_lanes: int = 1, query_heads_per_kv: int = 8) -> dict:
+    return {
+        "top_name": f"attention_decode_score_multivalue_gqa_group_s{scale_lanes}",
+        "attention_decode_score_multivalue_gqa_group": {
+            "max_blocks": 16,
+            "array_n": 8,
+            "value_slices": 16,
+            "divider_impl": "iterative_restoring",
+            "score_scale_lanes_per_cycle": scale_lanes,
+            "query_heads_per_kv": query_heads_per_kv,
+        },
+    }
+
+
+def _iverilog() -> str | None:
+    iverilog = shutil.which("iverilog")
+    if iverilog is not None:
+        return iverilog
+    fallback = Path("/oss-cad-suite/bin/iverilog")
+    return str(fallback) if fallback.exists() else None
+
+
+def _vvp() -> str | None:
+    vvp = shutil.which("vvp")
+    if vvp is not None:
+        return vvp
+    fallback = Path("/oss-cad-suite/bin/vvp")
+    return str(fallback) if fallback.exists() else None
+
+
+def _cluster_stub(module_name: str) -> str:
+    return f"""
+module {module_name} (
+    input wire clk, input wire rst_n,
+    input wire command_valid, output wire command_ready,
+    input wire [15:0] command_id, input wire [14:0] command_block_count,
+    input wire [31:0] command_score_multiplier, input wire [5:0] command_score_shift,
+    input wire input_valid, output wire input_ready, input wire input_last,
+    input wire signed [7:0] input_a, input wire signed [63:0] input_b,
+    output wire value_read_req_valid, input wire value_read_req_ready,
+    output wire [13:0] value_read_req_address, output wire [3:0] value_read_req_slice,
+    input wire value_response_valid, output wire value_response_ready,
+    input wire [13:0] value_response_address, input wire [3:0] value_response_slice,
+    input wire [511:0] value_response_matrix,
+    output wire result_valid, input wire result_ready,
+    output wire [15:0] result_command_id, output wire signed [31:0] result_global_max,
+    output wire [32:0] result_exp_sum, output wire [3:0] result_slice,
+    output wire result_last, output wire [319:0] result_value,
+    output reg [31:0] accepted_count, output reg [31:0] completed_count,
+    output reg [31:0] cycle_count, output wire protocol_error
+);
+  localparam IDLE = 3'd0, INPUT = 3'd1, REQUEST = 3'd2,
+      RESPONSE = 3'd3, RESULT = 3'd4;
+  reg [2:0] state_q;
+  reg [3:0] slice_q;
+  reg [15:0] command_id_q;
+  reg signed [7:0] input_a_q;
+  assign command_ready = state_q == IDLE;
+  assign input_ready = state_q == INPUT;
+  assign value_read_req_valid = state_q == REQUEST;
+  assign value_read_req_address = 14'd0;
+  assign value_read_req_slice = slice_q;
+  assign value_response_ready = state_q == RESPONSE;
+  assign result_valid = state_q == RESULT;
+  assign result_command_id = command_id_q;
+  assign result_global_max = 32'sd7;
+  assign result_exp_sum = 33'd11;
+  assign result_slice = slice_q;
+  assign result_last = slice_q == 4'd15;
+  assign result_value = {{{{308{{1'b0}}}}, slice_q, input_a_q}};
+  assign protocol_error = 1'b0;
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      state_q <= IDLE;
+      slice_q <= 0;
+      command_id_q <= 0;
+      input_a_q <= 0;
+      accepted_count <= 0;
+      completed_count <= 0;
+      cycle_count <= 0;
+    end else begin
+      cycle_count <= cycle_count + 1'b1;
+      case (state_q)
+        IDLE: if (command_valid && command_ready) begin
+          command_id_q <= command_id;
+          accepted_count <= accepted_count + 1'b1;
+          state_q <= INPUT;
+        end
+        INPUT: if (input_valid && input_ready && input_last) begin
+          input_a_q <= input_a;
+          slice_q <= 0;
+          state_q <= REQUEST;
+        end
+        REQUEST: if (value_read_req_valid && value_read_req_ready) state_q <= RESPONSE;
+        RESPONSE: if (value_response_valid && value_response_ready) begin
+          if (slice_q == 4'd15) begin
+            slice_q <= 0;
+            state_q <= RESULT;
+          end else begin
+            slice_q <= slice_q + 1'b1;
+            state_q <= REQUEST;
+          end
+        end
+        RESULT: if (result_valid && result_ready) begin
+          if (slice_q == 4'd15) begin
+            completed_count <= completed_count + 1'b1;
+            state_q <= IDLE;
+          end else slice_q <= slice_q + 1'b1;
+        end
+        default: state_q <= IDLE;
+      endcase
+    end
+  end
+endmodule
+"""
+
+
+def test_multivalue_gqa_group_manifest_and_structure(tmp_path: Path) -> None:
+    config = _config()
+    generate(config, tmp_path)
+    top_name = config["top_name"]
+    manifest = json.loads(
+        (tmp_path / "attention_decode_score_multivalue_gqa_group_manifest.json").read_text(encoding="utf-8")
+    )
+    text = (tmp_path / "top.v").read_text(encoding="utf-8")
+
+    assert manifest["semantic_profile"] == "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_v1"
+    assert manifest["query_heads_per_kv"] == 8
+    assert manifest["parallel_query_head_clusters"] == 8
+    assert manifest["query_head_score_computations_per_command"] == 8
+    assert manifest["score_passes_per_query_head"] == 1
+    assert manifest["shared_external_value_reads_per_block"] == 16
+    assert manifest["result_beats_per_command"] == 128
+    assert manifest["submodule_manifests"]["multivalue_cluster"]["result_beats_per_command"] == 16
+
+    assert text.count(f"module {top_name}__cluster (") == 1
+    assert text.count(f"{top_name}__cluster u_head_") == 8
+    assert "output wire [2:0] result_head" in text
+    assert "wire value_req_divergent" in text
+    assert "assign child_value_response_valid = {QUERY_HEADS_PER_KV{value_response_valid && value_response_ready}};" in text
+    assert "assign command_ready = !command_active_q && command_block_count_valid && command_ready_all;" in text
+
+
+def test_multivalue_gqa_group_rejects_wrong_query_heads_per_kv(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="query_heads_per_kv must be 8"):
+        generate(_config(query_heads_per_kv=4), tmp_path)
+
+
+def test_multivalue_gqa_group_atomic_replay_and_result_order(tmp_path: Path) -> None:
+    iverilog = _iverilog()
+    vvp = _vvp()
+    if iverilog is None or vvp is None:
+        pytest.skip("iverilog/vvp unavailable")
+
+    design_dir = tmp_path / "design"
+    design_dir.mkdir()
+    config = _config()
+    generate(config, design_dir)
+    top_name = config["top_name"]
+    generated = (design_dir / "top.v").read_text(encoding="utf-8")
+    wrapper_marker = f"module {top_name} ("
+    wrapper_path = tmp_path / "wrapper.v"
+    wrapper_path.write_text(
+        _cluster_stub(f"{top_name}__cluster") + generated[generated.index(wrapper_marker) :],
+        encoding="utf-8",
+    )
+
+    tb_text = f"""
+module tb;
+  reg clk = 1'b0;
+  always #5 clk = ~clk;
+
+  reg rst_n = 1'b0;
+  reg command_valid = 1'b0;
+  wire command_ready;
+  reg [15:0] command_id = 16'd0;
+  reg [14:0] command_block_count = 15'd0;
+  reg [31:0] command_score_multiplier = 32'd0;
+  reg [5:0] command_score_shift = 6'd0;
+  reg input_valid = 1'b0;
+  wire input_ready;
+  reg input_last = 1'b0;
+  reg signed [63:0] input_query = 64'sd0;
+  reg signed [63:0] input_key = 64'sd0;
+  wire value_read_req_valid;
+  reg value_read_req_ready = 1'b1;
+  wire [13:0] value_read_req_address;
+  wire [3:0] value_read_req_slice;
+  reg value_response_valid = 1'b0;
+  wire value_response_ready;
+  reg [13:0] value_response_address = 14'd0;
+  reg [3:0] value_response_slice = 4'd0;
+  reg [511:0] value_response_matrix = 512'd0;
+  wire result_valid;
+  reg result_ready = 1'b1;
+  wire [2:0] result_head;
+  wire [15:0] result_command_id;
+  wire signed [31:0] result_global_max;
+  wire [32:0] result_exp_sum;
+  wire [3:0] result_slice;
+  wire result_last;
+  wire [319:0] result_value;
+  wire [31:0] accepted_count;
+  wire [31:0] completed_count;
+  wire [31:0] cycle_count;
+  wire protocol_error;
+
+  integer request_count = 0;
+  integer result_count = 0;
+  integer watchdog = 0;
+  integer expected_head = 0;
+  integer expected_slice = 0;
+  reg pending_rsp = 1'b0;
+  reg [13:0] pending_addr = 14'd0;
+  reg [3:0] pending_slice = 4'd0;
+  reg command_inflight = 1'b0;
+  reg first_command_done = 1'b0;
+
+  {top_name} dut (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(command_valid),
+      .command_ready(command_ready),
+      .command_id(command_id),
+      .command_block_count(command_block_count),
+      .command_score_multiplier(command_score_multiplier),
+      .command_score_shift(command_score_shift),
+      .input_valid(input_valid),
+      .input_ready(input_ready),
+      .input_last(input_last),
+      .input_query(input_query),
+      .input_key(input_key),
+      .value_read_req_valid(value_read_req_valid),
+      .value_read_req_ready(value_read_req_ready),
+      .value_read_req_address(value_read_req_address),
+      .value_read_req_slice(value_read_req_slice),
+      .value_response_valid(value_response_valid),
+      .value_response_ready(value_response_ready),
+      .value_response_address(value_response_address),
+      .value_response_slice(value_response_slice),
+      .value_response_matrix(value_response_matrix),
+      .result_valid(result_valid),
+      .result_ready(result_ready),
+      .result_head(result_head),
+      .result_command_id(result_command_id),
+      .result_global_max(result_global_max),
+      .result_exp_sum(result_exp_sum),
+      .result_slice(result_slice),
+      .result_last(result_last),
+      .result_value(result_value),
+      .accepted_count(accepted_count),
+      .completed_count(completed_count),
+      .cycle_count(cycle_count),
+      .protocol_error(protocol_error)
+  );
+
+  task automatic send_command(input [15:0] cmd_id);
+    begin
+      @(negedge clk);
+      command_id = cmd_id;
+      command_block_count = 15'd1;
+      command_score_multiplier = 32'd1;
+      command_score_shift = 6'd0;
+      command_valid = 1'b1;
+      @(posedge clk);
+      while (!command_ready) @(posedge clk);
+      @(negedge clk);
+      command_valid = 1'b0;
+      command_inflight = 1'b1;
+    end
+  endtask
+
+  task automatic send_input_beat(input [63:0] query_pack, input [63:0] key_pack);
+    begin
+      @(negedge clk);
+      input_query = query_pack;
+      input_key = key_pack;
+      input_last = 1'b1;
+      input_valid = 1'b1;
+      @(posedge clk);
+      while (!input_ready) @(posedge clk);
+      @(negedge clk);
+      input_valid = 1'b0;
+      input_last = 1'b0;
+    end
+  endtask
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      watchdog <= watchdog + 1;
+      if (watchdog > 1000) begin
+        $display("FAIL timeout active=%0d head=%0d child0_state=%0d reqs=%0d results=%0d",
+            dut.command_active_q, dut.result_head_q, dut.u_head_0.state_q, request_count, result_count);
+        $finish(1);
+      end
+    end
+    value_response_valid <= 1'b0;
+    if (value_read_req_valid && value_read_req_ready) begin
+      if (!first_command_done) begin
+        if (request_count >= 16) begin
+          $display("FAIL expected one shared external request per slice");
+          $finish(1);
+        end
+        if (value_read_req_address !== 14'd0) begin
+          $display("FAIL unexpected request address %0d", value_read_req_address);
+          $finish(1);
+        end
+        if (value_read_req_slice !== request_count[3:0]) begin
+          $display("FAIL request slice order mismatch got=%0d expected=%0d", value_read_req_slice, request_count);
+          $finish(1);
+        end
+      end
+      pending_rsp <= 1'b1;
+      pending_addr <= value_read_req_address;
+      pending_slice <= value_read_req_slice;
+      request_count <= request_count + 1;
+    end else if (pending_rsp && value_response_ready) begin
+      value_response_valid <= 1'b1;
+      value_response_address <= pending_addr;
+      value_response_slice <= pending_slice;
+      value_response_matrix <= {{64{{8'h01}}}};
+      pending_rsp <= 1'b0;
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rst_n && !first_command_done && protocol_error) begin
+      $display("FAIL protocol_error asserted during aligned replay");
+      $finish(1);
+    end
+    if (rst_n && command_inflight && !first_command_done && command_ready) begin
+      $display("FAIL command_ready reasserted before every head completed");
+      $finish(1);
+    end
+    if (!first_command_done && result_valid && result_ready) begin
+      if (result_command_id !== 16'h1234) begin
+        $display("FAIL unexpected command id %0d", result_command_id);
+        $finish(1);
+      end
+      if (result_head !== expected_head[2:0]) begin
+        $display("FAIL result head order mismatch got=%0d expected=%0d", result_head, expected_head);
+        $finish(1);
+      end
+      if (result_slice !== expected_slice[3:0]) begin
+        $display("FAIL result slice order mismatch got=%0d expected=%0d", result_slice, expected_slice);
+        $finish(1);
+      end
+      if (result_last !== (expected_slice == 15)) begin
+        $display("FAIL result_last mismatch at head=%0d slice=%0d", expected_head, expected_slice);
+        $finish(1);
+      end
+      if (result_value[7:0] !== expected_head + 1 || result_value[11:8] !== expected_slice[3:0]) begin
+        $display("FAIL result payload mapping mismatch head=%0d slice=%0d value=%0h",
+            expected_head, expected_slice, result_value[11:0]);
+        $finish(1);
+      end
+      result_count <= result_count + 1;
+      if (expected_slice == 15) begin
+        expected_slice <= 0;
+        if (expected_head == 7) begin
+          first_command_done <= 1'b1;
+          command_inflight <= 1'b0;
+        end else begin
+          expected_head <= expected_head + 1;
+        end
+      end else begin
+        expected_slice <= expected_slice + 1;
+      end
+    end
+  end
+
+  initial begin
+    repeat (4) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+
+    send_command(16'h1234);
+    send_input_beat(64'h08_07_06_05_04_03_02_01, 64'h01_01_01_01_01_01_01_01);
+
+    wait (first_command_done);
+    @(posedge clk);
+    if (request_count != 16) begin
+      $display("FAIL expected 16 shared requests, saw %0d", request_count);
+      $finish(1);
+    end
+    if (result_count != 128) begin
+      $display("FAIL expected 128 serialized result beats, saw %0d", result_count);
+      $finish(1);
+    end
+    if (!command_ready) begin
+      $display("FAIL command_ready did not return after full group completion");
+      $finish(1);
+    end
+    if (accepted_count != 32'd1 || completed_count != 32'd1) begin
+      $display("FAIL wrapper counters accepted=%0d completed=%0d", accepted_count, completed_count);
+      $finish(1);
+    end
+
+    send_command(16'h5678);
+    force dut.u_head_7.value_read_req_slice = 4'd15;
+    send_input_beat(64'h08_07_06_05_04_03_02_01, 64'h01_01_01_01_01_01_01_01);
+    wait (dut.u_head_7.value_read_req_valid);
+    @(posedge clk);
+    @(negedge clk);
+    release dut.u_head_7.value_read_req_slice;
+    repeat (3) @(posedge clk);
+    if (!protocol_error) begin
+      $display("FAIL protocol_error did not assert on divergent request");
+      $finish(1);
+    end
+
+    $display("PASS attention_decode_score_multivalue_gqa_group protocol");
+    $finish(0);
+  end
+endmodule
+"""
+
+    tb_path = tmp_path / "tb.v"
+    tb_path.write_text(tb_text, encoding="utf-8")
+
+    subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-s",
+            "tb",
+            "-o",
+            str(tmp_path / "simv"),
+            str(tb_path),
+            str(wrapper_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    run = subprocess.run(
+        [vvp, str(tmp_path / "simv")],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert "PASS attention_decode_score_multivalue_gqa_group protocol" in run.stdout

--- a/tests/test_attention_decode_score_multivalue_gqa_group_equivalence.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_equivalence.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from npu.eval.audit_attention_decode_score_multivalue_gqa_group_equivalence import (
+    _ordered_group_hash,
+    _render_markdown,
+    build_report,
+)
+
+
+def _config() -> dict:
+    return {
+        "top_name": "attention_decode_score_multivalue_gqa8_arithmetic_audit",
+        "attention_decode_score_multivalue_gqa_group": {
+            "max_blocks": 16,
+            "array_n": 8,
+            "value_slices": 16,
+            "divider_impl": "iterative_restoring",
+            "score_scale_lanes_per_cycle": 8,
+            "query_heads_per_kv": 8,
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def report() -> dict:
+    return build_report(_config())
+
+
+def test_gqa8_shared_kv_real_cluster_arithmetic_equivalence(report: dict) -> None:
+    assert report["decision"] == "llama7b_gqa8_shared_kv_equivalence_pass", json.dumps(report, indent=2)
+    assert report["equivalence_pass"] is True
+    assert report["arithmetic_equivalence_pass"] is True
+    assert report["query_heads_per_kv"] == 8
+    assert report["head_dim"] == 128
+    assert len(report["heads"]) == 8
+    assert [row["head"] for row in report["heads"]] == list(range(8))
+    assert len({row["query_sha256"] for row in report["heads"]}) == 8
+    assert report["shared_inputs_pass"] is True
+    assert {row["shared_key_sha256"] for row in report["heads"]} == {report["shared_key_sha256"]}
+    assert {row["shared_value_sha256"] for row in report["heads"]} == {report["shared_value_sha256"]}
+    assert all(row["expected_score_sha256"] == row["observed_score_sha256"] for row in report["heads"])
+    assert all(row["expected_result_sha256"] == row["observed_result_sha256"] for row in report["heads"])
+    assert report["expected_group_result_sha256"] == report["observed_group_result_sha256"]
+    assert report["group_result_sha256"] == report["observed_group_result_sha256"]
+    assert report["expected_group_results"] == report["observed_group_results"]
+    assert len(report["observed_group_results"]) == 128
+    assert [(row["head"], row["slice"]) for row in report["observed_group_results"]] == [
+        (head, value_slice) for head in range(8) for value_slice in range(16)
+    ]
+    assert report["per_head_result_sha256"] == [row["observed_result_sha256"] for row in report["heads"]]
+
+
+def test_gqa8_report_states_compositional_scope_and_protocol_gate(report: dict) -> None:
+    assert report["wrapper_protocol"]["sharing_and_order_pass"] is True
+    assert report["wrapper_protocol"]["passed_test_count"] == 1
+    proof = report["compositional_proof"]
+    assert proof["method"] == "single_cluster_arithmetic_plus_wrapper_protocol"
+    assert proof["flat_8_cluster_rtl_simulation_run"] is False
+    markdown = _render_markdown(report)
+    assert "real single-cluster arithmetic pass: `True`" in markdown
+    assert "wrapper sharing/order protocol pass: `True`" in markdown
+    assert "does not claim that a flat eight-cluster RTL simulation was run" in markdown
+
+
+def test_ordered_group_hash_is_deterministic_and_head_order_sensitive() -> None:
+    heads = [
+        {"head": 1, "observed_result_sha256": "head-one"},
+        {"head": 0, "observed_result_sha256": "head-zero"},
+    ]
+    assert _ordered_group_hash(heads, "observed_result_sha256") == _ordered_group_hash(
+        list(reversed(heads)), "observed_result_sha256"
+    )
+    changed = [dict(row) for row in heads]
+    changed[0]["head"] = 2
+    assert _ordered_group_hash(heads, "observed_result_sha256") != _ordered_group_hash(
+        changed, "observed_result_sha256"
+    )


### PR DESCRIPTION
## Summary
- add an eight-query-head GQA wrapper around the measured shared-score multivalue cluster
- broadcast one shared key stream and collapse aligned value replay to one external request stream
- serialize 128 result beats in head-major, slice-major order and detect child protocol divergence
- add a compositional arithmetic gate using real single-cluster RTL for eight distinct queries with identical K/V tensors

## Why
The previous Llama7B frontier treated each query head independently and therefore could not represent GQA8 value sharing. This closes that abstraction before PPA and frontier recosting.

## Equivalence scope
The arithmetic gate runs the real generated cluster RTL independently for all eight query heads and compares score rows and all output values with the performance/reference model. The wrapper protocol simulation proves key broadcast, shared external value replay, query-lane mapping, backpressure, and deterministic output order. It explicitly does not claim a flat eight-cluster RTL simulation.

## Validation
- `PYTHONPATH=. pytest -q tests/test_attention_decode_score_multivalue_cluster.py tests/test_attention_decode_score_multivalue_gqa_group.py tests/test_attention_decode_score_multivalue_gqa_group_equivalence.py` (10 passed)
- `python3 -m py_compile` on the generator, audit, and tests
- `git diff --cached --check`