### PR TITLE
Gate Layer 1 tasks on proposal dependencies

### DIFF
--- a/control_plane/control_plane/cli/generate_l1_sweep.py
+++ b/control_plane/control_plane/cli/generate_l1_sweep.py
@@ -31,6 +31,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--make-target")
     parser.add_argument("--evaluation-mode")
     parser.add_argument("--abstraction-layer")
+    parser.add_argument("--expected-direction")
+    parser.add_argument("--expected-reason")
+    parser.add_argument("--comparison-role")
+    parser.add_argument("--paired-baseline-item-id")
+    parser.add_argument("--depends-on-item-id", action="append")
+    parser.add_argument("--requires-merged-inputs", action="store_true")
+    parser.add_argument("--requires-materialized-refs", action="store_true")
     parser.add_argument("--trial-count", type=int, default=1)
     parser.add_argument("--seed-start", type=int, default=0)
     parser.add_argument("--stop-after-failures", type=int)
@@ -65,6 +72,13 @@ def main(argv: list[str] | None = None) -> int:
                 make_target=args.make_target,
                 evaluation_mode=args.evaluation_mode,
                 abstraction_layer=args.abstraction_layer,
+                expected_direction=args.expected_direction,
+                expected_reason=args.expected_reason,
+                comparison_role=args.comparison_role,
+                paired_baseline_item_id=args.paired_baseline_item_id,
+                depends_on_item_ids=args.depends_on_item_id,
+                requires_merged_inputs=args.requires_merged_inputs,
+                requires_materialized_refs=args.requires_materialized_refs,
                 trial_count=args.trial_count,
                 seed_start=args.seed_start,
                 stop_after_failures=args.stop_after_failures,

--- a/control_plane/control_plane/cli/main.py
+++ b/control_plane/control_plane/cli/main.py
@@ -83,6 +83,13 @@ def main(argv: list[str] | None = None) -> int:
     generate_l1_parser.add_argument("--make-target")
     generate_l1_parser.add_argument("--evaluation-mode")
     generate_l1_parser.add_argument("--abstraction-layer")
+    generate_l1_parser.add_argument("--expected-direction")
+    generate_l1_parser.add_argument("--expected-reason")
+    generate_l1_parser.add_argument("--comparison-role")
+    generate_l1_parser.add_argument("--paired-baseline-item-id")
+    generate_l1_parser.add_argument("--depends-on-item-id", action="append")
+    generate_l1_parser.add_argument("--requires-merged-inputs", action="store_true")
+    generate_l1_parser.add_argument("--requires-materialized-refs", action="store_true")
     generate_l1_parser.add_argument("--trial-count", type=int, default=1)
     generate_l1_parser.add_argument("--seed-start", type=int, default=0)
     generate_l1_parser.add_argument("--stop-after-failures", type=int)
@@ -541,6 +548,10 @@ def main(argv: list[str] | None = None) -> int:
             ("--make-target", args.make_target),
             ("--evaluation-mode", args.evaluation_mode),
             ("--abstraction-layer", args.abstraction_layer),
+            ("--expected-direction", args.expected_direction),
+            ("--expected-reason", args.expected_reason),
+            ("--comparison-role", args.comparison_role),
+            ("--paired-baseline-item-id", args.paired_baseline_item_id),
             ("--stop-after-failures", args.stop_after_failures),
             ("--dispatch-machine-key", args.dispatch_machine_key),
         ]:
@@ -548,6 +559,12 @@ def main(argv: list[str] | None = None) -> int:
                 argv2.extend([key, str(value)])
         if args.no_auto_dispatch:
             argv2.append("--no-auto-dispatch")
+        for item_id in args.depends_on_item_id or []:
+            argv2.extend(["--depends-on-item-id", str(item_id)])
+        if args.requires_merged_inputs:
+            argv2.append("--requires-merged-inputs")
+        if args.requires_materialized_refs:
+            argv2.append("--requires-materialized-refs")
         if args.no_update_proposal_files:
             argv2.append("--no-update-proposal-files")
         if args.dispatch_freshness_seconds is not None:

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -18,6 +18,7 @@ from control_plane.clock import utcnow
 from control_plane.models.enums import FlowName, LayerName, WorkItemState
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
+from control_plane.services.dependency_gate import evaluate_work_item_dependencies
 from control_plane.services.docs_paths import canonicalize_proposal_path, resolve_proposal_dir, resolve_proposal_file
 from control_plane.services.proposal_scaffold import ensure_proposal_scaffold
 from control_plane.services.source_requirement import build_source_requirement
@@ -47,6 +48,13 @@ class Layer1SweepGenerateRequest:
     make_target: str | None = None
     evaluation_mode: str | None = None
     abstraction_layer: str | None = None
+    expected_direction: str | None = None
+    expected_reason: str | None = None
+    comparison_role: str | None = None
+    paired_baseline_item_id: str | None = None
+    depends_on_item_ids: list[str] | None = None
+    requires_merged_inputs: bool = False
+    requires_materialized_refs: bool = False
     trial_count: int = 1
     seed_start: int = 0
     stop_after_failures: int | None = None
@@ -108,6 +116,101 @@ def _resolve_proposal_abstraction_layer(repo_root: Path, proposal_path: str | No
     return resolved or None
 
 
+def _proposal_dir(repo_root: Path, proposal_path: str | None) -> Path | None:
+    proposal_path_text = str(proposal_path or "").strip()
+    if not proposal_path_text:
+        return None
+    return resolve_proposal_dir(repo_root, proposal_path=proposal_path_text)
+
+
+def _load_requested_item_entry(repo_root: Path, proposal_path: str | None, item_id: str) -> dict[str, Any] | None:
+    proposal_dir = _proposal_dir(repo_root, proposal_path)
+    if proposal_dir is None:
+        return None
+    evaluation_requests_path = proposal_dir / "evaluation_requests.json"
+    if not evaluation_requests_path.exists():
+        return None
+    try:
+        payload = _load_json(evaluation_requests_path)
+    except Exception:
+        return None
+    requested_items = payload.get("requested_items")
+    if not isinstance(requested_items, list):
+        return None
+    for entry in requested_items:
+        if isinstance(entry, dict) and str(entry.get("item_id", "")).strip() == item_id:
+            return entry
+    retry_base = _retry_base(item_id)
+    retry_matches = [
+        entry
+        for entry in requested_items
+        if isinstance(entry, dict) and _retry_base(str(entry.get("item_id", "")).strip()) == retry_base
+    ]
+    return retry_matches[0] if len(retry_matches) == 1 else None
+
+
+def _resolve_requested_entry_text(
+    entry: dict[str, Any] | None,
+    *,
+    key: str,
+    explicit: str | None,
+) -> str | None:
+    resolved = str(explicit or "").strip()
+    if resolved:
+        return resolved
+    if not isinstance(entry, dict):
+        return None
+    candidate = str(entry.get(key, "")).strip()
+    return candidate or None
+
+
+def _resolve_requested_entry_expected_result_text(
+    entry: dict[str, Any] | None,
+    *,
+    key: str,
+    explicit: str | None,
+) -> str | None:
+    resolved = str(explicit or "").strip()
+    if resolved:
+        return resolved
+    if not isinstance(entry, dict):
+        return None
+    expected_result = entry.get("expected_result")
+    if not isinstance(expected_result, dict):
+        return None
+    candidate = str(expected_result.get(key, "")).strip()
+    return candidate or None
+
+
+def _resolve_requested_entry_list(
+    entry: dict[str, Any] | None,
+    *,
+    key: str,
+    explicit: list[str] | None,
+) -> list[str] | None:
+    if explicit is not None:
+        return [str(value).strip() for value in explicit if str(value).strip()]
+    if not isinstance(entry, dict):
+        return None
+    values = entry.get(key)
+    if not isinstance(values, list):
+        return None
+    return [str(value).strip() for value in values if str(value).strip()]
+
+
+def _resolve_requested_entry_bool(
+    entry: dict[str, Any] | None,
+    *,
+    key: str,
+    explicit: bool,
+) -> bool:
+    if explicit:
+        return True
+    if not isinstance(entry, dict):
+        return False
+    return bool(entry.get(key))
+
+
 def _retry_base(item_id: str) -> str:
     return item_id.rsplit("_r", 1)[0] if "_r" in item_id else item_id
 
@@ -122,6 +225,13 @@ def _upsert_evaluation_request_entry(
     objective: str,
     evaluation_mode: str,
     abstraction_layer: str | None,
+    expected_direction: str | None,
+    expected_reason: str | None,
+    comparison_role: str | None,
+    paired_baseline_item_id: str | None,
+    depends_on_item_ids: list[str] | None,
+    requires_merged_inputs: bool,
+    requires_materialized_refs: bool,
     acceptance_notes: str | None,
     source_commit: str,
 ) -> None:
@@ -178,6 +288,16 @@ def _upsert_evaluation_request_entry(
     entry["objective"] = objective
     entry["evaluation_mode"] = evaluation_mode
     entry["abstraction_layer"] = str(abstraction_layer or "").strip()
+    entry["comparison_role"] = str(comparison_role or "").strip()
+    entry["paired_baseline_item_id"] = str(paired_baseline_item_id or "").strip()
+    entry["depends_on_item_ids"] = [str(value).strip() for value in (depends_on_item_ids or []) if str(value).strip()]
+    entry["requires_merged_inputs"] = bool(requires_merged_inputs)
+    entry["requires_materialized_refs"] = bool(requires_materialized_refs)
+    if str(expected_direction or "").strip() or str(expected_reason or "").strip():
+        entry["expected_result"] = {
+            "direction": str(expected_direction or "").strip(),
+            "reason": str(expected_reason or "").strip(),
+        }
     acceptance_notes_text = str(acceptance_notes or "").strip()
     if acceptance_notes_text:
         entry["acceptance_notes"] = acceptance_notes_text
@@ -1265,6 +1385,13 @@ def _build_payload(
     proposal_path: str | None,
     evaluation_mode: str,
     abstraction_layer: str | None,
+    expected_direction: str | None,
+    expected_reason: str | None,
+    comparison_role: str | None,
+    paired_baseline_item_id: str | None,
+    depends_on_item_ids: list[str] | None,
+    requires_merged_inputs: bool,
+    requires_materialized_refs: bool,
     trial_policy: dict[str, int],
     acceptance_notes: str | None,
 ) -> dict[str, Any]:
@@ -1347,12 +1474,26 @@ def _build_payload(
             "proposal_path": proposal_path or "",
             "evaluation": {
                 "mode": evaluation_mode,
+                "expected_direction": expected_direction or "",
+                "expected_reason": expected_reason or "",
                 "trial_policy": trial_policy,
             },
         }
         if abstraction_layer:
             payload["developer_loop"]["abstraction"] = {
                 "layer": abstraction_layer,
+            }
+        if comparison_role or paired_baseline_item_id:
+            payload["developer_loop"]["comparison"] = {
+                "role": comparison_role or "",
+                "paired_baseline_item_id": paired_baseline_item_id or "",
+            }
+        dependency_ids = [str(item).strip() for item in (depends_on_item_ids or []) if str(item).strip()]
+        if dependency_ids or requires_merged_inputs or requires_materialized_refs:
+            payload["developer_loop"]["dependencies"] = {
+                "item_ids": dependency_ids,
+                "requires_merged_inputs": requires_merged_inputs,
+                "requires_materialized_refs": requires_materialized_refs,
             }
     if not acceptance_notes_text:
         payload["task"].pop("metadata", None)
@@ -1367,9 +1508,65 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
     sweep_path = _repo_rel(request.sweep_path, repo_root)
     config_paths = [_repo_rel(path, repo_root) for path in request.config_paths]
     out_root = _repo_rel(request.out_root, repo_root)
+    item_id = request.item_id or _default_item_id(
+        sweep_path=sweep_path,
+        platform=request.platform,
+        config_paths=config_paths,
+    )
     proposal_path = _repo_rel(request.proposal_path, repo_root) if request.proposal_path else None
     proposal_path = canonicalize_proposal_path(repo_root, proposal_path=proposal_path, proposal_id=request.proposal_id)
-    effective_abstraction_layer = _resolve_proposal_abstraction_layer(repo_root, proposal_path, request.abstraction_layer)
+    effective_proposal_id = str(request.proposal_id or "").strip()
+    if not effective_proposal_id and proposal_path:
+        proposal_path_obj = Path(proposal_path)
+        effective_proposal_id = (
+            proposal_path_obj.parent.name if proposal_path_obj.name == "proposal.json" else proposal_path_obj.name
+        )
+    requested_entry = _load_requested_item_entry(repo_root, proposal_path, item_id)
+    effective_evaluation_mode = _resolve_requested_entry_text(
+        requested_entry,
+        key="evaluation_mode",
+        explicit=request.evaluation_mode,
+    )
+    effective_abstraction_layer = _resolve_requested_entry_text(
+        requested_entry,
+        key="abstraction_layer",
+        explicit=request.abstraction_layer,
+    ) or _resolve_proposal_abstraction_layer(repo_root, proposal_path, request.abstraction_layer)
+    effective_expected_direction = _resolve_requested_entry_expected_result_text(
+        requested_entry,
+        key="direction",
+        explicit=request.expected_direction,
+    )
+    effective_expected_reason = _resolve_requested_entry_expected_result_text(
+        requested_entry,
+        key="reason",
+        explicit=request.expected_reason,
+    )
+    effective_comparison_role = _resolve_requested_entry_text(
+        requested_entry,
+        key="comparison_role",
+        explicit=request.comparison_role,
+    )
+    effective_paired_baseline_item_id = _resolve_requested_entry_text(
+        requested_entry,
+        key="paired_baseline_item_id",
+        explicit=request.paired_baseline_item_id,
+    )
+    effective_depends_on_item_ids = _resolve_requested_entry_list(
+        requested_entry,
+        key="depends_on_item_ids",
+        explicit=request.depends_on_item_ids,
+    )
+    effective_requires_merged_inputs = _resolve_requested_entry_bool(
+        requested_entry,
+        key="requires_merged_inputs",
+        explicit=request.requires_merged_inputs,
+    )
+    effective_requires_materialized_refs = _resolve_requested_entry_bool(
+        requested_entry,
+        key="requires_materialized_refs",
+        explicit=request.requires_materialized_refs,
+    )
     _validate_architecture_block_sweep_policy(
         sweep_path=(repo_root / sweep_path).resolve(),
         abstraction_layer=effective_abstraction_layer,
@@ -1406,11 +1603,6 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         expected_outputs.append(target.expected_metrics_path)
         expected_outputs.extend(target.expected_report_paths)
 
-    item_id = request.item_id or _default_item_id(
-        sweep_path=sweep_path,
-        platform=request.platform,
-        config_paths=config_paths,
-    )
     title = request.title or _default_title(sweep_path=sweep_path, platform=request.platform)
     objective = request.objective or _default_objective(
         platform=request.platform,
@@ -1438,13 +1630,20 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         out_root=out_root,
         expected_outputs=expected_outputs,
         command_manifest=command_manifest,
-        proposal_id=request.proposal_id,
+        proposal_id=effective_proposal_id,
         proposal_path=proposal_path,
         evaluation_mode=_effective_evaluation_mode(
-            evaluation_mode=request.evaluation_mode,
+            evaluation_mode=effective_evaluation_mode,
             make_target=request.make_target,
         ),
         abstraction_layer=effective_abstraction_layer,
+        expected_direction=effective_expected_direction,
+        expected_reason=effective_expected_reason,
+        comparison_role=effective_comparison_role,
+        paired_baseline_item_id=effective_paired_baseline_item_id,
+        depends_on_item_ids=effective_depends_on_item_ids,
+        requires_merged_inputs=effective_requires_merged_inputs,
+        requires_materialized_refs=effective_requires_materialized_refs,
         trial_policy=trial_policy,
         acceptance_notes=request.acceptance_notes,
     )
@@ -1455,16 +1654,53 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
     if request.update_proposal_files:
         _upsert_evaluation_request_entry(
             repo_root=repo_root,
-            proposal_id=request.proposal_id,
+            proposal_id=effective_proposal_id,
             proposal_path=proposal_path,
             item_id=item_id,
             task_type="l1_sweep",
             objective=objective,
             evaluation_mode=((payload.get("developer_loop") or {}).get("evaluation") or {}).get("mode") or "",
             abstraction_layer=effective_abstraction_layer,
+            expected_direction=effective_expected_direction,
+            expected_reason=effective_expected_reason,
+            comparison_role=effective_comparison_role,
+            paired_baseline_item_id=effective_paired_baseline_item_id,
+            depends_on_item_ids=effective_depends_on_item_ids,
+            requires_merged_inputs=effective_requires_merged_inputs,
+            requires_materialized_refs=effective_requires_materialized_refs,
             acceptance_notes=request.acceptance_notes,
             source_commit=source_commit,
         )
+
+    initial_state = WorkItemState.DISPATCH_PENDING
+    transient_work_item = WorkItem(
+        work_item_key=f"l1_sweep:{item_id}",
+        task_request_id="",
+        item_id=item_id,
+        layer=LayerName.LAYER1,
+        flow=FlowName.OPENROAD,
+        platform=request.platform,
+        task_type="l1_sweep",
+        state=WorkItemState.DRAFT,
+        priority=request.priority,
+        source_mode="config",
+    )
+    transient_task_request = TaskRequest(
+        request_key=f"l1_sweep:{item_id}",
+        source="l1_task_generator",
+        requested_by=request.requested_by,
+        title=title,
+        description=objective,
+        layer=LayerName.LAYER1,
+        flow=FlowName.OPENROAD,
+        priority=request.priority,
+        request_payload=payload,
+        source_commit=source_commit,
+    )
+    transient_work_item.task_request = transient_task_request
+    gate = evaluate_work_item_dependencies(session, repo_root=repo_root, work_item=transient_work_item)
+    if not gate.satisfied:
+        initial_state = WorkItemState.BLOCKED
 
     existing = session.query(WorkItem).filter(WorkItem.item_id == item_id).one_or_none()
     if existing is None:
@@ -1491,7 +1727,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             flow=FlowName.OPENROAD,
             platform=request.platform,
             task_type="l1_sweep",
-            state=WorkItemState.DISPATCH_PENDING,
+            state=initial_state,
             priority=request.priority,
             source_mode="config",
             input_manifest=payload["task"]["inputs"],
@@ -1532,8 +1768,13 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
     existing.acceptance_rules = payload["task"]["acceptance"]
     existing.source_commit = source_commit
     existing.trial_policy_json = ((payload.get("developer_loop") or {}).get("evaluation") or {}).get("trial_policy") or {}
-    if existing.state == WorkItemState.FAILED:
-        existing.state = WorkItemState.DISPATCH_PENDING
+    if existing.state in {
+        WorkItemState.DRAFT,
+        WorkItemState.BLOCKED,
+        WorkItemState.DISPATCH_PENDING,
+        WorkItemState.FAILED,
+    }:
+        existing.state = initial_state
         existing.assigned_machine_key = None
         existing.queue_snapshot_path = None
     session.commit()

--- a/control_plane/control_plane/tests/test_cli_generate_l1.py
+++ b/control_plane/control_plane/tests/test_cli_generate_l1.py
@@ -31,6 +31,18 @@ def test_top_level_generate_l1_forwards_extended_generation_flags() -> None:
                 "measurement_only",
                 "--abstraction-layer",
                 "circuit_block",
+                "--expected-direction",
+                "lower_power",
+                "--expected-reason",
+                "shared datapath",
+                "--comparison-role",
+                "candidate_pnr",
+                "--paired-baseline-item-id",
+                "l1_baseline",
+                "--depends-on-item-id",
+                "l2_equivalence",
+                "--requires-merged-inputs",
+                "--requires-materialized-refs",
                 "--acceptance-notes",
                 "accept timing/flow failures as boundary evidence",
                 "--trial-count",
@@ -50,6 +62,13 @@ def test_top_level_generate_l1_forwards_extended_generation_flags() -> None:
     assert forwarded[forwarded.index("--make-target") + 1] == "1_1_yosys_canonicalize"
     assert forwarded[forwarded.index("--evaluation-mode") + 1] == "measurement_only"
     assert forwarded[forwarded.index("--abstraction-layer") + 1] == "circuit_block"
+    assert forwarded[forwarded.index("--expected-direction") + 1] == "lower_power"
+    assert forwarded[forwarded.index("--expected-reason") + 1] == "shared datapath"
+    assert forwarded[forwarded.index("--comparison-role") + 1] == "candidate_pnr"
+    assert forwarded[forwarded.index("--paired-baseline-item-id") + 1] == "l1_baseline"
+    assert forwarded[forwarded.index("--depends-on-item-id") + 1] == "l2_equivalence"
+    assert "--requires-merged-inputs" in forwarded
+    assert "--requires-materialized-refs" in forwarded
     assert forwarded[forwarded.index("--acceptance-notes") + 1] == "accept timing/flow failures as boundary evidence"
     assert forwarded[forwarded.index("--trial-count") + 1] == "3"
     assert forwarded[forwarded.index("--seed-start") + 1] == "100"

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -1503,6 +1503,11 @@ def test_generate_l1_sweep_task_records_requested_item_in_proposal_evaluation_re
                 ),
                 "evaluation_mode": "measurement_only",
                 "abstraction_layer": "circuit_block",
+                "comparison_role": "",
+                "paired_baseline_item_id": "",
+                "depends_on_item_ids": [],
+                "requires_merged_inputs": False,
+                "requires_materialized_refs": False,
                 "acceptance_notes": "Accept flow_failed rows as explicit boundary evidence.",
                 "status": "pending",
             }
@@ -1575,6 +1580,92 @@ def test_generate_l1_sweep_task_can_refresh_db_without_updating_proposal_files()
         assert evaluation_requests_path.read_text(encoding="utf-8") == before
 
 
+def test_generate_l1_sweep_task_inherits_proposal_dependencies_and_starts_blocked() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        item_id = "l1_demo_dependent_pnr_v1"
+        dependency_item_id = "l2_demo_equivalence_v1"
+        proposal_dir = repo_root / "docs" / "proposals" / "prop_l1_dependent_v1"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        (proposal_dir / "proposal.json").write_text(
+            json.dumps(
+                {"proposal_id": "prop_l1_dependent_v1", "abstraction_layer": "circuit_block"},
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (proposal_dir / "evaluation_requests.json").write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_l1_dependent_v1",
+                    "requested_items": [
+                        {
+                            "item_id": item_id,
+                            "task_type": "l1_sweep",
+                            "evaluation_mode": "frontier_followup",
+                            "abstraction_layer": "circuit_block",
+                            "comparison_role": "candidate_pnr",
+                            "paired_baseline_item_id": "l1_demo_baseline_pnr_v1",
+                            "depends_on_item_ids": [dependency_item_id],
+                            "requires_merged_inputs": True,
+                            "requires_materialized_refs": True,
+                            "expected_result": {
+                                "direction": "measure_candidate_ppa",
+                                "reason": "Run PPA only after equivalence evidence is merged.",
+                            },
+                        }
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    item_id=item_id,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l1_dependent_v1",
+                    proposal_path="docs/proposals/prop_l1_dependent_v1",
+                    update_proposal_files=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            payload = work_item.task_request.request_payload
+            assert work_item.state == WorkItemState.BLOCKED
+            assert payload["developer_loop"]["evaluation"] == {
+                "mode": "frontier_followup",
+                "expected_direction": "measure_candidate_ppa",
+                "expected_reason": "Run PPA only after equivalence evidence is merged.",
+                "trial_policy": {"trial_count": 1, "seed_start": 0, "stop_after_failures": 1},
+            }
+            assert payload["developer_loop"]["comparison"] == {
+                "role": "candidate_pnr",
+                "paired_baseline_item_id": "l1_demo_baseline_pnr_v1",
+            }
+            assert payload["developer_loop"]["dependencies"] == {
+                "item_ids": [dependency_item_id],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+
+
 def test_generate_l1_sweep_task_strips_placeholder_requested_items_from_template() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -1635,6 +1726,11 @@ def test_generate_l1_sweep_task_strips_placeholder_requested_items_from_template
                 ),
                 "evaluation_mode": "measurement_only",
                 "abstraction_layer": "circuit_block",
+                "comparison_role": "",
+                "paired_baseline_item_id": "",
+                "depends_on_item_ids": [],
+                "requires_merged_inputs": False,
+                "requires_materialized_refs": False,
                 "status": "pending",
             }
         ]

--- a/docs/developer_agent_artifacts.md
+++ b/docs/developer_agent_artifacts.md
@@ -223,6 +223,13 @@ consume prior developer-loop evidence rather than only historical baselines:
 - set `requires_materialized_refs` when the dependent item's exporter resolves
   baseline evidence by repo path, not only by DB metadata
 
+Task generators must load the matching `evaluation_requests.json` entry before
+building the work-item payload. This applies to both Layer 1 and Layer 2 items:
+copy comparison, expected-result, and dependency fields into `developer_loop`,
+evaluate the dependency gate before selecting the initial state, and keep an
+unsatisfied item `BLOCKED`. Do not rely on the proposal file alone to enforce
+dispatch order.
+
 ## 2. implementation_summary.md
 
 ### Purpose


### PR DESCRIPTION
## Summary
- load matching Layer 1 proposal evaluation-request metadata before building the work item
- preserve comparison, expected-result, and dependency fields in `developer_loop`
- evaluate dependencies before initial dispatch and keep unsatisfied PPA items blocked
- expose the dependency contract through the Layer 1 CLI and document the invariant

## Root cause
Layer 1 generation copied proposal identity and abstraction only. It always created `DISPATCH_PENDING`, so a proposal dependency on a preceding equivalence item was silently discarded.

## Validation
- 44 Layer 1 generator and CLI tests
- 21 dependency-gate, dispatcher, and operator-status tests
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`