### PR TITLE
eval: run measure shared-score multivalue cluster activity power v4

### DIFF
--- a/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json
+++ b/control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json
@@ -1,0 +1,92 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-19T11:59:47.529652Z",
+  "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4",
+  "run_key": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4_run_cf7b2b313a94c62b",
+  "layer": "layer2",
+  "flow": "openroad",
+  "platform": "nangate45",
+  "task_type": "l2_campaign",
+  "source_commit": "78131c3dc05171c600c8198eaec53ce06d8fda11",
+  "review_metadata_source_commit": "78131c3dc05171c600c8198eaec53ce06d8fda11",
+  "objective": "Rerun shared-score multivalue-cluster activity-backed power with same-net trace activity transferred to FakeRAM inputs and stronger finite-power diagnostics, without heuristic activity or gate relaxation.",
+  "input_manifest": {
+    "decoder_contract": {
+      "decode_score_multivalue_cluster_config": "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json",
+      "decode_score_multivalue_cluster_activity_dir": "/tmp/rtlgen_multivalue_cluster_activity",
+      "decode_score_multivalue_cluster_pnr_metrics_csv": "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv",
+      "decode_score_multivalue_cluster_equivalence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json",
+      "decode_score_multivalue_cluster_activity_power_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+      "decode_score_multivalue_cluster_orfs_design_config": "/orfs/flow/designs/nangate45/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.mk",
+      "decode_score_multivalue_cluster_activity_power_scope": "Audit the shared-score multivalue cluster with activity-backed power evidence after merged equivalence and PNR. Keep VCD/ODB/SPEF evaluator-local, commit only repo-portable JSON/MD artifacts, preserve the FakeRAM proxy qualification, and reject vectorless power as a substitute for annotated power or token-energy claims.",
+      "decode_score_multivalue_cluster_activity_power_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.md",
+      "decode_score_multivalue_cluster_activity_power_promotion_gate": "Promotion requires explicit annotation coverage, declared clock assumptions, macro activity attribution, and finite power-gate accounting.",
+      "decode_score_multivalue_cluster_activity_power_local_only_artifacts": [
+        "VCD",
+        "ODB",
+        "SPEF"
+      ]
+    }
+  },
+  "recommendation": {
+    "source": "decoder_evidence",
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+    "arch_id": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+    "macro_mode": "evidence_only",
+    "outcome": "activity_power_rejected_no_gated_candidate"
+  },
+  "objective_profiles": [],
+  "evaluation_record": {
+    "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+    "title": "Activity-backed power gate for the shared-score multivalue decode cluster",
+    "primary_question": "Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+    "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+    "expected_direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+    "expected_reason": "Promotion requires direct VCD roots, post-propagation coverage, transferred macro active coverage, exact clock, and finite positive power.",
+    "summary": "Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.",
+    "outcome": "activity_power_rejected_no_gated_candidate",
+    "expectation_status": "unspecified"
+  },
+  "proposal_assessment": {
+    "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+    "title": "Activity-backed power gate for the shared-score multivalue decode cluster",
+    "kind": "architecture",
+    "primary_question": "Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?",
+    "evaluation_mode": "frontier_detail",
+    "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+    "outcome": "activity_power_rejected_no_gated_candidate",
+    "summary": "Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.",
+    "baseline_ref": null,
+    "baseline_item_id": null,
+    "matched_row_count": 0,
+    "matched_rows": [],
+    "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+    "decoder_quality": {
+      "diagnosis": {},
+      "remaining_abstractions": [
+        "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
+        "Value-memory, NoC, HBM/DRAM, command-distribution, and clock-tree composition outside the cluster are not included.",
+        "RTL VCD is mapped to the routed netlist; each candidate records and gates direct annotation coverage.",
+        "Score multiplier and shift derivation remain external to the cluster boundary."
+      ],
+      "best": null
+    }
+  },
+  "source_refs": {
+    "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+    "decoder_decode_score_multivalue_cluster_activity_power_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+    "decoder_decode_score_multivalue_cluster_activity_power_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.md"
+  },
+  "decoder_quality": {
+    "diagnosis": {},
+    "remaining_abstractions": [
+      "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
+      "Value-memory, NoC, HBM/DRAM, command-distribution, and clock-tree composition outside the cluster are not included.",
+      "RTL VCD is mapped to the routed netlist; each candidate records and gates direct annotation coverage.",
+      "Score multiplier and shift derivation remain external to the cluster boundary."
+    ],
+    "best": null
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/evaluated.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/evaluated.json
@@ -1,0 +1,116 @@
+{
+  "flow": "openroad",
+  "task": {
+    "inputs": {
+      "decoder_contract": {
+        "decode_score_multivalue_cluster_config": "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json",
+        "decode_score_multivalue_cluster_activity_dir": "/tmp/rtlgen_multivalue_cluster_activity",
+        "decode_score_multivalue_cluster_pnr_metrics_csv": "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv",
+        "decode_score_multivalue_cluster_equivalence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json",
+        "decode_score_multivalue_cluster_activity_power_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+        "decode_score_multivalue_cluster_orfs_design_config": "/orfs/flow/designs/nangate45/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.mk",
+        "decode_score_multivalue_cluster_activity_power_scope": "Audit the shared-score multivalue cluster with activity-backed power evidence after merged equivalence and PNR. Keep VCD/ODB/SPEF evaluator-local, commit only repo-portable JSON/MD artifacts, preserve the FakeRAM proxy qualification, and reject vectorless power as a substitute for annotated power or token-energy claims.",
+        "decode_score_multivalue_cluster_activity_power_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.md",
+        "decode_score_multivalue_cluster_activity_power_promotion_gate": "Promotion requires explicit annotation coverage, declared clock assumptions, macro activity attribution, and finite power-gate accounting.",
+        "decode_score_multivalue_cluster_activity_power_local_only_artifacts": [
+          "VCD",
+          "ODB",
+          "SPEF"
+        ]
+      }
+    },
+    "commands": [
+      {
+        "run": "python3 -m npu.eval.audit_attention_decode_score_multivalue_cluster_activity_power --config runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json --cluster-metrics-csv runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv --equivalence-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json --orfs-design-config /orfs/flow/designs/nangate45/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.mk --clock-period-ns 8 --activity-dir /tmp/rtlgen_multivalue_cluster_activity --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json --out-md runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.md",
+        "name": "audit_decode_score_multivalue_cluster_activity_power"
+      },
+      {
+        "run": "python3 scripts/validate_runs.py --skip_eval_queue",
+        "name": "validate_runs"
+      }
+    ],
+    "objective": "Rerun shared-score multivalue-cluster activity-backed power with same-net trace activity transferred to FakeRAM inputs and stronger finite-power diagnostics, without heuristic activity or gate relaxation.",
+    "acceptance": [
+      "Write all declared decoder evidence artifacts",
+      "Keep evidence artifact paths repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "source_mode": "src_verilog",
+    "expected_outputs": [
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+      "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.md"
+    ]
+  },
+  "layer": "layer2",
+  "state": "evaluated",
+  "title": "Measure shared-score multivalue cluster activity power v4",
+  "result": {
+    "branch": "eval/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/s20260719t115948z",
+    "completed_utc": "2026-07-19T11:59:46.448762Z",
+    "evaluator_id": "control_plane",
+    "executor": "@control_plane",
+    "host": "b7c2d9c80c1c",
+    "identity_block": "[role:evaluator][account:control_plane][session:s20260719t115948z][host:b7c2d9c80c1c][item:l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4]",
+    "metrics_rows": [],
+    "metrics_exempt_reason": "evidence_only_decoder_evidence",
+    "queue_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4",
+    "session_id": "s20260719t115948z",
+    "status": "ok",
+    "summary": "2/2 commands succeeded"
+  },
+  "handoff": {
+    "branch": "eval/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/s20260719t115948z",
+    "pr_title": "eval: run measure shared-score multivalue cluster activity power v4",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ],
+    "pr_body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260719t115948z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4"
+    },
+    "identity_block_format": "[role:evaluator][account:<evaluator_id>][session:<session_id>][host:<host>][item:<queue_item_id>]"
+  },
+  "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4",
+  "version": 0.1,
+  "platform": "nangate45",
+  "priority": 95,
+  "created_utc": "2026-07-19T11:57:33.765194Z",
+  "requested_by": "developer_agent",
+  "developer_loop": {
+    "comparison": {
+      "role": "shared_score_multivalue_cluster_activity_power_gate",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "Promotion requires direct VCD roots, post-propagation coverage, transferred macro active coverage, exact clock, and finite positive power.",
+      "expected_direction": "record_shared_score_multivalue_cluster_activity_power_gate"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_decode_score_multivalue_cluster_activity_power"
+    },
+    "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+  },
+  "source_requirement": {
+    "repo": "",
+    "reason": "evaluator runtime must contain the queued job source commit",
+    "version": 1,
+    "required_ref": "origin/master",
+    "required_sha": "78131c3dc05171c600c8198eaec53ce06d8fda11",
+    "requires_daemon_restart": true
+  }
+}

--- a/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/pr_body.md
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/pr_body.md
@@ -1,0 +1,40 @@
+## Summary
+- item_id: `l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4`
+- run_key: `l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4_run_cf7b2b313a94c62b`
+- layer: `layer2`
+- task_type: `l2_campaign`
+- status: `ok`
+- summary: `2/2 commands succeeded`
+- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/evaluated.json`
+- metrics_rows_count: `0`
+- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json`
+
+## Developer Context
+- proposal_id: `prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1`
+- proposal_path: `docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1`
+- reviewer_first_read: `docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1` plus `docs/developer_agent_review.md`
+- execution_source_commit: `78131c3dc05171c600c8198eaec53ce06d8fda11`
+- review_metadata_source_commit: `78131c3dc05171c600c8198eaec53ce06d8fda11`
+
+## Evaluation Mode
+- evaluation_mode: `frontier_detail`
+- abstraction_layer: `decoder_attention_decode_score_multivalue_cluster_activity_power`
+- comparison_role: `shared_score_multivalue_cluster_activity_power_gate`
+- expected_direction: `record_shared_score_multivalue_cluster_activity_power_gate`
+- expected_reason: `Promotion requires direct VCD roots, post-propagation coverage, transferred macro active coverage, exact clock, and finite positive power.`
+- expectation_status: `unspecified`
+- evaluation_summary: `Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.`
+
+## Focused Comparison
+- primary_question: `Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?`
+- comparison_role: `shared_score_multivalue_cluster_activity_power_gate`
+- proposal_outcome: `activity_power_rejected_no_gated_candidate`
+- comparison_summary: `Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.`
+- baseline_ref: `None`
+- baseline_item_id: `None`
+
+## Checklist
+- [ ] Commit lightweight campaign artifacts only
+- [ ] Include metrics row references in result.metrics_rows
+- [ ] Keep committed result_path fields repo-portable
+- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing

--- a/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/review_package.json
+++ b/control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/review_package.json
@@ -1,0 +1,169 @@
+{
+  "version": 0.1,
+  "generated_utc": "2026-07-19T11:59:50.651735Z",
+  "control_plane_source_commit": "78131c3dc05171c600c8198eaec53ce06d8fda11",
+  "review_metadata_source_commit": "78131c3dc05171c600c8198eaec53ce06d8fda11",
+  "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4",
+  "run_key": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4_run_cf7b2b313a94c62b",
+  "layer": "layer2",
+  "flow": "openroad",
+  "task_type": "l2_campaign",
+  "source_commit": "78131c3dc05171c600c8198eaec53ce06d8fda11",
+  "queue_snapshot": {
+    "path": "control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/evaluated.json",
+    "result": {
+      "branch": "eval/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/s20260719t115948z",
+      "completed_utc": "2026-07-19T11:59:46.448762Z",
+      "evaluator_id": "control_plane",
+      "executor": "@control_plane",
+      "host": "b7c2d9c80c1c",
+      "identity_block": "[role:evaluator][account:control_plane][session:s20260719t115948z][host:b7c2d9c80c1c][item:l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4]",
+      "metrics_rows": [],
+      "metrics_exempt_reason": "evidence_only_decoder_evidence",
+      "queue_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4",
+      "session_id": "s20260719t115948z",
+      "status": "ok",
+      "summary": "2/2 commands succeeded"
+    }
+  },
+  "review_artifact": {
+    "kind": "decision_proposal",
+    "path": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+    "storage_mode": "repo",
+    "sha256": "47c1f51a066d2a9f6b577297f53ab47ac05ee00d5591fc39a6738a2d7c5e47b6",
+    "payload": {
+      "version": 0.1,
+      "generated_utc": "2026-07-19T11:59:47.529652Z",
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4",
+      "run_key": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4_run_cf7b2b313a94c62b",
+      "layer": "layer2",
+      "flow": "openroad",
+      "platform": "nangate45",
+      "task_type": "l2_campaign",
+      "source_commit": "78131c3dc05171c600c8198eaec53ce06d8fda11",
+      "review_metadata_source_commit": "78131c3dc05171c600c8198eaec53ce06d8fda11",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power with same-net trace activity transferred to FakeRAM inputs and stronger finite-power diagnostics, without heuristic activity or gate relaxation.",
+      "input_manifest": {
+        "decoder_contract": {
+          "decode_score_multivalue_cluster_config": "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json",
+          "decode_score_multivalue_cluster_activity_dir": "/tmp/rtlgen_multivalue_cluster_activity",
+          "decode_score_multivalue_cluster_pnr_metrics_csv": "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv",
+          "decode_score_multivalue_cluster_equivalence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json",
+          "decode_score_multivalue_cluster_activity_power_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+          "decode_score_multivalue_cluster_orfs_design_config": "/orfs/flow/designs/nangate45/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.mk",
+          "decode_score_multivalue_cluster_activity_power_scope": "Audit the shared-score multivalue cluster with activity-backed power evidence after merged equivalence and PNR. Keep VCD/ODB/SPEF evaluator-local, commit only repo-portable JSON/MD artifacts, preserve the FakeRAM proxy qualification, and reject vectorless power as a substitute for annotated power or token-energy claims.",
+          "decode_score_multivalue_cluster_activity_power_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.md",
+          "decode_score_multivalue_cluster_activity_power_promotion_gate": "Promotion requires explicit annotation coverage, declared clock assumptions, macro activity attribution, and finite power-gate accounting.",
+          "decode_score_multivalue_cluster_activity_power_local_only_artifacts": [
+            "VCD",
+            "ODB",
+            "SPEF"
+          ]
+        }
+      },
+      "recommendation": {
+        "source": "decoder_evidence",
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+        "arch_id": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+        "macro_mode": "evidence_only",
+        "outcome": "activity_power_rejected_no_gated_candidate"
+      },
+      "objective_profiles": [],
+      "evaluation_record": {
+        "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+        "title": "Activity-backed power gate for the shared-score multivalue decode cluster",
+        "primary_question": "Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+        "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+        "expected_direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "expected_reason": "Promotion requires direct VCD roots, post-propagation coverage, transferred macro active coverage, exact clock, and finite positive power.",
+        "summary": "Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.",
+        "outcome": "activity_power_rejected_no_gated_candidate",
+        "expectation_status": "unspecified"
+      },
+      "proposal_assessment": {
+        "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+        "title": "Activity-backed power gate for the shared-score multivalue decode cluster",
+        "kind": "architecture",
+        "primary_question": "Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?",
+        "evaluation_mode": "frontier_detail",
+        "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+        "outcome": "activity_power_rejected_no_gated_candidate",
+        "summary": "Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.",
+        "baseline_ref": null,
+        "baseline_item_id": null,
+        "matched_row_count": 0,
+        "matched_rows": [],
+        "decoder_evidence_ref": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+        "decoder_quality": {
+          "diagnosis": {},
+          "remaining_abstractions": [
+            "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
+            "Value-memory, NoC, HBM/DRAM, command-distribution, and clock-tree composition outside the cluster are not included.",
+            "RTL VCD is mapped to the routed netlist; each candidate records and gates direct annotation coverage.",
+            "Score multiplier and shift derivation remain external to the cluster boundary."
+          ],
+          "best": null
+        }
+      },
+      "source_refs": {
+        "decoder_evidence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+        "decoder_decode_score_multivalue_cluster_activity_power_out": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json",
+        "decoder_decode_score_multivalue_cluster_activity_power_report": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.md"
+      },
+      "decoder_quality": {
+        "diagnosis": {},
+        "remaining_abstractions": [
+          "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
+          "Value-memory, NoC, HBM/DRAM, command-distribution, and clock-tree composition outside the cluster are not included.",
+          "RTL VCD is mapped to the routed netlist; each candidate records and gates direct annotation coverage.",
+          "Score multiplier and shift derivation remain external to the cluster boundary."
+        ],
+        "best": null
+      }
+    }
+  },
+  "developer_loop": {
+    "comparison": {
+      "role": "shared_score_multivalue_cluster_activity_power_gate",
+      "paired_baseline_item_id": ""
+    },
+    "evaluation": {
+      "mode": "frontier_detail",
+      "expected_reason": "Promotion requires direct VCD roots, post-propagation coverage, transferred macro active coverage, exact clock, and finite positive power.",
+      "expected_direction": "record_shared_score_multivalue_cluster_activity_power_gate"
+    },
+    "abstraction": {
+      "layer": "decoder_attention_decode_score_multivalue_cluster_activity_power"
+    },
+    "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
+    "dependencies": {
+      "item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    "proposal_path": "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1"
+  },
+  "submission_history": null,
+  "pr_payload": {
+    "branch": "eval/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/s20260719t115948z",
+    "title": "eval: run measure shared-score multivalue cluster activity power v4",
+    "body_fields": {
+      "host": "b7c2d9c80c1c",
+      "session_id": "s20260719t115948z",
+      "evaluator_id": "control_plane",
+      "queue_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4"
+    },
+    "body_md": "## Summary\n- item_id: `l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4`\n- run_key: `l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4_run_cf7b2b313a94c62b`\n- layer: `layer2`\n- task_type: `l2_campaign`\n- status: `ok`\n- summary: `2/2 commands succeeded`\n- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/evaluated.json`\n- metrics_rows_count: `0`\n- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json`\n\n## Developer Context\n- proposal_id: `prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1`\n- proposal_path: `docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1`\n- reviewer_first_read: `docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1` plus `docs/developer_agent_review.md`\n- execution_source_commit: `78131c3dc05171c600c8198eaec53ce06d8fda11`\n- review_metadata_source_commit: `78131c3dc05171c600c8198eaec53ce06d8fda11`\n\n## Evaluation Mode\n- evaluation_mode: `frontier_detail`\n- abstraction_layer: `decoder_attention_decode_score_multivalue_cluster_activity_power`\n- comparison_role: `shared_score_multivalue_cluster_activity_power_gate`\n- expected_direction: `record_shared_score_multivalue_cluster_activity_power_gate`\n- expected_reason: `Promotion requires direct VCD roots, post-propagation coverage, transferred macro active coverage, exact clock, and finite positive power.`\n- expectation_status: `unspecified`\n- evaluation_summary: `Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.`\n\n## Focused Comparison\n- primary_question: `Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?`\n- comparison_role: `shared_score_multivalue_cluster_activity_power_gate`\n- proposal_outcome: `activity_power_rejected_no_gated_candidate`\n- comparison_summary: `Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.`\n- baseline_ref: `None`\n- baseline_item_id: `None`\n\n## Checklist\n- [ ] Commit lightweight campaign artifacts only\n- [ ] Include metrics row references in result.metrics_rows\n- [ ] Keep committed result_path fields repo-portable\n- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing\n",
+    "checklist": [
+      "Commit lightweight campaign artifacts only",
+      "Include metrics row references in result.metrics_rows",
+      "Keep committed result_path fields repo-portable",
+      "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing"
+    ]
+  }
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json
@@ -1,0 +1,512 @@
+{
+  "activity_contract": {
+    "clock_period_ns": 8.0,
+    "phase_partition_cycle_sum": 8334,
+    "phases": [
+      {
+        "full_context_cycles": 2277377,
+        "measured_cycles": 418,
+        "phase": "score_fill",
+        "requires_macro_activity": true,
+        "scaling": {
+          "command_setup_cycles": 1,
+          "cycles_per_block": 139,
+          "formula": "command_setup_cycles + cycles_per_block * target_max_blocks",
+          "full_context_cycles": 2277377,
+          "kind": "fixed_setup_plus_linear_by_block_count",
+          "representative_block_count": 3,
+          "target_max_blocks": 16384
+        },
+        "vcd": "score_fill.vcd",
+        "vcd_sha256": "d1db7f02e16c216cea31c9d2bce0a17ff4f8215beba9f61a2f858eaac9ec12a1"
+      },
+      {
+        "full_context_cycles": 1114128,
+        "measured_cycles": 220,
+        "phase": "replay_value",
+        "requires_macro_activity": true,
+        "scaling": {
+          "clear_cycles": 16,
+          "formula": "clear_cycles + replay_cycles_per_block * target_max_blocks",
+          "full_context_cycles": 1114128,
+          "kind": "fixed_clear_plus_linear_by_block_count",
+          "replay_cycles_per_block": 68,
+          "representative_block_count": 3,
+          "target_max_blocks": 16384
+        },
+        "vcd": "replay_value.vcd",
+        "vcd_sha256": "fa96e9179fb92798b72f400682002e93a2d3b4f7f2d1882c4c4466245739507f"
+      },
+      {
+        "full_context_cycles": 7696,
+        "measured_cycles": 7696,
+        "phase": "finalize_result",
+        "requires_macro_activity": false,
+        "scaling": {
+          "divide_cycles_per_dimension": 60,
+          "formula": "value_dimensions * divide_cycles_per_dimension + result_emit_cycles",
+          "full_context_cycles": 7696,
+          "kind": "fixed_per_command",
+          "result_emit_cycles": 16,
+          "target_max_blocks": 16384,
+          "value_dimensions": 128
+        },
+        "vcd": "finalize_result.vcd",
+        "vcd_sha256": "aec5a3693a03eb703e6364627999f4fc0b6ea3fb8087855d915ccc450bf0214f"
+      }
+    ],
+    "representative_block_count": 3,
+    "representative_full_transaction_cycles": 8334
+  },
+  "best": null,
+  "best_candidate_id": null,
+  "candidate_count": 1,
+  "candidates": [
+    {
+      "activity_power": {
+        "clock_period_ns": 8.0,
+        "flow_variant": "decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500",
+        "full_context_cycles": 3399201,
+        "full_context_energy_j": null,
+        "full_context_latency_s": 0.027193608,
+        "min_macro_trace_active_coverage": 0.01,
+        "min_macro_trace_active_pins": 16,
+        "min_vcd_annotated_pins": 32,
+        "min_vcd_annotation_coverage": 0.05,
+        "model": "postroute_phase_vcd_power_v1",
+        "orfs_design_config": "designs/nangate45/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.mk",
+        "orfs_design_config_sha256": "b7a1f177828302987eb9d2af032d232c675149044db964d8217ce3ef2f293b7b",
+        "phases": [
+          {
+            "annotation_gate_pass": true,
+            "clock_period_gate_pass": true,
+            "direct_vcd_annotation_coverage": 0.016086543078530878,
+            "direct_vcd_annotation_pin_gate_pass": true,
+            "full_context_cycles": 2277377,
+            "full_context_energy_j": 0.004184121739595014,
+            "macro_activity_gate_pass": false,
+            "macro_trace_active_coverage": 0.0,
+            "measured_cycles": 418,
+            "phase": "score_fill",
+            "phase_gate_pass": false,
+            "power": {
+              "activity_annotation_counts": {
+                "unannotated": 522522,
+                "vcd": 8543
+              },
+              "annotatable_pin_count": 529858,
+              "design_power_quartets": {
+                "clock": {
+                  "internal_w": 0.00316751585342,
+                  "leakage_w": 8.44854512252e-05,
+                  "switching_w": 0.00402905419469,
+                  "total_w": 0.0072810552083
+                },
+                "combinational": {
+                  "internal_w": 0.00741981528699,
+                  "leakage_w": 0.00387729192153,
+                  "switching_w": 0.00939501076937,
+                  "total_w": 0.0206921175122
+                },
+                "macro": {
+                  "internal_w": 0.0959726572037,
+                  "leakage_w": 0.105089597404,
+                  "switching_w": 0,
+                  "total_w": 0.201062262058
+                },
+                "pad": {
+                  "internal_w": 0,
+                  "leakage_w": 0,
+                  "switching_w": 0,
+                  "total_w": 0
+                },
+                "sequential": {
+                  "internal_w": 0,
+                  "leakage_w": 0.000623499276116,
+                  "switching_w": 0,
+                  "total_w": 0.000623499276116
+                },
+                "total": {
+                  "internal_w": 0.106559813023,
+                  "leakage_w": 0.109672941267,
+                  "switching_w": 0.0134240929037,
+                  "total_w": 0.229656845331
+                }
+              },
+              "direct_annotatable_pin_count": 531065,
+              "direct_unannotated_pin_count": 522522,
+              "direct_vcd_pin_count": 8543,
+              "internal_w": 0.106559813023,
+              "leaf_activity_origin_counts": {
+                "clock": 13447,
+                "constant": 549,
+                "other": 226727,
+                "propagated": 289135,
+                "vcd": 0
+              },
+              "leaf_annotatable_pin_count": 529858,
+              "leaf_direct_annotatable_pin_count": 531065,
+              "leaf_direct_vcd_pin_count": 8543,
+              "leaf_trace_backed_pin_count": 289135,
+              "leaf_vcd_annotated_pin_count": 8543,
+              "leakage_w": 0.109672941267,
+              "macro_activity_origin_counts": {
+                "clock": 56,
+                "constant": 544,
+                "other": 7008,
+                "propagated": 0,
+                "transferred": 0,
+                "vcd": 0
+              },
+              "macro_annotatable_pin_count": 7608,
+              "macro_pin_transfer": {
+                "active_count": 0,
+                "applied_count": 0,
+                "apply_error_count": 0,
+                "candidate_count": 0,
+                "query_error_count": 0,
+                "source_propagated_count": 0,
+                "source_vcd_count": 0,
+                "transferred": [],
+                "zero_count": 0
+              },
+              "macro_trace_active_pin_count": 0,
+              "macro_trace_backed_pin_count": 0,
+              "macro_trace_backed_zero_toggle_pin_count": 0,
+              "sdc_clock_period_ns": 8,
+              "switching_w": 0.0134240929037,
+              "total_w": 0.229656845331,
+              "trace_backed_pin_count": 289135,
+              "vcd_annotated_pin_count": 289135
+            },
+            "power_numeric_gate_pass": true,
+            "requires_macro_activity": true,
+            "scaling": {
+              "command_setup_cycles": 1,
+              "cycles_per_block": 139,
+              "formula": "command_setup_cycles + cycles_per_block * target_max_blocks",
+              "full_context_cycles": 2277377,
+              "kind": "fixed_setup_plus_linear_by_block_count",
+              "representative_block_count": 3,
+              "target_max_blocks": 16384
+            },
+            "trace_backed_vcd_annotation_coverage": 0.5456839379607367,
+            "trace_coverage_gate_pass": true,
+            "vcd": "score_fill.vcd",
+            "vcd_annotation_coverage": 0.5456839379607367,
+            "vcd_sha256": "d1db7f02e16c216cea31c9d2bce0a17ff4f8215beba9f61a2f858eaac9ec12a1"
+          },
+          {
+            "annotation_gate_pass": true,
+            "clock_period_gate_pass": true,
+            "direct_vcd_annotation_coverage": 0.016086543078530878,
+            "direct_vcd_annotation_pin_gate_pass": true,
+            "full_context_cycles": 1114128,
+            "full_context_energy_j": 0.0019302178136234643,
+            "macro_activity_gate_pass": false,
+            "macro_trace_active_coverage": 0.0,
+            "measured_cycles": 220,
+            "phase": "replay_value",
+            "phase_gate_pass": false,
+            "power": {
+              "activity_annotation_counts": {
+                "unannotated": 522522,
+                "vcd": 8543
+              },
+              "annotatable_pin_count": 529858,
+              "design_power_quartets": {
+                "clock": {
+                  "internal_w": 0.00316751585342,
+                  "leakage_w": 8.44854512252e-05,
+                  "switching_w": 0.00402905419469,
+                  "total_w": 0.0072810552083
+                },
+                "combinational": {
+                  "internal_w": 0.00143941945862,
+                  "leakage_w": 0.0040071066469,
+                  "switching_w": 0.00215618126094,
+                  "total_w": 0.00760270748287
+                },
+                "macro": {
+                  "internal_w": 0.0959726572037,
+                  "leakage_w": 0.105089597404,
+                  "switching_w": 0,
+                  "total_w": 0.201062262058
+                },
+                "pad": {
+                  "internal_w": 0,
+                  "leakage_w": 0,
+                  "switching_w": 0,
+                  "total_w": 0
+                },
+                "sequential": {
+                  "internal_w": 0,
+                  "leakage_w": 0.000623499276116,
+                  "switching_w": 0,
+                  "total_w": 0.000623499276116
+                },
+                "total": {
+                  "internal_w": 0.100577741861,
+                  "leakage_w": 0.109798520803,
+                  "switching_w": 0.00618522893637,
+                  "total_w": 0.216561496258
+                }
+              },
+              "direct_annotatable_pin_count": 531065,
+              "direct_unannotated_pin_count": 522522,
+              "direct_vcd_pin_count": 8543,
+              "internal_w": 0.100577741861,
+              "leaf_activity_origin_counts": {
+                "clock": 13447,
+                "constant": 549,
+                "other": 226727,
+                "propagated": 289135,
+                "vcd": 0
+              },
+              "leaf_annotatable_pin_count": 529858,
+              "leaf_direct_annotatable_pin_count": 531065,
+              "leaf_direct_vcd_pin_count": 8543,
+              "leaf_trace_backed_pin_count": 289135,
+              "leaf_vcd_annotated_pin_count": 8543,
+              "leakage_w": 0.109798520803,
+              "macro_activity_origin_counts": {
+                "clock": 56,
+                "constant": 544,
+                "other": 7008,
+                "propagated": 0,
+                "transferred": 0,
+                "vcd": 0
+              },
+              "macro_annotatable_pin_count": 7608,
+              "macro_pin_transfer": {
+                "active_count": 0,
+                "applied_count": 0,
+                "apply_error_count": 0,
+                "candidate_count": 0,
+                "query_error_count": 0,
+                "source_propagated_count": 0,
+                "source_vcd_count": 0,
+                "transferred": [],
+                "zero_count": 0
+              },
+              "macro_trace_active_pin_count": 0,
+              "macro_trace_backed_pin_count": 0,
+              "macro_trace_backed_zero_toggle_pin_count": 0,
+              "sdc_clock_period_ns": 8,
+              "switching_w": 0.00618522893637,
+              "total_w": 0.216561496258,
+              "trace_backed_pin_count": 289135,
+              "vcd_annotated_pin_count": 289135
+            },
+            "power_numeric_gate_pass": true,
+            "requires_macro_activity": true,
+            "scaling": {
+              "clear_cycles": 16,
+              "formula": "clear_cycles + replay_cycles_per_block * target_max_blocks",
+              "full_context_cycles": 1114128,
+              "kind": "fixed_clear_plus_linear_by_block_count",
+              "replay_cycles_per_block": 68,
+              "representative_block_count": 3,
+              "target_max_blocks": 16384
+            },
+            "trace_backed_vcd_annotation_coverage": 0.5456839379607367,
+            "trace_coverage_gate_pass": true,
+            "vcd": "replay_value.vcd",
+            "vcd_annotation_coverage": 0.5456839379607367,
+            "vcd_sha256": "fa96e9179fb92798b72f400682002e93a2d3b4f7f2d1882c4c4466245739507f"
+          },
+          {
+            "annotation_gate_pass": true,
+            "clock_period_gate_pass": true,
+            "direct_vcd_annotation_coverage": 0.016086543078530878,
+            "direct_vcd_annotation_pin_gate_pass": true,
+            "full_context_cycles": 7696,
+            "full_context_energy_j": 0.0,
+            "macro_activity_gate_pass": true,
+            "macro_trace_active_coverage": 0.0,
+            "measured_cycles": 7696,
+            "phase": "finalize_result",
+            "phase_gate_pass": false,
+            "power": {
+              "activity_annotation_counts": {
+                "unannotated": 522522,
+                "vcd": 8543
+              },
+              "annotatable_pin_count": 529858,
+              "design_power_quartets": {
+                "clock": {
+                  "internal_w": 0.00316751585342,
+                  "leakage_w": 8.44854512252e-05,
+                  "switching_w": 0.00402905419469,
+                  "total_w": 0.0072810552083
+                },
+                "combinational": {
+                  "internal_w": null,
+                  "leakage_w": null,
+                  "switching_w": null,
+                  "total_w": null
+                },
+                "macro": {
+                  "internal_w": 0.0959726572037,
+                  "leakage_w": 0.105089597404,
+                  "switching_w": 0,
+                  "total_w": 0.201062262058
+                },
+                "pad": {
+                  "internal_w": 0,
+                  "leakage_w": 0,
+                  "switching_w": 0,
+                  "total_w": 0
+                },
+                "sequential": {
+                  "internal_w": null,
+                  "leakage_w": null,
+                  "switching_w": 0,
+                  "total_w": null
+                },
+                "total": {
+                  "internal_w": null,
+                  "leakage_w": null,
+                  "switching_w": null,
+                  "total_w": null
+                }
+              },
+              "direct_annotatable_pin_count": 531065,
+              "direct_unannotated_pin_count": 522522,
+              "direct_vcd_pin_count": 8543,
+              "internal_w": null,
+              "leaf_activity_origin_counts": {
+                "clock": 13447,
+                "constant": 549,
+                "other": 226727,
+                "propagated": 289135,
+                "vcd": 0
+              },
+              "leaf_annotatable_pin_count": 529858,
+              "leaf_direct_annotatable_pin_count": 531065,
+              "leaf_direct_vcd_pin_count": 8543,
+              "leaf_trace_backed_pin_count": 289135,
+              "leaf_vcd_annotated_pin_count": 8543,
+              "leakage_w": null,
+              "macro_activity_origin_counts": {
+                "clock": 56,
+                "constant": 544,
+                "other": 7008,
+                "propagated": 0,
+                "transferred": 0,
+                "vcd": 0
+              },
+              "macro_annotatable_pin_count": 7608,
+              "macro_pin_transfer": {
+                "active_count": 0,
+                "applied_count": 0,
+                "apply_error_count": 0,
+                "candidate_count": 0,
+                "query_error_count": 0,
+                "source_propagated_count": 0,
+                "source_vcd_count": 0,
+                "transferred": [],
+                "zero_count": 0
+              },
+              "macro_trace_active_pin_count": 0,
+              "macro_trace_backed_pin_count": 0,
+              "macro_trace_backed_zero_toggle_pin_count": 0,
+              "non_finite_leaf_instance_power": {
+                "bad_shape_row_count": 0,
+                "candidate_cell_count": 724570,
+                "checked_instance_power_count": 0,
+                "finite_component_sums": {
+                  "internal_w": 0,
+                  "leakage_w": 0,
+                  "switching_w": 0,
+                  "total_w": 0
+                },
+                "finite_row_count": 0,
+                "instance_count": 0,
+                "non_leaf_skip_count": 0,
+                "query_error_count": 724571,
+                "samples": []
+              },
+              "sdc_clock_period_ns": 8,
+              "switching_w": null,
+              "total_w": null,
+              "trace_backed_pin_count": 289135,
+              "vcd_annotated_pin_count": 289135
+            },
+            "power_numeric_gate_pass": false,
+            "requires_macro_activity": false,
+            "scaling": {
+              "divide_cycles_per_dimension": 60,
+              "formula": "value_dimensions * divide_cycles_per_dimension + result_emit_cycles",
+              "full_context_cycles": 7696,
+              "kind": "fixed_per_command",
+              "result_emit_cycles": 16,
+              "target_max_blocks": 16384,
+              "value_dimensions": 128
+            },
+            "trace_backed_vcd_annotation_coverage": 0.5456839379607367,
+            "trace_coverage_gate_pass": true,
+            "vcd": "finalize_result.vcd",
+            "vcd_annotation_coverage": 0.5456839379607367,
+            "vcd_sha256": "aec5a3693a03eb703e6364627999f4fc0b6ea3fb8087855d915ccc450bf0214f"
+          }
+        ],
+        "promotion_gate_pass": false,
+        "remaining_abstractions": [
+          "FakeRAM power uses the Nangate45 proxy Liberty model, not SRAM compiler signoff.",
+          "RTL-generated VCD is mapped onto the post-route netlist; annotation coverage is explicit and gated.",
+          "Off-cluster value-memory, NoC, and HBM energy are outside this cluster power result."
+        ],
+        "scope": "tb/dut",
+        "source_activity_manifest": "attention_decode_score_multivalue_cluster_activity_manifest.json",
+        "source_activity_manifest_sha256": "6f5040bd7e9b023f17e0accf2fb0a21a1d6cb701f6e1effcbb317c4161f652fb",
+        "status": "rejected_annotation_gate",
+        "version": 1
+      },
+      "candidate_id": "multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500",
+      "flow_variant": "decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500",
+      "ppa_metric": {
+        "config_hash": "d037eabb6abd",
+        "core_area_um2": "5760000.0",
+        "critical_path_ns": "7.1765",
+        "design": "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv",
+        "die_area": "6250000.0",
+        "flow_elapsed_seconds": "2089.11",
+        "instance_area_um2": "2785000.0",
+        "metrics_csv": "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv",
+        "param_hash": "939c71c3",
+        "params_json": "{\"CLOCK_PERIOD\": 8, \"CORE_AREA\": \"50 50 2450 2450\", \"DIE_AREA\": \"0 0 2500 2500\", \"FLOW_VARIANT\": \"decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500\", \"PLACE_DENSITY\": 0.4, \"SYNTH_HIERARCHICAL\": 1, \"SYNTH_MEMORY_MAX_BITS\": 65536, \"TAG\": \"decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500\", \"tag_prefix\": \"decode_score_multivalue_cluster_v1_8ns_bridge\"}",
+        "platform": "nangate45",
+        "status": "ok",
+        "stdcell_area_um2": "238187.0",
+        "stdcell_count": "180833.0",
+        "tag": "decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500",
+        "total_power_mw": "0.348",
+        "utilization_pct": "48.35069444444444"
+      },
+      "status": "rejected_gate"
+    }
+  ],
+  "decision": "activity_power_rejected_no_gated_candidate",
+  "equivalence": {
+    "decision": "decode_score_multivalue_cluster_equivalence_pass",
+    "equivalence_pass": true,
+    "final_tensor_hash": "fbbbe51bfe1d4ebf5f9910fdfdbf7e5eb322fe7633c9d523ac5a3587545cd457",
+    "score_tensor_hash": "dcdf04e9e1981a3447a532037c35bc10afc81c339014d09fc9bc039578c34387"
+  },
+  "model": "decoder_attention_decode_score_multivalue_cluster_activity_power_v1",
+  "precision_status": "unchanged_integer_contract_from_merged_multivalue_equivalence",
+  "promoted_candidate_count": 0,
+  "promotion_gate_pass": false,
+  "remaining_abstractions": [
+    "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
+    "Value-memory, NoC, HBM/DRAM, command-distribution, and clock-tree composition outside the cluster are not included.",
+    "RTL VCD is mapped to the routed netlist; each candidate records and gates direct annotation coverage.",
+    "Score multiplier and shift derivation remain external to the cluster boundary."
+  ],
+  "source_dependencies": [
+    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+    "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+  ],
+  "version": 1
+}

--- a/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.md
+++ b/runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.md
@@ -1,0 +1,16 @@
+# Shared-score multivalue cluster activity power
+
+- decision: `activity_power_rejected_no_gated_candidate`
+- promoted candidates: `0`
+- measured candidates: `1`
+
+| variant | path ns | instance mm2 | status | head cycles | head latency ms | energy mJ |
+|---|---:|---:|---|---:|---:|---:|
+| decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500 | 7.1765 | 2.785000 | rejected_gate | 3399201 | 27.193608 | None |
+
+## Remaining Abstractions
+
+- FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.
+- Value-memory, NoC, HBM/DRAM, command-distribution, and clock-tree composition outside the cluster are not included.
+- RTL VCD is mapped to the routed netlist; each candidate records and gates direct annotation coverage.
+- Score multiplier and shift derivation remain external to the cluster boundary.


### PR DESCRIPTION
## Summary
- item_id: `l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4`
- run_key: `l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4_run_cf7b2b313a94c62b`
- layer: `layer2`
- task_type: `l2_campaign`
- status: `ok`
- summary: `2/2 commands succeeded`
- queue_snapshot: `control_plane/shadow_exports/review/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4/evaluated.json`
- metrics_rows_count: `0`
- review_artifact: `decision_proposal` at `control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json`

## Developer Context
- proposal_id: `prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1`
- proposal_path: `docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1`
- reviewer_first_read: `docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1` plus `docs/developer_agent_review.md`
- execution_source_commit: `78131c3dc05171c600c8198eaec53ce06d8fda11`
- review_metadata_source_commit: `78131c3dc05171c600c8198eaec53ce06d8fda11`

## Evaluation Mode
- evaluation_mode: `frontier_detail`
- abstraction_layer: `decoder_attention_decode_score_multivalue_cluster_activity_power`
- comparison_role: `shared_score_multivalue_cluster_activity_power_gate`
- expected_direction: `record_shared_score_multivalue_cluster_activity_power_gate`
- expected_reason: `Promotion requires direct VCD roots, post-propagation coverage, transferred macro active coverage, exact clock, and finite positive power.`
- expectation_status: `unspecified`
- evaluation_summary: `Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.`

## Focused Comparison
- primary_question: `Does the shared-score multivalue cluster remain physically interesting once evaluator-local activity evidence replaces the current vectorless-power placeholder?`
- comparison_role: `shared_score_multivalue_cluster_activity_power_gate`
- proposal_outcome: `activity_power_rejected_no_gated_candidate`
- comparison_summary: `Decoder multivalue-cluster activity-power evidence recorded from runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v4.json: decision=activity_power_rejected_no_gated_candidate; promotion_gate_pass=False; candidate_count=1; promoted_candidate_count=0; best_candidate_id=None; representative_candidate_id=multivalue_cluster_activity_decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_flow_variant=decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500; representative_status=rejected_gate; representative_activity_status=rejected_annotation_gate; representative_activity_promotion_gate_pass=False; representative_full_context_latency_s=0.027193608; representative_full_context_cycles=3399201; representative_ppa_critical_path_ns=7.1765; representative_ppa_instance_area_um2=2785000.0; representative_ppa_total_power_mw=0.348.`
- baseline_ref: `None`
- baseline_item_id: `None`

## Checklist
- [ ] Commit lightweight campaign artifacts only
- [ ] Include metrics row references in result.metrics_rows
- [ ] Keep committed result_path fields repo-portable
- [ ] Run python3 scripts/validate_runs.py --skip_eval_queue before pushing
