### PR TITLE
Register folded GQA8 lane PPA

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -63,6 +63,75 @@
       "status": "pending_implementation_merge"
     },
     {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the one-lane folded GQA8 group at the matched-density 2.50 mm die and 8/10 ns targets.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
+      "comparison_role": "gqa8_folded_lanes1_matched_density_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes1_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes1.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_gqa8_folded_lanes1_matched_density_ppa",
+        "reason": "Establish the minimum-area full-GQA8 point while preserving explicit eight-wave replay costs."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the two-lane folded GQA8 group at the matched-density 3.55 mm die and 8/10 ns targets.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
+      "comparison_role": "gqa8_folded_lanes2_matched_density_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes2.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_gqa8_folded_lanes2_matched_density_ppa",
+        "reason": "Measure the first area-versus-replay midpoint without changing placement density."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the four-lane folded GQA8 group at the matched-density 5.05 mm die and 8/10 ns targets.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
+      "comparison_role": "gqa8_folded_lanes4_matched_density_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes4_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes4.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_gqa8_folded_lanes4_matched_density_ppa",
+        "reason": "Measure the near-parallel point before paying for all 448 score SRAM macros."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
       "task_type": "l1_sweep",
       "objective": "Measure the complete GQA8 group at 7.2, 8.0, and 9.0 mm dies and 8/10 ns targets.",

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -96,6 +96,75 @@
       "status": "pending_control_plane_merge"
     },
     {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the one-lane folded group at matched macro density.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
+      "comparison_role": "gqa8_folded_lanes1_matched_density_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes1_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes1.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_gqa8_folded_lanes1_matched_density_ppa",
+        "reason": "Anchor minimum physical area with explicit eight-wave replay."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the two-lane folded group at matched macro density.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
+      "comparison_role": "gqa8_folded_lanes2_matched_density_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes2.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_gqa8_folded_lanes2_matched_density_ppa",
+        "reason": "Measure the first area and replay midpoint."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the four-lane folded group at matched macro density.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
+      "comparison_role": "gqa8_folded_lanes4_matched_density_pnr",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes4_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes4.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_gqa8_folded_lanes4_matched_density_ppa",
+        "reason": "Measure the near-parallel point before full eight-lane SRAM replication."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
       "task_type": "l1_sweep",
       "objective": "Measure the complete eight-head GQA group over the macro-derived physical envelope.",


### PR DESCRIPTION
## Summary

- register matched-density Nangate45 PPA jobs for 1/2/4 folded GQA8 lanes
- gate every physical job on direct folded-lane RTL equivalence
- limit each first-pass sweep to 8 ns and 10 ns at one density-matched die size

## Physical points

- 1 lane: 56 macros, 2.50 mm die
- 2 lanes: 112 macros, 3.55 mm die
- 4 lanes: 224 macros, 5.05 mm die
- 8-lane baseline: 448 macros, existing 7.20 mm point

## Validation

- JSON parsing
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
