### PR TITLE
Trace macro activity through same-net peers

### DIFF
--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -211,6 +211,14 @@ set macro_pin_transfer_driver_origin_other_count 0
 set macro_pin_transfer_scan_sample_limit 16
 set macro_pin_transfer_scan_samples {}
 
+set macro_pin_transfer_peer_pin_count 0
+set macro_pin_transfer_peer_eligible_count 0
+set macro_pin_transfer_peer_origin_vcd_count 0
+set macro_pin_transfer_peer_origin_propagated_count 0
+set macro_pin_transfer_peer_origin_clock_count 0
+set macro_pin_transfer_peer_origin_constant_count 0
+set macro_pin_transfer_peer_origin_other_count 0
+
 set macro_pin_transfer_candidate_count 0
 set macro_pin_transfer_applied_count 0
 set macro_pin_transfer_source_vcd_count 0
@@ -221,9 +229,11 @@ set macro_pin_transfer_apply_error_count 0
 set macro_pin_transfer_records {}
 set macro_pin_transfer_updates {}
 set macro_pin_transfer_candidate_source_by_full_name {}
+set macro_pin_transfer_candidate_source_kind_by_full_name {}
 set macro_pin_transfer_candidate_toggle_by_full_name {}
 set macro_pin_transfer_source_by_full_name {}
 set macro_pin_transfer_toggle_by_full_name {}
+set macro_pin_transfer_source_kind_by_full_name {}
 set macro_pin_transfer_apply_results {}
 foreach macro_pin $all_design_pins {
   if {[catch {set is_hierarchical [get_property $macro_pin is_hierarchical]}]} {
@@ -267,6 +277,7 @@ foreach macro_pin $all_design_pins {
   set macro_pin_has_driver 0
   set selected_driver_origin_observed none
   set selected_driver_origin ""
+  set selected_driver_source_kind none
   set selected_driver_toggle 0.0
   set selected_driver_duty 0.0
   set macro_nets_sorted [rtlgen_sorted_list $macro_nets]
@@ -316,6 +327,7 @@ foreach macro_pin $all_design_pins {
           incr macro_pin_transfer_driver_origin_propagated_count
         }
         set selected_driver_origin $driver_origin_bucket
+        set selected_driver_source_kind driver
         set selected_driver_toggle $driver_toggle
         set selected_driver_duty $driver_duty
         break
@@ -331,6 +343,64 @@ foreach macro_pin $all_design_pins {
     if {$selected_driver_origin ne ""} {
       break
     }
+    if {[catch {set peer_pins [get_pins -of_objects $macro_net]}]} {
+      incr macro_pin_transfer_query_error_count
+      continue
+    }
+    set peer_pins_sorted [rtlgen_sorted_list $peer_pins]
+    foreach peer_pin $peer_pins_sorted {
+      if {$peer_pin eq $macro_pin} {
+        continue
+      }
+      incr macro_pin_transfer_peer_pin_count
+      if {[catch {set peer_activity [get_property $peer_pin activity]}]} {
+        incr macro_pin_transfer_query_error_count
+        continue
+      }
+      if {[llength $peer_activity] < 3} {
+        incr macro_pin_transfer_query_error_count
+        continue
+      }
+      set peer_toggle [lindex $peer_activity 0]
+      set peer_duty [lindex $peer_activity 1]
+      set peer_origin [lindex $peer_activity [expr {[llength $peer_activity] - 1}]]
+      set peer_origin_bucket [rtlgen_activity_origin_bucket $peer_origin]
+      if {$peer_origin_bucket == "vcd"} {
+        incr macro_pin_transfer_peer_origin_vcd_count
+      } elseif {$peer_origin_bucket == "propagated"} {
+        incr macro_pin_transfer_peer_origin_propagated_count
+      } elseif {$peer_origin_bucket == "clock"} {
+        incr macro_pin_transfer_peer_origin_clock_count
+      } elseif {$peer_origin_bucket == "constant"} {
+        incr macro_pin_transfer_peer_origin_constant_count
+      } else {
+        incr macro_pin_transfer_peer_origin_other_count
+      }
+      if {![rtlgen_is_finite_power_value $peer_toggle] ||
+          ![rtlgen_is_finite_power_value $peer_duty]} {
+        incr macro_pin_transfer_query_error_count
+        continue
+      }
+      if {$peer_toggle < 0.0} {
+        incr macro_pin_transfer_query_error_count
+        continue
+      }
+      if {$peer_duty < 0.0 || $peer_duty > 1.0} {
+        incr macro_pin_transfer_query_error_count
+        continue
+      }
+      if {$peer_origin_bucket == "vcd" || $peer_origin_bucket == "propagated"} {
+        incr macro_pin_transfer_peer_eligible_count
+        set selected_driver_origin $peer_origin_bucket
+        set selected_driver_source_kind net_peer
+        set selected_driver_toggle $peer_toggle
+        set selected_driver_duty $peer_duty
+        break
+      }
+    }
+    if {$selected_driver_origin ne ""} {
+      break
+    }
   }
   if {$macro_pin_has_driver} {
     incr macro_pin_transfer_driver_pin_count
@@ -340,12 +410,12 @@ foreach macro_pin $all_design_pins {
   if {[llength $macro_pin_transfer_scan_samples] < $macro_pin_transfer_scan_sample_limit} {
     if {$selected_driver_origin ne ""} {
       lappend macro_pin_transfer_scan_samples \
-        [list $macro_pin_full_name $selected_driver_origin]
+        [list $macro_pin_full_name $selected_driver_origin $selected_driver_source_kind]
     } elseif {$selected_driver_origin_observed ne "none"} {
       lappend macro_pin_transfer_scan_samples \
-        [list $macro_pin_full_name $selected_driver_origin_observed]
+        [list $macro_pin_full_name $selected_driver_origin_observed $selected_driver_source_kind]
     } else {
-      lappend macro_pin_transfer_scan_samples [list $macro_pin_full_name none]
+      lappend macro_pin_transfer_scan_samples [list $macro_pin_full_name none none]
     }
   }
   if {$selected_driver_origin ne ""} {
@@ -353,6 +423,7 @@ foreach macro_pin $all_design_pins {
     lappend macro_pin_transfer_updates \
       [list $macro_pin_full_name $macro_pin $selected_driver_toggle $selected_driver_duty]
     dict set macro_pin_transfer_candidate_source_by_full_name $macro_pin_full_name $selected_driver_origin
+    dict set macro_pin_transfer_candidate_source_kind_by_full_name $macro_pin_full_name $selected_driver_source_kind
     dict set macro_pin_transfer_candidate_toggle_by_full_name $macro_pin_full_name $selected_driver_toggle
   }
 }
@@ -370,8 +441,14 @@ if {[llength $macro_pin_transfer_updates] > 0} {
       incr macro_pin_transfer_applied_count
       lappend macro_pin_transfer_record_full_names $pin_full_name
       set pin_source [dict get $macro_pin_transfer_candidate_source_by_full_name $pin_full_name]
+      if {[dict exists $macro_pin_transfer_candidate_source_kind_by_full_name $pin_full_name]} {
+        set pin_source_kind [dict get $macro_pin_transfer_candidate_source_kind_by_full_name $pin_full_name]
+      } else {
+        set pin_source_kind none
+      }
       set pin_toggle [dict get $macro_pin_transfer_candidate_toggle_by_full_name $pin_full_name]
       dict set macro_pin_transfer_source_by_full_name $pin_full_name $pin_source
+      dict set macro_pin_transfer_source_kind_by_full_name $pin_full_name $pin_source_kind
       dict set macro_pin_transfer_toggle_by_full_name $pin_full_name $pin_toggle
       if {$pin_source == "vcd"} {
         incr macro_pin_transfer_source_vcd_count
@@ -398,6 +475,7 @@ if {[llength $macro_pin_transfer_updates] > 0} {
           [list \
             $macro_pin_transfer_full_name \
             [dict get $macro_pin_transfer_source_by_full_name $macro_pin_transfer_full_name] \
+            [dict get $macro_pin_transfer_source_kind_by_full_name $macro_pin_transfer_full_name] \
           ]
       }
     }
@@ -538,15 +616,9 @@ foreach pin $all_design_pins {
 
 if {$has_nonfinite_design_total} {
   set leaf_cells {}
-  if {[catch {set leaf_cells [get_cells -hierarchical -filter "is_leaf"]}]} {
+  if {[catch {set leaf_cells [sta::network_leaf_instances]}]} {
     incr non_finite_leaf_instance_power_query_error_count
     set leaf_cells {}
-  }
-  if {[llength $leaf_cells] == 0} {
-    if {[catch {set leaf_cells [get_cells -hierarchical *]}]} {
-      incr non_finite_leaf_instance_power_query_error_count
-      set leaf_cells {}
-    }
   }
   set leaf_cells_unsorted $leaf_cells
   if {[catch {set leaf_cells [lsort -dictionary $leaf_cells_unsorted]}]} {
@@ -557,14 +629,6 @@ if {$has_nonfinite_design_total} {
   }
   set non_finite_leaf_instance_power_candidate_cell_count [llength $leaf_cells]
   foreach leaf $leaf_cells {
-    if {[catch {set is_leaf [get_property $leaf is_leaf]}]} {
-      incr non_finite_leaf_instance_power_query_error_count
-      continue
-    }
-    if {!$is_leaf} {
-      incr non_finite_leaf_instance_power_non_leaf_skip_count
-      continue
-    }
     set instance_power_error [catch {sta::instance_power "$leaf" $power_corner} instance_power]
     if {$instance_power_error} {
       incr non_finite_leaf_instance_power_query_error_count
@@ -675,6 +739,15 @@ puts $fp "    \"query_error_count\": $macro_pin_transfer_query_error_count,"
 puts $fp "    \"apply_error_count\": $macro_pin_transfer_apply_error_count,"
 puts $fp "    \"source_vcd_count\": $macro_pin_transfer_source_vcd_count,"
 puts $fp "    \"source_propagated_count\": $macro_pin_transfer_source_propagated_count,"
+puts $fp "    \"peer_pin_examined_count\": $macro_pin_transfer_peer_pin_count,"
+puts $fp "    \"peer_eligible_count\": $macro_pin_transfer_peer_eligible_count,"
+puts $fp "    \"peer_origin_counts\": {"
+puts $fp "      \"vcd\": $macro_pin_transfer_peer_origin_vcd_count,"
+puts $fp "      \"propagated\": $macro_pin_transfer_peer_origin_propagated_count,"
+puts $fp "      \"clock\": $macro_pin_transfer_peer_origin_clock_count,"
+puts $fp "      \"constant\": $macro_pin_transfer_peer_origin_constant_count,"
+puts $fp "      \"other\": $macro_pin_transfer_peer_origin_other_count"
+puts $fp "    },"
 puts $fp "    \"active_count\": $macro_pin_transfer_active_count,"
 puts $fp "    \"zero_count\": $macro_pin_transfer_zero_count,"
 puts $fp "    \"scanned_pin_count\": $macro_pin_transfer_scanned_pin_count,"
@@ -697,8 +770,9 @@ set macro_pin_transfer_scan_sample_index 0
 foreach macro_pin_transfer_scan_sample $macro_pin_transfer_scan_samples {
   set macro_pin_transfer_scan_sample_full_name [lindex $macro_pin_transfer_scan_sample 0]
   set macro_pin_transfer_scan_sample_origin [lindex $macro_pin_transfer_scan_sample 1]
+  set macro_pin_transfer_scan_sample_source_kind [lindex $macro_pin_transfer_scan_sample 2]
   set escaped_full_name [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $macro_pin_transfer_scan_sample_full_name]]
-  set macro_pin_transfer_scan_sample_line "      {\"full_name\": \"$escaped_full_name\", \"driver_origin\": \"$macro_pin_transfer_scan_sample_origin\"}"
+  set macro_pin_transfer_scan_sample_line "      {\"full_name\": \"$escaped_full_name\", \"driver_origin\": \"$macro_pin_transfer_scan_sample_origin\", \"source_kind\": \"$macro_pin_transfer_scan_sample_source_kind\"}"
   incr macro_pin_transfer_scan_sample_index
   if {$macro_pin_transfer_scan_sample_index < $macro_pin_transfer_scan_sample_count} {
     puts $fp "$macro_pin_transfer_scan_sample_line,"
@@ -713,8 +787,9 @@ set macro_pin_transfer_record_index 0
 foreach macro_pin_transfer_record $macro_pin_transfer_records {
   set macro_pin_transfer_full_name [lindex $macro_pin_transfer_record 0]
   set macro_pin_transfer_source [lindex $macro_pin_transfer_record 1]
+  set macro_pin_transfer_record_source_kind [lindex $macro_pin_transfer_record 2]
   set escaped_full_name [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $macro_pin_transfer_full_name]]
-  set macro_pin_transfer_record_line "      {\"full_name\": \"$escaped_full_name\", \"source\": \"$macro_pin_transfer_source\"}"
+  set macro_pin_transfer_record_line "      {\"full_name\": \"$escaped_full_name\", \"source\": \"$macro_pin_transfer_source\", \"source_kind\": \"$macro_pin_transfer_record_source_kind\"}"
   incr macro_pin_transfer_record_index
   if {$macro_pin_transfer_record_index < $macro_pin_transfer_records_count} {
     puts $fp "$macro_pin_transfer_record_line,"

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -28,11 +28,18 @@ class PostrouteVcdPowerTests(unittest.TestCase):
     ) -> str:
         if macro_transfer:
             all_pins = "{pin_other_0 pin_input_u_group_0 pin_nonfinite_u_group}"
+            net_pins = "{driver_pin_u_group_0 peer_pin_u_group_0 pin_input_u_group_0}"
             get_pins_body = (
                 "  if {[lindex $args 0] eq \"-hierarchical\"} {\n"
                 "    set pattern [lindex $args end]\n"
                 "    if {$pattern eq \"*u_group_*\"} {\n"
                 "      return {}\n"
+                "    }\n"
+                "  }\n"
+                "  if {[lindex $args 0] eq \"-of_objects\"} {\n"
+                "    set net [lindex $args end]\n"
+                "    if {$net eq {net_u_group_0}} {\n"
+                f"      return {net_pins}\n"
                 "    }\n"
                 "  }\n"
                 f"  return {all_pins}\n"
@@ -45,7 +52,10 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "    if {$property eq \"full_name\"} { return $obj }\n"
                 "  }\n"
                 "  if {$obj eq {driver_pin_u_group_0}} {\n"
-                "    if {$property eq \"activity\"} { return {0.4 0.9 vcd} }\n"
+                "    if {$property eq \"activity\"} { return {0.4 0.9 other} }\n"
+                "  }\n"
+                "  if {$obj eq {peer_pin_u_group_0}} {\n"
+                "    if {$property eq \"activity\"} { return {0.9 0.8 propagated} }\n"
                 "  }\n"
             )
             net_driver_body = (
@@ -110,7 +120,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             "}\n"
             + net_and_activity_body
             + "proc get_cells {args} {\n"
-            "  return {leaf_group[7]/instance_a leaf_group_b/leaf_b}\n"
+            "  error \"get_cells should not be used for nonfinite leaf scan\"\n"
             "}\n"
             "proc instance_power {args} {\n"
             "  error \"use sta::instance_power <leaf> <corner>\"\n"
@@ -149,6 +159,9 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             "  }\n"
             "  proc corners {} {\n"
             "    return {corner0}\n"
+            "  }\n"
+            "  proc network_leaf_instances {} {\n"
+            "    return {leaf_group[7]/instance_a leaf_group_b/leaf_b}\n"
             "  }\n"
             "  variable power_pin_activity_calls {}\n"
             + net_driver_body
@@ -257,8 +270,8 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(transfer["applied_count"], 1)
             self.assertEqual(transfer["query_error_count"], 0)
             self.assertEqual(transfer["apply_error_count"], 0)
-            self.assertEqual(transfer["source_vcd_count"], 1)
-            self.assertEqual(transfer["source_propagated_count"], 0)
+            self.assertEqual(transfer["source_vcd_count"], 0)
+            self.assertEqual(transfer["source_propagated_count"], 1)
             self.assertEqual(transfer["active_count"], 1)
             self.assertEqual(transfer["zero_count"], 0)
             self.assertEqual(transfer["scanned_pin_count"], 3)
@@ -268,22 +281,31 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(transfer["no_net_pin_count"], 0)
             self.assertEqual(transfer["driver_pin_count"], 1)
             self.assertEqual(transfer["no_driver_pin_count"], 0)
-            self.assertEqual(transfer["driver_origin_counts"]["vcd"], 1)
+            self.assertEqual(transfer["driver_origin_counts"]["vcd"], 0)
             self.assertEqual(transfer["driver_origin_counts"]["propagated"], 0)
             self.assertEqual(transfer["driver_origin_counts"]["clock"], 0)
             self.assertEqual(transfer["driver_origin_counts"]["constant"], 0)
-            self.assertEqual(transfer["driver_origin_counts"]["other"], 0)
+            self.assertEqual(transfer["driver_origin_counts"]["other"], 1)
+            self.assertEqual(transfer["peer_origin_counts"]["vcd"], 0)
+            self.assertEqual(transfer["peer_origin_counts"]["propagated"], 1)
+            self.assertEqual(transfer["peer_origin_counts"]["clock"], 0)
+            self.assertEqual(transfer["peer_origin_counts"]["constant"], 0)
+            self.assertEqual(transfer["peer_origin_counts"]["other"], 1)
+            self.assertEqual(transfer["peer_pin_examined_count"], 2)
+            self.assertEqual(transfer["peer_eligible_count"], 1)
             self.assertEqual(len(transfer["transferred"]), 1)
             self.assertEqual(
                 transfer["transferred"][0]["full_name"], "pin_input_u_group_0"
             )
-            self.assertEqual(transfer["transferred"][0]["source"], "vcd")
+            self.assertEqual(transfer["transferred"][0]["source"], "propagated")
+            self.assertEqual(transfer["transferred"][0]["source_kind"], "net_peer")
             self.assertEqual(len(transfer["scan_samples"]), 1)
             self.assertEqual(
                 transfer["scan_samples"][0]["full_name"],
                 "pin_input_u_group_0",
             )
-            self.assertEqual(transfer["scan_samples"][0]["driver_origin"], "vcd")
+            self.assertEqual(transfer["scan_samples"][0]["driver_origin"], "propagated")
+            self.assertEqual(transfer["scan_samples"][0]["source_kind"], "net_peer")
             self.assertEqual(payload["macro_activity_origin_counts"]["transferred"], 1)
             self.assertEqual(payload["macro_trace_backed_pin_count"], 1)
             self.assertEqual(payload["macro_trace_active_pin_count"], 1)
@@ -313,6 +335,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
         self.assertIn("if {![string match \"*u_group_*\" $macro_pin_full_name]}", script)
         self.assertIn("sta::instance_power \"$leaf\" $power_corner", script)
         self.assertIn("non_finite_leaf_instance_power", script)
+        self.assertIn("sta::network_leaf_instances", script)
         self.assertIn("scan_samples", script)
         self.assertIn(
             "if {$origin_bucket == \"vcd\" || $origin_bucket == \"propagated\"}",
@@ -323,26 +346,25 @@ class PostrouteVcdPowerTests(unittest.TestCase):
         script = MODULE._tcl_script()
         init_idx = script.find("set leaf_cells {}")
         primary_catch_idx = script.find(
-            'if {[catch {set leaf_cells [get_cells -hierarchical -filter "is_leaf"]}]}'
-        )
-        empty_check_idx = script.find("if {[llength $leaf_cells] == 0}")
-        fallback_catch_idx = script.find(
-            'if {[catch {set leaf_cells [get_cells -hierarchical *]}]}'
+            'if {[catch {set leaf_cells [sta::network_leaf_instances]}]}'
         )
         self.assertGreater(init_idx, -1)
         self.assertGreater(primary_catch_idx, -1)
-        self.assertGreater(empty_check_idx, primary_catch_idx)
-        self.assertGreater(fallback_catch_idx, empty_check_idx)
         self.assertLess(init_idx, primary_catch_idx)
         self.assertNotIn(
             "if {[catch {set leaf_cells [get_cells -hierarchical -filter \"is_leaf\"]}] ||",
             script,
         )
+        self.assertNotIn("get_cells -hierarchical -filter \"is_leaf\"", script)
+        self.assertNotIn("get_cells -hierarchical *", script)
 
     def test_tcl_nonfinite_leaf_instance_fallback_keeps_diagnostics_nonfatal(self) -> None:
         script = MODULE._tcl_script()
         self.assertIn('set leaf_cells {}', script)
-        self.assertIn('if {[catch {set leaf_cells [get_cells -hierarchical *]}]} {', script)
+        self.assertIn(
+            'if {[catch {set leaf_cells [sta::network_leaf_instances]}]} {',
+            script,
+        )
         self.assertIn("set leaf_cells {}", script, msg="Fallback catch should recover to empty diagnostics")
         self.assertIn(
             "set leaf_cells_unsorted $leaf_cells",
@@ -365,6 +387,8 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             script,
             "Ungarded fallback sort would still be fatal",
         )
+        self.assertNotIn("get_cells -hierarchical -filter \"is_leaf\"", script)
+        self.assertNotIn("get_cells -hierarchical *", script)
 
     def test_activity_annotation_provenance_is_preserved(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:


### PR DESCRIPTION
## Summary
- scan real STA network leaf instances for non-finite per-instance power
- fall back from unannotated net drivers to trace-backed pins on the identical macro-input net
- record bounded peer-origin and source-kind diagnostics
- preserve existing promotion gates and prohibit heuristic activity

## Validation
- focused postroute, cluster, and GQA activity suites: 38 passed