### PR TITLE
Keep power diagnostics non-fatal

### DIFF
--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -266,13 +266,21 @@ foreach pin [get_pins -hierarchical *] {
 }
 
 if {$has_nonfinite_design_total} {
-  if {[catch {set leaf_cells [get_cells -hierarchical -filter "is_leaf"]}] ||
-      [llength $leaf_cells] == 0} {
-    set leaf_cells [get_cells -hierarchical]
+  set leaf_cells {}
+  if {[catch {set leaf_cells [get_cells -hierarchical -filter "is_leaf"]}]} {
+    set leaf_cells {}
   }
-  if {[catch {set leaf_cells [lsort -dictionary $leaf_cells]}]} {
-    # Keep order stable as best effort if sorting is unsupported for this object type.
-    set leaf_cells [lsort $leaf_cells]
+  if {[llength $leaf_cells] == 0} {
+    if {[catch {set leaf_cells [get_cells -hierarchical *]}]} {
+      set leaf_cells {}
+    }
+  }
+  set leaf_cells_unsorted $leaf_cells
+  if {[catch {set leaf_cells [lsort -dictionary $leaf_cells_unsorted]}]} {
+    if {[catch {set leaf_cells [lsort $leaf_cells_unsorted]}]} {
+      # Keep original order as best effort if sorting is unsupported for this object type.
+      set leaf_cells $leaf_cells_unsorted
+    }
   }
   set corners [sta::corners]
   if {[llength $corners] > 0} {

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -44,6 +44,53 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             script,
         )
 
+    def test_tcl_has_initialised_leaf_cells_for_nonfinite_diagnostics(self) -> None:
+        script = MODULE._tcl_script()
+        init_idx = script.find("set leaf_cells {}")
+        primary_catch_idx = script.find(
+            'if {[catch {set leaf_cells [get_cells -hierarchical -filter "is_leaf"]}]}'
+        )
+        empty_check_idx = script.find("if {[llength $leaf_cells] == 0}")
+        fallback_catch_idx = script.find(
+            'if {[catch {set leaf_cells [get_cells -hierarchical *]}]}'
+        )
+        self.assertGreater(init_idx, -1)
+        self.assertGreater(primary_catch_idx, -1)
+        self.assertGreater(empty_check_idx, primary_catch_idx)
+        self.assertGreater(fallback_catch_idx, empty_check_idx)
+        self.assertLess(init_idx, primary_catch_idx)
+        self.assertNotIn(
+            "if {[catch {set leaf_cells [get_cells -hierarchical -filter \"is_leaf\"]}] ||",
+            script,
+        )
+
+    def test_tcl_nonfinite_leaf_instance_fallback_keeps_diagnostics_nonfatal(self) -> None:
+        script = MODULE._tcl_script()
+        self.assertIn('set leaf_cells {}', script)
+        self.assertIn('if {[catch {set leaf_cells [get_cells -hierarchical *]}]} {', script)
+        self.assertIn("set leaf_cells {}", script, msg="Fallback catch should recover to empty diagnostics")
+        self.assertIn(
+            "set leaf_cells_unsorted $leaf_cells",
+            script,
+            "Sort fallback should preserve original list order",
+        )
+        self.assertIn(
+            "if {[catch {set leaf_cells [lsort -dictionary $leaf_cells_unsorted]}]",
+            script,
+            "Dictionary sort is now guarded in diagnostics path",
+        )
+        self.assertIn(
+            "if {[catch {set leaf_cells [lsort $leaf_cells_unsorted]}]",
+            script,
+            "Fallback sort is now guarded to avoid diagnostics abort",
+        )
+        self.assertIn("set leaf_cells $leaf_cells_unsorted", script)
+        self.assertNotIn(
+            "set leaf_cells [lsort $leaf_cells]",
+            script,
+            "Ungarded fallback sort would still be fatal",
+        )
+
     def test_activity_annotation_provenance_is_preserved(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:
             root = Path(temp_text)


### PR DESCRIPTION
## Summary
- initialize the non-finite leaf-instance diagnostic collection before guarded queries
- guard both cell-query and sorting fallbacks so diagnostics cannot abort measurement
- add regression coverage for the Tcl fallback structure

## Verification
- `python3 -m pytest -q tests/test_postroute_vcd_power.py tests/test_attention_decode_score_multivalue_cluster_activity_power.py tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py` (26 passed)