### PR TITLE
Correct OpenSTA activity diagnostic queries

### DIFF
--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -188,6 +188,12 @@ set totals [sta::design_power [sta::corners]]
 set design_power_category_names {total sequential combinational clock macro pad}
 set design_power_category_count [expr {[llength $totals] / 4}]
 set design_power_totals [lrange $totals 0 3]
+set all_design_pins {}
+set macro_pin_transfer_query_error_count 0
+if {[catch {set all_design_pins [get_pins -hierarchical *]}]} {
+  incr macro_pin_transfer_query_error_count
+  set all_design_pins {}
+}
 
 set macro_pin_transfer_candidate_count 0
 set macro_pin_transfer_applied_count 0
@@ -195,20 +201,15 @@ set macro_pin_transfer_source_vcd_count 0
 set macro_pin_transfer_source_propagated_count 0
 set macro_pin_transfer_active_count 0
 set macro_pin_transfer_zero_count 0
-set macro_pin_transfer_query_error_count 0
 set macro_pin_transfer_apply_error_count 0
 set macro_pin_transfer_records {}
 set macro_pin_transfer_updates {}
-if {[catch {get_pins -hierarchical "*u_group_*"} macro_input_pins]} {
-  incr macro_pin_transfer_query_error_count
-  set macro_input_pins {}
-}
 set macro_pin_transfer_candidate_source_by_full_name {}
 set macro_pin_transfer_candidate_toggle_by_full_name {}
 set macro_pin_transfer_source_by_full_name {}
 set macro_pin_transfer_toggle_by_full_name {}
 set macro_pin_transfer_apply_results {}
-foreach macro_pin $macro_input_pins {
+foreach macro_pin $all_design_pins {
   if {[catch {set is_hierarchical [get_property $macro_pin is_hierarchical]}]} {
     incr macro_pin_transfer_query_error_count
     continue
@@ -216,15 +217,18 @@ foreach macro_pin $macro_input_pins {
   if {$is_hierarchical} {
     continue
   }
+  if {[catch {set macro_pin_full_name [get_property $macro_pin full_name]}]} {
+    incr macro_pin_transfer_query_error_count
+    continue
+  }
+  if {![string match "*u_group_*" $macro_pin_full_name]} {
+    continue
+  }
   if {[catch {set direction [get_property $macro_pin direction]}]} {
     incr macro_pin_transfer_query_error_count
     continue
   }
   if {$direction ne "input"} {
-    continue
-  }
-  if {[catch {set macro_pin_full_name [get_property $macro_pin full_name]}]} {
-    incr macro_pin_transfer_query_error_count
     continue
   }
   if {[catch {set macro_nets [get_nets -of_objects $macro_pin]}]} {
@@ -403,7 +407,7 @@ set non_finite_leaf_instance_power_switching_sum 0.0
 set non_finite_leaf_instance_power_leakage_sum 0.0
 set non_finite_leaf_instance_power_total_sum 0.0
 set non_finite_leaf_instance_samples {}
-foreach pin [get_pins -hierarchical *] {
+foreach pin $all_design_pins {
   if {[get_property $pin is_hierarchical]} {
     continue
   }
@@ -505,9 +509,9 @@ if {$has_nonfinite_design_total} {
       continue
     }
     if {$corner ne ""} {
-      set instance_power_error [catch {sta::instance_power $leaf $corner} instance_power]
+      set instance_power_error [catch {instance_power $leaf $corner} instance_power]
     } else {
-      set instance_power_error [catch {sta::instance_power $leaf} instance_power]
+      set instance_power_error [catch {instance_power $leaf} instance_power]
     }
     if {$instance_power_error} {
       incr non_finite_leaf_instance_power_query_error_count

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -27,7 +27,16 @@ class PostrouteVcdPowerTests(unittest.TestCase):
         self, root: Path, result: Path, *, macro_transfer: bool = False
     ) -> str:
         if macro_transfer:
-            get_pins_body = "  return {pin_input_u_group_0 pin_nonfinite_u_group}\n"
+            all_pins = "{pin_other_0 pin_input_u_group_0 pin_nonfinite_u_group}"
+            get_pins_body = (
+                "  if {[lindex $args 0] eq \"-hierarchical\"} {\n"
+                "    set pattern [lindex $args end]\n"
+                "    if {$pattern eq \"*u_group_*\"} {\n"
+                "      return {}\n"
+                "    }\n"
+                "  }\n"
+                f"  return {all_pins}\n"
+            )
             pin_property_body = (
                 "  if {$obj eq {pin_input_u_group_0}} {\n"
                 "    if {$property eq \"is_hierarchical\"} { return 0 }\n"
@@ -107,6 +116,12 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             + "proc get_cells {args} {\n"
             "  return {leaf_group[7]/instance_a leaf_group_b/leaf_b}\n"
             "}\n"
+            "proc instance_power {leaf args} {\n"
+            "  if {$leaf eq {leaf_group[7]/instance_a}} {\n"
+            "    return {0.0 nan inf nan}\n"
+            "  }\n"
+            "  return {1.0 2.0 3.0 4.0}\n"
+            "}\n"
             "namespace eval sta {\n"
             "  proc corners {} {\n"
             "    return {corner0}\n"
@@ -114,12 +129,6 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             "  proc design_power {args} {\n"
             "    # First quartet has non-finite total, triggering sample capture.\n"
             "    return {1.0 2.0 3.0 nan 4.0 5.0 6.0 7.0}\n"
-            "  }\n"
-            "  proc instance_power {leaf args} {\n"
-            "    if {$leaf eq {leaf_group[7]/instance_a}} {\n"
-            "      return {0.0 nan inf nan}\n"
-            "    }\n"
-            "    return {1.0 2.0 3.0 4.0}\n"
             "  }\n"
             + net_driver_body
             + "}\n"
@@ -172,9 +181,14 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(diagnostics.get("non_leaf_skip_count"), 0)
             self.assertEqual(diagnostics["candidate_cell_count"], 2)
             self.assertEqual(diagnostics["checked_instance_power_count"], 2)
+            self.assertGreater(diagnostics["checked_instance_power_count"], 0)
             self.assertEqual(diagnostics["finite_row_count"], 1)
             self.assertEqual(diagnostics["bad_shape_row_count"], 0)
             self.assertEqual(diagnostics["query_error_count"], 0)
+            self.assertLess(
+                diagnostics["query_error_count"],
+                diagnostics["candidate_cell_count"],
+            )
             self.assertEqual(
                 diagnostics["checked_instance_power_count"],
                 diagnostics["finite_row_count"] + diagnostics["instance_count"],
@@ -250,7 +264,10 @@ class PostrouteVcdPowerTests(unittest.TestCase):
         self.assertIn("macro_trace_backed_zero_toggle_count", script)
         self.assertIn("leaf_activity_origin_counts", script)
         self.assertIn("macro_activity_origin_counts", script)
-        self.assertIn("sta::instance_power $leaf $corner", script)
+        self.assertIn("set all_design_pins {}", script)
+        self.assertIn("foreach pin $all_design_pins", script)
+        self.assertIn("if {![string match \"*u_group_*\" $macro_pin_full_name]}", script)
+        self.assertIn("instance_power $leaf $corner", script)
         self.assertIn("non_finite_leaf_instance_power", script)
         self.assertIn(
             "if {$origin_bucket == \"vcd\" || $origin_bucket == \"propagated\"}",


### PR DESCRIPTION
## Summary
- discover FakeRAM candidates by filtering one complete hierarchical pin collection
- reuse that collection for final origin accounting
- call OpenSTA global `instance_power` so finalize diagnostics inspect real leaf power

## Verification
- related post-route, cluster, and GQA activity suites: 38 passed
- cluster/GQA activity selection: 22 passed