### PR TITLE
Expose macro input activity in simulation VCD

### DIFF
--- a/npu/eval/probe_attention_decode_score_multivalue_cluster_equivalence.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_cluster_equivalence.py
@@ -20,6 +20,11 @@ from npu.sim.perf.attention_separated import unpack_signed
 JsonDict = dict[str, Any]
 
 
+def _scalar_aliases(*, vector: str, width: int) -> str:
+    """Return escaped scalar aliases for every bit of a vector port."""
+    return "\n".join(f"  wire \\{vector}[{index}] = {vector}[{index}];" for index in range(width))
+
+
 def _tool(name: str) -> str:
     path = shutil.which(name)
     if path:
@@ -93,7 +98,7 @@ def _raw_scores(block: list[tuple[int, list[int]]]) -> list[int]:
     return [sum(query * keys[lane] for query, keys in block) for lane in range(8)]
 
 
-_FAKERAM_MODEL = r"""
+_FAKERAM_MODEL = f"""
 module fakeram45_2048x39 (
     output wire [38:0] rd_out, input wire [10:0] addr_in,
     input wire we_in, input wire [38:0] wd_in, input wire [38:0] w_mask_in,
@@ -113,6 +118,10 @@ module fakeram45_2048x39 (
     end
   end
   assign rd_out = rd_out_q;
+
+{_scalar_aliases(vector="addr_in", width=11)}
+{_scalar_aliases(vector="wd_in", width=39)}
+{_scalar_aliases(vector="w_mask_in", width=39)}
 endmodule
 """
 

--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -164,6 +164,18 @@ proc rtlgen_sorted_list {values} {
   return $sorted
 }
 
+proc rtlgen_compare_ref_name_bucket {left right} {
+  lassign $left left_count left_name
+  lassign $right right_count right_name
+  if {$left_count > $right_count} {
+    return -1
+  }
+  if {$left_count < $right_count} {
+    return 1
+  }
+  return [string compare $left_name $right_name]
+}
+
 proc rtlgen_apply_macro_pin_activities {assignments} {
   set results {}
   if {[llength $assignments] == 0} {
@@ -542,12 +554,16 @@ set non_finite_leaf_instance_power_checked_count 0
 set non_finite_leaf_instance_power_query_error_count 0
 set non_finite_leaf_instance_power_non_leaf_skip_count 0
 set non_finite_leaf_instance_power_bad_shape_row_count 0
+set non_finite_leaf_instance_power_ref_name_query_error_count 0
+set non_finite_leaf_instance_power_ref_name_counts {}
 set non_finite_leaf_instance_power_finite_row_count 0
 set non_finite_leaf_instance_power_internal_sum 0.0
 set non_finite_leaf_instance_power_switching_sum 0.0
 set non_finite_leaf_instance_power_leakage_sum 0.0
 set non_finite_leaf_instance_power_total_sum 0.0
 set non_finite_leaf_instance_samples {}
+set non_finite_leaf_instance_power_sample_limit 16
+set non_finite_leaf_instance_power_ref_name_bucket_limit 32
 foreach pin $all_design_pins {
   if {[get_property $pin is_hierarchical]} {
     continue
@@ -648,9 +664,17 @@ if {$has_nonfinite_design_total} {
         ![rtlgen_is_finite_power_value $leakage_power_value] ||
         ![rtlgen_is_finite_power_value $total_power_value]} {
       incr non_finite_leaf_instance_power_count
-      if {[llength $non_finite_leaf_instance_samples] < 16} {
-        if {[catch {set leaf_name [get_full_name $leaf]}]} {
-          if {[catch {set leaf_name [get_property $leaf name]}]} {
+      if {[catch {set leaf_ref_name [get_property $leaf ref_name]}]} {
+        incr non_finite_leaf_instance_power_ref_name_query_error_count
+        set leaf_ref_name unknown
+      }
+      if {$leaf_ref_name eq ""} {
+        set leaf_ref_name unknown
+      }
+      dict incr non_finite_leaf_instance_power_ref_name_counts $leaf_ref_name
+      if {[llength $non_finite_leaf_instance_samples] < $non_finite_leaf_instance_power_sample_limit} {
+        if {[catch {set leaf_name [lindex [get_full_name $leaf] 0]}]} {
+          if {[catch {set leaf_name [lindex [get_property $leaf name] 0]}]} {
             set leaf_name $leaf
           }
         }
@@ -661,6 +685,7 @@ if {$has_nonfinite_design_total} {
             $switching_power_value \
             $leakage_power_value \
             $total_power_value \
+            $leaf_ref_name \
           ]
       }
     } else {
@@ -674,6 +699,37 @@ if {$has_nonfinite_design_total} {
       set non_finite_leaf_instance_power_total_sum \
         [expr {$non_finite_leaf_instance_power_total_sum + $total_power_value}]
     }
+  }
+}
+
+set non_finite_leaf_instance_power_ref_name_buckets {}
+set non_finite_leaf_instance_power_ref_name_bucket_other_count 0
+if {[dict size $non_finite_leaf_instance_power_ref_name_counts] > 0} {
+  set non_finite_leaf_instance_power_ref_name_bucket_pairs {}
+  dict for {leaf_ref_name leaf_ref_name_count} $non_finite_leaf_instance_power_ref_name_counts {
+    lappend non_finite_leaf_instance_power_ref_name_bucket_pairs [list $leaf_ref_name_count $leaf_ref_name]
+  }
+  set non_finite_leaf_instance_power_ref_name_bucket_pairs \
+    [lsort -command rtlgen_compare_ref_name_bucket $non_finite_leaf_instance_power_ref_name_bucket_pairs]
+  set non_finite_leaf_instance_power_ref_name_bucket_total [llength $non_finite_leaf_instance_power_ref_name_bucket_pairs]
+  set non_finite_leaf_instance_power_ref_name_bucket_display_limit $non_finite_leaf_instance_power_ref_name_bucket_limit
+  if {$non_finite_leaf_instance_power_ref_name_bucket_total > $non_finite_leaf_instance_power_ref_name_bucket_limit} {
+    set non_finite_leaf_instance_power_ref_name_bucket_display_limit \
+      [expr {$non_finite_leaf_instance_power_ref_name_bucket_limit - 1}]
+  }
+  set non_finite_leaf_instance_power_ref_name_bucket_index 0
+  foreach ref_name_bucket_pair $non_finite_leaf_instance_power_ref_name_bucket_pairs {
+    if {$non_finite_leaf_instance_power_ref_name_bucket_index < $non_finite_leaf_instance_power_ref_name_bucket_display_limit} {
+      lappend non_finite_leaf_instance_power_ref_name_buckets $ref_name_bucket_pair
+    } else {
+      lassign $ref_name_bucket_pair leaf_ref_name_count leaf_ref_name
+      incr non_finite_leaf_instance_power_ref_name_bucket_other_count $leaf_ref_name_count
+    }
+    incr non_finite_leaf_instance_power_ref_name_bucket_index
+  }
+  if {$non_finite_leaf_instance_power_ref_name_bucket_other_count > 0} {
+    lappend non_finite_leaf_instance_power_ref_name_buckets \
+      [list $non_finite_leaf_instance_power_ref_name_bucket_other_count "other"]
   }
 }
 
@@ -806,6 +862,7 @@ if {$has_nonfinite_design_total} {
   puts $fp "    \"candidate_cell_count\": $non_finite_leaf_instance_power_candidate_cell_count,"
   puts $fp "    \"checked_instance_power_count\": $non_finite_leaf_instance_power_checked_count,"
   puts $fp "    \"query_error_count\": $non_finite_leaf_instance_power_query_error_count,"
+  puts $fp "    \"ref_name_query_error_count\": $non_finite_leaf_instance_power_ref_name_query_error_count,"
   puts $fp "    \"non_leaf_skip_count\": $non_finite_leaf_instance_power_non_leaf_skip_count,"
   puts $fp "    \"bad_shape_row_count\": $non_finite_leaf_instance_power_bad_shape_row_count,"
   puts $fp "    \"finite_row_count\": $non_finite_leaf_instance_power_finite_row_count,"
@@ -815,6 +872,21 @@ if {$has_nonfinite_design_total} {
   puts $fp "      \"leakage_w\": [rtlgen_json_number $non_finite_leaf_instance_power_leakage_sum],"
   puts $fp "      \"total_w\": [rtlgen_json_number $non_finite_leaf_instance_power_total_sum]"
   puts $fp "    },"
+  puts $fp "    \"ref_name_buckets\": \["
+  set ref_name_bucket_count [llength $non_finite_leaf_instance_power_ref_name_buckets]
+  set ref_name_bucket_index 0
+  foreach ref_name_bucket $non_finite_leaf_instance_power_ref_name_buckets {
+    lassign $ref_name_bucket ref_name_count ref_name
+    incr ref_name_bucket_index
+    set escaped_ref_name [rtlgen_json_escape $ref_name]
+    set ref_name_bucket_line "      {\"ref_name\": \"$escaped_ref_name\", \"count\": $ref_name_count}"
+    if {$ref_name_bucket_index < $ref_name_bucket_count} {
+      puts $fp "$ref_name_bucket_line,"
+    } else {
+      puts $fp "$ref_name_bucket_line"
+    }
+  }
+  puts $fp "    \],"
   puts $fp "    \"samples\": \["
   set sample_count [llength $non_finite_leaf_instance_samples]
   set sample_index 0
@@ -824,14 +896,16 @@ if {$has_nonfinite_design_total} {
       leaf_internal_power \
       leaf_switching_power \
       leaf_leakage_power \
-      leaf_total_power
+      leaf_total_power \
+      leaf_ref_name
     set leaf_internal_power_json [rtlgen_json_number $leaf_internal_power]
     set leaf_switching_power_json [rtlgen_json_number $leaf_switching_power]
     set leaf_leakage_power_json [rtlgen_json_number $leaf_leakage_power]
     set leaf_total_power_json [rtlgen_json_number $leaf_total_power]
     incr sample_index
     set escaped_leaf_name [rtlgen_json_escape $leaf_name]
-    set sample_line "      {\"full_name\": \"$escaped_leaf_name\", \"internal_w\": $leaf_internal_power_json, \"switching_w\": $leaf_switching_power_json, \"leakage_w\": $leaf_leakage_power_json, \"total_w\": $leaf_total_power_json}"
+    set escaped_ref_name [rtlgen_json_escape $leaf_ref_name]
+    set sample_line "      {\"full_name\": \"$escaped_leaf_name\", \"ref_name\": \"$escaped_ref_name\", \"internal_w\": $leaf_internal_power_json, \"switching_w\": $leaf_switching_power_json, \"leakage_w\": $leaf_leakage_power_json, \"total_w\": $leaf_total_power_json}"
     if {$sample_index < $sample_count} {
       puts $fp "$sample_line,"
     } else {

--- a/tests/test_attention_decode_score_multivalue_cluster_activity.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity.py
@@ -1,11 +1,39 @@
 import hashlib
 import json
-from pathlib import Path
+import re
 import shutil
+from pathlib import Path
 
 import pytest
 
 from npu.eval.generate_attention_decode_score_multivalue_cluster_activity import generate_phase_activity
+
+
+_SCOPE_VCD_VAR_RE = re.compile(r"^\s*\$var\s+\w+\s+1\s+\S+\s+(?P<name>\\\S+)\s+\$end$")
+
+
+def _score_bank_scalar_vcd_aliases(vcd_path: Path, *, scope: str = "score_bank") -> set[str]:
+    inside_score_bank = False
+    scope_depth = 0
+    names: set[str] = set()
+    for line in vcd_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        stripped = line.strip()
+        if not inside_score_bank:
+            if stripped == f"$scope module {scope} $end":
+                inside_score_bank = True
+                scope_depth = 1
+            continue
+
+        if stripped.startswith("$scope "):
+            scope_depth += 1
+        elif stripped.startswith("$upscope"):
+            scope_depth -= 1
+            if scope_depth == 0:
+                break
+        elif scope_depth >= 1 and stripped.startswith("$var "):
+            if match := _SCOPE_VCD_VAR_RE.match(stripped):
+                names.add(match.group("name"))
+    return names
 
 
 def _tool_available(name: str) -> bool:
@@ -107,3 +135,16 @@ def test_phase_scaling_is_invariant_across_representative_block_counts(
     assert phases["replay_value"]["full_context_cycles"] == 16 + 68 * 16384
     assert phases["finalize_result"]["full_context_cycles"] == 7696
     assert manifest["phase_partition_cycle_sum"] == manifest["representative_full_transaction_cycles"]
+
+
+def test_score_fill_vcd_contains_fakeram_scalar_aliases_for_vector_ports(tmp_path: Path) -> None:
+    if not _tool_available("iverilog") or not _tool_available("vvp"):
+        pytest.skip("iverilog/vvp unavailable")
+
+    manifest = generate_phase_activity(_config(), tmp_path, block_count=1, head_dim=3, clock_period_ns=10.0)
+    phases = {row["phase"]: row for row in manifest["phases"]}
+    score_fill_vcd = tmp_path / phases["score_fill"]["vcd"]
+    aliases = _score_bank_scalar_vcd_aliases(score_fill_vcd)
+
+    for alias in ["\\addr_in[0]", "\\wd_in[0]", "\\wd_in[38]", "\\w_mask_in[0]", "\\w_mask_in[38]"]:
+        assert alias in aliases, f"missing escaped scalar alias {alias} in score_bank scope"

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -24,157 +24,205 @@ SPEC.loader.exec_module(MODULE)
 
 class PostrouteVcdPowerTests(unittest.TestCase):
     def _write_tcl_runtime_stub(
-        self, root: Path, result: Path, *, macro_transfer: bool = False
+        self,
+        root: Path,
+        result: Path,
+        *,
+        macro_transfer: bool = False,
+        leaf_specs: tuple[tuple[str, str, str], ...] | None = None,
     ) -> str:
+        if leaf_specs is None:
+            leaf_specs = (
+                ("leaf_group[7]/instance_a", "reducer", "0.0 nan inf nan"),
+                ("leaf_group_b/leaf_b", "other", "1.0 2.0 3.0 4.0"),
+            )
+        leaf_names = " ".join(f"{{{name}}}" for name, _ref, _value in leaf_specs)
+        leaf_ref_name_cases = []
+        leaf_instance_power_cases = []
+        for leaf_name, ref_name, instance_power in leaf_specs:
+            leaf_ref_name_cases.extend(
+                [
+                    f"    if {{$obj eq {{{leaf_name}}}}} {{",
+                    f"      assert_non_empty_string {{{ref_name}}}",
+                    f"      return {{{ref_name}}}",
+                    "    }",
+                ]
+            )
+            leaf_instance_power_cases.extend(
+                [
+                    f"    if {{$leaf eq {{{leaf_name}}}}} {{",
+                    f"      return {{{instance_power}}}",
+                    "    }",
+                ]
+            )
         if macro_transfer:
-            all_pins = "{pin_other_0 pin_input_u_group_0 pin_nonfinite_u_group}"
-            net_pins = "{driver_pin_u_group_0 peer_pin_u_group_0 pin_input_u_group_0}"
-            get_pins_body = (
-                "  if {[lindex $args 0] eq \"-hierarchical\"} {\n"
-                "    set pattern [lindex $args end]\n"
-                "    if {$pattern eq \"*u_group_*\"} {\n"
-                "      return {}\n"
-                "    }\n"
-                "  }\n"
-                "  if {[lindex $args 0] eq \"-of_objects\"} {\n"
-                "    set net [lindex $args end]\n"
-                "    if {$net eq {net_u_group_0}} {\n"
-                f"      return {net_pins}\n"
-                "    }\n"
-                "  }\n"
-                f"  return {all_pins}\n"
-            )
-            pin_property_body = (
-                "  if {$obj eq {pin_input_u_group_0}} {\n"
-                "    if {$property eq \"is_hierarchical\"} { return 0 }\n"
-                "    if {$property eq \"direction\"} { return \"input\" }\n"
-                "    if {$property eq \"activity\"} { return {0.0 0.0 constant} }\n"
-                "    if {$property eq \"full_name\"} { return $obj }\n"
-                "  }\n"
-                "  if {$obj eq {driver_pin_u_group_0}} {\n"
-                "    if {$property eq \"activity\"} { return {0.4 0.9 other} }\n"
-                "  }\n"
-                "  if {$obj eq {peer_pin_u_group_0}} {\n"
-                "    if {$property eq \"activity\"} { return {0.9 0.8 propagated} }\n"
-                "  }\n"
-            )
-            net_driver_body = (
-                "  proc net_driver_pins {net} {\n"
-                "    if {$net eq {net_u_group_0}} { return {driver_pin_u_group_0} }\n"
-                "    return {}\n"
-                "  }\n"
-            )
-            net_and_activity_body = (
-                "proc get_nets {args} {\n"
-                "  if {[lindex $args 0] eq \"-of_objects\" && [lindex $args 1] eq {pin_input_u_group_0}} {\n"
-                "    return {net_u_group_0}\n"
-                "  }\n"
-                "  return {}\n"
-                "}\n"
-            )
+            all_pins = [
+                "pin_other_0",
+                "pin_input_u_group_0",
+                "pin_nonfinite_u_group",
+            ]
+            net_pins = [
+                "driver_pin_u_group_0",
+                "peer_pin_u_group_0",
+                "pin_input_u_group_0",
+            ]
+            get_pins_body = [
+                "  if {[lindex $args 0] eq \"-hierarchical\"} {",
+                "    set pattern [lindex $args end]",
+                "    if {$pattern eq \"*u_group_*\"} {",
+                "      return {}",
+                "    }",
+                "  }",
+                "  if {[lindex $args 0] eq \"-of_objects\"} {",
+                "    set net [lindex $args end]",
+                "    if {$net eq {net_u_group_0}} {",
+                f"      return {{{' '.join(net_pins)}}}",
+                "    }",
+                "  }",
+                f"  return {{{' '.join(all_pins)}}}",
+            ]
+            pin_property_body = [
+                "  if {$obj eq {pin_input_u_group_0}} {",
+                "    if {$property eq \"is_hierarchical\"} { return 0 }",
+                "    if {$property eq \"direction\"} { return \"input\" }",
+                "    if {$property eq \"activity\"} { return {0.0 0.0 constant} }",
+                "    if {$property eq \"full_name\"} { return $obj }",
+                "  }",
+                "  if {$obj eq {driver_pin_u_group_0}} {",
+                "    if {$property eq \"activity\"} { return {0.4 0.9 other} }",
+                "  }",
+                "  if {$obj eq {peer_pin_u_group_0}} {",
+                "    if {$property eq \"activity\"} { return {0.9 0.8 propagated} }",
+                "  }",
+            ]
+            net_driver_body = [
+                "  proc net_driver_pins {net} {",
+                "    if {$net eq {net_u_group_0}} { return {driver_pin_u_group_0} }",
+                "    return {}",
+                "  }",
+            ]
+            net_and_activity_body = [
+                "proc get_nets {args} {",
+                "  if {[lindex $args 0] eq \"-of_objects\" && [lindex $args 1] eq {pin_input_u_group_0}} {",
+                "    return {net_u_group_0}",
+                "  }",
+                "  return {}",
+                "}",
+            ]
         else:
-            get_pins_body = "  return {pin_nonfinite_u_group}\n"
-            pin_property_body = ""
-            net_driver_body = ""
-            net_and_activity_body = ""
-        script = (
-            "\n"
-            "proc load_design {args} {}\n"
-            "proc read_spef {args} {}\n"
-            "proc log_cmd {args} {}\n"
-            "proc report_activity_annotation {} {}\n"
-            "proc report_power {} {}\n"
-            "proc get_clocks {args} {\n"
-            "  return {clk}\n"
-            "}\n"
-            "proc get_full_name {leaf} {\n"
-            "  return $leaf\n"
-            "}\n"
-            "proc get_pins {args} {\n"
-            + get_pins_body
-            + "}\n"
-            "proc get_property {obj property} {\n"
-            + pin_property_body
-            + "  if {[string match \"pin_*\" $obj]} {\n"
-            "    if {$property eq \"is_hierarchical\"} {\n"
-            "      return 0\n"
-            "    }\n"
-            "    if {$property eq \"direction\"} {\n"
-            "      return \"output\"\n"
-            "    }\n"
-            "    if {$property eq \"activity\"} {\n"
-            "      return {0.25 0.5 vcd}\n"
-            "    }\n"
-            "    if {$property eq \"full_name\"} {\n"
-            "      return $obj\n"
-            "    }\n"
-            "    return {}\n"
-            "  }\n"
-            "  if {$property eq \"is_leaf\"} {\n"
-            "    return 1\n"
-            "  }\n"
-            "  if {$property eq \"name\"} {\n"
-            "    return $obj\n"
-            "  }\n"
-            "  return {}\n"
-            "}\n"
-            + net_and_activity_body
-            + "proc get_cells {args} {\n"
-            "  error \"get_cells should not be used for nonfinite leaf scan\"\n"
-            "}\n"
-            "proc instance_power {args} {\n"
-            "  error \"use sta::instance_power <leaf> <corner>\"\n"
-            "}\n"
-            "proc set_power_pin_activity {args} {\n"
-            "  error \"use sta::set_power_pin_activity <pin> <density> <duty>\"\n"
-            "}\n"
-            "proc design_power {args} {\n"
-            "  error \"use sta::design_power <corner>\"\n"
-            "}\n"
-            "proc corners {} {\n"
-            "  error \"do not call sta::corners\"\n"
-            "}\n"
-            "namespace eval sta {\n"
-            "  proc cmd_corner {} {\n"
-            "    return corner0\n"
-            "  }\n"
-            "  proc design_power {corner} {\n"
-            "    if {$corner ne \"corner0\"} {\n"
-            "      error \"design_power corner mismatch: $corner\"\n"
-            "    }\n"
-            "    # First quartet has non-finite total, triggering sample capture.\n"
-            "    return {1.0 2.0 3.0 nan 4.0 5.0 6.0 7.0}\n"
-            "  }\n"
-            "  proc instance_power {leaf corner} {\n"
-            "    if {$corner ne \"corner0\"} {\n"
-            "      error \"instance_power corner mismatch: $corner\"\n"
-            "    }\n"
-            "    if {$leaf eq {leaf_group[7]/instance_a}} {\n"
-            "      return {0.0 nan inf nan}\n"
-            "    }\n"
-            "    return {1.0 2.0 3.0 4.0}\n"
-            "  }\n"
-            "  proc set_power_pin_activity {pin density duty} {\n"
-            "    lappend ::sta::power_pin_activity_calls [list $pin $density $duty]\n"
-            "  }\n"
-            "  proc corners {} {\n"
-            "    return {corner0}\n"
-            "  }\n"
-            "  proc network_leaf_instances {} {\n"
-            "    return {leaf_group[7]/instance_a leaf_group_b/leaf_b}\n"
-            "  }\n"
-            "  variable power_pin_activity_calls {}\n"
-            + net_driver_body
-            + "}\n"
-            f"set ::env(SCRIPTS_DIR) \"{root / 'scripts'}\"\n"
-            f"set ::env(RESULTS_DIR) \"{root}\"\n"
-            f"set ::env(RTLGEN_ACTIVITY_VCD) \"{root / 'trace.vcd'}\"\n"
-            f"set ::env(RTLGEN_ACTIVITY_SCOPE) \"tb/dut\"\n"
-            f"set ::env(RTLGEN_ACTIVITY_RESULT) \"{result}\"\n"
-            "\n"
-            + MODULE._tcl_script()
-        )
-        return script
+            get_pins_body = ["  return {pin_nonfinite_u_group}"]
+            pin_property_body = []
+            net_driver_body = []
+            net_and_activity_body = []
+        lines = [
+            "",
+            "proc load_design {args} {}",
+            "proc read_spef {args} {}",
+            "proc log_cmd {args} {}",
+            "proc report_activity_annotation {} {}",
+            "proc report_power {} {}",
+            "proc get_clocks {args} {",
+            "  return {clk}",
+            "}",
+            "proc get_full_name {leaf} {",
+            "  return $leaf",
+            "}",
+            "proc assert_non_empty_string {value} {",
+            "  if {$value eq \"\"} {",
+            "    error \"assertion failed: expected non-empty string\"",
+            "  }",
+            "}",
+            "set ::ref_name_query_count 0",
+            "proc get_pins {args} {",
+            *get_pins_body,
+            "}",
+            "proc get_property {obj property} {",
+            *pin_property_body,
+            "  if {[string match \"pin_*\" $obj]} {",
+            "    if {$property eq \"is_hierarchical\"} {",
+            "      return 0",
+            "    }",
+            "    if {$property eq \"direction\"} {",
+            "      return \"output\"",
+            "    }",
+            "    if {$property eq \"activity\"} {",
+            "      return {0.25 0.5 vcd}",
+            "    }",
+            "    if {$property eq \"full_name\"} {",
+            "      return $obj",
+            "    }",
+            "    return {}",
+            "  }",
+            "  if {$property eq \"ref_name\"} {",
+            "    incr ::ref_name_query_count",
+            *leaf_ref_name_cases,
+            "    return \"\"",
+            "  }",
+            "  if {$property eq \"is_leaf\"} {",
+            "    return 1",
+            "  }",
+            "  if {$property eq \"name\"} {",
+            "    return $obj",
+            "  }",
+            "  return {}",
+            "}",
+            *net_and_activity_body,
+            "proc get_cells {args} {",
+            "  error \"get_cells should not be used for nonfinite leaf scan\"",
+            "}",
+            "proc instance_power {args} {",
+            "  error \"use sta::instance_power <leaf> <corner>\"",
+            "}",
+            "proc set_power_pin_activity {args} {",
+            "  error \"use sta::set_power_pin_activity <pin> <density> <duty>\"",
+            "}",
+            "proc design_power {args} {",
+            "  error \"use sta::design_power <corner>\"",
+            "}",
+            "proc corners {} {",
+            "  error \"do not call sta::corners\"",
+            "}",
+            "namespace eval sta {",
+            "  proc cmd_corner {} {",
+            "    return corner0",
+            "  }",
+            "  proc design_power {corner} {",
+            "    if {$corner ne \"corner0\"} {",
+            "      error \"design_power corner mismatch: $corner\"",
+            "    }",
+            "    # First quartet has non-finite total, triggering sample capture.",
+            "    return {1.0 2.0 3.0 nan 4.0 5.0 6.0 7.0}",
+            "  }",
+            "  proc instance_power {leaf corner} {",
+            "    if {$corner ne \"corner0\"} {",
+            "      error \"instance_power corner mismatch: $corner\"",
+            "    }",
+            *leaf_instance_power_cases,
+            "    return {1.0 2.0 3.0 4.0}",
+            "  }",
+            "  proc set_power_pin_activity {pin density duty} {",
+            "    lappend ::sta::power_pin_activity_calls [list $pin $density $duty]",
+            "  }",
+            "  proc corners {} {",
+            "    return {corner0}",
+            "  }",
+            "  proc network_leaf_instances {} {",
+            f"    return {{{leaf_names}}}",
+            "  }",
+            "  variable power_pin_activity_calls {}",
+            *net_driver_body,
+            "}",
+            f"set ::env(SCRIPTS_DIR) \"{root / 'scripts'}\"",
+            f"set ::env(RESULTS_DIR) \"{root}\"",
+            f"set ::env(RTLGEN_ACTIVITY_VCD) \"{root / 'trace.vcd'}\"",
+            f"set ::env(RTLGEN_ACTIVITY_SCOPE) \"tb/dut\"",
+            f"set ::env(RTLGEN_ACTIVITY_RESULT) \"{result}\"",
+            MODULE._tcl_script(),
+            "if {$::ref_name_query_count == 0} {",
+            "  error \"assertion failed: expected at least one instance ref_name query\"",
+            "}",
+        ]
+        return "\n".join(lines)
 
     def test_tcl_script_non_finite_samples_have_escaped_json_array_literals(self) -> None:
         if shutil.which("tclsh") is None:
@@ -211,6 +259,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(len(diagnostics["samples"]), 1)
             sample = diagnostics["samples"][0]
             self.assertEqual(sample["full_name"], "leaf_group[7]/instance_a")
+            self.assertEqual(sample["ref_name"], "reducer")
             self.assertIsNone(sample["switching_w"])
             self.assertEqual(diagnostics.get("non_leaf_skip_count"), 0)
             self.assertEqual(diagnostics["candidate_cell_count"], 2)
@@ -219,6 +268,10 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(diagnostics["finite_row_count"], 1)
             self.assertEqual(diagnostics["bad_shape_row_count"], 0)
             self.assertEqual(diagnostics["query_error_count"], 0)
+            self.assertEqual(diagnostics["ref_name_query_error_count"], 0)
+            self.assertEqual(len(diagnostics["ref_name_buckets"]), 1)
+            self.assertEqual(diagnostics["ref_name_buckets"][0]["ref_name"], "reducer")
+            self.assertEqual(diagnostics["ref_name_buckets"][0]["count"], 1)
             self.assertLess(
                 diagnostics["query_error_count"],
                 diagnostics["candidate_cell_count"],
@@ -232,6 +285,98 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(finite_sums["switching_w"], 2.0)
             self.assertEqual(finite_sums["leakage_w"], 3.0)
             self.assertEqual(finite_sums["total_w"], 4.0)
+
+    def test_tcl_script_ref_name_buckets_are_sorted_and_bounded(self) -> None:
+        if shutil.which("tclsh") is None:
+            self.skipTest("tclsh is required for Tcl runtime regression")
+
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "load.tcl").write_text("", encoding="utf-8")
+
+            result = root / "activity_power.json"
+            ref_names = [
+                "10",
+                "2",
+                "1",
+                "11",
+                "20",
+                "3",
+                "30",
+                "4",
+                "5",
+                "6",
+                "7",
+                "8",
+                "9",
+                "001",
+                "002",
+                "003",
+                "004",
+                "005",
+                "006",
+                "007",
+                "008",
+                "009",
+                "010",
+                "011",
+                "012",
+                "013",
+                "014",
+                "015",
+                "016",
+                "017",
+                "018",
+                "019",
+                "020",
+                "021",
+                "022",
+            ]
+            leaf_specs = tuple(
+                (
+                    f"leaf_group[7]/instance_{index:03d}",
+                    ref_name,
+                    "nan nan nan nan",
+                )
+                for index, ref_name in enumerate(ref_names)
+            )
+            tcl_script_path = root / "activity_power.tcl"
+            tcl_script = self._write_tcl_runtime_stub(
+                root=root, result=result, leaf_specs=leaf_specs
+            )
+            tcl_script_path.write_text(tcl_script, encoding="utf-8")
+            tcl = shutil.which("tclsh")
+            assert tcl is not None
+            completed = MODULE.subprocess.run(
+                [tcl, str(tcl_script_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                msg=f"tcl failed: stdout={completed.stdout} stderr={completed.stderr}",
+            )
+            self.assertFalse(completed.stderr.strip())
+
+            payload = json.loads(result.read_text(encoding="utf-8"))
+            diagnostics = payload["non_finite_leaf_instance_power"]
+            self.assertEqual(diagnostics["instance_count"], 35)
+            self.assertEqual(diagnostics["checked_instance_power_count"], 35)
+            self.assertEqual(diagnostics["ref_name_query_error_count"], 0)
+            buckets = diagnostics["ref_name_buckets"]
+            self.assertEqual(len(buckets), 32)
+            bucket_names = [bucket["ref_name"] for bucket in buckets]
+            self.assertEqual(bucket_names[-1], "other")
+            self.assertEqual(buckets[-1]["count"], 4)
+            sorted_ref_names = sorted(ref_names)
+            self.assertEqual(sorted_ref_names[30], "5")
+            self.assertEqual([bucket["ref_name"] for bucket in buckets[:-1]], sorted_ref_names[:31])
+            self.assertEqual(len(diagnostics["samples"]), 16)
+            self.assertEqual(diagnostics["samples"][0]["ref_name"], ref_names[0])
 
     def test_tcl_script_transfers_macro_input_activity(self) -> None:
         if shutil.which("tclsh") is None:


### PR DESCRIPTION
## Summary
- emit scalar escaped aliases for every FakeRAM vector input bit in simulation VCDs
- preserve memory behavior and physical RTL while making macro pins directly mappable by OpenSTA
- aggregate bounded reducer ref-name diagnostics for non-finite instance power
- keep all power gates and totals unchanged

## Validation
- cluster equivalence/activity tests: 8 passed
- postroute and cluster/GQA power tests: 31 passed