### PR TITLE
Accept reviewed partial Layer 1 dependencies

### DIFF
--- a/control_plane/control_plane/services/dependency_gate.py
+++ b/control_plane/control_plane/services/dependency_gate.py
@@ -15,7 +15,13 @@ from control_plane.models.enums import RunStatus, WorkItemState
 from control_plane.models.runs import Run
 from control_plane.models.work_items import WorkItem
 
-_MATERIALIZED_ARTIFACT_KINDS = {"expected_output", "decision_proposal", "review_package", "queue_snapshot"}
+_MATERIALIZED_ARTIFACT_KINDS = {
+    "expected_output",
+    "promotion_proposal",
+    "decision_proposal",
+    "review_package",
+    "queue_snapshot",
+}
 
 
 @dataclass(frozen=True)
@@ -48,6 +54,57 @@ def _latest_successful_run(work_item: WorkItem) -> Run | None:
     if not successful:
         return None
     return sorted(successful, key=lambda row: (row.attempt, row.created_at))[ -1]
+
+
+def _latest_reviewed_partial_run(
+    session: Session,
+    *,
+    repo_root: Path,
+    work_item: WorkItem,
+) -> Run | None:
+    if work_item.state != WorkItemState.MERGED:
+        return None
+    terminal_statuses = {RunStatus.FAILED, RunStatus.TIMED_OUT, RunStatus.CANCELED}
+    candidates = sorted(
+        (run for run in work_item.runs if run.status in terminal_statuses),
+        key=lambda row: (row.attempt, row.created_at),
+        reverse=True,
+    )
+    for run in candidates:
+        promotion = (
+            session.query(Artifact)
+            .filter(Artifact.run_id == run.id, Artifact.kind == "promotion_proposal")
+            .one_or_none()
+        )
+        if promotion is None:
+            continue
+        promotion_path = Path(promotion.path)
+        if not promotion_path.is_absolute():
+            promotion_path = repo_root / promotion_path
+        if not promotion_path.exists():
+            continue
+        try:
+            payload = json.loads(promotion_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        assessment = payload.get("proposal_assessment")
+        partial = payload.get("partial_run_evidence")
+        if not isinstance(assessment, dict) or not isinstance(partial, dict):
+            continue
+        if str(assessment.get("outcome", "")).strip() != "partial_sweep_measured_points":
+            continue
+        if assessment.get("sweep_complete") is not False or partial.get("sweep_complete") is not False:
+            continue
+        if str(partial.get("promotion_scope", "")).strip() != "captured_metrics_rows_only":
+            continue
+        try:
+            proposal_count = int(payload.get("proposal_count") or 0)
+        except (TypeError, ValueError):
+            continue
+        if proposal_count < 1:
+            continue
+        return run
+    return None
 
 
 def _path_exists(repo_root: Path, path_text: str) -> bool:
@@ -88,9 +145,16 @@ def _refresh_released_source_requirement(work_item: WorkItem, *, repo_root: Path
 
 
 def _materialized_artifacts_exist(session: Session, *, repo_root: Path, work_item: WorkItem) -> DependencyGateResult:
-    run = _latest_successful_run(work_item)
+    run = _latest_successful_run(work_item) or _latest_reviewed_partial_run(
+        session,
+        repo_root=repo_root,
+        work_item=work_item,
+    )
     if run is None:
-        return DependencyGateResult(False, f"dependency {work_item.item_id} has no successful run")
+        return DependencyGateResult(
+            False,
+            f"dependency {work_item.item_id} has no successful or reviewed partial run",
+        )
 
     artifacts = (
         session.query(Artifact)

--- a/control_plane/control_plane/tests/test_dependency_gate.py
+++ b/control_plane/control_plane/tests/test_dependency_gate.py
@@ -130,6 +130,151 @@ def test_refresh_all_blocked_items_releases_satisfied_dependent() -> None:
         assert blocked.state == WorkItemState.DISPATCH_PENDING
 
 
+def test_refresh_all_blocked_items_accepts_merged_reviewed_partial_l1_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        promotion_rel = "control_plane/shadow_exports/l1_promotions/partial_l1.json"
+        review_rel = "control_plane/shadow_exports/review/partial_l1/review_package.json"
+        queue_rel = "control_plane/shadow_exports/review/partial_l1/evaluated.json"
+        metrics_rel = "runs/designs/npu_blocks/partial_l1/metrics.csv"
+        for rel, text in (
+            (
+                promotion_rel,
+                json.dumps(
+                    {
+                        "proposal_count": 1,
+                        "proposal_assessment": {
+                            "outcome": "partial_sweep_measured_points",
+                            "sweep_complete": False,
+                        },
+                        "partial_run_evidence": {
+                            "run_status": "canceled",
+                            "sweep_complete": False,
+                            "promotion_scope": "captured_metrics_rows_only",
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            ),
+            (review_rel, "{}\n"),
+            (queue_rel, "{}\n"),
+            (metrics_rel, "platform,status,param_hash\nnangate45,ok,measured1\n"),
+        ):
+            path = repo_root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+
+        with make_session() as session:
+            dep_task = TaskRequest(
+                request_key="queue:partial_l1",
+                source="test",
+                requested_by="tester",
+                title="partial l1",
+                description="partial l1",
+                layer="layer1",
+                flow="openroad",
+                priority=1,
+                request_payload={},
+            )
+            session.add(dep_task)
+            session.flush()
+            dependency = WorkItem(
+                work_item_key="queue:partial_l1",
+                task_request_id=dep_task.id,
+                item_id="partial_l1",
+                layer="layer1",
+                flow="openroad",
+                platform="nangate45",
+                task_type="l1_sweep",
+                state=WorkItemState.MERGED,
+                priority=1,
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[metrics_rel],
+                acceptance_rules=[],
+            )
+            session.add(dependency)
+            session.flush()
+            run = Run(
+                run_key="partial_l1_run",
+                work_item_id=dependency.id,
+                attempt=1,
+                executor_type="internal_worker",
+                status=RunStatus.CANCELED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                result_summary="canceled after measured point",
+                result_payload={},
+            )
+            session.add(run)
+            session.flush()
+            for kind, rel in (
+                ("promotion_proposal", promotion_rel),
+                ("review_package", review_rel),
+                ("queue_snapshot", queue_rel),
+                ("expected_output", metrics_rel),
+            ):
+                session.add(
+                    Artifact(
+                        run_id=run.id,
+                        kind=kind,
+                        storage_mode="repo",
+                        path=rel,
+                        sha256="x",
+                        metadata_={},
+                    )
+                )
+
+            blocked_task = TaskRequest(
+                request_key="queue:partial_dependent",
+                source="test",
+                requested_by="tester",
+                title="partial dependent",
+                description="partial dependent",
+                layer="layer2",
+                flow="openroad",
+                priority=1,
+                request_payload={
+                    "developer_loop": {
+                        "dependencies": {
+                            "item_ids": ["partial_l1"],
+                            "requires_merged_inputs": True,
+                            "requires_materialized_refs": True,
+                        }
+                    }
+                },
+            )
+            session.add(blocked_task)
+            session.flush()
+            blocked = WorkItem(
+                work_item_key="queue:partial_dependent",
+                task_request_id=blocked_task.id,
+                item_id="partial_dependent",
+                layer="layer2",
+                flow="openroad",
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.BLOCKED,
+                priority=1,
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[],
+                acceptance_rules=[],
+            )
+            session.add(blocked)
+            session.commit()
+
+            released = refresh_all_blocked_items(session, repo_root=repo_root)
+            session.commit()
+            session.refresh(blocked)
+
+        assert released == ["partial_dependent"]
+        assert blocked.state == WorkItemState.DISPATCH_PENDING
+
+
 def test_refresh_all_blocked_items_releases_repo_materialized_missing_dependency() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- allow a merged Layer 1 dependency to use a terminal run only when its merged promotion artifact explicitly records `partial_sweep_measured_points`
- require `sweep_complete: false`, `captured_metrics_rows_only`, at least one measured proposal, and all materialized review artifacts
- continue preferring successful runs and reject unreviewed terminal runs

## Motivation
The recovered multivalue-cluster PPA result merged in PR #1334, but downstream activity remains blocked because the dependency gate only searches for `SUCCEEDED` runs. The run correctly remains canceled; changing its status would falsify history. This gate recognizes the reviewed partial-evidence contract instead.

## Validation
- `python -m pytest control_plane/control_plane/tests/test_dependency_gate.py -q` (3 passed)
- production DB dry evaluation: `l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1` reports `satisfied=True`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`