### PR TITLE
Add exact 8ns multivalue cluster bridge

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1394,6 +1394,13 @@ def _command_manifest_for_targets(targets: list[Layer1ConfigTarget]) -> list[dic
     return commands
 
 
+def _is_multivalue_cluster_8ns_bridge_sweep(*, item_id: str, sweep_path: str) -> bool:
+    return (
+        item_id == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2"
+        and Path(sweep_path).name == "nangate45_decode_score_multivalue_cluster_8ns_proxy_die_2500.json"
+    )
+
+
 def _expand_expected_outputs_for_trials(*, expected_outputs: list[str], trial_policy: dict[str, int]) -> list[str]:
     trial_count = max(int((trial_policy or {}).get("trial_count") or 1), 1)
     if trial_count <= 1:
@@ -1650,6 +1657,21 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             sweep_path=sweep_path,
             config_paths=config_args,
         )
+
+    if _is_multivalue_cluster_8ns_bridge_sweep(item_id=item_id, sweep_path=sweep_path) and targets:
+        checker_command = {
+            "name": "check_attention_decode_score_multivalue_cluster_8ns_bridge",
+            "run": f"python3 npu/eval/check_attention_decode_score_multivalue_cluster_8ns_bridge.py "
+            f"--metrics-path {targets[0].expected_metrics_path}",
+        }
+        inserted = False
+        for idx, command in enumerate(command_manifest):
+            if command.get("name") == "run_block_sweep":
+                command_manifest.insert(idx + 1, checker_command)
+                inserted = True
+                break
+        if not inserted:
+            command_manifest.append(checker_command)
     expected_outputs = []
     for target in targets:
         expected_outputs.append(target.expected_metrics_path)

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -863,6 +863,44 @@ def _write_example_attention_decode_score_multivalue_cluster_repo(repo_root: Pat
     return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
 
 
+def _write_attention_decode_score_multivalue_cluster_8ns_bridge_sweep(repo_root: Path) -> str:
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "decode_score_multivalue_cluster_v1"
+        / "sweeps"
+        / "nangate45_decode_score_multivalue_cluster_8ns_proxy_die_2500.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "flow_params": {
+                    "TAG": ["decode_score_multivalue_cluster_v1_8ns_bridge"],
+                    "FLOW_VARIANT": ["decode_score_multivalue_cluster_v1_8ns_bridge"],
+                    "CLOCK_PERIOD": [8],
+                },
+                "mode_compare": {
+                    "modes": [
+                        {
+                            "name": "proxy_die_2500",
+                            "use_macro": True,
+                            "param_overrides": {
+                                "DIE_AREA": "0 0 2500 2500",
+                                "CORE_AREA": "50 50 2450 2450",
+                            },
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(sweep_path.relative_to(repo_root))
+
+
 def _write_example_attention_decode_score_multivalue_gqa_group_repo(
     repo_root: Path,
 ) -> tuple[str, str]:
@@ -2542,6 +2580,43 @@ def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_clust
                 "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv",
                 "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/timing_debug_report.md",
             ]
+
+
+def test_generate_l1_sweep_task_adds_bridge_checker_for_exact_8ns_multivalue_cluster_item() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, _ = _write_example_attention_decode_score_multivalue_cluster_repo(repo_root)
+        sweep_path = _write_attention_decode_score_multivalue_cluster_8ns_bridge_sweep(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    item_id="l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_cluster",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert "check_attention_decode_score_multivalue_cluster_8ns_bridge" in [
+                command["name"] for command in work_item.command_manifest
+            ]
+            assert (
+                "python3 npu/eval/check_attention_decode_score_multivalue_cluster_8ns_bridge.py "
+                "--metrics-path runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv"
+                in [command["run"] for command in work_item.command_manifest]
+            )
 
 
 def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_gqa_group_configs() -> None:

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
@@ -1,7 +1,7 @@
 # Evaluation Gate
 
 1. Queue only after merged
-   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1` and
+   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2` and
    `l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1`
    evidence is available.
 2. Run the activity-power audit on the remote evaluator with evaluator-local
@@ -12,3 +12,8 @@
    silicon-current claim is allowed from LEF/LIB proxy views.
 5. Treat vectorless OpenROAD power as structural diagnostics only. It cannot
    substitute for activity-backed power or token-energy claims.
+
+6. Preserve the merged 10 ns Nangate45 row as prior evidence and append the new
+   8 ns proxy-die_2500 (2.5 mm die / 2.4 mm square core) bridge row from the
+   refreshed routed evaluator-local artifacts as the next data point for the same
+   design.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "Queue this audit only after the activity-power hook merges; it depends on already-merged shared-score multivalue-cluster PNR and equivalence evidence.",
+  "source_commit_note": "Queue this audit only after the activity-power hook merges; it depends on the 8 ns shared-score multivalue-cluster PNR bridge and equivalence evidence.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -10,7 +10,7 @@
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -9,10 +9,11 @@
   "hypothesis": "The shared-score multivalue decode cluster can only become promotable if activity-annotated power remains coherent after the merged equivalence proof and merged Nangate45 PNR row are combined with evaluator-local switching evidence; vectorless power alone is insufficient.",
   "direct_comparison": {
     "primary_question": "Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?",
-    "baseline": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+    "baseline": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1 and the forthcoming l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2 bridge row (2.5 mm die / 2.4 mm square core).",
     "include": [
       "merged shared-score multivalue-cluster equivalence evidence",
-      "merged Nangate45 PNR metrics at the committed 8 ns point",
+      "merged Nangate45 PNR 10 ns row for the 2.5 mm die / 2.4 mm square core",
+      "forthcoming 8 ns bridge row for the same 2.5 mm die / 2.4 mm square core using refreshed evaluator-local routed artifacts",
       "evaluator-local VCD, ODB, and SPEF used only to derive portable JSON/MD outputs",
       "annotation, clock, macro activity, and finite power-gate assumptions called out explicitly",
       "repo-portable evidence outputs under runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
@@ -56,7 +57,7 @@
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
@@ -60,6 +60,28 @@
       "merge_commit": "872b177c6be5cec2da0d565609cf69677553f63e",
       "merged_utc": "2026-07-16T12:09:43.974242Z",
       "notes": "Merged via PR #1334 and merge 872b177c6be5cec2da0d565609cf69677553f63e at 2026-07-16T12:09:43.974242Z."
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "task_type": "l1_sweep",
+      "objective": "Re-run the shared-score multivalue cluster at 8 ns for the 2.5 mm die / 2.4 mm square core bridge evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_proxy_die_2500.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_ppa",
+        "reason": "Collect the missing 8 ns Nangate45 evidence in 2.5 mm envelope while keeping current vectorless metrics as bounded frontier evidence."
+      },
+      "status": "pending_implementation"
     }
   ],
   "source_commit": "40fd671e19b79660e28ecf99ab07f38043e0e937"

--- a/npu/eval/check_attention_decode_score_multivalue_cluster_8ns_bridge.py
+++ b/npu/eval/check_attention_decode_score_multivalue_cluster_8ns_bridge.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Validate the 8 ns bridge sweep row for decode-score multivalue cluster."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+EXPECTED_CLOCK_PERIOD = 8
+EXPECTED_FLOW_VARIANT = "decode_score_multivalue_cluster_v1_8ns_bridge"
+EXPECTED_DIE_AREA = "0 0 2500 2500"
+EXPECTED_CORE_AREA = "50 50 2450 2450"
+EXPECTED_RESULT_PATH_TOKEN = "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv"
+
+
+def _parse_params_json(value: str) -> dict[str, object]:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("empty params_json")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+            parsed = json.loads(text[1:-1].replace('""', '"'))
+        else:
+            raise
+    if not isinstance(parsed, dict):
+        raise ValueError("params_json did not decode to a JSON object")
+    return parsed
+
+
+def _to_str(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _iter_metrics_rows(metrics_path: Path):
+    with metrics_path.open(newline="", encoding="utf-8") as stream:
+        reader = csv.DictReader(stream)
+        for row in reader:
+            if row is None:
+                continue
+            yield row
+
+
+def _parse_critical_path(row: dict[str, str]) -> float:
+    value = float(row.get("critical_path_ns", "inf"))
+    return float(value)
+
+
+def _row_matches_bridge(row: dict[str, str]) -> bool:
+    if _to_str(row.get("status")).lower() != "ok":
+        return False
+
+    try:
+        params = _parse_params_json(_to_str(row.get("params_json", "")))
+    except Exception:
+        return False
+
+    if _to_str(params.get("FLOW_VARIANT")) != EXPECTED_FLOW_VARIANT:
+        return False
+
+    try:
+        clock_period = float(_to_str(params.get("CLOCK_PERIOD", "")))
+    except ValueError:
+        return False
+    if clock_period != float(EXPECTED_CLOCK_PERIOD):
+        return False
+
+    if _to_str(params.get("DIE_AREA")) != EXPECTED_DIE_AREA:
+        return False
+    if _to_str(params.get("CORE_AREA")) != EXPECTED_CORE_AREA:
+        return False
+
+    if EXPECTED_RESULT_PATH_TOKEN not in _to_str(row.get("result_path", "")):
+        return False
+
+    try:
+        return _parse_critical_path(row) <= 8
+    except Exception:
+        return False
+
+
+def validate_bridge_metrics(*, metrics_path: Path) -> int:
+    if not metrics_path.exists():
+        raise ValueError(f"missing metrics.csv: {metrics_path}")
+
+    for row in _iter_metrics_rows(metrics_path):
+        if _row_matches_bridge(row):
+            return 0
+
+    raise ValueError("missing required 8ns decode-score multivalue-cluster bridge row (status=ok, CLOCK_PERIOD=8, FLOW_VARIANT=decode_score_multivalue_cluster_v1_8ns_bridge, DIE_AREA=0 0 2500 2500, CORE_AREA=50 50 2450 2450, critical_path_ns<=8)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metrics-path", type=Path, required=True)
+    args = parser.parse_args()
+    validate_bridge_metrics(metrics_path=args.metrics_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_proxy_die_2500.json
+++ b/runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_proxy_die_2500.json
@@ -1,0 +1,35 @@
+{
+  "tag_prefix": "decode_score_multivalue_cluster_v1_8ns_bridge",
+  "flow_params": {
+    "TAG": [
+      "decode_score_multivalue_cluster_v1_8ns_bridge"
+    ],
+    "FLOW_VARIANT": [
+      "decode_score_multivalue_cluster_v1_8ns_bridge"
+    ],
+    "CLOCK_PERIOD": [
+      8
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "proxy_die_2500",
+        "use_macro": true,
+        "param_overrides": {
+          "DIE_AREA": "0 0 2500 2500",
+          "CORE_AREA": "50 50 2450 2450"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_check_attention_decode_score_multivalue_cluster_8ns_bridge.py
+++ b/tests/test_check_attention_decode_score_multivalue_cluster_8ns_bridge.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import csv
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _metrics_path(root: Path) -> Path:
+    design_dir = root / "runs" / "designs" / "npu_blocks" / "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv"
+    return design_dir / "metrics.csv"
+
+
+def _write_metrics(metrics_path: Path, rows: list[tuple]) -> None:
+    header = [
+        "design",
+        "platform",
+        "config_hash",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "total_power_mw",
+        "params_json",
+        "result_path",
+    ]
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    with metrics_path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def _write_row(*, status: str, critical_path_ns: float, params_json: str, result_path: str) -> tuple[str, ...]:
+    return (
+        "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv",
+        "nangate45",
+        "cfg",
+        "param8",
+        "tag",
+        status,
+        f"{critical_path_ns}",
+        "0.2",
+        "0.5",
+        params_json,
+        result_path,
+    )
+
+
+def _run_checker(metrics_path: Path) -> subprocess.CompletedProcess[str]:
+    script = _repo_root() / "npu" / "eval" / "check_attention_decode_score_multivalue_cluster_8ns_bridge.py"
+    return subprocess.run(
+        [sys.executable, str(script), "--metrics-path", str(metrics_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_check_attention_decode_score_multivalue_cluster_8ns_bridge_passes_with_exact_8ns_row() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    params_json='{"FLOW_VARIANT":"decode_score_multivalue_cluster_v1_8ns_bridge","CLOCK_PERIOD":8.0,"DIE_AREA":"0 0 2500 2500","CORE_AREA":"50 50 2450 2450"}',
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+            ],
+        )
+        assert _run_checker(metrics).returncode == 0
+
+
+def test_check_attention_decode_score_multivalue_cluster_8ns_bridge_rejects_existing_10ns_ok_row() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.2189,
+                    params_json='{"FLOW_VARIANT":"decode_score_multivalue_cluster_v1_proxy_die_2500","CLOCK_PERIOD":10,"DIE_AREA":"0 0 2500 2500","CORE_AREA":"50 50 2450 2450"}',
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+            ],
+        )
+        proc = _run_checker(metrics)
+        assert proc.returncode != 0
+        assert "missing required 8ns" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_8ns_bridge_rejects_non_ok_status() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="flow_failed",
+                    critical_path_ns=7.5,
+                    params_json='{"FLOW_VARIANT":"decode_score_multivalue_cluster_v1_8ns_bridge","CLOCK_PERIOD":8,"DIE_AREA":"0 0 2500 2500","CORE_AREA":"50 50 2450 2450"}',
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+            ],
+        )
+        proc = _run_checker(metrics)
+        assert proc.returncode != 0
+        assert "missing required 8ns" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_8ns_bridge_rejects_clock_period_8p5() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    params_json='{"FLOW_VARIANT":"decode_score_multivalue_cluster_v1_8ns_bridge","CLOCK_PERIOD":8.5,"DIE_AREA":"0 0 2500 2500","CORE_AREA":"50 50 2450 2450"}',
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+            ],
+        )
+        proc = _run_checker(metrics)
+        assert proc.returncode != 0
+
+
+def test_check_attention_decode_score_multivalue_cluster_8ns_bridge_rejects_wrong_variant_area_or_path() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    params_json='{"FLOW_VARIANT":"other_variant","CLOCK_PERIOD":8,"DIE_AREA":"0 0 2500 2500","CORE_AREA":"50 50 2450 2450"}',
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    params_json='{"FLOW_VARIANT":"decode_score_multivalue_cluster_v1_8ns_bridge","CLOCK_PERIOD":8,"DIE_AREA":"0 0 3000 3000","CORE_AREA":"50 50 2950 2950"}',
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    params_json='{"FLOW_VARIANT":"decode_score_multivalue_cluster_v1_8ns_bridge","CLOCK_PERIOD":8,"DIE_AREA":"0 0 2500 2500","CORE_AREA":"50 50 2450 2450"}',
+                    result_path="/tmp/other/design/metrics.json",
+                ),
+            ],
+        )
+        proc = _run_checker(metrics)
+        assert proc.returncode != 0
+        assert "missing required 8ns" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_8ns_bridge_skips_malformed_rows() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    params_json="not-json",
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    params_json='{"FLOW_VARIANT":"decode_score_multivalue_cluster_v1_8ns_bridge","CLOCK_PERIOD":8,"DIE_AREA":"0 0 2500 2500","CORE_AREA":"50 50 2450 2450"}',
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+            ],
+        )
+        assert _run_checker(metrics).returncode == 0


### PR DESCRIPTION
## Summary
- add an isolated 8 ns, 2.5 mm die / 2.4 mm core cluster PPA sweep
- require an exact bridge row before the L1 item can submit
- correct the activity proposal's false assumption that merged cluster PPA already included an 8 ns row
- gate cluster activity power on the new physical bridge and preserve the existing 10 ns row as prior evidence

## Root cause
The first cluster activity run failed before power analysis because its audit filters for `CLOCK_PERIOD=8`, while interrupted/recovered cluster PPA preserved only a 10 ns target row. The generic L1 acceptance could also have mistaken that existing row for successful bridge output.

## Validation
- `PYTHONPATH=control_plane pytest -q tests/test_check_attention_decode_score_multivalue_cluster_8ns_bridge.py control_plane/control_plane/tests/test_l1_task_generator.py` (49 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`