### PR TITLE
Auto-discover L1 proposal linkage

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -116,6 +116,61 @@ def _resolve_proposal_abstraction_layer(repo_root: Path, proposal_path: str | No
     return resolved or None
 
 
+def _proposal_mentions_item(payload: dict[str, Any], item_id: str) -> bool:
+    item_retry_base = _retry_base(item_id)
+    for key in ("required_evaluations", "requested_items"):
+        values = payload.get(key)
+        if not isinstance(values, list):
+            continue
+        for entry in values:
+            if not isinstance(entry, dict):
+                continue
+            candidate_item_id = str(entry.get("item_id", "")).strip()
+            if candidate_item_id == item_id or _retry_base(candidate_item_id) == item_retry_base:
+                return True
+    return False
+
+
+def _discover_proposal_for_item(repo_root: Path, item_id: str) -> tuple[str | None, str | None]:
+    proposal_root = repo_root / "docs" / "proposals"
+    if not proposal_root.exists():
+        return None, None
+
+    matches: list[tuple[str, str]] = []
+    for proposal_dir in sorted(path for path in proposal_root.iterdir() if path.is_dir()):
+        proposal_file = proposal_dir / "proposal.json"
+        proposal_id = proposal_dir.name
+        if proposal_file.exists():
+            try:
+                proposal_payload = _load_json(proposal_file)
+            except Exception:
+                proposal_payload = {}
+            if isinstance(proposal_payload, dict):
+                proposal_id = str(proposal_payload.get("proposal_id", "")).strip() or proposal_id
+            else:
+                proposal_payload = {}
+            if _proposal_mentions_item(proposal_payload, item_id):
+                matches.append((proposal_id, str(proposal_dir.relative_to(repo_root))))
+                continue
+
+        evaluation_requests_path = proposal_dir / "evaluation_requests.json"
+        if not evaluation_requests_path.exists():
+            continue
+        try:
+            evaluation_payload = _load_json(evaluation_requests_path)
+        except Exception:
+            continue
+        if not isinstance(evaluation_payload, dict):
+            continue
+        if _proposal_mentions_item(evaluation_payload, item_id):
+            request_proposal_id = str(evaluation_payload.get("proposal_id", "")).strip()
+            matches.append((request_proposal_id or proposal_id, str(proposal_dir.relative_to(repo_root))))
+
+    if len(matches) == 1:
+        return matches[0]
+    return None, None
+
+
 def _proposal_dir(repo_root: Path, proposal_path: str | None) -> Path | None:
     proposal_path_text = str(proposal_path or "").strip()
     if not proposal_path_text:
@@ -1574,6 +1629,9 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
     )
     proposal_path = _repo_rel(request.proposal_path, repo_root) if request.proposal_path else None
     proposal_path = canonicalize_proposal_path(repo_root, proposal_path=proposal_path, proposal_id=request.proposal_id)
+    if not proposal_path:
+        proposal_id, proposal_path = _discover_proposal_for_item(repo_root, item_id)
+        proposal_path = canonicalize_proposal_path(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
     effective_proposal_id = str(request.proposal_id or "").strip()
     if not effective_proposal_id and proposal_path:
         proposal_path_obj = Path(proposal_path)

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -1754,6 +1754,105 @@ def test_generate_l1_sweep_task_inherits_proposal_dependencies_and_starts_blocke
             }
 
 
+def test_generate_l1_sweep_task_auto_discovers_proposal_for_existing_item() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, _ = _write_example_attention_decode_score_multivalue_cluster_repo(repo_root)
+        sweep_path = _write_attention_decode_score_multivalue_cluster_8ns_bridge_sweep(repo_root)
+        proposal_dir = repo_root / "docs" / "proposals" / "prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1"
+        proposal_dir.mkdir(parents=True)
+        item_id = "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2"
+        required_entry = {
+            "item_id": item_id,
+            "task_type": "l1_sweep",
+            "objective": "Re-run the shared-score multivalue cluster at 8 ns for the 2.5 mm die / 2.4 mm square core bridge evidence.",
+            "evaluation_mode": "frontier_followup",
+            "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+            "comparison_role": "shared_score_multivalue_cluster_pnr",
+            "depends_on_item_ids": ["l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"],
+            "requires_merged_inputs": True,
+            "requires_materialized_refs": True,
+            "expected_result": {
+                "direction": "measure_shared_score_multivalue_cluster_ppa",
+                "reason": "Collect the missing 8 ns Nangate45 evidence in 2.5 mm envelope while keeping current vectorless metrics as bounded frontier evidence.",
+            },
+            "config_paths": [
+                "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+            ],
+            "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/"
+            "nangate45_decode_score_multivalue_cluster_8ns_proxy_die_2500.json",
+            "status": "pending_implementation_merge",
+        }
+        (proposal_dir / "proposal.json").write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1",
+                    "required_evaluations": [required_entry],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (proposal_dir / "evaluation_requests.json").write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1",
+                    "source_commit": "",
+                    "requested_items": [required_entry],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    item_id=item_id,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    # No proposal fields provided; auto-discovery should infer proposal linkage.
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = work_item.task_request.request_payload["developer_loop"]
+            assert work_item.state == WorkItemState.BLOCKED
+            assert payload["proposal_id"] == "prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1"
+            assert (
+                payload["proposal_path"]
+                == "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1"
+            )
+            assert payload["dependencies"] == {
+                "item_ids": ["l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+            assert payload["evaluation"] == {
+                "mode": "frontier_followup",
+                "expected_direction": "measure_shared_score_multivalue_cluster_ppa",
+                "expected_reason": (
+                    "Collect the missing 8 ns Nangate45 evidence in 2.5 mm envelope while keeping "
+                    "current vectorless metrics as bounded frontier evidence."
+                ),
+                "trial_policy": {"trial_count": 1, "seed_start": 0, "stop_after_failures": 1},
+            }
+
+        assert result.status == "applied"
+
+
 def test_generate_l1_sweep_task_strips_placeholder_requested_items_from_template() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
@@ -92,6 +92,28 @@
         "reason": "Vectorless power is needed for structural comparison, but token energy remains blocked until activity-backed evidence exists."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "task_type": "l1_sweep",
+      "objective": "Re-run the shared-score multivalue cluster at 8 ns for the 2.5 mm die / 2.4 mm square core bridge evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_proxy_die_2500.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_ppa",
+        "reason": "Collect the missing 8 ns Nangate45 evidence in 2.5 mm envelope while keeping current vectorless metrics as bounded frontier evidence."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "baseline_refs": [


### PR DESCRIPTION
## Summary
- register the exact 8 ns cluster bridge in the proposal's authoritative required evaluations
- auto-discover unique Layer-1 proposal ownership by item ID when callers omit proposal flags
- inherit evaluation, comparison, and dependency contracts before materialization
- test that auto-discovered unresolved dependencies start blocked with complete linkage

## Root cause
The bridge appeared only in `evaluation_requests.json`, while L1 generation had no proposal auto-discovery fallback. Materialization therefore produced empty `proposal_id`, `proposal_path`, and dependencies.

## Validation
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l1_task_generator.py` (44 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`