### PR TITLE
Retain GQA8 physical boundary evidence

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -65,7 +65,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the one-lane folded GQA8 group at the matched-density 2.50 mm die and 8/10 ns targets.",
+      "objective": "Measure the one-lane folded GQA8 group at the matched-density 2.50 mm die and 8/10 ns targets, retaining failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
       "comparison_role": "gqa8_folded_lanes1_matched_density_pnr",
@@ -88,7 +88,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the two-lane folded GQA8 group at the matched-density 3.55 mm die and 8/10 ns targets.",
+      "objective": "Measure the two-lane folded GQA8 group at the matched-density 3.55 mm die and 8/10 ns targets, retaining failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
       "comparison_role": "gqa8_folded_lanes2_matched_density_pnr",
@@ -111,7 +111,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the four-lane folded GQA8 group at the matched-density 5.05 mm die and 8/10 ns targets.",
+      "objective": "Measure the four-lane folded GQA8 group at the matched-density 5.05 mm die and 8/10 ns targets, retaining failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
       "comparison_role": "gqa8_folded_lanes4_matched_density_pnr",
@@ -134,7 +134,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the complete GQA8 group at 7.2, 8.0, and 9.0 mm dies and 8/10 ns targets.",
+      "objective": "Measure the complete GQA8 group at 7.2, 8.0, and 9.0 mm dies and 8/10 ns targets, retaining failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group",
       "comparison_role": "gqa8_shared_kv_group_pnr",
@@ -269,7 +269,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g1_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the one-group array wrapper at 7.2 mm and 8/10 ns.",
+      "objective": "Measure the one-group array wrapper at 7.2 mm and 8/10 ns, retaining failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
       "comparison_role": "gqa8_array_g1_pnr",
@@ -292,7 +292,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g2_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the two-group array at 10.2 mm and 8/10 ns.",
+      "objective": "Measure the two-group array at 10.2 mm and 8/10 ns, retaining failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
       "comparison_role": "gqa8_array_g2_pnr",
@@ -315,7 +315,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g4_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the complete four-group array at 14.4 mm and 8/10 ns.",
+      "objective": "Measure the complete four-group array at 14.4 mm and 8/10 ns, retaining failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
       "comparison_role": "gqa8_array_g4_pnr",

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -98,7 +98,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the one-lane folded group at matched macro density.",
+      "objective": "Measure the one-lane folded group at matched macro density and retain failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
       "comparison_role": "gqa8_folded_lanes1_matched_density_pnr",
@@ -121,7 +121,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the two-lane folded group at matched macro density.",
+      "objective": "Measure the two-lane folded group at matched macro density and retain failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
       "comparison_role": "gqa8_folded_lanes2_matched_density_pnr",
@@ -144,7 +144,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the four-lane folded group at matched macro density.",
+      "objective": "Measure the four-lane folded group at matched macro density and retain failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
       "comparison_role": "gqa8_folded_lanes4_matched_density_pnr",
@@ -167,7 +167,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the complete eight-head GQA group over the macro-derived physical envelope.",
+      "objective": "Measure the complete eight-head GQA group over the macro-derived physical envelope and retain failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group",
       "comparison_role": "gqa8_shared_kv_group_pnr",
@@ -302,7 +302,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g1_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the direct one-group array wrapper at the equal-density physical point.",
+      "objective": "Measure the direct one-group array wrapper at the equal-density physical point and retain failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
       "comparison_role": "gqa8_array_g1_pnr",
@@ -325,7 +325,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g2_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the direct two-group array at equal macro density.",
+      "objective": "Measure the direct two-group array at equal macro density and retain failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
       "comparison_role": "gqa8_array_g2_pnr",
@@ -348,7 +348,7 @@
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_array_g4_pnr_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the complete four-group Llama7B GQA array at equal macro density.",
+      "objective": "Measure the complete four-group Llama7B GQA array at equal macro density and retain failed rows as explicit boundary evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_array",
       "comparison_role": "gqa8_array_g4_pnr",


### PR DESCRIPTION
## Summary

- mark full, folded-lane, and array GQA8 PPA sweeps as physical-boundary measurements
- activate the existing L1 worker policy that accepts all-`flow_failed` metrics as explicit boundary evidence
- prevent future all-infeasible sweeps from discarding completed physical results

## Motivation

The full eight-lane sweep completed all six OpenROAD points, but acceptance rejected the result solely because every row was `flow_failed`. Those rows define the current physical feasibility boundary and must remain reviewable.

## Validation

- `python3 scripts/validate_runs.py --skip_eval_queue`
- boundary-focused L1 generator/worker tests: 4 passed
- `git diff --check`