### PR TITLE
Retain OpenROAD failure signatures

### DIFF
--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -15,6 +15,7 @@ import csv
 import hashlib
 import itertools
 import json
+from collections import deque
 import os
 import re
 import shutil
@@ -30,6 +31,7 @@ REPORT_BASE = Path("/orfs/flow/reports")
 RESULT_BASE = Path("/orfs/flow/results")
 LOG_BASE = Path("/orfs/flow/logs")
 SRC_BASE = DEST_BASE / "src"
+DEFAULT_FAILURE_SIGNATURE_MAX_LEN = 255
 
 
 def sha1_file(path: Path) -> str:
@@ -810,6 +812,109 @@ def parse_rect_param(value: object) -> Optional[tuple[float, float, float, float
     return x1, y1, x2, y2
 
 
+def _bounded_text(value: object, max_len: int = DEFAULT_FAILURE_SIGNATURE_MAX_LEN) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if len(text) <= max_len:
+        return text
+    digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:12]
+    suffix = f"... [sha1:{digest}]"
+    keep = max_len - len(suffix)
+    if keep <= 0:
+        return suffix[:max_len]
+    return text[:keep] + suffix
+
+
+def _normalize_failure_stage(raw_stage: str) -> str:
+    text = str(raw_stage or "").lower().replace("-", "_")
+    if "synth" in text or "yosys" in text:
+        return "synth"
+    if "place_gp" in text or "globalplace" in text or "global_place" in text:
+        return "globalplace"
+    if "place_resized" in text or "placeopt" in text:
+        return "placeopt"
+    if "place_dp" in text or "detailedplace" in text or "detailed_place" in text:
+        return "detailedplace"
+    if "cts" in text:
+        return "cts"
+    if "route" in text:
+        return "route"
+    if "finish" in text:
+        return "finish"
+    return "flow"
+
+
+def _infer_failure_log_path(log_dir: Path, make_target: Optional[str]) -> Optional[Path]:
+    if make_target:
+        explicit_log = log_dir / f"{make_target}.log"
+        if explicit_log.exists():
+            return explicit_log
+    candidates: list[tuple[float, Path]] = []
+    try:
+        for path in log_dir.glob("*.log"):
+            try:
+                candidates.append((path.stat().st_mtime, path))
+            except OSError:
+                continue
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    candidates.sort(reverse=True)
+    return candidates[0][1]
+
+
+def _normalize_failure_line(line: str) -> str:
+    sanitized = line.replace("\x1b", "")
+    sanitized = re.sub(r"\[[0-9;]*m", "", sanitized)
+    sanitized = re.sub(r"/\S+", "<path>", sanitized)
+    sanitized = re.sub(r"\b0x[0-9a-fA-F]+\b", "0x<hex>", sanitized)
+    return " ".join(sanitized.strip().split())
+
+
+def _extract_failure_signature(
+    log_path: Optional[Path],
+    command: List[object],
+    returncode: int,
+) -> str:
+    fallback = _bounded_text(
+        f"exit_code={returncode} command={command_to_text(command)}",
+        max_len=DEFAULT_FAILURE_SIGNATURE_MAX_LEN,
+    )
+    if log_path is None or not log_path.exists():
+        return fallback
+
+    fail_patterns = (
+        re.compile(r"(?i)\bfatal\b"),
+        re.compile(r"(?i)\berror\b"),
+        re.compile(r"(?i)\bfailed\b"),
+        re.compile(r"(?i)\bno rule to make target\b"),
+        re.compile(r"(?i)\btraceback\b"),
+        re.compile(r"(?i)\bsegmentation fault\b"),
+        re.compile(r"(?i)\baborted\b"),
+    )
+    try:
+        with log_path.open("r", encoding="utf-8", errors="ignore") as handle:
+            tail = list(deque(handle, maxlen=240))
+    except OSError:
+        return fallback
+
+    for line in reversed(tail):
+        if any(pattern.search(line) for pattern in fail_patterns):
+            return _bounded_text(
+                _normalize_failure_line(line),
+                max_len=DEFAULT_FAILURE_SIGNATURE_MAX_LEN,
+            )
+
+    for line in reversed(tail):
+        line = line.strip()
+        if line:
+            return _bounded_text(_normalize_failure_line(line), max_len=DEFAULT_FAILURE_SIGNATURE_MAX_LEN)
+
+    return fallback
+
+
 def parse_macro_size_from_lef(lef_path: Path) -> Optional[tuple[float, float]]:
     try:
         text = lef_path.read_text(encoding="utf-8", errors="ignore")
@@ -1308,6 +1413,10 @@ def append_metrics(metrics_path: Path, row: Dict[str, object]):
         "params_json",
         "result_path",
         "work_result_json",
+        "failure_stage",
+        "failure_returncode",
+        "failure_signature",
+        "failure_log_path",
         "synth_script_path",
         "synth_script_sha1",
     ]
@@ -1389,6 +1498,20 @@ def write_flow_failure_result(
     compare_group: str,
 ) -> Dict[str, object]:
     log_dir = resolve_flow_log_dir(platform, design_name, str(tag), flow_variant)
+    failure_log_path = _infer_failure_log_path(
+        log_dir=log_dir,
+        make_target=resolve_make_target(failing_stage),
+    )
+    normalized_failure_stage = _normalize_failure_stage(failing_stage)
+    if failure_log_path is not None:
+        normalized_failure_stage = _normalize_failure_stage(
+            failure_log_path.stem
+        )
+    failure_signature = _extract_failure_signature(
+        log_path=failure_log_path,
+        command=failing_command,
+        returncode=returncode,
+    )
     flow_elapsed_seconds = sum_elapsed_seconds_in_log_dir(log_dir)
     payload = {
         "design": design_name,
@@ -1409,9 +1532,11 @@ def write_flow_failure_result(
         "stage_elapsed_seconds": None,
         "params_json": json.dumps(sweep_params, sort_keys=True),
         "result_path": str(log_dir),
-        "failure_stage": failing_stage,
+        "failure_stage": normalized_failure_stage,
         "failure_returncode": returncode,
         "failure_command": command_to_text(failing_command),
+        "failure_signature": failure_signature,
+        "failure_log_path": str(failure_log_path) if failure_log_path is not None else "",
         "blackbox_instance_counts": {},
         "missing_blackboxes": [],
         "macro_manifest_path": (
@@ -1433,7 +1558,7 @@ def write_flow_failure_result(
     append_metrics(circuit_root / "metrics.csv", payload)
     print(
         "[WARN] OpenROAD sweep point failed; recorded flow_failed metrics row "
-        f"stage={failing_stage} returncode={returncode} tag={tag}"
+        f"stage={normalized_failure_stage} returncode={returncode} tag={tag}"
     )
     return payload
 

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -315,11 +315,103 @@ class ModeCompareRegressionTest(unittest.TestCase):
 
             self.assertEqual("flow_failed", row["status"])
             self.assertEqual(17, row["failure_returncode"])
+            self.assertEqual("flow", row["failure_stage"])
+            self.assertIn("exit_code=17", row["failure_signature"])
+            self.assertEqual("", row["failure_log_path"])
             metrics_text = (tmp / "out" / "demo_design" / "metrics.csv").read_text(
                 encoding="utf-8"
             )
             self.assertIn("flow_failed", metrics_text)
+            self.assertIn("failure_signature", metrics_text)
             self.assertTrue((tmp / "out" / "demo_design" / "work").is_dir())
+            payload = json.loads(Path(row["work_result_json"]).read_text(encoding="utf-8"))
+            self.assertEqual("flow_failed", payload["status"])
+            self.assertEqual("flow", payload["failure_stage"])
+            self.assertEqual(17, payload["failure_returncode"])
+
+    def test_run_single_failure_infers_stage_and_signature_from_logs(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done);\\n"
+                "  assign done = clk;\\n"
+                "endmodule\\n",
+                encoding="utf-8",
+            )
+
+            old_dest = self.run_block_sweep.DEST_BASE
+            old_src = self.run_block_sweep.SRC_BASE
+            old_report = self.run_block_sweep.REPORT_BASE
+            old_result = self.run_block_sweep.RESULT_BASE
+            old_log = self.run_block_sweep.LOG_BASE
+            old_run = self.run_block_sweep.subprocess.run
+
+            def fake_run(cmd, *, cwd, check, env):
+                log_dir = (
+                    self.run_block_sweep.LOG_BASE
+                    / "nangate45"
+                    / "demo_design"
+                    / "demo_fail"
+                )
+                log_dir.mkdir(parents=True, exist_ok=True)
+                log_path = log_dir / "3_3_place_gp.log"
+                long_error = "error: " + ("E" * 400)
+                log_path.write_text(
+                    "\\n".join(
+                        [
+                            "running place_gp...",
+                            long_error,
+                        ]
+                    ),
+                    encoding="utf-8",
+                )
+                raise subprocess.CalledProcessError(returncode=19, cmd=cmd)
+
+            self.run_block_sweep.DEST_BASE = tmp / "orfs" / "designs"
+            self.run_block_sweep.SRC_BASE = self.run_block_sweep.DEST_BASE / "src"
+            self.run_block_sweep.REPORT_BASE = tmp / "orfs" / "reports"
+            self.run_block_sweep.RESULT_BASE = tmp / "orfs" / "results"
+            self.run_block_sweep.LOG_BASE = tmp / "orfs" / "logs"
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                row = self.run_block_sweep.run_single(
+                    design_dir=design_dir,
+                    design_name="demo_design",
+                    platform="nangate45",
+                    top="npu_top",
+                    verilog_dir=verilog_dir,
+                    sdc_template=None,
+                    sweep_params={
+                        "TAG": "demo_fail",
+                        "FLOW_VARIANT": "demo_fail",
+                        "CLOCK_PERIOD": 10.0,
+                        "CORE_AREA": "0 0 100 100",
+                    },
+                    out_root=tmp / "out",
+                    skip_existing=False,
+                    dry_run=False,
+                    force_copy=True,
+                    make_target="3_3_place_gp",
+                    macro_manifest=None,
+                )
+            finally:
+                self.run_block_sweep.DEST_BASE = old_dest
+                self.run_block_sweep.SRC_BASE = old_src
+                self.run_block_sweep.REPORT_BASE = old_report
+                self.run_block_sweep.RESULT_BASE = old_result
+                self.run_block_sweep.LOG_BASE = old_log
+                self.run_block_sweep.subprocess.run = old_run
+
+            self.assertEqual("flow_failed", row["status"])
+            self.assertEqual("globalplace", row["failure_stage"])
+            expected_log = tmp / "orfs" / "logs" / "nangate45" / "demo_design" / "demo_fail" / "3_3_place_gp.log"
+            self.assertEqual(str(expected_log), row["failure_log_path"])
+            self.assertLessEqual(len(row["failure_signature"]), 255)
+            self.assertIn("failure_signature", row)
+            self.assertIn("error:", row["failure_signature"])
 
     def test_synth_keep_modules_must_exist_in_generated_rtl(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- retain normalized OpenROAD failure stage and return code in `metrics.csv`
- extract a bounded, path-normalized failure signature from the latest failing flow log
- retain the source log path for evaluator-side follow-up without committing full logs
- cover fallback and log-derived diagnostics

## Why
Folded GQA lane-2 produced valid `flow_failed` boundary rows, but the lightweight submitted artifact omitted the stage and error signature. Diagnosis then depended on transient evaluator files.

## Validation
- `pytest -q tests/test_run_block_sweep_mode_compare.py` (21 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`