### PR TITLE
Add post-route power failure diagnostics

### DIFF
--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -117,11 +117,96 @@ proc rtlgen_json_number {value} {
   }
   return $formatted
 }
+
+proc rtlgen_json_escape {value} {
+  return [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t"} $value]
+}
+
+proc rtlgen_is_finite_power_value {value} {
+  if {[catch {set numeric_value [expr {double($value)}]}]} {
+    return 0
+  }
+  if {$numeric_value != $numeric_value} {
+    return 0
+  }
+  if {$numeric_value == Inf || $numeric_value == -Inf} {
+    return 0
+  }
+  return 1
+}
+
+proc rtlgen_activity_origin_bucket {origin} {
+  if {$origin == "vcd"} {
+    return "vcd"
+  }
+  if {$origin == "propagated"} {
+    return "propagated"
+  }
+  if {$origin == "clock"} {
+    return "clock"
+  }
+  if {$origin == "constant"} {
+    return "constant"
+  }
+  return "other"
+}
+
 set totals [sta::design_power [sta::corners]]
+set design_power_category_names {total sequential combinational clock macro pad}
+set design_power_category_count [expr {[llength $totals] / 4}]
+set design_power_entries {}
+set design_power_totals [lrange $totals 0 3]
+set has_nonfinite_design_total 0
+foreach value $design_power_totals {
+  if {![rtlgen_is_finite_power_value $value]} {
+    set has_nonfinite_design_total 1
+    break
+  }
+}
+set design_power_index 0
+foreach design_power_name $design_power_category_names {
+  if {$design_power_index < $design_power_category_count} {
+    set offset [expr {$design_power_index * 4}]
+    set design_power_row [lrange $totals $offset [expr {$offset + 3}]]
+  } else {
+    set design_power_row {}
+  }
+  lassign $design_power_row design_power_internal design_power_switching design_power_leakage design_power_total
+  lappend design_power_entries \
+    [list \
+      $design_power_name \
+      [rtlgen_json_number $design_power_internal] \
+      [rtlgen_json_number $design_power_switching] \
+      [rtlgen_json_number $design_power_leakage] \
+      [rtlgen_json_number $design_power_total] \
+    ]
+  incr design_power_index
+}
+
+set design_power_lines {}
+foreach design_power_entry $design_power_entries {
+  lassign $design_power_entry design_name design_internal_w design_switching_w design_leakage_w design_total_w
+  lappend design_power_lines "    \"$design_name\": {\"internal_w\": $design_internal_w, \"switching_w\": $design_switching_w, \"leakage_w\": $design_leakage_w, \"total_w\": $design_total_w}"
+}
+
 set annotatable 0
 set trace_backed_count 0
 set macro_annotatable 0
 set macro_trace_active_count 0
+set macro_trace_backed_count 0
+set macro_trace_backed_zero_toggle_count 0
+set leaf_vcd_origin_count 0
+set leaf_propagated_origin_count 0
+set leaf_clock_origin_count 0
+set leaf_constant_origin_count 0
+set leaf_other_origin_count 0
+set macro_vcd_origin_count 0
+set macro_propagated_origin_count 0
+set macro_clock_origin_count 0
+set macro_constant_origin_count 0
+set macro_other_origin_count 0
+set non_finite_leaf_instance_power_count 0
+set non_finite_leaf_instance_samples {}
 foreach pin [get_pins -hierarchical *] {
   if {[get_property $pin is_hierarchical]} {
     continue
@@ -134,40 +219,193 @@ foreach pin [get_pins -hierarchical *] {
   set activity [get_property $pin activity]
   set origin [lindex $activity 2]
   set toggle_rate [lindex $activity 0]
-  if {$origin == "vcd" || $origin == "propagated"} {
+  if {![string is double -strict $toggle_rate]} {
+    set toggle_rate 0.0
+  }
+  set origin_bucket [rtlgen_activity_origin_bucket $origin]
+  if {$origin_bucket == "vcd"} {
+    incr leaf_vcd_origin_count
+  } elseif {$origin_bucket == "propagated"} {
+    incr leaf_propagated_origin_count
+  } elseif {$origin_bucket == "clock"} {
+    incr leaf_clock_origin_count
+  } elseif {$origin_bucket == "constant"} {
+    incr leaf_constant_origin_count
+  } else {
+    incr leaf_other_origin_count
+  }
+  if {$origin_bucket == "vcd" || $origin_bucket == "propagated"} {
     incr trace_backed_count
+    set is_trace_backed_pin 1
+  } else {
+    set is_trace_backed_pin 0
   }
   set full_name [get_property $pin full_name]
   if {[string match "*u_group_*" $full_name]} {
     incr macro_annotatable
-    if {($origin == "vcd" || $origin == "propagated") && $toggle_rate > 0.0} {
-      incr macro_trace_active_count
+    if {$origin_bucket == "vcd"} {
+      incr macro_vcd_origin_count
+    } elseif {$origin_bucket == "propagated"} {
+      incr macro_propagated_origin_count
+    } elseif {$origin_bucket == "clock"} {
+      incr macro_clock_origin_count
+    } elseif {$origin_bucket == "constant"} {
+      incr macro_constant_origin_count
+    } else {
+      incr macro_other_origin_count
+    }
+    if {$is_trace_backed_pin} {
+      incr macro_trace_backed_count
+      if {$toggle_rate > 0.0} {
+        incr macro_trace_active_count
+      } else {
+        incr macro_trace_backed_zero_toggle_count
+      }
     }
   }
 }
-set clocks [get_clocks *]
+
+if {$has_nonfinite_design_total} {
+  if {[catch {set leaf_cells [get_cells -hierarchical -filter "is_leaf"]}] ||
+      [llength $leaf_cells] == 0} {
+    set leaf_cells [get_cells -hierarchical]
+  }
+  if {[catch {set leaf_cells [lsort -dictionary $leaf_cells]}]} {
+    # Keep order stable as best effort if sorting is unsupported for this object type.
+    set leaf_cells [lsort $leaf_cells]
+  }
+  set corners [sta::corners]
+  if {[llength $corners] > 0} {
+    set corner [lindex $corners 0]
+  } else {
+    set corner ""
+  }
+  foreach leaf $leaf_cells {
+    if {[catch {set is_leaf [get_property $leaf is_leaf]}] || !$is_leaf} {
+      continue
+    }
+    if {$corner ne ""} {
+      set instance_power_error [catch {sta::instance_power $leaf $corner} instance_power]
+    } else {
+      set instance_power_error [catch {sta::instance_power $leaf} instance_power]
+    }
+    if {$instance_power_error} {
+      continue
+    }
+    if {[llength $instance_power] != 4} {
+      continue
+    }
+    set internal_power_value [lindex $instance_power 0]
+    set switching_power_value [lindex $instance_power 1]
+    set leakage_power_value [lindex $instance_power 2]
+    set total_power_value [lindex $instance_power 3]
+    if {![rtlgen_is_finite_power_value $internal_power_value] ||
+        ![rtlgen_is_finite_power_value $switching_power_value] ||
+        ![rtlgen_is_finite_power_value $leakage_power_value] ||
+        ![rtlgen_is_finite_power_value $total_power_value]} {
+      incr non_finite_leaf_instance_power_count
+      if {[llength $non_finite_leaf_instance_samples] < 16} {
+        if {[catch {set leaf_name [get_full_name $leaf]}]} {
+          if {[catch {set leaf_name [get_property $leaf name]}]} {
+            set leaf_name $leaf
+          }
+        }
+        lappend non_finite_leaf_instance_samples \
+          [list \
+            $leaf_name \
+            $internal_power_value \
+            $switching_power_value \
+            $leakage_power_value \
+            $total_power_value \
+          ]
+      }
+    }
+  }
+}
+
 set sdc_clock_period_ns "null"
+set clocks [get_clocks *]
 if {[llength $clocks] > 0} {
   set sdc_clock_period_ns [rtlgen_json_number [get_property [lindex $clocks 0] period]]
 }
-set internal_w [rtlgen_json_number [lindex $totals 0]]
-set switching_w [rtlgen_json_number [lindex $totals 1]]
-set leakage_w [rtlgen_json_number [lindex $totals 2]]
-set total_w [rtlgen_json_number [lindex $totals 3]]
+lassign $design_power_totals design_power_internal_w design_power_switching_w design_power_leakage_w design_power_total_w
+set internal_w [rtlgen_json_number $design_power_internal_w]
+set switching_w [rtlgen_json_number $design_power_switching_w]
+set leakage_w [rtlgen_json_number $design_power_leakage_w]
+set total_w [rtlgen_json_number $design_power_total_w]
+
 set fp [open $::env(RTLGEN_ACTIVITY_RESULT) w]
 puts $fp "{"
 puts $fp "  \"internal_w\": $internal_w,"
 puts $fp "  \"switching_w\": $switching_w,"
 puts $fp "  \"leakage_w\": $leakage_w,"
 puts $fp "  \"total_w\": $total_w,"
+puts $fp "  \"design_power_quartets\": {"
+set design_power_lines_count [llength $design_power_lines]
+set design_power_index 0
+foreach design_power_line $design_power_lines {
+  incr design_power_index
+  if {$design_power_index < $design_power_lines_count} {
+    puts $fp "$design_power_line,"
+  } else {
+    puts $fp "$design_power_line"
+  }
+}
+puts $fp "  },"
 puts $fp "  \"sdc_clock_period_ns\": $sdc_clock_period_ns,"
 puts $fp "  \"annotatable_pin_count\": $annotatable,"
 puts $fp "  \"leaf_annotatable_pin_count\": $annotatable,"
 puts $fp "  \"leaf_trace_backed_pin_count\": $trace_backed_count,"
 puts $fp "  \"vcd_annotated_pin_count\": $trace_backed_count,"
 puts $fp "  \"trace_backed_pin_count\": $trace_backed_count,"
+puts $fp "  \"leaf_activity_origin_counts\": {"
+puts $fp "    \"vcd\": $leaf_vcd_origin_count,"
+puts $fp "    \"propagated\": $leaf_propagated_origin_count,"
+puts $fp "    \"clock\": $leaf_clock_origin_count,"
+puts $fp "    \"constant\": $leaf_constant_origin_count,"
+puts $fp "    \"other\": $leaf_other_origin_count"
+puts $fp "  },"
 puts $fp "  \"macro_annotatable_pin_count\": $macro_annotatable,"
-puts $fp "  \"macro_trace_active_pin_count\": $macro_trace_active_count"
+puts $fp "  \"macro_activity_origin_counts\": {"
+puts $fp "    \"vcd\": $macro_vcd_origin_count,"
+puts $fp "    \"propagated\": $macro_propagated_origin_count,"
+puts $fp "    \"clock\": $macro_clock_origin_count,"
+puts $fp "    \"constant\": $macro_constant_origin_count,"
+puts $fp "    \"other\": $macro_other_origin_count"
+puts $fp "  },"
+puts $fp "  \"macro_trace_backed_pin_count\": $macro_trace_backed_count,"
+puts $fp "  \"macro_trace_active_pin_count\": $macro_trace_active_count,"
+puts $fp "  \"macro_trace_backed_zero_toggle_pin_count\": $macro_trace_backed_zero_toggle_count"
+if {$has_nonfinite_design_total} {
+  puts $fp ","
+  puts $fp "  \"non_finite_leaf_instance_power\": {"
+  puts $fp "    \"instance_count\": $non_finite_leaf_instance_power_count,"
+  puts $fp "    \"samples\": ["
+  set sample_count [llength $non_finite_leaf_instance_samples]
+  set sample_index 0
+  foreach sample $non_finite_leaf_instance_samples {
+    lassign $sample \
+      leaf_name \
+      leaf_internal_power \
+      leaf_switching_power \
+      leaf_leakage_power \
+      leaf_total_power
+    set leaf_internal_power_json [rtlgen_json_number $leaf_internal_power]
+    set leaf_switching_power_json [rtlgen_json_number $leaf_switching_power]
+    set leaf_leakage_power_json [rtlgen_json_number $leaf_leakage_power]
+    set leaf_total_power_json [rtlgen_json_number $leaf_total_power]
+    incr sample_index
+    set escaped_leaf_name [rtlgen_json_escape $leaf_name]
+    set sample_line "      {\"full_name\": \"$escaped_leaf_name\", \"internal_w\": $leaf_internal_power_json, \"switching_w\": $leaf_switching_power_json, \"leakage_w\": $leaf_leakage_power_json, \"total_w\": $leaf_total_power_json}"
+    if {$sample_index < $sample_count} {
+      puts $fp "$sample_line,"
+    } else {
+      puts $fp "$sample_line"
+    }
+  }
+  puts $fp "    ]"
+  puts $fp "  }"
+}
 puts $fp "}"
 close $fp
 
@@ -442,6 +680,35 @@ def write_markdown(payload: JsonDict, path: Path) -> None:
                 gate=row["phase_gate_pass"],
             )
         )
+    diagnostics = []
+    for row in payload["phases"]:
+        power = row["power"]
+        diag = power.get("non_finite_leaf_instance_power")
+        if not isinstance(diag, dict):
+            continue
+        sample_names = [
+            sample.get("full_name")
+            for sample in diag.get("samples", [])
+            if isinstance(sample, dict) and sample.get("full_name")
+        ]
+        diagnostics.append(
+            (
+                row["phase"],
+                int(diag.get("instance_count", 0)),
+                sample_names,
+            )
+        )
+    if diagnostics:
+        lines.extend(["", "## Power Diagnostics", ""])
+        for phase, instance_count, sample_names in diagnostics:
+            lines.append(
+                f"- `{phase}` non-finite leaf-instance power samples: `{instance_count}` instances"
+            )
+            if sample_names:
+                lines.append(
+                    "  - sample instances: "
+                    + ", ".join(f"`{name}`" for name in sample_names)
+                )
     lines.extend(["", "## Remaining Abstractions", ""])
     lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -29,9 +29,18 @@ class PostrouteVcdPowerTests(unittest.TestCase):
         self.assertGreater(totals_index, -1)
         self.assertGreater(loop_index, -1)
         self.assertLess(totals_index, loop_index)
-        self.assertIn('if {$origin == "vcd" || $origin == "propagated"}', script)
         self.assertIn(
-            'if {($origin == "vcd" || $origin == "propagated") && $toggle_rate > 0.0}',
+            "set design_power_category_names {total sequential combinational clock macro pad}",
+            script,
+        )
+        self.assertIn("design_power_quartets", script)
+        self.assertIn("macro_trace_backed_zero_toggle_count", script)
+        self.assertIn("leaf_activity_origin_counts", script)
+        self.assertIn("macro_activity_origin_counts", script)
+        self.assertIn("sta::instance_power $leaf $corner", script)
+        self.assertIn("non_finite_leaf_instance_power", script)
+        self.assertIn(
+            "if {$origin_bucket == \"vcd\" || $origin_bucket == \"propagated\"}",
             script,
         )
 
@@ -390,6 +399,114 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertTrue(phase["trace_coverage_gate_pass"])
             self.assertFalse(phase["direct_vcd_annotation_pin_gate_pass"])
             self.assertFalse(phase["annotation_gate_pass"])
+
+    def test_build_report_preserves_non_finite_power_diagnostics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, manifest_path = self._fixture(root)
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = {
+                "total_w": 1.0,
+                "internal_w": 0.5,
+                "switching_w": 0.4,
+                "leakage_w": 0.1,
+                "sdc_clock_period_ns": 8.0,
+                "annotatable_pin_count": 1000,
+                "leaf_annotatable_pin_count": 1000,
+                "leaf_trace_backed_pin_count": 500,
+                "vcd_annotated_pin_count": 500,
+                "macro_trace_active_pin_count": 10,
+                "macro_annotatable_pin_count": 100,
+                "design_power_quartets": {
+                    "total": {
+                        "internal_w": 0.5,
+                        "switching_w": 0.4,
+                        "leakage_w": 0.1,
+                        "total_w": 1.0,
+                    },
+                },
+                "non_finite_leaf_instance_power": {
+                    "instance_count": 1,
+                    "samples": [
+                        {
+                            "full_name": "u_group_a/u1",
+                            "internal_w": "null",
+                            "switching_w": "null",
+                            "leakage_w": "null",
+                            "total_w": "null",
+                        },
+                    ],
+                },
+            }
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                report = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.25,
+                    min_vcd_pins=32,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
+                    timeout_seconds=10,
+                )
+            phase_power = report["phases"][0]["power"]
+            self.assertIn("non_finite_leaf_instance_power", phase_power)
+            self.assertEqual(
+                phase_power["non_finite_leaf_instance_power"]["instance_count"], 1
+            )
+            self.assertEqual(
+                phase_power["design_power_quartets"]["total"]["total_w"], 1.0
+            )
+            self.assertIn("design_power_quartets", report["phases"][1]["power"])
+
+    def test_write_markdown_includes_power_diagnostics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            payload = {
+                "status": "rejected_annotation_gate",
+                "promotion_gate_pass": False,
+                "clock_period_ns": 8.0,
+                "full_context_cycles": 10,
+                "full_context_latency_s": 0.001,
+                "full_context_energy_j": 0.0,
+                "phases": [
+                    {
+                        "phase": "finalize_result",
+                        "measured_cycles": 10,
+                        "full_context_cycles": 10,
+                        "full_context_energy_j": 0.0,
+                        "phase_gate_pass": False,
+                        "trace_backed_vcd_annotation_coverage": 0.0,
+                        "direct_vcd_annotation_coverage": 0.0,
+                        "macro_trace_active_pin_count": 10,
+                        "power": {
+                            "total_w": 1.0,
+                            "macro_trace_active_pin_count": 10,
+                            "non_finite_leaf_instance_power": {
+                                "instance_count": 2,
+                                "samples": [
+                                    {
+                                        "full_name": "u_group_a/u1",
+                                        "internal_w": 1.0,
+                                        "switching_w": 1.0,
+                                        "leakage_w": 1.0,
+                                        "total_w": 1.0,
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                ],
+                "remaining_abstractions": [],
+            }
+            out_md = Path(temp_text) / "report.md"
+            MODULE.write_markdown(payload, out_md)
+            text = out_md.read_text(encoding="utf-8")
+            self.assertIn("## Power Diagnostics", text)
+            self.assertIn("`finalize_result` non-finite leaf-instance power samples", text)
+            self.assertIn("u_group_a/u1", text)
 
     def test_required_macro_phase_cannot_promote_without_macro_activity(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:


### PR DESCRIPTION
## Summary
- report activity origins separately for leaf and FakeRAM macro pins after propagation
- serialize OpenSTA power category quartets and bounded non-finite leaf-instance samples
- preserve the existing annotation and numeric power promotion gates

## Verification
- `python3 -m pytest -q tests/test_postroute_vcd_power.py tests/test_attention_decode_score_multivalue_cluster_activity_power.py tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py` (24 passed)