### PR TITLE
Consume folded GQA8 equivalence evidence

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -29,6 +29,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_decode_score_local_cluster_",
     "decoder_attention_decode_score_multivalue_cluster_",
     "decoder_attention_decode_score_multivalue_gqa_group_",
+    "decoder_attention_decode_score_multivalue_gqa_folded_lane_",
     "decoder_attention_mixed_int8_",
     "decoder_attention_noc_profile__",
     "decoder_attention_operational_component_frontier__",

--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -635,6 +635,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "decode_score_multivalue_gqa_group_equivalence_report",
     ),
     (
+        "decode_score_multivalue_gqa_folded_lane_equivalence_out",
+        "decode_score_multivalue_gqa_folded_lane_equivalence_report",
+    ),
+    (
         "decode_score_multivalue_gqa_array_equivalence_out",
         "decode_score_multivalue_gqa_array_equivalence_report",
     ),
@@ -1728,6 +1732,35 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         if direct_flat_rtl:
             parts.append(f"flat_8_cluster_equivalence_pass={flat_equivalence_pass}")
         parts.append(f"flat_8_cluster_simulation_proof={bool(flat_simulation_run and flat_equivalence_pass)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llama7b_gqa8_folded_query_head_lane_direct_rtl_equivalence_v1":
+        outcome = str(evidence_payload.get("decision") or "llama7b_gqa8_folded_lane_equivalence_recorded")
+        rows = evidence_payload.get("rows")
+        row_list = [dict(row) for row in rows if isinstance(row, dict)] if isinstance(rows, list) else []
+        parts = [f"Llama7B GQA8 folded query-head lane direct RTL equivalence recorded from {evidence_ref}: decision={outcome}"]
+        for key in (
+            "equivalence_pass",
+            "precision_contract",
+            "query_heads_per_kv",
+            "tested_parallel_query_head_lanes",
+            "shared_result_sha256",
+            "all_lane_result_hashes_match",
+            "latency_best_parallel_query_head_lanes",
+            "latency_best_completion_cycles",
+        ):
+            if key in evidence_payload:
+                parts.append(f"{key}={evidence_payload.get(key)}")
+        if row_list:
+            parts.append(f"lane_point_count={len(row_list)}")
+            parts.append(
+                "lane_cycles="
+                + ",".join(
+                    f"{row.get('parallel_query_head_lanes')}:{row.get('completion_cycles')}"
+                    for row in row_list
+                )
+            )
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -170,3 +170,14 @@ def test_transportable_expected_output_allows_decode_score_multivalue_gqa_group_
 
     assert is_transportable_expected_output(f"{base}{stem}.json")
     assert is_transportable_expected_output(f"{base}{stem}.md")
+
+
+def test_transportable_expected_output_allows_decode_score_multivalue_gqa_folded_lane_equivalence() -> None:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    stem = (
+        "decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence__"
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+    )
+
+    assert is_transportable_expected_output(f"{base}{stem}.json")
+    assert is_transportable_expected_output(f"{base}{stem}.md")

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -261,6 +261,7 @@ def test_decoder_evidence_paths_recognizes_decode_score_multivalue_gqa_group_equ
 @pytest.mark.parametrize(
     "prefix",
     [
+        "decode_score_multivalue_gqa_folded_lane_equivalence",
         "decode_score_multivalue_gqa_array_equivalence",
         "decode_score_multivalue_gqa_group_activity_power",
         "decode_score_multivalue_gqa_group_frontier",
@@ -501,6 +502,35 @@ def test_decoder_evidence_summary_recognizes_direct_flat_gqa_group_equivalence()
         "flat_8_cluster_simulation_proof=True",
     ):
         assert field in summary
+
+
+def test_decoder_evidence_summary_recognizes_folded_gqa_lane_equivalence() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/decode_score_multivalue_gqa_folded_lane_equivalence.json",
+        evidence_payload={
+            "model": "llama7b_gqa8_folded_query_head_lane_direct_rtl_equivalence_v1",
+            "decision": "llama7b_gqa8_folded_lane_equivalence_pass",
+            "equivalence_pass": True,
+            "precision_contract": "exact_signed_int8_qkv_s32_score_lut_softmax_integer_output",
+            "query_heads_per_kv": 8,
+            "tested_parallel_query_head_lanes": [1, 2, 4, 8],
+            "shared_result_sha256": "sharedhash",
+            "all_lane_result_hashes_match": True,
+            "latency_best_parallel_query_head_lanes": 8,
+            "latency_best_completion_cycles": 58845,
+            "rows": [
+                {"parallel_query_head_lanes": 1, "completion_cycles": 66671},
+                {"parallel_query_head_lanes": 2, "completion_cycles": 62199},
+                {"parallel_query_head_lanes": 4, "completion_cycles": 59963},
+                {"parallel_query_head_lanes": 8, "completion_cycles": 58845},
+            ],
+        },
+    )
+
+    assert outcome == "llama7b_gqa8_folded_lane_equivalence_pass"
+    assert "all_lane_result_hashes_match=True" in summary
+    assert "lane_point_count=4" in summary
+    assert "lane_cycles=1:66671,2:62199,4:59963,8:58845" in summary
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- make folded GQA8 lane JSON/Markdown transportable worker evidence
- register the folded lane output/report pair with the L2 decoder-evidence consumer
- summarize exact precision, shared hashes, lane cycles, and pass state in the decision record
- prevent successful folded equivalence runs from falling back to `/best_point.json`

## Recovery

The successful run `l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1_run_3b78069569b1754a` must be reprocessed from existing outputs after merge; do not rerun RTL simulation.

## Validation

- artifact policy and full L2 consumer tests: 119 passed
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`