### PR TITLE
Propose cluster activity power v7 evidence

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "Queue this rerun after PR #1389 / commit 718326d3301024e28a752d432648b5a94b7f04f6, which uses one-corner sta::cmd_corner with sta::design_power/sta::instance_power, sta::set_power_pin_activity, and bounded transfer-stage diagnostics while preserving existing gates and no-gate-relaxation constraints.",
+  "source_commit_note": "Queue this rerun after PR #1392 / commit 59c1038ece3e89aa875d16880426b1449f72f21f, which uses same-net trace-backed peer fallback and sta::network_leaf_instances while preserving one-Corner sta::set_power_pin_activity and no gate relaxation.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -194,7 +194,32 @@
       "merged_utc": "2026-07-19T12:49:20.184301Z",
       "notes": "Merged via PR #1391 and merge 98179c8e3802dc432bb5181163415c096bd50ceb at 2026-07-19T12:49:20.184301Z.",
       "revision_of_decision": "iterate"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power after PR #1392 / commit 59c1038ece3e89aa875d16880426b1449f72f21f; v6 had 5,152 connected macro inputs with driver origins 4,824 other / 272 constant / 56 clock / 0 vcd or propagated, and 724,570 per-instance scan candidates with 0 checked and 724,571 query errors. v7 uses sta::network_leaf_instances for instance_power and trace-backed same-net peer fallback when the designated driver has no usable activity. It retains one Corner, sta::set_power_pin_activity, no heuristic activity, and no gate relaxation.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "postroute_sta_leaf_handle_and_same_net_peer_activity_unresolved",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "Rerun after PR #1392 using sta::network_leaf_instances-backed instance_power and same-net trace-backed peer fallback while keeping one-Corner flow, sta::set_power_pin_activity, no heuristic activity, and no gate relaxation."
+      },
+      "status": "ready_to_queue"
     }
   ],
-  "source_commit": "e30cf47277ecd1567bd2a4fc27b3da52a339e186"
+  "source_commit": "59c1038ece3e89aa875d16880426b1449f72f21f"
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -171,7 +171,7 @@
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6",
       "task_type": "l2_campaign",
-      "objective": "Rerun shared-score multivalue-cluster activity-backed power after merged PR #1389 / commit 718326d3301024e28a752d432648b5a94b7f04f6; v5 had zero transfer candidates and all per-instance queries failed because global instance_power plus a corner collection were wrong. v6 uses sta::cmd_corner, sta::design_power/sta::instance_power with one Corner, sta::set_power_pin_activity, and bounded transfer-stage diagnostics with no gate relaxation and no heuristic activity.",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power after PR #1389 / commit 718326d3301024e28a752d432648b5a94b7f04f6; v5 had zero transfer candidates and all per-instance queries failed because global instance_power plus a corner collection was wrong. v6 uses sta::cmd_corner, sta::design_power/sta::instance_power with one Corner, sta::set_power_pin_activity, and bounded transfer-stage diagnostics with no gate relaxation and no heuristic activity.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
@@ -190,6 +190,31 @@
       "expected_result": {
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
         "reason": "Rerun after PR #1389, using one-corner sta::cmd_corner, sta::design_power/sta::instance_power, and sta::set_power_pin_activity while keeping existing gates, no gate relaxation, and no heuristic activity."
+      },
+      "status": "ready_to_queue"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power after PR #1392 / commit 59c1038ece3e89aa875d16880426b1449f72f21f. v6 had 5,152 connected macro inputs with driver origins 4,824 other / 272 constant / 56 clock / 0 vcd or propagated, and 724,570 per-instance scan candidates with 0 checked and 724,571 query errors. v7 uses sta::network_leaf_instances for instance_power and trace-backed same-net peer fallback when the designated driver has no usable activity. It retains one Corner, sta::set_power_pin_activity, and avoids heuristic activity and gate relaxation.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "postroute_sta_leaf_handle_and_same_net_peer_activity_unresolved",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "Rerun after PR #1392 using sta::network_leaf_instances-backed instance_power and trace-backed same-net peer fallback while keeping one-Corner flow, sta::set_power_pin_activity, no heuristic activity, and no gate relaxation."
       },
       "status": "ready_to_queue"
     }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
-  "source_commit_note": "Queue this evidence-only remote frontier recost only after the corrected local-cluster frontier v2 and the shared-score multivalue activity-power v6 rerun (PR #1389, commit 718326d3301024e28a752d432648b5a94b7f04f6) are both merged.",
+  "source_commit_note": "Queue this evidence-only remote frontier recost only after the corrected local-cluster frontier v2 and the shared-score multivalue activity-power v7 rerun (PR #1392, commit 59c1038ece3e89aa875d16880426b1449f72f21f) are both merged.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
@@ -12,7 +12,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
@@ -57,7 +57,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1",
-  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged; folded-lane activity tasks should consume the shared-score activity-power v6 rerun from PR #1389 (commit 718326d3301024e28a752d432648b5a94b7f04f6).",
+  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged; folded-lane activity tasks should consume the shared-score activity-power v7 rerun from PR #1392 (commit 59c1038ece3e89aa875d16880426b1449f72f21f).",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
@@ -200,7 +200,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -220,7 +220,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -240,7 +240,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -222,7 +222,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -242,7 +242,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -262,7 +262,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v6"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v7"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,


### PR DESCRIPTION
## Summary
- add v7 evidence for STA leaf handles and same-net trace-backed activity
- invalidate merged negative v6 evidence
- keep promotion gates unchanged and repoint only pending consumers

## Validation
- proposal and finalizer suites: 239 passed