### PR TITLE
Propose corrected cluster activity power v6 evidence

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "Queue this rerun after PR #1386 / commit 18cb2dcb7cc4bf26046711a57c7113df840ad1ac, which filters complete hierarchical pin collections by full_name and calls global OpenSTA instance_power.",
+  "source_commit_note": "Queue this rerun after PR #1389 / commit 718326d3301024e28a752d432648b5a94b7f04f6, which uses one-corner sta::cmd_corner with sta::design_power/sta::instance_power, sta::set_power_pin_activity, and bounded transfer-stage diagnostics while preserving existing gates and no-gate-relaxation constraints.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -160,7 +160,32 @@
       "merged_utc": "2026-07-19T12:23:51.832192Z",
       "notes": "Merged via PR #1388 and merge aee7d64c119ed6fe5af322ce4687ef279072ccc5 at 2026-07-19T12:23:51.832192Z.",
       "revision_of_decision": "iterate"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power after PR #1389 / commit 718326d3301024e28a752d432648b5a94b7f04f6; v5 had zero transfer candidates and all per-instance queries failed because global instance_power plus a corner collection were wrong. v6 uses sta::cmd_corner, sta::design_power/sta::instance_power with one Corner, sta::set_power_pin_activity, and bounded transfer-stage diagnostics with no heuristic activity or gate relaxation.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "postroute_corner_object_and_macro_transfer_stage_unresolved",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "Rerun after PR #1389, using one-corner sta::cmd_corner, sta::design_power/sta::instance_power, and sta::set_power_pin_activity while preserving existing gates, no gate relaxation, and no heuristic activity."
+      },
+      "status": "ready_to_queue"
     }
   ],
-  "source_commit": "ec5cc3d3237d16b41d739baa98cde42e36506786"
+  "source_commit": "718326d3301024e28a752d432648b5a94b7f04f6"
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -167,6 +167,31 @@
         "reason": "Rerun after PR #1386, using full-name hierarchical pin filtering and global OpenSTA instance_power, while keeping existing activity gates and no gate relaxation."
       },
       "status": "ready_to_queue"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power after merged PR #1389 / commit 718326d3301024e28a752d432648b5a94b7f04f6; v5 had zero transfer candidates and all per-instance queries failed because global instance_power plus a corner collection were wrong. v6 uses sta::cmd_corner, sta::design_power/sta::instance_power with one Corner, sta::set_power_pin_activity, and bounded transfer-stage diagnostics with no gate relaxation and no heuristic activity.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "postroute_corner_object_and_macro_transfer_stage_unresolved",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "Rerun after PR #1389, using one-corner sta::cmd_corner, sta::design_power/sta::instance_power, and sta::set_power_pin_activity while keeping existing gates, no gate relaxation, and no heuristic activity."
+      },
+      "status": "ready_to_queue"
     }
   ],
   "baseline_refs": [

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
-  "source_commit_note": "Queue this evidence-only remote frontier recost only after the corrected local-cluster frontier v2 and the shared-score multivalue activity-power v5 rerun (PR #1386, commit 18cb2dcb7cc4bf26046711a57c7113df840ad1ac) are both merged.",
+  "source_commit_note": "Queue this evidence-only remote frontier recost only after the corrected local-cluster frontier v2 and the shared-score multivalue activity-power v6 rerun (PR #1389, commit 718326d3301024e28a752d432648b5a94b7f04f6) are both merged.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
@@ -12,7 +12,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
@@ -57,7 +57,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1",
-  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged; folded-lane activity tasks should consume the shared-score activity-power v5 rerun from PR #1386 (commit 18cb2dcb7cc4bf26046711a57c7113df840ad1ac).",
+  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged; folded-lane activity tasks should consume the shared-score activity-power v6 rerun from PR #1389 (commit 718326d3301024e28a752d432648b5a94b7f04f6).",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
@@ -200,7 +200,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -220,7 +220,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -240,7 +240,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -222,7 +222,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -242,7 +242,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -262,7 +262,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v5"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,


### PR DESCRIPTION
## Summary
- add the v6 cluster activity-power evidence item pinned to PR #1389
- invalidate v5 while preserving all existing promotion gates
- point pending cluster-frontier and folded-lane consumers at v6

## Validation
- proposal and finalizer suites: 239 passed