### PR TITLE
Revise cluster activity power evidence

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -100,6 +100,27 @@ def _gqa_group_equivalence_item_for_consumer(item_id: str) -> str:
     return f"l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_{version}"
 
 
+def _cluster_activity_power_item_for_consumer(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None,
+) -> str:
+    cluster_activity_prefix = "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_"
+    candidate_item_ids = [
+        str(dep).strip()
+        for dep in (depends_on_item_ids or [])
+        if str(dep).strip().startswith(cluster_activity_prefix)
+    ]
+    if candidate_item_ids:
+        return max(
+            candidate_item_ids,
+            key=lambda candidate: int(_VERSION_SUFFIX_RE.search(_retry_base(candidate)).group(1))
+            if _VERSION_SUFFIX_RE.search(_retry_base(candidate))
+            else 1,
+        )
+    return f"{cluster_activity_prefix}{_gqa_evidence_version_for_consumer(item_id)}"
+
+
 def _gqa_folded_activity_lanes(item_id: str) -> int | None:
     match = _GQA_FOLDED_ACTIVITY_LANES_RE.search(_retry_base(item_id))
     return int(match.group(1)) if match else None
@@ -6908,7 +6929,9 @@ def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*
     }
 
 
-def _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence(*, item_id: str) -> dict[str, Any]:
+def _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence(
+    *, item_id: str, depends_on_item_ids: list[str] | None = None
+) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     folded_lanes = _gqa_folded_activity_lanes(item_id)
     design = (
@@ -6930,9 +6953,13 @@ def _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence
             f"{base}/decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
             f"{group_equivalence_item}.json"
         )
+    cluster_activity_power_item = _cluster_activity_power_item_for_consumer(
+        item_id=item_id,
+        depends_on_item_ids=depends_on_item_ids,
+    )
     cluster_activity_power_json = (
         f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__"
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+        f"{cluster_activity_power_item}.json"
     )
     orfs_design_config = f"/orfs/flow/designs/nangate45/{design}/config.mk"
     activity_dir = (
@@ -7075,15 +7102,21 @@ def _decoder_attention_decode_score_local_cluster_frontier_evidence(*, item_id: 
     }
 
 
-def _decoder_attention_decode_score_multivalue_cluster_frontier_evidence(*, item_id: str) -> dict[str, Any]:
+def _decoder_attention_decode_score_multivalue_cluster_frontier_evidence(
+    *, item_id: str, depends_on_item_ids: list[str] | None = None
+) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     prior = (
         f"{base}/decoder_attention_decode_score_local_cluster_frontier__"
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2.json"
     )
+    cluster_activity_power_item = _cluster_activity_power_item_for_consumer(
+        item_id=item_id,
+        depends_on_item_ids=depends_on_item_ids,
+    )
     activity_power = (
         f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__"
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+        f"{cluster_activity_power_item}.json"
     )
     cluster_counts = "1,2,4,8,16,32"
     out = f"{base}/decoder_attention_decode_score_multivalue_cluster_frontier__{item_id}.json"
@@ -11042,7 +11075,8 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_group_activity_power":
             decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence(
-                item_id=item_id
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_tile_frontier":
             decoder_evidence = _decoder_attention_decode_score_tile_frontier_evidence(item_id=item_id)
@@ -11050,7 +11084,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_decode_score_local_cluster_frontier_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_cluster_frontier":
             decoder_evidence = _decoder_attention_decode_score_multivalue_cluster_frontier_evidence(
-                item_id=item_id
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_group_frontier":
             decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_group_frontier_evidence(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -15,7 +15,12 @@ from control_plane.db import create_all
 from control_plane.models.enums import WorkItemState
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
-from control_plane.services.l2_task_generator import Layer2CampaignGenerateRequest, Layer2TaskGenerationError, generate_l2_campaign_task
+from control_plane.services.l2_task_generator import (
+    Layer2CampaignGenerateRequest,
+    Layer2TaskGenerationError,
+    _cluster_activity_power_item_for_consumer,
+    generate_l2_campaign_task,
+)
 
 
 def _write_campaign(repo_root: Path) -> str:
@@ -5095,6 +5100,85 @@ def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() 
             }
 
 
+def test_generate_l2_campaign_task_preserves_revision_metadata_on_materialization() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        proposal_dir = repo_root / "docs" / "developer_loop" / "prop_l2_demo_v1"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        requested_item_id = "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
+        (proposal_dir / "evaluation_requests.json").write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_l2_demo_v1",
+                    "requested_items": [
+                        {
+                            "item_id": requested_item_id,
+                            "task_type": "l2_campaign",
+                            "evaluation_mode": "frontier_detail",
+                            "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+                            "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+                            "depends_on_item_ids": [
+                                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+                                "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+                            ],
+                            "requires_merged_inputs": True,
+                            "requires_materialized_refs": True,
+                            "revision": {
+                                "reason": "pre_propagation_activity_counting_in_cluster_power_audit_is_incorrect_and_replaced",
+                                "invalidates_item_ids": [
+                                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+                                ],
+                            },
+                        }
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=requested_item_id,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_demo_v1",
+                    proposal_path="docs/developer_loop/prop_l2_demo_v1",
+                    run_physical=False,
+                ),
+            )
+
+            updated_requests = json.loads(
+                (proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8")
+            )
+            updated_entry = json.loads(
+                (proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8")
+            )["requested_items"][0]
+            assert updated_entry["item_id"] == requested_item_id
+            assert updated_entry["revision"] == {
+                "reason": "pre_propagation_activity_counting_in_cluster_power_audit_is_incorrect_and_replaced",
+                "invalidates_item_ids": [
+                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+                ],
+            }
+            assert result.status == "applied"
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert work_item.task_request.requested_by == "@tester"
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"]["layer"] == (
+                "decoder_attention_decode_score_multivalue_cluster_activity_power"
+            )
+
+
 def test_generate_l2_campaign_task_can_refresh_db_without_updating_proposal_files() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -8114,6 +8198,79 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
 
 
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity_power_v2() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_cluster_activity_power",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert (
+                "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.json" in run
+            )
+            assert decoder_inputs["decode_score_multivalue_cluster_activity_power_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.json"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.md"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
+def test_cluster_activity_power_item_for_consumer_prefers_requested_version_for_unknown_depends_on() -> None:
+    assert (
+        _cluster_activity_power_item_for_consumer(
+            item_id="l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1",
+            depends_on_item_ids=None,
+        )
+        == "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+    )
+    assert (
+        _cluster_activity_power_item_for_consumer(
+            item_id="l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v2",
+            depends_on_item_ids=None,
+        )
+        == "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
+    )
+    assert (
+        _cluster_activity_power_item_for_consumer(
+            item_id="l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1",
+            depends_on_item_ids=[
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2",
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+            ],
+        )
+        == "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
+    )
+
+
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activity_power() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -8134,6 +8291,9 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activi
                     source_commit=source_commit,
                     abstraction_layer="decoder_attention_decode_score_multivalue_gqa_group_activity_power",
                     evaluation_mode="frontier_detail",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+                    ],
                     run_physical=False,
                 ),
             )
@@ -8147,30 +8307,42 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activi
                 "audit_decode_score_multivalue_gqa_group_activity_power",
                 "validate_runs",
             ]
-            assert "-m npu.eval.audit_attention_decode_score_multivalue_gqa_group_activity_power" in run
+            assert (
+                "-m npu.eval.audit_attention_decode_score_multivalue_gqa_group_activity_power" in run
+            )
             assert (
                 "--config runs/designs/npu_blocks/"
                 "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv/config.json"
-            ) in run
+                in run
+            )
             assert (
                 "--group-metrics-csv runs/designs/npu_blocks/"
                 "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv/metrics.csv"
-            ) in run
+                in run
+            )
             assert (
                 "--equivalence-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_decode_score_multivalue_gqa_group_equivalence__"
                 "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1.json"
-            ) in run
+                in run
+            )
             assert (
                 "--cluster-activity-power-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_decode_score_multivalue_cluster_activity_power__"
                 "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
-            ) in run
+                in run
+            )
             assert (
                 "--group-orfs-design-config /orfs/flow/designs/nangate45/"
                 "attention_decode_score_multivalue_gqa_group_int8_m1x8_iterdiv/config.mk"
-            ) in run
+                in run
+            )
             assert "--activity-dir /tmp/rtlgen_multivalue_gqa_group_activity" in run
+            assert decoder_inputs["decode_score_multivalue_gqa_group_activity_power_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_gqa_group_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1.json"
+            )
             assert decoder_inputs[
                 "decode_score_multivalue_gqa_group_activity_power_local_only_artifacts"
             ] == ["VCD", "ODB", "SPEF"]
@@ -8180,13 +8352,69 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activi
             assert "mislabeled as direct full-group measurement" in decoder_inputs[
                 "decode_score_multivalue_gqa_group_activity_power_promotion_gate"
             ]
-            assert decoder_inputs["decode_score_multivalue_gqa_group_activity_power_out"].endswith(
+            assert any(
+                output.endswith(
+                    "decoder_attention_decode_score_multivalue_gqa_group_activity_power__"
+                    "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1.md"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activity_power_v2_cluster_activity_dependency() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_gqa_group_activity_power",
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2",
+                    ],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:2]] == [
+                "audit_decode_score_multivalue_gqa_group_activity_power",
+                "validate_runs",
+            ]
+            assert (
+                "--cluster-activity-power-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.json"
+                in run
+            )
+            assert decoder_inputs["decode_score_multivalue_gqa_group_activity_power_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_decode_score_multivalue_gqa_group_activity_power__"
                 "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1.json"
             )
-            assert decoder_inputs[
-                "decode_score_multivalue_gqa_group_activity_power_report"
-            ] in work_item.expected_outputs
+            assert any(
+                output.endswith(
+                    "decoder_attention_decode_score_multivalue_gqa_group_activity_power__"
+                    "l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1.md"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
 
 
 def test_generate_l2_campaign_task_adds_folded_gqa_lane_activity_power() -> None:
@@ -8234,10 +8462,119 @@ def test_generate_l2_campaign_task_adds_folded_gqa_lane_activity_power() -> None
                     "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_"
                     "equivalence_llama7b_v1.json"
                 ) in run
+                assert (
+                    "--cluster-activity-power-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                    "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+                    in run
+                )
+                assert decoder_inputs[
+                    "decode_score_multivalue_cluster_activity_power_json"
+                ].endswith(
+                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+                )
                 assert f"--activity-dir /tmp/rtlgen_multivalue_gqa_folded_lanes{lanes}_activity" in run
                 assert f"{lanes} physical query-head lane(s)" in decoder_inputs[
                     "decode_score_multivalue_gqa_group_activity_power_scope"
                 ]
+
+
+def test_generate_l2_campaign_task_folded_lane_activity_reads_revisioned_cluster_activity() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        lanes = 1
+        item_id = (
+            "l2_decoder_attention_decode_score_multivalue_gqa8_folded_"
+            f"lanes{lanes}_activity_power_llama7b_v1"
+        )
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=item_id,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_decode_score_multivalue_gqa_group_activity_power"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2",
+                        "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
+                    ],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            assert (
+                "--cluster-activity-power-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.json"
+                in run
+            )
+            assert (
+                f"l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes{lanes}_activity_power_"
+                "llama7b_v1.json"
+                in run
+            )
+
+
+def test_generate_l2_campaign_task_cluster_frontier_uses_cluster_activity_v2_dependency() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_cluster_frontier",
+                    evaluation_mode="frontier_recost",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+                        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2",
+                    ],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert (
+                "--activity-power-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.json"
+                in run
+            )
+            assert (
+                decoder_inputs["decode_score_multivalue_cluster_frontier_activity_power"].endswith(
+                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.json"
+                )
+            )
+            assert (
+                "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1.json"
+                in run
+            )
 
 
 def test_generate_l2_campaign_task_adds_decode_score_tile_frontier() -> None:
@@ -8359,7 +8696,8 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_frontier
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_decode_score_multivalue_cluster_activity_power__"
                 "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
-            ) in run
+                in run
+            )
             assert "--cluster-counts 1,2,4,8,16,32" in run
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_frontier_prior_frontier"].endswith(
@@ -8393,6 +8731,45 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_frontier
                     "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1.md"
                 )
                 for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
+def test_generate_l2_campaign_task_cluster_frontier_uses_cluster_activity_v1_dependency() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_cluster_frontier",
+                    evaluation_mode="frontier_recost",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+                        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+                    ],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            assert (
+                "--activity-power-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+                in run
             )
 
 

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -24,6 +24,31 @@
       "merge_commit": "c53909910f6506c7a01877ecddbc06ff0afe7cb9",
       "merged_utc": "2026-07-19T09:57:29.336801Z",
       "notes": "Merged via PR #1368 and merge c53909910f6506c7a01877ecddbc06ff0afe7cb9 at 2026-07-19T09:57:29.336801Z."
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2",
+      "task_type": "l2_campaign",
+      "objective": "Re-run shared-score multivalue-cluster activity-backed power where v1's before-propagation VCD counting is replaced by direct VCD root separation, post-propagation trace-backed coverage, and macro measurements after propagation.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "postroute_activity_counted_before_propagation",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "V1 counted activity before propagation; v2 now separates direct VCD roots, uses post-propagation trace-backed coverage, and measures macros after propagation while still requiring explicit annotation coverage, declared clocks, and finite power-gate accounting for promotion."
+      },
+      "status": "ready_to_queue"
     }
   ],
   "source_commit": "7b01c7e452af6f658c566900fef0513f6ba2490b"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -67,6 +67,31 @@
         "reason": "Promotion requires explicit annotation, clock, macro activity, and finite power-gate evidence; vectorless power cannot substitute."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2",
+      "task_type": "l2_campaign",
+      "objective": "Re-run shared-score multivalue-cluster activity-backed power where v1's before-propagation VCD counting is replaced by direct VCD root separation, post-propagation trace-backed coverage, and macro measurements after propagation.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "postroute_activity_counted_before_propagation",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "V1 counted activity before propagation; v2 now separates direct VCD roots, uses post-propagation trace-backed coverage, and measures macros after propagation while still requiring explicit annotation coverage, declared clocks, and finite power-gate accounting for promotion."
+      },
+      "status": "ready_to_queue"
     }
   ],
   "baseline_refs": [

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -12,7 +12,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
@@ -57,7 +57,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -71,7 +71,7 @@
   "baseline_refs": [
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_local_cluster_frontier__l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2.json",
     "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2.json",
-    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.json",
     "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json",
     "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json"
   ],

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -200,7 +200,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -220,7 +220,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -240,7 +240,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -222,7 +222,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -242,7 +242,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -262,7 +262,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,


### PR DESCRIPTION
## Summary

- add a v2 revision of the rejected cluster activity-power item
- preserve v1 as merged negative evidence and explicitly invalidate it only when v2 is promoted
- route pending folded-lane and cluster-frontier consumers to the v2 artifact
- select cluster activity evidence from explicit proposal dependencies, preserving historical v1 reproduction

## Why

The v1 run counted activity before OpenSTA propagated VCD roots through the gate netlist. PR #1369 corrected the backend. A revision item is required because the v1 work item and evidence PR are already merged.

## Validation

- `PYTHONPATH=control_plane python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py`: 222 passed
- `python3 scripts/validate_runs.py --skip_eval_queue`: passed
- JSON validation for all edited proposal files: passed