### PR TITLE
Add folded GQA8 lane equivalence gate

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6755,6 +6755,45 @@ def _decoder_attention_decode_score_multivalue_gqa_group_equivalence_evidence(
     }
 
 
+def _decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence_evidence(
+    *, item_id: str
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    design_base = "runs/designs/npu_blocks"
+    configs = [
+        f"{design_base}/attention_decode_score_multivalue_gqa_group_lanes{lanes}_int8_m1x8_iterdiv/config.json"
+        for lanes in (1, 2, 4)
+    ] + [
+        f"{design_base}/attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv/config.json"
+    ]
+    out = f"{base}/decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence__{item_id}.json"
+    report = f"{base}/decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence__{item_id}.md"
+    config_args = " ".join(f"--config {config}" for config in configs)
+    return {
+        "inputs": {
+            "decode_score_multivalue_gqa_folded_lane_configs": configs,
+            "decode_score_multivalue_gqa_folded_lane_equivalence_out": out,
+            "decode_score_multivalue_gqa_folded_lane_equivalence_report": report,
+            "decode_score_multivalue_gqa_folded_lane_equivalence_scope": (
+                "Directly simulate 1/2/4/8 physical query-head lanes, checking intermediate score writes and "
+                "reads plus all 128 ordered outputs. Charge one complete packed Q/K replay and one shared value "
+                "pass per wave; do not assume hidden query or key buffering."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decode_score_multivalue_gqa_folded_lane_equivalence",
+                "run": (
+                    "python3 -m npu.eval.audit_attention_decode_score_multivalue_gqa_folded_lane_equivalence "
+                    f"{config_args} --out {out} --out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_decode_score_multivalue_gqa_array_equivalence_evidence(
     *, item_id: str
 ) -> dict[str, Any]:
@@ -10691,6 +10730,7 @@ def _build_payload(
         "decoder_attention_decode_score_local_cluster_equivalence",
         "decoder_attention_decode_score_multivalue_cluster_equivalence",
         "decoder_attention_decode_score_multivalue_gqa_group_equivalence",
+        "decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence",
         "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
         "decoder_attention_decode_score_multivalue_cluster_activity_power",
         "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
@@ -10938,6 +10978,12 @@ def _build_payload(
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_group_equivalence":
             decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_group_equivalence_evidence(
                 item_id=item_id
+            )
+        elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence":
+            decoder_evidence = (
+                _decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence_evidence(
+                    item_id=item_id
+                )
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_array_equivalence":
             decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_array_equivalence_evidence(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7884,6 +7884,53 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_equiva
             ]
 
 
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_folded_lane_equivalence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_"
+                        "equivalence_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence"
+                    ),
+                    evaluation_mode="equivalence_gate",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            command = work_item.task_request.request_payload["task"]["commands"][0]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert command["name"] == "audit_decode_score_multivalue_gqa_folded_lane_equivalence"
+            assert command["run"].count("--config") == 4
+            for lanes in (1, 2, 4):
+                assert f"gqa_group_lanes{lanes}_int8_m1x8_iterdiv/config.json" in command["run"]
+            assert "gqa_group_int8_m1x8_iterdiv/config.json" in command["run"]
+            assert len(decoder_inputs["decode_score_multivalue_gqa_folded_lane_configs"]) == 4
+            assert "do not assume hidden query or key buffering" in decoder_inputs[
+                "decode_score_multivalue_gqa_folded_lane_equivalence_scope"
+            ]
+            assert decoder_inputs[
+                "decode_score_multivalue_gqa_folded_lane_equivalence_report"
+            ] in work_item.expected_outputs
+
+
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_array_equivalence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_folded_lane_equivalence.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_folded_lane_equivalence.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Prove direct RTL equivalence across folded Llama7B GQA8 lane counts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from npu.eval.audit_attention_decode_score_multivalue_gqa_group_equivalence import (
+    HEAD_COUNT,
+    VALUE_SLICES,
+    _run_flat_group,
+    _shared_vectors,
+)
+
+JsonDict = dict[str, Any]
+_EXPECTED_LANES = {1, 2, 4, 8}
+_SCORE_BANK_MACROS_PER_LANE = 56
+
+
+def _lane_count(config: JsonDict) -> int:
+    body = config.get("attention_decode_score_multivalue_gqa_group")
+    if not isinstance(body, dict):
+        raise ValueError("config requires attention_decode_score_multivalue_gqa_group")
+    if int(body.get("query_heads_per_kv", 0)) != HEAD_COUNT:
+        raise ValueError("folded lane audit requires query_heads_per_kv=8")
+    lanes = int(body.get("parallel_query_head_lanes", HEAD_COUNT))
+    if lanes not in _EXPECTED_LANES:
+        raise ValueError("parallel_query_head_lanes must be one of 1,2,4,8")
+    return lanes
+
+
+def build_report(configs: list[tuple[str, JsonDict]]) -> JsonDict:
+    indexed: dict[int, tuple[str, JsonDict]] = {}
+    for source, config in configs:
+        lanes = _lane_count(config)
+        if lanes in indexed:
+            raise ValueError(f"duplicate folded lane config: {lanes}")
+        indexed[lanes] = (source, config)
+    if set(indexed) != _EXPECTED_LANES:
+        raise ValueError("folded lane audit requires exactly one config for lanes 1,2,4,8")
+
+    queries, keys, values = _shared_vectors()
+    rows: list[JsonDict] = []
+    for lanes in sorted(indexed):
+        source, config = indexed[lanes]
+        direct = _run_flat_group(
+            config=config,
+            queries=queries,
+            keys=keys,
+            values=values,
+            multiplier=1,
+            shift=0,
+        )
+        waves = HEAD_COUNT // lanes
+        rows.append(
+            {
+                "parallel_query_head_lanes": lanes,
+                "physical_query_head_clusters": lanes,
+                "query_head_waves": waves,
+                "score_bank_macro_count": _SCORE_BANK_MACROS_PER_LANE * lanes,
+                "query_input_replays_per_command": waves,
+                "key_input_replays_per_command": waves,
+                "shared_value_reads_per_block": VALUE_SLICES * waves,
+                "shared_value_read_request_count": direct["shared_value_read_request_count"],
+                "completion_cycles": direct["completion_cycles"],
+                "equivalence_pass": direct["equivalence_pass"],
+                "expected_group_result_sha256": direct["expected_group_result_sha256"],
+                "observed_group_result_sha256": direct["observed_group_result_sha256"],
+                "shared_value_read_requests_sha256": direct[
+                    "shared_value_read_requests_sha256"
+                ],
+                "score_write_count": sum(row["score_write_count"] for row in direct["heads"]),
+                "score_read_count": sum(row["score_read_count"] for row in direct["heads"]),
+                "result_count": sum(row["result_count"] for row in direct["heads"]),
+                "config_path": source,
+            }
+        )
+
+    reference_hash = rows[-1]["expected_group_result_sha256"]
+    all_hashes_match = all(
+        row["expected_group_result_sha256"] == reference_hash
+        and row["observed_group_result_sha256"] == reference_hash
+        for row in rows
+    )
+    passed = all(row["equivalence_pass"] for row in rows) and all_hashes_match
+    latency_best = min(rows, key=lambda row: int(row["completion_cycles"]))
+    return {
+        "version": 1,
+        "model": "llama7b_gqa8_folded_query_head_lane_direct_rtl_equivalence_v1",
+        "decision": (
+            "llama7b_gqa8_folded_lane_equivalence_pass"
+            if passed
+            else "llama7b_gqa8_folded_lane_equivalence_fail"
+        ),
+        "equivalence_pass": passed,
+        "precision_contract": "exact_signed_int8_qkv_s32_score_lut_softmax_integer_output",
+        "query_heads_per_kv": HEAD_COUNT,
+        "tested_parallel_query_head_lanes": sorted(indexed),
+        "shared_result_sha256": reference_hash,
+        "all_lane_result_hashes_match": all_hashes_match,
+        "latency_best_parallel_query_head_lanes": latency_best[
+            "parallel_query_head_lanes"
+        ],
+        "latency_best_completion_cycles": latency_best["completion_cycles"],
+        "rows": rows,
+        "scope": {
+            "block_count": len(keys),
+            "head_dimension": 128,
+            "value_slices": VALUE_SLICES,
+            "direct_rtl_simulation": True,
+            "intermediate_score_writes_and_reads_checked": True,
+            "ordered_result_beats_checked": HEAD_COUNT * VALUE_SLICES,
+            "producer_contract": (
+                "Each of 8/L waves replays one complete packed Q/K packet; no hidden query or key buffer is assumed."
+            ),
+        },
+    }
+
+
+def _render_markdown(payload: JsonDict) -> str:
+    lines = [
+        "# Llama7B GQA8 Folded Query-Head Lane Equivalence",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- equivalence pass: `{payload['equivalence_pass']}`",
+        f"- shared result hash: `{payload['shared_result_sha256']}`",
+        f"- precision contract: `{payload['precision_contract']}`",
+        "",
+        "| lanes | waves | macros | cycles | Q/K replays | value reads/block | pass |",
+        "|---:|---:|---:|---:|---:|---:|:---:|",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {parallel_query_head_lanes} | {query_head_waves} | {score_bank_macro_count} | "
+            "{completion_cycles} | {query_input_replays_per_command} | "
+            "{shared_value_reads_per_block} | {equivalence_pass} |".format(**row)
+        )
+    lines.extend(["", payload["scope"]["producer_contract"]])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", action="append", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    configs = [
+        (str(path), json.loads(path.read_text(encoding="utf-8")))
+        for path in args.config
+    ]
+    payload = build_report(configs)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.write_text(_render_markdown(payload), encoding="utf-8")
+    print(json.dumps({"decision": payload["decision"], "ok": payload["equivalence_pass"]}, sort_keys=True))
+    return 0 if payload["equivalence_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_attention_decode_score_multivalue_gqa_folded_lane_equivalence.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_folded_lane_equivalence.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.audit_attention_decode_score_multivalue_gqa_folded_lane_equivalence import (
+    _render_markdown,
+    build_report,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _configs() -> list[tuple[str, dict]]:
+    design_root = REPO_ROOT / "runs" / "designs" / "npu_blocks"
+    names = {
+        1: "attention_decode_score_multivalue_gqa_group_lanes1_int8_m1x8_iterdiv",
+        2: "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv",
+        4: "attention_decode_score_multivalue_gqa_group_lanes4_int8_m1x8_iterdiv",
+        8: "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv",
+    }
+    rows = []
+    for lanes, name in names.items():
+        path = design_root / name / "config.json"
+        rows.append((str(path.relative_to(REPO_ROOT)), json.loads(path.read_text(encoding="utf-8"))))
+    return rows
+
+
+@pytest.fixture(scope="module")
+def report() -> dict:
+    return build_report(_configs())
+
+
+def test_folded_lane_direct_rtl_equivalence(report: dict) -> None:
+    assert report["decision"] == "llama7b_gqa8_folded_lane_equivalence_pass"
+    assert report["equivalence_pass"] is True
+    assert report["all_lane_result_hashes_match"] is True
+    assert report["tested_parallel_query_head_lanes"] == [1, 2, 4, 8]
+    assert report["precision_contract"].startswith("exact_signed_int8")
+    assert report["shared_result_sha256"]
+
+    rows = {row["parallel_query_head_lanes"]: row for row in report["rows"]}
+    assert {lanes: row["query_head_waves"] for lanes, row in rows.items()} == {
+        1: 8,
+        2: 4,
+        4: 2,
+        8: 1,
+    }
+    assert {lanes: row["score_bank_macro_count"] for lanes, row in rows.items()} == {
+        1: 56,
+        2: 112,
+        4: 224,
+        8: 448,
+    }
+    assert {lanes: row["shared_value_reads_per_block"] for lanes, row in rows.items()} == {
+        1: 128,
+        2: 64,
+        4: 32,
+        8: 16,
+    }
+    assert all(row["score_write_count"] == 24 for row in rows.values())
+    assert all(row["score_read_count"] == 24 for row in rows.values())
+    assert all(row["result_count"] == 128 for row in rows.values())
+    assert all(row["expected_group_result_sha256"] == report["shared_result_sha256"] for row in rows.values())
+    assert all(row["observed_group_result_sha256"] == report["shared_result_sha256"] for row in rows.values())
+
+
+def test_folded_lane_report_is_compact_and_states_replay_contract(report: dict) -> None:
+    assert len(json.dumps(report, sort_keys=True)) < 20_000
+    assert report["scope"]["direct_rtl_simulation"] is True
+    assert report["scope"]["intermediate_score_writes_and_reads_checked"] is True
+    assert report["scope"]["ordered_result_beats_checked"] == 128
+    assert "no hidden query or key buffer" in report["scope"]["producer_contract"]
+    markdown = _render_markdown(report)
+    assert "| lanes | waves | macros | cycles |" in markdown
+    assert "| 1 | 8 | 56 |" in markdown
+    assert "| 8 | 1 | 448 |" in markdown
+
+
+def test_folded_lane_report_requires_complete_lane_set() -> None:
+    with pytest.raises(ValueError, match="exactly one config"):
+        build_report(_configs()[:-1])


### PR DESCRIPTION
## Summary

- add a compact direct RTL equivalence audit for 1/2/4/8 GQA8 query-head lanes
- check every intermediate score write/read and all 128 ordered result beats
- record physical lane count, score SRAM macros, cycles, Q/K replays, and value reads per block
- add a Layer 2 task-generator contract for remote evidence production

## Measured direct-simulation boundary

| lanes | macros | cycles | Q/K replays | value reads/block |
|---:|---:|---:|---:|---:|
| 1 | 56 | 66,671 | 8 | 128 |
| 2 | 112 | 62,199 | 4 | 64 |
| 4 | 224 | 59,963 | 2 | 32 |
| 8 | 448 | 58,845 | 1 | 16 |

All four configurations produce the same exact integer result hash. No hidden query or key buffer is assumed.

## Validation

- `3 passed` folded equivalence artifact tests
- `213 passed` Layer 2 generator tests
- exact production-config audit passed
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
