### PR TITLE
Measure direct multi-group GQA arrays

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -679,6 +679,58 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "attention_decode_score_multivalue_gqa_array" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                f"decode-score multivalue GQA-array config must live under repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        macro_manifest = f"{design_dir}/macro_manifest.json"
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": "generate_attention_decode_score_multivalue_gqa_array_rtl",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py "
+                        f"--config {config_rel} --out {design_dir}/verilog"
+                    ),
+                },
+                {
+                    "name": "check_attention_decode_score_multivalue_gqa_array_guard",
+                    "run": (
+                        "python3 npu/eval/check_attention_decode_score_multivalue_gqa_array_guard.py "
+                        f"--design-dir {design_dir}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/synth/run_block_sweep.py "
+                        f"--design_dir {design_dir} --platform {{platform}} --top {top_name} "
+                        f"--sweep {{sweep_path}} --out_root {out_root} "
+                        f"--macro_manifest {macro_manifest} "
+                        + (f"--make_target {make_target} " if make_target else "")
+                        + "--skip_existing"
+                    ),
+                },
+                {
+                    "name": "extract_attention_decode_score_multivalue_gqa_array_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} --out {design_dir}/timing_debug_report.md --max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "attention_decode_score_multivalue_gqa_group" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6743,6 +6743,50 @@ def _decoder_attention_decode_score_multivalue_gqa_group_equivalence_evidence(
     }
 
 
+def _decoder_attention_decode_score_multivalue_gqa_array_equivalence_evidence(
+    *, item_id: str
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    group_equivalence = (
+        f"{base}/decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1.json"
+    )
+    config_base = "runs/designs/npu_blocks"
+    configs = [
+        f"{config_base}/attention_decode_score_multivalue_gqa_array_g{count}_int8_m1x8_iterdiv/config.json"
+        for count in (1, 2, 4)
+    ]
+    out = f"{base}/decoder_attention_decode_score_multivalue_gqa_array_equivalence__{item_id}.json"
+    report = f"{base}/decoder_attention_decode_score_multivalue_gqa_array_equivalence__{item_id}.md"
+    config_args = " ".join(f"--array-config {config}" for config in configs)
+    return {
+        "inputs": {
+            "decode_score_multivalue_gqa_array_group_equivalence_json": group_equivalence,
+            "decode_score_multivalue_gqa_array_configs": configs,
+            "decode_score_multivalue_gqa_array_equivalence_out": out,
+            "decode_score_multivalue_gqa_array_equivalence_report": report,
+            "decode_score_multivalue_gqa_array_equivalence_scope": (
+                "Compose the merged complete GQA8 group arithmetic/sharing proof with direct protocol simulations "
+                "of one-, two-, and four-group generated arrays. Verify atomic command/input broadcast and "
+                "independent value-memory and result channels. This remains a compositional proof rather than a "
+                "monolithic 32-cluster arithmetic simulation."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decode_score_multivalue_gqa_array_equivalence",
+                "run": (
+                    "python3 -m npu.eval.audit_attention_decode_score_multivalue_gqa_array_equivalence "
+                    f"--group-equivalence-json {group_equivalence} {config_args} "
+                    f"--out {out} --out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     config = (
@@ -10581,6 +10625,7 @@ def _build_payload(
         "decoder_attention_decode_score_local_cluster_equivalence",
         "decoder_attention_decode_score_multivalue_cluster_equivalence",
         "decoder_attention_decode_score_multivalue_gqa_group_equivalence",
+        "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
         "decoder_attention_decode_score_multivalue_cluster_activity_power",
         "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
         "decoder_attention_decode_score_tile_frontier",
@@ -10825,6 +10870,10 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_group_equivalence":
             decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_group_equivalence_evidence(
+                item_id=item_id
+            )
+        elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_array_equivalence":
+            decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_array_equivalence_evidence(
                 item_id=item_id
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_cluster_activity_power":

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7086,6 +7086,56 @@ def _decoder_attention_decode_score_multivalue_gqa_group_frontier_evidence(*, it
     }
 
 
+def _decoder_attention_decode_score_multivalue_gqa_array_frontier_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    prior = (
+        f"{base}/decoder_attention_decode_score_multivalue_gqa_group_frontier__"
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1.json"
+    )
+    equivalence = (
+        f"{base}/decoder_attention_decode_score_multivalue_gqa_array_equivalence__"
+        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1.json"
+    )
+    metrics = {
+        count: (
+            "runs/designs/npu_blocks/"
+            f"attention_decode_score_multivalue_gqa_array_g{count}_int8_m1x8_iterdiv/metrics.csv"
+        )
+        for count in (1, 2, 4)
+    }
+    out = f"{base}/decoder_attention_decode_score_multivalue_gqa_array_frontier__{item_id}.json"
+    report = f"{base}/decoder_attention_decode_score_multivalue_gqa_array_frontier__{item_id}.md"
+    metrics_args = " ".join(f"--array-metrics {count}={path}" for count, path in metrics.items())
+    return {
+        "inputs": {
+            "decode_score_multivalue_gqa_array_frontier_prior_frontier": prior,
+            "decode_score_multivalue_gqa_array_frontier_equivalence": equivalence,
+            "decode_score_multivalue_gqa_array_frontier_metrics": {
+                str(count): path for count, path in metrics.items()
+            },
+            "decode_score_multivalue_gqa_array_frontier_out": out,
+            "decode_score_multivalue_gqa_array_frontier_report": report,
+            "decode_score_multivalue_gqa_array_frontier_scope": (
+                "Replace linearly composed one-, two-, and four-group timing and area with direct equal-density "
+                "array PNR. Preserve the prior measured group-component activity energy only as compositional "
+                "evidence; direct array activity, external memory/NoC/HBM, and total-token energy remain open."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decode_score_multivalue_gqa_array_frontier",
+                "run": (
+                    "python3 -m npu.eval.audit_attention_decode_score_multivalue_gqa_array_frontier "
+                    f"--prior-frontier-json {prior} --array-equivalence-json {equivalence} "
+                    f"{metrics_args} --out {out} --out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score_bank_proxy_equivalence_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score_bank_proxy_equivalence__{item_id}.json"
@@ -10632,6 +10682,7 @@ def _build_payload(
         "decoder_attention_decode_score_local_cluster_frontier",
         "decoder_attention_decode_score_multivalue_cluster_frontier",
         "decoder_attention_decode_score_multivalue_gqa_group_frontier",
+        "decoder_attention_decode_score_multivalue_gqa_array_frontier",
         "decoder_attention_score_bank_proxy_equivalence",
         "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
         "decoder_attention_score32_hbm_controller_replay",
@@ -10894,6 +10945,10 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_group_frontier":
             decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_group_frontier_evidence(
+                item_id=item_id
+            )
+        elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_array_frontier":
+            decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_array_frontier_evidence(
                 item_id=item_id
             )
         elif abstraction_layer_name == "decoder_attention_score_bank_proxy_equivalence":

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -912,6 +912,56 @@ def _write_example_attention_decode_score_multivalue_gqa_group_repo(
     return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
 
 
+def _write_example_attention_decode_score_multivalue_gqa_array_repo(
+    repo_root: Path,
+) -> tuple[str, str]:
+    design_dir = (
+        repo_root
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv"
+    )
+    design_dir.mkdir(parents=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv",
+                "attention_decode_score_multivalue_gqa_array": {
+                    "max_blocks": 16384,
+                    "array_n": 8,
+                    "value_slices": 16,
+                    "divider_impl": "iterative_restoring",
+                    "score_scale_lanes_per_cycle": 1,
+                    "query_heads_per_kv": 8,
+                    "group_count": 2,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (design_dir / "macro_manifest.json").write_text(
+        json.dumps({"manifest_params": {"score_bank_macro_count": 896}}),
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "decode_score_multivalue_gqa_array_g2_v1"
+        / "sweeps"
+        / "nangate45_decode_score_multivalue_gqa_array_g2.json"
+    )
+    sweep_path.parent.mkdir(parents=True)
+    sweep_path.write_text(
+        json.dumps({"parameters": {"CLOCK_PERIOD": [10], "PLACE_DENSITY": [0.4]}}),
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
 def _write_example_attention_hbm_replay_controller_repo(repo_root: Path) -> tuple[str, str]:
     design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_hbm_replay_controller_smoke"
     design_dir.mkdir(parents=True, exist_ok=True)
@@ -2551,6 +2601,66 @@ def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_gqa_g
             assert work_item.expected_outputs == [
                 "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv/metrics.csv",
                 "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv/"
+                "timing_debug_report.md",
+            ]
+
+
+def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_gqa_array_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_decode_score_multivalue_gqa_array_repo(
+            repo_root
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_gqa_array",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_decode_score_multivalue_gqa_array_rtl",
+                "check_attention_decode_score_multivalue_gqa_array_guard",
+                "run_block_sweep",
+                "extract_attention_decode_score_multivalue_gqa_array_timing_paths",
+                "build_runs_index",
+                "validate",
+            ]
+            assert "gen_attention_decode_score_multivalue_gqa_array.py" in work_item.command_manifest[0][
+                "run"
+            ]
+            assert "check_attention_decode_score_multivalue_gqa_array_guard.py" in work_item.command_manifest[
+                1
+            ]["run"]
+            sweep_command = work_item.command_manifest[2]["run"]
+            assert (
+                "--top attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv"
+                in sweep_command
+            )
+            assert (
+                "--macro_manifest runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/macro_manifest.json"
+                in sweep_command
+            )
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/metrics.csv",
+                "runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/"
                 "timing_debug_report.md",
             ]
 

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8303,6 +8303,65 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_fronti
             ] in work_item.expected_outputs
 
 
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_array_frontier() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_gqa8_array_frontier_"
+                        "llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_gqa_array_frontier",
+                    evaluation_mode="frontier_recost",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:2]] == [
+                "audit_decode_score_multivalue_gqa_array_frontier",
+                "validate_runs",
+            ]
+            assert "-m npu.eval.audit_attention_decode_score_multivalue_gqa_array_frontier" in run
+            assert "gqa8_group_frontier_llama7b_v1.json" in run
+            assert "gqa8_array_equivalence_llama7b_v1.json" in run
+            assert run.count("--array-metrics") == 3
+            for count in (1, 2, 4):
+                assert (
+                    f"--array-metrics {count}=runs/designs/npu_blocks/"
+                    f"attention_decode_score_multivalue_gqa_array_g{count}_int8_m1x8_iterdiv/"
+                    "metrics.csv"
+                ) in run
+            assert set(decoder_inputs["decode_score_multivalue_gqa_array_frontier_metrics"]) == {
+                "1",
+                "2",
+                "4",
+            }
+            assert "direct equal-density array PNR" in decoder_inputs[
+                "decode_score_multivalue_gqa_array_frontier_scope"
+            ]
+            assert decoder_inputs[
+                "decode_score_multivalue_gqa_array_frontier_report"
+            ] in work_item.expected_outputs
+
+
 def test_generate_l2_campaign_task_adds_score_bank_proxy_equivalence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7881,6 +7881,59 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_equiva
             ]
 
 
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_array_equivalence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_"
+                        "llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_decode_score_multivalue_gqa_array_equivalence"
+                    ),
+                    evaluation_mode="equivalence_gate",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command = work_item.task_request.request_payload["task"]["commands"][0]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert command["name"] == "audit_decode_score_multivalue_gqa_array_equivalence"
+            assert command["run"].startswith(
+                "python3 -m npu.eval.audit_attention_decode_score_multivalue_gqa_array_equivalence "
+            )
+            assert command["run"].count("--array-config") == 3
+            for count in (1, 2, 4):
+                assert (
+                    f"attention_decode_score_multivalue_gqa_array_g{count}_int8_m1x8_iterdiv/"
+                    "config.json"
+                ) in command["run"]
+            assert "gqa8_group_equivalence_llama7b_v1.json" in command["run"]
+            assert len(decoder_inputs["decode_score_multivalue_gqa_array_configs"]) == 3
+            assert "monolithic 32-cluster arithmetic simulation" in decoder_inputs[
+                "decode_score_multivalue_gqa_array_equivalence_scope"
+            ]
+            assert decoder_inputs[
+                "decode_score_multivalue_gqa_array_equivalence_report"
+            ] in work_item.expected_outputs
+
+
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity_power() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_gate.md
@@ -31,3 +31,7 @@
 12. Treat direct array PNR as timing, area, routing, command-fanout, and
     clock-tree evidence. It does not close external value memory, NoC, HBM,
     total-token energy, or a monolithic 32-cluster arithmetic simulation.
+13. Recompute QKV tile allocation, layer latency, throughput, and embodied
+    logic-plus-SRAM area from every timing-feasible direct array row. Preserve
+    all rejected physical rows and label inherited group-component energy as
+    compositional until direct array activity is measured.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_gate.md
@@ -21,3 +21,13 @@
    layer. Use measured one-group timing, area, and activity energy, identify
    multi-group area/power as linear composition rather than array PNR, and
    retain off-group memory/NoC/HBM and total-token energy as open boundaries.
+10. Before direct array PPA, compose the merged complete-group equivalence
+    result with protocol simulations of generated one-, two-, and four-group
+    wrappers. Require atomic command/input acceptance and independent external
+    value-memory and result channels.
+11. Compare array PPA only at matched macro density: 7.2 mm for one group,
+    10.2 mm for two groups, and 14.4 mm for four groups. Keep the 8 ns and
+    10 ns targets and retain infeasible points.
+12. Treat direct array PNR as timing, area, routing, command-fanout, and
+    clock-tree evidence. It does not close external value memory, NoC, HBM,
+    total-token energy, or a monolithic 32-cluster arithmetic simulation.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -81,6 +81,93 @@
         "reason": "Convert measured group PPA and component energy into Llama7B latency, throughput, and area points while retaining composition limits."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Compose merged group equivalence with direct one-, two-, and four-group wrapper protocol simulation.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
+      "comparison_role": "gqa8_multigroup_array_semantic_gate",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_gqa8_multigroup_array_compositional_equivalence",
+        "reason": "Direct array PPA requires proven atomic broadcast and independent value/result channels."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g1_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the one-group array wrapper at 7.2 mm and 8/10 ns.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
+      "comparison_role": "gqa8_array_g1_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_array_g1_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g1.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_direct_gqa8_array_g1_ppa",
+        "reason": "Calibrate direct array-wrapper overhead against standalone group PPA."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g2_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the two-group array at 10.2 mm and 8/10 ns.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
+      "comparison_role": "gqa8_array_g2_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g1_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_array_g2_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g2.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_direct_gqa8_array_g2_ppa",
+        "reason": "Measure fanout, routing, and clock-tree scaling at matched macro density."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g4_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the complete four-group array at 14.4 mm and 8/10 ns.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
+      "comparison_role": "gqa8_array_g4_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g2_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_array_g4_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g4.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_direct_gqa8_array_g4_ppa",
+        "reason": "Replace linear four-group area/timing composition with full-array PNR."
+      },
+      "status": "pending_implementation_merge"
     }
   ]
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1",
-  "source_commit_note": "Queue only after the GQA8 generator, compositional audit, design target, guard, and control-plane handlers are merged.",
+  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged. Queue array jobs only after the direct array generator, exact 1/2/4 design targets, wrapper equivalence audit, equal-density sweeps, and direct-frontier handler are merged.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -168,6 +168,29 @@
         "reason": "Replace linear four-group area/timing composition with full-array PNR."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_array_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the Llama7B frontier with direct one-, two-, and four-group array PPA.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array_frontier",
+      "comparison_role": "gqa8_direct_array_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_array_g1_pnr_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_array_g2_pnr_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_array_g4_pnr_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_direct_gqa8_array_ppa_points",
+        "reason": "Replace linear timing/area scaling with direct array measurements while withholding direct-array and total-token energy claims."
+      },
+      "status": "pending_implementation_merge"
     }
   ]
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/implementation_summary.md
@@ -33,3 +33,9 @@ does not hide bandwidth by arbitration or serialization. Equal-density die
 dimensions scale with the exact 448 FakeRAM macros per group, allowing direct
 array PNR to replace linear multi-group timing and area composition while
 keeping external memories and NoC explicit.
+
+The direct-array frontier recost consumes all three routed metrics files. It
+reallocates dense QKV tiles within the same compute budget and recomputes
+waves, layer cycles, clock, throughput, and embodied area for each feasible
+row. Group-component activity energy remains inherited and visibly
+compositional until an array-level VCD/routed-power run closes that boundary.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/implementation_summary.md
@@ -25,3 +25,11 @@ The frontier follow-on deploys one, two, or four measured groups. Four logical
 GQA groups are required per layer; fewer physical groups execute them in
 waves. One-group PPA is composed linearly for larger counts and is explicitly
 not treated as array-level placement evidence.
+
+The next physical boundary instantiates one, two, or four complete groups
+under one clock and atomic command/input broadcast. Every group retains a
+separate value-memory request/response port and result stream; the wrapper
+does not hide bandwidth by arbitration or serialization. Equal-density die
+dimensions scale with the exact 448 FakeRAM macros per group, allowing direct
+array PNR to replace linear multi-group timing and area composition while
+keeping external memories and NoC explicit.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -205,6 +205,29 @@
         "reason": "This directly embodies all four Llama7B KV groups and replaces linear multi-group area/timing composition."
       },
       "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_array_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replace compositional multi-group timing and area with direct equal-density array PPA in the Llama7B frontier.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array_frontier",
+      "comparison_role": "gqa8_direct_array_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_array_g1_pnr_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_array_g2_pnr_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_array_g4_pnr_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "rank_direct_gqa8_array_ppa_points",
+        "reason": "Substitute measured array timing and instance area while preserving compositional energy provenance and open memory/NoC boundaries."
+      },
+      "status": "pending_control_plane_merge"
     }
   ],
   "baseline_refs": [

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -237,7 +237,7 @@
   ],
   "remaining_abstractions_after_this_step": [
     "The GQA group uses eight fully parallel query-head clusters; folded 1/2/4-head execution remains an area-throughput design space.",
-    "Activity-backed power is required before token-energy ranking.",
+    "Direct array activity-backed power is required before replacing compositional component energy.",
     "The shared value stream still terminates at a local request/response boundary rather than an embodied SRAM/NoC service.",
     "HBM/DRAM service and full-layer scheduling remain outside this physical block."
   ]

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -118,6 +118,93 @@
         "reason": "Use measured one-group timing, area, and activity energy while exposing linear multi-group PPA composition."
       },
       "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove atomic broadcast and independent channels for generated one-, two-, and four-group arrays.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
+      "comparison_role": "gqa8_multigroup_array_semantic_gate",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_gqa8_multigroup_array_compositional_equivalence",
+        "reason": "Array PPA is ineligible until group arithmetic and array-level command, memory, and result routing are proven."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g1_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the direct one-group array wrapper at the equal-density physical point.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
+      "comparison_role": "gqa8_array_g1_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_array_g1_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g1.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_direct_gqa8_array_g1_ppa",
+        "reason": "The direct wrapper point calibrates array integration overhead against the standalone group."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g2_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the direct two-group array at equal macro density.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
+      "comparison_role": "gqa8_array_g2_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g1_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_array_g2_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g2.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_direct_gqa8_array_g2_ppa",
+        "reason": "Equal-density placement isolates array fanout, routing, and clock-tree scaling from utilization changes."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g4_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the complete four-group Llama7B GQA array at equal macro density.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
+      "comparison_role": "gqa8_array_g4_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g2_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_array_g4_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g4.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_direct_gqa8_array_g4_ppa",
+        "reason": "This directly embodies all four Llama7B KV groups and replaces linear multi-group area/timing composition."
+      },
+      "status": "pending_control_plane_merge"
     }
   ],
   "baseline_refs": [

--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_array_equivalence.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_array_equivalence.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Compose the measured GQA8 group proof with the direct array wrapper protocol proof."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JsonDict = dict[str, Any]
+_GROUP_MODEL = "llama7b_gqa8_shared_kv_compositional_arithmetic_equivalence_v1"
+_GROUP_DECISION = "llama7b_gqa8_shared_kv_equivalence_pass"
+_ARRAY_COUNTS = (1, 2, 4)
+_PROTOCOL_TEST = (
+    "tests/test_attention_decode_score_multivalue_gqa_array.py::"
+    "test_multivalue_gqa_array_atomic_broadcast_and_independent_channels"
+)
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _hash(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _validate_group_equivalence(payload: JsonDict) -> JsonDict:
+    wrapper = payload.get("wrapper_protocol")
+    expected_hash = payload.get("expected_group_result_sha256")
+    observed_hash = payload.get("observed_group_result_sha256")
+    if not (
+        payload.get("model") == _GROUP_MODEL
+        and payload.get("decision") == _GROUP_DECISION
+        and payload.get("equivalence_pass") is True
+        and payload.get("distinct_query_heads_pass") is True
+        and payload.get("shared_inputs_pass") is True
+        and payload.get("arithmetic_equivalence_pass") is True
+        and int(payload.get("query_heads_per_kv", 0)) == 8
+        and isinstance(wrapper, dict)
+        and wrapper.get("sharing_and_order_pass") is True
+        and isinstance(expected_hash, str)
+        and bool(expected_hash)
+        and expected_hash == observed_hash
+    ):
+        raise ValueError("merged GQA8 group equivalence contract did not pass")
+    return {
+        "model": payload["model"],
+        "decision": payload["decision"],
+        "semantic_profile": payload.get("semantic_profile"),
+        "expected_group_result_sha256": expected_hash,
+        "observed_group_result_sha256": observed_hash,
+    }
+
+
+def _validate_array_configs(configs: list[JsonDict]) -> list[JsonDict]:
+    rows: list[JsonDict] = []
+    for config in configs:
+        body = config.get("attention_decode_score_multivalue_gqa_array")
+        if not isinstance(body, dict):
+            raise ValueError("array config lacks attention_decode_score_multivalue_gqa_array")
+        row = {
+            "top_name": str(config.get("top_name") or ""),
+            "group_count": int(body.get("group_count", 0)),
+            "max_blocks": int(body.get("max_blocks", 0)),
+            "array_n": int(body.get("array_n", 0)),
+            "value_slices": int(body.get("value_slices", 0)),
+            "score_scale_lanes_per_cycle": int(body.get("score_scale_lanes_per_cycle", 0)),
+            "query_heads_per_kv": int(body.get("query_heads_per_kv", 0)),
+            "divider_impl": str(body.get("divider_impl") or ""),
+        }
+        if not row["top_name"]:
+            raise ValueError("array config top_name is empty")
+        if (
+            row["max_blocks"] != 16384
+            or row["array_n"] != 8
+            or row["value_slices"] != 16
+            or row["score_scale_lanes_per_cycle"] != 1
+            or row["query_heads_per_kv"] != 8
+            or row["divider_impl"] != "iterative_restoring"
+        ):
+            raise ValueError("array config is not the exact Llama7B GQA8 physical profile")
+        rows.append(row)
+    counts = tuple(sorted(row["group_count"] for row in rows))
+    if counts != _ARRAY_COUNTS:
+        raise ValueError(f"array configs must cover group counts {_ARRAY_COUNTS}")
+    return sorted(rows, key=lambda row: int(row["group_count"]))
+
+
+def _run_protocol_test(target: str) -> JsonDict:
+    command = [sys.executable, "-m", "pytest", "-q", target]
+    run = subprocess.run(command, cwd=REPO_ROOT, capture_output=True, text=True, timeout=180)
+    output = (run.stdout + "\n" + run.stderr).strip()
+    passed_count = sum(int(value) for value in re.findall(r"(\d+) passed", output))
+    return {
+        "test_target": target,
+        "command": ["python3", "-m", "pytest", "-q", target],
+        "returncode": run.returncode,
+        "passed_test_count": passed_count,
+        "atomic_broadcast_and_independent_channels_pass": (
+            run.returncode == 0 and passed_count == len(_ARRAY_COUNTS)
+        ),
+    }
+
+
+def _build_report(
+    *, group_equivalence: JsonDict, array_configs: list[JsonDict], protocol: JsonDict
+) -> JsonDict:
+    group = _validate_group_equivalence(group_equivalence)
+    config_rows = _validate_array_configs(array_configs)
+    protocol_pass = protocol.get("atomic_broadcast_and_independent_channels_pass") is True
+    per_array_hashes = [
+        {
+            "group_count": row["group_count"],
+            "expected_array_result_sha256": _hash(
+                [group["expected_group_result_sha256"]] * int(row["group_count"])
+            ),
+            "observed_array_result_sha256": _hash(
+                [group["observed_group_result_sha256"]] * int(row["group_count"])
+            ),
+        }
+        for row in config_rows
+    ]
+    hashes_pass = all(
+        row["expected_array_result_sha256"] == row["observed_array_result_sha256"]
+        for row in per_array_hashes
+    )
+    passed = protocol_pass and hashes_pass
+    return {
+        "version": 1,
+        "model": "llama7b_gqa8_multigroup_array_compositional_equivalence_v1",
+        "decision": (
+            "llama7b_gqa8_multigroup_array_equivalence_pass"
+            if passed
+            else "llama7b_gqa8_multigroup_array_equivalence_fail"
+        ),
+        "equivalence_pass": passed,
+        "precision_status": "exact" if passed else "rejected",
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1",
+        "query_heads_per_kv": 8,
+        "logical_kv_groups": 4,
+        "measured_group_counts": list(_ARRAY_COUNTS),
+        "array_configs": config_rows,
+        "group_equivalence": group,
+        "array_result_hashes": per_array_hashes,
+        "array_protocol": protocol,
+        "compositional_proof": {
+            "method": "merged_complete_group_equivalence_plus_array_wrapper_protocol",
+            "group_claim": (
+                "Each instantiated group is the same generated complete GQA8 group whose arithmetic, shared-K/V "
+                "behavior, and ordered result stream passed the merged group equivalence gate."
+            ),
+            "array_claim": (
+                "The generated array wrapper protocol simulation covers one, two, and four groups and verifies "
+                "atomic command/input broadcast plus independent value-memory and result channels."
+            ),
+            "flat_32_cluster_arithmetic_simulation_run": False,
+            "scope_limit": (
+                "The proof composes a merged complete-group arithmetic proof with direct array-wrapper protocol "
+                "simulation; it does not claim a monolithic 32-cluster arithmetic simulation."
+            ),
+        },
+    }
+
+
+def build_report(
+    *, group_equivalence_json: Path, array_config_paths: list[Path], protocol_test_target: str
+) -> JsonDict:
+    return _build_report(
+        group_equivalence=_load(group_equivalence_json),
+        array_configs=[_load(path) for path in array_config_paths],
+        protocol=_run_protocol_test(protocol_test_target),
+    )
+
+
+def _markdown(payload: JsonDict) -> str:
+    proof = payload["compositional_proof"]
+    return (
+        "# Llama7B GQA8 Multi-Group Array Equivalence\n\n"
+        f"- decision: `{payload['decision']}`\n"
+        f"- equivalence pass: `{payload['equivalence_pass']}`\n"
+        f"- group counts: `{payload['measured_group_counts']}`\n"
+        f"- wrapper protocol pass: "
+        f"`{payload['array_protocol']['atomic_broadcast_and_independent_channels_pass']}`\n\n"
+        "## Proof Boundary\n\n"
+        f"{proof['group_claim']}\n\n{proof['array_claim']}\n\n"
+        f"**Scope:** {proof['scope_limit']}\n"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--group-equivalence-json", type=Path, required=True)
+    parser.add_argument("--array-config", type=Path, action="append", required=True)
+    parser.add_argument("--protocol-test-target", default=_PROTOCOL_TEST)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        group_equivalence_json=args.group_equivalence_json,
+        array_config_paths=args.array_config,
+        protocol_test_target=args.protocol_test_target,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.write_text(_markdown(payload), encoding="utf-8")
+    return 0 if payload["equivalence_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_array_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_array_frontier.py
@@ -165,9 +165,7 @@ def _parse_metrics_row(raw: Mapping[str, Any], *, metrics_path: Path, count: int
         critical_path = _positive(
             _first_value(raw, ("critical_path_ns", "critical_path")), "critical path"
         )
-        instance_value = _first_value(
-            raw, ("instance_area_um2", "instance_area", "die_area_um2", "die_area", "area_um2")
-        )
+        instance_value = _first_value(raw, ("instance_area_um2", "instance_area"))
         instance_area = _positive(instance_value, "instance area")
         row_group = params.get("GROUP_COUNT", params.get("group_count"))
         if row_group is not None and int(row_group) != count:

--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_array_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_array_frontier.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Recost the Llama7B GQA frontier with directly measured GQA arrays."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+
+JsonDict = dict[str, Any]
+_QUERY_HEADS_PER_KV = 8
+_GROUP_COUNTS = (1, 2, 4)
+_PRIOR_MODEL = "decoder_attention_decode_score_multivalue_gqa_group_frontier_llama7b_v1"
+_PRIOR_DECISION = "measured_complete_gqa8_group_component_frontier_promoted"
+_EQUIVALENCE_MODEL = "llama7b_gqa8_multigroup_array_compositional_equivalence_v1"
+_EQUIVALENCE_DECISION = "llama7b_gqa8_multigroup_array_equivalence_pass"
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _linked_path(link: str, frontier_path: Path) -> Path:
+    linked = Path(link)
+    candidates = [linked] if linked.is_absolute() else [frontier_path.parent / linked, Path.cwd() / linked]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise ValueError(f"linked prior frontier does not exist: {link}")
+
+
+def _frontier_chain(frontier: JsonDict, frontier_path: Path) -> Iterator[tuple[JsonDict, Path]]:
+    current, current_path = frontier, frontier_path
+    visited: set[Path] = set()
+    while True:
+        resolved = current_path.resolve()
+        if resolved in visited:
+            raise ValueError("prior frontier linkage contains a cycle")
+        visited.add(resolved)
+        yield current, current_path
+        inputs = current.get("inputs")
+        link = inputs.get("prior_frontier_json") if isinstance(inputs, dict) else None
+        if not isinstance(link, str) or not link:
+            return
+        current_path = _linked_path(link, current_path)
+        current = _load(current_path)
+
+
+def _source_evidence(frontier: JsonDict, frontier_path: Path, key: str) -> tuple[JsonDict, str]:
+    for candidate, candidate_path in _frontier_chain(frontier, frontier_path):
+        value = candidate.get(key)
+        if isinstance(value, dict):
+            return value, str(candidate_path)
+    raise ValueError(f"prior frontier chain lacks {key}")
+
+
+def _positive(value: Any, label: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be finite and positive") from exc
+    if not math.isfinite(result) or result <= 0:
+        raise ValueError(f"{label} must be finite and positive")
+    return result
+
+
+def _finite_positive(value: Any) -> float:
+    result = float(value)
+    if not math.isfinite(result) or result <= 0:
+        raise ValueError("value must be finite and positive")
+    return result
+
+
+def _validate_prior(prior: JsonDict) -> JsonDict:
+    if prior.get("model") != _PRIOR_MODEL:
+        raise ValueError("prior frontier model contract failed")
+    if prior.get("decision") != _PRIOR_DECISION:
+        raise ValueError("prior frontier decision contract failed")
+    precision = prior.get("precision")
+    if not isinstance(precision, dict) or precision.get("status") != "exact":
+        raise ValueError("prior frontier precision contract failed")
+    return {
+        "model": prior["model"],
+        "decision": prior["decision"],
+        "precision_status": precision["status"],
+        "precision": precision,
+    }
+
+
+def _validate_equivalence(equivalence: JsonDict) -> JsonDict:
+    if (
+        equivalence.get("model") != _EQUIVALENCE_MODEL
+        or equivalence.get("decision") != _EQUIVALENCE_DECISION
+        or equivalence.get("equivalence_pass") is not True
+        or equivalence.get("precision_status") != "exact"
+        or equivalence.get("measured_group_counts") != list(_GROUP_COUNTS)
+    ):
+        raise ValueError("array equivalence model/decision/precision/count contract failed")
+    return {
+        "model": equivalence["model"],
+        "decision": equivalence["decision"],
+        "equivalence_pass": True,
+        "precision_status": equivalence["precision_status"],
+        "semantic_profile": equivalence.get("semantic_profile"),
+        "query_heads_per_kv": equivalence.get("query_heads_per_kv"),
+        "measured_group_counts": list(_GROUP_COUNTS),
+        "array_configs": equivalence.get("array_configs"),
+    }
+
+
+def _first_value(row: Mapping[str, Any], names: tuple[str, ...]) -> Any:
+    for name in names:
+        value = row.get(name)
+        if value is not None and str(value).strip() != "":
+            return value
+    return None
+
+
+def _parse_metrics_row(raw: Mapping[str, Any], *, metrics_path: Path, count: int, line: int) -> JsonDict:
+    evidence: JsonDict = {
+        "metrics_path": str(metrics_path),
+        "csv_line": line,
+        "requested_group_count": count,
+        "raw": dict(raw),
+        "status": raw.get("status", ""),
+        "design": raw.get("design"),
+        "platform": raw.get("platform"),
+        "config_hash": raw.get("config_hash"),
+        "param_hash": raw.get("param_hash"),
+        "result_path": raw.get("result_path"),
+    }
+    try:
+        params_text = raw.get("params_json")
+        params = json.loads(params_text) if isinstance(params_text, str) else None
+        if not isinstance(params, dict):
+            raise ValueError("params_json is not an object")
+        evidence["params"] = params
+    except (TypeError, json.JSONDecodeError, ValueError) as exc:
+        evidence.update({"accepted": False, "reason": f"invalid params_json: {exc}"})
+        return evidence
+
+    params = evidence["params"]
+    evidence.update(
+        {
+            "flow_variant": _first_value(raw, ("flow_variant",)) or params.get("FLOW_VARIANT"),
+            "die_area": _first_value(raw, ("die_area",)) or params.get("DIE_AREA"),
+            "core_area": _first_value(raw, ("core_area",)) or params.get("CORE_AREA"),
+            "core_utilization": _first_value(raw, ("core_utilization",)) or params.get("CORE_UTILIZATION"),
+        }
+    )
+    status = str(raw.get("status") or "").strip().lower()
+    if status != "ok":
+        evidence.update({"accepted": False, "reason": f"status is {status or 'missing'}, not ok"})
+        return evidence
+
+    try:
+        configured_clock = _positive(params.get("CLOCK_PERIOD"), "configured CLOCK_PERIOD")
+        critical_path = _positive(
+            _first_value(raw, ("critical_path_ns", "critical_path")), "critical path"
+        )
+        instance_value = _first_value(
+            raw, ("instance_area_um2", "instance_area", "die_area_um2", "die_area", "area_um2")
+        )
+        instance_area = _positive(instance_value, "instance area")
+        row_group = params.get("GROUP_COUNT", params.get("group_count"))
+        if row_group is not None and int(row_group) != count:
+            raise ValueError(f"params group_count {row_group} does not match requested {count}")
+        if critical_path > configured_clock:
+            raise ValueError(
+                f"critical path {critical_path} ns exceeds configured CLOCK_PERIOD {configured_clock} ns"
+            )
+    except (TypeError, ValueError, OverflowError) as exc:
+        evidence.update({"accepted": False, "reason": str(exc)})
+        return evidence
+
+    evidence.update(
+        {
+            "accepted": True,
+            "reason": "timing-feasible direct metrics row",
+            "configured_clock_period_ns": configured_clock,
+            "critical_path_ns": critical_path,
+            "instance_area_um2": instance_area,
+        }
+    )
+    return evidence
+
+
+def _read_metrics(path: Path, count: int) -> list[JsonDict]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if not reader.fieldnames:
+            raise ValueError(f"metrics CSV has no header: {path}")
+        return [_parse_metrics_row(row, metrics_path=path, count=count, line=index) for index, row in enumerate(reader, 2)]
+
+
+def _prior_rows_by_group(prior: JsonDict) -> dict[int, JsonDict]:
+    rows = prior.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("prior frontier lacks rows")
+    result: dict[int, JsonDict] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        try:
+            count = int(row["group_count"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if count in result:
+            raise ValueError(f"prior frontier has duplicate group_count {count}")
+        result[count] = row
+    missing = set(_GROUP_COUNTS) - set(result)
+    if missing:
+        raise ValueError(f"prior frontier lacks rows for group counts {sorted(missing)}")
+    return result
+
+
+def _recost_candidate(
+    *, group_count: int, schedule: JsonDict, dense_tile: JsonDict, prior_row: JsonDict, metric: JsonDict
+) -> JsonDict:
+    hidden = int(schedule["hidden_size"])
+    attention_heads = int(schedule["attention_heads"])
+    kv_heads = int(schedule["kv_heads"])
+    layers = int(schedule["layers"])
+    head_dim = hidden // attention_heads
+    group_cycles_raw = schedule.get("group_full_context_cycles")
+    if group_cycles_raw is None:
+        raise ValueError("schedule lacks group_full_context_cycles")
+    group_cycles = int(group_cycles_raw)
+    if group_cycles <= 0 or group_cycles != float(group_cycles_raw):
+        raise ValueError("group_full_context_cycles must be a positive integer")
+    direct_area = _positive(metric["instance_area_um2"], "direct array instance area")
+    dense_area = _positive(dense_tile["area_um2"], "dense QKV tile area")
+    dense_macs = _positive(dense_tile["effective_macs_per_cycle"], "dense QKV MAC/cycle")
+    budget = _positive(schedule["compute_budget_um2"], "compute budget")
+    useful_limit = hidden // 8 + 2 * kv_heads * head_dim // 8
+    dense_count = min(useful_limit, max(0, math.floor((budget - direct_area) / dense_area)))
+    area_fit = dense_count > 0 and direct_area + dense_count * dense_area <= budget
+    qkv_work = hidden**2 + 2 * hidden * kv_heads * head_dim
+    qkv_cycles = math.ceil(qkv_work / (dense_count * dense_macs)) if dense_count else None
+    waves = math.ceil(kv_heads / group_count)
+    attention_cycles = waves * group_cycles
+    fixed_cycles = int(schedule.get("command_dispatch_cycles", 0)) + int(schedule.get("kv_write_cycles", 0))
+    layer_cycles = qkv_cycles + attention_cycles + fixed_cycles if qkv_cycles is not None else None
+    source_clock = _positive(schedule["clock_ns"], "source schedule clock")
+    ppa_clock = _positive(metric["configured_clock_period_ns"], "configured CLOCK_PERIOD")
+    effective_clock = max(source_clock, ppa_clock)
+    total_cycles = layer_cycles * layers if layer_cycles is not None else None
+    latency = total_cycles * effective_clock / 1000.0 if total_cycles is not None else None
+    noncompute_logic = float(schedule["logic_area_used_um2"]) - float(schedule["compute_area_um2"])
+    shared_sram = float(schedule.get("measured_shared_sram_used_area_um2", 0.0)) + float(
+        schedule.get("measured_tile_local_sram_area_um2", 0.0)
+    )
+    prior_energy = prior_row.get("gqa_group_component_energy_mj_per_token")
+    if prior_energy is None and prior_row.get("gqa_group_component_energy_j_per_token") is not None:
+        prior_energy = float(prior_row["gqa_group_component_energy_j_per_token"]) * 1.0e3
+    prior_energy = _positive(prior_energy, "prior compositional group-component energy")
+    logic_area = noncompute_logic + direct_area + dense_count * dense_area
+
+    prior_area = float(prior_row["group_area_mm2"]) * 1.0e6
+    prior_latency = _positive(prior_row["latency_us"], "prior group-composed latency")
+    prior_throughput = _positive(prior_row["token_throughput_per_s"], "prior group-composed throughput")
+    prior_clock = _positive(prior_row["clock_ns"], "prior group-composed clock")
+    return {
+        "candidate_id": f"decode_score_multivalue_gqa_array_g{group_count}_{metric['param_hash'] or 'metric'}",
+        "group_count": group_count,
+        "dense_qkv_tile_count": dense_count,
+        "dense_qkv_useful_parallelism_limit": useful_limit,
+        "qkv_work": qkv_work,
+        "qkv_cycles": qkv_cycles,
+        "logical_groups_per_layer": kv_heads,
+        "group_waves_per_layer": waves,
+        "attention_cycles": attention_cycles,
+        "fixed_cycles": fixed_cycles,
+        "layer_cycles": layer_cycles,
+        "total_cycles": total_cycles,
+        "critical_path_ns": metric["critical_path_ns"],
+        "direct_array_critical_path_ns": metric["critical_path_ns"],
+        "configured_clock_period_ns": ppa_clock,
+        "source_schedule_clock_ns": source_clock,
+        "clock_ns": effective_clock,
+        "clock_provenance": "max(source_schedule.clock_ns, metrics.params_json.CLOCK_PERIOD)",
+        "latency_us": round(latency, 6) if latency is not None else None,
+        "token_throughput_per_s": round(1.0e6 / latency, 12) if latency else None,
+        "direct_array_instance_area_um2": direct_area,
+        "direct_array_instance_area_mm2": round(direct_area / 1.0e6, 9),
+        "noncompute_logic_area_um2": noncompute_logic,
+        "measured_shared_sram_used_area_um2": float(schedule.get("measured_shared_sram_used_area_um2", 0.0)),
+        "measured_tile_local_sram_area_um2": float(schedule.get("measured_tile_local_sram_area_um2", 0.0)),
+        "measured_shared_plus_local_sram_area_um2": shared_sram,
+        "dense_qkv_area_mm2": round(dense_count * dense_area / 1.0e6, 9),
+        "compute_budget_slack_mm2": round((budget - direct_area - dense_count * dense_area) / 1.0e6, 9),
+        "logic_area_mm2": round(logic_area / 1.0e6, 9),
+        "embodied_logic_plus_shared_sram_area_mm2": round((logic_area + shared_sram) / 1.0e6, 9),
+        "direct_embodied_logic_plus_shared_sram_area_mm2": round((logic_area + shared_sram) / 1.0e6, 9),
+        "compute_budget_area_fit": area_fit,
+        "timing_feasible": True,
+        "recost_status": "accepted" if area_fit else "compute_budget_infeasible",
+        "prior_compositional_gqa_group_component_energy_mj_per_token": prior_energy,
+        "energy_scope": "prior GQA8 group-component activity evidence only; not direct array activity and not total-token energy",
+        "energy_status": "NOT_direct_array_activity_NOT_total_token_energy_prior_compositional_evidence",
+        "metrics_provenance": {
+            "metrics_path": metric["metrics_path"],
+            "csv_line": metric["csv_line"],
+            "config_hash": metric["config_hash"],
+            "param_hash": metric["param_hash"],
+            "flow_variant": metric["flow_variant"],
+            "platform": metric["platform"],
+            "die_area": metric["die_area"],
+            "core_area": metric["core_area"],
+            "core_utilization": metric["core_utilization"],
+            "critical_path_ns": metric["critical_path_ns"],
+            "instance_area_um2": direct_area,
+            "configured_clock_period_ns": ppa_clock,
+            "params_json": metric["params"],
+        },
+        "prior_group_composed": {
+            "candidate_id": prior_row.get("candidate_id"),
+            "instance_area_um2": prior_area,
+            "latency_us": prior_latency,
+            "token_throughput_per_s": prior_throughput,
+            "clock_ns": prior_clock,
+            "clock_provenance": "prior group frontier max(source schedule clock, group activity clock)",
+        },
+        "direct_vs_prior_compositional_delta": {
+            "instance_area_um2": direct_area - prior_area,
+            "latency_us": (latency - prior_latency) if latency is not None else None,
+            "throughput_per_s": (1.0e6 / latency - prior_throughput) if latency else None,
+            "clock_ns": effective_clock - prior_clock,
+            "clock_provenance": {
+                "direct": "max(source schedule clock, direct metrics configured CLOCK_PERIOD)",
+                "prior": "prior group frontier effective clock, including group activity clock",
+                "differing_clock_sources": True,
+            },
+        },
+    }
+
+
+def _pareto(rows: list[JsonDict]) -> list[JsonDict]:
+    feasible = [
+        row for row in rows
+        if row.get("compute_budget_area_fit") and row.get("timing_feasible") and row.get("latency_us") is not None
+    ]
+    energy_key = "prior_compositional_gqa_group_component_energy_mj_per_token"
+    result: list[JsonDict] = []
+    for row in feasible:
+        dominated = any(
+            other is not row
+            and float(other["latency_us"]) <= float(row["latency_us"])
+            and float(other["embodied_logic_plus_shared_sram_area_mm2"]) <= float(row["embodied_logic_plus_shared_sram_area_mm2"])
+            and float(other[energy_key]) <= float(row[energy_key])
+            and (
+                float(other["latency_us"]) < float(row["latency_us"])
+                or float(other["embodied_logic_plus_shared_sram_area_mm2"]) < float(row["embodied_logic_plus_shared_sram_area_mm2"])
+                or float(other[energy_key]) < float(row[energy_key])
+            )
+            for other in feasible
+        )
+        if not dominated:
+            result.append(row)
+    return result
+
+
+def build_report(
+    *, prior_frontier_json: Path, array_equivalence_json: Path, array_metrics: Mapping[int, Path]
+) -> JsonDict:
+    if set(array_metrics) != set(_GROUP_COUNTS):
+        raise ValueError(f"array metrics must cover exact group counts {list(_GROUP_COUNTS)}")
+    prior = _load(prior_frontier_json)
+    equivalence = _validate_equivalence(_load(array_equivalence_json))
+    prior_contract = _validate_prior(prior)
+    schedule, schedule_source = _source_evidence(prior, prior_frontier_json, "source_schedule")
+    dense_tile, dense_source = _source_evidence(prior, prior_frontier_json, "dense_qkv_tile")
+    if (
+        int(schedule.get("hidden_size", 0)) != 4096
+        or int(schedule.get("attention_heads", 0)) != 32
+        or int(schedule.get("kv_heads", 0)) != 4
+        or int(schedule.get("layers", 0)) != 32
+        or int(schedule["attention_heads"]) != int(schedule["kv_heads"]) * _QUERY_HEADS_PER_KV
+    ):
+        raise ValueError("frontier is not the expected Llama7B 4096D/32Q-head/4KV-head/32-layer schedule")
+    schedule_contract = prior.get("schedule_contract")
+    if not isinstance(schedule_contract, dict):
+        raise ValueError("prior frontier lacks schedule_contract")
+    group_cycles = schedule_contract.get("group_full_context_cycles")
+    if group_cycles is None:
+        group_cycles = schedule.get("group_full_context_cycles")
+    schedule = dict(schedule)
+    schedule["group_full_context_cycles"] = group_cycles
+    prior_rows = _prior_rows_by_group(prior)
+
+    raw_rows: list[JsonDict] = []
+    candidates: list[JsonDict] = []
+    for count in _GROUP_COUNTS:
+        parsed = _read_metrics(Path(array_metrics[count]), count)
+        for metric in parsed:
+            raw_rows.append(metric)
+            if not metric["accepted"]:
+                continue
+            try:
+                candidate = _recost_candidate(
+                    group_count=count,
+                    schedule=schedule,
+                    dense_tile=dense_tile,
+                    prior_row=prior_rows[count],
+                    metric=metric,
+                )
+            except (KeyError, TypeError, ValueError, OverflowError) as exc:
+                metric["accepted"] = False
+                metric["reason"] = f"recost rejected: {exc}"
+                continue
+            metric["recost_candidate_id"] = candidate["candidate_id"]
+            candidates.append(candidate)
+    pareto = _pareto(candidates)
+    if not pareto:
+        raise ValueError("no feasible direct GQA array frontier row")
+    best = max(pareto, key=lambda row: float(row["token_throughput_per_s"]))
+    prior_best = prior.get("best_throughput_candidate")
+    prior_comparison = {
+        "available": isinstance(prior_best, dict) and prior_best.get("token_throughput_per_s") is not None,
+    }
+    if prior_comparison["available"]:
+        prior_comparison.update(
+            {
+                "prior_candidate_id": prior_best.get("candidate_id"),
+                "prior_token_throughput_per_s": float(prior_best["token_throughput_per_s"]),
+                "best_direct_array_token_throughput_per_s": best["token_throughput_per_s"],
+                "throughput_delta_per_s": best["token_throughput_per_s"] - float(prior_best["token_throughput_per_s"]),
+            }
+        )
+    return {
+        "version": 1,
+        "model": "decoder_attention_decode_score_multivalue_gqa_array_frontier_llama7b_v1",
+        "decision": "direct_gqa_array_timing_area_frontier_promoted_energy_blocked",
+        "inputs": {
+            "prior_frontier_json": str(prior_frontier_json),
+            "array_equivalence_json": str(array_equivalence_json),
+            "array_metrics": {str(count): str(array_metrics[count]) for count in _GROUP_COUNTS},
+            "source_schedule_json": schedule_source,
+            "dense_qkv_tile_source_json": dense_source,
+        },
+        "prior_contract": prior_contract,
+        "array_equivalence": equivalence,
+        "schedule_contract": {
+            "hidden_size": 4096,
+            "attention_heads": 32,
+            "kv_heads": 4,
+            "query_heads_per_kv": _QUERY_HEADS_PER_KV,
+            "head_dim": 128,
+            "sequence_length": int(schedule["sequence_length"]),
+            "layers": 32,
+            "logical_groups_per_layer": 4,
+            "group_full_context_cycles": int(group_cycles),
+            "sequence_sharding_supported": False,
+        },
+        "dense_qkv_tile": dense_tile,
+        "raw_metrics_evidence": raw_rows,
+        "recost_candidates": candidates,
+        "rows": candidates,
+        "pareto_candidates": pareto,
+        "pareto_rows": pareto,
+        "best_throughput_candidate": best,
+        "comparison_to_prior_best": prior_comparison,
+        "per_group_direct_vs_prior_compositional_deltas": {
+            str(count): [
+                {
+                    "candidate_id": row["candidate_id"],
+                    **row["direct_vs_prior_compositional_delta"],
+                }
+                for row in candidates
+                if row["group_count"] == count
+            ]
+            for count in _GROUP_COUNTS
+        },
+        "promotion_status": "direct array timing/area promoted but energy/full architecture blocked",
+        "promotion": {
+            "direct_array_timing": "promoted",
+            "direct_array_area": "promoted",
+            "direct_array_activity_energy": "blocked",
+            "full_architecture": "blocked",
+        },
+        "remaining_abstractions": [
+            "Direct array activity power is not measured.",
+            "External value memory, NoC, and HBM are outside this frontier.",
+            "SRAM compiler signoff is not available.",
+            "Total-token energy is incomplete.",
+            "No monolithic 32-cluster arithmetic simulation was run.",
+        ],
+    }
+
+
+def _write_markdown(payload: JsonDict, path: Path) -> None:
+    best = payload["best_throughput_candidate"]
+    lines = [
+        "# Llama7B GQA8 Direct Array Frontier",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- promotion: `{payload['promotion_status']}`",
+        f"- best throughput: `{best['token_throughput_per_s']}` token/s",
+        "- energy: prior compositional group-component evidence only; direct activity and total-token energy are blocked",
+        "",
+        "## Raw Metrics Evidence",
+        "",
+        "| group | line | status | accepted | reason | metrics path | config hash | param hash | critical path ns | instance area um2 | clock ns |",
+        "|---:|---:|---|---|---|---|---|---|---:|---:|---:|",
+    ]
+    for row in payload["raw_metrics_evidence"]:
+        lines.append(
+            f"| {row['requested_group_count']} | {row['csv_line']} | {row.get('status', '')} | {row['accepted']} | {row['reason']} | "
+            f"{row['metrics_path']} | {row.get('config_hash', '')} | {row.get('param_hash', '')} | "
+            f"{row.get('critical_path_ns', '')} | {row.get('instance_area_um2', '')} | {row.get('configured_clock_period_ns', '')} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Recost Candidates",
+            "",
+            "| candidate | group | timing | area fit | latency us | throughput token/s | direct array area mm2 | embodied area mm2 | prior compositional energy mJ/token |",
+            "|---|---:|---|---|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in payload["recost_candidates"]:
+        lines.append(
+            f"| {row['candidate_id']} | {row['group_count']} | {row['timing_feasible']} | {row['compute_budget_area_fit']} | "
+            f"{row['latency_us']} | {row['token_throughput_per_s']} | {row['direct_array_instance_area_mm2']} | "
+            f"{row['embodied_logic_plus_shared_sram_area_mm2']} | {row['prior_compositional_gqa_group_component_energy_mj_per_token']} |"
+        )
+    lines.extend(["", "## Pareto Candidates", ""])
+    lines.extend(f"- `{row['candidate_id']}`" for row in payload["pareto_candidates"])
+    lines.extend(["", "## Per-Group Direct vs Prior Compositional", "", "| group | area delta um2 | latency delta us | throughput delta token/s | clock delta ns |", "|---:|---:|---:|---:|---:|"])
+    for count, deltas in payload["per_group_direct_vs_prior_compositional_deltas"].items():
+        for delta in deltas:
+            lines.append(f"| {count} | {delta['instance_area_um2']} | {delta['latency_us']} | {delta['throughput_per_s']} | {delta['clock_ns']} |")
+    lines.extend(["", "## Remaining Abstractions", ""])
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prior-frontier-json", type=Path, required=True)
+    parser.add_argument("--array-equivalence-json", type=Path, required=True)
+    parser.add_argument("--array-metrics", action="append", required=True, metavar="COUNT=PATH")
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    metrics: dict[int, Path] = {}
+    for item in args.array_metrics:
+        if "=" not in item:
+            parser.error("--array-metrics must be COUNT=PATH")
+        count_text, path_text = item.split("=", 1)
+        try:
+            count = int(count_text)
+        except ValueError:
+            parser.error(f"invalid array metrics count: {count_text}")
+        if count in metrics:
+            parser.error(f"duplicate array metrics count: {count}")
+        metrics[count] = Path(path_text)
+    payload = build_report(
+        prior_frontier_json=args.prior_frontier_json,
+        array_equivalence_json=args.array_equivalence_json,
+        array_metrics=metrics,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/check_attention_decode_score_multivalue_gqa_array_guard.py
+++ b/npu/eval/check_attention_decode_score_multivalue_gqa_array_guard.py
@@ -158,6 +158,50 @@ def main() -> int:
         raise SystemExit("GQA-array RTL must expose the packed query bus")
     if not re.search(rf"input\s+wire\s+signed\s+\[{packed_width - 1}:0\]\s+input_key", text):
         raise SystemExit("GQA-array RTL must expose the packed key bus")
+    for group in range(group_count):
+        q_lo = group * 64
+        q_hi = q_lo + 63
+        addr_lo = group * 14
+        addr_hi = addr_lo + 13
+        slice_lo = group * 4
+        slice_hi = slice_lo + 3
+        matrix_lo = group * 512
+        matrix_hi = matrix_lo + 511
+        head_lo = group * 3
+        head_hi = head_lo + 2
+        command_lo = group * 16
+        command_hi = command_lo + 15
+        max_lo = group * 32
+        max_hi = max_lo + 31
+        sum_lo = group * 33
+        sum_hi = sum_lo + 32
+        value_lo = group * 320
+        value_hi = value_lo + 319
+        connections = (
+            f".input_query(input_query[{q_hi}:{q_lo}])",
+            f".input_key(input_key[{q_hi}:{q_lo}])",
+            f".value_read_req_valid(value_read_req_valid[{group}])",
+            f".value_read_req_ready(value_read_req_ready[{group}])",
+            f".value_read_req_address(value_read_req_address[{addr_hi}:{addr_lo}])",
+            f".value_read_req_slice(value_read_req_slice[{slice_hi}:{slice_lo}])",
+            f".value_response_valid(value_response_valid[{group}])",
+            f".value_response_ready(value_response_ready[{group}])",
+            f".value_response_address(value_response_address[{addr_hi}:{addr_lo}])",
+            f".value_response_slice(value_response_slice[{slice_hi}:{slice_lo}])",
+            f".value_response_matrix(value_response_matrix[{matrix_hi}:{matrix_lo}])",
+            f".result_valid(result_valid[{group}])",
+            f".result_ready(result_ready[{group}])",
+            f".result_head(result_head[{head_hi}:{head_lo}])",
+            f".result_command_id(result_command_id[{command_hi}:{command_lo}])",
+            f".result_global_max(result_global_max[{max_hi}:{max_lo}])",
+            f".result_exp_sum(result_exp_sum[{sum_hi}:{sum_lo}])",
+            f".result_slice(result_slice[{slice_hi}:{slice_lo}])",
+            f".result_last(result_last[{group}])",
+            f".result_value(result_value[{value_hi}:{value_lo}])",
+        )
+        for connection in connections:
+            if connection not in text:
+                raise SystemExit(f"GQA-array RTL missing exact group {group} connection: {connection}")
     for token in (
         "GROUP_COUNT =",
         "TOTAL_PARALLEL_QUERY_HEADS",

--- a/npu/eval/check_attention_decode_score_multivalue_gqa_array_guard.py
+++ b/npu/eval/check_attention_decode_score_multivalue_gqa_array_guard.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Guard the direct Llama7B GQA8 multi-group array before physical evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+
+
+_SUPPORTED_GROUP_COUNTS = (1, 2, 4)
+_FAKERAM = "fakeram45_2048x39"
+_FAKERAM_LEF = "/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef"
+_FAKERAM_LIB = "/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require(mapping: dict, key: str, expected: object, label: str) -> None:
+    if mapping.get(key) != expected:
+        raise SystemExit(f"{label} {key} must be {expected}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    args = parser.parse_args()
+    paths = {
+        "config": args.design_dir / "config.json",
+        "generated": args.design_dir / "verilog" / "config.json",
+        "manifest": args.design_dir / "verilog" / "attention_decode_score_multivalue_gqa_array_manifest.json",
+        "top": args.design_dir / "verilog" / "top.v",
+        "macro_manifest": args.design_dir / "macro_manifest.json",
+    }
+    for path in paths.values():
+        if not path.is_file():
+            raise SystemExit(f"missing decode-score multivalue GQA-array artifact: {path}")
+
+    config = _load(paths["config"])
+    if config != _load(paths["generated"]):
+        raise SystemExit("generated config does not match source config")
+    body = config.get("attention_decode_score_multivalue_gqa_array")
+    if not isinstance(body, dict):
+        raise SystemExit("config must contain attention_decode_score_multivalue_gqa_array object")
+
+    expected_config = {
+        "max_blocks": 16384,
+        "array_n": 8,
+        "value_slices": 16,
+        "divider_impl": "iterative_restoring",
+        "score_scale_lanes_per_cycle": 1,
+        "query_heads_per_kv": 8,
+    }
+    for key, expected in expected_config.items():
+        _require(body, key, expected, "GQA-array config")
+    group_count = body.get("group_count")
+    if group_count not in _SUPPORTED_GROUP_COUNTS:
+        raise SystemExit("GQA-array config group_count must be exactly one of 1, 2, or 4")
+
+    top_name = str(config.get("top_name") or "")
+    if f"_g{group_count}" not in top_name:
+        raise SystemExit("GQA-array top_name must encode its group count as _g1, _g2, or _g4")
+
+    manifest = _load(paths["manifest"])
+    expected_manifest = {
+        "top_name": top_name,
+        "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py",
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1",
+        "max_blocks": 16384,
+        "score_tile_array_n": 8,
+        "score_scale_lanes_per_cycle": 1,
+        "divider_impl": "iterative_restoring",
+        "value_slices": 16,
+        "query_heads_per_kv": 8,
+        "group_count": group_count,
+        "logical_kv_groups": group_count,
+        "total_parallel_query_heads": 8 * group_count,
+        "total_score_bank_macros": 448 * group_count,
+        "per_group_macro_count": 448,
+        "independent_external_value_ports": group_count,
+        "serialization": "none",
+        "no_serialization": True,
+    }
+    for key, expected in expected_manifest.items():
+        _require(manifest, key, expected, "generated manifest")
+
+    group_manifest = manifest.get("submodule_manifests", {}).get("gqa_group", {})
+    _require(group_manifest, "top_name", f"{top_name}__group", "embedded GQA-group manifest")
+    _require(
+        group_manifest,
+        "semantic_profile",
+        "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_v1",
+        "embedded GQA-group manifest",
+    )
+    _require(group_manifest, "query_heads_per_kv", 8, "embedded GQA-group manifest")
+    _require(group_manifest, "value_slices", 16, "embedded GQA-group manifest")
+    _require(group_manifest.get("submodule_manifests", {}).get("multivalue_cluster", {}), "score_bank_macro_count", 56, "embedded cluster manifest")
+
+    macro_manifest = _load(paths["macro_manifest"])
+    if macro_manifest.get("design_id") != top_name or macro_manifest.get("module") != top_name:
+        raise SystemExit("macro manifest design_id and module must match config top_name")
+    if macro_manifest.get("platform") != "nangate45":
+        raise SystemExit("macro manifest platform must be nangate45")
+    if macro_manifest.get("flow_variant") != "decode_score_multivalue_gqa_array_v1":
+        raise SystemExit("macro manifest flow_variant must be decode_score_multivalue_gqa_array_v1")
+    if macro_manifest.get("blackboxes") != [_FAKERAM]:
+        raise SystemExit("macro manifest must contain exactly the FakeRAM blackbox contract")
+    if macro_manifest.get("additional_lefs") != [_FAKERAM_LEF]:
+        raise SystemExit("macro manifest must contain the FakeRAM LEF contract")
+    if macro_manifest.get("additional_libs") != [_FAKERAM_LIB]:
+        raise SystemExit("macro manifest must contain the FakeRAM Liberty contract")
+    if macro_manifest.get("additional_gds") != []:
+        raise SystemExit("macro manifest additional_gds must be empty")
+    if macro_manifest.get("blackbox_verilog") != ["npu/rtl/fakeram45_2048x39_blackbox.v"]:
+        raise SystemExit("macro manifest must contain the FakeRAM blackbox Verilog contract")
+    source = macro_manifest.get("source", {})
+    if source.get("generator") != "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py":
+        raise SystemExit("macro manifest source generator must identify the GQA-array generator")
+    if source.get("config") != f"runs/designs/npu_blocks/{top_name}/config.json":
+        raise SystemExit("macro manifest source config must identify the source design config")
+
+    macro_params = macro_manifest.get("manifest_params", {})
+    expected_macro_params = {
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1",
+        "macro_count": 448 * group_count,
+        "score_bank_macro_count": 448 * group_count,
+        "per_group_macro_count": 448,
+        "group_count": group_count,
+        "logical_kv_groups": group_count,
+        "total_parallel_query_heads": 8 * group_count,
+        "independent_external_value_ports": group_count,
+        "serialization": "none",
+        "query_heads_per_kv": 8,
+        "score_scale_lanes_per_cycle": 1,
+        "score_passes_per_query_head": 1,
+        "value_slices": 16,
+    }
+    for key, expected in expected_macro_params.items():
+        _require(macro_params, key, expected, "macro manifest")
+
+    text = paths["top"].read_text(encoding="utf-8", errors="replace")
+    group_top = f"{top_name}__group"
+    if len(re.findall(rf"^module\s+{re.escape(top_name)}\s*\(", text, re.MULTILINE)) != 1:
+        raise SystemExit(f"generated RTL must define exactly one array top module {top_name}")
+    if len(re.findall(rf"^module\s+{re.escape(group_top)}\s*\(", text, re.MULTILINE)) != 1:
+        raise SystemExit(f"generated RTL must define exactly one complete group module {group_top}")
+    if text.count(f"{group_top} u_group_") != group_count:
+        raise SystemExit("GQA-array RTL group instance count does not match group_count")
+    if text.count(f"{group_top}__cluster u_head_") != 8:
+        raise SystemExit("embedded GQA group must instantiate eight query-head clusters")
+    if text.count("fakeram45_2048x39 u_group_") != 56:
+        raise SystemExit("embedded GQA group must contain exactly 56 score-bank macro instances")
+    packed_width = 64 * group_count
+    if not re.search(rf"input\s+wire\s+signed\s+\[{packed_width - 1}:0\]\s+input_query", text):
+        raise SystemExit("GQA-array RTL must expose the packed query bus")
+    if not re.search(rf"input\s+wire\s+signed\s+\[{packed_width - 1}:0\]\s+input_key", text):
+        raise SystemExit("GQA-array RTL must expose the packed key bus")
+    for token in (
+        "GROUP_COUNT =",
+        "TOTAL_PARALLEL_QUERY_HEADS",
+        "TOTAL_SCORE_BANK_MACROS",
+        "wire command_ready_all = &child_command_ready",
+        "wire input_ready_all = &child_input_ready",
+        ".command_valid(command_valid && command_ready)",
+        ".input_valid(input_valid && input_ready)",
+        "assign protocol_error = |child_protocol_error",
+        "value_read_req_valid[0]",
+        "value_response_valid[0]",
+        "result_valid[0]",
+    ):
+        if token not in text:
+            raise SystemExit(f"GQA-array RTL missing semantic token: {token}")
+    for forbidden in (
+        "result_hash",
+        "equivalence_hash",
+        "hash",
+        "value_read_req_arbiter",
+        "value_response_arbiter",
+        "serialize",
+        " / exp_sum_accum",
+        "% exp_sum_accum",
+    ):
+        if forbidden in text.lower():
+            raise SystemExit(f"GQA-array RTL contains forbidden abstraction token: {forbidden}")
+
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "guard": "attention_decode_score_multivalue_gqa_array_v1",
+                "group_count": group_count,
+                "macro_count": 448 * group_count,
+                "status": "ok",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py
+++ b/npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Generate a direct parallel array of complete Llama7B GQA8 groups."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_gqa_group import generate as generate_group
+
+
+_SUPPORTED_GROUP_COUNTS = (1, 2, 4)
+_GROUP_MACRO_COUNT = 448
+_GROUP_QUERY_HEADS = 8
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate(config: dict[str, Any]) -> dict[str, int | str]:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get("attention_decode_score_multivalue_gqa_array")
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit("config requires top_name and attention_decode_score_multivalue_gqa_array")
+
+    max_blocks = int(body.get("max_blocks", 16384))
+    array_n = int(body.get("array_n", 8))
+    value_slices = int(body.get("value_slices", 16))
+    scale_lanes = int(body.get("score_scale_lanes_per_cycle", 1))
+    divider_impl = str(body.get("divider_impl", "iterative_restoring")).strip()
+    query_heads_per_kv = int(body.get("query_heads_per_kv", 8))
+    group_count = int(body.get("group_count", 0))
+
+    if max_blocks < 8 or max_blocks > 16384 or max_blocks & (max_blocks - 1):
+        raise SystemExit("max_blocks must be a power of two in [8, 16384]")
+    if array_n != 8:
+        raise SystemExit("array_n must be 8")
+    if value_slices != 16:
+        raise SystemExit("value_slices must be 16")
+    if scale_lanes != 1:
+        raise SystemExit("score_scale_lanes_per_cycle must be 1 for the GQA array")
+    if divider_impl != "iterative_restoring":
+        raise SystemExit("divider_impl must be iterative_restoring")
+    if query_heads_per_kv != 8:
+        raise SystemExit("query_heads_per_kv must be 8 for Llama7B GQA8")
+    if group_count not in _SUPPORTED_GROUP_COUNTS:
+        raise SystemExit("group_count must be exactly one of 1, 2, or 4")
+
+    body.update(
+        {
+            "max_blocks": max_blocks,
+            "array_n": array_n,
+            "value_slices": value_slices,
+            "score_scale_lanes_per_cycle": scale_lanes,
+            "divider_impl": divider_impl,
+            "query_heads_per_kv": query_heads_per_kv,
+            "group_count": group_count,
+        }
+    )
+    return {
+        "top_name": top_name,
+        "max_blocks": max_blocks,
+        "array_n": array_n,
+        "value_slices": value_slices,
+        "score_scale_lanes_per_cycle": scale_lanes,
+        "divider_impl": divider_impl,
+        "query_heads_per_kv": query_heads_per_kv,
+        "group_count": group_count,
+    }
+
+
+def _slice(name: str, index: int, width: int) -> str:
+    lo = index * width
+    return f"{name}[{lo + width - 1}:{lo}]"
+
+
+def _group_instances(group_top: str, group_count: int) -> str:
+    instances = []
+    for group in range(group_count):
+        instances.append(
+            f"""  {group_top} u_group_{group} (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(command_valid && command_ready),
+      .command_ready(child_command_ready[{group}]),
+      .command_id(command_id),
+      .command_block_count(command_block_count),
+      .command_score_multiplier(command_score_multiplier),
+      .command_score_shift(command_score_shift),
+      .input_valid(input_valid && input_ready),
+      .input_ready(child_input_ready[{group}]),
+      .input_last(input_last),
+      .input_query({_slice("input_query", group, 64)}),
+      .input_key({_slice("input_key", group, 64)}),
+      .value_read_req_valid(value_read_req_valid[{group}]),
+      .value_read_req_ready(value_read_req_ready[{group}]),
+      .value_read_req_address({_slice("value_read_req_address", group, 14)}),
+      .value_read_req_slice({_slice("value_read_req_slice", group, 4)}),
+      .value_response_valid(value_response_valid[{group}]),
+      .value_response_ready(value_response_ready[{group}]),
+      .value_response_address({_slice("value_response_address", group, 14)}),
+      .value_response_slice({_slice("value_response_slice", group, 4)}),
+      .value_response_matrix({_slice("value_response_matrix", group, 512)}),
+      .result_valid(result_valid[{group}]),
+      .result_ready(result_ready[{group}]),
+      .result_head({_slice("result_head", group, 3)}),
+      .result_command_id({_slice("result_command_id", group, 16)}),
+      .result_global_max({_slice("result_global_max", group, 32)}),
+      .result_exp_sum({_slice("result_exp_sum", group, 33)}),
+      .result_slice({_slice("result_slice", group, 4)}),
+      .result_last(result_last[{group}]),
+      .result_value({_slice("result_value", group, 320)}),
+      .accepted_count({_slice("accepted_count", group, 32)}),
+      .completed_count({_slice("completed_count", group, 32)}),
+      .cycle_count({_slice("cycle_count", group, 32)}),
+      .protocol_error(child_protocol_error[{group}])
+  );"""
+        )
+    return "\n\n".join(instances)
+
+
+def _wrapper(*, top_name: str, group_top: str, group_count: int) -> str:
+    total_query_bits = group_count * 64
+    total_result_heads = group_count * 3
+    total_result_commands = group_count * 16
+    total_result_max = group_count * 32
+    total_result_sums = group_count * 33
+    total_result_slices = group_count * 4
+    total_result_values = group_count * 320
+    total_counter_bits = group_count * 32
+    return f"""// Auto-generated by npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py
+module {top_name} (
+    input  wire                         clk,
+    input  wire                         rst_n,
+    input  wire                         command_valid,
+    output wire                         command_ready,
+    input  wire [15:0]                  command_id,
+    input  wire [14:0]                  command_block_count,
+    input  wire [31:0]                  command_score_multiplier,
+    input  wire [5:0]                   command_score_shift,
+    input  wire                         input_valid,
+    output wire                         input_ready,
+    input  wire                         input_last,
+    input  wire signed [{total_query_bits - 1}:0] input_query,
+    input  wire signed [{total_query_bits - 1}:0] input_key,
+    output wire [{group_count - 1}:0]   value_read_req_valid,
+    input  wire [{group_count - 1}:0]   value_read_req_ready,
+    output wire [{group_count * 14 - 1}:0] value_read_req_address,
+    output wire [{group_count * 4 - 1}:0] value_read_req_slice,
+    input  wire [{group_count - 1}:0]   value_response_valid,
+    output wire [{group_count - 1}:0]   value_response_ready,
+    input  wire [{group_count * 14 - 1}:0] value_response_address,
+    input  wire [{group_count * 4 - 1}:0] value_response_slice,
+    input  wire [{group_count * 512 - 1}:0] value_response_matrix,
+    output wire [{group_count - 1}:0]   result_valid,
+    input  wire [{group_count - 1}:0]   result_ready,
+    output wire [{total_result_heads - 1}:0] result_head,
+    output wire [{total_result_commands - 1}:0] result_command_id,
+    output wire signed [{total_result_max - 1}:0] result_global_max,
+    output wire [{total_result_sums - 1}:0] result_exp_sum,
+    output wire [{total_result_slices - 1}:0] result_slice,
+    output wire [{group_count - 1}:0]   result_last,
+    output wire [{total_result_values - 1}:0] result_value,
+    output wire [{total_counter_bits - 1}:0] accepted_count,
+    output wire [{total_counter_bits - 1}:0] completed_count,
+    output wire [{total_counter_bits - 1}:0] cycle_count,
+    output wire                         protocol_error
+);
+  localparam integer GROUP_COUNT = {group_count};
+  localparam integer QUERY_HEADS_PER_KV = 8;
+  localparam integer TOTAL_PARALLEL_QUERY_HEADS = 8 * GROUP_COUNT;
+  localparam integer SCORE_BANK_MACROS_PER_GROUP = 448;
+  localparam integer TOTAL_SCORE_BANK_MACROS = SCORE_BANK_MACROS_PER_GROUP * GROUP_COUNT;
+
+  wire [GROUP_COUNT-1:0] child_command_ready;
+  wire [GROUP_COUNT-1:0] child_input_ready;
+  wire [GROUP_COUNT-1:0] child_protocol_error;
+
+  wire command_ready_all = &child_command_ready;
+  wire input_ready_all = &child_input_ready;
+
+  assign command_ready = command_ready_all;
+  assign input_ready = input_ready_all;
+  assign protocol_error = |child_protocol_error;
+
+{_group_instances(group_top, group_count)}
+endmodule
+"""
+
+
+def generate(config: dict[str, Any], out_dir: Path) -> None:
+    params = _validate(config)
+    top_name = str(params["top_name"])
+    group_count = int(params["group_count"])
+    group_top = f"{top_name}__group"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp_text:
+        group_dir = Path(tmp_text) / "group"
+        generate_group(
+            {
+                "top_name": group_top,
+                "attention_decode_score_multivalue_gqa_group": {
+                    "max_blocks": int(params["max_blocks"]),
+                    "array_n": int(params["array_n"]),
+                    "value_slices": int(params["value_slices"]),
+                    "divider_impl": str(params["divider_impl"]),
+                    "score_scale_lanes_per_cycle": int(params["score_scale_lanes_per_cycle"]),
+                    "query_heads_per_kv": int(params["query_heads_per_kv"]),
+                },
+            },
+            group_dir,
+        )
+        group_rtl = (group_dir / "top.v").read_text(encoding="utf-8")
+        group_manifest = json.loads(
+            (group_dir / "attention_decode_score_multivalue_gqa_group_manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+    rtl = group_rtl + "\n\n" + _wrapper(top_name=top_name, group_top=group_top, group_count=group_count) + "\n"
+    (out_dir / "top.v").write_text(rtl, encoding="utf-8")
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    manifest = {
+        "version": 1,
+        "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py",
+        "top_name": top_name,
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1",
+        "max_blocks": int(params["max_blocks"]),
+        "score_tile_array_n": int(params["array_n"]),
+        "score_scale_lanes_per_cycle": int(params["score_scale_lanes_per_cycle"]),
+        "divider_impl": str(params["divider_impl"]),
+        "value_slices": int(params["value_slices"]),
+        "query_heads_per_kv": int(params["query_heads_per_kv"]),
+        "group_count": group_count,
+        "logical_kv_groups": group_count,
+        "total_parallel_query_heads": _GROUP_QUERY_HEADS * group_count,
+        "total_score_bank_macros": _GROUP_MACRO_COUNT * group_count,
+        "per_group_macro_count": _GROUP_MACRO_COUNT,
+        "independent_external_value_ports": group_count,
+        "serialization": "none",
+        "no_serialization": True,
+        "result_beats_per_command_per_group": 128,
+        "result_value_bits_per_beat": 320,
+        "submodule_manifests": {"gqa_group": group_manifest},
+    }
+    (out_dir / "attention_decode_score_multivalue_gqa_array_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/decode_score_multivalue_gqa_array_g1_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g1.json
+++ b/runs/campaigns/npu/decode_score_multivalue_gqa_array_g1_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g1.json
@@ -1,0 +1,36 @@
+{
+  "tag_prefix": "decode_score_multivalue_gqa_array_g1_v1",
+  "flow_params": {
+    "TAG": [
+      "decode_score_multivalue_gqa_array_g1_v1"
+    ],
+    "FLOW_VARIANT": [
+      "decode_score_multivalue_gqa_array_g1_v1"
+    ],
+    "CLOCK_PERIOD": [
+      10,
+      8
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "macro_equal_density_g1_die_7200",
+        "use_macro": true,
+        "param_overrides": {
+          "DIE_AREA": "0 0 7200 7200",
+          "CORE_AREA": "50 50 7150 7150"
+        }
+      }
+    ]
+  }
+}

--- a/runs/campaigns/npu/decode_score_multivalue_gqa_array_g2_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g2.json
+++ b/runs/campaigns/npu/decode_score_multivalue_gqa_array_g2_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g2.json
@@ -1,0 +1,36 @@
+{
+  "tag_prefix": "decode_score_multivalue_gqa_array_g2_v1",
+  "flow_params": {
+    "TAG": [
+      "decode_score_multivalue_gqa_array_g2_v1"
+    ],
+    "FLOW_VARIANT": [
+      "decode_score_multivalue_gqa_array_g2_v1"
+    ],
+    "CLOCK_PERIOD": [
+      10,
+      8
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "macro_equal_density_g2_die_10200",
+        "use_macro": true,
+        "param_overrides": {
+          "DIE_AREA": "0 0 10200 10200",
+          "CORE_AREA": "50 50 10150 10150"
+        }
+      }
+    ]
+  }
+}

--- a/runs/campaigns/npu/decode_score_multivalue_gqa_array_g4_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g4.json
+++ b/runs/campaigns/npu/decode_score_multivalue_gqa_array_g4_v1/sweeps/nangate45_decode_score_multivalue_gqa_array_g4.json
@@ -1,0 +1,36 @@
+{
+  "tag_prefix": "decode_score_multivalue_gqa_array_g4_v1",
+  "flow_params": {
+    "TAG": [
+      "decode_score_multivalue_gqa_array_g4_v1"
+    ],
+    "FLOW_VARIANT": [
+      "decode_score_multivalue_gqa_array_g4_v1"
+    ],
+    "CLOCK_PERIOD": [
+      10,
+      8
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "macro_equal_density_g4_die_14400",
+        "use_macro": true,
+        "param_overrides": {
+          "DIE_AREA": "0 0 14400 14400",
+          "CORE_AREA": "50 50 14350 14350"
+        }
+      }
+    ]
+  }
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv/config.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv/config.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "top_name": "attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv",
+  "attention_decode_score_multivalue_gqa_array": {
+    "max_blocks": 16384,
+    "array_n": 8,
+    "value_slices": 16,
+    "divider_impl": "iterative_restoring",
+    "score_scale_lanes_per_cycle": 1,
+    "query_heads_per_kv": 8,
+    "group_count": 1
+  }
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv/macro_manifest.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.1",
+  "design_id": "attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv",
+  "module": "attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv",
+  "platform": "nangate45",
+  "flow_variant": "decode_score_multivalue_gqa_array_v1",
+  "blackboxes": ["fakeram45_2048x39"],
+  "additional_lefs": ["/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef"],
+  "additional_libs": ["/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib"],
+  "additional_gds": [],
+  "blackbox_verilog": ["npu/rtl/fakeram45_2048x39_blackbox.v"],
+  "source": {
+    "mode": "generated_composed_multivalue_gqa_array",
+    "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py",
+    "config": "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g1_int8_m1x8_iterdiv/config.json"
+  },
+  "manifest_params": {
+    "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1",
+    "macro_count": 448,
+    "score_bank_macro_count": 448,
+    "per_group_macro_count": 448,
+    "group_count": 1,
+    "logical_kv_groups": 1,
+    "total_parallel_query_heads": 8,
+    "independent_external_value_ports": 1,
+    "serialization": "none",
+    "query_heads_per_kv": 8,
+    "score_scale_lanes_per_cycle": 1,
+    "score_passes_per_query_head": 1,
+    "value_slices": 16
+  }
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/config.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/config.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "top_name": "attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv",
+  "attention_decode_score_multivalue_gqa_array": {
+    "max_blocks": 16384,
+    "array_n": 8,
+    "value_slices": 16,
+    "divider_impl": "iterative_restoring",
+    "score_scale_lanes_per_cycle": 1,
+    "query_heads_per_kv": 8,
+    "group_count": 2
+  }
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/macro_manifest.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.1",
+  "design_id": "attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv",
+  "module": "attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv",
+  "platform": "nangate45",
+  "flow_variant": "decode_score_multivalue_gqa_array_v1",
+  "blackboxes": ["fakeram45_2048x39"],
+  "additional_lefs": ["/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef"],
+  "additional_libs": ["/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib"],
+  "additional_gds": [],
+  "blackbox_verilog": ["npu/rtl/fakeram45_2048x39_blackbox.v"],
+  "source": {
+    "mode": "generated_composed_multivalue_gqa_array",
+    "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py",
+    "config": "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv/config.json"
+  },
+  "manifest_params": {
+    "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1",
+    "macro_count": 896,
+    "score_bank_macro_count": 896,
+    "per_group_macro_count": 448,
+    "group_count": 2,
+    "logical_kv_groups": 2,
+    "total_parallel_query_heads": 16,
+    "independent_external_value_ports": 2,
+    "serialization": "none",
+    "query_heads_per_kv": 8,
+    "score_scale_lanes_per_cycle": 1,
+    "score_passes_per_query_head": 1,
+    "value_slices": 16
+  }
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv/config.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv/config.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "top_name": "attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv",
+  "attention_decode_score_multivalue_gqa_array": {
+    "max_blocks": 16384,
+    "array_n": 8,
+    "value_slices": 16,
+    "divider_impl": "iterative_restoring",
+    "score_scale_lanes_per_cycle": 1,
+    "query_heads_per_kv": 8,
+    "group_count": 4
+  }
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv/macro_manifest.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.1",
+  "design_id": "attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv",
+  "module": "attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv",
+  "platform": "nangate45",
+  "flow_variant": "decode_score_multivalue_gqa_array_v1",
+  "blackboxes": ["fakeram45_2048x39"],
+  "additional_lefs": ["/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef"],
+  "additional_libs": ["/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib"],
+  "additional_gds": [],
+  "blackbox_verilog": ["npu/rtl/fakeram45_2048x39_blackbox.v"],
+  "source": {
+    "mode": "generated_composed_multivalue_gqa_array",
+    "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py",
+    "config": "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_array_g4_int8_m1x8_iterdiv/config.json"
+  },
+  "manifest_params": {
+    "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1",
+    "macro_count": 1792,
+    "score_bank_macro_count": 1792,
+    "per_group_macro_count": 448,
+    "group_count": 4,
+    "logical_kv_groups": 4,
+    "total_parallel_query_heads": 32,
+    "independent_external_value_ports": 4,
+    "serialization": "none",
+    "query_heads_per_kv": 8,
+    "score_scale_lanes_per_cycle": 1,
+    "score_passes_per_query_head": 1,
+    "value_slices": 16
+  }
+}

--- a/tests/test_attention_decode_score_multivalue_gqa_array.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_array.py
@@ -1,0 +1,393 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_gqa_array import generate
+
+
+def _config(*, group_count: int, top_name: str | None = None, max_blocks: int = 16) -> dict:
+    return {
+        "top_name": top_name or f"attention_decode_score_multivalue_gqa_array_smoke_g{group_count}",
+        "attention_decode_score_multivalue_gqa_array": {
+            "max_blocks": max_blocks,
+            "array_n": 8,
+            "value_slices": 16,
+            "divider_impl": "iterative_restoring",
+            "score_scale_lanes_per_cycle": 1,
+            "query_heads_per_kv": 8,
+            "group_count": group_count,
+        },
+    }
+
+
+def _iverilog() -> str | None:
+    return shutil.which("iverilog") or (
+        "/oss-cad-suite/bin/iverilog" if Path("/oss-cad-suite/bin/iverilog").exists() else None
+    )
+
+
+def _vvp() -> str | None:
+    return shutil.which("vvp") or ("/oss-cad-suite/bin/vvp" if Path("/oss-cad-suite/bin/vvp").exists() else None)
+
+
+def _macro_manifest(top_name: str, group_count: int) -> dict:
+    return {
+        "version": "0.1",
+        "design_id": top_name,
+        "module": top_name,
+        "platform": "nangate45",
+        "flow_variant": "decode_score_multivalue_gqa_array_v1",
+        "blackboxes": ["fakeram45_2048x39"],
+        "additional_lefs": ["/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef"],
+        "additional_libs": ["/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib"],
+        "additional_gds": [],
+        "blackbox_verilog": ["npu/rtl/fakeram45_2048x39_blackbox.v"],
+        "source": {
+            "mode": "generated_composed_multivalue_gqa_array",
+            "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py",
+            "config": f"runs/designs/npu_blocks/{top_name}/config.json",
+        },
+        "manifest_params": {
+            "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1",
+            "macro_count": 448 * group_count,
+            "score_bank_macro_count": 448 * group_count,
+            "per_group_macro_count": 448,
+            "group_count": group_count,
+            "logical_kv_groups": group_count,
+            "total_parallel_query_heads": 8 * group_count,
+            "independent_external_value_ports": group_count,
+            "serialization": "none",
+            "query_heads_per_kv": 8,
+            "score_scale_lanes_per_cycle": 1,
+            "score_passes_per_query_head": 1,
+            "value_slices": 16,
+        },
+    }
+
+
+def test_multivalue_gqa_array_manifest_and_structure(tmp_path: Path) -> None:
+    group_count = 4
+    config = _config(group_count=group_count)
+    generate(config, tmp_path)
+    text = (tmp_path / "top.v").read_text(encoding="utf-8")
+    manifest = json.loads(
+        (tmp_path / "attention_decode_score_multivalue_gqa_array_manifest.json").read_text(encoding="utf-8")
+    )
+
+    assert manifest["semantic_profile"] == "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1"
+    assert manifest["group_count"] == 4
+    assert manifest["logical_kv_groups"] == 4
+    assert manifest["total_parallel_query_heads"] == 32
+    assert manifest["total_score_bank_macros"] == 1792
+    assert manifest["per_group_macro_count"] == 448
+    assert manifest["independent_external_value_ports"] == 4
+    assert manifest["serialization"] == "none"
+    assert manifest["no_serialization"] is True
+
+    top_name = config["top_name"]
+    assert text.count(f"module {top_name} (") == 1
+    assert text.count(f"module {top_name}__group (") == 1
+    assert text.count(f"{top_name}__group u_group_") == 4
+    assert text.count(f"{top_name}__group__cluster u_head_") == 8
+    assert text.count("fakeram45_2048x39 u_group_") == 56
+    assert "input  wire signed [255:0] input_query" in text
+    assert "input  wire signed [255:0] input_key" in text
+    assert "assign command_ready = command_ready_all;" in text
+    assert "assign input_ready = input_ready_all;" in text
+    assert "assign protocol_error = |child_protocol_error;" in text
+    assert ".command_valid(command_valid && command_ready)" in text
+    assert ".input_valid(input_valid && input_ready)" in text
+
+
+@pytest.mark.parametrize("group_count", [0, 3, 8])
+def test_multivalue_gqa_array_rejects_unsupported_group_count(tmp_path: Path, group_count: int) -> None:
+    with pytest.raises(SystemExit, match="group_count must be exactly one of 1, 2, or 4"):
+        generate(_config(group_count=group_count), tmp_path)
+
+
+@pytest.mark.parametrize("group_count", [1, 2, 4])
+def test_multivalue_gqa_array_guard_accepts_llama7b_design(tmp_path: Path, group_count: int) -> None:
+    source_name = f"attention_decode_score_multivalue_gqa_array_g{group_count}_int8_m1x8_iterdiv"
+    source_design = REPO_ROOT / "runs" / "designs" / "npu_blocks" / source_name
+    design_dir = tmp_path / source_name
+    design_dir.mkdir()
+    config = json.loads((source_design / "config.json").read_text(encoding="utf-8"))
+    shutil.copy(source_design / "config.json", design_dir / "config.json")
+    shutil.copy(source_design / "macro_manifest.json", design_dir / "macro_manifest.json")
+    generate(config, design_dir / "verilog")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_decode_score_multivalue_gqa_array_guard.py",
+            "--design-dir",
+            str(design_dir),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["group_count"] == group_count
+    assert payload["macro_count"] == 448 * group_count
+
+
+def test_multivalue_gqa_array_guard_rejects_wrong_macro_total(tmp_path: Path) -> None:
+    group_count = 2
+    source_name = "attention_decode_score_multivalue_gqa_array_g2_int8_m1x8_iterdiv"
+    source_design = REPO_ROOT / "runs" / "designs" / "npu_blocks" / source_name
+    design_dir = tmp_path / source_name
+    design_dir.mkdir()
+    config = json.loads((source_design / "config.json").read_text(encoding="utf-8"))
+    shutil.copy(source_design / "config.json", design_dir / "config.json")
+    macro_manifest = json.loads((source_design / "macro_manifest.json").read_text(encoding="utf-8"))
+    macro_manifest["manifest_params"]["macro_count"] = 448
+    (design_dir / "macro_manifest.json").write_text(json.dumps(macro_manifest), encoding="utf-8")
+    generate(config, design_dir / "verilog")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_decode_score_multivalue_gqa_array_guard.py",
+            "--design-dir",
+            str(design_dir),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "macro manifest macro_count must be 896" in result.stderr
+
+
+def test_multivalue_gqa_array_generated_smoke_compiles(tmp_path: Path) -> None:
+    iverilog = _iverilog()
+    if not iverilog:
+        pytest.skip("iverilog unavailable")
+    config = _config(group_count=1, top_name="attention_decode_score_multivalue_gqa_array_compile", max_blocks=16)
+    generate(config, tmp_path)
+    subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-s",
+            config["top_name"],
+            "-o",
+            str(tmp_path / "simv"),
+            str(tmp_path / "top.v"),
+            str(REPO_ROOT / "npu" / "rtl" / "fakeram45_2048x39_blackbox.v"),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _group_stub(module_name: str) -> str:
+    return f"""
+module {module_name} (
+    input wire clk, input wire rst_n,
+    input wire command_valid, output wire command_ready,
+    input wire [15:0] command_id, input wire [14:0] command_block_count,
+    input wire [31:0] command_score_multiplier, input wire [5:0] command_score_shift,
+    input wire input_valid, output wire input_ready, input wire input_last,
+    input wire signed [63:0] input_query, input wire signed [63:0] input_key,
+    output wire value_read_req_valid, input wire value_read_req_ready,
+    output wire [13:0] value_read_req_address, output wire [3:0] value_read_req_slice,
+    input wire value_response_valid, output wire value_response_ready,
+    input wire [13:0] value_response_address, input wire [3:0] value_response_slice,
+    input wire [511:0] value_response_matrix,
+    output wire result_valid, input wire result_ready, output wire [2:0] result_head,
+    output wire [15:0] result_command_id, output wire signed [31:0] result_global_max,
+    output wire [32:0] result_exp_sum, output wire [3:0] result_slice,
+    output wire result_last, output wire [319:0] result_value,
+    output reg [31:0] accepted_count, output reg [31:0] completed_count,
+    output reg [31:0] cycle_count, output wire protocol_error
+);
+  localparam IDLE = 3'd0, INPUT = 3'd1, REQUEST = 3'd2,
+      RESPONSE = 3'd3, RESULT = 3'd4;
+  reg [2:0] state_q;
+  reg [15:0] command_id_q;
+  assign command_ready = state_q == IDLE;
+  assign input_ready = state_q == INPUT;
+  assign value_read_req_valid = state_q == REQUEST;
+  assign value_read_req_address = 14'd0;
+  assign value_read_req_slice = 4'd0;
+  assign value_response_ready = state_q == RESPONSE;
+  assign result_valid = state_q == RESULT;
+  assign result_head = 3'd0;
+  assign result_command_id = command_id_q;
+  assign result_global_max = 32'sd7;
+  assign result_exp_sum = 33'd11;
+  assign result_slice = 4'd0;
+  assign result_last = 1'b1;
+  assign result_value = 320'd0;
+  assign protocol_error = 1'b0;
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      state_q <= IDLE;
+      command_id_q <= 16'd0;
+      accepted_count <= 32'd0;
+      completed_count <= 32'd0;
+      cycle_count <= 32'd0;
+    end else begin
+      cycle_count <= cycle_count + 1'b1;
+      case (state_q)
+        IDLE: if (command_valid && command_ready) begin
+          command_id_q <= command_id;
+          accepted_count <= accepted_count + 1'b1;
+          state_q <= INPUT;
+        end
+        INPUT: if (input_valid && input_ready && input_last) state_q <= REQUEST;
+        REQUEST: if (value_read_req_valid && value_read_req_ready) state_q <= RESPONSE;
+        RESPONSE: if (value_response_valid && value_response_ready) state_q <= RESULT;
+        RESULT: if (result_valid && result_ready) begin
+          completed_count <= completed_count + 1'b1;
+          state_q <= IDLE;
+        end
+        default: state_q <= IDLE;
+      endcase
+    end
+  end
+endmodule
+"""
+
+
+@pytest.mark.parametrize("group_count", [1, 2, 4])
+def test_multivalue_gqa_array_atomic_broadcast_and_independent_channels(tmp_path: Path, group_count: int) -> None:
+    iverilog = _iverilog()
+    vvp = _vvp()
+    if iverilog is None or vvp is None:
+        pytest.skip("iverilog/vvp unavailable")
+
+    config = _config(group_count=group_count, top_name=f"attention_decode_score_multivalue_gqa_array_protocol_g{group_count}")
+    generate(config, tmp_path)
+    generated = (tmp_path / "top.v").read_text(encoding="utf-8")
+    wrapper_marker = f"module {config['top_name']} ("
+    wrapper_path = tmp_path / "wrapper.v"
+    wrapper_path.write_text(
+        _group_stub(f"{config['top_name']}__group") + generated[generated.index(wrapper_marker) :],
+        encoding="utf-8",
+    )
+
+    bus_ones = f"{{{group_count}{{1'b1}}}}"
+    tb_text = f"""
+module tb;
+  localparam integer GC = {group_count};
+  reg clk = 1'b0;
+  always #1 clk = ~clk;
+  reg rst_n = 1'b0;
+  reg command_valid = 1'b0;
+  wire command_ready;
+  reg [15:0] command_id = 16'h1234;
+  reg [14:0] command_block_count = 15'd1;
+  reg [31:0] command_score_multiplier = 32'd1;
+  reg [5:0] command_score_shift = 6'd0;
+  reg input_valid = 1'b0;
+  wire input_ready;
+  reg input_last = 1'b0;
+  reg signed [GC*64-1:0] input_query = '0;
+  reg signed [GC*64-1:0] input_key = '0;
+  wire [GC-1:0] value_read_req_valid;
+  reg [GC-1:0] value_read_req_ready = '0;
+  wire [GC*14-1:0] value_read_req_address;
+  wire [GC*4-1:0] value_read_req_slice;
+  reg [GC-1:0] value_response_valid = '0;
+  wire [GC-1:0] value_response_ready;
+  reg [GC*14-1:0] value_response_address = '0;
+  reg [GC*4-1:0] value_response_slice = '0;
+  reg [GC*512-1:0] value_response_matrix = '0;
+  wire [GC-1:0] result_valid;
+  reg [GC-1:0] result_ready = '0;
+  wire [GC*3-1:0] result_head;
+  wire [GC*16-1:0] result_command_id;
+  wire signed [GC*32-1:0] result_global_max;
+  wire [GC*33-1:0] result_exp_sum;
+  wire [GC*4-1:0] result_slice;
+  wire [GC-1:0] result_last;
+  wire [GC*320-1:0] result_value;
+  wire [GC*32-1:0] accepted_count;
+  wire [GC*32-1:0] completed_count;
+  wire [GC*32-1:0] cycle_count;
+  wire protocol_error;
+  integer i;
+
+  {config['top_name']} dut (
+      .clk(clk), .rst_n(rst_n), .command_valid(command_valid), .command_ready(command_ready),
+      .command_id(command_id), .command_block_count(command_block_count),
+      .command_score_multiplier(command_score_multiplier), .command_score_shift(command_score_shift),
+      .input_valid(input_valid), .input_ready(input_ready), .input_last(input_last),
+      .input_query(input_query), .input_key(input_key),
+      .value_read_req_valid(value_read_req_valid), .value_read_req_ready(value_read_req_ready),
+      .value_read_req_address(value_read_req_address), .value_read_req_slice(value_read_req_slice),
+      .value_response_valid(value_response_valid), .value_response_ready(value_response_ready),
+      .value_response_address(value_response_address), .value_response_slice(value_response_slice),
+      .value_response_matrix(value_response_matrix), .result_valid(result_valid), .result_ready(result_ready),
+      .result_head(result_head), .result_command_id(result_command_id), .result_global_max(result_global_max),
+      .result_exp_sum(result_exp_sum), .result_slice(result_slice), .result_last(result_last),
+      .result_value(result_value), .accepted_count(accepted_count), .completed_count(completed_count),
+      .cycle_count(cycle_count), .protocol_error(protocol_error)
+  );
+
+  initial begin
+    #3 rst_n = 1'b1;
+    @(negedge clk); command_valid = 1'b1;
+    @(posedge clk); #0.1;
+    if (!command_ready) $fatal(1, "command broadcast was not accepted atomically");
+    @(negedge clk); command_valid = 1'b0; input_valid = 1'b1; input_last = 1'b1;
+    input_query = '0; input_key = '0;
+    @(posedge clk); #0.1;
+    if (!input_ready) $fatal(1, "input broadcast was not accepted atomically");
+    @(negedge clk); input_valid = 1'b0; input_last = 1'b0; value_read_req_ready = {bus_ones};
+    wait (value_read_req_valid === {bus_ones});
+    @(posedge clk); #0.1;
+    if (value_read_req_valid !== {bus_ones}) $fatal(1, "value requests were not parallel");
+    @(negedge clk); value_read_req_ready = '0;
+    for (i = 0; i < GC; i = i + 1) begin
+      wait (value_response_ready[i]);
+      @(negedge clk); value_response_valid[i] = 1'b1;
+      @(posedge clk); #0.1;
+      if (!value_response_ready[i]) $fatal(1, "group response lane was not independently ready");
+      @(negedge clk); value_response_valid[i] = 1'b0;
+    end
+    for (i = 0; i < GC; i = i + 1) begin
+      wait (result_valid[i]);
+      if (result_command_id[i*16 +: 16] !== 16'h1234 || result_slice[i*4 +: 4] !== 4'd0 || !result_last[i])
+        $fatal(1, "group result lane %0d mismatch", i);
+      @(negedge clk); result_ready[i] = 1'b1;
+      @(posedge clk); #0.1;
+      result_ready[i] = 1'b0;
+    end
+    #2;
+    if (protocol_error) $fatal(1, "protocol_error asserted");
+    for (i = 0; i < GC; i = i + 1) begin
+      if (accepted_count[i*32 +: 32] !== 32'd1 || completed_count[i*32 +: 32] !== 32'd1)
+        $fatal(1, "counter mismatch for group %0d", i);
+    end
+    $display("PASS group_count=%0d", GC);
+    $finish;
+  end
+endmodule
+"""
+    tb_path = tmp_path / "tb.v"
+    tb_path.write_text(tb_text, encoding="utf-8")
+    simv = tmp_path / "simv"
+    subprocess.run(
+        [iverilog, "-g2012", "-s", "tb", "-o", str(simv), str(wrapper_path), str(tb_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = subprocess.run([vvp, str(simv)], check=True, capture_output=True, text=True)
+    assert f"PASS group_count={group_count}" in result.stdout

--- a/tests/test_attention_decode_score_multivalue_gqa_array.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_array.py
@@ -196,6 +196,7 @@ def test_multivalue_gqa_array_generated_smoke_compiles(tmp_path: Path) -> None:
 
 def _group_stub(module_name: str) -> str:
     return f"""
+`timescale 1ns/1ps
 module {module_name} (
     input wire clk, input wire rst_n,
     input wire command_valid, output wire command_ready,
@@ -219,6 +220,10 @@ module {module_name} (
       RESPONSE = 3'd3, RESULT = 3'd4;
   reg [2:0] state_q;
   reg [15:0] command_id_q;
+  reg [31:0] input_accepted_count;
+  reg [63:0] input_query_q;
+  reg [63:0] input_key_q;
+  reg [511:0] value_response_matrix_q;
   assign command_ready = state_q == IDLE;
   assign input_ready = state_q == INPUT;
   assign value_read_req_valid = state_q == REQUEST;
@@ -232,12 +237,16 @@ module {module_name} (
   assign result_exp_sum = 33'd11;
   assign result_slice = 4'd0;
   assign result_last = 1'b1;
-  assign result_value = 320'd0;
+  assign result_value = {{312'd0, input_query_q[7:0] ^ input_key_q[7:0] ^ value_response_matrix_q[7:0]}};
   assign protocol_error = 1'b0;
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
       state_q <= IDLE;
       command_id_q <= 16'd0;
+      input_accepted_count <= 32'd0;
+      input_query_q <= 64'd0;
+      input_key_q <= 64'd0;
+      value_response_matrix_q <= 512'd0;
       accepted_count <= 32'd0;
       completed_count <= 32'd0;
       cycle_count <= 32'd0;
@@ -249,9 +258,17 @@ module {module_name} (
           accepted_count <= accepted_count + 1'b1;
           state_q <= INPUT;
         end
-        INPUT: if (input_valid && input_ready && input_last) state_q <= REQUEST;
+        INPUT: if (input_valid && input_ready && input_last) begin
+          input_accepted_count <= input_accepted_count + 1'b1;
+          input_query_q <= input_query;
+          input_key_q <= input_key;
+          state_q <= REQUEST;
+        end
         REQUEST: if (value_read_req_valid && value_read_req_ready) state_q <= RESPONSE;
-        RESPONSE: if (value_response_valid && value_response_ready) state_q <= RESULT;
+        RESPONSE: if (value_response_valid && value_response_ready) begin
+          value_response_matrix_q <= value_response_matrix;
+          state_q <= RESULT;
+        end
         RESULT: if (result_valid && result_ready) begin
           completed_count <= completed_count + 1'b1;
           state_q <= IDLE;
@@ -282,6 +299,31 @@ def test_multivalue_gqa_array_atomic_broadcast_and_independent_channels(tmp_path
     )
 
     bus_ones = f"{{{group_count}{{1'b1}}}}"
+    command_zero_checks = "\n".join(
+        f"      if (dut.u_group_{group}.accepted_count !== 32'd0) $fatal(1, \"command accepted by group {group} while blocked\");"
+        for group in range(group_count)
+    )
+    command_one_checks = "\n".join(
+        f"      if (dut.u_group_{group}.accepted_count !== 32'd1) $fatal(1, \"command count mismatch for group {group}\");"
+        for group in range(group_count)
+    )
+    input_zero_checks = "\n".join(
+        f"      if (dut.u_group_{group}.input_accepted_count !== 32'd0) $fatal(1, \"input accepted by group {group} while blocked\");"
+        for group in range(group_count)
+    )
+    input_one_checks = "\n".join(
+        f"      if (dut.u_group_{group}.input_accepted_count !== 32'd1) $fatal(1, \"input count mismatch for group {group}\");"
+        for group in range(group_count)
+    )
+    query_marker_assigns = "\n".join(
+        f"    input_query[{group * 64 + 63}:{group * 64}] = 64'h{0x10 + group:014x}{0x10 + group:02x};\n"
+        f"    input_key[{group * 64 + 63}:{group * 64}] = 64'h{0x20 + group:014x}{0x20 + group:02x};"
+        for group in range(group_count)
+    )
+    value_marker_assigns = "\n".join(
+        f"    value_response_matrix[{group * 512 + 511}:{group * 512}] = 512'h{0x40 + group:0126x}{0x40 + group:02x};"
+        for group in range(group_count)
+    )
     tb_text = f"""
 module tb;
   localparam integer GC = {group_count};
@@ -342,29 +384,55 @@ module tb;
 
   initial begin
     #3 rst_n = 1'b1;
+    if (GC > 1) force dut.child_command_ready[{group_count - 1}] = 1'b0;
+{query_marker_assigns}
+{value_marker_assigns}
     @(negedge clk); command_valid = 1'b1;
+    #0.1;
+    if (GC > 1 && command_ready) $fatal(1, "command_ready ignored a blocked child");
     @(posedge clk); #0.1;
-    if (!command_ready) $fatal(1, "command broadcast was not accepted atomically");
-    @(negedge clk); command_valid = 1'b0; input_valid = 1'b1; input_last = 1'b1;
-    input_query = '0; input_key = '0;
+    if (GC > 1) begin
+{command_zero_checks}
+      release dut.child_command_ready[{group_count - 1}];
+      #0.1;
+      if (!command_ready) $fatal(1, "command broadcast did not recover after release");
+      @(posedge clk); #0.1;
+    end
+{command_one_checks}
+    @(negedge clk); command_valid = 1'b0;
+    if (GC > 1) force dut.child_input_ready[{group_count - 1}] = 1'b0;
+    @(negedge clk); input_valid = 1'b1; input_last = 1'b1;
+    #0.1;
+    if (GC > 1 && input_ready) $fatal(1, "input_ready ignored a blocked child");
     @(posedge clk); #0.1;
-    if (!input_ready) $fatal(1, "input broadcast was not accepted atomically");
+    if (GC > 1) begin
+{input_zero_checks}
+      release dut.child_input_ready[{group_count - 1}];
+      #0.1;
+      if (!input_ready) $fatal(1, "input broadcast did not recover after release");
+      @(posedge clk); #0.1;
+    end
+{input_one_checks}
     @(negedge clk); input_valid = 1'b0; input_last = 1'b0; value_read_req_ready = {bus_ones};
     wait (value_read_req_valid === {bus_ones});
-    @(posedge clk); #0.1;
     if (value_read_req_valid !== {bus_ones}) $fatal(1, "value requests were not parallel");
+    @(posedge clk); #0.1;
     @(negedge clk); value_read_req_ready = '0;
     for (i = 0; i < GC; i = i + 1) begin
       wait (value_response_ready[i]);
       @(negedge clk); value_response_valid[i] = 1'b1;
-      @(posedge clk); #0.1;
+      #0.1;
       if (!value_response_ready[i]) $fatal(1, "group response lane was not independently ready");
+      @(posedge clk); #0.1;
       @(negedge clk); value_response_valid[i] = 1'b0;
     end
     for (i = 0; i < GC; i = i + 1) begin
       wait (result_valid[i]);
       if (result_command_id[i*16 +: 16] !== 16'h1234 || result_slice[i*4 +: 4] !== 4'd0 || !result_last[i])
         $fatal(1, "group result lane %0d mismatch", i);
+      if (result_value[i*320 +: 8] !== ((8'h10 + i) ^ (8'h20 + i) ^ (8'h40 + i)) ||
+          result_value[i*320 + 8 +: 312] !== 312'd0)
+        $fatal(1, "result marker mismatch for group %0d", i);
       @(negedge clk); result_ready[i] = 1'b1;
       @(posedge clk); #0.1;
       result_ready[i] = 1'b0;

--- a/tests/test_attention_decode_score_multivalue_gqa_array_equivalence.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_array_equivalence.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from npu.eval.audit_attention_decode_score_multivalue_gqa_array_equivalence import _build_report
+
+
+def _group_equivalence() -> dict:
+    return {
+        "model": "llama7b_gqa8_shared_kv_compositional_arithmetic_equivalence_v1",
+        "decision": "llama7b_gqa8_shared_kv_equivalence_pass",
+        "equivalence_pass": True,
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_v1",
+        "query_heads_per_kv": 8,
+        "distinct_query_heads_pass": True,
+        "shared_inputs_pass": True,
+        "arithmetic_equivalence_pass": True,
+        "expected_group_result_sha256": "same-group-hash",
+        "observed_group_result_sha256": "same-group-hash",
+        "wrapper_protocol": {"sharing_and_order_pass": True},
+    }
+
+
+def _configs() -> list[dict]:
+    return [
+        {
+            "top_name": f"gqa_array_g{count}",
+            "attention_decode_score_multivalue_gqa_array": {
+                "max_blocks": 16384,
+                "array_n": 8,
+                "value_slices": 16,
+                "divider_impl": "iterative_restoring",
+                "score_scale_lanes_per_cycle": 1,
+                "query_heads_per_kv": 8,
+                "group_count": count,
+            },
+        }
+        for count in (1, 2, 4)
+    ]
+
+
+def _protocol(passed: bool = True) -> dict:
+    return {
+        "passed_test_count": 3 if passed else 2,
+        "atomic_broadcast_and_independent_channels_pass": passed,
+    }
+
+
+def test_array_equivalence_composes_exact_group_and_protocol_gates() -> None:
+    report = _build_report(
+        group_equivalence=_group_equivalence(), array_configs=_configs(), protocol=_protocol()
+    )
+    assert report["equivalence_pass"] is True
+    assert report["precision_status"] == "exact"
+    assert report["measured_group_counts"] == [1, 2, 4]
+    assert report["logical_kv_groups"] == 4
+    assert all(
+        row["expected_array_result_sha256"] == row["observed_array_result_sha256"]
+        for row in report["array_result_hashes"]
+    )
+    assert report["compositional_proof"]["flat_32_cluster_arithmetic_simulation_run"] is False
+
+
+def test_array_equivalence_rejects_weak_group_or_protocol_evidence() -> None:
+    group = _group_equivalence()
+    group["arithmetic_equivalence_pass"] = False
+    with pytest.raises(ValueError, match="group equivalence contract"):
+        _build_report(group_equivalence=group, array_configs=_configs(), protocol=_protocol())
+
+    report = _build_report(
+        group_equivalence=_group_equivalence(),
+        array_configs=_configs(),
+        protocol=_protocol(False),
+    )
+    assert report["equivalence_pass"] is False
+    assert report["precision_status"] == "rejected"
+
+
+def test_array_equivalence_requires_exact_one_two_four_config_set() -> None:
+    configs = _configs()[:-1]
+    with pytest.raises(ValueError, match="must cover group counts"):
+        _build_report(
+            group_equivalence=_group_equivalence(), array_configs=configs, protocol=_protocol()
+        )
+
+    configs = copy.deepcopy(_configs())
+    configs[1]["attention_decode_score_multivalue_gqa_array"]["value_slices"] = 8
+    with pytest.raises(ValueError, match="exact Llama7B"):
+        _build_report(
+            group_equivalence=_group_equivalence(), array_configs=configs, protocol=_protocol()
+        )

--- a/tests/test_attention_decode_score_multivalue_gqa_array_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_array_frontier.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.audit_attention_decode_score_multivalue_gqa_array_frontier import (
+    _pareto,
+    _parse_metrics_row,
+    _recost_candidate,
+    build_report,
+)
+
+
+def _write(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _prior(tmp_path: Path) -> Path:
+    source = _write(
+        tmp_path / "source.json",
+        {
+            "source_schedule": {
+                "hidden_size": 4096,
+                "attention_heads": 32,
+                "kv_heads": 4,
+                "sequence_length": 131072,
+                "clock_ns": 6.0,
+                "layers": 32,
+                "compute_budget_um2": 400_000_000,
+                "logic_area_used_um2": 399_000_000,
+                "compute_area_um2": 396_000_000,
+                "measured_shared_sram_used_area_um2": 240_000_000,
+                "measured_tile_local_sram_area_um2": 40_000_000,
+                "command_dispatch_cycles": 2,
+                "kv_write_cycles": 10,
+            }
+        },
+    )
+    middle = _write(tmp_path / "middle.json", {"inputs": {"prior_frontier_json": source.name}})
+    return _write(
+        tmp_path / "prior.json",
+        {
+            "model": "decoder_attention_decode_score_multivalue_gqa_group_frontier_llama7b_v1",
+            "decision": "measured_complete_gqa8_group_component_frontier_promoted",
+            "precision": {"status": "exact"},
+            "inputs": {"prior_frontier_json": middle.name},
+            "schedule_contract": {"group_full_context_cycles": 300},
+            "dense_qkv_tile": {"area_um2": 10_000, "effective_macs_per_cycle": 8.0},
+            "rows": [
+                {
+                    "group_count": count,
+                    "group_area_mm2": 2.0 * count,
+                    "latency_us": 1000.0 / count,
+                    "token_throughput_per_s": 100.0 * count,
+                    "clock_ns": 8.0,
+                    "gqa_group_component_energy_mj_per_token": 1.792,
+                }
+                for count in (1, 2, 4)
+            ],
+            "best_throughput_candidate": {"candidate_id": "prior", "token_throughput_per_s": 400.0},
+        },
+    )
+
+
+def _equivalence(tmp_path: Path) -> Path:
+    return _write(
+        tmp_path / "equivalence.json",
+        {
+            "model": "llama7b_gqa8_multigroup_array_compositional_equivalence_v1",
+            "decision": "llama7b_gqa8_multigroup_array_equivalence_pass",
+            "equivalence_pass": True,
+            "precision_status": "exact",
+            "measured_group_counts": [1, 2, 4],
+        },
+    )
+
+
+def _metrics(path: Path, rows: list[dict[str, object]]) -> Path:
+    fields = [
+        "design", "platform", "config_hash", "param_hash", "tag", "status",
+        "critical_path_ns", "die_area", "params_json", "result_path",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+    return path
+
+
+def _metric_row(count: int, *, area: float = 1_000_000, cp: float = 7.0, clock: float = 8.0) -> dict[str, object]:
+    return {
+        "design": f"array_g{count}", "platform": "nangate45", "config_hash": f"config{count}",
+        "param_hash": f"param{count}", "tag": "tag", "status": "ok", "critical_path_ns": cp,
+        "die_area": area, "params_json": json.dumps({"CLOCK_PERIOD": clock, "FLOW_VARIANT": "array_v1", "GROUP_COUNT": count, "CORE_UTILIZATION": 50}),
+        "result_path": "result.json",
+    }
+
+
+def test_formulas_use_direct_area_and_expected_gqa_work(tmp_path: Path) -> None:
+    prior = _prior(tmp_path)
+    report = build_report(
+        prior_frontier_json=prior,
+        array_equivalence_json=_equivalence(tmp_path),
+        array_metrics={count: _metrics(tmp_path / f"g{count}.csv", [_metric_row(count, area=1_000_000 * count)]) for count in (1, 2, 4)},
+    )
+    rows = {row["group_count"]: row for row in report["rows"]}
+    assert rows[1]["direct_array_instance_area_um2"] == 1_000_000
+    assert rows[2]["direct_array_instance_area_um2"] == 2_000_000
+    assert rows[1]["qkv_work"] == 4096**2 + 2 * 4096 * 4 * 128
+    assert rows[1]["group_waves_per_layer"] == 4
+    assert rows[4]["attention_cycles"] == 300
+    assert rows[1]["clock_ns"] == 8.0
+    assert rows[1]["energy_status"].startswith("NOT_")
+    assert report["promotion"]["direct_array_timing"] == "promoted"
+
+
+def test_parser_preserves_failed_and_negative_rows(tmp_path: Path) -> None:
+    failed = _parse_metrics_row(
+        {"status": "failed", "params_json": json.dumps({"CLOCK_PERIOD": 8})},
+        metrics_path=tmp_path / "m.csv", count=1, line=2,
+    )
+    assert failed["accepted"] is False
+    assert "status is failed" in failed["reason"]
+    negative = _parse_metrics_row(
+        {"status": "ok", "critical_path_ns": 7, "die_area": -1, "params_json": json.dumps({"CLOCK_PERIOD": 8})},
+        metrics_path=tmp_path / "m.csv", count=1, line=3,
+    )
+    assert negative["accepted"] is False
+    assert "instance area" in negative["reason"]
+
+
+def test_contract_rejection(tmp_path: Path) -> None:
+    prior = _prior(tmp_path)
+    equivalence = _equivalence(tmp_path)
+    payload = json.loads(equivalence.read_text(encoding="utf-8"))
+    payload["measured_group_counts"] = [1, 2]
+    equivalence.write_text(json.dumps(payload), encoding="utf-8")
+    paths = {count: _metrics(tmp_path / f"g{count}.csv", [_metric_row(count)]) for count in (1, 2, 4)}
+    with pytest.raises(ValueError, match="contract"):
+        build_report(prior_frontier_json=prior, array_equivalence_json=equivalence, array_metrics=paths)
+
+
+def test_pareto_uses_latency_area_and_compositional_energy() -> None:
+    def row(name: str, latency: float, area: float, energy: float, fit: bool = True) -> dict[str, object]:
+        return {
+            "candidate_id": name, "latency_us": latency,
+            "embodied_logic_plus_shared_sram_area_mm2": area,
+            "prior_compositional_gqa_group_component_energy_mj_per_token": energy,
+            "compute_budget_area_fit": fit, "timing_feasible": True,
+        }
+    result = _pareto([row("fast", 1, 3, 2), row("small", 2, 1, 2), row("energy", 2, 2, 1), row("bad", 0.5, 0.5, 0.5, False)])
+    assert {item["candidate_id"] for item in result} == {"fast", "small", "energy"}
+
+
+def test_recost_direct_area_substitution() -> None:
+    schedule = {
+        "hidden_size": 4096, "attention_heads": 32, "kv_heads": 4, "layers": 32,
+        "group_full_context_cycles": 300, "clock_ns": 6, "compute_budget_um2": 100_000,
+        "logic_area_used_um2": 90_000, "compute_area_um2": 80_000,
+        "measured_shared_sram_used_area_um2": 10, "measured_tile_local_sram_area_um2": 20,
+    }
+    row = _recost_candidate(
+        group_count=1, schedule=schedule,
+        dense_tile={"area_um2": 10_000, "effective_macs_per_cycle": 8},
+        prior_row={"group_area_mm2": 0.001, "latency_us": 100, "token_throughput_per_s": 10, "clock_ns": 8, "gqa_group_component_energy_mj_per_token": 1},
+        metric={"instance_area_um2": 40_000, "critical_path_ns": 7, "configured_clock_period_ns": 8, "param_hash": "p", "metrics_path": "m", "csv_line": 2, "config_hash": "c", "flow_variant": "v", "platform": "n", "die_area": 40_000, "core_area": None, "core_utilization": None, "params": {}},
+    )
+    assert row["direct_array_instance_area_um2"] == 40_000
+    assert row["direct_array_instance_area_um2"] != 0.001 * 1e6

--- a/tests/test_attention_decode_score_multivalue_gqa_array_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_array_frontier.py
@@ -82,7 +82,7 @@ def _equivalence(tmp_path: Path) -> Path:
 def _metrics(path: Path, rows: list[dict[str, object]]) -> Path:
     fields = [
         "design", "platform", "config_hash", "param_hash", "tag", "status",
-        "critical_path_ns", "die_area", "params_json", "result_path",
+        "critical_path_ns", "die_area", "instance_area_um2", "params_json", "result_path",
     ]
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=fields)
@@ -95,7 +95,8 @@ def _metric_row(count: int, *, area: float = 1_000_000, cp: float = 7.0, clock: 
     return {
         "design": f"array_g{count}", "platform": "nangate45", "config_hash": f"config{count}",
         "param_hash": f"param{count}", "tag": "tag", "status": "ok", "critical_path_ns": cp,
-        "die_area": area, "params_json": json.dumps({"CLOCK_PERIOD": clock, "FLOW_VARIANT": "array_v1", "GROUP_COUNT": count, "CORE_UTILIZATION": 50}),
+        "die_area": area * 2, "instance_area_um2": area,
+        "params_json": json.dumps({"CLOCK_PERIOD": clock, "FLOW_VARIANT": "array_v1", "GROUP_COUNT": count, "CORE_UTILIZATION": 50}),
         "result_path": "result.json",
     }
 
@@ -126,11 +127,17 @@ def test_parser_preserves_failed_and_negative_rows(tmp_path: Path) -> None:
     assert failed["accepted"] is False
     assert "status is failed" in failed["reason"]
     negative = _parse_metrics_row(
-        {"status": "ok", "critical_path_ns": 7, "die_area": -1, "params_json": json.dumps({"CLOCK_PERIOD": 8})},
+        {"status": "ok", "critical_path_ns": 7, "instance_area_um2": -1, "params_json": json.dumps({"CLOCK_PERIOD": 8})},
         metrics_path=tmp_path / "m.csv", count=1, line=3,
     )
     assert negative["accepted"] is False
     assert "instance area" in negative["reason"]
+    missing = _parse_metrics_row(
+        {"status": "ok", "critical_path_ns": 7, "die_area": 1_000_000, "params_json": json.dumps({"CLOCK_PERIOD": 8})},
+        metrics_path=tmp_path / "m.csv", count=1, line=4,
+    )
+    assert missing["accepted"] is False
+    assert "instance area" in missing["reason"]
 
 
 def test_contract_rejection(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- generate direct 1-, 2-, and 4-group GQA8 arrays with atomic command/input broadcast and independent value/result channels
- add exact compositional equivalence and physical-design guards
- add equal-density Nangate45 PPA sweeps and a Llama7B frontier recost consumer
- require measured instance area, retaining failed physical rows and explicitly withholding direct-array energy claims

## Why

The current frontier linearly composes independently measured GQA groups. Direct array PNR is needed to measure command fanout, routing congestion, clock-tree effects, and non-linear area/timing scaling.

## Validation

- `27 passed` across array RTL, equivalence, frontier, and neighboring group tests
- `252 passed` across full L1/L2 task-generator suites
- `python3 scripts/validate_runs.py --skip_eval_queue`
- JSON validation and `git diff --check`
- local Yosys g4 elaboration retained 1,792 FakeRAM macros