### PR TITLE
Gate GQA8 follow-ons on direct equivalence

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -55,7 +55,8 @@
       ],
       "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_group_v1/sweeps/nangate45_decode_score_multivalue_gqa_group.json",
       "depends_on_item_ids": [
-        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -74,6 +75,7 @@
       "comparison_role": "gqa8_shared_kv_group_activity_power",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v2",
         "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
         "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
       ],
@@ -113,7 +115,8 @@
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
       "comparison_role": "gqa8_multigroup_array_semantic_gate",
       "depends_on_item_ids": [
-        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -88,7 +88,8 @@
       ],
       "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_group_v1/sweeps/nangate45_decode_score_multivalue_gqa_group.json",
       "depends_on_item_ids": [
-        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -107,6 +108,7 @@
       "comparison_role": "gqa8_shared_kv_group_activity_power",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v2",
         "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
         "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
       ],
@@ -146,7 +148,8 @@
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
       "comparison_role": "gqa8_multigroup_array_semantic_gate",
       "depends_on_item_ids": [
-        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,


### PR DESCRIPTION
## Summary

- require the direct-flat GQA8 v2 equivalence gate before group PPA and activity work
- require the same direct proof before array equivalence and downstream array work
- keep the merged compositional v1 result as the v2 baseline

## Root cause

PR #1338 registered the stronger direct-flat equivalence item, but existing follow-on requests continued to depend only on the compositional v1 proof. That allowed future physical and array work to dispatch before the stronger semantic gate completed.

The currently running group PPA was admitted under the prior contract and is not interrupted; this change governs subsequent dispatch and reruns.

## Validation

- `jq -e` on both proposal JSON files
- `git diff --check`
- `python3 scripts/validate_runs.py --skip_eval_queue`
