### PR TITLE
Fix post-route activity annotation gating

### DIFF
--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -107,10 +107,19 @@ load_design 6_final.odb 6_final.sdc
 read_spef $::env(RESULTS_DIR)/6_final.spef
 log_cmd read_vcd -scope $::env(RTLGEN_ACTIVITY_SCOPE) $::env(RTLGEN_ACTIVITY_VCD)
 
+proc rtlgen_json_number {value} {
+  if {[string match -nocase "*nan*" "$value"] ||
+      [string match -nocase "*inf*" "$value"]} {
+    return "null"
+  }
+  if {[catch {format "%.12g" $value} formatted]} {
+    return "null"
+  }
+  return $formatted
+}
+set totals [sta::design_power [sta::corners]]
 set annotatable 0
-set vcd_count 0
-set constant_count 0
-set clock_count 0
+set trace_backed_count 0
 set macro_annotatable 0
 set macro_trace_active_count 0
 foreach pin [get_pins -hierarchical *] {
@@ -124,34 +133,18 @@ foreach pin [get_pins -hierarchical *] {
   incr annotatable
   set activity [get_property $pin activity]
   set origin [lindex $activity 2]
-  if {$origin == "vcd"} {
-    incr vcd_count
-  } elseif {$origin == "constant"} {
-    incr constant_count
-  } elseif {$origin == "clock"} {
-    incr clock_count
+  set toggle_rate [lindex $activity 0]
+  if {$origin == "vcd" || $origin == "propagated"} {
+    incr trace_backed_count
   }
   set full_name [get_property $pin full_name]
   if {[string match "*u_group_*" $full_name]} {
     incr macro_annotatable
-    set toggle_rate [lindex $activity 0]
     if {($origin == "vcd" || $origin == "propagated") && $toggle_rate > 0.0} {
       incr macro_trace_active_count
     }
   }
 }
-
-proc rtlgen_json_number {value} {
-  if {[string match -nocase "*nan*" "$value"] ||
-      [string match -nocase "*inf*" "$value"]} {
-    return "null"
-  }
-  if {[catch {format "%.12g" $value} formatted]} {
-    return "null"
-  }
-  return $formatted
-}
-set totals [sta::design_power [sta::corners]]
 set clocks [get_clocks *]
 set sdc_clock_period_ns "null"
 if {[llength $clocks] > 0} {
@@ -169,9 +162,10 @@ puts $fp "  \"leakage_w\": $leakage_w,"
 puts $fp "  \"total_w\": $total_w,"
 puts $fp "  \"sdc_clock_period_ns\": $sdc_clock_period_ns,"
 puts $fp "  \"annotatable_pin_count\": $annotatable,"
-puts $fp "  \"vcd_annotated_pin_count\": $vcd_count,"
-puts $fp "  \"constant_pin_count\": $constant_count,"
-puts $fp "  \"clock_pin_count\": $clock_count,"
+puts $fp "  \"leaf_annotatable_pin_count\": $annotatable,"
+puts $fp "  \"leaf_trace_backed_pin_count\": $trace_backed_count,"
+puts $fp "  \"vcd_annotated_pin_count\": $trace_backed_count,"
+puts $fp "  \"trace_backed_pin_count\": $trace_backed_count,"
 puts $fp "  \"macro_annotatable_pin_count\": $macro_annotatable,"
 puts $fp "  \"macro_trace_active_pin_count\": $macro_trace_active_count"
 puts $fp "}"
@@ -236,12 +230,18 @@ def _run_openroad_phase(
         raise RuntimeError("OpenROAD completed without writing the activity power result")
     payload = _load_json(result)
     annotation_counts = _activity_annotation_counts(completed.stdout)
-    if "vcd" in annotation_counts and "unannotated" in annotation_counts:
-        payload["leaf_vcd_annotated_pin_count"] = payload.get("vcd_annotated_pin_count", 0)
-        payload["leaf_annotatable_pin_count"] = payload.get("annotatable_pin_count", 0)
-        payload["vcd_annotated_pin_count"] = annotation_counts["vcd"]
-        payload["annotatable_pin_count"] = sum(annotation_counts.values())
+    if annotation_counts:
         payload["activity_annotation_counts"] = annotation_counts
+        direct_annotatable = sum(annotation_counts.values())
+        direct_vcd = annotation_counts.get("vcd", 0)
+        payload["direct_annotatable_pin_count"] = direct_annotatable
+        payload["direct_vcd_pin_count"] = direct_vcd
+        # Optional backward-compatible aliases.
+        payload["leaf_direct_annotatable_pin_count"] = direct_annotatable
+        payload["leaf_direct_vcd_pin_count"] = direct_vcd
+        payload["leaf_vcd_annotated_pin_count"] = annotation_counts.get("vcd", 0)
+        for category, count in annotation_counts.items():
+            payload[f"direct_{category}_pin_count"] = count
     return payload
 
 
@@ -296,19 +296,58 @@ def build_report(
                 result=result,
                 timeout_seconds=timeout_seconds,
             )
-            annotatable = int(power.get("annotatable_pin_count", 0))
-            annotated = int(power.get("vcd_annotated_pin_count", 0))
-            coverage = annotated / annotatable if annotatable else 0.0
+            leaf_annotatable = int(
+                power.get(
+                    "leaf_annotatable_pin_count",
+                    power.get("annotatable_pin_count", 0),
+                )
+            )
+            trace_backed = int(
+                power.get(
+                    "leaf_trace_backed_pin_count",
+                    power.get("vcd_annotated_pin_count", 0),
+                )
+            )
+            direct_annotatable = int(
+                power.get(
+                    "direct_annotatable_pin_count",
+                    power.get("leaf_direct_annotatable_pin_count", 0),
+                )
+            )
+            direct_vcd = int(
+                power.get(
+                    "direct_vcd_pin_count",
+                    power.get("leaf_direct_vcd_pin_count", 0),
+                )
+            )
+            trace_coverage = (
+                trace_backed / leaf_annotatable
+                if leaf_annotatable
+                else 0.0
+            )
+            direct_coverage = (
+                direct_vcd / direct_annotatable
+                if direct_annotatable
+                else 0.0
+            )
             macro_active = int(power.get("macro_trace_active_pin_count", 0))
             macro_annotatable = int(power.get("macro_annotatable_pin_count", 0))
-            macro_coverage = macro_active / macro_annotatable if macro_annotatable else 0.0
-            coverage_pass = annotated >= min_vcd_pins and coverage >= min_vcd_coverage
+            macro_coverage = (
+                macro_active / macro_annotatable if macro_annotatable else 0.0
+            )
+            direct_pin_gate_pass = direct_vcd >= min_vcd_pins
+            trace_coverage_gate_pass = trace_coverage >= min_vcd_coverage
+            annotation_gate_pass = (
+                direct_pin_gate_pass and trace_coverage_gate_pass
+            )
             macro_pass = not phase["requires_macro_activity"] or (
                 macro_active >= min_macro_active_pins
                 and macro_coverage >= min_macro_active_coverage
             )
             sdc_period_value = power.get("sdc_clock_period_ns")
-            sdc_period_ns = float(sdc_period_value) if sdc_period_value is not None else 0.0
+            sdc_period_ns = (
+                float(sdc_period_value) if sdc_period_value is not None else 0.0
+            )
             clock_period_pass = abs(sdc_period_ns - clock_period_ns) <= 1e-6
             component_names = ("internal_w", "switching_w", "leakage_w", "total_w")
             component_values = [power.get(name) for name in component_names]
@@ -325,13 +364,20 @@ def build_report(
                 {
                     **{key: value for key, value in phase.items() if not key.startswith("_")},
                     "power": power,
-                    "vcd_annotation_coverage": coverage,
-                    "annotation_gate_pass": coverage_pass,
+                    "direct_vcd_annotation_coverage": direct_coverage,
+                    "trace_backed_vcd_annotation_coverage": trace_coverage,
+                    "vcd_annotation_coverage": trace_coverage,
+                    "direct_vcd_annotation_pin_gate_pass": direct_pin_gate_pass,
+                    "trace_coverage_gate_pass": trace_coverage_gate_pass,
+                    "annotation_gate_pass": annotation_gate_pass,
                     "macro_activity_gate_pass": macro_pass,
                     "macro_trace_active_coverage": macro_coverage,
                     "clock_period_gate_pass": clock_period_pass,
                     "power_numeric_gate_pass": power_numeric_pass,
-                    "phase_gate_pass": coverage_pass and macro_pass and clock_period_pass and power_numeric_pass,
+                    "phase_gate_pass": annotation_gate_pass
+                    and macro_pass
+                    and clock_period_pass
+                    and power_numeric_pass,
                     "full_context_energy_j": energy_j,
                 }
             )
@@ -377,19 +423,20 @@ def write_markdown(payload: JsonDict, path: Path) -> None:
         f"- full_context_latency_s: `{payload['full_context_latency_s']}`",
         f"- full_context_energy_j: `{payload['full_context_energy_j']}`",
         "",
-        "| phase | measured cycles | full cycles | total W | VCD coverage | macro active pins | energy J | gate |",
-        "|---|---:|---:|---:|---:|---:|---:|---|",
+        "| phase | measured cycles | full cycles | total W | direct/trace-backed VCD coverage | macro active pins | energy J | gate |",
+        "|---|---:|---:|---:|---|---:|---:|---|",
     ]
     for row in payload["phases"]:
         power = row["power"]
         lines.append(
             "| {phase} | {measured_cycles} | {full_context_cycles} | {total_w} | "
-            "{coverage:.6f} | {macro_pins} | {energy} | {gate} |".format(
+            "{direct_coverage:.6f} / {coverage:.6f} | {macro_pins} | {energy} | {gate} |".format(
                 phase=row["phase"],
                 measured_cycles=row["measured_cycles"],
                 full_context_cycles=row["full_context_cycles"],
                 total_w=power.get("total_w"),
-                coverage=row["vcd_annotation_coverage"],
+                coverage=row["trace_backed_vcd_annotation_coverage"],
+                direct_coverage=row["direct_vcd_annotation_coverage"],
                 macro_pins=power.get("macro_trace_active_pin_count", 0),
                 energy=row["full_context_energy_j"],
                 gate=row["phase_gate_pass"],

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -22,6 +22,78 @@ SPEC.loader.exec_module(MODULE)
 
 
 class PostrouteVcdPowerTests(unittest.TestCase):
+    def test_tcl_counts_after_design_power(self) -> None:
+        script = MODULE._tcl_script()
+        totals_index = script.find("set totals [sta::design_power")
+        loop_index = script.find("foreach pin")
+        self.assertGreater(totals_index, -1)
+        self.assertGreater(loop_index, -1)
+        self.assertLess(totals_index, loop_index)
+        self.assertIn('if {$origin == "vcd" || $origin == "propagated"}', script)
+        self.assertIn(
+            'if {($origin == "vcd" || $origin == "propagated") && $toggle_rate > 0.0}',
+            script,
+        )
+
+    def test_activity_annotation_provenance_is_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            orfs = root / "orfs"
+            orfs.mkdir()
+            config = root / "external" / "config.mk"
+            config.parent.mkdir()
+            config.write_text("", encoding="utf-8")
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            tcl = root / "power.tcl"
+            tcl.write_text("", encoding="utf-8")
+            result = root / "result.json"
+            result.write_text(
+                json.dumps(
+                    {
+                        "total_w": 1.0,
+                        "internal_w": 0.5,
+                        "switching_w": 0.4,
+                        "leakage_w": 0.1,
+                        "annotatable_pin_count": 1000,
+                        "leaf_annotatable_pin_count": 1000,
+                        "leaf_trace_backed_pin_count": 12,
+                        "vcd_annotated_pin_count": 12,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            completed = SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "vcd 4\n"
+                    "saif 1\n"
+                    "input 2\n"
+                    "unannotated 993\n"
+                ),
+                stderr="",
+            )
+            with mock.patch.object(MODULE, "ORFS_FLOW", orfs), mock.patch.object(
+                MODULE.subprocess, "run", return_value=completed
+            ) as run:
+                payload = MODULE._run_openroad_phase(
+                    design_config=config,
+                    flow_variant="test",
+                    vcd=vcd,
+                    scope="tb/dut",
+                    tcl=tcl,
+                    result=result,
+                    timeout_seconds=10,
+            )
+            self.assertEqual(run.call_args.args[0][0], "make")
+            self.assertEqual(payload.get("vcd_annotated_pin_count"), 12)
+            self.assertEqual(payload.get("direct_vcd_pin_count"), 4)
+            self.assertEqual(payload.get("direct_annotatable_pin_count"), 1000)
+            self.assertEqual(payload.get("leaf_direct_vcd_pin_count"), 4)
+            self.assertEqual(payload.get("leaf_direct_annotatable_pin_count"), 1000)
+            self.assertEqual(payload["direct_vcd_pin_count"], 4)
+            self.assertEqual(payload["activity_annotation_counts"]["vcd"], 4)
+
     def test_activity_annotation_counts_parse_openroad_report(self) -> None:
         counts = MODULE._activity_annotation_counts(
             "vcd            35\nsaif 2\ninput 3\nunannotated 664519\n"
@@ -120,9 +192,13 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                         "leakage_w": 0.2,
                         "sdc_clock_period_ns": 8.0,
                         "annotatable_pin_count": 1000,
+                        "leaf_annotatable_pin_count": 1000,
+                        "leaf_trace_backed_pin_count": 500,
                         "vcd_annotated_pin_count": 500,
                         "macro_trace_active_pin_count": 10,
                         "macro_annotatable_pin_count": 100,
+                        "direct_annotatable_pin_count": 1000,
+                        "direct_vcd_pin_count": 200,
                     },
                     {
                         "total_w": 3.0,
@@ -131,9 +207,13 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                         "leakage_w": 0.3,
                         "sdc_clock_period_ns": 8.0,
                         "annotatable_pin_count": 1000,
+                        "leaf_annotatable_pin_count": 1000,
+                        "leaf_trace_backed_pin_count": 400,
                         "vcd_annotated_pin_count": 400,
                         "macro_trace_active_pin_count": 8,
                         "macro_annotatable_pin_count": 100,
+                        "direct_annotatable_pin_count": 1000,
+                        "direct_vcd_pin_count": 160,
                     },
                     {
                         "total_w": 1.0,
@@ -142,9 +222,13 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                         "leakage_w": 0.1,
                         "sdc_clock_period_ns": 8.0,
                         "annotatable_pin_count": 1000,
+                        "leaf_annotatable_pin_count": 1000,
+                        "leaf_trace_backed_pin_count": 300,
                         "vcd_annotated_pin_count": 300,
                         "macro_trace_active_pin_count": 0,
                         "macro_annotatable_pin_count": 100,
+                        "direct_annotatable_pin_count": 1000,
+                        "direct_vcd_pin_count": 80,
                     },
                 ]
             )
@@ -165,6 +249,147 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(report["full_context_cycles"], 540)
             expected = (2.0 * 200 + 3.0 * 300 + 1.0 * 40) * 8.0e-9
             self.assertAlmostEqual(report["full_context_energy_j"], expected)
+            self.assertEqual(report["phases"][0]["vcd_annotation_coverage"], 0.5)
+            self.assertAlmostEqual(
+                report["phases"][0]["direct_vcd_annotation_coverage"],
+                0.2,
+            )
+            self.assertTrue(report["phases"][0]["direct_vcd_annotation_pin_gate_pass"])
+            self.assertTrue(report["phases"][0]["trace_coverage_gate_pass"])
+
+    def test_build_report_gates_on_trace_backed_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": "0",
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                        "requires_macro_activity": False,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            vcd = root / "trace.vcd"
+            vcd.write_text("$comment test $end\n", encoding="utf-8")
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = {
+                "total_w": 1.0,
+                "internal_w": 0.5,
+                "switching_w": 0.4,
+                "leakage_w": 0.1,
+                "sdc_clock_period_ns": 8.0,
+                "annotatable_pin_count": 1000,
+                "leaf_annotatable_pin_count": 1000,
+                "leaf_trace_backed_pin_count": 300,
+                "vcd_annotated_pin_count": 300,
+                "direct_annotatable_pin_count": 1000,
+                "direct_vcd_pin_count": 300,
+                "macro_trace_active_pin_count": 10,
+                "macro_annotatable_pin_count": 1000,
+            }
+            with mock.patch.object(MODULE, "_phase_rows", return_value=[{
+                "phase": "score_fill",
+                "vcd": "trace.vcd",
+                "vcd_sha256": "0000",
+                "measured_cycles": 20,
+                "full_context_cycles": 20,
+                "requires_macro_activity": False,
+                "_resolved_vcd": str(vcd),
+            }]):
+                with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                    report = MODULE.build_report(
+                        manifest=manifest,
+                        manifest_path=manifest_path,
+                        design_config=design_config,
+                        flow_variant="activity_test",
+                        scope="tb/dut",
+                        min_vcd_coverage=0.20,
+                        min_vcd_pins=250,
+                        min_macro_active_coverage=0.01,
+                        min_macro_active_pins=2,
+                        timeout_seconds=10,
+            )
+            self.assertTrue(report["promotion_gate_pass"])
+            self.assertAlmostEqual(report["phases"][0]["vcd_annotation_coverage"], 0.3)
+            self.assertEqual(report["phases"][0]["direct_vcd_annotation_coverage"], 0.3)
+
+    def test_build_report_requires_direct_vcd_pin_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": "0",
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                        "requires_macro_activity": False,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            vcd = root / "trace.vcd"
+            vcd.write_text("$comment test $end\n", encoding="utf-8")
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = {
+                "total_w": 1.0,
+                "internal_w": 0.5,
+                "switching_w": 0.4,
+                "leakage_w": 0.1,
+                "sdc_clock_period_ns": 8.0,
+                "annotatable_pin_count": 1000,
+                "leaf_annotatable_pin_count": 1000,
+                "leaf_trace_backed_pin_count": 900,
+                "vcd_annotated_pin_count": 900,
+                "direct_annotatable_pin_count": 1000,
+                "direct_vcd_pin_count": 2,
+                "macro_trace_active_pin_count": 10,
+                "macro_annotatable_pin_count": 1000,
+            }
+            with mock.patch.object(
+                MODULE,
+                "_phase_rows",
+                return_value=[
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": "0000",
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                        "requires_macro_activity": False,
+                        "_resolved_vcd": str(vcd),
+                    }
+                ],
+            ):
+                with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                    report = MODULE.build_report(
+                        manifest=manifest,
+                        manifest_path=manifest_path,
+                        design_config=design_config,
+                        flow_variant="activity_test",
+                        scope="tb/dut",
+                        min_vcd_coverage=0.05,
+                        min_vcd_pins=3,
+                        min_macro_active_coverage=0.01,
+                        min_macro_active_pins=2,
+                        timeout_seconds=10,
+                    )
+            self.assertFalse(report["promotion_gate_pass"])
+            phase = report["phases"][0]
+            self.assertTrue(phase["trace_coverage_gate_pass"])
+            self.assertFalse(phase["direct_vcd_annotation_pin_gate_pass"])
+            self.assertFalse(phase["annotation_gate_pass"])
 
     def test_required_macro_phase_cannot_promote_without_macro_activity(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:
@@ -179,6 +404,8 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "vcd_annotated_pin_count": 80,
                 "macro_trace_active_pin_count": 1,
                 "macro_annotatable_pin_count": 100,
+                "direct_annotatable_pin_count": 100,
+                "direct_vcd_pin_count": 80,
             }
             with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
                 report = MODULE.build_report(
@@ -213,6 +440,8 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "vcd_annotated_pin_count": 80,
                 "macro_trace_active_pin_count": 10,
                 "macro_annotatable_pin_count": 100,
+                "direct_annotatable_pin_count": 100,
+                "direct_vcd_pin_count": 80,
             }
             with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
                 report = MODULE.build_report(


### PR DESCRIPTION
## Summary

- run OpenSTA activity propagation before counting post-route pin coverage
- preserve direct VCD annotation counts separately from propagated trace-backed coverage
- require both the existing direct-pin minimum and trace-backed coverage threshold
- measure macro activity only after propagation

## Root cause

The previous Tcl counted pin origins before `sta::design_power` propagated VCD activity through the gate netlist. This reported zero trace-backed leaf and macro pins, while Python divided direct VCD roots by every gate pin. The resulting 1.6% coverage was not a valid mapping-completeness measure.

## Impact

Activity-power evidence now distinguishes directly matched VCD roots from post-propagation coverage. Thresholds are not relaxed. The cluster activity job can be rerun against the existing 8 ns PNR result.

## Validation

`python3 -m pytest -q tests/test_postroute_vcd_power.py tests/test_attention_decode_score_multivalue_cluster_activity_power.py tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py`

Result: 22 passed.