### PR TITLE
npu: annotate FakeRAM pins from phase VCD activity

### DIFF
--- a/npu/eval/extract_fakeram_vcd_activity.py
+++ b/npu/eval/extract_fakeram_vcd_activity.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Extract per-pin activity from Fakeram VCD for structural macro annotations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+import math
+import re
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+TARGET_SCOPE_PREFIX = "tb/dut"
+_TARGET_GROUP_SCOPE_RE = re.compile(r"^u_group_(\d+)_slice_(\d+)$")
+_VAR_RE = re.compile(r"^\$var\s+\S+\s+(\d+)\s+(\S+)\s+(.*?)\s+\$end$")
+_SCOPE_RE = re.compile(r"^\$scope\s+\S+\s+(\S+)\s+\$end$")
+_SCALAR_UPDATE_RE = re.compile(r"^([01xXzZ])(\S+)$")
+_VECTOR_UPDATE_RE = re.compile(r"^b([01xXzZ]+)\s+(\S+)$")
+
+_DEFAULT_PIN_WIDTHS = {
+    "addr_in": 11,
+    "wd_in": 39,
+    "w_mask_in": 39,
+    "we_in": 1,
+    "ce_in": 1,
+}
+
+
+@dataclass
+class _PinActivity:
+    full_name: str
+    last_value: str | None
+    last_tick: int
+    transition_count: float
+    high_ticks: int
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_float_bits(value: str, unit: str) -> float:
+    factors = {
+        "s": 1.0,
+        "ms": 1e-3,
+        "us": 1e-6,
+        "ns": 1e-9,
+        "ps": 1e-12,
+        "fs": 1e-15,
+    }
+    unit_key = unit.strip().lower()
+    if unit_key not in factors:
+        raise ValueError(f"unsupported timescale unit: {unit}")
+    try:
+        return float(value) * factors[unit_key]
+    except ValueError as exc:
+        raise ValueError(f"invalid timescale value: {value}") from exc
+
+
+def _parse_timescale(vcd_text: str) -> float:
+    match = re.search(r"\$timescale\b(.*?)\$end", vcd_text, flags=re.S | re.I)
+    if match is None:
+        raise ValueError("missing $timescale declaration")
+    body = " ".join(match.group(1).split())
+    range_match = re.fullmatch(r"([0-9]+)\s*([A-Za-z]+)\s*/\s*([0-9]+)\s*([A-Za-z]+)", body)
+    if range_match:
+        return _safe_float_bits(range_match.group(3), range_match.group(4))
+    direct_match = re.fullmatch(r"([0-9]+)\s*([A-Za-z]+)", body)
+    if direct_match:
+        return _safe_float_bits(direct_match.group(1), direct_match.group(2))
+    raise ValueError(f"unrecognized $timescale format: {body!r}")
+
+
+def _parse_range_indices(raw: str | None, width: int) -> list[int]:
+    if raw is None:
+        return list(range(width))
+    match = re.fullmatch(r"\[\s*([+-]?\d+)\s*:\s*([+-]?\d+)\s*\]", raw)
+    if match is None:
+        return list(range(width))
+    start = int(match.group(1))
+    end = int(match.group(2))
+    if width <= 0:
+        raise ValueError("signal width must be > 0")
+    step = -1 if start > end else 1
+    expected = list(range(start, end + step, step))
+    if len(expected) != width:
+        raise ValueError(
+            f"vector range has {len(expected)} bits but declaration reports width {width}: [{start}:{end}]"
+        )
+    return expected
+
+
+def _parse_target_scope(scope_path: str, root_scope: str = TARGET_SCOPE_PREFIX) -> tuple[str, int, int] | None:
+    if scope_path == root_scope:
+        return None
+    if not scope_path.startswith(f"{root_scope}/"):
+        return None
+    remainder = scope_path[len(root_scope) + 1 :]
+    if not remainder:
+        return None
+    parts = remainder.split("/")
+    for index, part in enumerate(parts):
+        if part != "score_bank":
+            continue
+        if index + 1 >= len(parts):
+            return None
+        group_scope = parts[index + 1]
+        match = _TARGET_GROUP_SCOPE_RE.fullmatch(group_scope)
+        if match is None:
+            continue
+        # Require the target slice to be declared directly under score_bank.
+        if index + 2 != len(parts):
+            continue
+        return (f"score_bank/{group_scope}", int(match.group(1)), int(match.group(2)))
+    return None
+
+
+def _sanitize_bit(value: str) -> str:
+    val = value.lower()
+    if val not in {"0", "1", "x", "z"}:
+        raise ValueError(f"unsupported logic value: {value!r}")
+    return val
+
+
+def _transition_delta(old: str, new: str) -> float:
+    if old == new:
+        return 0.0
+    if (old in {"0", "1"}) and (new in {"0", "1"}):
+        return 1.0
+    return 0.5
+
+
+def _normalize_vector_update(value: str, width: int) -> list[str]:
+    if len(value) > width:
+        raise ValueError(f"vector value has {len(value)} bits but declared width is {width}")
+    bits = [_sanitize_bit(ch) for ch in value]
+    if len(bits) == width:
+        return bits
+    if len(bits) < width:
+        if set(bits) == {"x"}:
+            return ["x"] * width
+        if set(bits) == {"z"}:
+            return ["z"] * width
+        return ["0"] * (width - len(bits)) + bits
+    return bits
+
+
+def _value_to_tick_delta(value: str | None, tick_delta: int) -> int:
+    if tick_delta < 0:
+        raise ValueError("timestamps in VCD must be nondecreasing")
+    if tick_delta == 0 or value != "1":
+        return 0
+    return tick_delta
+
+
+def extract_fakeram_vcd_activity(
+    vcd_path: Path,
+    *,
+    source_vcd_sha256: str,
+    scope: str = TARGET_SCOPE_PREFIX,
+    pin_widths: dict[str, int] | None = None,
+    group_indices: tuple[int, ...] = tuple(range(8)),
+    slice_indices: tuple[int, ...] = tuple(range(7)),
+    expected_pin_count: int | None = None,
+) -> JsonDict:
+    if not source_vcd_sha256:
+        raise ValueError("source_vcd_sha256 is required")
+    expected = _DEFAULT_PIN_WIDTHS.copy()
+    if pin_widths is not None:
+        expected.update(pin_widths)
+        required = set(expected)
+        unexpected = set(pin_widths) - set(expected)
+        if unexpected:
+            raise ValueError(f"unexpected pin_widths keys: {', '.join(sorted(unexpected))}")
+    else:
+        required = set(expected)
+    for pin_name in required:
+        width = expected[pin_name]
+        if width <= 0:
+            raise ValueError(f"invalid width for {pin_name}: {width}")
+
+    vcd_text = vcd_path.read_text(encoding="utf-8", errors="replace")
+    actual_hash = _sha256_file(vcd_path)
+    if actual_hash != source_vcd_sha256.lower():
+        raise ValueError("source_vcd_sha256 does not match actual vcd content")
+
+    timescale_seconds = _parse_timescale(vcd_text)
+    if not math.isfinite(timescale_seconds) or timescale_seconds <= 0:
+        raise ValueError("timescale_seconds must be a positive finite value")
+
+    id_to_full_names: dict[str, tuple[str, ...]] = {}
+    id_to_specs: dict[str, tuple[str, int]] = {}
+    all_pin_last_values: dict[str, str | None] = {}
+    full_name_specs: dict[str, tuple[str, int]] = {}
+    scope_stack: list[str] = []
+
+    # Parse VCD declarations.
+    lines = vcd_text.splitlines()
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "$enddefinitions":
+            break
+        if stripped == "$scope":
+            pass
+        if stripped.startswith("$scope "):
+            scope_match = _SCOPE_RE.match(stripped)
+            if scope_match:
+                scope_stack.append(scope_match.group(1).strip())
+            continue
+        if stripped == "$upscope" or stripped == "$upscope $end":
+            if scope_stack:
+                scope_stack.pop()
+            continue
+        if not (stripped.startswith("$var ") and stripped.endswith("$end")):
+            continue
+
+        match = _VAR_RE.match(stripped)
+        if match is None:
+            continue
+        width = int(match.group(1))
+        var_id = match.group(2)
+        body = match.group(3).strip()
+        decl_tokens = body.split()
+        if not decl_tokens:
+            continue
+        name = decl_tokens[0]
+        if name.startswith("\\"):
+            continue
+        if width <= 0 or name not in required:
+            continue
+
+        scope_path = "/".join(scope_stack)
+        scope_result = _parse_target_scope(scope_path, root_scope=scope)
+        if scope_result is None:
+            continue
+        full_scope, group, slice_idx = scope_result
+        if group not in group_indices or slice_idx not in slice_indices:
+            continue
+
+        expected_width = expected[name]
+        if width != expected_width:
+            raise ValueError(f"{scope_path}/{name} width mismatch: expected {expected_width}, got {width}")
+
+        if len(decl_tokens) > 1:
+            range_expr = decl_tokens[1]
+            if range_expr.startswith("[") and range_expr.endswith("]"):
+                bit_indices = _parse_range_indices(range_expr, width)
+            else:
+                bit_indices = list(range(width))
+        else:
+            bit_indices = list(range(width))
+
+        if width == 1:
+            full_names = (f"{full_scope}/{name}",)
+        else:
+            if len(bit_indices) != width:
+                raise ValueError(f"{scope_path}/{name} requires {width} bits but range mapping was {len(bit_indices)}")
+            full_names = tuple(f"{full_scope}/{name}[{index}]" for index in bit_indices)
+
+        def _signal_base(full_name: str) -> str:
+            leaf = full_name.rsplit("/", 1)[-1]
+            return leaf.split("[", 1)[0]
+
+        # Duplicate full_name declarations should be consistent and deterministic.
+        unique_full_names: list[str] = []
+        for bit_index, full_name in enumerate(full_names):
+            existing = full_name_specs.get(full_name)
+            if existing is None:
+                full_name_specs[full_name] = (var_id, bit_index)
+                all_pin_last_values[full_name] = None
+                unique_full_names.append(full_name)
+                continue
+            existing_var_id, existing_bit_index = existing
+            if existing_var_id != var_id or existing_bit_index != bit_index:
+                raise ValueError(f"duplicate declaration for {full_name}")
+            # Exact repeated declaration: ignore as a deterministic alias.
+
+        if var_id in id_to_full_names:
+            existing = id_to_full_names[var_id]
+            expected_base, expected_width = id_to_specs[var_id]
+            signal_base = _signal_base(full_names[0]) if full_names else ""
+            if signal_base != expected_base or len(full_names) != expected_width:
+                raise ValueError(f"duplicate id {var_id} with mismatched width/bit-count")
+            if {_signal_base(name) for name in existing} != {_signal_base(name) for name in full_names}:
+                raise ValueError(f"duplicate id {var_id} with inconsistent target names")
+            if unique_full_names:
+                id_to_full_names[var_id] = existing + tuple(unique_full_names)
+        else:
+            id_to_full_names[var_id] = tuple(unique_full_names)
+            id_to_specs[var_id] = (_signal_base(full_names[0]), len(full_names))
+
+    if expected_pin_count is None:
+        expected_pin_count = sum(expected[name] for name in required) * len(group_indices) * len(slice_indices)
+
+    # Replay lines from the full file for value changes and dumpon timing.
+    active_start: int | None = None
+    active_end: int | None = None
+    current_time = 0
+    dumping = False
+    state_by_pin = {name: None for name in all_pin_last_values}
+
+    pin_rows: dict[str, _PinActivity] = {}
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            current_time = int(stripped[1:])
+            continue
+        if stripped == "$dumpon":
+            if active_end is not None:
+                raise ValueError("found $dumpon after $dumpoff")
+            if dumping:
+                raise ValueError("found nested $dumpon without $dumpoff")
+            active_start = current_time
+            dumping = True
+            pin_rows = {
+                full_name: _PinActivity(
+                    full_name=full_name,
+                    last_value=value,
+                    last_tick=current_time,
+                    transition_count=0.0,
+                    high_ticks=0,
+                )
+                for full_name, value in state_by_pin.items()
+            }
+            continue
+        if stripped == "$dumpoff":
+            if not dumping:
+                raise ValueError("found $dumpoff without active $dumpon")
+            active_end = current_time
+            dumping = False
+            break
+
+        if current_time is None:
+            continue
+
+        # Scalar update.
+        scalar_update = _SCALAR_UPDATE_RE.match(stripped)
+        if scalar_update is not None:
+            new_value = _sanitize_bit(scalar_update.group(1))
+            var_id = scalar_update.group(2)
+            if var_id not in id_to_full_names:
+                continue
+            for full_name in id_to_full_names[var_id]:
+                state_by_pin[full_name] = new_value
+                if not dumping:
+                    continue
+                row = pin_rows[full_name]
+                if row.last_value is not None:
+                    row.transition_count += _transition_delta(row.last_value, new_value)
+                row.high_ticks += _value_to_tick_delta(row.last_value, current_time - row.last_tick)
+                row.last_value = new_value
+                row.last_tick = current_time
+            continue
+
+        # Binary/vector update.
+        vector_update = _VECTOR_UPDATE_RE.match(stripped)
+        if vector_update is not None:
+            bits = vector_update.group(1).lower()
+            var_id = vector_update.group(2)
+            if var_id not in id_to_full_names:
+                continue
+            # VCD vector updates may omit leading zeros in fixed-width literals.
+            bit_values = _normalize_vector_update(bits, len(id_to_full_names[var_id]))
+            full_names = id_to_full_names[var_id]
+            if len(bit_values) != len(full_names):
+                raise ValueError(f"vector update width mismatch for {var_id}: expected {len(full_names)}, got {len(bit_values)}")
+
+            for index, full_name in enumerate(full_names):
+                state_by_pin[full_name] = bit_values[index]
+                if not dumping:
+                    continue
+                row = pin_rows[full_name]
+                new_value = bit_values[index]
+                if row.last_value is not None:
+                    row.transition_count += _transition_delta(row.last_value, new_value)
+                row.high_ticks += _value_to_tick_delta(row.last_value, current_time - row.last_tick)
+                row.last_value = new_value
+                row.last_tick = current_time
+            continue
+
+    if len(all_pin_last_values) != expected_pin_count:
+        raise ValueError(
+            "missing expected target pin declarations: "
+            f"found {len(all_pin_last_values)} expected {expected_pin_count}"
+        )
+    if active_start is None or active_end is None:
+        raise ValueError("missing active dumpon/dumpoff interval")
+    if active_end <= active_start:
+        raise ValueError("active_end_tick must be greater than active_start_tick")
+
+    # Finish duty accounting for the final active span.
+    duration = active_end - active_start
+    for row in pin_rows.values():
+        if row.last_value is not None:
+            row.high_ticks += _value_to_tick_delta(row.last_value, active_end - row.last_tick)
+
+    pins: list[dict[str, Any]] = []
+    for row in sorted(pin_rows.values(), key=lambda entry: entry.full_name):
+        duty = row.high_ticks / duration
+        density = row.transition_count / (duration * timescale_seconds)
+        if not math.isfinite(row.transition_count) or row.transition_count < 0:
+            raise ValueError(f"non-finite transition count for {row.full_name}")
+        if not math.isfinite(duty) or duty < 0.0 or duty > 1.0:
+            raise ValueError(f"non-finite or out-of-range duty_cycle for {row.full_name}")
+        if not math.isfinite(density) or density < 0.0:
+            raise ValueError(f"non-finite density_hz for {row.full_name}")
+        pins.append(
+            {
+                "full_name": row.full_name,
+                "density_hz": density,
+                "duty_cycle": duty,
+                "transition_count": row.transition_count,
+                "source": "vcd",
+            }
+        )
+
+    return {
+        "version": 1,
+        "model": "fakeram_macro_pin_vcd_activity_v1",
+        "scope": scope,
+        "source_vcd": vcd_path.name,
+        "source_vcd_sha256": actual_hash,
+        "timescale_seconds": timescale_seconds,
+        "active_start_tick": active_start,
+        "active_end_tick": active_end,
+        "pins": pins,
+    }
+
+
+def write_fakeram_vcd_activity(vcd_path: Path, *, output_path: Path, **kwargs: Any) -> JsonDict:
+    payload = extract_fakeram_vcd_activity(vcd_path, **kwargs)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+if __name__ == "__main__":
+    raise SystemExit("extractor is library-only")

--- a/npu/eval/generate_attention_decode_score_multivalue_cluster_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_cluster_activity.py
@@ -23,6 +23,7 @@ from npu.eval.probe_attention_decode_score_multivalue_cluster_equivalence import
     _tool,
     _vectors,
 )
+from npu.eval.extract_fakeram_vcd_activity import extract_fakeram_vcd_activity
 from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate  # noqa: E402
 
 JsonDict = dict[str, Any]
@@ -279,7 +280,7 @@ def _run_phase(
     clock_period_ns: float,
     score_multiplier: int,
     score_shift: int,
-) -> tuple[int, int, Path]:
+) -> tuple[int, int, Path, Path]:
     validated = _validate_request(config=config, block_count=block_count, head_dim=head_dim)
     with tempfile.TemporaryDirectory(prefix=f"decode-score-multivalue-{phase}-") as tmp_text:
         tmp = Path(tmp_text)
@@ -317,7 +318,14 @@ def _run_phase(
         cycle_count, service_cycles = _parse_phase_cycles(run.stdout, phase)
         phase_out = out_dir / f"{phase}.vcd"
         phase_out.write_bytes(vcd_path.read_bytes())
-        return cycle_count, service_cycles, phase_out
+        sidecar_path = out_dir / f"{phase}_fakeram_macro_pin_vcd_activity_v1.json"
+        sidecar = extract_fakeram_vcd_activity(
+            phase_out,
+            source_vcd_sha256=_sha256_file(phase_out),
+            scope="tb/dut",
+        )
+        sidecar_path.write_text(json.dumps(sidecar, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return cycle_count, service_cycles, phase_out, sidecar_path
 
 
 def _score_fill_scaling(*, cycle_count: int, block_count: int) -> JsonDict:
@@ -384,7 +392,7 @@ def generate_phase_activity(
     phases: list[JsonDict] = []
     full_service_cycles = 0
     for phase in _PHASES:
-        cycle_count, service_cycles, vcd_path = _run_phase(
+        cycle_count, service_cycles, vcd_path, macro_activity_path = _run_phase(
             config=config,
             phase=phase,
             out_dir=out_dir,
@@ -407,6 +415,8 @@ def generate_phase_activity(
             "full_context_cycles": scaling["full_context_cycles"],
             "vcd": vcd_path.name,
             "vcd_sha256": _sha256_file(vcd_path),
+            "macro_activity": macro_activity_path.name,
+            "macro_activity_sha256": _sha256_file(macro_activity_path),
             "requires_macro_activity": phase in {"score_fill", "replay_value"},
             "scaling": scaling,
         })

--- a/npu/eval/probe_attention_decode_score_multivalue_cluster_equivalence.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_cluster_equivalence.py
@@ -18,13 +18,6 @@ from npu.sim.perf.attention_online import finalize_value, requantize_score_row, 
 from npu.sim.perf.attention_separated import unpack_signed
 
 JsonDict = dict[str, Any]
-
-
-def _scalar_aliases(*, vector: str, width: int) -> str:
-    """Return escaped scalar aliases for every bit of a vector port."""
-    return "\n".join(f"  wire \\{vector}[{index}] = {vector}[{index}];" for index in range(width))
-
-
 def _tool(name: str) -> str:
     path = shutil.which(name)
     if path:
@@ -118,10 +111,6 @@ module fakeram45_2048x39 (
     end
   end
   assign rd_out = rd_out_q;
-
-{_scalar_aliases(vector="addr_in", width=11)}
-{_scalar_aliases(vector="wd_in", width=39)}
-{_scalar_aliases(vector="w_mask_in", width=39)}
 endmodule
 """
 

--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -22,6 +22,8 @@ from typing import Any
 
 JsonDict = dict[str, Any]
 ORFS_FLOW = Path(os.environ.get("ORFS_FLOW", "/orfs/flow"))
+_FAKERAM_ACTIVITY_MODEL = "fakeram_macro_pin_vcd_activity_v1"
+_SAFE_PIN_NAME = re.compile(r"^[A-Za-z0-9_./:+\-\[\]]+$")
 
 
 def _load_json(path: Path) -> JsonDict:
@@ -48,6 +50,128 @@ def _activity_annotation_counts(stdout: str) -> dict[str, int]:
     return counts
 
 
+def _must_be_positive_finite(name: str, value: Any) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"invalid {name}: expected a number")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < 0.0:
+        raise ValueError(f"invalid {name}: expected finite, nonnegative")
+    return numeric
+
+
+def _must_be_duty_cycle(value: Any) -> float:
+    duty = _must_be_positive_finite("duty_cycle", value)
+    if duty > 1.0:
+        raise ValueError("duty_cycle must be within [0, 1]")
+    return duty
+
+
+def _must_be_int(name: str, value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"invalid {name}: expected an integer")
+    return int(value)
+
+
+def _must_be_safe_pin_name(name: Any) -> str:
+    full_name = str(name).strip()
+    if not full_name:
+        raise ValueError("full_name must be nonempty")
+    if not _SAFE_PIN_NAME.fullmatch(full_name):
+        raise ValueError(f"unsafe full_name '{full_name}'")
+    return full_name
+
+
+def _load_macro_activity(
+    path: Path,
+    *,
+    vcd_sha256: str,
+    phase_vcd_basename: str,
+) -> list[JsonDict]:
+    raw = _load_json(path)
+    version = raw.get("version")
+    if not isinstance(version, int) or isinstance(version, bool) or version != 1:
+        raise ValueError(
+            f"macro activity version mismatch for {path}: expected 1, got {version!r}"
+        )
+    model = str(raw.get("model", "")).strip()
+    if not isinstance(raw.get("model"), str) or not model:
+        raise ValueError(f"macro activity model missing for {path}")
+    source = str(raw.get("source_vcd_sha256", "")).strip().lower()
+    source_vcd_value = raw.get("source_vcd")
+    if not isinstance(source_vcd_value, str):
+        source_vcd = ""
+    else:
+        source_vcd = source_vcd_value.strip()
+    if not source_vcd:
+        raise ValueError(f"macro activity missing source_vcd for {path}")
+    if source_vcd != phase_vcd_basename:
+        raise ValueError(
+            f"macro activity source_vcd mismatch for {path}: expected {phase_vcd_basename}, got {source_vcd}"
+        )
+    if model != _FAKERAM_ACTIVITY_MODEL:
+        raise ValueError(
+            f"macro activity model mismatch for {path}: expected {_FAKERAM_ACTIVITY_MODEL}, got {model or 'missing'}"
+        )
+    if source != vcd_sha256:
+        raise ValueError(
+            f"macro activity hash mismatch for {path}: expected {vcd_sha256}, got {source or 'missing'}"
+        )
+    scope_value = raw.get("scope")
+    if not isinstance(scope_value, str):
+        scope = ""
+    else:
+        scope = scope_value.strip()
+    if not scope:
+        raise ValueError(f"macro activity missing scope for {path}")
+    timescale_seconds = _must_be_positive_finite("timescale_seconds", raw.get("timescale_seconds"))
+    active_start_tick = _must_be_int("active_start_tick", raw.get("active_start_tick"))
+    active_end_tick = _must_be_int("active_end_tick", raw.get("active_end_tick"))
+    if active_end_tick <= active_start_tick:
+        raise ValueError(
+            f"macro activity active range invalid for {path}: active_end_tick must be > active_start_tick"
+        )
+    pins = raw.get("pins")
+    if not isinstance(pins, list) or not pins:
+        raise ValueError(f"macro activity sidecar must contain non-empty pins[]: {path}")
+    seen: set[str] = set()
+    rows: list[JsonDict] = []
+    for index, pin in enumerate(pins):
+        if not isinstance(pin, dict):
+            raise ValueError(f"{path}: macro activity pin row[{index}] must be an object")
+        full_name = _must_be_safe_pin_name(pin.get("full_name"))
+        if full_name in seen:
+            raise ValueError(f"duplicate macro_activity full_name '{full_name}' in {path}")
+        seen.add(full_name)
+        source_value = str(pin.get("source", "")).strip()
+        if source_value != "vcd":
+            raise ValueError(f"unsupported macro activity source '{source_value or 'missing'}' in {path}")
+        rows.append(
+            {
+                "full_name": full_name,
+                "density_hz": _must_be_positive_finite("density_hz", pin.get("density_hz")),
+                "duty_cycle": _must_be_duty_cycle(pin.get("duty_cycle")),
+                "transition_count": _must_be_positive_finite("transition_count", pin.get("transition_count")),
+                "source": source_value,
+            }
+        )
+    return rows
+
+
+def _write_macro_activity_tcl_assignments(*, path: Path, rows: list[JsonDict]) -> None:
+    lines = ["set rtlgen_macro_activity_assignments {"]
+    for row in sorted(rows, key=lambda item: item["full_name"]):
+        lines.append(
+            "  {{{full_name} {density} {duty} {transition}}}".format(
+                full_name=row["full_name"],
+                density=f"{row['density_hz']:.17g}",
+                duty=f"{row['duty_cycle']:.17g}",
+                transition=f"{row['transition_count']:.17g}",
+            )
+        )
+    lines.append("}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
     raw_phases = manifest.get("phases")
     if not isinstance(raw_phases, list) or not raw_phases:
@@ -70,16 +194,49 @@ def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
         if not vcd.is_file():
             raise FileNotFoundError(f"phase VCD does not exist: {vcd}")
         expected_hash = str(raw.get("vcd_sha256", "")).strip().lower()
+        if not expected_hash:
+            raise ValueError(f"phase {phase} requires vcd_sha256")
         actual_hash = _sha256(vcd)
-        if expected_hash and expected_hash != actual_hash:
+        if expected_hash != actual_hash:
             raise ValueError(
                 f"phase {phase} VCD hash mismatch: expected {expected_hash}, got {actual_hash}"
             )
-        measured_cycles = int(raw.get("measured_cycles", raw.get("trace_cycles", 0)))
-        scaling = raw.get("scaling") if isinstance(raw.get("scaling"), dict) else {}
-        full_context_cycles = int(
-            raw.get("full_context_cycles", scaling.get("full_context_cycles", 0))
+        vcd_basename = vcd.name
+        macro_activity_value = str(
+            raw.get("macro_activity", raw.get("macro_activity_path", ""))
+        ).strip()
+        if not macro_activity_value:
+            raise ValueError(f"phase {phase} is missing macro_activity")
+        macro_activity = Path(macro_activity_value)
+        if not macro_activity.is_absolute():
+            macro_activity = (manifest_path.parent / macro_activity).resolve()
+        if not macro_activity.is_file():
+            raise FileNotFoundError(f"phase macro activity sidecar does not exist: {macro_activity}")
+        expected_macro_activity_hash = str(raw.get("macro_activity_sha256", "")).strip().lower()
+        if not expected_macro_activity_hash:
+            raise ValueError(f"phase {phase} requires macro_activity_sha256")
+        macro_activity_hash = _sha256(macro_activity)
+        if expected_macro_activity_hash != macro_activity_hash:
+            raise ValueError(
+                f"phase {phase} macro activity hash mismatch: "
+                f"expected {expected_macro_activity_hash}, got {macro_activity_hash}"
+            )
+        macro_activity_rows = _load_macro_activity(
+            macro_activity,
+            vcd_sha256=actual_hash,
+            phase_vcd_basename=vcd_basename,
         )
+        measured_cycles_raw = raw.get("measured_cycles")
+        if measured_cycles_raw is None:
+            raise ValueError(f"phase {phase} is missing measured_cycles")
+        measured_cycles = int(measured_cycles_raw)
+        scaling = raw.get("scaling") if isinstance(raw.get("scaling"), dict) else {}
+        full_context_raw = raw.get("full_context_cycles")
+        if full_context_raw is None:
+            full_context_raw = scaling.get("full_context_cycles")
+            if full_context_raw is None:
+                raise ValueError(f"phase {phase} is missing full_context_cycles")
+        full_context_cycles = int(full_context_raw)
         if measured_cycles <= 0 or full_context_cycles <= 0:
             raise ValueError(
                 f"phase {phase} requires positive measured_cycles and full_context_cycles"
@@ -91,6 +248,11 @@ def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
                 "vcd": vcd_value,
                 "_resolved_vcd": str(vcd),
                 "vcd_sha256": actual_hash,
+                "macro_activity": macro_activity_value,
+                "_resolved_macro_activity": str(macro_activity),
+                "macro_activity_sha256": macro_activity_hash,
+                "macro_activity_rows": macro_activity_rows,
+                "macro_activity_assignment_count": len(macro_activity_rows),
                 "measured_cycles": measured_cycles,
                 "full_context_cycles": full_context_cycles,
                 "requires_macro_activity": bool(
@@ -203,6 +365,38 @@ set design_power_category_count [expr {[llength $totals] / 4}]
 set design_power_totals [lrange $totals 0 3]
 set all_design_pins_unsorted {}
 set macro_pin_transfer_query_error_count 0
+set macro_pin_transfer_structural_query_error_count 0
+set macro_pin_transfer_structural_assignment_count 0
+set macro_pin_transfer_structural_matched_count 0
+set macro_pin_transfer_structural_applied_count 0
+set macro_pin_transfer_structural_unmatched_count 0
+set macro_pin_transfer_structural_apply_error_count 0
+set macro_pin_transfer_structural_assignments {}
+set macro_pin_transfer_structural_assignment_rows_by_full_name {}
+set macro_pin_transfer_structural_unmatched_rows_by_full_name {}
+set macro_pin_transfer_structural_unmatched_full_names {}
+if {[info exists ::env(RTLGEN_MACRO_ACTIVITY_TCL)] && $::env(RTLGEN_MACRO_ACTIVITY_TCL) ne ""} {
+  if {[catch {source $::env(RTLGEN_MACRO_ACTIVITY_TCL)} structural_source_error]} {
+    incr macro_pin_transfer_structural_query_error_count
+  } else {
+    if {[info exists rtlgen_macro_activity_assignments]} {
+      set macro_pin_transfer_structural_assignments $rtlgen_macro_activity_assignments
+    } else {
+      incr macro_pin_transfer_structural_query_error_count
+    }
+  }
+}
+set macro_pin_transfer_structural_assignment_count [llength $macro_pin_transfer_structural_assignments]
+foreach macro_pin_transfer_structural_row $macro_pin_transfer_structural_assignments {
+  if {[llength $macro_pin_transfer_structural_row] != 4} {
+    incr macro_pin_transfer_structural_query_error_count
+    continue
+  }
+  lassign $macro_pin_transfer_structural_row macro_pin_transfer_structural_full_name macro_pin_transfer_structural_density macro_pin_transfer_structural_duty macro_pin_transfer_structural_transition_count
+  dict set macro_pin_transfer_structural_assignment_rows_by_full_name $macro_pin_transfer_structural_full_name [list $macro_pin_transfer_structural_density $macro_pin_transfer_structural_duty $macro_pin_transfer_structural_transition_count]
+  dict set macro_pin_transfer_structural_unmatched_rows_by_full_name $macro_pin_transfer_structural_full_name 1
+}
+set macro_pin_transfer_structural_candidate_count $macro_pin_transfer_structural_assignment_count
 if {[catch {set all_design_pins_unsorted [get_pins -hierarchical *]}]} {
   incr macro_pin_transfer_query_error_count
   set all_design_pins_unsorted {}
@@ -248,15 +442,35 @@ set macro_pin_transfer_toggle_by_full_name {}
 set macro_pin_transfer_source_kind_by_full_name {}
 set macro_pin_transfer_apply_results {}
 foreach macro_pin $all_design_pins {
+  if {[catch {set macro_pin_full_name [get_property $macro_pin full_name]}]} {
+    incr macro_pin_transfer_query_error_count
+    if {[llength $macro_pin_transfer_structural_assignments] > 0} {
+      incr macro_pin_transfer_structural_query_error_count
+    }
+    continue
+  }
+  if {[dict exists $macro_pin_transfer_structural_assignment_rows_by_full_name $macro_pin_full_name]} {
+    set macro_pin_transfer_structural_row \
+      [dict get $macro_pin_transfer_structural_assignment_rows_by_full_name $macro_pin_full_name]
+    dict unset macro_pin_transfer_structural_unmatched_rows_by_full_name $macro_pin_full_name
+    incr macro_pin_transfer_structural_matched_count
+    lassign $macro_pin_transfer_structural_row macro_pin_structural_density macro_pin_structural_duty macro_pin_structural_transition_count
+    lappend macro_pin_transfer_updates \
+      [list $macro_pin_full_name $macro_pin $macro_pin_structural_density $macro_pin_structural_duty]
+    dict set macro_pin_transfer_candidate_source_by_full_name $macro_pin_full_name vcd
+    dict set macro_pin_transfer_candidate_source_kind_by_full_name $macro_pin_full_name structural_vcd_sidecar
+    dict set macro_pin_transfer_candidate_toggle_by_full_name $macro_pin_full_name $macro_pin_structural_transition_count
+    if {[llength $macro_pin_transfer_scan_samples] < $macro_pin_transfer_scan_sample_limit} {
+    lappend macro_pin_transfer_scan_samples \
+      [list $macro_pin_full_name structural_vcd_sidecar structural_vcd_sidecar]
+    }
+    continue
+  }
   if {[catch {set is_hierarchical [get_property $macro_pin is_hierarchical]}]} {
     incr macro_pin_transfer_query_error_count
     continue
   }
   if {$is_hierarchical} {
-    continue
-  }
-  if {[catch {set macro_pin_full_name [get_property $macro_pin full_name]}]} {
-    incr macro_pin_transfer_query_error_count
     continue
   }
   if {![string match "*u_group_*" $macro_pin_full_name]} {
@@ -439,6 +653,13 @@ foreach macro_pin $all_design_pins {
     dict set macro_pin_transfer_candidate_toggle_by_full_name $macro_pin_full_name $selected_driver_toggle
   }
 }
+set macro_pin_transfer_structural_unmatched_count [dict size $macro_pin_transfer_structural_unmatched_rows_by_full_name]
+if {$macro_pin_transfer_structural_unmatched_count > 0} {
+  dict for {macro_pin_transfer_structural_unmatched_full_name _} \
+    $macro_pin_transfer_structural_unmatched_rows_by_full_name {
+    lappend macro_pin_transfer_structural_unmatched_full_names $macro_pin_transfer_structural_unmatched_full_name
+  }
+}
 
 if {[llength $macro_pin_transfer_updates] > 0} {
   set macro_pin_transfer_apply_results [rtlgen_apply_macro_pin_activities $macro_pin_transfer_updates]
@@ -451,6 +672,10 @@ if {[llength $macro_pin_transfer_updates] > 0} {
         continue
       }
       incr macro_pin_transfer_applied_count
+      if {[dict exists $macro_pin_transfer_candidate_source_kind_by_full_name $pin_full_name] &&
+          [dict get $macro_pin_transfer_candidate_source_kind_by_full_name $pin_full_name] eq "structural_vcd_sidecar"} {
+        incr macro_pin_transfer_structural_applied_count
+      }
       lappend macro_pin_transfer_record_full_names $pin_full_name
       set pin_source [dict get $macro_pin_transfer_candidate_source_by_full_name $pin_full_name]
       if {[dict exists $macro_pin_transfer_candidate_source_kind_by_full_name $pin_full_name]} {
@@ -474,6 +699,10 @@ if {[llength $macro_pin_transfer_updates] > 0} {
       }
     } else {
       incr macro_pin_transfer_apply_error_count
+      if {[dict exists $macro_pin_transfer_candidate_source_kind_by_full_name $pin_full_name] &&
+          [dict get $macro_pin_transfer_candidate_source_kind_by_full_name $pin_full_name] eq "structural_vcd_sidecar"} {
+        incr macro_pin_transfer_structural_apply_error_count
+      }
     }
   }
   if {[llength $macro_pin_transfer_record_full_names] > 0} {
@@ -604,7 +833,9 @@ foreach pin $all_design_pins {
     set macro_pin_toggle_for_macro_activity \
       [dict get $macro_pin_transfer_toggle_by_full_name $full_name]
   }
-  if {[string match "*u_group_*" $full_name]} {
+  set is_macro_pin_for_activity \
+    [expr {[dict exists $macro_pin_transfer_source_by_full_name $full_name] || [string match "*u_group_*" $full_name]}]
+  if {$is_macro_pin_for_activity} {
     incr macro_annotatable
     if {$macro_pin_origin_bucket == "vcd"} {
       incr macro_vcd_origin_count
@@ -789,6 +1020,12 @@ puts $fp "  \"macro_trace_active_pin_count\": $macro_trace_active_count,"
 puts $fp "  \"macro_trace_backed_zero_toggle_pin_count\": $macro_trace_backed_zero_toggle_count"
 puts $fp ","
 puts $fp "  \"macro_pin_transfer\": {"
+puts $fp "    \"structural_assignment_count\": $macro_pin_transfer_structural_assignment_count,"
+puts $fp "    \"structural_matched_count\": $macro_pin_transfer_structural_matched_count,"
+puts $fp "    \"structural_applied_count\": $macro_pin_transfer_structural_applied_count,"
+puts $fp "    \"structural_unmatched_count\": $macro_pin_transfer_structural_unmatched_count,"
+puts $fp "    \"structural_query_error_count\": $macro_pin_transfer_structural_query_error_count,"
+puts $fp "    \"structural_apply_error_count\": $macro_pin_transfer_structural_apply_error_count,"
 puts $fp "    \"candidate_count\": $macro_pin_transfer_candidate_count,"
 puts $fp "    \"applied_count\": $macro_pin_transfer_applied_count,"
 puts $fp "    \"query_error_count\": $macro_pin_transfer_query_error_count,"
@@ -929,6 +1166,7 @@ def _run_openroad_phase(
     flow_variant: str,
     vcd: Path,
     scope: str,
+    macro_activity_tcl: Path | None = None,
     tcl: Path,
     result: Path,
     timeout_seconds: int,
@@ -946,6 +1184,8 @@ def _run_openroad_phase(
         ".PHONY: rtlgen_activity_power\n"
         "rtlgen_activity_power:\n"
         f"\t@RTLGEN_ACTIVITY_VCD='{vcd}' "
+        +(f"RTLGEN_MACRO_ACTIVITY_TCL='{macro_activity_tcl}' " if macro_activity_tcl else "")
+        +
         f"RTLGEN_ACTIVITY_SCOPE='{scope}' "
         f"RTLGEN_ACTIVITY_RESULT='{result}' "
         f"$(OPENROAD_CMD) '{tcl}'\n"
@@ -1033,12 +1273,21 @@ def build_report(
         tcl = temp / "activity_power.tcl"
         tcl.write_text(_tcl_script(), encoding="utf-8")
         for phase in phases:
+            phase_macro_activity_tcl: Path | None = None
+            phase_macro_activity_rows = phase.get("macro_activity_rows")
+            if phase_macro_activity_rows:
+                phase_macro_activity_tcl = temp / f"{phase['phase']}.macro_activity.tcl"
+                _write_macro_activity_tcl_assignments(
+                    path=phase_macro_activity_tcl,
+                    rows=phase_macro_activity_rows,  # type: ignore[arg-type]
+                )
             result = temp / f"{phase['phase']}.json"
             power = _run_openroad_phase(
                 design_config=design_config,
                 flow_variant=flow_variant,
                 vcd=Path(str(phase["_resolved_vcd"])),
                 scope=scope,
+                macro_activity_tcl=phase_macro_activity_tcl,
                 tcl=tcl,
                 result=result,
                 timeout_seconds=timeout_seconds,
@@ -1067,6 +1316,28 @@ def build_report(
                     power.get("leaf_direct_vcd_pin_count", 0),
                 )
             )
+            macro_activity_assignment_count = int(phase.get("macro_activity_assignment_count", 0))
+            macro_pin_transfer = power.get("macro_pin_transfer", {})
+            if not isinstance(macro_pin_transfer, dict):
+                macro_pin_transfer = {}
+            macro_pin_transfer_structural_assignment_count = int(
+                macro_pin_transfer.get("structural_assignment_count", 0)
+            )
+            macro_pin_transfer_structural_matched_count = int(
+                macro_pin_transfer.get("structural_matched_count", 0)
+            )
+            macro_pin_transfer_structural_applied_count = int(
+                macro_pin_transfer.get("structural_applied_count", 0)
+            )
+            macro_pin_transfer_structural_unmatched_count = int(
+                macro_pin_transfer.get("structural_unmatched_count", 0)
+            )
+            macro_pin_transfer_structural_query_error_count = int(
+                macro_pin_transfer.get("structural_query_error_count", 0)
+            )
+            macro_pin_transfer_structural_apply_error_count = int(
+                macro_pin_transfer.get("structural_apply_error_count", 0)
+            )
             trace_coverage = (
                 trace_backed / leaf_annotatable
                 if leaf_annotatable
@@ -1091,6 +1362,17 @@ def build_report(
                 macro_active >= min_macro_active_pins
                 and macro_coverage >= min_macro_active_coverage
             )
+            structural_macro_gate = (
+                macro_pin_transfer_structural_assignment_count
+                == macro_pin_transfer_structural_matched_count
+                == macro_pin_transfer_structural_applied_count
+                == macro_activity_assignment_count
+                and macro_pin_transfer_structural_unmatched_count == 0
+                and macro_pin_transfer_structural_query_error_count == 0
+                and macro_pin_transfer_structural_apply_error_count == 0
+            )
+            if phase["requires_macro_activity"]:
+                macro_pass = macro_pass and macro_activity_assignment_count > 0
             sdc_period_value = power.get("sdc_clock_period_ns")
             sdc_period_ns = (
                 float(sdc_period_value) if sdc_period_value is not None else 0.0
@@ -1119,10 +1401,12 @@ def build_report(
                     "annotation_gate_pass": annotation_gate_pass,
                     "macro_activity_gate_pass": macro_pass,
                     "macro_trace_active_coverage": macro_coverage,
+                    "structural_macro_activity_gate_pass": structural_macro_gate,
                     "clock_period_gate_pass": clock_period_pass,
                     "power_numeric_gate_pass": power_numeric_pass,
                     "phase_gate_pass": annotation_gate_pass
                     and macro_pass
+                    and structural_macro_gate
                     and clock_period_pass
                     and power_numeric_pass,
                     "full_context_energy_j": energy_j,

--- a/tests/test_attention_decode_score_multivalue_cluster_activity.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity.py
@@ -1,39 +1,11 @@
 import hashlib
 import json
-import re
 import shutil
 from pathlib import Path
 
 import pytest
 
 from npu.eval.generate_attention_decode_score_multivalue_cluster_activity import generate_phase_activity
-
-
-_SCOPE_VCD_VAR_RE = re.compile(r"^\s*\$var\s+\w+\s+1\s+\S+\s+(?P<name>\\\S+)\s+\$end$")
-
-
-def _score_bank_scalar_vcd_aliases(vcd_path: Path, *, scope: str = "score_bank") -> set[str]:
-    inside_score_bank = False
-    scope_depth = 0
-    names: set[str] = set()
-    for line in vcd_path.read_text(encoding="utf-8", errors="ignore").splitlines():
-        stripped = line.strip()
-        if not inside_score_bank:
-            if stripped == f"$scope module {scope} $end":
-                inside_score_bank = True
-                scope_depth = 1
-            continue
-
-        if stripped.startswith("$scope "):
-            scope_depth += 1
-        elif stripped.startswith("$upscope"):
-            scope_depth -= 1
-            if scope_depth == 0:
-                break
-        elif scope_depth >= 1 and stripped.startswith("$var "):
-            if match := _SCOPE_VCD_VAR_RE.match(stripped):
-                names.add(match.group("name"))
-    return names
 
 
 def _tool_available(name: str) -> bool:
@@ -84,6 +56,22 @@ def test_multivalue_cluster_activity_generates_phase_vcds_and_manifest(tmp_path:
         assert "$timescale" in text
         assert "$scope module tb $end" in text
         assert phase["measured_cycles"] > 0
+        assert "macro_activity" in phase
+        assert "macro_activity_sha256" in phase
+        macro_activity_path = tmp_path / phase["macro_activity"]
+        assert macro_activity_path.exists()
+        sidecar_raw = macro_activity_path.read_bytes()
+        assert phase["macro_activity_sha256"] == hashlib.sha256(sidecar_raw).hexdigest()
+        macro = json.loads(sidecar_raw)
+        assert macro["version"] == 1
+        assert macro["model"] == "fakeram_macro_pin_vcd_activity_v1"
+        assert macro["scope"] == "tb/dut"
+        assert macro["source_vcd"] == phase["vcd"]
+        assert macro["source_vcd_sha256"] == phase["vcd_sha256"]
+        assert macro["active_start_tick"] < macro["active_end_tick"]
+        assert macro["timescale_seconds"] > 0
+        assert len(macro["pins"]) == 5096
+        assert macro["pins"] == sorted(macro["pins"], key=lambda row: row["full_name"])
 
     score_fill = phases["score_fill"]
     assert (score_fill["measured_cycles"] - 1) % manifest["block_count"] == 0
@@ -135,16 +123,3 @@ def test_phase_scaling_is_invariant_across_representative_block_counts(
     assert phases["replay_value"]["full_context_cycles"] == 16 + 68 * 16384
     assert phases["finalize_result"]["full_context_cycles"] == 7696
     assert manifest["phase_partition_cycle_sum"] == manifest["representative_full_transaction_cycles"]
-
-
-def test_score_fill_vcd_contains_fakeram_scalar_aliases_for_vector_ports(tmp_path: Path) -> None:
-    if not _tool_available("iverilog") or not _tool_available("vvp"):
-        pytest.skip("iverilog/vvp unavailable")
-
-    manifest = generate_phase_activity(_config(), tmp_path, block_count=1, head_dim=3, clock_period_ns=10.0)
-    phases = {row["phase"]: row for row in manifest["phases"]}
-    score_fill_vcd = tmp_path / phases["score_fill"]["vcd"]
-    aliases = _score_bank_scalar_vcd_aliases(score_fill_vcd)
-
-    for alias in ["\\addr_in[0]", "\\wd_in[0]", "\\wd_in[38]", "\\w_mask_in[0]", "\\w_mask_in[38]"]:
-        assert alias in aliases, f"missing escaped scalar alias {alias} in score_bank scope"

--- a/tests/test_extract_fakeram_vcd_activity.py
+++ b/tests/test_extract_fakeram_vcd_activity.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Tests for Fakeram VCD extractor."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from npu.eval.extract_fakeram_vcd_activity import extract_fakeram_vcd_activity
+
+
+def _write_vcd(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+
+
+def _mini_vcd() -> str:
+    zero_11 = "0" * 11
+    one_11 = "10000000001"
+    zero_39 = "0" * 39
+    return "\n".join(
+        [
+            "$date",
+            " Mini activity vcd",
+            "$end",
+            "$version",
+            "  test",
+            "$end",
+            "$timescale",
+            " 1ns/1ps",
+            "$end",
+            "$scope module tb $end",
+            "$scope module dut $end",
+            "$scope module outer $end",
+            "$scope module score_bank $end",
+            "$scope module u_group_0_slice_0 $end",
+            "$var reg 11 a addr_in [10:0] $end",
+            "$var reg 39 b wd_in [38:0] $end",
+            "$var reg 39 c w_mask_in [38:0] $end",
+            "$var reg 1 d we_in $end",
+            "$var reg 1 e ce_in $end",
+            "$var reg 1 f \\ alias_we_in $end",
+            "$upscope $end",
+            "$upscope $end",
+            "$upscope $end",
+            "$upscope $end",
+            "$upscope $end",
+            "$enddefinitions",
+            "#0",
+            f"b{zero_11} a",
+            f"b{zero_39} b",
+            f"b{zero_39} c",
+            "0d",
+            "1e",
+            "#10",
+            "$dumpon",
+            "#15",
+            f"b{one_11} a",
+            "1d",
+            "#20",
+            "xd",
+            "#25",
+            f"b{zero_11} a",  # addr_in[10] goes low again
+            "#30",
+            "xd",
+            "#35",
+            "#40",
+            "1d",
+            "#50",
+            "0d",
+            "#55",
+            "zd",
+            "#60",
+            "$dumpoff",
+        ]
+    )
+
+
+def test_extract_fakeram_activity_mini_vcd_semantics(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "mini.vcd"
+    _write_vcd(vcd_path, _mini_vcd())
+    payload = extract_fakeram_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+        scope="tb/dut",
+        group_indices=(0,),
+        slice_indices=(0,),
+        expected_pin_count=91,
+    )
+
+    assert payload["version"] == 1
+    assert payload["model"] == "fakeram_macro_pin_vcd_activity_v1"
+    assert payload["scope"] == "tb/dut"
+    assert payload["source_vcd"] == vcd_path.name
+    assert payload["timescale_seconds"] == 1e-12
+    assert payload["active_start_tick"] == 10
+    assert payload["active_end_tick"] == 60
+    assert payload["active_end_tick"] > payload["active_start_tick"]
+    assert len(payload["pins"]) == 91
+
+    ordered = [row["full_name"] for row in payload["pins"]]
+    assert ordered == sorted(ordered)
+
+    by_name = {row["full_name"]: row for row in payload["pins"]}
+    assert "score_bank/u_group_0_slice_0/addr_in[10]" in by_name
+    assert "score_bank/u_group_0_slice_0/addr_in[0]" in by_name
+    assert by_name["score_bank/u_group_0_slice_0/addr_in[10]"]["transition_count"] == 2.0
+    assert by_name["score_bank/u_group_0_slice_0/addr_in[0]"]["transition_count"] == 2.0
+    assert by_name["score_bank/u_group_0_slice_0/we_in"]["transition_count"] == 3.5
+    assert by_name["score_bank/u_group_0_slice_0/we_in"]["duty_cycle"] == pytest.approx(0.3)
+    assert by_name["score_bank/u_group_0_slice_0/we_in"]["density_hz"] == pytest.approx(
+        3.5 / (50 * 1e-12)
+    )
+    assert "score_bank/u_group_0_slice_0/alias_we_in" not in by_name
+
+
+def test_extract_fakeram_activity_rejects_bad_hash(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "mini.vcd"
+    _write_vcd(vcd_path, _mini_vcd())
+    wrong_hash = hashlib.sha256(b"wrong").hexdigest()
+    with pytest.raises(ValueError, match="source_vcd_sha256 does not match"):
+        extract_fakeram_vcd_activity(vcd_path, source_vcd_sha256=wrong_hash, expected_pin_count=91)
+
+
+def test_extract_fakeram_activity_rejects_missing_active_window(tmp_path: Path) -> None:
+    path = tmp_path / "missing_active.vcd"
+    _write_vcd(
+        path,
+        "\n".join(
+            [
+                "$timescale",
+                "1ns/1ps",
+                "$end",
+                "$scope module tb $end",
+                "$scope module dut $end",
+                "$scope module score_bank $end",
+                "$scope module u_group_0_slice_0 $end",
+                "$var reg 11 a addr_in [10:0] $end",
+                "$var reg 1 d we_in $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$enddefinitions",
+                "#0",
+                "b00000000000 a",
+                "0d",
+            ]
+        ),
+    )
+    with pytest.raises(ValueError, match="missing active dumpon/dumpoff interval"):
+        extract_fakeram_vcd_activity(path, source_vcd_sha256=hashlib.sha256(path.read_bytes()).hexdigest(), expected_pin_count=12)
+
+
+def test_extract_fakeram_activity_accepts_exact_duplicate_declarations(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "duplicate_declaration.vcd"
+    _write_vcd(
+        vcd_path,
+        "\n".join(
+            [
+                "$timescale",
+                "1ns/1ps",
+                "$end",
+                "$scope module tb $end",
+                "$scope module dut $end",
+                "$scope module outer $end",
+                "$scope module score_bank $end",
+                "$scope module u_group_0_slice_0 $end",
+                "$var reg 11 a addr_in [10:0] $end",
+                "$var reg 11 a addr_in [10:0] $end",
+                "$var reg 39 b wd_in [38:0] $end",
+                "$var reg 39 b wd_in [38:0] $end",
+                "$var reg 39 c w_mask_in [38:0] $end",
+                "$var reg 39 c w_mask_in [38:0] $end",
+                "$var reg 1 d we_in $end",
+                "$var reg 1 d we_in $end",
+                "$var reg 1 e ce_in $end",
+                "$var reg 1 e ce_in $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$enddefinitions",
+                "#0",
+                f"b{'0'*11} a",
+                f"b{'0'*39} b",
+                f"b{'0'*39} c",
+                "0d",
+                "0e",
+                "#1",
+                "$dumpon",
+                "#2",
+                "1d",
+                "#3",
+                "0d",
+                "#4",
+                "$dumpoff",
+            ]
+        ),
+    )
+    payload = extract_fakeram_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+        scope="tb/dut",
+        group_indices=(0,),
+        slice_indices=(0,),
+        expected_pin_count=91,
+    )
+    assert len(payload["pins"]) == 91
+    row = {row["full_name"]: row for row in payload["pins"]}["score_bank/u_group_0_slice_0/we_in"]
+    assert row["transition_count"] == 2.0
+
+
+def test_extract_fakeram_activity_rejects_inconsistent_duplicate_full_name(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "bad_duplicate.vcd"
+    _write_vcd(
+        vcd_path,
+        "\n".join(
+            [
+                "$timescale",
+                "1ns/1ps",
+                "$end",
+                "$scope module tb $end",
+                "$scope module dut $end",
+                "$scope module outer $end",
+                "$scope module score_bank $end",
+                "$scope module u_group_0_slice_0 $end",
+                "$var reg 11 a addr_in [10:0] $end",
+                "$var reg 11 b addr_in [10:0] $end",
+                "$var reg 39 c wd_in [38:0] $end",
+                "$var reg 39 d w_mask_in [38:0] $end",
+                "$var reg 1 e we_in $end",
+                "$var reg 1 f ce_in $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$enddefinitions",
+                "#0",
+                f"b{'0'*11} a",
+                f"b{'0'*39} c",
+                f"b{'0'*39} d",
+                "0e",
+                "0f",
+                "#1",
+                "$dumpon",
+                "#2",
+                "$dumpoff",
+            ]
+        ),
+    )
+    with pytest.raises(ValueError, match="duplicate declaration for .*addr_in"):
+        extract_fakeram_vcd_activity(
+            vcd_path,
+            source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+            scope="tb/dut",
+            group_indices=(0,),
+            slice_indices=(0,),
+            expected_pin_count=91,
+        )

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -23,12 +23,53 @@ SPEC.loader.exec_module(MODULE)
 
 
 class PostrouteVcdPowerTests(unittest.TestCase):
+    def _macro_activity(
+        self,
+        *,
+        phase_name: str,
+        vcd: Path,
+        overrides: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        sidecar: dict[str, object] = {
+            "version": 1,
+            "model": MODULE._FAKERAM_ACTIVITY_MODEL,
+            "source_vcd_sha256": MODULE._sha256(vcd),
+            "source_vcd": vcd.name,
+            "scope": "tb/dut",
+            "timescale_seconds": 1e-9,
+            "active_start_tick": 0,
+            "active_end_tick": 1000,
+            "pins": [
+                {
+                    "full_name": f"{phase_name}_macro_u_group/u_pin_1",
+                    "density_hz": 1_000_000.0,
+                    "duty_cycle": 0.5,
+                    "transition_count": 10.0,
+                    "source": "vcd",
+                }
+            ],
+        }
+        if overrides is not None:
+            sidecar.update(overrides)
+        return sidecar
+
+    def _write_macro_activity(self, root: Path, *, phase_name: str, vcd: Path) -> Path:
+        sidecar = self._macro_activity(
+            phase_name=phase_name,
+            vcd=vcd,
+        )
+        path = root / f"{phase_name}.macro_activity.json"
+        path.write_text(json.dumps(sidecar), encoding="utf-8")
+        return path
+
     def _write_tcl_runtime_stub(
         self,
         root: Path,
         result: Path,
         *,
         macro_transfer: bool = False,
+        macro_activity_tcl: Path | None = None,
+        macro_transfer_pin_names: tuple[str, str, str] | None = None,
         leaf_specs: tuple[tuple[str, str, str], ...] | None = None,
     ) -> str:
         if leaf_specs is None:
@@ -56,16 +97,17 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 ]
             )
         if macro_transfer:
-            all_pins = [
-                "pin_other_0",
-                "pin_input_u_group_0",
-                "pin_nonfinite_u_group",
-            ]
-            net_pins = [
-                "driver_pin_u_group_0",
-                "peer_pin_u_group_0",
-                "pin_input_u_group_0",
-            ]
+            if macro_transfer_pin_names is None:
+                macro_transfer_pin_names = (
+                    "pin_other_0",
+                    "pin_input_u_group_0",
+                    "pin_nonfinite_u_group",
+                )
+            input_pin = macro_transfer_pin_names[1]
+            driver_pin = f"driver_{input_pin}"
+            peer_pin = f"peer_{input_pin}"
+            all_pins = list(macro_transfer_pin_names)
+            net_pins = [driver_pin, peer_pin, input_pin]
             get_pins_body = [
                 "  if {[lindex $args 0] eq \"-hierarchical\"} {",
                 "    set pattern [lindex $args end]",
@@ -78,32 +120,33 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "    if {$net eq {net_u_group_0}} {",
                 f"      return {{{' '.join(net_pins)}}}",
                 "    }",
+                "    return {}",
                 "  }",
                 f"  return {{{' '.join(all_pins)}}}",
             ]
             pin_property_body = [
-                "  if {$obj eq {pin_input_u_group_0}} {",
+                f"  if {{$obj eq {{{input_pin}}}}} {{",
                 "    if {$property eq \"is_hierarchical\"} { return 0 }",
                 "    if {$property eq \"direction\"} { return \"input\" }",
                 "    if {$property eq \"activity\"} { return {0.0 0.0 constant} }",
                 "    if {$property eq \"full_name\"} { return $obj }",
                 "  }",
-                "  if {$obj eq {driver_pin_u_group_0}} {",
+                f"  if {{$obj eq {{{driver_pin}}}}} {{",
                 "    if {$property eq \"activity\"} { return {0.4 0.9 other} }",
                 "  }",
-                "  if {$obj eq {peer_pin_u_group_0}} {",
+                f"  if {{$obj eq {{{peer_pin}}}}} {{",
                 "    if {$property eq \"activity\"} { return {0.9 0.8 propagated} }",
                 "  }",
             ]
             net_driver_body = [
                 "  proc net_driver_pins {net} {",
-                "    if {$net eq {net_u_group_0}} { return {driver_pin_u_group_0} }",
+                f"    if {{$net eq {{net_u_group_0}}}} {{ return {{{driver_pin}}} }}",
                 "    return {}",
                 "  }",
             ]
             net_and_activity_body = [
                 "proc get_nets {args} {",
-                "  if {[lindex $args 0] eq \"-of_objects\" && [lindex $args 1] eq {pin_input_u_group_0}} {",
+                f"  if {{[lindex $args 0] eq \"-of_objects\" && [lindex $args 1] eq {{{input_pin}}}}} {{",
                 "    return {net_u_group_0}",
                 "  }",
                 "  return {}",
@@ -217,6 +260,11 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             f"set ::env(RTLGEN_ACTIVITY_VCD) \"{root / 'trace.vcd'}\"",
             f"set ::env(RTLGEN_ACTIVITY_SCOPE) \"tb/dut\"",
             f"set ::env(RTLGEN_ACTIVITY_RESULT) \"{result}\"",
+            (
+                f"set ::env(RTLGEN_MACRO_ACTIVITY_TCL) \"{macro_activity_tcl}\""
+                if macro_activity_tcl is not None
+                else "set ::env(RTLGEN_MACRO_ACTIVITY_TCL) \"\""
+            ),
             MODULE._tcl_script(),
             "if {$::ref_name_query_count == 0} {",
             "  error \"assertion failed: expected at least one instance ref_name query\"",
@@ -389,9 +437,24 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             (scripts / "load.tcl").write_text("", encoding="utf-8")
 
             result = root / "activity_power.json"
+            macro_activity_tcl = root / "macro_activity.tcl"
+            macro_activity_tcl.write_text(
+                "set rtlgen_macro_activity_assignments {\n"
+                "  {pin_input_u_group[7]/dq[3] 1.234 0.5 8.9}\n"
+                "}\n",
+                encoding="utf-8",
+            )
             tcl_script_path = root / "activity_power.tcl"
             tcl_script = self._write_tcl_runtime_stub(
-                root=root, result=result, macro_transfer=True
+                root=root,
+                result=result,
+                macro_transfer=True,
+                macro_activity_tcl=macro_activity_tcl,
+                macro_transfer_pin_names=(
+                    "pin_other_0",
+                    "pin_input_u_group[7]/dq[3]",
+                    "pin_nonfinite_u_group",
+                ),
             )
             tcl_script_path.write_text(tcl_script, encoding="utf-8")
             tcl = shutil.which("tclsh")
@@ -411,46 +474,58 @@ class PostrouteVcdPowerTests(unittest.TestCase):
 
             payload = json.loads(result.read_text(encoding="utf-8"))
             transfer = payload["macro_pin_transfer"]
-            self.assertEqual(transfer["candidate_count"], 1)
+            self.assertEqual(transfer["candidate_count"], 0)
             self.assertEqual(transfer["applied_count"], 1)
             self.assertEqual(transfer["query_error_count"], 0)
             self.assertEqual(transfer["apply_error_count"], 0)
-            self.assertEqual(transfer["source_vcd_count"], 0)
-            self.assertEqual(transfer["source_propagated_count"], 1)
+            self.assertEqual(transfer["structural_assignment_count"], 1)
+            self.assertEqual(transfer["structural_matched_count"], 1)
+            self.assertEqual(transfer["structural_applied_count"], 1)
+            self.assertEqual(transfer["structural_unmatched_count"], 0)
+            self.assertEqual(transfer["structural_query_error_count"], 0)
+            self.assertEqual(transfer["structural_apply_error_count"], 0)
+            self.assertEqual(transfer["source_vcd_count"], 1)
+            self.assertEqual(transfer["source_propagated_count"], 0)
             self.assertEqual(transfer["active_count"], 1)
             self.assertEqual(transfer["zero_count"], 0)
             self.assertEqual(transfer["scanned_pin_count"], 3)
-            self.assertEqual(transfer["name_match_pin_count"], 1)
-            self.assertEqual(transfer["input_pin_count"], 1)
-            self.assertEqual(transfer["connected_pin_count"], 1)
+            self.assertEqual(transfer["name_match_pin_count"], 0)
+            self.assertEqual(transfer["input_pin_count"], 0)
+            self.assertEqual(transfer["connected_pin_count"], 0)
             self.assertEqual(transfer["no_net_pin_count"], 0)
-            self.assertEqual(transfer["driver_pin_count"], 1)
+            self.assertEqual(transfer["driver_pin_count"], 0)
             self.assertEqual(transfer["no_driver_pin_count"], 0)
             self.assertEqual(transfer["driver_origin_counts"]["vcd"], 0)
             self.assertEqual(transfer["driver_origin_counts"]["propagated"], 0)
             self.assertEqual(transfer["driver_origin_counts"]["clock"], 0)
             self.assertEqual(transfer["driver_origin_counts"]["constant"], 0)
-            self.assertEqual(transfer["driver_origin_counts"]["other"], 1)
+            self.assertEqual(transfer["driver_origin_counts"]["other"], 0)
             self.assertEqual(transfer["peer_origin_counts"]["vcd"], 0)
-            self.assertEqual(transfer["peer_origin_counts"]["propagated"], 1)
+            self.assertEqual(transfer["peer_origin_counts"]["propagated"], 0)
             self.assertEqual(transfer["peer_origin_counts"]["clock"], 0)
             self.assertEqual(transfer["peer_origin_counts"]["constant"], 0)
-            self.assertEqual(transfer["peer_origin_counts"]["other"], 1)
-            self.assertEqual(transfer["peer_pin_examined_count"], 2)
-            self.assertEqual(transfer["peer_eligible_count"], 1)
+            self.assertEqual(transfer["peer_origin_counts"]["other"], 0)
+            self.assertEqual(transfer["peer_pin_examined_count"], 0)
+            self.assertEqual(transfer["peer_eligible_count"], 0)
             self.assertEqual(len(transfer["transferred"]), 1)
             self.assertEqual(
-                transfer["transferred"][0]["full_name"], "pin_input_u_group_0"
+                transfer["transferred"][0]["full_name"], "pin_input_u_group[7]/dq[3]"
             )
-            self.assertEqual(transfer["transferred"][0]["source"], "propagated")
-            self.assertEqual(transfer["transferred"][0]["source_kind"], "net_peer")
+            self.assertEqual(transfer["transferred"][0]["source"], "vcd")
+            self.assertEqual(
+                transfer["transferred"][0]["source_kind"], "structural_vcd_sidecar"
+            )
             self.assertEqual(len(transfer["scan_samples"]), 1)
             self.assertEqual(
                 transfer["scan_samples"][0]["full_name"],
-                "pin_input_u_group_0",
+                "pin_input_u_group[7]/dq[3]",
             )
-            self.assertEqual(transfer["scan_samples"][0]["driver_origin"], "propagated")
-            self.assertEqual(transfer["scan_samples"][0]["source_kind"], "net_peer")
+            self.assertEqual(
+                transfer["scan_samples"][0]["driver_origin"], "structural_vcd_sidecar"
+            )
+            self.assertEqual(
+                transfer["scan_samples"][0]["source_kind"], "structural_vcd_sidecar"
+            )
             self.assertEqual(payload["macro_activity_origin_counts"]["transferred"], 1)
             self.assertEqual(payload["macro_trace_backed_pin_count"], 1)
             self.assertEqual(payload["macro_trace_active_pin_count"], 1)
@@ -655,11 +730,18 @@ class PostrouteVcdPowerTests(unittest.TestCase):
         ):
             vcd = root / f"{name}.vcd"
             vcd.write_text(f"$comment {name} $end\n", encoding="utf-8")
+            macro_activity = self._write_macro_activity(
+                root=root,
+                phase_name=name,
+                vcd=vcd,
+            )
             phases.append(
                 {
                     "phase": name,
                     "vcd": vcd.name,
                     "vcd_sha256": MODULE._sha256(vcd),
+                    "macro_activity": macro_activity.name,
+                    "macro_activity_sha256": MODULE._sha256(macro_activity),
                     "measured_cycles": measured,
                     "full_context_cycles": full,
                 }
@@ -669,6 +751,22 @@ class PostrouteVcdPowerTests(unittest.TestCase):
         path.write_text(json.dumps(manifest), encoding="utf-8")
         return manifest, path
 
+    def _with_structural_macro_transfer(
+        self,
+        power: dict[str, object],
+        assignment_count: int,
+    ) -> dict[str, object]:
+        payload = dict(power)
+        payload["macro_pin_transfer"] = {
+            "structural_assignment_count": assignment_count,
+            "structural_matched_count": assignment_count,
+            "structural_applied_count": assignment_count,
+            "structural_unmatched_count": 0,
+            "structural_query_error_count": 0,
+            "structural_apply_error_count": 0,
+        }
+        return payload
+
     def test_phase_manifest_rejects_hash_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:
             root = Path(temp_text)
@@ -676,6 +774,343 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             manifest["phases"][0]["vcd_sha256"] = "0" * 64
             with self.assertRaisesRegex(ValueError, "hash mismatch"):
                 MODULE._phase_rows(manifest, path)
+
+    def test_phase_manifest_rejects_macro_activity_hash_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, path = self._fixture(root)
+            manifest["phases"][0]["macro_activity_sha256"] = "f" * 64
+            with self.assertRaisesRegex(ValueError, "macro activity hash mismatch"):
+                MODULE._phase_rows(manifest, path)
+
+    def test_phase_manifest_rejects_missing_macro_activity_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, path = self._fixture(root)
+            manifest["phases"][0].pop("macro_activity")
+            with self.assertRaisesRegex(ValueError, "macro_activity"):
+                MODULE._phase_rows(manifest, path)
+
+    def test_phase_rows_rejects_invalid_macro_activity_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            invalid_sidecar = root / "bad_macro_activity.json"
+            invalid_sidecar.write_text(
+                json.dumps(
+                    self._macro_activity(
+                        phase_name="score_fill",
+                        vcd=vcd,
+                        overrides={
+                            "pins": [
+                                {
+                                    "full_name": "",
+                                    "density_hz": -1.0,
+                                    "duty_cycle": 1.2,
+                                    "transition_count": float("nan"),
+                                    "source": "vcd",
+                                }
+                            ],
+                        },
+                    )
+                ),
+                encoding="utf-8",
+            )
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": str(invalid_sidecar),
+                        "macro_activity_sha256": MODULE._sha256(invalid_sidecar),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "full_name"):
+                MODULE._phase_rows(manifest, manifest_path)
+
+    def test_phase_rows_rejects_macro_activity_version_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            invalid_sidecar = root / "bad_macro_activity.json"
+            invalid_sidecar.write_text(
+                json.dumps(
+                    self._macro_activity(
+                        phase_name="score_fill",
+                        vcd=vcd,
+                        overrides={"version": 2},
+                    )
+                ),
+                encoding="utf-8",
+            )
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": str(invalid_sidecar),
+                        "macro_activity_sha256": MODULE._sha256(invalid_sidecar),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "version"):
+                MODULE._phase_rows(manifest, manifest_path)
+
+    def test_phase_rows_rejects_macro_activity_source_vcd_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            invalid_sidecar = root / "bad_macro_activity.json"
+            invalid_sidecar.write_text(
+                json.dumps(
+                    self._macro_activity(
+                        phase_name="score_fill",
+                        vcd=vcd,
+                        overrides={"source_vcd": "other_trace.vcd"},
+                    )
+                ),
+                encoding="utf-8",
+            )
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": str(invalid_sidecar),
+                        "macro_activity_sha256": MODULE._sha256(invalid_sidecar),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "source_vcd"):
+                MODULE._phase_rows(manifest, manifest_path)
+
+    def test_phase_rows_rejects_macro_activity_scope_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            invalid_sidecar = root / "bad_macro_activity.json"
+            invalid_sidecar.write_text(
+                json.dumps(
+                    self._macro_activity(
+                        phase_name="score_fill",
+                        vcd=vcd,
+                        overrides={"scope": ""},
+                    )
+                ),
+                encoding="utf-8",
+            )
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": str(invalid_sidecar),
+                        "macro_activity_sha256": MODULE._sha256(invalid_sidecar),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "scope"):
+                MODULE._phase_rows(manifest, manifest_path)
+
+    def test_phase_rows_rejects_macro_activity_timescale_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            invalid_sidecar = root / "bad_macro_activity.json"
+            invalid_sidecar.write_text(
+                json.dumps(
+                    self._macro_activity(
+                        phase_name="score_fill",
+                        vcd=vcd,
+                        overrides={"timescale_seconds": -1.0},
+                    )
+                ),
+                encoding="utf-8",
+            )
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": str(invalid_sidecar),
+                        "macro_activity_sha256": MODULE._sha256(invalid_sidecar),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "timescale_seconds"):
+                MODULE._phase_rows(manifest, manifest_path)
+
+    def test_phase_rows_rejects_macro_activity_active_tick_order(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            invalid_sidecar = root / "bad_macro_activity.json"
+            invalid_sidecar.write_text(
+                json.dumps(
+                    self._macro_activity(
+                        phase_name="score_fill",
+                        vcd=vcd,
+                        overrides={"active_end_tick": 10, "active_start_tick": 10},
+                    )
+                ),
+                encoding="utf-8",
+            )
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": str(invalid_sidecar),
+                        "macro_activity_sha256": MODULE._sha256(invalid_sidecar),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "active range"):
+                MODULE._phase_rows(manifest, manifest_path)
+
+    def test_phase_rows_rejects_macro_activity_active_ticks_non_integer(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            invalid_sidecar = root / "bad_macro_activity.json"
+            invalid_sidecar.write_text(
+                json.dumps(
+                    self._macro_activity(
+                        phase_name="score_fill",
+                        vcd=vcd,
+                        overrides={"active_end_tick": 10.5},
+                    )
+                ),
+                encoding="utf-8",
+            )
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": "trace.vcd",
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": str(invalid_sidecar),
+                        "macro_activity_sha256": MODULE._sha256(invalid_sidecar),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "active_start_tick|active_end_tick|integer"):
+                MODULE._phase_rows(manifest, manifest_path)
+
+    def test_build_report_fails_if_structural_macro_activity_incomplete(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$comment score_fill $end\n", encoding="utf-8")
+            macro_activity = self._write_macro_activity(
+                root=root,
+                phase_name="score_fill",
+                vcd=vcd,
+            )
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": vcd.name,
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": macro_activity.name,
+                        "macro_activity_sha256": MODULE._sha256(macro_activity),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = self._with_structural_macro_transfer(
+                {
+                    "total_w": 1.0,
+                    "internal_w": 0.5,
+                    "switching_w": 0.5,
+                    "leakage_w": 0.0,
+                    "sdc_clock_period_ns": 8.0,
+                    "annotatable_pin_count": 1000,
+                    "leaf_annotatable_pin_count": 1000,
+                    "leaf_trace_backed_pin_count": 1000,
+                    "vcd_annotated_pin_count": 1000,
+                    "macro_trace_active_pin_count": 100,
+                    "macro_annotatable_pin_count": 100,
+                    "direct_annotatable_pin_count": 1000,
+                    "direct_vcd_pin_count": 1000,
+                },
+                assignment_count=1,
+            )
+            assert isinstance(power.get("macro_pin_transfer"), dict)
+            power["macro_pin_transfer"]["structural_applied_count"] = 0
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                report = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.5,
+                    min_vcd_pins=1,
+                    min_macro_active_coverage=0.5,
+                    min_macro_active_pins=1,
+                    timeout_seconds=10,
+                )
+            phase = report["phases"][0]
+            self.assertFalse(phase["structural_macro_activity_gate_pass"])
+            self.assertFalse(phase["phase_gate_pass"])
+            self.assertFalse(report["promotion_gate_pass"])
 
     def test_build_report_accounts_phase_energy_and_gates_coverage(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:
@@ -685,51 +1120,60 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             design_config.write_text("", encoding="utf-8")
             power_rows = iter(
                 [
-                    {
-                        "total_w": 2.0,
-                        "internal_w": 1.0,
-                        "switching_w": 0.8,
-                        "leakage_w": 0.2,
-                        "sdc_clock_period_ns": 8.0,
-                        "annotatable_pin_count": 1000,
-                        "leaf_annotatable_pin_count": 1000,
-                        "leaf_trace_backed_pin_count": 500,
-                        "vcd_annotated_pin_count": 500,
-                        "macro_trace_active_pin_count": 10,
-                        "macro_annotatable_pin_count": 100,
-                        "direct_annotatable_pin_count": 1000,
-                        "direct_vcd_pin_count": 200,
-                    },
-                    {
-                        "total_w": 3.0,
-                        "internal_w": 1.5,
-                        "switching_w": 1.2,
-                        "leakage_w": 0.3,
-                        "sdc_clock_period_ns": 8.0,
-                        "annotatable_pin_count": 1000,
-                        "leaf_annotatable_pin_count": 1000,
-                        "leaf_trace_backed_pin_count": 400,
-                        "vcd_annotated_pin_count": 400,
-                        "macro_trace_active_pin_count": 8,
-                        "macro_annotatable_pin_count": 100,
-                        "direct_annotatable_pin_count": 1000,
-                        "direct_vcd_pin_count": 160,
-                    },
-                    {
-                        "total_w": 1.0,
-                        "internal_w": 0.5,
-                        "switching_w": 0.4,
-                        "leakage_w": 0.1,
-                        "sdc_clock_period_ns": 8.0,
-                        "annotatable_pin_count": 1000,
-                        "leaf_annotatable_pin_count": 1000,
-                        "leaf_trace_backed_pin_count": 300,
-                        "vcd_annotated_pin_count": 300,
-                        "macro_trace_active_pin_count": 0,
-                        "macro_annotatable_pin_count": 100,
-                        "direct_annotatable_pin_count": 1000,
-                        "direct_vcd_pin_count": 80,
-                    },
+                    self._with_structural_macro_transfer(
+                        {
+                            "total_w": 2.0,
+                            "internal_w": 1.0,
+                            "switching_w": 0.8,
+                            "leakage_w": 0.2,
+                            "sdc_clock_period_ns": 8.0,
+                            "annotatable_pin_count": 1000,
+                            "leaf_annotatable_pin_count": 1000,
+                            "leaf_trace_backed_pin_count": 500,
+                            "vcd_annotated_pin_count": 500,
+                            "macro_trace_active_pin_count": 10,
+                            "macro_annotatable_pin_count": 100,
+                            "direct_annotatable_pin_count": 1000,
+                            "direct_vcd_pin_count": 200,
+                        },
+                        assignment_count=1,
+                    ),
+                    self._with_structural_macro_transfer(
+                        {
+                            "total_w": 3.0,
+                            "internal_w": 1.5,
+                            "switching_w": 1.2,
+                            "leakage_w": 0.3,
+                            "sdc_clock_period_ns": 8.0,
+                            "annotatable_pin_count": 1000,
+                            "leaf_annotatable_pin_count": 1000,
+                            "leaf_trace_backed_pin_count": 400,
+                            "vcd_annotated_pin_count": 400,
+                            "macro_trace_active_pin_count": 8,
+                            "macro_annotatable_pin_count": 100,
+                            "direct_annotatable_pin_count": 1000,
+                            "direct_vcd_pin_count": 160,
+                        },
+                        assignment_count=1,
+                    ),
+                    self._with_structural_macro_transfer(
+                        {
+                            "total_w": 1.0,
+                            "internal_w": 0.5,
+                            "switching_w": 0.4,
+                            "leakage_w": 0.1,
+                            "sdc_clock_period_ns": 8.0,
+                            "annotatable_pin_count": 1000,
+                            "leaf_annotatable_pin_count": 1000,
+                            "leaf_trace_backed_pin_count": 300,
+                            "vcd_annotated_pin_count": 300,
+                            "macro_trace_active_pin_count": 0,
+                            "macro_annotatable_pin_count": 100,
+                            "direct_annotatable_pin_count": 1000,
+                            "direct_vcd_pin_count": 80,
+                        },
+                        assignment_count=1,
+                    ),
                 ]
             )
             with mock.patch.object(MODULE, "_run_openroad_phase", side_effect=lambda **_: next(power_rows)):
@@ -897,39 +1341,42 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             manifest, manifest_path = self._fixture(root)
             design_config = root / "config.mk"
             design_config.write_text("", encoding="utf-8")
-            power = {
-                "total_w": 1.0,
-                "internal_w": 0.5,
-                "switching_w": 0.4,
-                "leakage_w": 0.1,
-                "sdc_clock_period_ns": 8.0,
-                "annotatable_pin_count": 1000,
-                "leaf_annotatable_pin_count": 1000,
-                "leaf_trace_backed_pin_count": 500,
-                "vcd_annotated_pin_count": 500,
-                "macro_trace_active_pin_count": 10,
-                "macro_annotatable_pin_count": 100,
-                "design_power_quartets": {
-                    "total": {
-                        "internal_w": 0.5,
-                        "switching_w": 0.4,
-                        "leakage_w": 0.1,
-                        "total_w": 1.0,
+            power = self._with_structural_macro_transfer(
+                {
+                    "total_w": 1.0,
+                    "internal_w": 0.5,
+                    "switching_w": 0.4,
+                    "leakage_w": 0.1,
+                    "sdc_clock_period_ns": 8.0,
+                    "annotatable_pin_count": 1000,
+                    "leaf_annotatable_pin_count": 1000,
+                    "leaf_trace_backed_pin_count": 500,
+                    "vcd_annotated_pin_count": 500,
+                    "macro_trace_active_pin_count": 10,
+                    "macro_annotatable_pin_count": 100,
+                    "design_power_quartets": {
+                        "total": {
+                            "internal_w": 0.5,
+                            "switching_w": 0.4,
+                            "leakage_w": 0.1,
+                            "total_w": 1.0,
+                        },
+                    },
+                    "non_finite_leaf_instance_power": {
+                        "instance_count": 1,
+                        "samples": [
+                            {
+                                "full_name": "u_group_a/u1",
+                                "internal_w": "null",
+                                "switching_w": "null",
+                                "leakage_w": "null",
+                                "total_w": "null",
+                            },
+                        ],
                     },
                 },
-                "non_finite_leaf_instance_power": {
-                    "instance_count": 1,
-                    "samples": [
-                        {
-                            "full_name": "u_group_a/u1",
-                            "internal_w": "null",
-                            "switching_w": "null",
-                            "leakage_w": "null",
-                            "total_w": "null",
-                        },
-                    ],
-                },
-            }
+                assignment_count=1,
+            )
             with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
                 report = MODULE.build_report(
                     manifest=manifest,
@@ -1005,16 +1452,19 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             manifest, manifest_path = self._fixture(root)
             design_config = root / "config.mk"
             design_config.write_text("", encoding="utf-8")
-            power = {
-                "total_w": 1.0,
-                "sdc_clock_period_ns": 8.0,
-                "annotatable_pin_count": 100,
-                "vcd_annotated_pin_count": 80,
-                "macro_trace_active_pin_count": 1,
-                "macro_annotatable_pin_count": 100,
-                "direct_annotatable_pin_count": 100,
-                "direct_vcd_pin_count": 80,
-            }
+            power = self._with_structural_macro_transfer(
+                {
+                    "total_w": 1.0,
+                    "sdc_clock_period_ns": 8.0,
+                    "annotatable_pin_count": 100,
+                    "vcd_annotated_pin_count": 80,
+                    "macro_trace_active_pin_count": 1,
+                    "macro_annotatable_pin_count": 100,
+                    "direct_annotatable_pin_count": 100,
+                    "direct_vcd_pin_count": 80,
+                },
+                assignment_count=1,
+            )
             with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
                 report = MODULE.build_report(
                     manifest=manifest,
@@ -1038,19 +1488,22 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             manifest, manifest_path = self._fixture(root)
             design_config = root / "config.mk"
             design_config.write_text("", encoding="utf-8")
-            power = {
-                "total_w": 1.0,
-                "internal_w": None,
-                "switching_w": 0.8,
-                "leakage_w": 0.2,
-                "sdc_clock_period_ns": 8.0,
-                "annotatable_pin_count": 100,
-                "vcd_annotated_pin_count": 80,
-                "macro_trace_active_pin_count": 10,
-                "macro_annotatable_pin_count": 100,
-                "direct_annotatable_pin_count": 100,
-                "direct_vcd_pin_count": 80,
-            }
+            power = self._with_structural_macro_transfer(
+                {
+                    "total_w": 1.0,
+                    "internal_w": None,
+                    "switching_w": 0.8,
+                    "leakage_w": 0.2,
+                    "sdc_clock_period_ns": 8.0,
+                    "annotatable_pin_count": 100,
+                    "vcd_annotated_pin_count": 80,
+                    "macro_trace_active_pin_count": 10,
+                    "macro_annotatable_pin_count": 100,
+                    "direct_annotatable_pin_count": 100,
+                    "direct_vcd_pin_count": 80,
+                },
+                assignment_count=1,
+            )
             with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
                 report = MODULE.build_report(
                     manifest=manifest,


### PR DESCRIPTION
## Summary
- extract exact per-pin FakeRAM activity from each phase VCD into a hashed structural sidecar
- apply sidecar activity directly to post-route macro pins before fallback propagation
- reject promotion unless every structural assignment matches and applies cleanly
- remove the ineffective escaped scalar VCD aliases

## Verification
- `PYTHONPATH=. python3 -m pytest -q tests/test_extract_fakeram_vcd_activity.py tests/test_attention_decode_score_multivalue_cluster.py tests/test_attention_decode_score_multivalue_cluster_activity.py tests/test_postroute_vcd_power.py tests/test_attention_decode_score_multivalue_cluster_activity_power.py tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py` (53 passed)
- `python3 -m py_compile ...`
- `git diff --check`