### PR TITLE
Measure GQA8 shared-KV group activity power

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6806,6 +6806,67 @@ def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*
     }
 
 
+def _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    design = "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv"
+    config = f"runs/designs/npu_blocks/{design}/config.json"
+    metrics_csv = f"runs/designs/npu_blocks/{design}/metrics.csv"
+    equivalence_json = (
+        f"{base}/decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1.json"
+    )
+    cluster_activity_power_json = (
+        f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+    )
+    orfs_design_config = f"/orfs/flow/designs/nangate45/{design}/config.mk"
+    activity_dir = "/tmp/rtlgen_multivalue_gqa_group_activity"
+    out = f"{base}/decoder_attention_decode_score_multivalue_gqa_group_activity_power__{item_id}.json"
+    report = f"{base}/decoder_attention_decode_score_multivalue_gqa_group_activity_power__{item_id}.md"
+    return {
+        "inputs": {
+            "decode_score_multivalue_gqa_group_config": config,
+            "decode_score_multivalue_gqa_group_pnr_metrics_csv": metrics_csv,
+            "decode_score_multivalue_gqa_group_equivalence_json": equivalence_json,
+            "decode_score_multivalue_cluster_activity_power_json": cluster_activity_power_json,
+            "decode_score_multivalue_gqa_group_orfs_design_config": orfs_design_config,
+            "decode_score_multivalue_gqa_group_activity_dir": activity_dir,
+            "decode_score_multivalue_gqa_group_activity_power_out": out,
+            "decode_score_multivalue_gqa_group_activity_power_report": report,
+            "decode_score_multivalue_gqa_group_activity_power_scope": (
+                "Measure the GQA8 shared-K/V group activity contract after merged equivalence and PNR. "
+                "The report must distinguish directly annotated group activity from compositional scaling, "
+                "keep VCD/ODB/SPEF evaluator-local, and withhold total-token energy claims."
+            ),
+            "decode_score_multivalue_gqa_group_activity_power_promotion_gate": (
+                "Promotion requires explicit activity provenance, phase-cycle accounting, routed-power "
+                "annotation coverage for every directly measured component, finite energy, and no vectorless "
+                "or compositional estimate mislabeled as direct full-group measurement."
+            ),
+            "decode_score_multivalue_gqa_group_activity_power_local_only_artifacts": ["VCD", "ODB", "SPEF"],
+        },
+        "commands": [
+            {
+                "name": "audit_decode_score_multivalue_gqa_group_activity_power",
+                "run": (
+                    "python3 -m npu.eval.audit_attention_decode_score_multivalue_gqa_group_activity_power "
+                    f"--config {config} "
+                    f"--group-metrics-csv {metrics_csv} "
+                    f"--cluster-activity-power-json {cluster_activity_power_json} "
+                    f"--equivalence-json {equivalence_json} "
+                    f"--group-orfs-design-config {orfs_design_config} "
+                    "--clock-period-ns 8 "
+                    f"--activity-dir {activity_dir} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_decode_score_tile_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     operational = (
@@ -10476,6 +10537,7 @@ def _build_payload(
         "decoder_attention_decode_score_multivalue_cluster_equivalence",
         "decoder_attention_decode_score_multivalue_gqa_group_equivalence",
         "decoder_attention_decode_score_multivalue_cluster_activity_power",
+        "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
         "decoder_attention_decode_score_tile_frontier",
         "decoder_attention_decode_score_local_cluster_frontier",
         "decoder_attention_decode_score_multivalue_cluster_frontier",
@@ -10721,6 +10783,10 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_cluster_activity_power":
             decoder_evidence = _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(
+                item_id=item_id
+            )
+        elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_group_activity_power":
+            decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence(
                 item_id=item_id
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_tile_frontier":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7961,6 +7961,81 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
 
 
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activity_power() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:2]] == [
+                "audit_decode_score_multivalue_gqa_group_activity_power",
+                "validate_runs",
+            ]
+            assert "-m npu.eval.audit_attention_decode_score_multivalue_gqa_group_activity_power" in run
+            assert (
+                "--config runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv/config.json"
+            ) in run
+            assert (
+                "--group-metrics-csv runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv/metrics.csv"
+            ) in run
+            assert (
+                "--equivalence-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
+                "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1.json"
+            ) in run
+            assert (
+                "--cluster-activity-power-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+            ) in run
+            assert (
+                "--group-orfs-design-config /orfs/flow/designs/nangate45/"
+                "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv/config.mk"
+            ) in run
+            assert "--activity-dir /tmp/rtlgen_multivalue_gqa_group_activity" in run
+            assert decoder_inputs[
+                "decode_score_multivalue_gqa_group_activity_power_local_only_artifacts"
+            ] == ["VCD", "ODB", "SPEF"]
+            assert "distinguish directly annotated group activity" in decoder_inputs[
+                "decode_score_multivalue_gqa_group_activity_power_scope"
+            ]
+            assert "mislabeled as direct full-group measurement" in decoder_inputs[
+                "decode_score_multivalue_gqa_group_activity_power_promotion_gate"
+            ]
+            assert decoder_inputs["decode_score_multivalue_gqa_group_activity_power_out"].endswith(
+                "decoder_attention_decode_score_multivalue_gqa_group_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1.json"
+            )
+            assert decoder_inputs[
+                "decode_score_multivalue_gqa_group_activity_power_report"
+            ] in work_item.expected_outputs
+
+
 def test_generate_l2_campaign_task_adds_decode_score_tile_frontier() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_gate.md
@@ -13,3 +13,7 @@
 6. Keep timing- or placement-infeasible sweep rows as boundary evidence.
 7. Treat vectorless power as structural evidence only; activity-backed energy
    remains a follow-on gate.
+8. Gate activity power on merged equivalence and PPA, explicit phase-cycle
+   accounting, routed annotation coverage for directly measured components,
+   and direct-versus-compositional provenance. Do not promote compositional
+   scaling as a direct full-group power measurement or as total token energy.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -41,6 +41,26 @@
         "reason": "Use an explicit macro-derived die-size boundary and retain infeasible rows."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure activity-backed GQA8 group power after equivalence and routed PPA are merged.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+      "comparison_role": "gqa8_shared_kv_group_activity_power",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_gqa8_shared_kv_group_activity_energy",
+        "reason": "Token-energy ranking requires phase-accounted activity evidence and must distinguish direct routed measurement from compositional scaling."
+      },
+      "status": "pending_implementation_merge"
     }
   ]
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/implementation_summary.md
@@ -14,3 +14,9 @@ Results are exposed one child at a time in query-head order, with sixteen
 eight-dimensional slices per head. The wrapper counts one accepted and one
 completed GQA command, while child arithmetic and score storage remain the
 already-equivalent measured cluster implementation.
+
+The follow-on activity job consumes the merged group PPA and equivalence
+artifacts. Its report must separate directly annotated routed activity from
+any compositional scaling and keeps VCD, ODB, and SPEF evaluator-local. This
+closes group-component energy only; memory, NoC, HBM/DRAM, and total-token
+energy remain outside this measurement.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -78,6 +78,26 @@
         "reason": "The embodied group determines whether the 8x value-bandwidth reduction is affordable in area and timing."
       },
       "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure activity-backed group power with explicit direct-versus-compositional provenance.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+      "comparison_role": "gqa8_shared_kv_group_activity_power",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_gqa8_shared_kv_group_activity_energy",
+        "reason": "Energy ranking is ineligible until activity provenance, phase cycles, annotation coverage, and finite routed power are recorded."
+      },
+      "status": "pending_control_plane_merge"
     }
   ],
   "baseline_refs": [

--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_group_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_group_activity_power.py
@@ -58,7 +58,7 @@ def _metric_provenance(row: JsonDict, metrics_csv: Path) -> JsonDict:
         "params_json",
     )
     return {
-        "metrics_csv": metrics_csv.name,
+        "metrics_csv": str(metrics_csv),
         **{field: row[field] for field in fields if str(row.get(field, "")).strip()},
     }
 
@@ -114,7 +114,7 @@ def _finite_positive(value: object, label: str) -> float:
 
 def _cluster_baseline(path: Path, clock_period_ns: float) -> JsonDict:
     payload = _load(path)
-    if payload.get("model") not in {None, _CLUSTER_ACTIVITY_MODEL}:
+    if payload.get("model") != _CLUSTER_ACTIVITY_MODEL:
         raise ValueError("cluster activity power report model contract failed")
     if payload.get("promotion_gate_pass") is not True:
         raise ValueError("cluster activity power report is not a promoted measured baseline")
@@ -143,18 +143,60 @@ def _cluster_baseline(path: Path, clock_period_ns: float) -> JsonDict:
         activity_power.get("full_context_cycles"),
         "cluster best.activity_power.full_context_cycles",
     )
+    contract = payload.get("activity_contract")
+    if not isinstance(contract, dict) or not isinstance(contract.get("phases"), list):
+        raise ValueError("cluster activity baseline is missing its phase contract")
+    phases = contract["phases"]
+    if {str(row.get("phase")) for row in phases if isinstance(row, dict)} != {
+        "score_fill",
+        "replay_value",
+        "finalize_result",
+    }:
+        raise ValueError("cluster activity baseline phase set is incompatible")
+    phase_cycles = 0
+    target_max_blocks: int | None = None
+    for phase in phases:
+        if not isinstance(phase, dict):
+            raise ValueError("cluster activity baseline phase is malformed")
+        phase_cycles += int(_finite_positive(phase.get("full_context_cycles"), "cluster phase cycles"))
+        scaling = phase.get("scaling")
+        if not isinstance(scaling, dict) or scaling.get("target_max_blocks") is None:
+            raise ValueError("cluster activity baseline phase scaling is incomplete")
+        phase_target = int(scaling["target_max_blocks"])
+        if target_max_blocks is None:
+            target_max_blocks = phase_target
+        elif target_max_blocks != phase_target:
+            raise ValueError("cluster activity baseline phases disagree on target_max_blocks")
+    if phase_cycles != int(baseline_cycles):
+        raise ValueError("cluster activity baseline phase cycles do not sum to measured full-context cycles")
     return {
         "candidate_id": best.get("candidate_id"),
         "clock_period_ns": float(baseline_clock),
         "full_context_energy_j": baseline_energy,
         "full_context_cycles": int(baseline_cycles),
+        "target_max_blocks": target_max_blocks,
+        "phase_names": [str(row["phase"]) for row in phases],
         "activity_power_model": activity_power.get("model"),
         "report_model": payload.get("model"),
     }
 
 
 def _validate_gqa_equivalence(equivalence: JsonDict) -> JsonDict:
-    if equivalence.get("equivalence_pass") is not True:
+    wrapper = equivalence.get("wrapper_protocol")
+    expected_hash = equivalence.get("expected_group_result_sha256")
+    observed_hash = equivalence.get("observed_group_result_sha256")
+    if not (
+        equivalence.get("equivalence_pass") is True
+        and equivalence.get("decision") == "llama7b_gqa8_shared_kv_equivalence_pass"
+        and equivalence.get("distinct_query_heads_pass") is True
+        and equivalence.get("shared_inputs_pass") is True
+        and equivalence.get("arithmetic_equivalence_pass") is True
+        and isinstance(wrapper, dict)
+        and wrapper.get("sharing_and_order_pass") is True
+        and isinstance(expected_hash, str)
+        and expected_hash
+        and expected_hash == observed_hash
+    ):
         raise ValueError("GQA8 shared-KV equivalence did not pass")
     heads = equivalence.get("query_heads_per_kv")
     if heads is not None and int(heads) != _GQA_HEADS:
@@ -169,6 +211,19 @@ def _validate_gqa_equivalence(equivalence: JsonDict) -> JsonDict:
     }
 
 
+def _validate_activity_compatibility(activity_manifest: JsonDict, cluster_baseline: JsonDict) -> None:
+    phases = activity_manifest.get("phases")
+    if not isinstance(phases, list):
+        raise ValueError("group activity manifest is missing phases")
+    phase_names = [str(row.get("phase")) for row in phases if isinstance(row, dict)]
+    if set(phase_names) != set(cluster_baseline["phase_names"]):
+        raise ValueError("group and cluster activity phase sets are incompatible")
+    if int(activity_manifest.get("target_max_blocks", -1)) != int(cluster_baseline["target_max_blocks"]):
+        raise ValueError("group and cluster activity target_max_blocks contracts differ")
+    if int(activity_manifest.get("query_heads_per_kv", 0)) != _GQA_HEADS:
+        raise ValueError("group activity manifest is not GQA8")
+
+
 def _write_markdown(payload: JsonDict, path: Path) -> None:
     lines = [
         "# GQA8 shared-score multivalue group activity power",
@@ -177,14 +232,14 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
         f"- promoted candidates: `{payload['promoted_candidate_count']}`",
         f"- measured candidates: `{payload['candidate_count']}`",
         f"- energy scope: `{payload['energy_scope']}`",
-        f"- independent-cluster upper-bound factor: `{payload['independent_cluster_upper_bound_factor']}x`",
+        f"- independent-cluster reference factor: `{payload['independent_cluster_reference_factor']}x`",
         "",
-        "| variant | path ns | instance mm2 | status | group energy J | 8x cluster bound J | bound |",
+        "| variant | path ns | instance mm2 | status | group energy J | 8x cluster reference J | saves energy |",
         "|---|---:|---:|---|---:|---:|---|",
     ]
     for row in payload["candidates"]:
         metric = row["ppa_metric"]
-        comparison = row.get("independent_cluster_upper_bound", {})
+        comparison = row.get("eight_independent_clusters_reference", {})
         lines.append(
             "| {variant} | {path_ns} | {area_mm2:.6f} | {status} | {energy} | {bound} | {passed} |".format(
                 variant=row["flow_variant"],
@@ -234,7 +289,8 @@ def build_report(
     activity_manifest_path = (
         activity_dir / "attention_decode_score_multivalue_gqa_group_activity_manifest.json"
     )
-    upper_bound_energy = _GQA_HEADS * cluster_baseline["full_context_energy_j"]
+    _validate_activity_compatibility(activity_manifest, cluster_baseline)
+    reference_energy = _GQA_HEADS * cluster_baseline["full_context_energy_j"]
     rows: list[JsonDict] = []
     for metric in _feasible_metrics(group_metrics_csv, clock_period_ns):
         params = _params(metric)
@@ -262,22 +318,24 @@ def build_report(
                 direct_energy = _finite_positive(
                     direct_energy, "group activity power full_context_energy_j"
                 )
-            bound_pass = (
+            saves_energy = (
                 direct_energy is not None
                 and math.isfinite(float(direct_energy))
-                and float(direct_energy) <= upper_bound_energy
+                and float(direct_energy) <= reference_energy
             )
             candidate["activity_power"] = activity_power
             candidate["direct_group_full_context_energy_j"] = direct_energy
-            candidate["independent_cluster_upper_bound"] = {
+            candidate["eight_independent_clusters_reference"] = {
                 "factor": _GQA_HEADS,
                 "cluster_full_context_energy_j": cluster_baseline["full_context_energy_j"],
-                "energy_j": upper_bound_energy,
+                "energy_j": reference_energy,
                 "comparison": "direct_group_full_context_energy_j <= 8 * cluster_best.activity_power.full_context_energy_j",
-                "pass": bound_pass,
+                "pass": saves_energy,
+                "is_formal_upper_bound": False,
             }
-            candidate["independent_cluster_upper_bound_energy_j"] = upper_bound_energy
-            candidate["energy_upper_bound_pass"] = bound_pass
+            candidate["eight_independent_clusters_reference_energy_j"] = reference_energy
+            candidate["energy_saving_vs_eight_independent_clusters"] = saves_energy
+            candidate["energy_delta_vs_eight_independent_clusters_j"] = float(direct_energy) - reference_energy
             candidate["status"] = (
                 "activity_backed"
                 if activity_power.get("promotion_gate_pass")
@@ -313,7 +371,7 @@ def build_report(
         "best": best,
         "candidates": rows,
         "energy_scope": "one GQA8 group full-context decode attention command",
-        "independent_cluster_upper_bound_factor": _GQA_HEADS,
+        "independent_cluster_reference_factor": _GQA_HEADS,
         "cluster_baseline": cluster_baseline,
         "cluster_baseline_full_context_energy_j": cluster_baseline["full_context_energy_j"],
         "activity_contract": {
@@ -330,13 +388,14 @@ def build_report(
         },
         "equivalence": equivalence,
         "source_dependencies": [
-            "l2_decoder_attention_decode_score_multivalue_gqa_group_equivalence_llama7b_v1",
-            "l1_decoder_attention_decode_score_multivalue_gqa_group_pnr_v1",
+            "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+            "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
+            "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
             "prior_single_cluster_activity_power_best_activity_power",
         ],
         "remaining_abstractions": [
             "The direct result covers one GQA8 group command at the configured full context, not a total-token or full-model energy estimate.",
-            "The 8x independent-cluster value is an explicit comparison upper bound, not a regenerated cluster measurement or a FLOW_VARIANT pairing.",
+            "The 8x independent-cluster value is a measured comparison reference, not a formal upper bound, regenerated cluster measurement, or FLOW_VARIANT pairing.",
             "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
             "Off-group value memory, NoC, HBM/DRAM, command distribution, and clock-tree composition are outside this result.",
         ],

--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_group_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_group_activity_power.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Audit direct routed power for timing-feasible GQA group implementations."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from npu.eval.generate_attention_decode_score_multivalue_gqa_group_activity import (
+    generate_phase_activity,
+)
+from npu.synth.run_postroute_vcd_power import build_report as build_power_report
+
+JsonDict = dict[str, Any]
+_GQA_HEADS = 8
+_CLUSTER_ACTIVITY_MODEL = "decoder_attention_decode_score_multivalue_cluster_activity_power_v1"
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("expected a JSON object")
+    return payload
+
+
+def _params(row: JsonDict) -> JsonDict:
+    try:
+        payload = json.loads(str(row.get("params_json", "{}")))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid params_json for PPA row {row.get('param_hash')}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"params_json is not an object for PPA row {row.get('param_hash')}")
+    return payload
+
+
+def _metric_provenance(row: JsonDict, metrics_csv: Path) -> JsonDict:
+    fields = (
+        "design",
+        "platform",
+        "config_hash",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "total_power_mw",
+        "instance_area_um2",
+        "stdcell_area_um2",
+        "stdcell_count",
+        "core_area_um2",
+        "utilization_pct",
+        "flow_elapsed_seconds",
+        "stage_elapsed_seconds",
+        "params_json",
+    )
+    return {
+        "metrics_csv": metrics_csv.name,
+        **{field: row[field] for field in fields if str(row.get(field, "")).strip()},
+    }
+
+
+def _feasible_metrics(metrics_csv: Path, clock_period_ns: float) -> list[JsonDict]:
+    with metrics_csv.open(newline="", encoding="utf-8") as handle:
+        raw_rows = [dict(row) for row in csv.DictReader(handle)]
+    selected: dict[str, JsonDict] = {}
+    for row in raw_rows:
+        if str(row.get("status", "")) != "ok":
+            continue
+        params = _params(row)
+        row_clock = float(params.get("CLOCK_PERIOD", 0.0))
+        critical_path = float(row.get("critical_path_ns") or math.inf)
+        flow_variant = str(params.get("FLOW_VARIANT", "")).strip()
+        if not flow_variant or abs(row_clock - clock_period_ns) > 1e-9:
+            continue
+        if not math.isfinite(critical_path) or critical_path > clock_period_ns:
+            continue
+        previous = selected.get(flow_variant)
+        if previous is None or float(row.get("instance_area_um2") or math.inf) < float(
+            previous.get("instance_area_um2") or math.inf
+        ):
+            selected[flow_variant] = row
+    if not selected:
+        raise ValueError(f"no status=ok timing-feasible {clock_period_ns:g} ns group rows")
+    return sorted(
+        selected.values(),
+        key=lambda row: (
+            float(row.get("die_area") or math.inf),
+            float(row.get("instance_area_um2") or math.inf),
+            float(row.get("critical_path_ns") or math.inf),
+        ),
+    )
+
+
+def _sanitized_failure(exc: Exception) -> JsonDict:
+    message = str(exc).splitlines()[0].strip()
+    if "/" in message or "\\" in message:
+        message = f"evaluator-local path failure during {type(exc).__name__}"
+    return {"error_type": type(exc).__name__, "error_summary": message[:240]}
+
+
+def _finite_positive(value: object, label: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a finite positive number") from exc
+    if not math.isfinite(number) or number <= 0.0:
+        raise ValueError(f"{label} must be a finite positive number")
+    return number
+
+
+def _cluster_baseline(path: Path, clock_period_ns: float) -> JsonDict:
+    payload = _load(path)
+    if payload.get("model") not in {None, _CLUSTER_ACTIVITY_MODEL}:
+        raise ValueError("cluster activity power report model contract failed")
+    if payload.get("promotion_gate_pass") is not True:
+        raise ValueError("cluster activity power report is not a promoted measured baseline")
+    best = payload.get("best")
+    if not isinstance(best, dict):
+        raise ValueError("cluster activity power report best contract is missing")
+    activity_power = best.get("activity_power")
+    if not isinstance(activity_power, dict):
+        raise ValueError("cluster activity power report best.activity_power contract is missing")
+    if activity_power.get("promotion_gate_pass") is not True:
+        raise ValueError("cluster best.activity_power is not promotion-gated")
+    baseline_clock = activity_power.get("clock_period_ns")
+    if baseline_clock is None:
+        contract = payload.get("activity_contract")
+        if isinstance(contract, dict):
+            baseline_clock = contract.get("clock_period_ns")
+    if baseline_clock is None:
+        raise ValueError("cluster activity baseline is missing clock_period_ns")
+    if abs(float(baseline_clock) - clock_period_ns) > 1e-9:
+        raise ValueError("cluster activity baseline clock period does not match group audit")
+    baseline_energy = _finite_positive(
+        activity_power.get("full_context_energy_j"),
+        "cluster best.activity_power.full_context_energy_j",
+    )
+    baseline_cycles = _finite_positive(
+        activity_power.get("full_context_cycles"),
+        "cluster best.activity_power.full_context_cycles",
+    )
+    return {
+        "candidate_id": best.get("candidate_id"),
+        "clock_period_ns": float(baseline_clock),
+        "full_context_energy_j": baseline_energy,
+        "full_context_cycles": int(baseline_cycles),
+        "activity_power_model": activity_power.get("model"),
+        "report_model": payload.get("model"),
+    }
+
+
+def _validate_gqa_equivalence(equivalence: JsonDict) -> JsonDict:
+    if equivalence.get("equivalence_pass") is not True:
+        raise ValueError("GQA8 shared-KV equivalence did not pass")
+    heads = equivalence.get("query_heads_per_kv")
+    if heads is not None and int(heads) != _GQA_HEADS:
+        raise ValueError("equivalence report is not for GQA8")
+    return {
+        "equivalence_pass": True,
+        "decision": equivalence.get("decision"),
+        "semantic_profile": equivalence.get("semantic_profile"),
+        "query_heads_per_kv": int(heads) if heads is not None else _GQA_HEADS,
+        "expected_group_result_sha256": equivalence.get("expected_group_result_sha256"),
+        "observed_group_result_sha256": equivalence.get("observed_group_result_sha256"),
+    }
+
+
+def _write_markdown(payload: JsonDict, path: Path) -> None:
+    lines = [
+        "# GQA8 shared-score multivalue group activity power",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- promoted candidates: `{payload['promoted_candidate_count']}`",
+        f"- measured candidates: `{payload['candidate_count']}`",
+        f"- energy scope: `{payload['energy_scope']}`",
+        f"- independent-cluster upper-bound factor: `{payload['independent_cluster_upper_bound_factor']}x`",
+        "",
+        "| variant | path ns | instance mm2 | status | group energy J | 8x cluster bound J | bound |",
+        "|---|---:|---:|---|---:|---:|---|",
+    ]
+    for row in payload["candidates"]:
+        metric = row["ppa_metric"]
+        comparison = row.get("independent_cluster_upper_bound", {})
+        lines.append(
+            "| {variant} | {path_ns} | {area_mm2:.6f} | {status} | {energy} | {bound} | {passed} |".format(
+                variant=row["flow_variant"],
+                path_ns=metric.get("critical_path_ns"),
+                area_mm2=float(metric.get("instance_area_um2", 0.0)) / 1.0e6,
+                status=row["status"],
+                energy=row.get("direct_group_full_context_energy_j"),
+                bound=comparison.get("energy_j"),
+                passed=comparison.get("pass"),
+            )
+        )
+    lines.extend(["", "## Remaining Abstractions", ""])
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_report(
+    *,
+    config: Path,
+    group_metrics_csv: Path,
+    cluster_activity_power_json: Path,
+    equivalence_json: Path,
+    group_orfs_design_config: Path,
+    clock_period_ns: float,
+    activity_dir: Path,
+) -> JsonDict:
+    equivalence = _validate_gqa_equivalence(_load(equivalence_json))
+    cluster_baseline = _cluster_baseline(cluster_activity_power_json, clock_period_ns)
+    activity_dir.mkdir(parents=True, exist_ok=True)
+    for name in (
+        "score_fill.vcd",
+        "replay_value.vcd",
+        "finalize_result.vcd",
+        "attention_decode_score_multivalue_gqa_group_activity_manifest.json",
+    ):
+        path = activity_dir / name
+        if path.is_file():
+            path.unlink()
+    activity_manifest = generate_phase_activity(
+        _load(config),
+        activity_dir,
+        block_count=3,
+        head_dim=128,
+        clock_period_ns=clock_period_ns,
+    )
+    activity_manifest_path = (
+        activity_dir / "attention_decode_score_multivalue_gqa_group_activity_manifest.json"
+    )
+    upper_bound_energy = _GQA_HEADS * cluster_baseline["full_context_energy_j"]
+    rows: list[JsonDict] = []
+    for metric in _feasible_metrics(group_metrics_csv, clock_period_ns):
+        params = _params(metric)
+        flow_variant = str(params["FLOW_VARIANT"])
+        candidate: JsonDict = {
+            "candidate_id": f"multivalue_gqa_group_activity_{flow_variant}",
+            "flow_variant": flow_variant,
+            "ppa_metric": _metric_provenance(metric, group_metrics_csv),
+        }
+        try:
+            activity_power = build_power_report(
+                manifest=activity_manifest,
+                manifest_path=activity_manifest_path,
+                design_config=group_orfs_design_config,
+                flow_variant=flow_variant,
+                scope="tb/dut",
+                min_vcd_coverage=0.05,
+                min_vcd_pins=32,
+                min_macro_active_coverage=0.01,
+                min_macro_active_pins=16,
+                timeout_seconds=1800,
+            )
+            direct_energy = activity_power.get("full_context_energy_j")
+            if activity_power.get("promotion_gate_pass"):
+                direct_energy = _finite_positive(
+                    direct_energy, "group activity power full_context_energy_j"
+                )
+            bound_pass = (
+                direct_energy is not None
+                and math.isfinite(float(direct_energy))
+                and float(direct_energy) <= upper_bound_energy
+            )
+            candidate["activity_power"] = activity_power
+            candidate["direct_group_full_context_energy_j"] = direct_energy
+            candidate["independent_cluster_upper_bound"] = {
+                "factor": _GQA_HEADS,
+                "cluster_full_context_energy_j": cluster_baseline["full_context_energy_j"],
+                "energy_j": upper_bound_energy,
+                "comparison": "direct_group_full_context_energy_j <= 8 * cluster_best.activity_power.full_context_energy_j",
+                "pass": bound_pass,
+            }
+            candidate["independent_cluster_upper_bound_energy_j"] = upper_bound_energy
+            candidate["energy_upper_bound_pass"] = bound_pass
+            candidate["status"] = (
+                "activity_backed"
+                if activity_power.get("promotion_gate_pass")
+                else "rejected_gate"
+            )
+        except Exception as exc:  # preserve a sanitized negative row for physical-tool failures
+            candidate["status"] = "measurement_failed"
+            candidate["failure"] = _sanitized_failure(exc)
+        rows.append(candidate)
+    promoted = [row for row in rows if row["status"] == "activity_backed"]
+    best = None
+    if promoted:
+        best = min(
+            promoted,
+            key=lambda row: (
+                float(row["direct_group_full_context_energy_j"]),
+                float(row["ppa_metric"]["instance_area_um2"]),
+                float(row["ppa_metric"]["critical_path_ns"]),
+            ),
+        )
+    return {
+        "version": 1,
+        "model": "decoder_attention_decode_score_multivalue_gqa_group_activity_power_v1",
+        "decision": (
+            "activity_backed_gqa_group_power_measured"
+            if best is not None
+            else "activity_power_rejected_no_gated_candidate"
+        ),
+        "promotion_gate_pass": best is not None,
+        "candidate_count": len(rows),
+        "promoted_candidate_count": len(promoted),
+        "best_candidate_id": best["candidate_id"] if best is not None else None,
+        "best": best,
+        "candidates": rows,
+        "energy_scope": "one GQA8 group full-context decode attention command",
+        "independent_cluster_upper_bound_factor": _GQA_HEADS,
+        "cluster_baseline": cluster_baseline,
+        "cluster_baseline_full_context_energy_j": cluster_baseline["full_context_energy_j"],
+        "activity_contract": {
+            "scope": activity_manifest.get("scope"),
+            "scope_semantics": activity_manifest.get("scope_semantics"),
+            "clock_period_ns": activity_manifest["clock_period_ns"],
+            "query_heads_per_kv": activity_manifest["query_heads_per_kv"],
+            "representative_block_count": activity_manifest["block_count"],
+            "representative_full_transaction_cycles": activity_manifest[
+                "representative_full_transaction_cycles"
+            ],
+            "phase_partition_cycle_sum": activity_manifest["phase_partition_cycle_sum"],
+            "phases": activity_manifest["phases"],
+        },
+        "equivalence": equivalence,
+        "source_dependencies": [
+            "l2_decoder_attention_decode_score_multivalue_gqa_group_equivalence_llama7b_v1",
+            "l1_decoder_attention_decode_score_multivalue_gqa_group_pnr_v1",
+            "prior_single_cluster_activity_power_best_activity_power",
+        ],
+        "remaining_abstractions": [
+            "The direct result covers one GQA8 group command at the configured full context, not a total-token or full-model energy estimate.",
+            "The 8x independent-cluster value is an explicit comparison upper bound, not a regenerated cluster measurement or a FLOW_VARIANT pairing.",
+            "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
+            "Off-group value memory, NoC, HBM/DRAM, command distribution, and clock-tree composition are outside this result.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--group-metrics-csv", type=Path, required=True)
+    parser.add_argument("--cluster-activity-power-json", type=Path, required=True)
+    parser.add_argument("--equivalence-json", type=Path, required=True)
+    parser.add_argument("--group-orfs-design-config", type=Path, required=True)
+    parser.add_argument("--clock-period-ns", type=float, default=8.0)
+    parser.add_argument("--activity-dir", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        config=args.config,
+        group_metrics_csv=args.group_metrics_csv,
+        cluster_activity_power_json=args.cluster_activity_power_json,
+        equivalence_json=args.equivalence_json,
+        group_orfs_design_config=args.group_orfs_design_config,
+        clock_period_ns=args.clock_period_ns,
+        activity_dir=args.activity_dir,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/generate_attention_decode_score_multivalue_gqa_group_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_gqa_group_activity.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Generate phase VCD activity for the real eight-head GQA group wrapper."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.generate_attention_decode_score_multivalue_cluster_activity import (
+    _DEFAULT_CLOCK_PERIOD_NS,
+    _DEFAULT_HEAD_DIM,
+    _DEFAULT_SCORE_MULTIPLIER,
+    _DEFAULT_SCORE_SHIFT,
+    _FAKERAM_MODEL,
+    _FINALIZE_DIVIDE_CYCLES_PER_DIM,
+    _FINALIZE_RESULT_EMIT_CYCLES,
+    _PHASES,
+    _REPLAY_CLEAR_CYCLES,
+    _TARGET_MAX_BLOCKS,
+    _VALUE_DIMS,
+    _VALUE_SLICES,
+    _pack,
+    _parse_phase_cycles,
+    _replay_value_scaling,
+    _score_fill_scaling,
+    _sha256_file,
+    _tool,
+    _vectors,
+)
+from npu.rtlgen.gen_attention_decode_score_multivalue_gqa_group import (
+    generate as generate_group,
+)
+
+JsonDict = dict[str, Any]
+_PHASE_DONE_PREFIX = "PHASE_DONE"
+_QUERY_HEADS_PER_KV = 8
+_GQA_FINALIZE_RESULT_CYCLES = 58208
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("config must be a JSON object")
+    return payload
+
+
+def _validate_request(*, config: JsonDict, block_count: int, head_dim: int) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get("attention_decode_score_multivalue_gqa_group")
+    if not top_name or not isinstance(body, dict):
+        raise ValueError("config requires top_name and attention_decode_score_multivalue_gqa_group")
+    max_blocks = int(body.get("max_blocks", 0))
+    if max_blocks != _TARGET_MAX_BLOCKS:
+        raise ValueError(f"activity generation requires max_blocks={_TARGET_MAX_BLOCKS}")
+    if int(body.get("query_heads_per_kv", 8)) != _QUERY_HEADS_PER_KV:
+        raise ValueError("activity generation requires query_heads_per_kv=8")
+    if block_count < 1:
+        raise ValueError("block_count must be >= 1")
+    if head_dim not in {3, 128}:
+        raise ValueError("head_dim must be 3 or 128")
+    beats, values = _vectors(head_dim=head_dim)
+    if block_count > len(beats):
+        raise ValueError(f"block_count must be <= available representative blocks ({len(beats)})")
+    return {
+        "top_name": top_name,
+        "max_blocks": max_blocks,
+        "score_scale_lanes_per_cycle": int(body.get("score_scale_lanes_per_cycle", 1)),
+        "beats": beats[:block_count],
+        "values": values[:block_count],
+    }
+
+
+def _phase_expr(phase: str) -> str:
+    if phase == "score_fill":
+        states = " || ".join(
+            f"dut.u_head_{head}.state_q == 3'd{state}"
+            for head in range(_QUERY_HEADS_PER_KV)
+            for state in range(1, 6)
+        )
+        return f"(command_valid && command_ready) || ({states})"
+    if phase == "replay_value":
+        states = " || ".join(
+            f"dut.u_head_{head}.reducer.state == 4'd{state}"
+            for head in range(_QUERY_HEADS_PER_KV)
+            for state in range(2, 7)
+        )
+        return f"({states})"
+    if phase == "finalize_result":
+        states = " || ".join(
+            f"dut.u_head_{head}.reducer.state == 4'd{state}"
+            for head in range(_QUERY_HEADS_PER_KV)
+            for state in range(7, 11)
+        )
+        return f"({states})"
+    raise ValueError(f"unknown phase: {phase}")
+
+
+def _gqa_finalize_result_scaling(*, cycle_count: int) -> JsonDict:
+    single_head_cycles = _VALUE_DIMS * _FINALIZE_DIVIDE_CYCLES_PER_DIM + _FINALIZE_RESULT_EMIT_CYCLES
+    expected_cycles = _GQA_FINALIZE_RESULT_CYCLES
+    if cycle_count != expected_cycles:
+        raise RuntimeError(
+            "GQA finalize_result cycles diverged from the serialized eight-head result contract: "
+            f"measured={cycle_count} expected={expected_cycles}"
+        )
+    return {
+        "kind": "fixed_per_command_serialized_query_heads",
+        "query_heads_per_kv": _QUERY_HEADS_PER_KV,
+        "value_dimensions_per_head": _VALUE_DIMS,
+        "divide_cycles_per_dimension": _FINALIZE_DIVIDE_CYCLES_PER_DIM,
+        "result_emit_cycles_per_head": _FINALIZE_RESULT_EMIT_CYCLES,
+        "single_head_reference_cycles": single_head_cycles,
+        "target_max_blocks": _TARGET_MAX_BLOCKS,
+        "full_context_cycles": expected_cycles,
+        "formula": "query_heads_per_kv * (value_dimensions_per_head * divide_cycles_per_dimension + result_emit_cycles_per_head)",
+    }
+
+
+def _testbench(
+    *,
+    top_name: str,
+    beats: list[list[tuple[int, list[int]]]],
+    values: list[list[list[list[int]]]],
+    block_count: int,
+    head_dim: int,
+    score_multiplier: int,
+    score_shift: int,
+    phase: str,
+    vcd_path: Path,
+    clock_period_ns: float,
+) -> str:
+    flat_beats = [beat for block in beats for beat in block]
+    beat_init = "\n".join(
+        f"    query_mem[{index}] = 64'h{_pack([q] * _QUERY_HEADS_PER_KV, 8):016x}; "
+        f"key_mem[{index}] = 64'h{_pack(keys, 8):016x};"
+        for index, (q, keys) in enumerate(flat_beats)
+    )
+    last_indices = {
+        sum(len(block) for block in beats[: index + 1]) - 1
+        for index in range(len(beats))
+    }
+    last_cases = "\n".join(f"      {index}: input_last = 1'b1;" for index in sorted(last_indices))
+    value_init = "\n".join(
+        f"    value_mem[{block * _VALUE_SLICES + value_slice}] = 512'h"
+        f"{_pack([lane for row in values[block][value_slice] for lane in row], 8):0128x};"
+        for block in range(block_count)
+        for value_slice in range(_VALUE_SLICES)
+    )
+    phase_active = _phase_expr(phase)
+    clock_half_period = clock_period_ns / 2.0
+    return f"""`timescale 1ns/1ps
+{_FAKERAM_MODEL}
+module tb;
+  localparam integer BLOCK_COUNT = {block_count};
+  localparam integer HEAD_DIM = {head_dim};
+  localparam integer TOTAL_BEATS = {len(flat_beats)};
+  reg clk = 0, rst_n = 0;
+  reg command_valid, input_valid, input_last;
+  wire command_ready, input_ready;
+  reg [63:0] input_query;
+  reg signed [63:0] input_key;
+  wire value_read_req_valid, value_response_ready;
+  reg value_read_req_ready, value_response_valid;
+  wire [13:0] value_read_req_address;
+  wire [3:0] value_read_req_slice;
+  reg [13:0] value_response_address;
+  reg [3:0] value_response_slice;
+  reg [511:0] value_response_matrix;
+  wire result_valid, result_last;
+  reg result_ready;
+  wire [2:0] result_head;
+  wire [15:0] result_command_id;
+  wire signed [31:0] result_global_max;
+  wire [32:0] result_exp_sum;
+  wire [3:0] result_slice;
+  wire [319:0] result_value;
+  wire [31:0] accepted_count, completed_count, cycle_count;
+  wire protocol_error;
+  reg [63:0] query_mem [0:TOTAL_BEATS-1];
+  reg [63:0] key_mem [0:TOTAL_BEATS-1];
+  reg [511:0] value_mem [0:BLOCK_COUNT*{_VALUE_SLICES}-1];
+  integer input_index = 0;
+  integer phase_cycles = 0;
+  reg value_pending = 0;
+  reg [13:0] pending_addr = 0;
+  reg [3:0] pending_slice = 0;
+  integer pending_delay = 0;
+  reg phase_started = 0;
+
+  always #{clock_half_period:g} clk = ~clk;
+
+  {top_name} dut (
+      .clk(clk), .rst_n(rst_n), .command_valid(command_valid), .command_ready(command_ready),
+      .command_id(16'h4a21), .command_block_count(BLOCK_COUNT),
+      .command_score_multiplier(32'd{score_multiplier}), .command_score_shift(6'd{score_shift}),
+      .input_valid(input_valid), .input_ready(input_ready), .input_last(input_last),
+      .input_query(input_query), .input_key(input_key),
+      .value_read_req_valid(value_read_req_valid), .value_read_req_ready(value_read_req_ready),
+      .value_read_req_address(value_read_req_address), .value_read_req_slice(value_read_req_slice),
+      .value_response_valid(value_response_valid), .value_response_ready(value_response_ready),
+      .value_response_address(value_response_address), .value_response_slice(value_response_slice),
+      .value_response_matrix(value_response_matrix), .result_valid(result_valid), .result_ready(result_ready),
+      .result_head(result_head), .result_command_id(result_command_id), .result_global_max(result_global_max),
+      .result_exp_sum(result_exp_sum), .result_slice(result_slice), .result_last(result_last),
+      .result_value(result_value), .accepted_count(accepted_count), .completed_count(completed_count),
+      .cycle_count(cycle_count), .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    command_valid = rst_n && accepted_count == 0;
+    input_valid = rst_n && input_index < TOTAL_BEATS;
+    input_query = input_index < TOTAL_BEATS ? query_mem[input_index] : 0;
+    input_key = input_index < TOTAL_BEATS ? key_mem[input_index] : 0;
+    input_last = 0;
+    case (input_index)
+{last_cases}
+      default: input_last = 0;
+    endcase
+    value_read_req_ready = 1'b1;
+    result_ready = 1'b1;
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      input_index <= 0;
+      phase_cycles <= 0;
+      value_pending <= 0;
+      value_response_valid <= 0;
+      pending_delay <= 0;
+      value_response_address <= 0;
+      value_response_slice <= 0;
+      value_response_matrix <= 0;
+      phase_started <= 0;
+    end else begin
+      if (input_valid && input_ready) input_index <= input_index + 1;
+      if (value_read_req_valid && value_read_req_ready) begin
+        if (value_pending || value_response_valid) $fatal(1, "multiple outstanding value requests");
+        value_pending <= 1;
+        pending_addr <= value_read_req_address;
+        pending_slice <= value_read_req_slice;
+        pending_delay <= 1;
+      end
+      if (value_pending) begin
+        if (pending_delay == 0) begin
+          value_pending <= 0;
+          value_response_valid <= 1;
+          value_response_address <= pending_addr;
+          value_response_slice <= pending_slice;
+          value_response_matrix <= value_mem[pending_addr * {_VALUE_SLICES} + pending_slice];
+        end else pending_delay <= pending_delay - 1;
+      end
+      if (value_response_valid && value_response_ready) value_response_valid <= 0;
+      if (!phase_started && ({phase_active})) begin
+        phase_started <= 1;
+        phase_cycles <= 1;
+        $dumpon;
+      end else if (phase_started && ({phase_active})) begin
+        phase_cycles <= phase_cycles + 1;
+      end else if (phase_started && !({phase_active})) begin
+        if (protocol_error) $fatal(1, "protocol_error raised during {phase}");
+        $display("{_PHASE_DONE_PREFIX} phase={phase} cycles=%0d service_cycles=%0d accepted=%0d completed=%0d", phase_cycles, cycle_count, accepted_count, completed_count);
+        $dumpoff;
+        #1 $finish;
+      end
+      if (cycle_count > 100000) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+    $dumpfile("{vcd_path.as_posix()}");
+    $dumpvars(0, dut);
+    $dumpoff;
+{beat_init}
+{value_init}
+    value_response_valid = 0; value_response_address = 0; value_response_slice = 0; value_response_matrix = 0;
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1;
+  end
+endmodule
+"""
+
+
+def _run_phase(
+    *,
+    config: JsonDict,
+    phase: str,
+    out_dir: Path,
+    block_count: int,
+    head_dim: int,
+    clock_period_ns: float,
+    score_multiplier: int,
+    score_shift: int,
+) -> tuple[int, int, Path]:
+    validated = _validate_request(config=config, block_count=block_count, head_dim=head_dim)
+    with tempfile.TemporaryDirectory(prefix=f"decode-score-gqa-group-{phase}-") as tmp_text:
+        tmp = Path(tmp_text)
+        rtl_dir = tmp / "rtl"
+        generate_group(json.loads(json.dumps(config)), rtl_dir)
+        vcd_path = tmp / f"{phase}.vcd"
+        tb_path = tmp / "tb.sv"
+        tb_path.write_text(
+            _testbench(
+                top_name=str(validated["top_name"]),
+                beats=validated["beats"],
+                values=validated["values"],
+                block_count=block_count,
+                head_dim=head_dim,
+                score_multiplier=score_multiplier,
+                score_shift=score_shift,
+                phase=phase,
+                vcd_path=vcd_path,
+                clock_period_ns=clock_period_ns,
+            ),
+            encoding="utf-8",
+        )
+        simv = tmp / "simv"
+        compiled = subprocess.run(
+            [_tool("iverilog"), "-g2012", "-s", "tb", "-o", str(simv), str(rtl_dir / "top.v"), str(tb_path)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"iverilog failed for {phase}: {compiled.stderr}")
+        run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=120)
+        if run.returncode:
+            raise RuntimeError(f"simulation failed for {phase}:\n{run.stdout}\n{run.stderr}")
+        cycle_count, service_cycles = _parse_phase_cycles(run.stdout, phase)
+        phase_out = out_dir / f"{phase}.vcd"
+        phase_out.write_bytes(vcd_path.read_bytes())
+        return cycle_count, service_cycles, phase_out
+
+
+def generate_phase_activity(
+    config: JsonDict,
+    out_dir: Path,
+    *,
+    block_count: int = 3,
+    head_dim: int = _DEFAULT_HEAD_DIM,
+    clock_period_ns: float = _DEFAULT_CLOCK_PERIOD_NS,
+    score_multiplier: int = _DEFAULT_SCORE_MULTIPLIER,
+    score_shift: int = _DEFAULT_SCORE_SHIFT,
+) -> JsonDict:
+    if clock_period_ns <= 0.0:
+        raise ValueError("clock_period_ns must be > 0")
+    validated = _validate_request(config=config, block_count=block_count, head_dim=head_dim)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    phases: list[JsonDict] = []
+    full_service_cycles = 0
+    for phase in _PHASES:
+        cycle_count, service_cycles, vcd_path = _run_phase(
+            config=config,
+            phase=phase,
+            out_dir=out_dir,
+            block_count=block_count,
+            head_dim=head_dim,
+            clock_period_ns=clock_period_ns,
+            score_multiplier=score_multiplier,
+            score_shift=score_shift,
+        )
+        if phase == "score_fill":
+            scaling = _score_fill_scaling(cycle_count=cycle_count, block_count=block_count)
+        elif phase == "replay_value":
+            scaling = _replay_value_scaling(cycle_count=cycle_count, block_count=block_count)
+        else:
+            scaling = _gqa_finalize_result_scaling(cycle_count=cycle_count)
+            full_service_cycles = service_cycles
+        phases.append(
+            {
+                "phase": phase,
+                "measured_cycles": cycle_count,
+                "full_context_cycles": scaling["full_context_cycles"],
+                "vcd": vcd_path.name,
+                "vcd_sha256": _sha256_file(vcd_path),
+                "requires_macro_activity": phase in {"score_fill", "replay_value"},
+                "scaling": scaling,
+            }
+        )
+
+    partition_cycles = sum(int(row["measured_cycles"]) for row in phases)
+    if partition_cycles != full_service_cycles:
+        raise RuntimeError(
+            "GQA group phase activity does not partition the representative transaction: "
+            f"phases={partition_cycles}, service={full_service_cycles}"
+        )
+    manifest = {
+        "version": 1,
+        "model": "decode_score_multivalue_gqa_group_phase_activity_v1",
+        "generator": "npu/eval/generate_attention_decode_score_multivalue_gqa_group_activity.py",
+        "top_name": validated["top_name"],
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_activity_v1",
+        "activity_generation": "explicit_script_only",
+        "scope": "tb/dut",
+        "scope_semantics": "the complete generated GQA8 group wrapper, including all eight query-head clusters",
+        "clock_period_ns": clock_period_ns,
+        "block_count": block_count,
+        "head_dim": head_dim,
+        "beats_per_block": head_dim,
+        "max_blocks": validated["max_blocks"],
+        "target_max_blocks": _TARGET_MAX_BLOCKS,
+        "query_heads_per_kv": _QUERY_HEADS_PER_KV,
+        "score_multiplier": score_multiplier,
+        "score_shift": score_shift,
+        "score_scale_lanes_per_cycle": validated["score_scale_lanes_per_cycle"],
+        "value_slices": _VALUE_SLICES,
+        "value_dimensions_per_head": _VALUE_DIMS,
+        "representative_full_transaction_cycles": full_service_cycles,
+        "phase_partition_cycle_sum": partition_cycles,
+        "phases": phases,
+    }
+    manifest_path = out_dir / "attention_decode_score_multivalue_gqa_group_activity_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--block-count", type=int, default=3)
+    parser.add_argument("--head-dim", type=int, default=_DEFAULT_HEAD_DIM, choices=[3, 128])
+    parser.add_argument("--clock-period-ns", type=float, default=_DEFAULT_CLOCK_PERIOD_NS)
+    args = parser.parse_args()
+    generate_phase_activity(
+        _load(args.config),
+        args.out,
+        block_count=args.block_count,
+        head_dim=args.head_dim,
+        clock_period_ns=args.clock_period_ns,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/generate_attention_decode_score_multivalue_gqa_group_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_gqa_group_activity.py
@@ -120,10 +120,18 @@ def _gqa_finalize_result_scaling(*, cycle_count: int) -> JsonDict:
         "divide_cycles_per_dimension": _FINALIZE_DIVIDE_CYCLES_PER_DIM,
         "result_emit_cycles_per_head": _FINALIZE_RESULT_EMIT_CYCLES,
         "single_head_reference_cycles": single_head_cycles,
+        "measured_group_cycles": cycle_count,
         "target_max_blocks": _TARGET_MAX_BLOCKS,
-        "full_context_cycles": expected_cycles,
-        "formula": "query_heads_per_kv * (value_dimensions_per_head * divide_cycles_per_dimension + result_emit_cycles_per_head)",
+        "full_context_cycles": cycle_count,
+        "formula": "measured fixed group-finalize contract; child divide and serialized result phases overlap",
     }
+
+
+def _query_lanes(q: int, beat_index: int) -> list[int]:
+    return [
+        ((q + head * 31 + beat_index * head * 3 + 127) % 255) - 127
+        for head in range(_QUERY_HEADS_PER_KV)
+    ]
 
 
 def _testbench(
@@ -141,7 +149,7 @@ def _testbench(
 ) -> str:
     flat_beats = [beat for block in beats for beat in block]
     beat_init = "\n".join(
-        f"    query_mem[{index}] = 64'h{_pack([q] * _QUERY_HEADS_PER_KV, 8):016x}; "
+        f"    query_mem[{index}] = 64'h{_pack(_query_lanes(q, index), 8):016x}; "
         f"key_mem[{index}] = 64'h{_pack(keys, 8):016x};"
         for index, (q, keys) in enumerate(flat_beats)
     )
@@ -410,6 +418,7 @@ def generate_phase_activity(
         "max_blocks": validated["max_blocks"],
         "target_max_blocks": _TARGET_MAX_BLOCKS,
         "query_heads_per_kv": _QUERY_HEADS_PER_KV,
+        "query_activity_profile": "eight_distinct_deterministic_signed_int8_query_lanes",
         "score_multiplier": score_multiplier,
         "score_shift": score_shift,
         "score_scale_lanes_per_cycle": validated["score_scale_lanes_per_cycle"],

--- a/tests/test_attention_decode_score_multivalue_gqa_group_activity.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_activity.py
@@ -8,6 +8,7 @@ import shutil
 import pytest
 
 from npu.eval.generate_attention_decode_score_multivalue_gqa_group_activity import (
+    _query_lanes,
     generate_phase_activity,
 )
 
@@ -43,6 +44,7 @@ def test_gqa_group_activity_smoke_uses_actual_wrapper_and_manifest(tmp_path: Pat
     assert manifest["scope"] == "tb/dut"
     assert "complete generated GQA8 group wrapper" in manifest["scope_semantics"]
     assert manifest["query_heads_per_kv"] == 8
+    assert manifest["query_activity_profile"] == "eight_distinct_deterministic_signed_int8_query_lanes"
     assert manifest["clock_period_ns"] == 10.0
     assert manifest["phase_partition_cycle_sum"] == manifest["representative_full_transaction_cycles"]
 
@@ -56,3 +58,10 @@ def test_gqa_group_activity_smoke_uses_actual_wrapper_and_manifest(tmp_path: Pat
         assert raw
         assert phase["vcd_sha256"] == hashlib.sha256(raw).hexdigest()
         assert b"$scope module tb $end" in raw
+
+
+def test_query_activity_uses_distinct_signed_int8_lanes() -> None:
+    lanes = _query_lanes(-127, 17)
+    assert len(lanes) == 8
+    assert len(set(lanes)) == 8
+    assert all(-127 <= lane <= 127 for lane in lanes)

--- a/tests/test_attention_decode_score_multivalue_gqa_group_activity.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_activity.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import shutil
+
+import pytest
+
+from npu.eval.generate_attention_decode_score_multivalue_gqa_group_activity import (
+    generate_phase_activity,
+)
+
+
+def _tool_available(name: str) -> bool:
+    return shutil.which(name) is not None or (Path("/oss-cad-suite/bin") / name).exists()
+
+
+def _config() -> dict:
+    return {
+        "top_name": "attention_decode_score_multivalue_gqa_group_activity",
+        "attention_decode_score_multivalue_gqa_group": {
+            "max_blocks": 16384,
+            "array_n": 8,
+            "value_slices": 16,
+            "divider_impl": "iterative_restoring",
+            "score_scale_lanes_per_cycle": 1,
+            "query_heads_per_kv": 8,
+        },
+    }
+
+
+def test_gqa_group_activity_smoke_uses_actual_wrapper_and_manifest(tmp_path: Path) -> None:
+    if not _tool_available("iverilog") or not _tool_available("vvp"):
+        pytest.skip("iverilog/vvp unavailable")
+
+    manifest = generate_phase_activity(
+        _config(), tmp_path, block_count=1, head_dim=3, clock_period_ns=10.0
+    )
+    manifest_path = tmp_path / "attention_decode_score_multivalue_gqa_group_activity_manifest.json"
+    assert json.loads(manifest_path.read_text(encoding="utf-8")) == manifest
+    assert manifest["model"] == "decode_score_multivalue_gqa_group_phase_activity_v1"
+    assert manifest["scope"] == "tb/dut"
+    assert "complete generated GQA8 group wrapper" in manifest["scope_semantics"]
+    assert manifest["query_heads_per_kv"] == 8
+    assert manifest["clock_period_ns"] == 10.0
+    assert manifest["phase_partition_cycle_sum"] == manifest["representative_full_transaction_cycles"]
+
+    phases = {row["phase"]: row for row in manifest["phases"]}
+    assert set(phases) == {"score_fill", "replay_value", "finalize_result"}
+    assert phases["finalize_result"]["measured_cycles"] == 58208
+    assert phases["finalize_result"]["scaling"]["query_heads_per_kv"] == 8
+    for phase in phases.values():
+        vcd = tmp_path / phase["vcd"]
+        raw = vcd.read_bytes()
+        assert raw
+        assert phase["vcd_sha256"] == hashlib.sha256(raw).hexdigest()
+        assert b"$scope module tb $end" in raw

--- a/tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py
@@ -92,6 +92,26 @@ def _write_baseline(path: Path, *, promoted: bool = True) -> None:
                         "full_context_energy_j": 0.002,
                     },
                 },
+                "activity_contract": {
+                    "clock_period_ns": 8.0,
+                    "phases": [
+                        {
+                            "phase": "score_fill",
+                            "full_context_cycles": 10,
+                            "scaling": {"target_max_blocks": 16384},
+                        },
+                        {
+                            "phase": "replay_value",
+                            "full_context_cycles": 20,
+                            "scaling": {"target_max_blocks": 16384},
+                        },
+                        {
+                            "phase": "finalize_result",
+                            "full_context_cycles": 7765,
+                            "scaling": {"target_max_blocks": 16384},
+                        },
+                    ],
+                },
             }
         ),
         encoding="utf-8",
@@ -127,6 +147,12 @@ def test_build_report_gates_gqa_and_does_not_pair_cluster_flow(tmp_path: Path) -
                 "equivalence_pass": True,
                 "decision": "llama7b_gqa8_shared_kv_equivalence_pass",
                 "query_heads_per_kv": 8,
+                "distinct_query_heads_pass": True,
+                "shared_inputs_pass": True,
+                "arithmetic_equivalence_pass": True,
+                "wrapper_protocol": {"sharing_and_order_pass": True},
+                "expected_group_result_sha256": "same-hash",
+                "observed_group_result_sha256": "same-hash",
             }
         ),
         encoding="utf-8",
@@ -142,10 +168,15 @@ def test_build_report_gates_gqa_and_does_not_pair_cluster_flow(tmp_path: Path) -
         "scope_semantics": "the complete generated GQA8 group wrapper",
         "clock_period_ns": 8.0,
         "query_heads_per_kv": 8,
+        "target_max_blocks": 16384,
         "block_count": 3,
         "representative_full_transaction_cycles": 58307,
         "phase_partition_cycle_sum": 58307,
-        "phases": [],
+        "phases": [
+            {"phase": "score_fill"},
+            {"phase": "replay_value"},
+            {"phase": "finalize_result"},
+        ],
     }
     with mock.patch.object(audit, "generate_phase_activity", return_value=manifest), mock.patch.object(
         audit,
@@ -164,11 +195,12 @@ def test_build_report_gates_gqa_and_does_not_pair_cluster_flow(tmp_path: Path) -
 
     assert payload["decision"] == "activity_backed_gqa_group_power_measured"
     assert payload["best_candidate_id"] == "multivalue_gqa_group_activity_group_die7200"
-    assert payload["independent_cluster_upper_bound_factor"] == 8
+    assert payload["independent_cluster_reference_factor"] == 8
     best = payload["best"]
     assert best["direct_group_full_context_energy_j"] == 0.014
-    assert best["independent_cluster_upper_bound"]["energy_j"] == pytest.approx(0.016)
-    assert best["independent_cluster_upper_bound"]["pass"] is True
+    assert best["eight_independent_clusters_reference"]["energy_j"] == pytest.approx(0.016)
+    assert best["eight_independent_clusters_reference"]["pass"] is True
+    assert best["eight_independent_clusters_reference"]["is_formal_upper_bound"] is False
     assert payload["candidates"][1]["status"] == "measurement_failed"
     assert "/orfs/" not in json.dumps(payload["candidates"][1])
     assert [call.kwargs["flow_variant"] for call in build_power.call_args_list] == [

--- a/tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from npu.eval import audit_attention_decode_score_multivalue_gqa_group_activity_power as audit
+
+
+def _write_metrics(path: Path) -> None:
+    fields = [
+        "design",
+        "platform",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "instance_area_um2",
+        "params_json",
+    ]
+    rows = [
+        {
+            "design": "gqa_group",
+            "platform": "nangate45",
+            "param_hash": "group-a",
+            "tag": "die7200",
+            "status": "ok",
+            "critical_path_ns": "7.0",
+            "die_area": "51840000",
+            "instance_area_um2": "3100000",
+            "params_json": json.dumps({"CLOCK_PERIOD": 8, "FLOW_VARIANT": "group_die7200"}),
+        },
+        {
+            "design": "gqa_group",
+            "platform": "nangate45",
+            "param_hash": "group-b",
+            "tag": "die8000",
+            "status": "ok",
+            "critical_path_ns": "7.8",
+            "die_area": "64000000",
+            "instance_area_um2": "3200000",
+            "params_json": json.dumps({"CLOCK_PERIOD": 8, "FLOW_VARIANT": "group_die8000"}),
+        },
+        {
+            "design": "gqa_group",
+            "platform": "nangate45",
+            "param_hash": "slow",
+            "tag": "die7200",
+            "status": "ok",
+            "critical_path_ns": "8.1",
+            "die_area": "51840000",
+            "instance_area_um2": "3000000",
+            "params_json": json.dumps({"CLOCK_PERIOD": 8, "FLOW_VARIANT": "group_slow"}),
+        },
+        {
+            "design": "gqa_group",
+            "platform": "nangate45",
+            "param_hash": "wrong-clock",
+            "tag": "die7200",
+            "status": "ok",
+            "critical_path_ns": "7.0",
+            "die_area": "51840000",
+            "instance_area_um2": "2900000",
+            "params_json": json.dumps({"CLOCK_PERIOD": 10, "FLOW_VARIANT": "group_wrong_clock"}),
+        },
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_baseline(path: Path, *, promoted: bool = True) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "model": "decoder_attention_decode_score_multivalue_cluster_activity_power_v1",
+                "promotion_gate_pass": promoted,
+                "best_candidate_id": "cluster_independent_variant",
+                "best": {
+                    "candidate_id": "cluster_independent_variant",
+                    "flow_variant": "cluster_flow_that_must_not_be_paired",
+                    "activity_power": {
+                        "model": "postroute_phase_vcd_power_v1",
+                        "promotion_gate_pass": promoted,
+                        "clock_period_ns": 8.0,
+                        "full_context_cycles": 7795,
+                        "full_context_energy_j": 0.002,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _power(energy: float) -> dict:
+    return {
+        "model": "postroute_phase_vcd_power_v1",
+        "promotion_gate_pass": True,
+        "clock_period_ns": 8.0,
+        "full_context_cycles": 58207,
+        "full_context_latency_s": 0.000465656,
+        "full_context_energy_j": energy,
+    }
+
+
+def test_feasible_metrics_selects_timing_feasible_group_rows(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics)
+    rows = audit._feasible_metrics(metrics, 8.0)
+    assert [audit._params(row)["FLOW_VARIANT"] for row in rows] == [
+        "group_die7200",
+        "group_die8000",
+    ]
+
+
+def test_build_report_gates_gqa_and_does_not_pair_cluster_flow(tmp_path: Path) -> None:
+    equivalence = tmp_path / "equivalence.json"
+    equivalence.write_text(
+        json.dumps(
+            {
+                "equivalence_pass": True,
+                "decision": "llama7b_gqa8_shared_kv_equivalence_pass",
+                "query_heads_per_kv": 8,
+            }
+        ),
+        encoding="utf-8",
+    )
+    baseline = tmp_path / "cluster-power.json"
+    _write_baseline(baseline)
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics)
+    config = tmp_path / "config.json"
+    config.write_text("{}", encoding="utf-8")
+    manifest = {
+        "scope": "tb/dut",
+        "scope_semantics": "the complete generated GQA8 group wrapper",
+        "clock_period_ns": 8.0,
+        "query_heads_per_kv": 8,
+        "block_count": 3,
+        "representative_full_transaction_cycles": 58307,
+        "phase_partition_cycle_sum": 58307,
+        "phases": [],
+    }
+    with mock.patch.object(audit, "generate_phase_activity", return_value=manifest), mock.patch.object(
+        audit,
+        "build_power_report",
+        side_effect=[_power(0.014), RuntimeError("/orfs/private/result")],
+    ) as build_power:
+        payload = audit.build_report(
+            config=config,
+            group_metrics_csv=metrics,
+            cluster_activity_power_json=baseline,
+            equivalence_json=equivalence,
+            group_orfs_design_config=tmp_path / "group.mk",
+            clock_period_ns=8.0,
+            activity_dir=tmp_path / "activity",
+        )
+
+    assert payload["decision"] == "activity_backed_gqa_group_power_measured"
+    assert payload["best_candidate_id"] == "multivalue_gqa_group_activity_group_die7200"
+    assert payload["independent_cluster_upper_bound_factor"] == 8
+    best = payload["best"]
+    assert best["direct_group_full_context_energy_j"] == 0.014
+    assert best["independent_cluster_upper_bound"]["energy_j"] == pytest.approx(0.016)
+    assert best["independent_cluster_upper_bound"]["pass"] is True
+    assert payload["candidates"][1]["status"] == "measurement_failed"
+    assert "/orfs/" not in json.dumps(payload["candidates"][1])
+    assert [call.kwargs["flow_variant"] for call in build_power.call_args_list] == [
+        "group_die7200",
+        "group_die8000",
+    ]
+
+
+def test_build_report_rejects_unproven_gqa_equivalence(tmp_path: Path) -> None:
+    equivalence = tmp_path / "equivalence.json"
+    equivalence.write_text('{"equivalence_pass": false}', encoding="utf-8")
+    with mock.patch.object(audit, "generate_phase_activity") as generate:
+        with pytest.raises(ValueError, match="GQA8 shared-KV equivalence did not pass"):
+            audit.build_report(
+                config=tmp_path / "config.json",
+                group_metrics_csv=tmp_path / "metrics.csv",
+                cluster_activity_power_json=tmp_path / "cluster.json",
+                equivalence_json=equivalence,
+                group_orfs_design_config=tmp_path / "group.mk",
+                clock_period_ns=8.0,
+                activity_dir=tmp_path / "activity",
+            )
+    generate.assert_not_called()
+
+
+def test_cluster_baseline_requires_measured_best_activity_power(tmp_path: Path) -> None:
+    baseline = tmp_path / "cluster-power.json"
+    _write_baseline(baseline, promoted=False)
+    with pytest.raises(ValueError, match="not a promoted measured baseline"):
+        audit._cluster_baseline(baseline, 8.0)


### PR DESCRIPTION
## Summary
- generate phase-specific VCD activity from the actual eight-head GQA shared-KV wrapper
- measure direct routed group power for timing-feasible PPA rows
- compare measured group energy with a contract-checked `8 x` independent-cluster reference
- gate the job on merged GQA equivalence, GQA PPA, and prior single-cluster activity evidence
- keep VCD/ODB/SPEF local and explicitly withhold total-token energy claims

## Evidence integrity
- uses eight distinct deterministic signed-int8 query lanes
- requires the complete equivalence contract, including arithmetic, shared inputs, query distinctness, wrapper sharing/order, and matching result hashes
- validates clock, phase set, target context, and phase-cycle totals before consuming the cluster baseline
- labels the `8 x` value as a comparison reference, not a formal upper bound or FLOW_VARIANT pairing

## Validation
- 6 focused GQA activity/power tests, including real wrapper RTL/VCD smoke
- 20 neighboring cluster/GQA activity and equivalence tests
- 207 Layer 2 task-generator tests
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`