### PR TITLE
Resolve direct GQA evidence by consumer version

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -29,6 +29,7 @@ class Layer2TaskGenerationError(RuntimeError):
 
 
 _RETRY_SUFFIX_RE = re.compile(r"_r\d+$")
+_VERSION_SUFFIX_RE = re.compile(r"_v(\d+)$")
 
 
 @dataclass(frozen=True)
@@ -85,6 +86,13 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 def _retry_base(item_id: str) -> str:
     return _RETRY_SUFFIX_RE.sub("", item_id.strip())
+
+
+def _gqa_group_equivalence_item_for_consumer(item_id: str) -> str:
+    match = _VERSION_SUFFIX_RE.search(_retry_base(item_id))
+    revision = int(match.group(1)) if match else 1
+    suffix = "v2" if revision >= 2 else "v1"
+    return f"l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_{suffix}"
 
 
 def _proposal_dir(repo_root: Path, proposal_path: str | None) -> Path | None:
@@ -6747,9 +6755,10 @@ def _decoder_attention_decode_score_multivalue_gqa_array_equivalence_evidence(
     *, item_id: str
 ) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    group_equivalence_item = _gqa_group_equivalence_item_for_consumer(item_id)
     group_equivalence = (
         f"{base}/decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
-        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1.json"
+        f"{group_equivalence_item}.json"
     )
     config_base = "runs/designs/npu_blocks"
     configs = [
@@ -6855,9 +6864,10 @@ def _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence
     design = "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv"
     config = f"runs/designs/npu_blocks/{design}/config.json"
     metrics_csv = f"runs/designs/npu_blocks/{design}/metrics.csv"
+    group_equivalence_item = _gqa_group_equivalence_item_for_consumer(item_id)
     equivalence_json = (
         f"{base}/decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
-        "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1.json"
+        f"{group_equivalence_item}.json"
     )
     cluster_activity_power_json = (
         f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7937,6 +7937,56 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_array_equiva
             ] in work_item.expected_outputs
 
 
+def test_generate_l2_campaign_task_uses_direct_gqa_group_equivalence_for_v2_consumers() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        cases = (
+            (
+                "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v2",
+                "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
+                "decode_score_multivalue_gqa_array_group_equivalence_json",
+            ),
+            (
+                "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v2",
+                "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+                "decode_score_multivalue_gqa_group_equivalence_json",
+            ),
+        )
+        expected = (
+            "decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
+            "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v2.json"
+        )
+
+        with Session(engine) as session:
+            for item_id, abstraction_layer, input_key in cases:
+                result = generate_l2_campaign_task(
+                    session,
+                    Layer2CampaignGenerateRequest(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        item_id=item_id,
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        abstraction_layer=abstraction_layer,
+                        evaluation_mode="equivalence_gate",
+                        run_physical=False,
+                    ),
+                )
+
+                work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+                command = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+                equivalence_path = work_item.input_manifest["decoder_contract"][input_key]
+
+                assert equivalence_path.endswith(expected)
+                assert expected in command
+
+
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity_power() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary

- keep historical v1 GQA activity and array consumers bound to compositional v1 evidence
- bind v2 and later consumers to the direct-flat GQA8 v2 equivalence artifact
- cover both direct consumers with task-generation tests

## Root cause

Adding the v2 dependency gate made downstream tasks wait for direct equivalence, but generated command manifests still read the compositional v1 artifact. Waiting alone therefore did not strengthen the evidence actually consumed.

Version-aware resolution preserves prior records while allowing revised activity and array jobs to consume direct RTL proof explicitly.

## Validation

- `211 passed` in `control_plane/control_plane/tests/test_l2_task_generator.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
