### PR TITLE
Revise GQA8 equivalence task contract

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6723,10 +6723,10 @@ def _decoder_attention_decode_score_multivalue_gqa_group_equivalence_evidence(
             "decode_score_multivalue_gqa_group_equivalence_out": out,
             "decode_score_multivalue_gqa_group_equivalence_report": report,
             "decode_score_multivalue_gqa_group_equivalence_scope": (
-                "Prove Llama7B GQA8 shared-K/V arithmetic composition by simulating the generated single-cluster "
-                "RTL for eight distinct query heads over identical key/value tensors and composing that result "
-                "with the wrapper sharing/order protocol proof. This is a compositional proof, not a flat "
-                "eight-cluster RTL simulation."
+                "Directly simulate the generated flat eight-cluster Llama7B GQA8 RTL for eight distinct "
+                "128-element query heads over identical key/value tensors. Compare every intermediate score "
+                "write/read and all 128 ordered result beats against the perf/reference model, and retain the "
+                "separate wrapper sharing/order protocol test as a backpressure cross-check."
             ),
         },
         "commands": [

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7876,7 +7876,10 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_equiva
                 "l2_decoder_attention_decode_score_multivalue_gqa_group_equivalence_llama7b_v1.json"
             )
             assert decoder_inputs["decode_score_multivalue_gqa_group_equivalence_report"] in work_item.expected_outputs
-            assert "not a flat eight-cluster RTL simulation" in decoder_inputs[
+            assert "Directly simulate the generated flat eight-cluster" in decoder_inputs[
+                "decode_score_multivalue_gqa_group_equivalence_scope"
+            ]
+            assert "every intermediate score write/read" in decoder_inputs[
                 "decode_score_multivalue_gqa_group_equivalence_scope"
             ]
 

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -25,6 +25,25 @@
       "notes": "Merged via PR #1331 and merge 55e4afbdaf8d0d00cca1ff03e70f49d6861b48f2 at 2026-07-16T11:23:26.279255Z."
     },
     {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v2",
+      "task_type": "l2_campaign",
+      "objective": "Replace the bounded compositional-only scope with direct flat eight-cluster RTL/perf equivalence evidence.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_equivalence",
+      "comparison_role": "gqa8_direct_flat_rtl_semantic_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_gqa8_shared_kv_direct_flat_rtl_equivalence",
+        "reason": "The integrated eight-cluster datapath must match intermediate score tensors, shared value requests, and all ordered result beats instead of relying only on separate cluster and wrapper proofs."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
       "task_type": "l1_sweep",
       "objective": "Measure the complete GQA8 group at 7.2, 8.0, and 9.0 mm dies and 8/10 ns targets.",

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -15,11 +15,11 @@
       "eight parallel measured multivalue score/value clusters",
       "one shared external value request per block and value slice",
       "head-major and slice-major backpressured result serialization",
-      "real single-cluster RTL arithmetic for every head plus wrapper protocol composition",
+      "direct flat eight-cluster RTL arithmetic, score-tensor, shared-request, and ordered-result equivalence",
       "macro-aware Nangate45 timing, area, and power boundary points"
     ],
     "exclude": [
-      "do not claim a flat eight-cluster RTL equivalence simulation",
+      "the direct flat simulation remains bounded to three KV blocks rather than the full 16K context",
       "do not treat vectorless power as token energy",
       "do not assume the 2.5 mm to 3.0 mm single-cluster die envelope can contain 448 SRAM macros",
       "HBM and off-chip DRAM remain outside this local GQA-group boundary"
@@ -54,6 +54,25 @@
       "expected_result": {
         "direction": "prove_gqa8_shared_kv_compositional_equivalence",
         "reason": "PPA is ineligible until eight distinct Q heads, shared K/V tensors, request collapse, and output order are proven."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v2",
+      "task_type": "l2_campaign",
+      "objective": "Strengthen the semantic gate with direct flat eight-cluster RTL/perf equivalence.",
+      "evaluation_mode": "equivalence_gate",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_equivalence",
+      "comparison_role": "gqa8_direct_flat_rtl_semantic_gate",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "prove_gqa8_shared_kv_direct_flat_rtl_equivalence",
+        "reason": "Compare every integrated score write/read, collapsed shared-value request, and ordered output beat against the perf/reference model."
       },
       "status": "pending_control_plane_merge"
     },


### PR DESCRIPTION
## Summary
- describe the GQA8 semantic gate as a direct flat eight-cluster RTL/perf proof
- register a v2 strengthening evaluation while preserving the merged v1 compositional evidence as its baseline
- record the remaining three-block bounded-simulation scope explicitly

## Validation
- `pytest -q control_plane/control_plane/tests/test_l2_task_generator.py` (210 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- proposal and evaluation request JSON parse successfully