### PR TITLE
Compact GQA group equivalence evidence

### DIFF
--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_group_equivalence.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_group_equivalence.py
@@ -235,6 +235,18 @@ def _ordered_group_results(heads: list[JsonDict], field: str) -> list[JsonDict]:
     return [{"head": row["head"], **result} for row in ordered for result in row[field]]
 
 
+def _compact_head(row: JsonDict) -> JsonDict:
+    """Retain proof-carrying hashes and counts without serializing full tensors."""
+    return {
+        key: value
+        for key, value in row.items()
+        if key not in {"expected_results", "observed_results", "value_read_requests"}
+    } | {
+        "value_read_request_count": len(row["value_read_requests"]),
+        "value_read_requests_sha256": _hash(row["value_read_requests"]),
+    }
+
+
 def _run_protocol_test(repo_root: Path, target: str) -> JsonDict:
     command = [sys.executable, "-m", "pytest", "-q", target]
     run = subprocess.run(command, cwd=repo_root, capture_output=True, text=True, timeout=120)
@@ -284,12 +296,17 @@ def build_report(config: JsonDict, *, protocol_test_target: str = DEFAULT_PROTOC
     observed_group_hash = _ordered_group_hash(heads, "observed_result_sha256")
     expected_group_results = _ordered_group_results(heads, "expected_results")
     observed_group_results = _ordered_group_results(heads, "observed_results")
+    group_results_match = expected_group_results == observed_group_results
+    result_order = [
+        {"head": row["head"], "slice": row["slice"]}
+        for row in observed_group_results
+    ]
     passed = (
         arithmetic_pass
         and distinct_queries_pass
         and shared_inputs_pass
         and expected_group_hash == observed_group_hash
-        and expected_group_results == observed_group_results
+        and group_results_match
         and protocol["sharing_and_order_pass"]
     )
     return {
@@ -309,11 +326,13 @@ def build_report(config: JsonDict, *, protocol_test_target: str = DEFAULT_PROTOC
         "expected_group_result_sha256": expected_group_hash,
         "observed_group_result_sha256": observed_group_hash,
         "group_result_sha256": observed_group_hash,
-        "expected_group_results": expected_group_results,
-        "observed_group_results": observed_group_results,
+        "group_results_match": group_results_match,
+        "group_result_count": len(observed_group_results),
+        "group_result_order_sha256": _hash(result_order),
         "arithmetic_equivalence_pass": arithmetic_pass,
         "wrapper_protocol": protocol,
-        "heads": heads,
+        "heads": [_compact_head(row) for row in heads],
+        "evidence_detail_policy": "compact_hashes_and_counts_no_full_intermediate_tensors",
         "compositional_proof": {
             "method": "single_cluster_arithmetic_plus_wrapper_protocol",
             "arithmetic_claim": (

--- a/tests/test_attention_decode_score_multivalue_gqa_group_equivalence.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_equivalence.py
@@ -46,12 +46,22 @@ def test_gqa8_shared_kv_real_cluster_arithmetic_equivalence(report: dict) -> Non
     assert all(row["expected_result_sha256"] == row["observed_result_sha256"] for row in report["heads"])
     assert report["expected_group_result_sha256"] == report["observed_group_result_sha256"]
     assert report["group_result_sha256"] == report["observed_group_result_sha256"]
-    assert report["expected_group_results"] == report["observed_group_results"]
-    assert len(report["observed_group_results"]) == 128
-    assert [(row["head"], row["slice"]) for row in report["observed_group_results"]] == [
-        (head, value_slice) for head in range(8) for value_slice in range(16)
-    ]
+    assert report["group_results_match"] is True
+    assert report["group_result_count"] == 128
+    assert report["group_result_order_sha256"]
     assert report["per_head_result_sha256"] == [row["observed_result_sha256"] for row in report["heads"]]
+    assert all(row["value_read_request_count"] == 48 for row in report["heads"])
+    assert all(row["value_read_requests_sha256"] for row in report["heads"])
+
+
+def test_gqa8_report_is_compact_hash_evidence(report: dict) -> None:
+    assert report["evidence_detail_policy"] == "compact_hashes_and_counts_no_full_intermediate_tensors"
+    assert "expected_group_results" not in report
+    assert "observed_group_results" not in report
+    assert all("expected_results" not in row for row in report["heads"])
+    assert all("observed_results" not in row for row in report["heads"])
+    assert all("value_read_requests" not in row for row in report["heads"])
+    assert len(json.dumps(report, sort_keys=True)) < 50_000
 
 
 def test_gqa8_report_states_compositional_scope_and_protocol_gate(report: dict) -> None:


### PR DESCRIPTION
## Summary

- keep exact per-head score/result hashes, group result count/order hash, and request counts/hashes
- stop serializing duplicated expected and observed intermediate tensors
- enforce a 50 KB serialized evidence ceiling

## Why

The first GQA8 equivalence result was over 10,000 lines even though downstream consumers use only proof hashes. Full intermediate tensors are transient simulation data, not required evaluation artifacts.

## Validation

- `15 passed` across group equivalence, group activity/frontier, and array equivalence consumers
- real audit output: 199 lines, 10.9 KB
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`