### PR TITLE
Preserve activity power failure detail

### DIFF
--- a/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
@@ -7,6 +7,7 @@ import argparse
 import csv
 import json
 import math
+import re
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,39 @@ from npu.synth.run_postroute_vcd_power import build_report as build_power_report
 
 
 JsonDict = dict[str, Any]
+_MAX_FAILURE_DETAIL_LINES = 16
+_MAX_FAILURE_DETAIL_LINE_CHARS = 400
+_MAX_FAILURE_DETAIL_BYTES = 4096
+_ABSOLUTE_PATH_RE = re.compile(r"/[^\s\"'`<>|&(){}\[\]]+")
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EVALUATOR_LOCAL_PATH_PLACEHOLDER = "<evaluator-local-path>"
+
+
+def _redact_path(path: str) -> str:
+    normalized = path.rstrip(".,;:!?)]}")
+    token = Path(normalized)
+    if token.is_absolute():
+        try:
+            return str(token.relative_to(_REPO_ROOT))
+        except ValueError:
+            return _EVALUATOR_LOCAL_PATH_PLACEHOLDER
+    return normalized
+
+
+def _sanitize_failure_line(line: str) -> str:
+    return _ABSOLUTE_PATH_RE.sub(
+        lambda match: _redact_path(match.group(0)),
+        line,
+    )
+
+
+def _collect_failure_detail(lines: list[str]) -> list[str]:
+    detail = [line.strip() for line in lines if line.strip()]
+    detail = [line for line in detail if line]
+    detail = [line[:_MAX_FAILURE_DETAIL_LINE_CHARS] for line in detail[-_MAX_FAILURE_DETAIL_LINES:]]
+    while detail and sum(len(line) for line in detail) > _MAX_FAILURE_DETAIL_BYTES:
+        detail = detail[1:]
+    return detail
 
 
 def _load(path: Path) -> JsonDict:
@@ -97,10 +131,20 @@ def _feasible_metrics(metrics_csv: Path, clock_period_ns: float) -> list[JsonDic
 
 
 def _sanitized_failure(exc: Exception) -> JsonDict:
-    message = str(exc).splitlines()[0].strip()
-    if "/" in message:
-        message = f"evaluator-local path failure during {type(exc).__name__}"
-    return {"error_type": type(exc).__name__, "error_summary": message[:240]}
+    lines = [_sanitize_failure_line(line).strip() for line in str(exc).splitlines()]
+    lines = [line for line in lines if line]
+    if lines:
+        summary = lines[0][:240]
+    else:
+        summary = f"{type(exc).__name__} failure"
+    sanitized_lines = _collect_failure_detail(lines)
+    if not sanitized_lines:
+        sanitized_lines = lines[-_MAX_FAILURE_DETAIL_LINES:]
+    return {
+        "error_type": type(exc).__name__,
+        "error_summary": summary,
+        "detail": sanitized_lines,
+    }
 
 
 def _write_markdown(payload: JsonDict, path: Path) -> None:

--- a/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
@@ -157,3 +157,50 @@ def test_build_report_records_promoted_and_failed_variants(tmp_path: Path) -> No
     assert payload["equivalence"]["final_tensor_hash"] == "final-hash"
     assert payload["candidates"][1]["status"] == "measurement_failed"
     assert "/orfs/" not in json.dumps(payload)
+
+
+def test_sanitized_failure_preserves_openroad_detail_without_local_paths() -> None:
+    message = (
+        "post-route VCD power failed:\n"
+        "command: make --no-print-directory DESIGN_CONFIG=/tmp/workspaces/runner/config.mk ...\n"
+        "stdout:\n"
+        "   File /tmp/workspaces/runner/activities/runner.tcl\n"
+        "   Tcl line 42: ERROR: undefined variable\n"
+        "stderr:\n"
+        '   openroad command "/orfs/tools/openroad/bin/openroad" -gui /home/user/project/design/openroad.tcl\n'
+    )
+    failure = audit._sanitized_failure(RuntimeError(message))
+    detail = failure["detail"]
+    assert failure["error_type"] == "RuntimeError"
+    assert failure["error_summary"].startswith("post-route VCD power failed:")
+    assert len(detail) <= 16
+    assert all(len(line) <= 400 for line in detail)
+    assert sum(len(line) for line in detail) <= 4096
+    assert all(
+        basename not in line for line in detail for basename in ("runner.tcl", "config.mk", "openroad.tcl")
+    )
+    assert any("<evaluator-local-path>" in line for line in detail)
+    assert all("/tmp/" not in line for line in detail)
+    assert all(" /home/" not in line and " /orfs/" not in line for line in detail)
+    assert any("openroad command" in line for line in detail)
+    assert any("Tcl line 42" in line for line in detail)
+
+
+def test_sanitized_failure_bounds_to_tail_lines() -> None:
+    message = "\n".join(
+        [
+            f"line {index}: this is a long diagnostic line with extra padding."
+            + "x" * 600
+            + f" /tmp/job/{index}/artifact.log"
+            for index in range(30)
+        ]
+    )
+    failure = audit._sanitized_failure(RuntimeError(message))
+    detail = failure["detail"]
+    assert len(detail) <= 16
+    assert len(detail[0]) <= 400
+    assert len(detail[-1]) <= 400
+    assert detail[0].startswith("line 20")
+    assert detail[-1].startswith("line 29")
+    assert all("/tmp/" not in line for line in detail)
+    assert all("artifact.log" not in line for line in detail)


### PR DESCRIPTION
## Summary
- retain bounded OpenROAD/Tcl error-tail evidence when activity measurement fails
- redact evaluator-local absolute paths and temporary filenames
- leave promotion and decision behavior unchanged

## Verification
- `python3 -m pytest -q tests/test_attention_decode_score_multivalue_cluster_activity_power.py tests/test_postroute_vcd_power.py` (19 passed)