### PR TITLE
Keep GQA v2 recosting on direct evidence

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -88,11 +88,15 @@ def _retry_base(item_id: str) -> str:
     return _RETRY_SUFFIX_RE.sub("", item_id.strip())
 
 
-def _gqa_group_equivalence_item_for_consumer(item_id: str) -> str:
+def _gqa_evidence_version_for_consumer(item_id: str) -> str:
     match = _VERSION_SUFFIX_RE.search(_retry_base(item_id))
     revision = int(match.group(1)) if match else 1
-    suffix = "v2" if revision >= 2 else "v1"
-    return f"l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_{suffix}"
+    return "v2" if revision >= 2 else "v1"
+
+
+def _gqa_group_equivalence_item_for_consumer(item_id: str) -> str:
+    version = _gqa_evidence_version_for_consumer(item_id)
+    return f"l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_{version}"
 
 
 def _proposal_dir(repo_root: Path, proposal_path: str | None) -> Path | None:
@@ -7053,13 +7057,14 @@ def _decoder_attention_decode_score_multivalue_cluster_frontier_evidence(*, item
 
 def _decoder_attention_decode_score_multivalue_gqa_group_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    evidence_version = _gqa_evidence_version_for_consumer(item_id)
     prior = (
         f"{base}/decoder_attention_decode_score_multivalue_cluster_frontier__"
         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1.json"
     )
     activity_power = (
         f"{base}/decoder_attention_decode_score_multivalue_gqa_group_activity_power__"
-        "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1.json"
+        f"l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_{evidence_version}.json"
     )
     group_counts = "1,2,4"
     out = f"{base}/decoder_attention_decode_score_multivalue_gqa_group_frontier__{item_id}.json"
@@ -7098,13 +7103,14 @@ def _decoder_attention_decode_score_multivalue_gqa_group_frontier_evidence(*, it
 
 def _decoder_attention_decode_score_multivalue_gqa_array_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    evidence_version = _gqa_evidence_version_for_consumer(item_id)
     prior = (
         f"{base}/decoder_attention_decode_score_multivalue_gqa_group_frontier__"
-        "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1.json"
+        f"l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_{evidence_version}.json"
     )
     equivalence = (
         f"{base}/decoder_attention_decode_score_multivalue_gqa_array_equivalence__"
-        "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1.json"
+        f"l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_{evidence_version}.json"
     )
     metrics = {
         count: (

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8415,6 +8415,61 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_array_fronti
             ] in work_item.expected_outputs
 
 
+def test_generate_l2_campaign_task_uses_v2_gqa_evidence_for_v2_frontiers() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            group_result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_"
+                        "llama7b_v2"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_gqa_group_frontier",
+                    evaluation_mode="frontier_recost",
+                    run_physical=False,
+                ),
+            )
+            group_item = session.query(WorkItem).filter_by(item_id=group_result.item_id).one()
+            group_command = group_item.task_request.request_payload["task"]["commands"][0]["run"]
+            assert "gqa8_group_activity_power_llama7b_v2.json" in group_command
+            assert "gqa8_group_activity_power_llama7b_v1.json" not in group_command
+
+            array_result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_gqa8_array_frontier_"
+                        "llama7b_v2"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_gqa_array_frontier",
+                    evaluation_mode="frontier_recost",
+                    run_physical=False,
+                ),
+            )
+            array_item = session.query(WorkItem).filter_by(item_id=array_result.item_id).one()
+            array_command = array_item.task_request.request_payload["task"]["commands"][0]["run"]
+            assert "gqa8_group_frontier_llama7b_v2.json" in array_command
+            assert "gqa8_array_equivalence_llama7b_v2.json" in array_command
+            assert "gqa8_group_frontier_llama7b_v1.json" not in array_command
+            assert "gqa8_array_equivalence_llama7b_v1.json" not in array_command
+
+
 def test_generate_l2_campaign_task_adds_score_bank_proxy_equivalence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary

- resolve GQA consumer evidence generation from the item version
- make v2 group frontier consume v2 direct-backed activity evidence
- make v2 array frontier consume v2 group-frontier and array-equivalence evidence
- preserve all v1 references for historical retries

## Root cause

The first version-aware correction covered activity and array equivalence, but later recost consumers still contained fixed v1 paths. A revised subtree could therefore regress to compositional evidence at the final ranking stage.

## Validation

- `212 passed` in `control_plane/control_plane/tests/test_l2_task_generator.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
