### PR TITLE
Retain measured rows from terminal sweeps

### DIFF
--- a/control_plane/control_plane/services/l1_result_consumer.py
+++ b/control_plane/control_plane/services/l1_result_consumer.py
@@ -81,15 +81,10 @@ def _resolve_run(session: Session, request: Layer1ConsumeRequest) -> tuple[WorkI
     return work_item, run
 
 
-def _failed_acceptance_run_has_metrics(run: Run) -> bool:
-    if run.status != RunStatus.FAILED:
+def _terminal_run_has_metrics(run: Run) -> bool:
+    if run.status not in {RunStatus.FAILED, RunStatus.TIMED_OUT, RunStatus.CANCELED}:
         return False
     payload = dict(run.result_payload or {}) if isinstance(run.result_payload, dict) else {}
-    classification = dict(payload.get("failure_classification") or {})
-    if str(classification.get("category", "")).strip() != "validation_error":
-        return False
-    if str(classification.get("failed_command_name", "")).strip() != "acceptance":
-        return False
     queue_result = dict(payload.get("queue_result") or {})
     metrics_rows = queue_result.get("metrics_rows")
     if not isinstance(metrics_rows, list) or not metrics_rows:
@@ -103,7 +98,7 @@ def _failed_acceptance_run_has_metrics(run: Run) -> bool:
 
 
 def _run_can_contribute_l1_metrics(run: Run) -> bool:
-    return run.status == RunStatus.SUCCEEDED or _failed_acceptance_run_has_metrics(run)
+    return run.status == RunStatus.SUCCEEDED or _terminal_run_has_metrics(run)
 
 
 def _safe_float(value: str | None) -> float | None:
@@ -508,7 +503,10 @@ def _proposal_entry(*, metrics_csv: str, best_row: dict[str, Any], evaluation_re
 def _completed_trial_runs(work_item: WorkItem) -> list[Run]:
     completed: list[Run] = []
     for run in sorted(work_item.runs, key=lambda row: (row.attempt, row.created_at or utcnow())):
-        if run.status not in {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.TIMED_OUT}:
+        if (
+            run.status not in {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.TIMED_OUT}
+            and not _terminal_run_has_metrics(run)
+        ):
             continue
         completed.append(run)
     return completed
@@ -793,6 +791,7 @@ def _trial_aggregate_payloads(repo_root: Path, work_item: WorkItem) -> tuple[lis
     failure_category = Counter()
     failure_stage = Counter()
     success_count = 0
+    partial_metrics_count = 0
     seed_variance_selected_rows: dict[str, tuple[str, dict[str, Any]]] = {}
     selected_group_metadata: dict[str, Any] | None = None
     if _objective_name(work_item) == "measure_seed_variance":
@@ -814,7 +813,18 @@ def _trial_aggregate_payloads(repo_root: Path, work_item: WorkItem) -> tuple[lis
         best_row = None
         if best is not None:
             metrics_csv, best_row = best
-            success_count += 1
+            is_failed_acceptance = (
+                str(failure.get("category", "")).strip() == "validation_error"
+                and str(failure.get("failed_command_name", "")).strip() == "acceptance"
+            )
+            if run.status == RunStatus.SUCCEEDED or is_failed_acceptance:
+                success_count += 1
+            else:
+                partial_metrics_count += 1
+                category = str(failure.get("category", "") or run.failure_category or "unknown").strip() or "unknown"
+                stage = str(failure.get("stage", "") or run.failure_stage or "unknown").strip() or "unknown"
+                failure_category[category] += 1
+                failure_stage[stage] += 1
             for key in success_metric_values:
                 value = _safe_float(best_row.get(key))
                 if value is not None:
@@ -847,6 +857,7 @@ def _trial_aggregate_payloads(repo_root: Path, work_item: WorkItem) -> tuple[lis
         "success_count": success_count,
         "failure_count": failure_count,
         "success_rate": (float(success_count) / float(completed_trials)) if completed_trials else 0.0,
+        "partial_metrics_count": partial_metrics_count,
         "metrics": {key: value for key, value in {metric: _metric_summary(values) for metric, values in success_metric_values.items()}.items() if value is not None},
     }
     if selected_group_metadata is not None:
@@ -917,7 +928,7 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
     work_item, run = _resolve_run(session, request)
     if work_item.task_type != "l1_sweep":
         raise Layer1ResultConsumerError(f"work item is not l1_sweep: {work_item.item_id}")
-    if run.status != RunStatus.SUCCEEDED and not _failed_acceptance_run_has_metrics(run):
+    if run.status != RunStatus.SUCCEEDED and not _terminal_run_has_metrics(run):
         raise Layer1ResultConsumerError(f"run is not succeeded: {run.run_key} status={run.status.value}")
 
     metrics_csvs, summary_stats, failure_stats, trial_rows, selected_group_metadata = _trial_aggregate_payloads(repo_root, work_item)
@@ -983,6 +994,31 @@ def consume_l1_result(session: Session, request: Layer1ConsumeRequest) -> Layer1
         source_refs=source_refs,
     )
     payload["trial_summary"] = summary_stats
+    if run.status != RunStatus.SUCCEEDED:
+        run_payload = dict(run.result_payload or {}) if isinstance(run.result_payload, dict) else {}
+        failure = dict(run_payload.get("failure_classification") or {})
+        queue_result = dict(run_payload.get("queue_result") or {})
+        metrics_rows = queue_result.get("metrics_rows")
+        payload["partial_run_evidence"] = {
+            "run_status": run.status.value,
+            "failure_stage": str(failure.get("stage", "") or run.failure_stage or "").strip(),
+            "failure_category": str(failure.get("category", "") or run.failure_category or "").strip(),
+            "failure_signature": str(failure.get("signature", "") or run.failure_signature or "").strip(),
+            "captured_metrics_rows": list(metrics_rows) if isinstance(metrics_rows, list) else [],
+            "sweep_complete": False,
+            "promotion_scope": "captured_metrics_rows_only",
+        }
+        if proposals:
+            payload["proposal_assessment"] = {
+                "outcome": "partial_sweep_measured_points",
+                "summary": (
+                    "The run terminated after capturing status=ok physical rows. Retain only those "
+                    "rows as measured evidence; the sweep is incomplete and unmeasured points must "
+                    "not be inferred as feasible."
+                ),
+                "measured_point_count": len(proposals),
+                "sweep_complete": False,
+            }
     if boundary_rows:
         if not proposals:
             timing_infeasible_count = sum(

--- a/control_plane/control_plane/tests/test_l1_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l1_result_consumer.py
@@ -6,7 +6,9 @@ import csv
 import json
 from pathlib import Path
 import tempfile
+from types import SimpleNamespace
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -17,7 +19,11 @@ from control_plane.models.enums import ExecutorType, FlowName, LayerName, RunSta
 from control_plane.models.runs import Run
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
-from control_plane.services.l1_result_consumer import Layer1ConsumeRequest, consume_l1_result
+from control_plane.services.l1_result_consumer import (
+    Layer1ConsumeRequest,
+    _terminal_run_has_metrics,
+    consume_l1_result,
+)
 
 
 def _write_metrics(path: Path, rows: list[dict[str, str]]) -> None:
@@ -38,6 +44,16 @@ def _write_metrics(path: Path, rows: list[dict[str, str]]) -> None:
         writer.writeheader()
         for row in rows:
             writer.writerow({key: row.get(key, "") for key in headers})
+
+
+def test_terminal_run_metrics_require_captured_inline_artifact() -> None:
+    run = SimpleNamespace(
+        status=RunStatus.CANCELED,
+        result_payload={"queue_result": {"metrics_rows": ["runs/designs/demo/metrics.csv:2"]}},
+        artifacts=[],
+    )
+
+    assert _terminal_run_has_metrics(run) is False
 
 
 def _seed_succeeded_l1_sweep(session: Session, repo_root: Path) -> tuple[str, str]:
@@ -505,6 +521,141 @@ def test_consume_l1_result_accepts_failed_acceptance_run_with_mixed_metrics() ->
             assert payload["boundary_evidence"]["rows"][0]["metrics_csv"] == metrics_failed
             assert payload["boundary_evidence"]["rows"][0]["status"] == "failed"
             assert session.query(Artifact).filter_by(kind="promotion_proposal").one().metadata_["proposal_count"] == 1
+
+
+@pytest.mark.parametrize("run_status", [RunStatus.FAILED, RunStatus.CANCELED])
+def test_consume_l1_result_retains_partial_metrics_from_terminal_sweep(run_status: RunStatus) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        metrics_rel = "runs/designs/npu_blocks/partial_cluster/metrics.csv"
+        _write_metrics(
+            repo_root / metrics_rel,
+            [
+                {
+                    "platform": "nangate45",
+                    "status": "ok",
+                    "param_hash": "measured1",
+                    "tag": "partial_cluster_proxy_die_2500",
+                    "critical_path_ns": "7.2189",
+                    "die_area": "6250000",
+                    "total_power_mw": "0.3",
+                    "result_path": "runs/designs/npu_blocks/partial_cluster/work/measured1/result.json",
+                }
+            ],
+        )
+
+        with Session(engine) as session:
+            task_request = TaskRequest(
+                request_key="l1_sweep:test_partial_failed_sweep",
+                source="test",
+                requested_by="@tester",
+                title="Partial failed sweep",
+                description="retain measured rows from a terminal physical sweep",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": "l1_test_partial_failed_sweep",
+                    "layer": "layer1",
+                    "flow": "openroad",
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key="l1_sweep:test_partial_failed_sweep",
+                task_request_id=task_request.id,
+                item_id="l1_test_partial_failed_sweep",
+                layer=LayerName.LAYER1,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l1_sweep",
+                state=WorkItemState.FAILED,
+                priority=1,
+                source_mode="config",
+                input_manifest={"configs": [], "sweeps": []},
+                command_manifest=[],
+                expected_outputs=[metrics_rel],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+            run = Run(
+                run_key="l1_test_partial_failed_sweep_run_1",
+                work_item_id=work_item.id,
+                attempt=1,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=run_status,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                failure_stage="worker",
+                failure_category="worker_error",
+                failure_signature="heartbeat connection timeout",
+                result_summary="heartbeat connection timeout",
+                result_payload={
+                    "queue_result": {
+                        "status": "fail",
+                        "metrics_rows": [f"{metrics_rel}:2"],
+                    },
+                    "failure_classification": {
+                        "stage": "worker",
+                        "category": "worker_error",
+                        "signature": "heartbeat connection timeout",
+                    },
+                },
+            )
+            session.add(run)
+            session.flush()
+            session.add(
+                Artifact(
+                    run_id=run.id,
+                    kind="expected_output",
+                    storage_mode="repo",
+                    path=metrics_rel,
+                    metadata_={
+                        "transport_policy": "inline_text_evidence",
+                        "inline_utf8": (repo_root / metrics_rel).read_text(encoding="utf-8"),
+                    },
+                )
+            )
+            session.commit()
+
+            result = consume_l1_result(
+                session,
+                Layer1ConsumeRequest(repo_root=str(repo_root), run_key=run.run_key),
+            )
+
+            assert result.proposal_count == 1
+            proposal_path = (
+                repo_root
+                / "control_plane"
+                / "shadow_exports"
+                / "l1_promotions"
+                / f"{work_item.item_id}.json"
+            )
+            payload = json.loads(proposal_path.read_text(encoding="utf-8"))
+            assert payload["proposal_assessment"]["outcome"] == "partial_sweep_measured_points"
+            assert payload["proposal_assessment"]["sweep_complete"] is False
+            assert payload["trial_summary"]["success_count"] == 0
+            assert payload["trial_summary"]["failure_count"] == 1
+            assert payload["trial_summary"]["partial_metrics_count"] == 1
+            assert payload["partial_run_evidence"] == {
+                "run_status": run_status.value,
+                "failure_stage": "worker",
+                "failure_category": "worker_error",
+                "failure_signature": "heartbeat connection timeout",
+                "captured_metrics_rows": [f"{metrics_rel}:2"],
+                "sweep_complete": False,
+                "promotion_scope": "captured_metrics_rows_only",
+            }
+            assert payload["proposals"][0]["metrics_ref"]["param_hash"] == "measured1"
 
 
 def test_consume_l1_result_keeps_single_trial_metrics_without_trials_subdir() -> None:


### PR DESCRIPTION
## Summary
- allow failed, timed-out, or canceled Layer 1 runs to contribute metrics only when the run captured the referenced metrics file inline
- mark such decisions as incomplete `partial_sweep_measured_points` evidence and preserve terminal failure metadata
- distinguish partial measured attempts from successful trials in aggregate accounting
- retain retry history while deduplicating the architectural proposal by metrics path

## Motivation
`l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1` completed one valid Nangate45 PPA point before a 26-hour worker/DB failure, and its retry was later canceled after reproducing the long-running boundary. The valid row is stored in the DB artifact, but the previous consumer rejected all non-acceptance terminal failures. Re-running the known explosive sweep would waste evaluator time and keep downstream activity/frontier jobs blocked.

This change does not label the sweep successful: it records `sweep_complete: false`, the terminal status/category/signature, and limits promotion to captured rows only. Unmeasured points cannot be inferred as feasible.

## Validation
- `python -m pytest control_plane/control_plane/tests/test_l1_result_consumer.py -q` (17 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`