### PR TITLE
fix: link cluster activity to 8ns bridge

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -9,11 +9,11 @@
   "hypothesis": "The shared-score multivalue decode cluster can only become promotable if activity-annotated power remains coherent after the merged equivalence proof and merged Nangate45 PNR row are combined with evaluator-local switching evidence; vectorless power alone is insufficient.",
   "direct_comparison": {
     "primary_question": "Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?",
-    "baseline": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1 and the forthcoming l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2 bridge row (2.5 mm die / 2.4 mm square core).",
+    "baseline": "merged l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1 plus measured l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2 bridge row (2.5 mm die / 2.4 mm square core).",
     "include": [
       "merged shared-score multivalue-cluster equivalence evidence",
       "merged Nangate45 PNR 10 ns row for the 2.5 mm die / 2.4 mm square core",
-      "forthcoming 8 ns bridge row for the same 2.5 mm die / 2.4 mm square core using refreshed evaluator-local routed artifacts",
+      "measured 8 ns bridge row for the same 2.5 mm die / 2.4 mm square core using evaluator-local routed artifacts",
       "evaluator-local VCD, ODB, and SPEF used only to derive portable JSON/MD outputs",
       "annotation, clock, macro activity, and finite power-gate assumptions called out explicitly",
       "repo-portable evidence outputs under runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"

--- a/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
@@ -243,7 +243,7 @@ def build_report(
             "final_tensor_hash": equivalence.get("final_tensor_hash"),
         },
         "source_dependencies": [
-            "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+            "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
             "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
         ],
         "remaining_abstractions": [

--- a/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
@@ -148,6 +148,10 @@ def test_build_report_records_promoted_and_failed_variants(tmp_path: Path) -> No
             activity_dir=tmp_path / "activity",
         )
     assert payload["decision"] == "activity_backed_cluster_power_measured"
+    assert payload["source_dependencies"] == [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+    ]
     assert payload["promoted_candidate_count"] == 1
     assert payload["best_candidate_id"] == "multivalue_cluster_activity_cluster_die2500"
     assert payload["equivalence"]["final_tensor_hash"] == "final-hash"


### PR DESCRIPTION
## Summary
- report the exact 8 ns PPA bridge as the source of cluster activity measurements
- preserve the merged equivalence dependency
- update stale proposal wording from forthcoming to measured bridge evidence

## Tests
- `tests/test_attention_decode_score_multivalue_cluster_activity_power.py`: 3 passed
- `tests/test_attention_decode_score_multivalue_cluster_activity.py`: 3 passed
- runs validation passed