### PR TITLE
Prove flat GQA8 group RTL equivalence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1688,16 +1688,18 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 
-    if model == "llama7b_gqa8_shared_kv_compositional_arithmetic_equivalence_v1":
+    if model in {
+        "llama7b_gqa8_shared_kv_compositional_arithmetic_equivalence_v1",
+        "llama7b_gqa8_shared_kv_direct_rtl_equivalence_v2",
+    }:
+        direct_flat_rtl = model == "llama7b_gqa8_shared_kv_direct_rtl_equivalence_v2"
         outcome = str(evidence_payload.get("decision") or "llama7b_gqa8_shared_kv_equivalence_recorded")
         wrapper_protocol = evidence_payload.get("wrapper_protocol")
         wrapper_protocol_dict = dict(wrapper_protocol) if isinstance(wrapper_protocol, dict) else {}
         compositional_proof = evidence_payload.get("compositional_proof")
         compositional_proof_dict = dict(compositional_proof) if isinstance(compositional_proof, dict) else {}
-        parts = [
-            f"Llama7B GQA8 shared-K/V compositional arithmetic equivalence recorded from {evidence_ref}: "
-            f"decision={outcome}",
-        ]
+        proof_label = "direct flat RTL equivalence" if direct_flat_rtl else "compositional arithmetic equivalence"
+        parts = [f"Llama7B GQA8 shared-K/V {proof_label} recorded from {evidence_ref}: decision={outcome}"]
         for key in (
             "equivalence_pass",
             "arithmetic_equivalence_pass",
@@ -1714,12 +1716,18 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
                 "wrapper_protocol_sharing_and_order_pass="
                 f"{wrapper_protocol_dict.get('sharing_and_order_pass')}"
             )
-        parts.append("proof=compositional")
+        parts.append("proof=direct_flat_rtl" if direct_flat_rtl else "proof=compositional")
         if "method" in compositional_proof_dict:
             parts.append(f"compositional_proof_method={compositional_proof_dict.get('method')}")
-        flat_simulation_run = compositional_proof_dict.get("flat_8_cluster_rtl_simulation_run", False)
+        flat_simulation_run = evidence_payload.get(
+            "flat_8_cluster_rtl_simulation_run",
+            compositional_proof_dict.get("flat_8_cluster_rtl_simulation_run", False),
+        )
         parts.append(f"flat_8_cluster_rtl_simulation_run={flat_simulation_run}")
-        parts.append("flat_8_cluster_simulation_proof=False")
+        flat_equivalence_pass = bool(evidence_payload.get("flat_8_cluster_equivalence_pass", False))
+        if direct_flat_rtl:
+            parts.append(f"flat_8_cluster_equivalence_pass={flat_equivalence_pass}")
+        parts.append(f"flat_8_cluster_simulation_proof={bool(flat_simulation_run and flat_equivalence_pass)}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -468,6 +468,41 @@ def test_decoder_evidence_summary_recognizes_decode_score_multivalue_gqa_group_e
         assert field in summary
 
 
+def test_decoder_evidence_summary_recognizes_direct_flat_gqa_group_equivalence() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/decode_score_multivalue_gqa_group_equivalence.json",
+        evidence_payload={
+            "model": "llama7b_gqa8_shared_kv_direct_rtl_equivalence_v2",
+            "decision": "llama7b_gqa8_shared_kv_equivalence_pass",
+            "equivalence_pass": True,
+            "arithmetic_equivalence_pass": True,
+            "shared_inputs_pass": True,
+            "query_heads_per_kv": 8,
+            "head_dim": 128,
+            "group_result_sha256": "directhash",
+            "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_v1",
+            "wrapper_protocol": {"sharing_and_order_pass": True},
+            "flat_8_cluster_rtl_simulation_run": True,
+            "flat_8_cluster_equivalence_pass": True,
+            "compositional_proof": {
+                "method": "flat_8_cluster_rtl_plus_per_head_reference_and_protocol",
+                "flat_8_cluster_rtl_simulation_run": True,
+            },
+        },
+    )
+
+    assert outcome == "llama7b_gqa8_shared_kv_equivalence_pass"
+    for field in (
+        "shared-K/V direct flat RTL equivalence",
+        "proof=direct_flat_rtl",
+        "compositional_proof_method=flat_8_cluster_rtl_plus_per_head_reference_and_protocol",
+        "flat_8_cluster_rtl_simulation_run=True",
+        "flat_8_cluster_equivalence_pass=True",
+        "flat_8_cluster_simulation_proof=True",
+    ):
+        assert field in summary
+
+
 @pytest.mark.parametrize(
     ("model", "decision", "payload", "expected"),
     [

--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_group_equivalence.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_group_equivalence.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Audit Llama7B GQA8 arithmetic by composing cluster and wrapper proofs.
-
-This audit deliberately does not simulate a flat eight-cluster design. It runs
-the real generated single-cluster RTL once for each query head, with one shared
-key tensor and one shared value tensor, and compares every head against the
-performance/reference math. A separate wrapper protocol test proves shared key
-broadcast, shared external value replay, and serialized head/slice result order.
-"""
+"""Audit Llama7B GQA8 arithmetic through direct and compositional RTL proofs."""
 
 from __future__ import annotations
 
@@ -25,14 +18,17 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.eval.probe_attention_decode_score_multivalue_cluster_equivalence import (
+    _FAKERAM_MODEL,
     _RESULT_RE,
     _SREQ_RE,
     _VREQ_RE,
     _WRITE_RE,
+    _pack,
     _testbench,
     _tool,
 )
 from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate as generate_cluster
+from npu.rtlgen.gen_attention_decode_score_multivalue_gqa_group import generate as generate_group
 from npu.sim.perf.attention_online import finalize_value, requantize_score_row, two_pass_stats
 from npu.sim.perf.attention_separated import unpack_signed
 
@@ -149,6 +145,294 @@ def _expected_results(
             }
         )
     return rows
+
+
+_FLAT_WRITE_RE = re.compile(r"FWRITE head=(\d+) addr=(\d+) row=([0-9a-fA-F]+)")
+_FLAT_SREQ_RE = re.compile(r"FSREQ head=(\d+) addr=(\d+)")
+_FLAT_RESULT_RE = re.compile(
+    r"FRESULT head=(\d+) slice=(\d+) last=(\d+) id=(\d+) max=(-?\d+) "
+    r"sum=(\d+) value=([0-9a-fA-F]+) error=(\d+)"
+)
+_FLAT_COMPLETE_RE = re.compile(r"FCOMPLETE cycles=(\d+)")
+
+
+def _flat_testbench(
+    *,
+    top_name: str,
+    queries: list[list[list[int]]],
+    keys: list[list[list[int]]],
+    values: list[list[list[list[int]]]],
+    multiplier: int,
+    shift: int,
+) -> str:
+    block_count = len(keys)
+    total_beats = block_count * HEAD_DIM
+    beat_init = "\n".join(
+        "    q_mem[{index}] = 64'h{query:016x}; k_mem[{index}] = 64'h{key:016x};".format(
+            index=block * HEAD_DIM + dim,
+            query=_pack([queries[head][block][dim] for head in range(HEAD_COUNT)], 8),
+            key=_pack(keys[block][dim], 8),
+        )
+        for block in range(block_count)
+        for dim in range(HEAD_DIM)
+    )
+    last_cases = "\n".join(
+        f"      {((block + 1) * HEAD_DIM) - 1}: input_last = 1'b1;"
+        for block in range(block_count)
+    )
+    value_init = "\n".join(
+        "    value_mem[{index}] = 512'h{value:0128x};".format(
+            index=block * VALUE_SLICES + value_slice,
+            value=_pack([lane for row in values[block][value_slice] for lane in row], 8),
+        )
+        for block in range(block_count)
+        for value_slice in range(VALUE_SLICES)
+    )
+    child_monitors = "\n".join(
+        f"""      if (dut.u_head_{head}.score_write_valid && dut.u_head_{head}.score_write_ready)
+        $display("FWRITE head={head} addr=%0d row=%064x", dut.u_head_{head}.score_write_addr, dut.u_head_{head}.score_write_data);
+      if (dut.u_head_{head}.score_read_fire)
+        $display("FSREQ head={head} addr=%0d", dut.u_head_{head}.score_read_req_addr);"""
+        for head in range(HEAD_COUNT)
+    )
+    return f"""`timescale 1ns/1ps
+{_FAKERAM_MODEL}
+module tb;
+  localparam integer BLOCK_COUNT = {block_count};
+  localparam integer TOTAL_BEATS = {total_beats};
+  reg clk = 0, rst_n = 0;
+  reg command_valid, input_valid, input_last;
+  wire command_ready, input_ready;
+  reg signed [63:0] input_query, input_key;
+  wire value_read_req_valid, value_response_ready;
+  reg value_read_req_ready, value_response_valid;
+  wire [13:0] value_read_req_address;
+  wire [3:0] value_read_req_slice;
+  reg [13:0] value_response_address;
+  reg [3:0] value_response_slice;
+  reg [511:0] value_response_matrix;
+  wire result_valid, result_last;
+  reg result_ready;
+  wire [2:0] result_head;
+  wire [15:0] result_command_id;
+  wire signed [31:0] result_global_max;
+  wire [32:0] result_exp_sum;
+  wire [3:0] result_slice;
+  wire [319:0] result_value;
+  wire [31:0] accepted_count, completed_count, cycle_count;
+  wire protocol_error;
+  reg [63:0] q_mem [0:TOTAL_BEATS-1];
+  reg [63:0] k_mem [0:TOTAL_BEATS-1];
+  reg [511:0] value_mem [0:BLOCK_COUNT*16-1];
+  integer input_index = 0, cycle = 0, result_count = 0;
+  reg value_pending = 0;
+  reg [13:0] pending_addr = 0;
+  reg [3:0] pending_slice = 0;
+  integer pending_delay = 0;
+
+  always #5 clk = ~clk;
+  {top_name} dut (
+      .clk(clk), .rst_n(rst_n), .command_valid(command_valid), .command_ready(command_ready),
+      .command_id(16'h{COMMAND_ID:04x}), .command_block_count(BLOCK_COUNT),
+      .command_score_multiplier(32'd{multiplier}), .command_score_shift(6'd{shift}),
+      .input_valid(input_valid), .input_ready(input_ready), .input_last(input_last),
+      .input_query(input_query), .input_key(input_key),
+      .value_read_req_valid(value_read_req_valid), .value_read_req_ready(value_read_req_ready),
+      .value_read_req_address(value_read_req_address), .value_read_req_slice(value_read_req_slice),
+      .value_response_valid(value_response_valid), .value_response_ready(value_response_ready),
+      .value_response_address(value_response_address), .value_response_slice(value_response_slice),
+      .value_response_matrix(value_response_matrix), .result_valid(result_valid), .result_ready(result_ready),
+      .result_head(result_head), .result_command_id(result_command_id),
+      .result_global_max(result_global_max), .result_exp_sum(result_exp_sum),
+      .result_slice(result_slice), .result_last(result_last), .result_value(result_value),
+      .accepted_count(accepted_count), .completed_count(completed_count),
+      .cycle_count(cycle_count), .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    command_valid = rst_n && accepted_count == 0;
+    input_valid = rst_n && input_index < TOTAL_BEATS;
+    input_query = input_index < TOTAL_BEATS ? q_mem[input_index] : 0;
+    input_key = input_index < TOTAL_BEATS ? k_mem[input_index] : 0;
+    input_last = 0;
+    case (input_index)
+{last_cases}
+      default: input_last = 0;
+    endcase
+    value_read_req_ready = 1'b1;
+    result_ready = 1'b1;
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      input_index <= 0; cycle <= 0; result_count <= 0;
+      value_pending <= 0; value_response_valid <= 0; pending_delay <= 0;
+      value_response_address <= 0; value_response_slice <= 0; value_response_matrix <= 0;
+    end else begin
+      cycle <= cycle + 1;
+      if (input_valid && input_ready) input_index <= input_index + 1;
+      if (value_read_req_valid && value_read_req_ready) begin
+        if (value_pending || value_response_valid) $fatal(1, "multiple outstanding value requests");
+        value_pending <= 1;
+        pending_addr <= value_read_req_address;
+        pending_slice <= value_read_req_slice;
+        pending_delay <= 1;
+        $display("VREQ addr=%0d slice=%0d", value_read_req_address, value_read_req_slice);
+      end
+      if (value_pending) begin
+        if (pending_delay == 0) begin
+          value_pending <= 0;
+          value_response_valid <= 1;
+          value_response_address <= pending_addr;
+          value_response_slice <= pending_slice;
+          value_response_matrix <= value_mem[pending_addr * 16 + pending_slice];
+        end else pending_delay <= pending_delay - 1;
+      end
+      if (value_response_valid && value_response_ready) value_response_valid <= 0;
+{child_monitors}
+      if (result_valid && result_ready) begin
+        $display("FRESULT head=%0d slice=%0d last=%0d id=%0d max=%0d sum=%0d value=%080x error=%0d", result_head, result_slice, result_last, result_command_id, $signed(result_global_max), result_exp_sum, result_value, protocol_error);
+        result_count <= result_count + 1;
+        if (result_last && result_head == 3'd7) begin
+          if (result_count != 127) $fatal(1, "wrong result beat count");
+          $display("FCOMPLETE cycles=%0d", cycle);
+          #1 $finish;
+        end
+      end
+      if (cycle > 130000) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+{beat_init}
+{value_init}
+    value_response_valid = 0; value_response_address = 0;
+    value_response_slice = 0; value_response_matrix = 0;
+    repeat (3) @(posedge clk); @(negedge clk); rst_n = 1;
+  end
+endmodule
+"""
+
+
+def _run_flat_group(
+    *,
+    config: JsonDict,
+    queries: list[list[list[int]]],
+    keys: list[list[list[int]]],
+    values: list[list[list[list[int]]]],
+    multiplier: int,
+    shift: int,
+) -> JsonDict:
+    with tempfile.TemporaryDirectory(prefix="gqa8-flat-audit-") as tmp_text:
+        tmp = Path(tmp_text)
+        rtl_dir = tmp / "rtl"
+        direct_config = json.loads(json.dumps(config))
+        generate_group(direct_config, rtl_dir)
+        tb_path = tmp / "tb.sv"
+        tb_path.write_text(
+            _flat_testbench(
+                top_name=str(direct_config["top_name"]),
+                queries=queries,
+                keys=keys,
+                values=values,
+                multiplier=multiplier,
+                shift=shift,
+            ),
+            encoding="utf-8",
+        )
+        simv = tmp / "simv"
+        compiled = subprocess.run(
+            [_tool("iverilog"), "-g2012", "-s", "tb", "-o", str(simv), str(rtl_dir / "top.v"), str(tb_path)],
+            capture_output=True,
+            text=True,
+            timeout=240,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"flat GQA8 iverilog failed:\n{compiled.stderr}")
+        run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=240)
+        if run.returncode:
+            raise RuntimeError(f"flat GQA8 simulation failed:\n{run.stdout}\n{run.stderr}")
+
+    writes: list[list[tuple[int, list[int]]]] = [[] for _ in range(HEAD_COUNT)]
+    score_requests: list[list[int]] = [[] for _ in range(HEAD_COUNT)]
+    value_requests: list[tuple[int, int]] = []
+    results: list[list[JsonDict]] = [[] for _ in range(HEAD_COUNT)]
+    completion_cycles = 0
+    for raw_line in run.stdout.splitlines():
+        line = raw_line.strip()
+        if match := _FLAT_WRITE_RE.fullmatch(line):
+            head = int(match.group(1))
+            writes[head].append((int(match.group(2)), unpack_signed(int(match.group(3), 16), lanes=8, bits=32)))
+        elif match := _FLAT_SREQ_RE.fullmatch(line):
+            score_requests[int(match.group(1))].append(int(match.group(2)))
+        elif match := _VREQ_RE.fullmatch(line):
+            value_requests.append((int(match.group(1)), int(match.group(2))))
+        elif match := _FLAT_RESULT_RE.fullmatch(line):
+            head = int(match.group(1))
+            results[head].append(
+                {
+                    "slice": int(match.group(2)),
+                    "last": bool(int(match.group(3))),
+                    "command_id": int(match.group(4)),
+                    "global_max": int(match.group(5)),
+                    "exp_sum": int(match.group(6)),
+                    "value": unpack_signed(int(match.group(7), 16), lanes=8, bits=40),
+                    "protocol_error": bool(int(match.group(8))),
+                }
+            )
+        elif match := _FLAT_COMPLETE_RE.fullmatch(line):
+            completion_cycles = int(match.group(1))
+
+    expected_scores = [
+        [
+            list(requantize_score_row(_raw_scores(queries[head][block], keys[block]), multiplier=multiplier, shift=shift))
+            for block in range(len(keys))
+        ]
+        for head in range(HEAD_COUNT)
+    ]
+    expected_results = [_expected_results(expected_scores[head], values) for head in range(HEAD_COUNT)]
+    observed_results = [
+        [{key: value for key, value in row.items() if key != "protocol_error"} for row in head_rows]
+        for head_rows in results
+    ]
+    expected_value_requests = [
+        (block, value_slice) for block in range(len(keys)) for value_slice in range(VALUE_SLICES)
+    ]
+    passed = (
+        all([address for address, _ in writes[head]] == list(range(len(keys))) for head in range(HEAD_COUNT))
+        and all([row for _, row in writes[head]] == expected_scores[head] for head in range(HEAD_COUNT))
+        and all(score_requests[head] == list(range(len(keys))) for head in range(HEAD_COUNT))
+        and value_requests == expected_value_requests
+        and observed_results == expected_results
+        and not any(row["protocol_error"] for head_rows in results for row in head_rows)
+        and completion_cycles > 0
+    )
+    per_head = [
+        {
+            "head": head,
+            "expected_score_sha256": _hash(expected_scores[head]),
+            "observed_score_sha256": _hash([row for _, row in writes[head]]),
+            "expected_result_sha256": _hash(expected_results[head]),
+            "observed_result_sha256": _hash(observed_results[head]),
+            "score_write_count": len(writes[head]),
+            "score_read_count": len(score_requests[head]),
+            "result_count": len(observed_results[head]),
+        }
+        for head in range(HEAD_COUNT)
+    ]
+    return {
+        "simulation_run": True,
+        "equivalence_pass": passed,
+        "block_count": len(keys),
+        "head_dim": HEAD_DIM,
+        "value_slices": VALUE_SLICES,
+        "completion_cycles": completion_cycles,
+        "shared_value_read_request_count": len(value_requests),
+        "shared_value_read_requests_sha256": _hash([list(request) for request in value_requests]),
+        "expected_group_result_sha256": _ordered_group_hash(per_head, "expected_result_sha256"),
+        "observed_group_result_sha256": _ordered_group_hash(per_head, "observed_result_sha256"),
+        "heads": per_head,
+    }
 
 
 def _run_head(
@@ -284,6 +568,14 @@ def build_report(config: JsonDict, *, protocol_test_target: str = DEFAULT_PROTOC
             )
             for head in range(HEAD_COUNT)
         ]
+    flat_group = _run_flat_group(
+        config=config,
+        queries=queries,
+        keys=keys,
+        values=values,
+        multiplier=multiplier,
+        shift=shift,
+    )
     protocol = _run_protocol_test(REPO_ROOT, protocol_test_target)
     query_hashes = [row["query_sha256"] for row in heads]
     shared_inputs_pass = (
@@ -308,10 +600,13 @@ def build_report(config: JsonDict, *, protocol_test_target: str = DEFAULT_PROTOC
         and expected_group_hash == observed_group_hash
         and group_results_match
         and protocol["sharing_and_order_pass"]
+        and flat_group["equivalence_pass"]
+        and flat_group["expected_group_result_sha256"] == expected_group_hash
+        and flat_group["observed_group_result_sha256"] == observed_group_hash
     )
     return {
         "version": 1,
-        "model": "llama7b_gqa8_shared_kv_compositional_arithmetic_equivalence_v1",
+        "model": "llama7b_gqa8_shared_kv_direct_rtl_equivalence_v2",
         "decision": "llama7b_gqa8_shared_kv_equivalence_pass" if passed else "llama7b_gqa8_shared_kv_equivalence_fail",
         "equivalence_pass": passed,
         "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_v1",
@@ -331,10 +626,13 @@ def build_report(config: JsonDict, *, protocol_test_target: str = DEFAULT_PROTOC
         "group_result_order_sha256": _hash(result_order),
         "arithmetic_equivalence_pass": arithmetic_pass,
         "wrapper_protocol": protocol,
+        "flat_8_cluster_rtl": flat_group,
+        "flat_8_cluster_rtl_simulation_run": flat_group["simulation_run"],
+        "flat_8_cluster_equivalence_pass": flat_group["equivalence_pass"],
         "heads": [_compact_head(row) for row in heads],
         "evidence_detail_policy": "compact_hashes_and_counts_no_full_intermediate_tensors",
         "compositional_proof": {
-            "method": "single_cluster_arithmetic_plus_wrapper_protocol",
+            "method": "flat_8_cluster_rtl_plus_per_head_reference_and_protocol",
             "arithmetic_claim": (
                 "The real generated single-cluster RTL is simulated independently for each of eight distinct "
                 "query heads against the perf/reference math, while every run uses identical key and value tensors."
@@ -348,9 +646,11 @@ def build_report(config: JsonDict, *, protocol_test_target: str = DEFAULT_PROTOC
                 "arithmetic-equivalent children and serializes their unchanged results in the tested order, "
                 "the two checks compose to the GQA8 claim."
             ),
-            "flat_8_cluster_rtl_simulation_run": False,
+            "flat_8_cluster_rtl_simulation_run": True,
             "scope_limit": (
-                "This is a compositional proof; it does not claim that a flat eight-cluster RTL simulation was run."
+                "The direct flat simulation is bounded to three KV blocks, but exercises all eight query heads, "
+                "the full 128-element head dimension, all 16 value slices, shared K/V replay, intermediate score "
+                "writes and reads, and all 128 ordered result beats."
             ),
         },
     }
@@ -365,6 +665,7 @@ def _render_markdown(payload: JsonDict) -> str:
         f"- equivalence pass: `{payload['equivalence_pass']}`",
         f"- real single-cluster arithmetic pass: `{payload['arithmetic_equivalence_pass']}`",
         f"- wrapper sharing/order protocol pass: `{payload['wrapper_protocol']['sharing_and_order_pass']}`",
+        f"- direct flat eight-cluster RTL pass: `{payload['flat_8_cluster_equivalence_pass']}`",
         f"- expected group result hash: `{payload['expected_group_result_sha256']}`",
         f"- observed group result hash: `{payload['observed_group_result_sha256']}`",
         "",

--- a/tests/test_attention_decode_score_multivalue_gqa_group_equivalence.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_equivalence.py
@@ -68,12 +68,26 @@ def test_gqa8_report_states_compositional_scope_and_protocol_gate(report: dict) 
     assert report["wrapper_protocol"]["sharing_and_order_pass"] is True
     assert report["wrapper_protocol"]["passed_test_count"] == 1
     proof = report["compositional_proof"]
-    assert proof["method"] == "single_cluster_arithmetic_plus_wrapper_protocol"
-    assert proof["flat_8_cluster_rtl_simulation_run"] is False
+    assert proof["method"] == "flat_8_cluster_rtl_plus_per_head_reference_and_protocol"
+    assert proof["flat_8_cluster_rtl_simulation_run"] is True
+    assert report["flat_8_cluster_rtl_simulation_run"] is True
+    assert report["flat_8_cluster_equivalence_pass"] is True
+    direct = report["flat_8_cluster_rtl"]
+    assert direct["equivalence_pass"] is True
+    assert direct["head_dim"] == 128
+    assert direct["block_count"] == 3
+    assert direct["shared_value_read_request_count"] == 48
+    assert direct["completion_cycles"] > 0
+    assert direct["expected_group_result_sha256"] == report["expected_group_result_sha256"]
+    assert direct["observed_group_result_sha256"] == report["observed_group_result_sha256"]
+    assert all(row["score_write_count"] == 3 for row in direct["heads"])
+    assert all(row["score_read_count"] == 3 for row in direct["heads"])
+    assert all(row["result_count"] == 16 for row in direct["heads"])
     markdown = _render_markdown(report)
     assert "real single-cluster arithmetic pass: `True`" in markdown
     assert "wrapper sharing/order protocol pass: `True`" in markdown
-    assert "does not claim that a flat eight-cluster RTL simulation was run" in markdown
+    assert "direct flat eight-cluster RTL pass: `True`" in markdown
+    assert "bounded to three KV blocks" in markdown
 
 
 def test_ordered_group_hash_is_deterministic_and_head_order_sensitive() -> None:


### PR DESCRIPTION
## Summary
- simulate the generated eight-cluster GQA8 RTL directly with eight distinct 128-element query heads and shared K/V tensors
- compare every intermediate score write/read and all 128 ordered result beats against the perf/reference model
- retain compact hashes, counts, shared-read evidence, and observed completion cycles
- teach the result consumer to distinguish direct flat RTL proof from the earlier compositional proof

## Why
The existing GQA8 gate simulated one cluster per head and separately tested the wrapper with stubs. That evidence was valid but explicitly left `flat_8_cluster_rtl_simulation_run=false`, leaving the integrated datapath unverified.

## Validation
- exact production config audit: pass, direct group hash `e2f07a3c580991601458466bfbaab4127cbcb654065b0241197f462ca4977069`, 58,845 cycles
- `pytest -q tests/test_attention_decode_score_multivalue_gqa_group_equivalence.py` (4 passed)
- `pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py` (108 passed)