### PR TITLE
Measure folded GQA lane activity frontier

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1793,7 +1793,13 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         for key in ("promotion_gate_pass", "candidate_count", "promoted_candidate_count", "best_candidate_id", "energy_scope"):
             if key in evidence_payload:
                 parts.append(f"{key}={evidence_payload.get(key)}")
-        for key in ("direct_group_full_context_energy_j", "status", "flow_variant"):
+        for key in (
+            "direct_group_full_context_energy_j",
+            "status",
+            "flow_variant",
+            "parallel_query_head_lanes",
+            "query_head_waves",
+        ):
             if key in best_dict:
                 parts.append(f"best_{key}={best_dict.get(key)}")
         summary = "; ".join(parts)
@@ -1804,7 +1810,16 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         best = evidence_payload.get("best_throughput_candidate")
         best_dict = dict(best) if isinstance(best, dict) else {}
         parts = [f"Llama7B measured GQA8 group frontier recorded from {evidence_ref}: decision={outcome}"]
-        for key in ("candidate_id", "group_count", "token_throughput_per_s", "latency_us", "embodied_logic_plus_shared_sram_area_mm2", "gqa_group_component_energy_mj_per_token"):
+        for key in (
+            "candidate_id",
+            "parallel_query_head_lanes",
+            "query_head_waves",
+            "group_count",
+            "token_throughput_per_s",
+            "latency_us",
+            "embodied_logic_plus_shared_sram_area_mm2",
+            "gqa_group_component_energy_mj_per_token",
+        ):
             if key in best_dict:
                 parts.append(f"best_{key}={best_dict.get(key)}")
         if "promotion_status" in evidence_payload:

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -30,6 +30,7 @@ class Layer2TaskGenerationError(RuntimeError):
 
 _RETRY_SUFFIX_RE = re.compile(r"_r\d+$")
 _VERSION_SUFFIX_RE = re.compile(r"_v(\d+)$")
+_GQA_FOLDED_ACTIVITY_LANES_RE = re.compile(r"_gqa8_folded_lanes(1|2|4|8)_activity_power_")
 
 
 @dataclass(frozen=True)
@@ -97,6 +98,11 @@ def _gqa_evidence_version_for_consumer(item_id: str) -> str:
 def _gqa_group_equivalence_item_for_consumer(item_id: str) -> str:
     version = _gqa_evidence_version_for_consumer(item_id)
     return f"l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_{version}"
+
+
+def _gqa_folded_activity_lanes(item_id: str) -> int | None:
+    match = _GQA_FOLDED_ACTIVITY_LANES_RE.search(_retry_base(item_id))
+    return int(match.group(1)) if match else None
 
 
 def _proposal_dir(repo_root: Path, proposal_path: str | None) -> Path | None:
@@ -6904,20 +6910,36 @@ def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*
 
 def _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
-    design = "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv"
+    folded_lanes = _gqa_folded_activity_lanes(item_id)
+    design = (
+        f"attention_decode_score_multivalue_gqa_group_lanes{folded_lanes}_int8_m1x8_iterdiv"
+        if folded_lanes is not None and folded_lanes != 8
+        else "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv"
+    )
     config = f"runs/designs/npu_blocks/{design}/config.json"
     metrics_csv = f"runs/designs/npu_blocks/{design}/metrics.csv"
-    group_equivalence_item = _gqa_group_equivalence_item_for_consumer(item_id)
-    equivalence_json = (
-        f"{base}/decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
-        f"{group_equivalence_item}.json"
-    )
+    if folded_lanes is not None:
+        equivalence_json = (
+            f"{base}/decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence__"
+            "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_"
+            "llama7b_v1.json"
+        )
+    else:
+        group_equivalence_item = _gqa_group_equivalence_item_for_consumer(item_id)
+        equivalence_json = (
+            f"{base}/decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
+            f"{group_equivalence_item}.json"
+        )
     cluster_activity_power_json = (
         f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__"
         "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
     )
     orfs_design_config = f"/orfs/flow/designs/nangate45/{design}/config.mk"
-    activity_dir = "/tmp/rtlgen_multivalue_gqa_group_activity"
+    activity_dir = (
+        f"/tmp/rtlgen_multivalue_gqa_folded_lanes{folded_lanes}_activity"
+        if folded_lanes is not None
+        else "/tmp/rtlgen_multivalue_gqa_group_activity"
+    )
     out = f"{base}/decoder_attention_decode_score_multivalue_gqa_group_activity_power__{item_id}.json"
     report = f"{base}/decoder_attention_decode_score_multivalue_gqa_group_activity_power__{item_id}.md"
     return {
@@ -6932,8 +6954,13 @@ def _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence
             "decode_score_multivalue_gqa_group_activity_power_report": report,
             "decode_score_multivalue_gqa_group_activity_power_scope": (
                 "Measure the GQA8 shared-K/V group activity contract after merged equivalence and PNR. "
-                "The report must distinguish directly annotated group activity from compositional scaling, "
-                "keep VCD/ODB/SPEF evaluator-local, and withhold total-token energy claims."
+                + (
+                    f"This candidate has {folded_lanes} physical query-head lane(s) and charges all explicit waves and replays. "
+                    if folded_lanes is not None
+                    else ""
+                )
+                + "The report must distinguish directly annotated group activity from compositional scaling, "
+                + "keep VCD/ODB/SPEF evaluator-local, and withhold total-token energy claims."
             ),
             "decode_score_multivalue_gqa_group_activity_power_promotion_gate": (
                 "Promotion requires explicit activity provenance, phase-cycle accounting, routed-power "
@@ -7101,35 +7128,55 @@ def _decoder_attention_decode_score_multivalue_gqa_group_frontier_evidence(*, it
         f"{base}/decoder_attention_decode_score_multivalue_cluster_frontier__"
         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1.json"
     )
+    folded = "gqa8_folded_frontier" in _retry_base(item_id)
     activity_power = (
         f"{base}/decoder_attention_decode_score_multivalue_gqa_group_activity_power__"
         f"l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_{evidence_version}.json"
     )
+    folded_activity = {
+        lanes: (
+            f"{base}/decoder_attention_decode_score_multivalue_gqa_group_activity_power__"
+            f"l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes{lanes}_activity_power_"
+            "llama7b_v1.json"
+        )
+        for lanes in (1, 2, 4)
+    }
     group_counts = "1,2,4"
     out = f"{base}/decoder_attention_decode_score_multivalue_gqa_group_frontier__{item_id}.json"
     report = f"{base}/decoder_attention_decode_score_multivalue_gqa_group_frontier__{item_id}.md"
-    return {
-        "inputs": {
+    inputs = {
             "decode_score_multivalue_gqa_group_frontier_prior_frontier": prior,
-            "decode_score_multivalue_gqa_group_frontier_activity_power": activity_power,
             "decode_score_multivalue_gqa_group_frontier_group_counts": group_counts,
             "decode_score_multivalue_gqa_group_frontier_out": out,
             "decode_score_multivalue_gqa_group_frontier_report": report,
             "decode_score_multivalue_gqa_group_frontier_scope": (
                 "Recost the Llama7B GQA8 proxy with one, two, and four deployed complete shared-K/V groups, "
-                "using measured group timing, area, and activity energy. Preserve exact integer precision and "
+                "using measured group timing, area, and activity energy across explicit folded-lane points. "
+                "Preserve exact integer precision and "
                 "compare against the prior independent-cluster frontier. Multi-group PPA is linearly composed, "
                 "not array-PNR measured; off-group memory, NoC, HBM/DRAM, clock-tree composition, and total-token "
                 "energy remain explicit abstractions."
             ),
-        },
+    }
+    if folded:
+        inputs["decode_score_multivalue_gqa_group_frontier_folded_lane_activity_power"] = {
+            str(lanes): path for lanes, path in folded_activity.items()
+        }
+        activity_args = " ".join(
+            f"--lane-activity {lanes}={path}" for lanes, path in folded_activity.items()
+        )
+    else:
+        inputs["decode_score_multivalue_gqa_group_frontier_activity_power"] = activity_power
+        activity_args = f"--group-activity-power-json {activity_power}"
+    return {
+        "inputs": inputs,
         "commands": [
             {
                 "name": "audit_decode_score_multivalue_gqa_group_frontier",
                 "run": (
                     "python3 -m npu.eval.audit_attention_decode_score_multivalue_gqa_group_frontier "
                     f"--prior-frontier-json {prior} "
-                    f"--group-activity-power-json {activity_power} "
+                    f"{activity_args} "
                     f"--group-counts {group_counts} "
                     f"--out {out} --out-md {report}"
                 ),

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -580,6 +580,33 @@ def test_decoder_evidence_summary_recognizes_gqa_followons(
     assert expected in summary
 
 
+def test_decoder_evidence_summary_includes_folded_lane_identity() -> None:
+    _, activity_summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/folded-activity.json",
+        evidence_payload={
+            "model": "decoder_attention_decode_score_multivalue_gqa_group_activity_power_v1",
+            "decision": "activity_backed_gqa_group_power_measured",
+            "best": {"parallel_query_head_lanes": 2, "query_head_waves": 4},
+        },
+    )
+    _, frontier_summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/folded-frontier.json",
+        evidence_payload={
+            "model": "decoder_attention_decode_score_multivalue_gqa_group_frontier_llama7b_v1",
+            "decision": "measured_complete_gqa8_group_component_frontier_promoted",
+            "best_throughput_candidate": {
+                "parallel_query_head_lanes": 4,
+                "query_head_waves": 2,
+            },
+        },
+    )
+
+    assert "best_parallel_query_head_lanes=2" in activity_summary
+    assert "best_query_head_waves=4" in activity_summary
+    assert "best_parallel_query_head_lanes=4" in frontier_summary
+    assert "best_query_head_waves=2" in frontier_summary
+
+
 def test_consume_l2_result_uses_gqa_array_equivalence_evidence_without_best_point() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8189,6 +8189,57 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activi
             ] in work_item.expected_outputs
 
 
+def test_generate_l2_campaign_task_adds_folded_gqa_lane_activity_power() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            for lanes in (1, 2, 4):
+                item_id = (
+                    "l2_decoder_attention_decode_score_multivalue_gqa8_folded_"
+                    f"lanes{lanes}_activity_power_llama7b_v1"
+                )
+                result = generate_l2_campaign_task(
+                    session,
+                    Layer2CampaignGenerateRequest(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        item_id=item_id,
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        abstraction_layer=(
+                            "decoder_attention_decode_score_multivalue_gqa_group_activity_power"
+                        ),
+                        evaluation_mode="frontier_detail",
+                        run_physical=False,
+                    ),
+                )
+
+                work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+                run = work_item.command_manifest[0]["run"]
+                decoder_inputs = work_item.input_manifest["decoder_contract"]
+                design = (
+                    "attention_decode_score_multivalue_gqa_group_"
+                    f"lanes{lanes}_int8_m1x8_iterdiv"
+                )
+                assert f"--config runs/designs/npu_blocks/{design}/config.json" in run
+                assert f"--group-metrics-csv runs/designs/npu_blocks/{design}/metrics.csv" in run
+                assert (
+                    "decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence__"
+                    "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_"
+                    "equivalence_llama7b_v1.json"
+                ) in run
+                assert f"--activity-dir /tmp/rtlgen_multivalue_gqa_folded_lanes{lanes}_activity" in run
+                assert f"{lanes} physical query-head lane(s)" in decoder_inputs[
+                    "decode_score_multivalue_gqa_group_activity_power_scope"
+                ]
+
+
 def test_generate_l2_campaign_task_adds_decode_score_tile_frontier() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -8401,6 +8452,55 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_fronti
             assert decoder_inputs[
                 "decode_score_multivalue_gqa_group_frontier_report"
             ] in work_item.expected_outputs
+
+
+def test_generate_l2_campaign_task_adds_folded_gqa_frontier() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_"
+                        "frontier_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_decode_score_multivalue_gqa_group_frontier"
+                    ),
+                    evaluation_mode="frontier_recost",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert run.count("--lane-activity") == 3
+            for lanes in (1, 2, 4):
+                expected = (
+                    f"--lane-activity {lanes}=runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                    "decoder_attention_decode_score_multivalue_gqa_group_activity_power__"
+                    "l2_decoder_attention_decode_score_multivalue_gqa8_folded_"
+                    f"lanes{lanes}_activity_power_llama7b_v1.json"
+                )
+                assert expected in run
+            assert "--group-activity-power-json" not in run
+            assert set(
+                decoder_inputs[
+                    "decode_score_multivalue_gqa_group_frontier_folded_lane_activity_power"
+                ]
+            ) == {"1", "2", "4"}
 
 
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_array_frontier() -> None:

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_gate.md
@@ -11,16 +11,20 @@
 5. Preserve the explicit scope statement that no flat eight-cluster RTL
    equivalence simulation was run.
 6. Keep timing- or placement-infeasible sweep rows as boundary evidence.
-7. Treat vectorless power as structural evidence only; activity-backed energy
-   remains a follow-on gate.
-8. Gate activity power on merged equivalence and PPA, explicit phase-cycle
-   accounting, routed annotation coverage for directly measured components,
-   and direct-versus-compositional provenance. Do not promote compositional
-   scaling as a direct full-group power measurement or as total token energy.
-9. Recost only group counts 1, 2, and 4 for the four Llama7B GQA groups per
-   layer. Use measured one-group timing, area, and activity energy, identify
-   multi-group area/power as linear composition rather than array PNR, and
-   retain off-group memory/NoC/HBM and total-token energy as open boundaries.
+7. Treat vectorless power as structural evidence only. Measure activity-backed
+   energy separately for every timing-feasible folded lane count; never infer a
+   missing lane point by linear scaling.
+8. Gate folded activity power on the matching 1/2/4/8-lane equivalence row and
+   PPA artifact, explicit accounting for every query-head wave and replay,
+   routed annotation coverage, and direct-versus-compositional provenance. The
+   activity transaction may include one observation cycle after the equivalence
+   completion cycle, but no command-service cycle may be omitted.
+9. Recost the Cartesian product of measured folded lane counts and physical
+   group counts 1, 2, and 4 for the four Llama7B GQA groups per layer. Use each
+   lane point's measured timing, area, cycles, and activity energy. Identify
+   multi-group area/power as linear composition until direct array PNR/activity
+   exists, and retain off-group memory/NoC/HBM and total-token energy as open
+   boundaries.
 10. Before direct array PPA, compose the merged complete-group equivalence
     result with protocol simulations of generated one-, two-, and four-group
     wrappers. Require atomic command/input acceptance and independent external

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -164,6 +164,95 @@
         "direction": "measure_gqa8_shared_kv_group_ppa",
         "reason": "Use an explicit macro-derived die-size boundary and retain infeasible rows."
       },
+      "status": "boundary_evidence_merged_no_feasible_row",
+      "merged_pr_number": 1349
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure activity-backed power for the timing-feasible one-lane folded GQA8 group.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+      "comparison_role": "gqa8_folded_lanes1_activity_power",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_folded_lanes1_direct_activity_energy",
+        "reason": "The minimum-area point needs routed, phase-accounted energy with all eight waves charged."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure activity-backed power for the two-lane folded GQA8 group.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+      "comparison_role": "gqa8_folded_lanes2_activity_power",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_folded_lanes2_direct_activity_energy",
+        "reason": "The first lane-parallel midpoint needs routed energy rather than linear scaling from one lane."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure activity-backed power for the four-lane folded GQA8 group.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+      "comparison_role": "gqa8_folded_lanes4_activity_power",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_folded_lanes4_direct_activity_energy",
+        "reason": "The near-parallel point needs routed energy before it can trade area for latency."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_folded_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost Llama7B over folded lane counts 1/2/4 and deployed physical GQA-group counts 1/2/4.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_frontier",
+      "comparison_role": "gqa8_folded_lane_and_group_count_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_activity_power_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_activity_power_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "full_eight_lane_group_is_physically_infeasible_and_must_be_replaced_by_measured_folded_points",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "rank_measured_folded_lane_and_group_count_points",
+        "reason": "The Llama7B frontier must use measured cycles, PPA, and energy for each folded lane count rather than the failed eight-lane point or linear lane scaling."
+      },
       "status": "pending_implementation_merge"
     },
     {
@@ -185,7 +274,7 @@
         "direction": "measure_gqa8_shared_kv_group_activity_energy",
         "reason": "Token-energy ranking requires phase-accounted activity evidence and must distinguish direct routed measurement from compositional scaling."
       },
-      "status": "pending_implementation_merge"
+      "status": "superseded_by_folded_lane_activity"
     },
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v2",
@@ -212,7 +301,7 @@
         "direction": "measure_direct_equivalence_backed_gqa8_group_activity_energy",
         "reason": "The activity result must consume the direct-flat group proof rather than only wait for it while reading compositional v1 evidence."
       },
-      "status": "pending_implementation_merge"
+      "status": "superseded_by_folded_lane_activity"
     },
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1",
@@ -232,7 +321,7 @@
         "direction": "rank_measured_gqa8_group_deployments",
         "reason": "Convert measured group PPA and component energy into Llama7B latency, throughput, and area points while retaining composition limits."
       },
-      "status": "pending_implementation_merge"
+      "status": "superseded_by_folded_frontier"
     },
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1",

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -13,6 +13,7 @@
     "include": [
       "eight distinct query heads sharing one key and value tensor",
       "eight parallel measured multivalue score/value clusters",
+      "one, two, and four physical query-head lane implementations with explicit 8/L waves",
       "one shared external value request per block and value slice",
       "head-major and slice-major backpressured result serialization",
       "direct flat eight-cluster RTL arithmetic, score-tensor, shared-request, and ordered-result equivalence",
@@ -22,6 +23,7 @@
       "the direct flat simulation remains bounded to three KV blocks rather than the full 16K context",
       "do not treat vectorless power as token energy",
       "do not assume the 2.5 mm to 3.0 mm single-cluster die envelope can contain 448 SRAM macros",
+      "do not extrapolate folded-lane activity energy from another lane count",
       "HBM and off-chip DRAM remain outside this local GQA-group boundary"
     ],
     "metrics": [
@@ -185,6 +187,94 @@
         "direction": "measure_gqa8_shared_kv_group_ppa",
         "reason": "The embodied group determines whether the 8x value-bandwidth reduction is affordable in area and timing."
       },
+      "status": "boundary_evidence_merged_no_feasible_row"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure routed activity-backed power for the one-lane folded group with all eight waves charged.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+      "comparison_role": "gqa8_folded_lanes1_activity_power",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_folded_lanes1_direct_activity_energy",
+        "reason": "The minimum-area point needs direct phase-accounted energy rather than vectorless power."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure routed activity-backed power for the two-lane folded group.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+      "comparison_role": "gqa8_folded_lanes2_activity_power",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_folded_lanes2_direct_activity_energy",
+        "reason": "The midpoint needs direct routed energy instead of linear lane scaling."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure routed activity-backed power for the four-lane folded group.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+      "comparison_role": "gqa8_folded_lanes4_activity_power",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
+        "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_folded_lanes4_direct_activity_energy",
+        "reason": "The near-parallel point needs direct routed energy before trading area for latency."
+      },
+      "status": "pending_control_plane_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_folded_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost Llama7B over measured folded lane counts 1/2/4 and deployed physical group counts 1/2/4.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_group_frontier",
+      "comparison_role": "gqa8_folded_lane_and_group_count_frontier",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_activity_power_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_activity_power_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "full_eight_lane_group_is_physically_infeasible_and_must_be_replaced_by_measured_folded_points",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "rank_measured_folded_lane_and_group_count_points",
+        "reason": "Use measured cycles, PPA, and direct energy at each folded lane count."
+      },
       "status": "pending_control_plane_merge"
     },
     {
@@ -206,7 +296,7 @@
         "direction": "measure_gqa8_shared_kv_group_activity_energy",
         "reason": "Energy ranking is ineligible until activity provenance, phase cycles, annotation coverage, and finite routed power are recorded."
       },
-      "status": "pending_control_plane_merge"
+      "status": "superseded_by_folded_lane_activity"
     },
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v2",
@@ -233,7 +323,7 @@
         "direction": "measure_direct_equivalence_backed_gqa8_group_activity_energy",
         "reason": "Energy evidence is promoted only when its semantic input is the direct-flat v2 group proof."
       },
-      "status": "pending_control_plane_merge"
+      "status": "superseded_by_folded_lane_activity"
     },
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1",
@@ -253,7 +343,7 @@
         "direction": "rank_measured_gqa8_group_deployments",
         "reason": "Use measured one-group timing, area, and activity energy while exposing linear multi-group PPA composition."
       },
-      "status": "pending_control_plane_merge"
+      "status": "superseded_by_folded_frontier"
     },
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_array_equivalence_llama7b_v1",

--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_group_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_group_activity_power.py
@@ -17,6 +17,7 @@ from npu.synth.run_postroute_vcd_power import build_report as build_power_report
 
 JsonDict = dict[str, Any]
 _GQA_HEADS = 8
+_PARALLEL_QUERY_HEAD_LANES = {1, 2, 4, 8}
 _CLUSTER_ACTIVITY_MODEL = "decoder_attention_decode_score_multivalue_cluster_activity_power_v1"
 
 
@@ -112,6 +113,20 @@ def _finite_positive(value: object, label: str) -> float:
     return number
 
 
+def _parallel_query_head_lanes(config: JsonDict) -> int:
+    body = config.get("attention_decode_score_multivalue_gqa_group")
+    if not isinstance(body, dict):
+        raise ValueError("equivalence gating requires attention_decode_score_multivalue_gqa_group in config")
+    if int(body.get("query_heads_per_kv", _GQA_HEADS)) != _GQA_HEADS:
+        raise ValueError("equivalence gating requires GQA8")
+    lanes = int(body.get("parallel_query_head_lanes", _GQA_HEADS))
+    if lanes not in _PARALLEL_QUERY_HEAD_LANES:
+        raise ValueError("equivalence gating requires parallel_query_head_lanes in {1,2,4,8}")
+    if _GQA_HEADS % lanes != 0:
+        raise ValueError("equivalence gating requires parallel_query_head_lanes to divide 8")
+    return lanes
+
+
 def _cluster_baseline(path: Path, clock_period_ns: float) -> JsonDict:
     payload = _load(path)
     if payload.get("model") != _CLUSTER_ACTIVITY_MODEL:
@@ -181,7 +196,51 @@ def _cluster_baseline(path: Path, clock_period_ns: float) -> JsonDict:
     }
 
 
-def _validate_gqa_equivalence(equivalence: JsonDict) -> JsonDict:
+def _validate_gqa_equivalence(equivalence: JsonDict, *, parallel_query_head_lanes: int) -> JsonDict:
+    heads = int(equivalence.get("query_heads_per_kv", _GQA_HEADS))
+    if heads != _GQA_HEADS:
+        raise ValueError("equivalence report is not for GQA8")
+    rows = equivalence.get("rows")
+    if isinstance(rows, list):
+        selected_rows = [
+            row
+            for row in rows
+            if isinstance(row, dict) and int(row.get("parallel_query_head_lanes", -1)) == parallel_query_head_lanes
+        ]
+        if not selected_rows:
+            raise ValueError(
+                "folded-lane GQA8 equivalence report is missing the configured parallel_query_head_lanes row"
+            )
+        row = selected_rows[0]
+        expected_hash = row.get("expected_group_result_sha256")
+        observed_hash = row.get("observed_group_result_sha256")
+        if not (
+            row.get("equivalence_pass") is True
+            and isinstance(expected_hash, str)
+            and expected_hash
+            and expected_hash == observed_hash
+        ):
+            raise ValueError("folded-lane equivalence row did not pass for configured lane count")
+        completion_cycles = int(row.get("completion_cycles", 0))
+        if completion_cycles <= 0:
+            raise ValueError("folded-lane equivalence row lacks positive completion_cycles")
+        shared_hash = equivalence.get("shared_result_sha256")
+        if isinstance(shared_hash, str) and shared_hash and shared_hash != expected_hash:
+            raise ValueError(
+                "folded-lane equivalence report shared_result_sha256 does not match the selected lane row"
+            )
+        return {
+            "equivalence_pass": True,
+            "decision": equivalence.get("decision"),
+            "semantic_profile": equivalence.get("model"),
+            "query_heads_per_kv": heads,
+            "parallel_query_head_lanes": parallel_query_head_lanes,
+            "query_head_waves": _GQA_HEADS // parallel_query_head_lanes,
+            "completion_cycles": completion_cycles,
+            "expected_group_result_sha256": expected_hash,
+            "observed_group_result_sha256": observed_hash,
+        }
+
     wrapper = equivalence.get("wrapper_protocol")
     expected_hash = equivalence.get("expected_group_result_sha256")
     observed_hash = equivalence.get("observed_group_result_sha256")
@@ -198,20 +257,21 @@ def _validate_gqa_equivalence(equivalence: JsonDict) -> JsonDict:
         and expected_hash == observed_hash
     ):
         raise ValueError("GQA8 shared-KV equivalence did not pass")
-    heads = equivalence.get("query_heads_per_kv")
-    if heads is not None and int(heads) != _GQA_HEADS:
-        raise ValueError("equivalence report is not for GQA8")
     return {
         "equivalence_pass": True,
         "decision": equivalence.get("decision"),
         "semantic_profile": equivalence.get("semantic_profile"),
-        "query_heads_per_kv": int(heads) if heads is not None else _GQA_HEADS,
-        "expected_group_result_sha256": equivalence.get("expected_group_result_sha256"),
-        "observed_group_result_sha256": equivalence.get("observed_group_result_sha256"),
+        "query_heads_per_kv": heads,
+        "parallel_query_head_lanes": parallel_query_head_lanes,
+        "query_head_waves": _GQA_HEADS // parallel_query_head_lanes,
+        "expected_group_result_sha256": expected_hash,
+        "observed_group_result_sha256": observed_hash,
     }
 
 
-def _validate_activity_compatibility(activity_manifest: JsonDict, cluster_baseline: JsonDict) -> None:
+def _validate_activity_compatibility(
+    activity_manifest: JsonDict, cluster_baseline: JsonDict, equivalence: JsonDict
+) -> None:
     phases = activity_manifest.get("phases")
     if not isinstance(phases, list):
         raise ValueError("group activity manifest is missing phases")
@@ -222,6 +282,24 @@ def _validate_activity_compatibility(activity_manifest: JsonDict, cluster_baseli
         raise ValueError("group and cluster activity target_max_blocks contracts differ")
     if int(activity_manifest.get("query_heads_per_kv", 0)) != _GQA_HEADS:
         raise ValueError("group activity manifest is not GQA8")
+    if int(activity_manifest.get("parallel_query_head_lanes", _GQA_HEADS)) != int(
+        equivalence["parallel_query_head_lanes"]
+    ):
+        raise ValueError("group activity and equivalence lane counts differ")
+    if int(
+        activity_manifest.get(
+            "query_head_waves",
+            _GQA_HEADS // int(equivalence["parallel_query_head_lanes"]),
+        )
+    ) != int(equivalence["query_head_waves"]):
+        raise ValueError("group activity and equivalence wave counts differ")
+    completion_cycles = equivalence.get("completion_cycles")
+    if completion_cycles is not None and int(
+        activity_manifest.get("representative_full_transaction_cycles", 0)
+    ) != int(completion_cycles) + 1:
+        raise ValueError(
+            "group activity service cycles must equal equivalence completion cycles plus the observation cycle"
+        )
 
 
 def _write_markdown(payload: JsonDict, path: Path) -> None:
@@ -267,7 +345,12 @@ def build_report(
     clock_period_ns: float,
     activity_dir: Path,
 ) -> JsonDict:
-    equivalence = _validate_gqa_equivalence(_load(equivalence_json))
+    config_payload = _load(config)
+    parallel_query_head_lanes = _parallel_query_head_lanes(config_payload)
+    equivalence = _validate_gqa_equivalence(
+        _load(equivalence_json),
+        parallel_query_head_lanes=parallel_query_head_lanes,
+    )
     cluster_baseline = _cluster_baseline(cluster_activity_power_json, clock_period_ns)
     activity_dir.mkdir(parents=True, exist_ok=True)
     for name in (
@@ -280,7 +363,7 @@ def build_report(
         if path.is_file():
             path.unlink()
     activity_manifest = generate_phase_activity(
-        _load(config),
+        config_payload,
         activity_dir,
         block_count=3,
         head_dim=128,
@@ -289,7 +372,7 @@ def build_report(
     activity_manifest_path = (
         activity_dir / "attention_decode_score_multivalue_gqa_group_activity_manifest.json"
     )
-    _validate_activity_compatibility(activity_manifest, cluster_baseline)
+    _validate_activity_compatibility(activity_manifest, cluster_baseline, equivalence)
     reference_energy = _GQA_HEADS * cluster_baseline["full_context_energy_j"]
     rows: list[JsonDict] = []
     for metric in _feasible_metrics(group_metrics_csv, clock_period_ns):
@@ -298,6 +381,8 @@ def build_report(
         candidate: JsonDict = {
             "candidate_id": f"multivalue_gqa_group_activity_{flow_variant}",
             "flow_variant": flow_variant,
+            "parallel_query_head_lanes": parallel_query_head_lanes,
+            "query_head_waves": _GQA_HEADS // parallel_query_head_lanes,
             "ppa_metric": _metric_provenance(metric, group_metrics_csv),
         }
         try:
@@ -388,8 +473,16 @@ def build_report(
         },
         "equivalence": equivalence,
         "source_dependencies": [
-            "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
-            "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
+            (
+                "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+                if parallel_query_head_lanes != _GQA_HEADS
+                else "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1"
+            ),
+            (
+                f"l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes{parallel_query_head_lanes}_pnr_v1"
+                if parallel_query_head_lanes != _GQA_HEADS
+                else "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1"
+            ),
             "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
             "prior_single_cluster_activity_power_best_activity_power",
         ],

--- a/npu/eval/audit_attention_decode_score_multivalue_gqa_group_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_gqa_group_frontier.py
@@ -15,6 +15,7 @@ _QUERY_HEADS_PER_KV = 8
 _GROUP_ACTIVITY_MODEL = "decoder_attention_decode_score_multivalue_gqa_group_activity_power_v1"
 _GROUP_ACTIVITY_DECISION = "activity_backed_gqa_group_power_measured"
 _SUPPORTED_GROUP_COUNTS = {1, 2, 4}
+_SUPPORTED_QUERY_HEAD_LANES = {1, 2, 4, 8}
 
 
 def _load(path: Path) -> JsonDict:
@@ -99,6 +100,10 @@ def _validate_equivalence(equivalence: Any) -> JsonDict:
         "decision": equivalence["decision"],
         "semantic_profile": equivalence.get("semantic_profile"),
         "query_heads_per_kv": _QUERY_HEADS_PER_KV,
+        "parallel_query_head_lanes": int(
+            equivalence.get("parallel_query_head_lanes", _QUERY_HEADS_PER_KV)
+        ),
+        "query_head_waves": int(equivalence.get("query_head_waves", 1)),
         "expected_group_result_sha256": expected_hash,
         "observed_group_result_sha256": observed_hash,
     }
@@ -158,6 +163,7 @@ def _selected_group(activity_report: JsonDict) -> tuple[JsonDict, JsonDict, floa
 
 def _row(
     *,
+    query_head_lanes: int,
     group_count: int,
     schedule: JsonDict,
     group_metric: JsonDict,
@@ -204,14 +210,25 @@ def _row(
         schedule.get("measured_tile_local_sram_area_um2", 0.0)
     )
     component_energy_j = logical_groups * layers * group_energy_j
+    query_head_waves = _QUERY_HEADS_PER_KV // query_head_lanes
+    if _QUERY_HEADS_PER_KV % query_head_lanes != 0:
+        raise ValueError("query head lanes must divide query_heads_per_kv")
+    candidate_id = (
+        f"decode_score_multivalue_gqa_group_g{group_count}"
+        if query_head_lanes == _QUERY_HEADS_PER_KV
+        else f"decode_score_multivalue_gqa_group_l{query_head_lanes}_g{group_count}"
+    )
     return {
-        "candidate_id": f"decode_score_multivalue_gqa_group_g{group_count}",
+        "candidate_id": candidate_id,
+        "parallel_query_head_lanes": query_head_lanes,
+        "query_head_waves": query_head_waves,
         "group_count": group_count,
         "logical_groups_per_layer": logical_groups,
         "group_waves_per_layer": waves,
         "dense_qkv_tile_count": dense_count,
         "dense_qkv_useful_parallelism_limit": qkv_useful_limit,
         "qkv_cycles": qkv_cycles,
+        "group_full_context_cycles": group_cycles,
         "attention_cycles": attention_cycles,
         "fixed_cycles": fixed_cycles,
         "layer_cycles": layer_cycles,
@@ -272,6 +289,35 @@ def _pareto(rows: list[JsonDict]) -> list[JsonDict]:
     return result
 
 
+def _parse_lane_activities(
+    *, legacy_activity_json: Path | None, lane_activity: dict[int, Path] | None
+) -> dict[int, Path]:
+    lane_activity = dict(lane_activity or {})
+    if legacy_activity_json is not None:
+        if 8 in lane_activity:
+            raise ValueError("lane activity for 8 lanes duplicates group-activity-power-json")
+        lane_activity[8] = legacy_activity_json
+    if not lane_activity:
+        raise ValueError("at least one group activity report is required")
+    unsupported = set(lane_activity) - _SUPPORTED_QUERY_HEAD_LANES
+    if unsupported:
+        raise ValueError(f"unsupported query-head lane counts: {sorted(unsupported)}")
+    return lane_activity
+
+
+def _parse_lane_activity_spec(spec: str) -> tuple[int, Path]:
+    if "=" not in spec:
+        raise ValueError("--lane-activity must be LANES=PATH")
+    lane_text, path_text = spec.split("=", 1)
+    try:
+        lanes = int(lane_text)
+    except ValueError as exc:
+        raise ValueError(f"invalid lane count: {lane_text}") from exc
+    if lanes <= 0:
+        raise ValueError(f"invalid lane count: {lane_text}")
+    return lanes, Path(path_text)
+
+
 def _prior_comparison(prior: JsonDict, best: JsonDict) -> JsonDict:
     prior_best = prior.get("best_throughput_candidate")
     if not isinstance(prior_best, dict):
@@ -292,10 +338,51 @@ def _prior_comparison(prior: JsonDict, best: JsonDict) -> JsonDict:
 
 
 def build_report(
-    *, prior_frontier_json: Path, activity_power_json: Path, group_counts: list[int]
+    *,
+    prior_frontier_json: Path,
+    group_counts: list[int],
+    activity_power_json: Path | None = None,
+    lane_activity: dict[int, Path] | None = None,
 ) -> JsonDict:
     prior = _load(prior_frontier_json)
-    activity_report = _load(activity_power_json)
+    lane_activity = _parse_lane_activities(
+        legacy_activity_json=activity_power_json, lane_activity=lane_activity
+    )
+    selected_by_lanes: list[
+        tuple[int, JsonDict, JsonDict, float, int, float, JsonDict]
+    ] = []
+    for lanes in sorted(lane_activity):
+        best, group_metric, group_energy_j, group_cycles, activity_clock_ns, equivalence = _selected_group(
+            _load(lane_activity[lanes])
+        )
+        reported_lanes = int(equivalence.get("parallel_query_head_lanes", _QUERY_HEADS_PER_KV))
+        if reported_lanes != lanes:
+            raise ValueError(
+                f"lane activity key {lanes} does not match report equivalence lanes {reported_lanes}"
+            )
+        selected_by_lanes.append(
+            (lanes, best, group_metric, group_energy_j, group_cycles, activity_clock_ns, equivalence)
+        )
+
+    canonical_selected = selected_by_lanes[0] if selected_by_lanes else None
+    if canonical_selected is None:
+        raise ValueError("no validated group activity report available")
+    canonical_equivalence = canonical_selected[6]
+    equivalence_identity_keys = (
+        "equivalence_pass",
+        "decision",
+        "semantic_profile",
+        "query_heads_per_kv",
+        "expected_group_result_sha256",
+        "observed_group_result_sha256",
+    )
+    canonical_identity = {
+        key: canonical_equivalence.get(key) for key in equivalence_identity_keys
+    }
+    for _, _, _, _, _, _, lane_equivalence in selected_by_lanes:
+        lane_identity = {key: lane_equivalence.get(key) for key in equivalence_identity_keys}
+        if lane_identity != canonical_identity:
+            raise ValueError("lane activity reports do not share identical arithmetic equivalence")
     if not group_counts:
         raise ValueError("at least one group count is required")
     if len(group_counts) != len(set(group_counts)):
@@ -313,11 +400,10 @@ def build_report(
         != int(schedule["kv_heads"]) * _QUERY_HEADS_PER_KV
     ):
         raise ValueError("frontier is not the expected Llama7B 4096D/32Q-head/4KV-head schedule")
-    best, group_metric, group_energy_j, group_cycles, activity_clock_ns, equivalence = _selected_group(
-        activity_report
-    )
+
     rows = [
         _row(
+            query_head_lanes=lanes,
             group_count=count,
             schedule=schedule,
             group_metric=group_metric,
@@ -326,19 +412,30 @@ def build_report(
             group_energy_j=group_energy_j,
             dense_tile=dense_tile,
         )
+        for lanes, _, group_metric, group_energy_j, group_cycles, activity_clock_ns, _ in selected_by_lanes
         for count in group_counts
     ]
     pareto_rows = _pareto(rows)
     if not pareto_rows:
         raise ValueError("no feasible GQA8 group frontier row")
     best_throughput = max(pareto_rows, key=lambda row: float(row["token_throughput_per_s"]))
+    (
+        _,
+        canonical_best,
+        canonical_metric,
+        canonical_energy_j,
+        canonical_cycles,
+        _,
+        canonical_equivalence,
+    ) = canonical_selected
     return {
         "version": 1,
         "model": "decoder_attention_decode_score_multivalue_gqa_group_frontier_llama7b_v1",
         "decision": "measured_complete_gqa8_group_component_frontier_promoted",
         "inputs": {
             "prior_frontier_json": str(prior_frontier_json),
-            "group_activity_power_json": str(activity_power_json),
+            "group_activity_power_json": str(activity_power_json) if activity_power_json else None,
+            "lane_activity": {str(lanes): str(path) for lanes, path in sorted(lane_activity.items())},
             "source_schedule_json": schedule_source,
             "dense_qkv_tile_source_json": dense_tile_source,
         },
@@ -351,25 +448,29 @@ def build_report(
             "sequence_length": int(schedule["sequence_length"]),
             "layers": int(schedule["layers"]),
             "logical_groups_per_layer": int(schedule["kv_heads"]),
-            "group_full_context_cycles": group_cycles,
+            "group_full_context_cycles": canonical_cycles,
+            "group_full_context_cycles_by_lanes": {
+                str(lanes): group_cycles
+                for lanes, _, _, _, group_cycles, _, _ in selected_by_lanes
+            },
             "sequence_sharding_supported": False,
         },
         "selected_group": {
-            "candidate_id": best.get("candidate_id"),
-            "flow_variant": best.get("flow_variant"),
-            "ppa_metric": group_metric,
-            "direct_group_full_context_energy_j": group_energy_j,
-            "activity_power": best["activity_power"],
+            "candidate_id": canonical_best.get("candidate_id"),
+            "flow_variant": canonical_best.get("flow_variant"),
+            "ppa_metric": canonical_metric,
+            "direct_group_full_context_energy_j": canonical_energy_j,
+            "activity_power": canonical_best["activity_power"],
         },
         "dense_qkv_tile": dense_tile,
         "precision": {
             "status": "exact",
-            "equivalence_pass": equivalence["equivalence_pass"],
-            "decision": equivalence["decision"],
-            "semantic_profile": equivalence["semantic_profile"],
+            "equivalence_pass": canonical_equivalence["equivalence_pass"],
+            "decision": canonical_equivalence["decision"],
+            "semantic_profile": canonical_equivalence["semantic_profile"],
             "query_heads_per_kv": _QUERY_HEADS_PER_KV,
-            "expected_group_result_sha256": equivalence["expected_group_result_sha256"],
-            "observed_group_result_sha256": equivalence["observed_group_result_sha256"],
+            "expected_group_result_sha256": canonical_equivalence["expected_group_result_sha256"],
+            "observed_group_result_sha256": canonical_equivalence["observed_group_result_sha256"],
             "quality_change": "none_exact_integer_semantics_preserved",
         },
         "rows": rows,
@@ -428,16 +529,31 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prior-frontier-json", type=Path, required=True)
-    parser.add_argument("--group-activity-power-json", type=Path, required=True)
+    parser.add_argument("--group-activity-power-json", type=Path)
+    parser.add_argument("--lane-activity", action="append")
     parser.add_argument("--group-counts", default="1,2,4")
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
     args = parser.parse_args()
+    if args.group_activity_power_json is None and not args.lane_activity:
+        parser.error("provide --group-activity-power-json or at least one --lane-activity")
+
+    lane_activity: dict[int, Path] = {}
+    for raw in args.lane_activity or []:
+        lanes, path = _parse_lane_activity_spec(raw)
+        if lanes in lane_activity:
+            parser.error(f"duplicate --lane-activity for lanes={lanes}")
+        unsupported = {lanes} - _SUPPORTED_QUERY_HEAD_LANES
+        if unsupported:
+            parser.error(f"unsupported query-head lane count: {lanes}")
+        lane_activity[lanes] = path
+
     group_counts = [int(value.strip()) for value in args.group_counts.split(",") if value.strip()]
     payload = build_report(
         prior_frontier_json=args.prior_frontier_json,
         activity_power_json=args.group_activity_power_json,
         group_counts=group_counts,
+        lane_activity=lane_activity,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/npu/eval/generate_attention_decode_score_multivalue_gqa_group_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_gqa_group_activity.py
@@ -17,6 +17,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.eval.generate_attention_decode_score_multivalue_cluster_activity import (
+    _COMMAND_SETUP_CYCLES,
     _DEFAULT_CLOCK_PERIOD_NS,
     _DEFAULT_HEAD_DIM,
     _DEFAULT_SCORE_MULTIPLIER,
@@ -31,8 +32,6 @@ from npu.eval.generate_attention_decode_score_multivalue_cluster_activity import
     _VALUE_SLICES,
     _pack,
     _parse_phase_cycles,
-    _replay_value_scaling,
-    _score_fill_scaling,
     _sha256_file,
     _tool,
     _vectors,
@@ -44,6 +43,7 @@ from npu.rtlgen.gen_attention_decode_score_multivalue_gqa_group import (
 JsonDict = dict[str, Any]
 _PHASE_DONE_PREFIX = "PHASE_DONE"
 _QUERY_HEADS_PER_KV = 8
+_PARALLEL_QUERY_HEAD_LANE_OPTIONS = {1, 2, 4, 8}
 _GQA_FINALIZE_RESULT_CYCLES = 58208
 
 
@@ -64,6 +64,11 @@ def _validate_request(*, config: JsonDict, block_count: int, head_dim: int) -> J
         raise ValueError(f"activity generation requires max_blocks={_TARGET_MAX_BLOCKS}")
     if int(body.get("query_heads_per_kv", 8)) != _QUERY_HEADS_PER_KV:
         raise ValueError("activity generation requires query_heads_per_kv=8")
+    parallel_query_head_lanes = int(body.get("parallel_query_head_lanes", _QUERY_HEADS_PER_KV))
+    if parallel_query_head_lanes not in _PARALLEL_QUERY_HEAD_LANE_OPTIONS:
+        raise ValueError("parallel_query_head_lanes must be one of 1,2,4,8")
+    if _QUERY_HEADS_PER_KV % parallel_query_head_lanes != 0:
+        raise ValueError("parallel_query_head_lanes must divide query_heads_per_kv=8")
     if block_count < 1:
         raise ValueError("block_count must be >= 1")
     if head_dim not in {3, 128}:
@@ -75,47 +80,59 @@ def _validate_request(*, config: JsonDict, block_count: int, head_dim: int) -> J
         "top_name": top_name,
         "max_blocks": max_blocks,
         "score_scale_lanes_per_cycle": int(body.get("score_scale_lanes_per_cycle", 1)),
+        "parallel_query_head_lanes": parallel_query_head_lanes,
         "beats": beats[:block_count],
         "values": values[:block_count],
     }
 
 
-def _phase_expr(phase: str) -> str:
+def _phase_expr(phase: str, *, parallel_query_head_lanes: int) -> str:
+    if parallel_query_head_lanes == _QUERY_HEADS_PER_KV:
+        instance_prefix = "u_head_"
+        instance_count = _QUERY_HEADS_PER_KV
+    else:
+        instance_prefix = "u_lane_"
+        instance_count = parallel_query_head_lanes
     if phase == "score_fill":
         states = " || ".join(
-            f"dut.u_head_{head}.state_q == 3'd{state}"
-            for head in range(_QUERY_HEADS_PER_KV)
+            f"dut.{instance_prefix}{head}.state_q == 3'd{state}"
+            for head in range(instance_count)
             for state in range(1, 6)
         )
-        return f"(command_valid && command_ready) || ({states})"
+        wave_transition = (
+            " || dut.launch_pending_q"
+            if parallel_query_head_lanes != _QUERY_HEADS_PER_KV
+            else ""
+        )
+        return f"(command_valid && command_ready) || ({states}){wave_transition}"
     if phase == "replay_value":
         states = " || ".join(
-            f"dut.u_head_{head}.reducer.state == 4'd{state}"
-            for head in range(_QUERY_HEADS_PER_KV)
+            f"dut.{instance_prefix}{head}.reducer.state == 4'd{state}"
+            for head in range(instance_count)
             for state in range(2, 7)
         )
         return f"({states})"
     if phase == "finalize_result":
         states = " || ".join(
-            f"dut.u_head_{head}.reducer.state == 4'd{state}"
-            for head in range(_QUERY_HEADS_PER_KV)
+            f"dut.{instance_prefix}{head}.reducer.state == 4'd{state}"
+            for head in range(instance_count)
             for state in range(7, 11)
         )
         return f"({states})"
     raise ValueError(f"unknown phase: {phase}")
 
 
-def _gqa_finalize_result_scaling(*, cycle_count: int) -> JsonDict:
+def _gqa_finalize_result_scaling(*, cycle_count: int, query_head_waves: int) -> JsonDict:
     single_head_cycles = _VALUE_DIMS * _FINALIZE_DIVIDE_CYCLES_PER_DIM + _FINALIZE_RESULT_EMIT_CYCLES
-    expected_cycles = _GQA_FINALIZE_RESULT_CYCLES
-    if cycle_count != expected_cycles:
+    if query_head_waves == 1 and cycle_count != _GQA_FINALIZE_RESULT_CYCLES:
         raise RuntimeError(
             "GQA finalize_result cycles diverged from the serialized eight-head result contract: "
-            f"measured={cycle_count} expected={expected_cycles}"
+            f"measured={cycle_count} expected={_GQA_FINALIZE_RESULT_CYCLES}"
         )
     return {
         "kind": "fixed_per_command_serialized_query_heads",
         "query_heads_per_kv": _QUERY_HEADS_PER_KV,
+        "query_head_waves": query_head_waves,
         "value_dimensions_per_head": _VALUE_DIMS,
         "divide_cycles_per_dimension": _FINALIZE_DIVIDE_CYCLES_PER_DIM,
         "result_emit_cycles_per_head": _FINALIZE_RESULT_EMIT_CYCLES,
@@ -124,6 +141,56 @@ def _gqa_finalize_result_scaling(*, cycle_count: int) -> JsonDict:
         "target_max_blocks": _TARGET_MAX_BLOCKS,
         "full_context_cycles": cycle_count,
         "formula": "measured fixed group-finalize contract; child divide and serialized result phases overlap",
+    }
+
+
+def _gqa_score_fill_scaling(
+    *, cycle_count: int, block_count: int, query_head_waves: int
+) -> JsonDict:
+    wave_transition_cycles = query_head_waves - 1
+    fixed_cycles = _COMMAND_SETUP_CYCLES + wave_transition_cycles
+    variable_cycles = cycle_count - fixed_cycles
+    divisor = block_count * query_head_waves
+    if variable_cycles < 0 or variable_cycles % divisor != 0:
+        raise RuntimeError(
+            "GQA score_fill cycles do not match per-wave setup plus linear block contract"
+        )
+    cycles_per_block_per_wave = variable_cycles // divisor
+    return {
+        "kind": "per_wave_setup_plus_linear_by_block_count",
+        "query_head_waves": query_head_waves,
+        "command_setup_cycles": _COMMAND_SETUP_CYCLES,
+        "wave_transition_cycles": wave_transition_cycles,
+        "representative_block_count": block_count,
+        "cycles_per_block_per_wave": cycles_per_block_per_wave,
+        "target_max_blocks": _TARGET_MAX_BLOCKS,
+        "full_context_cycles": fixed_cycles
+        + query_head_waves * cycles_per_block_per_wave * _TARGET_MAX_BLOCKS,
+        "formula": "command_setup_cycles + wave_transition_cycles + query_head_waves * cycles_per_block_per_wave * target_max_blocks",
+    }
+
+
+def _gqa_replay_value_scaling(
+    *, cycle_count: int, block_count: int, query_head_waves: int
+) -> JsonDict:
+    clear_cycles = _REPLAY_CLEAR_CYCLES * query_head_waves
+    variable_cycles = cycle_count - clear_cycles
+    divisor = block_count * query_head_waves
+    if variable_cycles < 0 or variable_cycles % divisor != 0:
+        raise RuntimeError(
+            "GQA replay_value cycles do not match per-wave clear plus linear replay contract"
+        )
+    cycles_per_block_per_wave = variable_cycles // divisor
+    return {
+        "kind": "per_wave_clear_plus_linear_by_block_count",
+        "query_head_waves": query_head_waves,
+        "clear_cycles_per_wave": _REPLAY_CLEAR_CYCLES,
+        "representative_block_count": block_count,
+        "replay_cycles_per_block_per_wave": cycles_per_block_per_wave,
+        "target_max_blocks": _TARGET_MAX_BLOCKS,
+        "full_context_cycles": query_head_waves
+        * (_REPLAY_CLEAR_CYCLES + cycles_per_block_per_wave * _TARGET_MAX_BLOCKS),
+        "formula": "query_head_waves * (clear_cycles_per_wave + replay_cycles_per_block_per_wave * target_max_blocks)",
     }
 
 
@@ -138,6 +205,7 @@ def _testbench(
     *,
     top_name: str,
     beats: list[list[tuple[int, list[int]]]],
+    parallel_query_head_lanes: int,
     values: list[list[list[list[int]]]],
     block_count: int,
     head_dim: int,
@@ -148,30 +216,30 @@ def _testbench(
     clock_period_ns: float,
 ) -> str:
     flat_beats = [beat for block in beats for beat in block]
+    waves = _QUERY_HEADS_PER_KV // parallel_query_head_lanes
+    replayed_beats = flat_beats * waves
+    beat_total = len(flat_beats) * waves
     beat_init = "\n".join(
-        f"    query_mem[{index}] = 64'h{_pack(_query_lanes(q, index), 8):016x}; "
+        f"    query_mem[{index}] = 64'h{_pack(_query_lanes(q, index % len(flat_beats)), 8):016x}; "
         f"key_mem[{index}] = 64'h{_pack(keys, 8):016x};"
-        for index, (q, keys) in enumerate(flat_beats)
+        for index, (q, keys) in enumerate(replayed_beats)
     )
-    last_indices = {
-        sum(len(block) for block in beats[: index + 1]) - 1
-        for index in range(len(beats))
-    }
-    last_cases = "\n".join(f"      {index}: input_last = 1'b1;" for index in sorted(last_indices))
     value_init = "\n".join(
         f"    value_mem[{block * _VALUE_SLICES + value_slice}] = 512'h"
         f"{_pack([lane for row in values[block][value_slice] for lane in row], 8):0128x};"
         for block in range(block_count)
         for value_slice in range(_VALUE_SLICES)
     )
-    phase_active = _phase_expr(phase)
+    phase_active = _phase_expr(phase, parallel_query_head_lanes=parallel_query_head_lanes)
     clock_half_period = clock_period_ns / 2.0
     return f"""`timescale 1ns/1ps
 {_FAKERAM_MODEL}
 module tb;
   localparam integer BLOCK_COUNT = {block_count};
+  localparam integer QUERY_HEAD_WAVES = {waves};
   localparam integer HEAD_DIM = {head_dim};
   localparam integer TOTAL_BEATS = {len(flat_beats)};
+  localparam integer TOTAL_INPUT_BEATS = {beat_total};
   reg clk = 0, rst_n = 0;
   reg command_valid, input_valid, input_last;
   wire command_ready, input_ready;
@@ -194,8 +262,8 @@ module tb;
   wire [319:0] result_value;
   wire [31:0] accepted_count, completed_count, cycle_count;
   wire protocol_error;
-  reg [63:0] query_mem [0:TOTAL_BEATS-1];
-  reg [63:0] key_mem [0:TOTAL_BEATS-1];
+  reg [63:0] query_mem [0:TOTAL_INPUT_BEATS-1];
+  reg [63:0] key_mem [0:TOTAL_INPUT_BEATS-1];
   reg [511:0] value_mem [0:BLOCK_COUNT*{_VALUE_SLICES}-1];
   integer input_index = 0;
   integer phase_cycles = 0;
@@ -203,7 +271,8 @@ module tb;
   reg [13:0] pending_addr = 0;
   reg [3:0] pending_slice = 0;
   integer pending_delay = 0;
-  reg phase_started = 0;
+  reg phase_seen = 0;
+  reg phase_dumping = 0;
 
   always #{clock_half_period:g} clk = ~clk;
 
@@ -226,14 +295,10 @@ module tb;
 
   always @* begin
     command_valid = rst_n && accepted_count == 0;
-    input_valid = rst_n && input_index < TOTAL_BEATS;
-    input_query = input_index < TOTAL_BEATS ? query_mem[input_index] : 0;
-    input_key = input_index < TOTAL_BEATS ? key_mem[input_index] : 0;
-    input_last = 0;
-    case (input_index)
-{last_cases}
-      default: input_last = 0;
-    endcase
+    input_valid = rst_n && input_index < TOTAL_INPUT_BEATS;
+    input_query = input_index < TOTAL_INPUT_BEATS ? query_mem[input_index] : 0;
+    input_key = input_index < TOTAL_INPUT_BEATS ? key_mem[input_index] : 0;
+    input_last = (input_index < TOTAL_INPUT_BEATS && (input_index % HEAD_DIM) == (HEAD_DIM - 1));
     value_read_req_ready = 1'b1;
     result_ready = 1'b1;
   end
@@ -248,7 +313,8 @@ module tb;
       value_response_address <= 0;
       value_response_slice <= 0;
       value_response_matrix <= 0;
-      phase_started <= 0;
+      phase_seen <= 0;
+      phase_dumping <= 0;
     end else begin
       if (input_valid && input_ready) input_index <= input_index + 1;
       if (value_read_req_valid && value_read_req_ready) begin
@@ -268,16 +334,22 @@ module tb;
         end else pending_delay <= pending_delay - 1;
       end
       if (value_response_valid && value_response_ready) value_response_valid <= 0;
-      if (!phase_started && ({phase_active})) begin
-        phase_started <= 1;
-        phase_cycles <= 1;
-        $dumpon;
-      end else if (phase_started && ({phase_active})) begin
+      if ({phase_active}) begin
         phase_cycles <= phase_cycles + 1;
-      end else if (phase_started && !({phase_active})) begin
+        phase_seen <= 1;
+        if (!phase_dumping) begin
+          phase_dumping <= 1;
+          $dumpon;
+        end
+      end else if (phase_dumping) begin
+        phase_dumping <= 0;
+        $dumpoff;
+      end
+      if (completed_count != 0) begin
+        if (!phase_seen) $fatal(1, "phase {phase} was never observed");
         if (protocol_error) $fatal(1, "protocol_error raised during {phase}");
         $display("{_PHASE_DONE_PREFIX} phase={phase} cycles=%0d service_cycles=%0d accepted=%0d completed=%0d", phase_cycles, cycle_count, accepted_count, completed_count);
-        $dumpoff;
+        if (phase_dumping) $dumpoff;
         #1 $finish;
       end
       if (cycle_count > 100000) $fatal(1, "timeout");
@@ -321,6 +393,7 @@ def _run_phase(
             _testbench(
                 top_name=str(validated["top_name"]),
                 beats=validated["beats"],
+                parallel_query_head_lanes=validated["parallel_query_head_lanes"],
                 values=validated["values"],
                 block_count=block_count,
                 head_dim=head_dim,
@@ -366,6 +439,7 @@ def generate_phase_activity(
     out_dir.mkdir(parents=True, exist_ok=True)
     phases: list[JsonDict] = []
     full_service_cycles = 0
+    query_head_waves = _QUERY_HEADS_PER_KV // validated["parallel_query_head_lanes"]
     for phase in _PHASES:
         cycle_count, service_cycles, vcd_path = _run_phase(
             config=config,
@@ -378,11 +452,21 @@ def generate_phase_activity(
             score_shift=score_shift,
         )
         if phase == "score_fill":
-            scaling = _score_fill_scaling(cycle_count=cycle_count, block_count=block_count)
+            scaling = _gqa_score_fill_scaling(
+                cycle_count=cycle_count,
+                block_count=block_count,
+                query_head_waves=query_head_waves,
+            )
         elif phase == "replay_value":
-            scaling = _replay_value_scaling(cycle_count=cycle_count, block_count=block_count)
+            scaling = _gqa_replay_value_scaling(
+                cycle_count=cycle_count,
+                block_count=block_count,
+                query_head_waves=query_head_waves,
+            )
         else:
-            scaling = _gqa_finalize_result_scaling(cycle_count=cycle_count)
+            scaling = _gqa_finalize_result_scaling(
+                cycle_count=cycle_count, query_head_waves=query_head_waves
+            )
             full_service_cycles = service_cycles
         phases.append(
             {
@@ -407,10 +491,18 @@ def generate_phase_activity(
         "model": "decode_score_multivalue_gqa_group_phase_activity_v1",
         "generator": "npu/eval/generate_attention_decode_score_multivalue_gqa_group_activity.py",
         "top_name": validated["top_name"],
-        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_activity_v1",
+        "semantic_profile": (
+            "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_activity_v1"
+            if validated["parallel_query_head_lanes"] == _QUERY_HEADS_PER_KV
+            else "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_folded_group_activity_v1"
+        ),
         "activity_generation": "explicit_script_only",
         "scope": "tb/dut",
-        "scope_semantics": "the complete generated GQA8 group wrapper, including all eight query-head clusters",
+        "scope_semantics": (
+            "the complete generated GQA8 group wrapper, including all eight query-head clusters"
+            if validated["parallel_query_head_lanes"] == _QUERY_HEADS_PER_KV
+            else "the complete generated folded GQA8 group wrapper command stream"
+        ),
         "clock_period_ns": clock_period_ns,
         "block_count": block_count,
         "head_dim": head_dim,
@@ -418,6 +510,8 @@ def generate_phase_activity(
         "max_blocks": validated["max_blocks"],
         "target_max_blocks": _TARGET_MAX_BLOCKS,
         "query_heads_per_kv": _QUERY_HEADS_PER_KV,
+        "parallel_query_head_lanes": validated["parallel_query_head_lanes"],
+        "query_head_waves": query_head_waves,
         "query_activity_profile": "eight_distinct_deterministic_signed_int8_query_lanes",
         "score_multiplier": score_multiplier,
         "score_shift": score_shift,

--- a/tests/test_attention_decode_score_multivalue_gqa_group_activity.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_activity.py
@@ -17,7 +17,7 @@ def _tool_available(name: str) -> bool:
     return shutil.which(name) is not None or (Path("/oss-cad-suite/bin") / name).exists()
 
 
-def _config() -> dict:
+def _config(parallel_query_head_lanes: int | None = None) -> dict:
     return {
         "top_name": "attention_decode_score_multivalue_gqa_group_activity",
         "attention_decode_score_multivalue_gqa_group": {
@@ -27,30 +27,52 @@ def _config() -> dict:
             "divider_impl": "iterative_restoring",
             "score_scale_lanes_per_cycle": 1,
             "query_heads_per_kv": 8,
+            **({"parallel_query_head_lanes": parallel_query_head_lanes} if parallel_query_head_lanes else {}),
         },
     }
 
 
-def test_gqa_group_activity_smoke_uses_actual_wrapper_and_manifest(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "parallel_query_head_lanes,waves,folded",
+    [(8, 1, False), (4, 2, True), (2, 4, True), (1, 8, True)],
+)
+def test_gqa_group_activity_smoke_uses_actual_wrapper_and_manifest(
+    tmp_path: Path, parallel_query_head_lanes: int, waves: int, folded: bool
+) -> None:
     if not _tool_available("iverilog") or not _tool_available("vvp"):
         pytest.skip("iverilog/vvp unavailable")
 
     manifest = generate_phase_activity(
-        _config(), tmp_path, block_count=1, head_dim=3, clock_period_ns=10.0
+        _config(parallel_query_head_lanes), tmp_path, block_count=1, head_dim=3, clock_period_ns=10.0
     )
     manifest_path = tmp_path / "attention_decode_score_multivalue_gqa_group_activity_manifest.json"
     assert json.loads(manifest_path.read_text(encoding="utf-8")) == manifest
     assert manifest["model"] == "decode_score_multivalue_gqa_group_phase_activity_v1"
     assert manifest["scope"] == "tb/dut"
-    assert "complete generated GQA8 group wrapper" in manifest["scope_semantics"]
+    if folded:
+        assert "folded" in manifest["scope_semantics"]
+        assert (
+            manifest["semantic_profile"]
+            == "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_folded_group_activity_v1"
+        )
+    else:
+        assert "all eight query-head clusters" in manifest["scope_semantics"]
+        assert (
+            manifest["semantic_profile"]
+            == "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_group_activity_v1"
+        )
     assert manifest["query_heads_per_kv"] == 8
+    assert manifest["parallel_query_head_lanes"] == parallel_query_head_lanes
+    assert manifest["query_head_waves"] == waves
     assert manifest["query_activity_profile"] == "eight_distinct_deterministic_signed_int8_query_lanes"
     assert manifest["clock_period_ns"] == 10.0
     assert manifest["phase_partition_cycle_sum"] == manifest["representative_full_transaction_cycles"]
+    assert manifest["phases"][2]["scaling"]["query_head_waves"] == waves
 
     phases = {row["phase"]: row for row in manifest["phases"]}
     assert set(phases) == {"score_fill", "replay_value", "finalize_result"}
-    assert phases["finalize_result"]["measured_cycles"] == 58208
+    if not folded:
+        assert phases["finalize_result"]["measured_cycles"] == 58208
     assert phases["finalize_result"]["scaling"]["query_heads_per_kv"] == 8
     for phase in phases.values():
         vcd = tmp_path / phase["vcd"]

--- a/tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py
@@ -10,6 +10,26 @@ import pytest
 from npu.eval import audit_attention_decode_score_multivalue_gqa_group_activity_power as audit
 
 
+def _config(path: Path, parallel_query_head_lanes: int | None = None) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_decode_score_multivalue_gqa_group_activity_power",
+                "attention_decode_score_multivalue_gqa_group": {
+                    "max_blocks": 16384,
+                    "array_n": 8,
+                    "value_slices": 16,
+                    "divider_impl": "iterative_restoring",
+                    "score_scale_lanes_per_cycle": 1,
+                    "query_heads_per_kv": 8,
+                    **({"parallel_query_head_lanes": parallel_query_head_lanes} if parallel_query_head_lanes else {}),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def _write_metrics(path: Path) -> None:
     fields = [
         "design",
@@ -162,7 +182,7 @@ def test_build_report_gates_gqa_and_does_not_pair_cluster_flow(tmp_path: Path) -
     metrics = tmp_path / "metrics.csv"
     _write_metrics(metrics)
     config = tmp_path / "config.json"
-    config.write_text("{}", encoding="utf-8")
+    _config(config, parallel_query_head_lanes=8)
     manifest = {
         "scope": "tb/dut",
         "scope_semantics": "the complete generated GQA8 group wrapper",
@@ -209,11 +229,142 @@ def test_build_report_gates_gqa_and_does_not_pair_cluster_flow(tmp_path: Path) -
     ]
 
 
+@pytest.mark.parametrize("parallel_query_head_lanes", [1, 2, 4, 8])
+def test_build_report_accepts_folded_lane_equivalence_rows_for_configured_lanes(
+    tmp_path: Path, parallel_query_head_lanes: int
+) -> None:
+    equivalence = tmp_path / "equivalence.json"
+    shared_hash = "e2f07a3c580991601458466bfbaab4127cbcb654065b0241197f462ca4977069"
+    rows = []
+    completion_cycles = {1: 66671, 2: 62199, 4: 59963, 8: 58845}
+    for lanes in [1, 2, 4, 8]:
+        rows.append(
+            {
+                "equivalence_pass": True,
+                "parallel_query_head_lanes": lanes,
+                "query_head_waves": 8 // lanes,
+                "completion_cycles": completion_cycles[lanes],
+                "expected_group_result_sha256": shared_hash,
+                "observed_group_result_sha256": shared_hash,
+            }
+        )
+    equivalence.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "decision": "llama7b_gqa8_folded_lane_equivalence_pass",
+                "query_heads_per_kv": 8,
+                "rows": rows,
+                "shared_result_sha256": shared_hash,
+            }
+        ),
+        encoding="utf-8",
+    )
+    baseline = tmp_path / "cluster-power.json"
+    _write_baseline(baseline)
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics)
+    config = tmp_path / "config.json"
+    _config(config, parallel_query_head_lanes=parallel_query_head_lanes)
+    manifest = {
+        "query_head_waves": 8 // parallel_query_head_lanes,
+        "query_heads_per_kv": 8,
+        "parallel_query_head_lanes": parallel_query_head_lanes,
+        "scope": "tb/dut",
+        "scope_semantics": "the complete generated GQA8 group wrapper",
+        "clock_period_ns": 8.0,
+        "target_max_blocks": 16384,
+        "block_count": 3,
+        "representative_full_transaction_cycles": completion_cycles[parallel_query_head_lanes] + 1,
+        "phase_partition_cycle_sum": completion_cycles[parallel_query_head_lanes] + 1,
+        "phases": [
+            {"phase": "score_fill"},
+            {"phase": "replay_value"},
+            {"phase": "finalize_result"},
+        ],
+    }
+    with mock.patch.object(audit, "generate_phase_activity", return_value=manifest), mock.patch.object(
+        audit,
+        "build_power_report",
+        return_value=_power(0.014),
+    ) as build_power:
+        payload = audit.build_report(
+            config=config,
+            group_metrics_csv=metrics,
+            cluster_activity_power_json=baseline,
+            equivalence_json=equivalence,
+            group_orfs_design_config=tmp_path / "group.mk",
+            clock_period_ns=8.0,
+            activity_dir=tmp_path / "activity",
+        )
+
+        assert build_power.call_count == 2
+        if parallel_query_head_lanes == 8:
+            assert (
+                payload["source_dependencies"]
+                == [
+                    "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
+                    "l1_decoder_attention_decode_score_multivalue_gqa8_group_pnr_v1",
+                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+                    "prior_single_cluster_activity_power_best_activity_power",
+                ]
+            )
+        else:
+            assert (
+                payload["source_dependencies"]
+                == [
+                    "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
+                    f"l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes{parallel_query_head_lanes}_pnr_v1",
+                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+                    "prior_single_cluster_activity_power_best_activity_power",
+                ]
+            )
+        assert payload["equivalence"]["equivalence_pass"] is True
+        assert payload["equivalence"]["parallel_query_head_lanes"] == parallel_query_head_lanes
+        assert payload["equivalence"]["query_head_waves"] == 8 // parallel_query_head_lanes
+        assert payload["equivalence"]["expected_group_result_sha256"] == shared_hash
+
+
+def test_build_report_rejects_folded_lane_equivalence_hash_mismatch(tmp_path: Path) -> None:
+    equivalence = tmp_path / "equivalence.json"
+    equivalence.write_text(
+        json.dumps(
+            {
+                "decision": "llama7b_gqa8_folded_lane_equivalence_pass",
+                "query_heads_per_kv": 8,
+                "shared_result_sha256": "shared-hash",
+                "rows": [
+                    {
+                        "equivalence_pass": True,
+                        "parallel_query_head_lanes": 1,
+                        "expected_group_result_sha256": "row-hash",
+                        "observed_group_result_sha256": "other-hash",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = tmp_path / "config.json"
+    _config(config, parallel_query_head_lanes=1)
+    with pytest.raises(ValueError, match="did not pass for configured lane count"):
+        audit.build_report(
+            config=config,
+            group_metrics_csv=tmp_path / "metrics.csv",
+            cluster_activity_power_json=tmp_path / "cluster.json",
+            equivalence_json=equivalence,
+            group_orfs_design_config=tmp_path / "group.mk",
+            clock_period_ns=8.0,
+            activity_dir=tmp_path / "activity",
+        )
+
+
 def test_build_report_rejects_unproven_gqa_equivalence(tmp_path: Path) -> None:
     equivalence = tmp_path / "equivalence.json"
     equivalence.write_text('{"equivalence_pass": false}', encoding="utf-8")
     with mock.patch.object(audit, "generate_phase_activity") as generate:
         with pytest.raises(ValueError, match="GQA8 shared-KV equivalence did not pass"):
+            _config(tmp_path / "config.json", parallel_query_head_lanes=8)
             audit.build_report(
                 config=tmp_path / "config.json",
                 group_metrics_csv=tmp_path / "metrics.csv",

--- a/tests/test_attention_decode_score_multivalue_gqa_group_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_gqa_group_frontier.py
@@ -65,6 +65,8 @@ def _inputs(tmp_path: Path) -> tuple[Path, Path]:
                 "equivalence_pass": True,
                 "decision": "llama7b_gqa8_shared_kv_equivalence_pass",
                 "query_heads_per_kv": 8,
+                "parallel_query_head_lanes": 8,
+                "query_head_waves": 1,
                 "expected_group_result_sha256": "same-hash",
                 "observed_group_result_sha256": "same-hash",
             },
@@ -86,6 +88,44 @@ def _inputs(tmp_path: Path) -> tuple[Path, Path]:
     return prior, activity
 
 
+def _lane_activity(
+    tmp_path: Path, lanes: int, *, cycles: int, direct_energy: float
+) -> Path:
+    return _write(
+        tmp_path / f"group-activity-l{lanes}.json",
+        {
+            "model": "decoder_attention_decode_score_multivalue_gqa_group_activity_power_v1",
+            "decision": "activity_backed_gqa_group_power_measured",
+            "promotion_gate_pass": True,
+            "best_candidate_id": f"gqa-group-l{lanes}",
+            "energy_scope": "one GQA8 group full-context decode attention command",
+            "activity_contract": {"clock_period_ns": 8.0, "query_heads_per_kv": 8},
+            "equivalence": {
+                "equivalence_pass": True,
+                "decision": "llama7b_gqa8_shared_kv_equivalence_pass",
+                "query_heads_per_kv": 8,
+                "parallel_query_head_lanes": lanes,
+                "query_head_waves": 8 // lanes,
+                "expected_group_result_sha256": "same-hash",
+                "observed_group_result_sha256": "same-hash",
+            },
+            "best": {
+                "candidate_id": f"gqa-group-l{lanes}",
+                "status": "activity_backed",
+                "flow_variant": f"group_die7200_l{lanes}",
+                "ppa_metric": {"instance_area_um2": 2_000_000, "critical_path_ns": 7.5},
+                "direct_group_full_context_energy_j": direct_energy,
+                "activity_power": {
+                    "promotion_gate_pass": True,
+                    "clock_period_ns": 8.0,
+                    "full_context_cycles": cycles,
+                    "full_context_energy_j": direct_energy,
+                },
+            },
+        },
+    )
+
+
 def test_recost_uses_four_logical_groups_and_recursive_measured_evidence(tmp_path: Path) -> None:
     prior, activity = _inputs(tmp_path)
     report = build_report(
@@ -96,6 +136,10 @@ def test_recost_uses_four_logical_groups_and_recursive_measured_evidence(tmp_pat
 
     rows = {row["group_count"]: row for row in report["rows"]}
     assert report["inputs"]["source_schedule_json"].endswith("source.json")
+    assert report["inputs"]["group_activity_power_json"] == str(activity)
+    assert report["schedule_contract"]["group_full_context_cycles_by_lanes"] == {"8": 300}
+    assert rows[1]["parallel_query_head_lanes"] == 8
+    assert rows[1]["query_head_waves"] == 1
     assert report["schedule_contract"]["query_heads_per_kv"] == 8
     assert report["schedule_contract"]["logical_groups_per_layer"] == 4
     assert rows[1]["group_waves_per_layer"] == 4
@@ -117,6 +161,52 @@ def test_recost_uses_four_logical_groups_and_recursive_measured_evidence(tmp_pat
     assert report["comparison_to_prior_best"]["available"] is True
     assert report["comparison_to_prior_best"]["prior_candidate_id"] == "prior_best"
     assert {row["group_count"] for row in report["pareto_rows"]} == {1, 2, 4}
+
+
+def test_recost_cartesian_lane_activity_reports_generate_wave_and_cycle_formulas(tmp_path: Path) -> None:
+    prior, _ = _inputs(tmp_path)
+    lane_activity = {
+        lanes: _lane_activity(tmp_path, lanes, cycles=cycles, direct_energy=0.010 * (8 / lanes))
+        for lanes, cycles in {1: 320, 2: 160, 4: 120}.items()
+    }
+    report = build_report(
+        prior_frontier_json=prior,
+        lane_activity=lane_activity,
+        group_counts=[1, 2, 4],
+    )
+    rows_by_key = {(row["parallel_query_head_lanes"], row["group_count"]): row for row in report["rows"]}
+    assert len(rows_by_key) == 9
+    assert report["schedule_contract"]["group_full_context_cycles_by_lanes"] == {
+        "1": 320,
+        "2": 160,
+        "4": 120,
+    }
+
+    kv_heads = 4
+    layers = 32
+    for lanes in (1, 2, 4):
+        for group_count in (1, 2, 4):
+            row = rows_by_key[(lanes, group_count)]
+            row_cycles = {
+                1: 320,
+                2: 160,
+                4: 120,
+            }[lanes]
+            row_energy = {
+                1: 0.08,
+                2: 0.04,
+                4: 0.02,
+            }[lanes]
+            expected_waves = kv_heads // group_count
+            expected_attention = expected_waves * row_cycles
+            assert row["group_waves_per_layer"] == expected_waves
+            assert row["attention_cycles"] == expected_attention
+            assert row["query_head_waves"] == 8 // lanes
+            expected_id = f"decode_score_multivalue_gqa_group_l{lanes}_g{group_count}"
+            assert row["candidate_id"] == expected_id
+            expected_energy = 4 * 32 * row_energy
+            assert row["gqa_group_component_energy_j_per_token"] == pytest.approx(expected_energy)
+            assert row["parallel_query_head_lanes"] == lanes
 
 
 def test_recost_requires_promoted_complete_gqa8_group(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- generate phase-accurate activity for 1/2/4 folded GQA query-head lanes, charging every wave and replay
- require lane-matched equivalence and routed PPA provenance before accepting direct energy
- recost the Llama7B frontier over measured lane count x deployed group count without linearly inferring missing lane energy
- register lane-specific control-plane tasks, dependencies, result summaries, and proposal revisions

## Why
The full eight-lane physical group has no feasible measured row. The frontier must compare embodied folded implementations using each point's measured cycles, PPA, and activity energy rather than scaling one lane count.

## Validation
- `PYTHONPATH=. pytest -q tests/test_attention_decode_score_multivalue_gqa_group_activity.py tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py tests/test_attention_decode_score_multivalue_gqa_group_frontier.py` (19 passed)
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_l2_result_consumer.py` (326 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`