### PR TITLE
eval: add lane2 macro hierarchy placement probe

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1456,6 +1456,13 @@ def _is_multivalue_cluster_8ns_bridge_sweep(*, item_id: str, sweep_path: str) ->
     )
 
 
+def _is_gqa_lanes2_macro_hier_placement_sweep(*, item_id: str, sweep_path: str) -> bool:
+    return (
+        item_id == "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_macro_placement_v1"
+        and Path(sweep_path).name == "nangate45_decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550.json"
+    )
+
+
 def _expand_expected_outputs_for_trials(*, expected_outputs: list[str], trial_policy: dict[str, int]) -> list[str]:
     trial_count = max(int((trial_policy or {}).get("trial_count") or 1), 1)
     if trial_count <= 1:
@@ -1690,13 +1697,20 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
     )
     source_commit = _resolve_source_commit(repo_root, request.source_commit)
 
+    effective_make_target = request.make_target
+    if not effective_make_target and _is_gqa_lanes2_macro_hier_placement_sweep(
+        item_id=item_id,
+        sweep_path=sweep_path,
+    ):
+        effective_make_target = "3_5_place_dp"
+
     targets = [
         _read_config_target(
             (repo_root / config_path).resolve(),
             repo_root=repo_root,
             config_rel=config_path,
             out_root=out_root,
-            make_target=request.make_target,
+            make_target=effective_make_target,
         )
         for config_path in config_paths
     ]
@@ -1730,10 +1744,35 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
                 break
         if not inserted:
             command_manifest.append(checker_command)
+
+    if _is_gqa_lanes2_macro_hier_placement_sweep(item_id=item_id, sweep_path=sweep_path) and targets:
+        checker_command = {
+            "name": "check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement",
+            "run": (
+                "python3 npu/eval/check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement.py "
+                f"--metrics-path {targets[0].expected_metrics_path} --out "
+                f"{str(Path(targets[0].expected_metrics_path).parent / 'mode_compare_lanes2_placement_diag.json')}"
+            ),
+        }
+        inserted = False
+        for idx, command in enumerate(command_manifest):
+            if command.get("name") == "run_block_sweep":
+                command_manifest.insert(idx + 1, checker_command)
+                inserted = True
+                break
+        if not inserted:
+            command_manifest.append(checker_command)
+
     expected_outputs = []
     for target in targets:
         expected_outputs.append(target.expected_metrics_path)
         expected_outputs.extend(target.expected_report_paths)
+
+    if _is_gqa_lanes2_macro_hier_placement_sweep(item_id=item_id, sweep_path=sweep_path):
+        for target in targets:
+            expected_outputs.append(
+                f"{Path(target.expected_metrics_path).parent}/mode_compare_lanes2_placement_diag.json"
+            )
 
     title = request.title or _default_title(sweep_path=sweep_path, platform=request.platform)
     objective = request.objective or _default_objective(

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -11,8 +11,12 @@ from unittest.mock import patch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from control_plane.clock import utcnow
 from control_plane.db import create_all
-from control_plane.models.enums import WorkItemState
+from control_plane.models.artifacts import Artifact
+from control_plane.models.enums import RunStatus, WorkItemState
+from control_plane.models.runs import Run
+from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
 from control_plane.services.l1_task_generator import (
     Layer1SweepGenerateRequest,
@@ -998,6 +1002,99 @@ def _write_example_attention_decode_score_multivalue_gqa_array_repo(
         encoding="utf-8",
     )
     return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
+def _write_example_attention_decode_score_multivalue_gqa_group_lanes2_repo(
+    repo_root: Path,
+) -> str:
+    design_dir = (
+        repo_root
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv"
+    )
+    design_dir.mkdir(parents=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": "0.1",
+                "top_name": "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv",
+                "attention_decode_score_multivalue_gqa_group": {
+                    "max_blocks": 16384,
+                    "array_n": 8,
+                    "value_slices": 16,
+                    "divider_impl": "iterative_restoring",
+                    "score_scale_lanes_per_cycle": 1,
+                    "query_heads_per_kv": 8,
+                    "parallel_query_head_lanes": 2,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (design_dir / "macro_manifest.json").write_text(
+        json.dumps({"manifest_params": {"score_bank_macro_count": 112}}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
+def _write_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement_sweep(repo_root: Path) -> str:
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "decode_score_multivalue_gqa_folded_lanes_v1"
+        / "sweeps"
+        / "nangate45_decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550_v1",
+                "flow_params": {
+                    "TAG": ["decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550_v1"],
+                    "FLOW_VARIANT": ["decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550_v1"],
+                    "CLOCK_PERIOD": [10],
+                    "PLACE_DENSITY": [0.4],
+                    "SYNTH_HIERARCHICAL": [1],
+                    "SYNTH_MEMORY_MAX_BITS": [65536],
+                },
+                "mode_compare": {
+                    "modes": [
+                        {
+                            "name": "flattened_wrapper",
+                            "use_macro": True,
+                            "param_overrides": {
+                                "SYNTH_HIERARCHICAL": 0,
+                                "DIE_AREA": "0 0 3550 3550",
+                                "CORE_AREA": "50 50 3500 3500",
+                            },
+                        },
+                        {
+                            "name": "hierarchical_macro",
+                            "use_macro": True,
+                            "param_overrides": {
+                                "SYNTH_HIERARCHICAL": 1,
+                                "DIE_AREA": "0 0 3550 3550",
+                                "CORE_AREA": "50 50 3500 3500",
+                            },
+                        },
+                    ]
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(sweep_path.relative_to(repo_root))
 
 
 def _write_example_attention_hbm_replay_controller_repo(repo_root: Path) -> tuple[str, str]:
@@ -2716,6 +2813,216 @@ def test_generate_l1_sweep_task_adds_bridge_checker_for_exact_8ns_multivalue_clu
                 "--metrics-path runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv"
                 in [command["run"] for command in work_item.command_manifest]
             )
+
+
+def test_generate_l1_sweep_task_adds_lanes2_macro_hier_placement_checker() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path = _write_example_attention_decode_score_multivalue_gqa_group_lanes2_repo(repo_root)
+        sweep_path = _write_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement_sweep(repo_root)
+        proposal_dir = repo_root / "docs" / "proposals" / "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1"
+        proposal_dir.mkdir(parents=True)
+        item_id = "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_macro_placement_v1"
+        baseline_item_id = "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1"
+        equivalence_item_id = "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+        required_entry = {
+            "item_id": item_id,
+            "task_type": "l1_sweep",
+            "objective": "Diagnose folded GQA8 lane2 physical placement failure at the 3.55 mm die with macro-preserving hierarchy comparison, retaining failed rows as explicit boundary evidence.",
+            "evaluation_mode": "frontier_followup",
+            "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
+            "comparison_role": "gqa8_folded_lanes2_macro_placement",
+            "paired_baseline_item_id": baseline_item_id,
+            "depends_on_item_ids": [equivalence_item_id],
+            "requires_merged_inputs": True,
+            "requires_materialized_refs": True,
+            "expected_result": {
+                "direction": "diagnose_gqa8_folded_lanes2_macro_hierarchy_placement",
+                "reason": "Disentangle placement feasibility from flattening policy while keeping macros explicit.",
+            },
+            "config_paths": [
+                "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/config.json"
+            ],
+            "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/"
+            "nangate45_decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550.json",
+            "status": "pending_implementation_merge",
+        }
+        (proposal_dir / "proposal.json").write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1",
+                    "required_evaluations": [required_entry],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (proposal_dir / "evaluation_requests.json").write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1",
+                    "source_commit": "",
+                    "requested_items": [required_entry],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        equivalence_artifact_path = (
+            repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{equivalence_item_id}.json"
+        )
+        equivalence_artifact_path.parent.mkdir(parents=True)
+        equivalence_artifact_path.write_text("{}\n", encoding="utf-8")
+
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            equivalence_request = TaskRequest(
+                request_key=f"test:{equivalence_item_id}",
+                source="test",
+                requested_by="@tester",
+                title="Merged folded-lane equivalence",
+                description="",
+                layer="layer2",
+                flow="openroad",
+                priority=1,
+                request_payload={},
+            )
+            baseline_request = TaskRequest(
+                request_key=f"test:{baseline_item_id}",
+                source="test",
+                requested_by="@tester",
+                title="Unmerged lane2 physical baseline",
+                description="",
+                layer="layer1",
+                flow="openroad",
+                priority=1,
+                request_payload={},
+            )
+            session.add_all([equivalence_request, baseline_request])
+            session.flush()
+            equivalence_item = WorkItem(
+                work_item_key=f"test:{equivalence_item_id}",
+                task_request_id=equivalence_request.id,
+                item_id=equivalence_item_id,
+                layer="layer2",
+                flow="openroad",
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.MERGED,
+                priority=1,
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[],
+                acceptance_rules=[],
+            )
+            baseline_item = WorkItem(
+                work_item_key=f"test:{baseline_item_id}",
+                task_request_id=baseline_request.id,
+                item_id=baseline_item_id,
+                layer="layer1",
+                flow="openroad",
+                platform="nangate45",
+                task_type="l1_sweep",
+                state=WorkItemState.AWAITING_REVIEW,
+                priority=1,
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[],
+                acceptance_rules=[],
+            )
+            session.add_all([equivalence_item, baseline_item])
+            session.flush()
+            equivalence_run = Run(
+                run_key=f"test:{equivalence_item_id}:run",
+                work_item_id=equivalence_item.id,
+                attempt=1,
+                executor_type="internal_worker",
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit=source_commit,
+                result_summary="equivalence merged",
+                result_payload={},
+            )
+            session.add(equivalence_run)
+            session.flush()
+            session.add(
+                Artifact(
+                    run_id=equivalence_run.id,
+                    kind="decision_proposal",
+                    storage_mode="repo",
+                    path=str(equivalence_artifact_path.relative_to(repo_root)),
+                    sha256="test",
+                    metadata_={},
+                )
+            )
+            session.flush()
+
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    item_id=item_id,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    # Proposal linkage should be auto-discovered from local required_evaluations.
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert baseline_item.state == WorkItemState.AWAITING_REVIEW
+            assert work_item.state == WorkItemState.DISPATCH_PENDING
+            command_names = [command["name"] for command in work_item.command_manifest]
+            assert "check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement" in command_names
+            assert (
+                "python3 npu/eval/check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement.py "
+                "--metrics-path runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/metrics.csv "
+                "--out runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/"
+                "mode_compare_lanes2_placement_diag.json"
+                in [command["run"] for command in work_item.command_manifest]
+            )
+            sweep_command = work_item.command_manifest[2]["run"]
+            assert "--make_target 3_5_place_dp" in sweep_command
+            assert (
+                "runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/"
+                "mode_compare_lanes2_placement_diag.json"
+                in work_item.expected_outputs
+            )
+
+            dev_loop = work_item.task_request.request_payload["developer_loop"]
+            assert dev_loop["proposal_path"] == "docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1"
+            assert dev_loop["proposal_id"] == "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1"
+            assert dev_loop["comparison"]["role"] == "gqa8_folded_lanes2_macro_placement"
+            assert (
+                dev_loop["comparison"]["paired_baseline_item_id"]
+                == "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1"
+            )
+            assert dev_loop["dependencies"]["item_ids"] == [
+                equivalence_item_id,
+            ]
+            assert dev_loop["evaluation"]["expected_direction"] == (
+                "diagnose_gqa8_folded_lanes2_macro_hierarchy_placement"
+            )
+            assert (
+                dev_loop["evaluation"]["expected_reason"]
+                == "Disentangle placement feasibility from flattening policy while keeping macros explicit."
+            )
+
+        assert result.status == "applied"
 
 
 def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_gqa_group_configs() -> None:

--- a/docs/developer_agent_loop.md
+++ b/docs/developer_agent_loop.md
@@ -264,6 +264,11 @@ Required metadata per work item:
   - `depends_on_item_ids`
   - `requires_merged_inputs`
   - `requires_materialized_refs`
+- for macro-placement diagnostics, explicitly define both macro-preserving `mode_compare`
+  entries in the sweep (`use_macro: true` for each), rather than relying on the
+  default `flat_nomacro` baseline; keep the make target explicit (for example
+  `3_5_place_dp`) and keep `SYNTH_KEEP_MODULES` unset unless flow context
+  requires it
 
 `proposal_path` must resolve to the proposal's `proposal.json`, normally
 `docs/proposals/<proposal_id>/proposal.json`. Keep the proposal workspace

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -121,6 +121,29 @@
       "status": "pending_implementation_merge"
     },
     {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_macro_placement_v1",
+      "task_type": "l1_sweep",
+      "objective": "Diagnose folded GQA8 lane2 physical placement failure at the 3.55 mm die with macro-preserving hierarchy comparison, retaining failed rows as explicit boundary evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
+      "comparison_role": "gqa8_folded_lanes2_macro_placement",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "diagnose_gqa8_folded_lanes2_macro_hierarchy_placement",
+        "reason": "Disentangle flattening policy effects from synthesis feasibility while keeping macros and physical params fixed."
+      },
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550.json",
+      "status": "pending_implementation_merge"
+    },
+    {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
       "task_type": "l1_sweep",
       "objective": "Measure the four-lane folded GQA8 group at the matched-density 5.05 mm die and 8/10 ns targets, retaining failed rows as explicit boundary evidence.",

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -144,6 +144,29 @@
       "status": "pending_control_plane_merge"
     },
     {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_macro_placement_v1",
+      "task_type": "l1_sweep",
+      "objective": "Diagnose folded GQA8 lane2 physical placement failure at the 3.55 mm die with macro-preserving hierarchy comparison, retaining failed rows as explicit boundary evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_gqa_folded_lane",
+      "comparison_role": "gqa8_folded_lanes2_macro_placement",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "diagnose_gqa8_folded_lanes2_macro_hierarchy_placement",
+        "reason": "Disentangle flattening policy effects from synthesis feasibility while keeping macros and physical params fixed."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
       "item_id": "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
       "task_type": "l1_sweep",
       "objective": "Measure the four-lane folded group at matched macro density and retain failed rows as explicit boundary evidence.",

--- a/npu/eval/check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement.py
+++ b/npu/eval/check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Validate macro-placement mode-comparison evidence for folded GQA8 lane2."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+
+EXPECTED_CLOCK_PERIOD = 10
+EXPECTED_DIE_AREA = "0 0 3550 3550"
+EXPECTED_CORE_AREA = "50 50 3500 3500"
+EXPECTED_DESIGN = "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv"
+EXPECTED_RESULT_PATH_TOKEN = EXPECTED_DESIGN
+EXPECTED_PLACE_DENSITY = 0.4
+EXPECTED_SYNTH_MEMORY_MAX_BITS = 65536
+EXPECTED_FLOW_VARIANT_PREFIX = "decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550_v1"
+
+EXPECTED_MODES = [
+    {
+        "name": "flattened_wrapper",
+        "hierarchical": 0,
+        "flow_variant": f"{EXPECTED_FLOW_VARIANT_PREFIX}_flattened_wrapper",
+    },
+    {
+        "name": "hierarchical_macro",
+        "hierarchical": 1,
+        "flow_variant": f"{EXPECTED_FLOW_VARIANT_PREFIX}_hierarchical_macro",
+    },
+]
+
+VALID_STATUSES = {"ok", "flow_failed"}
+
+
+def _to_str(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _parse_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    token = _to_str(value).lower()
+    if token in {"1", "true", "yes", "on"}:
+        return True
+    if token in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def _parse_int(value: object) -> int:
+    if isinstance(value, bool):
+        raise ValueError("expected integer value")
+    if isinstance(value, int):
+        return value
+    try:
+        parsed = float(value) if isinstance(value, float) else float(_to_str(value))
+    except (TypeError, ValueError):
+        raise ValueError("expected integer value")
+    if not parsed.is_integer():
+        raise ValueError("expected integer value")
+    return int(parsed)
+
+
+def _parse_params_json(value: str) -> dict[str, object]:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("empty params_json")
+    parsed = json.loads(text)
+    if not isinstance(parsed, dict):
+        raise ValueError("params_json did not decode to an object")
+    return parsed
+
+
+def _iter_metrics_rows(metrics_path: Path):
+    with metrics_path.open(newline="", encoding="utf-8") as stream:
+        reader = csv.DictReader(stream)
+        for row in reader:
+            if row is not None:
+                yield row
+
+
+def _row_matches_mode(
+    row: dict[str, str],
+    *,
+    mode_name: str,
+    hierarchical: int,
+    flow_variant: str,
+) -> bool:
+    if _to_str(row.get("mode_name")) != mode_name:
+        return False
+    if _to_str(row.get("status")).lower() not in VALID_STATUSES:
+        return False
+
+    if _to_str(row.get("design")) != EXPECTED_DESIGN:
+        return False
+    if _to_str(row.get("result_path")).find(EXPECTED_RESULT_PATH_TOKEN) == -1:
+        return False
+
+    mode_use_macro = _parse_bool(row.get("mode_use_macro"))
+    if mode_use_macro is not True:
+        return False
+
+    try:
+        params = _parse_params_json(_to_str(row.get("params_json", "")))
+    except Exception:
+        return False
+
+    try:
+        clock_period = float(_to_str(params.get("CLOCK_PERIOD")))
+    except (TypeError, ValueError):
+        return False
+    if clock_period != float(EXPECTED_CLOCK_PERIOD):
+        return False
+
+    try:
+        if _parse_int(params.get("SYNTH_HIERARCHICAL")) != hierarchical:
+            return False
+        if _parse_int(params.get("SYNTH_MEMORY_MAX_BITS")) != EXPECTED_SYNTH_MEMORY_MAX_BITS:
+            return False
+        if float(_to_str(params.get("PLACE_DENSITY"))) != EXPECTED_PLACE_DENSITY:
+            return False
+    except Exception:
+        return False
+
+    return (
+        _to_str(params.get("FLOW_VARIANT")) == flow_variant
+        and _to_str(params.get("DIE_AREA")) == EXPECTED_DIE_AREA
+        and _to_str(params.get("CORE_AREA")) == EXPECTED_CORE_AREA
+    )
+
+
+def _collect_mode_rows(
+    rows: list[dict[str, str]],
+) -> dict[str, list[dict[str, str]]]:
+    by_mode: dict[str, list[dict[str, str]]] = {
+        mode["name"]: [] for mode in EXPECTED_MODES
+    }
+    for row in rows:
+        for mode in EXPECTED_MODES:
+            if _row_matches_mode(
+                row,
+                mode_name=mode["name"],
+                hierarchical=mode["hierarchical"],
+                flow_variant=mode["flow_variant"],
+            ):
+                by_mode[mode["name"]].append(row)
+    return by_mode
+
+
+def _summary_rows(by_mode: dict[str, list[dict[str, str]]]) -> dict[str, object]:
+    summaries: list[dict[str, object]] = []
+    failures: list[str] = []
+    for mode in EXPECTED_MODES:
+        name = mode["name"]
+        matches = by_mode.get(name, [])
+        if not matches:
+            failures.append(f"missing required mode: {name}")
+            continue
+
+        # Keep the first matching row as the representative, while still reporting all
+        # statuses to preserve explicit feasibility/boundary evidence.
+        row = matches[0]
+        summaries.append(
+            {
+                "mode": name,
+                "status": _to_str(row.get("status")),
+                "critical_path_ns": row.get("critical_path_ns") if row.get("critical_path_ns") else None,
+                "failure_stage": row.get("failure_stage") if row.get("failure_stage") else None,
+                "failure_signature": row.get("failure_signature") if row.get("failure_signature") else None,
+                "mode_use_macro": _to_str(row.get("mode_use_macro")),
+                "result_path": _to_str(row.get("result_path")),
+                "tag": _to_str(row.get("tag")),
+            }
+        )
+
+    return {
+        "status": "ok" if not failures else "invalid",
+        "status_mode_rows": summaries,
+        "failures": failures,
+    }
+
+
+def validate_mode_compare(*, metrics_path: Path, out_path: Path | None) -> int:
+    if not metrics_path.exists():
+        raise ValueError(f"missing metrics.csv: {metrics_path}")
+
+    rows = list(_iter_metrics_rows(metrics_path))
+    by_mode = _collect_mode_rows(rows)
+    summary = _summary_rows(by_mode)
+
+    for mode in EXPECTED_MODES:
+        if mode["name"] in [x.get("mode") for x in summary["status_mode_rows"]]:
+            continue
+        summary["status"] = "invalid"
+        missing_msg = f"missing required mode: {mode['name']}"
+        if missing_msg not in summary["failures"]:
+            summary["failures"].append(missing_msg)
+
+    if out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if summary["status"] != "ok":
+        raise ValueError("required mode-comparison evidence missing or malformed: " + "; ".join(summary["failures"]))
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metrics-path", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    return validate_mode_compare(metrics_path=args.metrics_path, out_path=args.out)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550.json
+++ b/runs/campaigns/npu/decode_score_multivalue_gqa_folded_lanes_v1/sweeps/nangate45_decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550.json
@@ -1,0 +1,33 @@
+{
+  "tag_prefix": "decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550_v1",
+  "flow_params": {
+    "TAG": ["decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550_v1"],
+    "FLOW_VARIANT": ["decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550_v1"],
+    "CLOCK_PERIOD": [10],
+    "PLACE_DENSITY": [0.4],
+    "SYNTH_HIERARCHICAL": [1],
+    "SYNTH_MEMORY_MAX_BITS": [65536]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "flattened_wrapper",
+        "use_macro": true,
+        "param_overrides": {
+          "SYNTH_HIERARCHICAL": 0,
+          "DIE_AREA": "0 0 3550 3550",
+          "CORE_AREA": "50 50 3500 3500"
+        }
+      },
+      {
+        "name": "hierarchical_macro",
+        "use_macro": true,
+        "param_overrides": {
+          "SYNTH_HIERARCHICAL": 1,
+          "DIE_AREA": "0 0 3550 3550",
+          "CORE_AREA": "50 50 3500 3500"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement.py
+++ b/tests/test_check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+FLOW_VARIANT_PREFIX = "decode_score_multivalue_gqa_lanes2_macro_hier_placement_compare_3550_v1"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _metrics_path(root: Path) -> Path:
+    design_dir = root / "runs" / "designs" / "npu_blocks" / "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv"
+    return design_dir / "metrics.csv"
+
+
+def _write_metrics(metrics_path: Path, rows: list[tuple]) -> None:
+    header = [
+        "design",
+        "platform",
+        "config_hash",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "total_power_mw",
+        "mode_name",
+        "mode_use_macro",
+        "failure_stage",
+        "failure_signature",
+        "params_json",
+        "result_path",
+    ]
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    with metrics_path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def _write_row(
+    *,
+    status: str,
+    mode_name: str,
+    mode_use_macro: bool,
+    critical_path_ns: float,
+    hierarchical: int,
+    result_path: str,
+    failure_stage: str = "",
+    failure_signature: str = "",
+    flow_variant: str | None = None,
+    place_density: float = 0.4,
+    synth_memory_max_bits: int = 65536,
+) -> tuple[str, ...]:
+    params = {
+        "CLOCK_PERIOD": 10,
+        "FLOW_VARIANT": flow_variant or f"{FLOW_VARIANT_PREFIX}_{mode_name}",
+        "PLACE_DENSITY": place_density,
+        "SYNTH_HIERARCHICAL": hierarchical,
+        "SYNTH_MEMORY_MAX_BITS": synth_memory_max_bits,
+        "DIE_AREA": "0 0 3550 3550",
+        "CORE_AREA": "50 50 3500 3500",
+    }
+    return (
+        "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv",
+        "nangate45",
+        "cfg",
+        "param10",
+        f"tag_{mode_name}",
+        status,
+        f"{critical_path_ns}",
+        "0.2",
+        "0.5",
+        mode_name,
+        str(mode_use_macro),
+        failure_stage,
+        failure_signature,
+        json.dumps(params),
+        result_path,
+    )
+
+
+def _run_checker(metrics_path: Path, out_path: Path) -> subprocess.CompletedProcess[str]:
+    script = _repo_root() / "npu" / "eval" / "check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement.py"
+    return subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--metrics-path",
+            str(metrics_path),
+            "--out",
+            str(out_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement_passes_with_one_failed_mode() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        metrics = _metrics_path(tmp)
+        report = tmp / "runs" / "designs" / "npu_blocks" / "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv" / "mode_compare_lanes2_placement_diag.json"
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    mode_name="flattened_wrapper",
+                    mode_use_macro=True,
+                    critical_path_ns=10.1,
+                    hierarchical=0,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/3_5_place_dp/base/params.json",
+                ),
+                _write_row(
+                    status="flow_failed",
+                    mode_name="hierarchical_macro",
+                    mode_use_macro=True,
+                    critical_path_ns=0,
+                    hierarchical=1,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/3_5_place_dp/base/params.json",
+                    failure_stage="place",
+                    failure_signature="exit_code=13",
+                ),
+            ],
+        )
+
+        proc = _run_checker(metrics, report)
+        assert proc.returncode == 0
+        payload = json.loads(report.read_text(encoding="utf-8"))
+        assert payload["status"] == "ok"
+        modes = {entry["mode"] for entry in payload["status_mode_rows"]}
+        assert modes == {"flattened_wrapper", "hierarchical_macro"}
+        assert payload["status_mode_rows"][0]["mode_use_macro"] in {"True", "true"}
+
+
+def test_check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement_rejects_missing_mode() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        metrics = _metrics_path(tmp)
+        report = tmp / "runs" / "designs" / "npu_blocks" / "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv" / "mode_compare_lanes2_placement_diag.json"
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    mode_name="flattened_wrapper",
+                    mode_use_macro=True,
+                    critical_path_ns=10.1,
+                    hierarchical=0,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/3_5_place_dp/base/params.json",
+                ),
+            ],
+        )
+
+        proc = _run_checker(metrics, report)
+        assert proc.returncode != 0
+        assert "missing required mode" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement_rejects_non_macro_mode() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        metrics = _metrics_path(tmp)
+        report = tmp / "runs" / "designs" / "npu_blocks" / "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv" / "mode_compare_lanes2_placement_diag.json"
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    mode_name="flattened_wrapper",
+                    mode_use_macro=False,
+                    critical_path_ns=9.9,
+                    hierarchical=0,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/3_5_place_dp/base/params.json",
+                ),
+                _write_row(
+                    status="ok",
+                    mode_name="hierarchical_macro",
+                    mode_use_macro=True,
+                    critical_path_ns=9.6,
+                    hierarchical=1,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/3_5_place_dp/base/params.json",
+                ),
+            ],
+        )
+
+        proc = _run_checker(metrics, report)
+        assert proc.returncode != 0
+        assert "missing required mode" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement_rejects_malformed_hier_setting() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        metrics = _metrics_path(tmp)
+        report = tmp / "runs" / "designs" / "npu_blocks" / "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv" / "mode_compare_lanes2_placement_diag.json"
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    mode_name="flattened_wrapper",
+                    mode_use_macro=True,
+                    critical_path_ns=9.9,
+                    hierarchical=1,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/3_5_place_dp/base/params.json",
+                ),
+                _write_row(
+                    status="ok",
+                    mode_name="hierarchical_macro",
+                    mode_use_macro=True,
+                    critical_path_ns=9.6,
+                    hierarchical=1,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/3_5_place_dp/base/params.json",
+                ),
+            ],
+        )
+
+        proc = _run_checker(metrics, report)
+        assert proc.returncode != 0
+        assert "missing required mode" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "bad_param",
+    [
+        {"flow_variant": f"{FLOW_VARIANT_PREFIX}_wrong_mode"},
+        {"place_density": 0.41},
+        {"synth_memory_max_bits": 32768},
+    ],
+    ids=["wrong-flow-variant", "wrong-place-density", "wrong-memory-threshold"],
+)
+def test_check_attention_decode_score_multivalue_gqa_lanes2_macro_hier_placement_rejects_changed_fixed_param(
+    bad_param: dict[str, object],
+) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        metrics = _metrics_path(tmp)
+        report = (
+            tmp
+            / "runs"
+            / "designs"
+            / "npu_blocks"
+            / "attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv"
+            / "mode_compare_lanes2_placement_diag.json"
+        )
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    mode_name="flattened_wrapper",
+                    mode_use_macro=True,
+                    critical_path_ns=9.9,
+                    hierarchical=0,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/3_5_place_dp/base/params.json",
+                    **bad_param,
+                ),
+                _write_row(
+                    status="flow_failed",
+                    mode_name="hierarchical_macro",
+                    mode_use_macro=True,
+                    critical_path_ns=0,
+                    hierarchical=1,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_gqa_group_lanes2_int8_m1x8_iterdiv/3_5_place_dp/base/params.json",
+                    failure_stage="place",
+                    failure_signature="exit_code=13",
+                ),
+            ],
+        )
+
+        proc = _run_checker(metrics, report)
+        assert proc.returncode != 0
+        assert "missing required mode: flattened_wrapper" in proc.stderr

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -105,6 +105,43 @@ class ModeCompareRegressionTest(unittest.TestCase):
         self.assertFalse(cfg["modes"][0]["use_macro"])
         self.assertTrue(cfg["modes"][1]["use_macro"])
 
+    def test_parse_mode_compare_macro_placement_modes(self):
+        raw = {
+            "mode_compare": {
+                "modes": [
+                    {
+                        "name": "Flattened_wrapper",
+                        "use_macro": True,
+                        "param_overrides": {
+                            "SYNTH_HIERARCHICAL": 0,
+                            "DIE_AREA": "0 0 3550 3550",
+                            "CORE_AREA": "50 50 3500 3500",
+                        },
+                    },
+                    {
+                        "name": "Hierarchical_macro",
+                        "use_macro": "true",
+                        "param_overrides": {
+                            "SYNTH_HIERARCHICAL": 1,
+                            "DIE_AREA": "0 0 3550 3550",
+                            "CORE_AREA": "50 50 3500 3500",
+                        },
+                    },
+                ]
+            }
+        }
+        cfg = self.run_block_sweep.parse_mode_compare_config(raw)
+        self.assertIsNotNone(cfg)
+        assert cfg is not None
+        modes = cfg["modes"]
+        self.assertEqual("flattened_wrapper", modes[0]["slug"])
+        self.assertEqual("hierarchical_macro", modes[1]["slug"])
+        self.assertTrue(modes[0]["use_macro"])
+        self.assertTrue(modes[1]["use_macro"])
+        self.assertEqual(0, modes[0]["param_overrides"]["SYNTH_HIERARCHICAL"])
+        self.assertEqual(1, modes[1]["param_overrides"]["SYNTH_HIERARCHICAL"])
+
+
     def test_apply_mode_to_params(self):
         base = {
             "TAG": "run_tag",


### PR DESCRIPTION
## Summary
- add an isolated folded-GQA lane2 placement-only A/B diagnostic
- keep FakeRAM macros hardened in both modes and vary only `SYNTH_HIERARCHICAL`
- validate exact mode-specific physical contracts while retaining `flow_failed` rows as boundary evidence
- proposal-link the diagnostic without requiring the unmerged failed baseline, avoiding a dependency deadlock
- document why the default `flat_nomacro` comparison is invalid for this diagnosis

## Physical comparison
- 10 ns, 3.55 mm die / 3.50 mm core, density 0.4
- `flattened_wrapper`: macros retained, `SYNTH_HIERARCHICAL=0`
- `hierarchical_macro`: macros retained, `SYNTH_HIERARCHICAL=1`
- target: `3_5_place_dp`

## Tests
- focused suite: 74 passed
- `scripts/validate_runs.py --skip_eval_queue`: passed
- `git diff --check`: passed