### PR TITLE
npu: diagnose invalid postroute pin activity

### DIFF
--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -317,6 +317,33 @@ proc rtlgen_activity_origin_bucket {origin} {
   return "other"
 }
 
+proc rtlgen_append_activity_value_sample {samples_var limit_var full_name toggle duty origin reason} {
+  upvar 1 $samples_var samples
+  upvar 1 $limit_var sample_limit
+  if {[llength $samples] >= $sample_limit} {
+    return
+  }
+  lappend samples [list $full_name $toggle $duty $origin $reason]
+}
+
+proc rtlgen_append_activity_value_valid_sample {samples_var limit_var full_name toggle duty origin reason} {
+  upvar 1 $samples_var samples
+  upvar 1 $limit_var sample_limit
+  if {[llength $samples] >= $sample_limit} {
+    return
+  }
+  lappend samples [list $full_name $toggle $duty $origin $reason]
+}
+
+proc rtlgen_append_leaf_instance_pin_sample {samples_var limit_var instance_full_name ref_name pin_full_name pin_direction activity reason} {
+  upvar 1 $samples_var samples
+  upvar 1 $limit_var sample_limit
+  if {[llength $samples] >= $sample_limit} {
+    return
+  }
+  lappend samples [list $instance_full_name $ref_name $pin_full_name $pin_direction $activity $reason]
+}
+
 proc rtlgen_sorted_list {values} {
   if {[catch {lsort -dictionary $values} sorted]} {
     if {[catch {lsort $values} sorted]} {
@@ -792,7 +819,52 @@ set non_finite_leaf_instance_power_leakage_sum 0.0
 set non_finite_leaf_instance_power_total_sum 0.0
 set non_finite_leaf_instance_samples {}
 set non_finite_leaf_instance_power_sample_limit 16
+set non_finite_leaf_instance_power_pin_inspected_count 0
+set non_finite_leaf_instance_power_pin_malformed_activity_tuple_count 0
+set non_finite_leaf_instance_power_pin_query_error_count 0
+set non_finite_leaf_instance_power_pin_non_finite_toggle_count 0
+set non_finite_leaf_instance_power_pin_negative_toggle_count 0
+set non_finite_leaf_instance_power_pin_non_finite_duty_count 0
+set non_finite_leaf_instance_power_pin_duty_less_than_zero_count 0
+set non_finite_leaf_instance_power_pin_duty_greater_than_one_count 0
+set non_finite_leaf_instance_power_pin_valid_pin_count 0
+set non_finite_leaf_instance_power_pin_origin_vcd_count 0
+set non_finite_leaf_instance_power_pin_origin_propagated_count 0
+set non_finite_leaf_instance_power_pin_origin_clock_count 0
+set non_finite_leaf_instance_power_pin_origin_constant_count 0
+set non_finite_leaf_instance_power_pin_origin_other_count 0
+set non_finite_leaf_instance_power_pin_min_toggle ""
+set non_finite_leaf_instance_power_pin_max_toggle ""
+set non_finite_leaf_instance_power_pin_min_duty ""
+set non_finite_leaf_instance_power_pin_max_duty ""
+set non_finite_leaf_instance_power_pin_samples {}
+set non_finite_leaf_instance_power_pin_sample_limit 16
+set non_finite_leaf_instance_power_pin_valid_samples {}
+set non_finite_leaf_instance_power_pin_valid_sample_limit 4
+set non_finite_leaf_instance_power_pin_seen {}
 set non_finite_leaf_instance_power_ref_name_bucket_limit 32
+set activity_value_diagnostic_query_pin_count 0
+set activity_value_diagnostic_malformed_activity_tuple_count 0
+set activity_value_diagnostic_query_error_count 0
+set activity_value_diagnostic_non_finite_toggle_count 0
+set activity_value_diagnostic_negative_toggle_count 0
+set activity_value_diagnostic_non_finite_duty_count 0
+set activity_value_diagnostic_duty_less_than_zero_count 0
+set activity_value_diagnostic_duty_greater_than_one_count 0
+set activity_value_diagnostic_valid_pin_count 0
+set activity_value_diagnostic_origin_vcd_count 0
+set activity_value_diagnostic_origin_propagated_count 0
+set activity_value_diagnostic_origin_clock_count 0
+set activity_value_diagnostic_origin_constant_count 0
+set activity_value_diagnostic_origin_other_count 0
+set activity_value_diagnostic_min_toggle ""
+set activity_value_diagnostic_max_toggle ""
+set activity_value_diagnostic_min_duty ""
+set activity_value_diagnostic_max_duty ""
+set activity_value_diagnostic_sample_limit 16
+set activity_value_diagnostic_valid_sample_limit 4
+set activity_value_diagnostic_samples {}
+set activity_value_diagnostic_valid_samples {}
 foreach pin $all_design_pins {
   if {[get_property $pin is_hierarchical]} {
     continue
@@ -861,6 +933,118 @@ foreach pin $all_design_pins {
   }
 }
 
+foreach macro_pin $all_design_pins {
+  if {[catch {set macro_pin_full_name [get_property $macro_pin full_name]}]} {
+    set macro_pin_full_name $macro_pin
+  }
+  incr activity_value_diagnostic_query_pin_count
+  if {[catch {set activity [get_property $macro_pin activity]}]} {
+    incr activity_value_diagnostic_query_error_count
+    rtlgen_append_activity_value_sample \
+      activity_value_diagnostic_samples \
+      activity_value_diagnostic_sample_limit \
+      $macro_pin_full_name {} {} other query_error
+    incr activity_value_diagnostic_origin_other_count
+    continue
+  }
+  if {[llength $activity] < 3} {
+    incr activity_value_diagnostic_malformed_activity_tuple_count
+    set activity_toggle ""
+    set activity_duty ""
+    set activity_origin other
+    if {[llength $activity] > 0} {
+      set activity_origin [rtlgen_activity_origin_bucket [lindex $activity end]]
+    }
+    if {$activity_origin == "vcd"} {
+      incr activity_value_diagnostic_origin_vcd_count
+    } elseif {$activity_origin == "propagated"} {
+      incr activity_value_diagnostic_origin_propagated_count
+    } elseif {$activity_origin == "clock"} {
+      incr activity_value_diagnostic_origin_clock_count
+    } elseif {$activity_origin == "constant"} {
+      incr activity_value_diagnostic_origin_constant_count
+    } else {
+      incr activity_value_diagnostic_origin_other_count
+    }
+    rtlgen_append_activity_value_sample \
+      activity_value_diagnostic_samples \
+      activity_value_diagnostic_sample_limit \
+      $macro_pin_full_name {} {} $activity_origin malformed_activity_tuple
+    continue
+  }
+  set activity_toggle [lindex $activity 0]
+  set activity_duty [lindex $activity 1]
+  set activity_origin [rtlgen_activity_origin_bucket [lindex $activity end]]
+  if {$activity_origin == "vcd"} {
+    incr activity_value_diagnostic_origin_vcd_count
+  } elseif {$activity_origin == "propagated"} {
+    incr activity_value_diagnostic_origin_propagated_count
+  } elseif {$activity_origin == "clock"} {
+    incr activity_value_diagnostic_origin_clock_count
+  } elseif {$activity_origin == "constant"} {
+    incr activity_value_diagnostic_origin_constant_count
+  } else {
+    incr activity_value_diagnostic_origin_other_count
+  }
+  if {![rtlgen_is_finite_power_value $activity_toggle]} {
+    incr activity_value_diagnostic_non_finite_toggle_count
+    rtlgen_append_activity_value_sample \
+      activity_value_diagnostic_samples \
+      activity_value_diagnostic_sample_limit \
+      $macro_pin_full_name $activity_toggle $activity_duty $activity_origin non_finite_toggle
+    continue
+  }
+  if {$activity_toggle < 0.0} {
+    incr activity_value_diagnostic_negative_toggle_count
+    rtlgen_append_activity_value_sample \
+      activity_value_diagnostic_samples \
+      activity_value_diagnostic_sample_limit \
+      $macro_pin_full_name $activity_toggle $activity_duty $activity_origin negative_toggle
+    continue
+  }
+  if {![rtlgen_is_finite_power_value $activity_duty]} {
+    incr activity_value_diagnostic_non_finite_duty_count
+    rtlgen_append_activity_value_sample \
+      activity_value_diagnostic_samples \
+      activity_value_diagnostic_sample_limit \
+      $macro_pin_full_name $activity_toggle $activity_duty $activity_origin non_finite_duty
+    continue
+  }
+  if {$activity_duty < 0.0} {
+    incr activity_value_diagnostic_duty_less_than_zero_count
+    rtlgen_append_activity_value_sample \
+      activity_value_diagnostic_samples \
+      activity_value_diagnostic_sample_limit \
+      $macro_pin_full_name $activity_toggle $activity_duty $activity_origin duty_lt_zero
+    continue
+  }
+  if {$activity_duty > 1.0} {
+    incr activity_value_diagnostic_duty_greater_than_one_count
+    rtlgen_append_activity_value_sample \
+      activity_value_diagnostic_samples \
+      activity_value_diagnostic_sample_limit \
+      $macro_pin_full_name $activity_toggle $activity_duty $activity_origin duty_gt_one
+    continue
+  }
+  incr activity_value_diagnostic_valid_pin_count
+  if {$activity_value_diagnostic_min_toggle eq "" || $activity_toggle < $activity_value_diagnostic_min_toggle} {
+    set activity_value_diagnostic_min_toggle $activity_toggle
+  }
+  if {$activity_value_diagnostic_max_toggle eq "" || $activity_toggle > $activity_value_diagnostic_max_toggle} {
+    set activity_value_diagnostic_max_toggle $activity_toggle
+  }
+  if {$activity_value_diagnostic_min_duty eq "" || $activity_duty < $activity_value_diagnostic_min_duty} {
+    set activity_value_diagnostic_min_duty $activity_duty
+  }
+  if {$activity_value_diagnostic_max_duty eq "" || $activity_duty > $activity_value_diagnostic_max_duty} {
+    set activity_value_diagnostic_max_duty $activity_duty
+  }
+  rtlgen_append_activity_value_valid_sample \
+    activity_value_diagnostic_valid_samples \
+    activity_value_diagnostic_valid_sample_limit \
+    $macro_pin_full_name $activity_toggle $activity_duty $activity_origin valid
+}
+
 if {$has_nonfinite_design_total} {
   set leaf_cells {}
   if {[catch {set leaf_cells [sta::network_leaf_instances]}]} {
@@ -895,6 +1079,11 @@ if {$has_nonfinite_design_total} {
         ![rtlgen_is_finite_power_value $leakage_power_value] ||
         ![rtlgen_is_finite_power_value $total_power_value]} {
       incr non_finite_leaf_instance_power_count
+      if {[catch {set leaf_name [lindex [get_full_name $leaf] 0]}]} {
+        if {[catch {set leaf_name [lindex [get_property $leaf name] 0]}]} {
+          set leaf_name $leaf
+        }
+      }
       if {[catch {set leaf_ref_name [get_property $leaf ref_name]}]} {
         incr non_finite_leaf_instance_power_ref_name_query_error_count
         set leaf_ref_name unknown
@@ -903,12 +1092,169 @@ if {$has_nonfinite_design_total} {
         set leaf_ref_name unknown
       }
       dict incr non_finite_leaf_instance_power_ref_name_counts $leaf_ref_name
-      if {[llength $non_finite_leaf_instance_samples] < $non_finite_leaf_instance_power_sample_limit} {
-        if {[catch {set leaf_name [lindex [get_full_name $leaf] 0]}]} {
-          if {[catch {set leaf_name [lindex [get_property $leaf name] 0]}]} {
-            set leaf_name $leaf
+      if {![catch {set leaf_pins [get_pins -of_objects $leaf]}]} {
+        set leaf_pins_sorted [rtlgen_sorted_list $leaf_pins]
+        foreach leaf_pin $leaf_pins_sorted {
+          if {[dict exists $non_finite_leaf_instance_power_pin_seen $leaf_pin]} {
+            continue
           }
+          dict set non_finite_leaf_instance_power_pin_seen $leaf_pin 1
+          incr non_finite_leaf_instance_power_pin_inspected_count
+          if {[catch {set leaf_pin_full_name [get_property $leaf_pin full_name]}]} {
+            set leaf_pin_full_name $leaf_pin
+          }
+          if {[catch {set leaf_pin_direction [get_property $leaf_pin direction]}]} {
+            set leaf_pin_direction unknown
+          }
+          if {[catch {set leaf_pin_activity [get_property $leaf_pin activity]}]} {
+            incr non_finite_leaf_instance_power_pin_query_error_count
+            rtlgen_append_leaf_instance_pin_sample \
+              non_finite_leaf_instance_power_pin_samples \
+              non_finite_leaf_instance_power_pin_sample_limit \
+              $leaf_name \
+              $leaf_ref_name \
+              $leaf_pin_full_name \
+              $leaf_pin_direction \
+              {} \
+              query_error
+            continue
+          }
+          if {[llength $leaf_pin_activity] < 3} {
+            incr non_finite_leaf_instance_power_pin_malformed_activity_tuple_count
+            set leaf_pin_toggle ""
+            set leaf_pin_duty ""
+            set leaf_pin_origin other
+            if {[llength $leaf_pin_activity] > 0} {
+              set leaf_pin_origin [rtlgen_activity_origin_bucket [lindex $leaf_pin_activity end]]
+            }
+            if {$leaf_pin_origin == "vcd"} {
+              incr non_finite_leaf_instance_power_pin_origin_vcd_count
+            } elseif {$leaf_pin_origin == "propagated"} {
+              incr non_finite_leaf_instance_power_pin_origin_propagated_count
+            } elseif {$leaf_pin_origin == "clock"} {
+              incr non_finite_leaf_instance_power_pin_origin_clock_count
+            } elseif {$leaf_pin_origin == "constant"} {
+              incr non_finite_leaf_instance_power_pin_origin_constant_count
+            } else {
+              incr non_finite_leaf_instance_power_pin_origin_other_count
+            }
+            rtlgen_append_leaf_instance_pin_sample \
+              non_finite_leaf_instance_power_pin_samples \
+              non_finite_leaf_instance_power_pin_sample_limit \
+              $leaf_name \
+              $leaf_ref_name \
+              $leaf_pin_full_name \
+              $leaf_pin_direction \
+              $leaf_pin_activity \
+              malformed_activity_tuple
+            continue
+          }
+          set leaf_pin_toggle [lindex $leaf_pin_activity 0]
+          set leaf_pin_duty [lindex $leaf_pin_activity 1]
+          set leaf_pin_origin [rtlgen_activity_origin_bucket [lindex $leaf_pin_activity end]]
+          if {$leaf_pin_origin == "vcd"} {
+            incr non_finite_leaf_instance_power_pin_origin_vcd_count
+          } elseif {$leaf_pin_origin == "propagated"} {
+            incr non_finite_leaf_instance_power_pin_origin_propagated_count
+          } elseif {$leaf_pin_origin == "clock"} {
+            incr non_finite_leaf_instance_power_pin_origin_clock_count
+          } elseif {$leaf_pin_origin == "constant"} {
+            incr non_finite_leaf_instance_power_pin_origin_constant_count
+          } else {
+            incr non_finite_leaf_instance_power_pin_origin_other_count
+          }
+          if {![rtlgen_is_finite_power_value $leaf_pin_toggle]} {
+            incr non_finite_leaf_instance_power_pin_non_finite_toggle_count
+            rtlgen_append_leaf_instance_pin_sample \
+              non_finite_leaf_instance_power_pin_samples \
+              non_finite_leaf_instance_power_pin_sample_limit \
+              $leaf_name \
+              $leaf_ref_name \
+              $leaf_pin_full_name \
+              $leaf_pin_direction \
+              $leaf_pin_activity \
+              non_finite_toggle
+            continue
+          }
+          if {$leaf_pin_toggle < 0.0} {
+            incr non_finite_leaf_instance_power_pin_negative_toggle_count
+            rtlgen_append_leaf_instance_pin_sample \
+              non_finite_leaf_instance_power_pin_samples \
+              non_finite_leaf_instance_power_pin_sample_limit \
+              $leaf_name \
+              $leaf_ref_name \
+              $leaf_pin_full_name \
+              $leaf_pin_direction \
+              $leaf_pin_activity \
+              negative_toggle
+            continue
+          }
+          if {![rtlgen_is_finite_power_value $leaf_pin_duty]} {
+            incr non_finite_leaf_instance_power_pin_non_finite_duty_count
+            rtlgen_append_leaf_instance_pin_sample \
+              non_finite_leaf_instance_power_pin_samples \
+              non_finite_leaf_instance_power_pin_sample_limit \
+              $leaf_name \
+              $leaf_ref_name \
+              $leaf_pin_full_name \
+              $leaf_pin_direction \
+              $leaf_pin_activity \
+              non_finite_duty
+            continue
+          }
+          if {$leaf_pin_duty < 0.0} {
+            incr non_finite_leaf_instance_power_pin_duty_less_than_zero_count
+            rtlgen_append_leaf_instance_pin_sample \
+              non_finite_leaf_instance_power_pin_samples \
+              non_finite_leaf_instance_power_pin_sample_limit \
+              $leaf_name \
+              $leaf_ref_name \
+              $leaf_pin_full_name \
+              $leaf_pin_direction \
+              $leaf_pin_activity \
+              duty_lt_zero
+            continue
+          }
+          if {$leaf_pin_duty > 1.0} {
+            incr non_finite_leaf_instance_power_pin_duty_greater_than_one_count
+            rtlgen_append_leaf_instance_pin_sample \
+              non_finite_leaf_instance_power_pin_samples \
+              non_finite_leaf_instance_power_pin_sample_limit \
+              $leaf_name \
+              $leaf_ref_name \
+              $leaf_pin_full_name \
+              $leaf_pin_direction \
+              $leaf_pin_activity \
+              duty_gt_one
+            continue
+          }
+          incr non_finite_leaf_instance_power_pin_valid_pin_count
+          if {$non_finite_leaf_instance_power_pin_min_toggle eq "" || $leaf_pin_toggle < $non_finite_leaf_instance_power_pin_min_toggle} {
+            set non_finite_leaf_instance_power_pin_min_toggle $leaf_pin_toggle
+          }
+          if {$non_finite_leaf_instance_power_pin_max_toggle eq "" || $leaf_pin_toggle > $non_finite_leaf_instance_power_pin_max_toggle} {
+            set non_finite_leaf_instance_power_pin_max_toggle $leaf_pin_toggle
+          }
+          if {$non_finite_leaf_instance_power_pin_min_duty eq "" || $leaf_pin_duty < $non_finite_leaf_instance_power_pin_min_duty} {
+            set non_finite_leaf_instance_power_pin_min_duty $leaf_pin_duty
+          }
+          if {$non_finite_leaf_instance_power_pin_max_duty eq "" || $leaf_pin_duty > $non_finite_leaf_instance_power_pin_max_duty} {
+            set non_finite_leaf_instance_power_pin_max_duty $leaf_pin_duty
+          }
+          rtlgen_append_leaf_instance_pin_sample \
+            non_finite_leaf_instance_power_pin_valid_samples \
+            non_finite_leaf_instance_power_pin_valid_sample_limit \
+            $leaf_name \
+            $leaf_ref_name \
+            $leaf_pin_full_name \
+            $leaf_pin_direction \
+            $leaf_pin_activity \
+            valid
         }
+      } else {
+        incr non_finite_leaf_instance_power_pin_query_error_count
+      }
+      if {[llength $non_finite_leaf_instance_samples] < $non_finite_leaf_instance_power_sample_limit} {
         lappend non_finite_leaf_instance_samples \
           [list \
             $leaf_name \
@@ -1019,6 +1365,80 @@ puts $fp "  \"macro_trace_backed_pin_count\": $macro_trace_backed_count,"
 puts $fp "  \"macro_trace_active_pin_count\": $macro_trace_active_count,"
 puts $fp "  \"macro_trace_backed_zero_toggle_pin_count\": $macro_trace_backed_zero_toggle_count"
 puts $fp ","
+puts $fp "  \"activity_value_diagnostics\": {"
+puts $fp "    \"queried_pin_count\": $activity_value_diagnostic_query_pin_count,"
+puts $fp "    \"malformed_activity_tuple_count\": $activity_value_diagnostic_malformed_activity_tuple_count,"
+puts $fp "    \"query_error_count\": $activity_value_diagnostic_query_error_count,"
+puts $fp "    \"non_finite_toggle_count\": $activity_value_diagnostic_non_finite_toggle_count,"
+puts $fp "    \"negative_toggle_count\": $activity_value_diagnostic_negative_toggle_count,"
+puts $fp "    \"non_finite_duty_count\": $activity_value_diagnostic_non_finite_duty_count,"
+puts $fp "    \"duty_less_than_zero_count\": $activity_value_diagnostic_duty_less_than_zero_count,"
+puts $fp "    \"duty_greater_than_one_count\": $activity_value_diagnostic_duty_greater_than_one_count,"
+puts $fp "    \"valid_pin_count\": $activity_value_diagnostic_valid_pin_count,"
+puts $fp "    \"finite_extrema\": {"
+puts $fp "      \"min_toggle\": [rtlgen_json_number $activity_value_diagnostic_min_toggle],"
+puts $fp "      \"max_toggle\": [rtlgen_json_number $activity_value_diagnostic_max_toggle],"
+puts $fp "      \"min_duty\": [rtlgen_json_number $activity_value_diagnostic_min_duty],"
+puts $fp "      \"max_duty\": [rtlgen_json_number $activity_value_diagnostic_max_duty]"
+puts $fp "    },"
+puts $fp "    \"origin_counts\": {"
+puts $fp "      \"vcd\": $activity_value_diagnostic_origin_vcd_count,"
+puts $fp "      \"propagated\": $activity_value_diagnostic_origin_propagated_count,"
+puts $fp "      \"clock\": $activity_value_diagnostic_origin_clock_count,"
+puts $fp "      \"constant\": $activity_value_diagnostic_origin_constant_count,"
+puts $fp "      \"other\": $activity_value_diagnostic_origin_other_count"
+puts $fp "    },"
+puts $fp "    \"samples\": \["
+set activity_value_diagnostic_sample_count [llength $activity_value_diagnostic_samples]
+set activity_value_diagnostic_sample_index 0
+foreach activity_value_diagnostic_sample $activity_value_diagnostic_samples {
+  lassign \
+    $activity_value_diagnostic_sample \
+    activity_value_diagnostic_sample_full_name \
+    activity_value_diagnostic_sample_toggle \
+    activity_value_diagnostic_sample_duty \
+    activity_value_diagnostic_sample_origin \
+    activity_value_diagnostic_sample_reason
+  set escaped_full_name [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $activity_value_diagnostic_sample_full_name]]
+  set escaped_reason [rtlgen_json_escape $activity_value_diagnostic_sample_reason]
+  set sample_toggle_json [rtlgen_json_number $activity_value_diagnostic_sample_toggle]
+  set sample_duty_json [rtlgen_json_number $activity_value_diagnostic_sample_duty]
+  incr activity_value_diagnostic_sample_index
+  set activity_value_diagnostic_sample_line "      {\"full_name\": \"$escaped_full_name\", \"toggle\": $sample_toggle_json, \"duty\": $sample_duty_json, \"origin\": \"$activity_value_diagnostic_sample_origin\", \"reason\": \"$escaped_reason\"}"
+  if {$activity_value_diagnostic_sample_index < $activity_value_diagnostic_sample_count} {
+    puts $fp "$activity_value_diagnostic_sample_line,"
+  } else {
+    puts $fp "$activity_value_diagnostic_sample_line"
+  }
+}
+puts $fp "    \],"
+puts $fp "    \"valid_samples\": \["
+set activity_value_diagnostic_valid_sample_count [llength $activity_value_diagnostic_valid_samples]
+set activity_value_diagnostic_valid_sample_index 0
+foreach activity_value_diagnostic_valid_sample $activity_value_diagnostic_valid_samples {
+  lassign \
+    $activity_value_diagnostic_valid_sample \
+    activity_value_diagnostic_valid_sample_full_name \
+    activity_value_diagnostic_valid_sample_toggle \
+    activity_value_diagnostic_valid_sample_duty \
+    activity_value_diagnostic_valid_sample_origin \
+    activity_value_diagnostic_valid_sample_reason
+  set escaped_full_name \
+    [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $activity_value_diagnostic_valid_sample_full_name]]
+  set escaped_reason [rtlgen_json_escape $activity_value_diagnostic_valid_sample_reason]
+  set valid_sample_toggle_json [rtlgen_json_number $activity_value_diagnostic_valid_sample_toggle]
+  set valid_sample_duty_json [rtlgen_json_number $activity_value_diagnostic_valid_sample_duty]
+  incr activity_value_diagnostic_valid_sample_index
+  set activity_value_diagnostic_valid_sample_line "      {\"full_name\": \"$escaped_full_name\", \"toggle\": $valid_sample_toggle_json, \"duty\": $valid_sample_duty_json, \"origin\": \"$activity_value_diagnostic_valid_sample_origin\", \"reason\": \"$escaped_reason\"}"
+  if {$activity_value_diagnostic_valid_sample_index < $activity_value_diagnostic_valid_sample_count} {
+    puts $fp "$activity_value_diagnostic_valid_sample_line,"
+  } else {
+    puts $fp "$activity_value_diagnostic_valid_sample_line"
+  }
+}
+puts $fp "    \]"
+puts $fp "  }"
+puts $fp ","
 puts $fp "  \"macro_pin_transfer\": {"
 puts $fp "    \"structural_assignment_count\": $macro_pin_transfer_structural_assignment_count,"
 puts $fp "    \"structural_matched_count\": $macro_pin_transfer_structural_matched_count,"
@@ -1108,6 +1528,82 @@ if {$has_nonfinite_design_total} {
   puts $fp "      \"switching_w\": [rtlgen_json_number $non_finite_leaf_instance_power_switching_sum],"
   puts $fp "      \"leakage_w\": [rtlgen_json_number $non_finite_leaf_instance_power_leakage_sum],"
   puts $fp "      \"total_w\": [rtlgen_json_number $non_finite_leaf_instance_power_total_sum]"
+  puts $fp "    },"
+  puts $fp "    \"pin_activity\": {"
+  puts $fp "      \"inspected_pin_count\": $non_finite_leaf_instance_power_pin_inspected_count,"
+  puts $fp "      \"malformed_activity_tuple_count\": $non_finite_leaf_instance_power_pin_malformed_activity_tuple_count,"
+  puts $fp "      \"query_error_count\": $non_finite_leaf_instance_power_pin_query_error_count,"
+  puts $fp "      \"non_finite_toggle_count\": $non_finite_leaf_instance_power_pin_non_finite_toggle_count,"
+  puts $fp "      \"negative_toggle_count\": $non_finite_leaf_instance_power_pin_negative_toggle_count,"
+  puts $fp "      \"non_finite_duty_count\": $non_finite_leaf_instance_power_pin_non_finite_duty_count,"
+  puts $fp "      \"duty_less_than_zero_count\": $non_finite_leaf_instance_power_pin_duty_less_than_zero_count,"
+  puts $fp "      \"duty_greater_than_one_count\": $non_finite_leaf_instance_power_pin_duty_greater_than_one_count,"
+  puts $fp "      \"valid_pin_count\": $non_finite_leaf_instance_power_pin_valid_pin_count,"
+  puts $fp "      \"finite_extrema\": {"
+  puts $fp "        \"min_toggle\": [rtlgen_json_number $non_finite_leaf_instance_power_pin_min_toggle],"
+  puts $fp "        \"max_toggle\": [rtlgen_json_number $non_finite_leaf_instance_power_pin_max_toggle],"
+  puts $fp "        \"min_duty\": [rtlgen_json_number $non_finite_leaf_instance_power_pin_min_duty],"
+  puts $fp "        \"max_duty\": [rtlgen_json_number $non_finite_leaf_instance_power_pin_max_duty]"
+  puts $fp "      },"
+  puts $fp "      \"origin_counts\": {"
+  puts $fp "        \"vcd\": $non_finite_leaf_instance_power_pin_origin_vcd_count,"
+  puts $fp "        \"propagated\": $non_finite_leaf_instance_power_pin_origin_propagated_count,"
+  puts $fp "        \"clock\": $non_finite_leaf_instance_power_pin_origin_clock_count,"
+  puts $fp "        \"constant\": $non_finite_leaf_instance_power_pin_origin_constant_count,"
+  puts $fp "        \"other\": $non_finite_leaf_instance_power_pin_origin_other_count"
+  puts $fp "      },"
+  puts $fp "      \"samples\": \["
+  set leaf_instance_pin_sample_count [llength $non_finite_leaf_instance_power_pin_samples]
+  set leaf_instance_pin_sample_index 0
+  foreach leaf_instance_pin_sample $non_finite_leaf_instance_power_pin_samples {
+    lassign \
+      $leaf_instance_pin_sample \
+      leaf_instance_pin_sample_name \
+      leaf_instance_pin_sample_ref_name \
+      leaf_instance_pin_sample_pin_name \
+      leaf_instance_pin_sample_pin_direction \
+      leaf_instance_pin_sample_activity \
+      leaf_instance_pin_sample_reason
+    set leaf_instance_pin_sample_name_escaped [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $leaf_instance_pin_sample_name]]
+    set leaf_instance_pin_sample_ref_name_escaped [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $leaf_instance_pin_sample_ref_name]]
+    set leaf_instance_pin_sample_pin_name_escaped [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $leaf_instance_pin_sample_pin_name]]
+    set leaf_instance_pin_sample_reason_escaped [rtlgen_json_escape $leaf_instance_pin_sample_reason]
+    set leaf_instance_pin_sample_activity_json "[rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $leaf_instance_pin_sample_activity]]"
+    set leaf_instance_pin_sample_line "      {\"instance\": \"$leaf_instance_pin_sample_name_escaped\", \"ref\": \"$leaf_instance_pin_sample_ref_name_escaped\", \"pin\": \"$leaf_instance_pin_sample_pin_name_escaped\", \"direction\": \"$leaf_instance_pin_sample_pin_direction\", \"activity\": \"$leaf_instance_pin_sample_activity_json\", \"reason\": \"$leaf_instance_pin_sample_reason_escaped\"}"
+    incr leaf_instance_pin_sample_index
+    if {$leaf_instance_pin_sample_index < $leaf_instance_pin_sample_count} {
+      puts $fp "$leaf_instance_pin_sample_line,"
+    } else {
+      puts $fp "$leaf_instance_pin_sample_line"
+    }
+  }
+  puts $fp "      \],"
+  puts $fp "    \"valid_samples\": \["
+  set leaf_instance_pin_valid_sample_count [llength $non_finite_leaf_instance_power_pin_valid_samples]
+  set leaf_instance_pin_valid_sample_index 0
+  foreach leaf_instance_pin_sample $non_finite_leaf_instance_power_pin_valid_samples {
+    lassign \
+      $leaf_instance_pin_sample \
+      leaf_instance_pin_sample_name \
+      leaf_instance_pin_sample_ref_name \
+      leaf_instance_pin_sample_pin_name \
+      leaf_instance_pin_sample_pin_direction \
+      leaf_instance_pin_sample_activity \
+      leaf_instance_pin_sample_reason
+    set leaf_instance_pin_sample_name_escaped [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $leaf_instance_pin_sample_name]]
+    set leaf_instance_pin_sample_ref_name_escaped [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $leaf_instance_pin_sample_ref_name]]
+    set leaf_instance_pin_sample_pin_name_escaped [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $leaf_instance_pin_sample_pin_name]]
+    set leaf_instance_pin_sample_reason_escaped [rtlgen_json_escape $leaf_instance_pin_sample_reason]
+    set leaf_instance_pin_sample_activity_json "[rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $leaf_instance_pin_sample_activity]]"
+    set leaf_instance_pin_sample_line "      {\"instance\": \"$leaf_instance_pin_sample_name_escaped\", \"ref\": \"$leaf_instance_pin_sample_ref_name_escaped\", \"pin\": \"$leaf_instance_pin_sample_pin_name_escaped\", \"direction\": \"$leaf_instance_pin_sample_pin_direction\", \"activity\": \"$leaf_instance_pin_sample_activity_json\", \"reason\": \"$leaf_instance_pin_sample_reason_escaped\"}"
+    incr leaf_instance_pin_valid_sample_index
+    if {$leaf_instance_pin_valid_sample_index < $leaf_instance_pin_valid_sample_count} {
+      puts $fp "$leaf_instance_pin_sample_line,"
+    } else {
+      puts $fp "$leaf_instance_pin_sample_line"
+    }
+  }
+  puts $fp "      \]"
   puts $fp "    },"
   puts $fp "    \"ref_name_buckets\": \["
   set ref_name_bucket_count [llength $non_finite_leaf_instance_power_ref_name_buckets]

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -70,6 +70,9 @@ class PostrouteVcdPowerTests(unittest.TestCase):
         macro_transfer: bool = False,
         macro_activity_tcl: Path | None = None,
         macro_transfer_pin_names: tuple[str, str, str] | None = None,
+        all_pin_names: tuple[str, ...] | None = None,
+        pin_properties: dict[str, dict[str, object]] | None = None,
+        leaf_pin_map: dict[str, tuple[str, ...]] | None = None,
         leaf_specs: tuple[tuple[str, str, str], ...] | None = None,
     ) -> str:
         if leaf_specs is None:
@@ -78,6 +81,51 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 ("leaf_group_b/leaf_b", "other", "1.0 2.0 3.0 4.0"),
             )
         leaf_names = " ".join(f"{{{name}}}" for name, _ref, _value in leaf_specs)
+        if pin_properties is None:
+            pin_properties = {}
+        if leaf_pin_map is None:
+            leaf_pin_map = {}
+        pin_property_overrides: list[str] = []
+        for pin_name in sorted(pin_properties):
+            config = pin_properties[pin_name]
+            is_hierarchical = int(config.get("is_hierarchical", False))
+            direction = str(config.get("direction", "output"))
+            full_name = str(config.get("full_name", pin_name))
+            activity = config.get("activity")
+            if activity is None:
+                pin_property_overrides.extend(
+                    [
+                        f"  if {{$obj eq {{{pin_name}}}}} {{",
+                        f"    if {{$property eq \"is_hierarchical\"}} {{ return {is_hierarchical} }}",
+                        f"    if {{$property eq \"direction\"}} {{ return \"{direction}\" }}",
+                        f"    if {{$property eq \"full_name\"}} {{ return {{{full_name}}} }}",
+                        "    if {$property eq \"activity\"} {",
+                        f"      error \"forced_activity_query_error {pin_name}\"",
+                        "    }",
+                        "    return {}",
+                        "  }",
+                    ]
+                )
+            else:
+                pin_property_overrides.extend(
+                    [
+                        f"  if {{$obj eq {{{pin_name}}}}} {{",
+                        f"    if {{$property eq \"is_hierarchical\"}} {{ return {is_hierarchical} }}",
+                        f"    if {{$property eq \"direction\"}} {{ return \"{direction}\" }}",
+                        f"    if {{$property eq \"full_name\"}} {{ return {{{full_name}}} }}",
+                        f"    if {{$property eq \"activity\"}} {{ return {{{activity}}} }}",
+                        "    return {}",
+                        "  }",
+                    ]
+                )
+        leaf_pin_map_init_lines = ["set leaf_pin_map_dict {}"]
+        for leaf, pins in sorted(leaf_pin_map.items()):
+            leaf_pin_map_init_lines.append(
+                "dict set leaf_pin_map_dict {{{}}} {{{}}}".format(
+                    leaf,
+                    " ".join("{" + pin + "}" for pin in pins),
+                )
+            )
         leaf_ref_name_cases = []
         leaf_instance_power_cases = []
         for leaf_name, ref_name, instance_power in leaf_specs:
@@ -116,7 +164,11 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "    }",
                 "  }",
                 "  if {[lindex $args 0] eq \"-of_objects\"} {",
-                "    set net [lindex $args end]",
+                "    set object [lindex $args end]",
+                "    if {[dict exists $leaf_pin_map_dict $object]} {",
+                "      return [dict get $leaf_pin_map_dict $object]",
+                "    }",
+                "    set net $object",
                 "    if {$net eq {net_u_group_0}} {",
                 f"      return {{{' '.join(net_pins)}}}",
                 "    }",
@@ -153,7 +205,20 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "}",
             ]
         else:
-            get_pins_body = ["  return {pin_nonfinite_u_group}"]
+            if all_pin_names is None:
+                all_pins = ["pin_nonfinite_u_group"]
+            else:
+                all_pins = list(all_pin_names)
+            get_pins_body = [
+                "  if {[lindex $args 0] eq \"-of_objects\"} {",
+                "    set object [lindex $args end]",
+                "    if {[dict exists $leaf_pin_map_dict $object]} {",
+                "      return [dict get $leaf_pin_map_dict $object]",
+                "    }",
+                "    return {}",
+                "  }",
+                f"  return {{{' '.join(all_pins)}}}",
+            ]
             pin_property_body = []
             net_driver_body = []
             net_and_activity_body = []
@@ -176,11 +241,15 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             "  }",
             "}",
             "set ::ref_name_query_count 0",
+            *leaf_pin_map_init_lines,
+            "set ::leaf_pin_map_dict $leaf_pin_map_dict",
             "proc get_pins {args} {",
+            "  global leaf_pin_map_dict",
             *get_pins_body,
             "}",
             "proc get_property {obj property} {",
             *pin_property_body,
+            *pin_property_overrides,
             "  if {[string match \"pin_*\" $obj]} {",
             "    if {$property eq \"is_hierarchical\"} {",
             "      return 0",
@@ -333,6 +402,277 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(finite_sums["switching_w"], 2.0)
             self.assertEqual(finite_sums["leakage_w"], 3.0)
             self.assertEqual(finite_sums["total_w"], 4.0)
+
+    def test_tcl_script_activity_value_diagnostics_invalid_classification(self) -> None:
+        if shutil.which("tclsh") is None:
+            self.skipTest("tclsh is required for Tcl runtime regression")
+
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "load.tcl").write_text("", encoding="utf-8")
+
+            result = root / "activity_power.json"
+            pin_names = (
+                "pin_query_error",
+                "pin_malformed",
+                "pin_nonfinite_toggle",
+                "pin_negative_toggle",
+                "pin_nonfinite_duty",
+                "pin_duty_lt_zero",
+                "pin_duty_gt_one",
+                "pin_valid",
+            )
+            tcl_script = self._write_tcl_runtime_stub(
+                root=root,
+                result=result,
+                all_pin_names=pin_names,
+                pin_properties={
+                    "pin_query_error": {"activity": None, "direction": "internal"},
+                    "pin_malformed": {"activity": "0.5"},
+                    "pin_nonfinite_toggle": {"activity": "nan 0.5 vcd"},
+                    "pin_negative_toggle": {"activity": "-0.2 0.5 vcd"},
+                    "pin_nonfinite_duty": {"activity": "0.2 nan vcd"},
+                    "pin_duty_lt_zero": {"activity": "0.2 -0.1 vcd"},
+                    "pin_duty_gt_one": {"activity": "0.2 1.2 vcd"},
+                    "pin_valid": {"activity": "0.8 0.4 vcd"},
+                },
+            )
+            tcl_script_path = root / "activity_power.tcl"
+            tcl_script_path.write_text(tcl_script, encoding="utf-8")
+            tcl = shutil.which("tclsh")
+            assert tcl is not None
+            completed = MODULE.subprocess.run(
+                [tcl, str(tcl_script_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                msg=f"tcl failed: stdout={completed.stdout} stderr={completed.stderr}",
+            )
+            self.assertFalse(completed.stderr.strip())
+
+            payload = json.loads(result.read_text(encoding="utf-8"))
+            diag = payload["activity_value_diagnostics"]
+            self.assertEqual(diag["queried_pin_count"], 8)
+            self.assertEqual(diag["malformed_activity_tuple_count"], 1)
+            self.assertEqual(diag["query_error_count"], 1)
+            self.assertEqual(diag["non_finite_toggle_count"], 1)
+            self.assertEqual(diag["negative_toggle_count"], 1)
+            self.assertEqual(diag["non_finite_duty_count"], 1)
+            self.assertEqual(diag["duty_less_than_zero_count"], 1)
+            self.assertEqual(diag["duty_greater_than_one_count"], 1)
+            self.assertEqual(diag["valid_pin_count"], 1)
+            self.assertEqual(diag["finite_extrema"]["min_toggle"], 0.8)
+            self.assertEqual(diag["finite_extrema"]["max_toggle"], 0.8)
+            self.assertEqual(diag["finite_extrema"]["min_duty"], 0.4)
+            self.assertEqual(diag["finite_extrema"]["max_duty"], 0.4)
+            self.assertEqual(len(diag["samples"]), 7)
+            reasons = {sample["reason"] for sample in diag["samples"]}
+            self.assertEqual(
+                reasons,
+                {
+                    "query_error",
+                    "malformed_activity_tuple",
+                    "non_finite_toggle",
+                    "negative_toggle",
+                    "non_finite_duty",
+                    "duty_lt_zero",
+                    "duty_gt_one",
+                },
+            )
+            self.assertEqual(len(diag["valid_samples"]), 1)
+            sample_fields = diag["samples"][0]
+            self.assertEqual(
+                set(sample_fields),
+                {"full_name", "toggle", "duty", "origin", "reason"},
+            )
+            valid_sample = diag["valid_samples"][0]
+            self.assertEqual(
+                set(valid_sample),
+                {"full_name", "toggle", "duty", "origin", "reason"},
+            )
+
+    def test_tcl_script_activity_value_diagnostics_samples_are_bounded_and_deterministic(self) -> None:
+        if shutil.which("tclsh") is None:
+            self.skipTest("tclsh is required for Tcl runtime regression")
+
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "load.tcl").write_text("", encoding="utf-8")
+
+            result = root / "activity_power.json"
+            valid_pin_names = tuple(f"pin[{i:03d}]" for i in range(20))
+            invalid_pin_name = "pin[999]"
+            pin_names = valid_pin_names + (invalid_pin_name,)
+            pin_properties = {
+                pin_name: {"activity": f"{i / 100:.3f} 0.2 vcd"}
+                for i, pin_name in enumerate(valid_pin_names)
+            }
+            pin_properties[invalid_pin_name] = {"activity": "nan 0.2 vcd"}
+            tcl_script = self._write_tcl_runtime_stub(
+                root=root,
+                result=result,
+                all_pin_names=pin_names,
+                pin_properties=pin_properties,
+            )
+            tcl_script_path = root / "activity_power.tcl"
+            tcl_script_path.write_text(tcl_script, encoding="utf-8")
+            tcl = shutil.which("tclsh")
+            assert tcl is not None
+            completed = MODULE.subprocess.run(
+                [tcl, str(tcl_script_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                msg=f"tcl failed: stdout={completed.stdout} stderr={completed.stderr}",
+            )
+            self.assertFalse(completed.stderr.strip())
+
+            payload = json.loads(result.read_text(encoding="utf-8"))
+            diag = payload["activity_value_diagnostics"]
+            self.assertEqual(diag["queried_pin_count"], 21)
+            self.assertEqual(diag["valid_pin_count"], 20)
+            self.assertEqual(len(diag["samples"]), 1)
+            self.assertEqual(diag["samples"][0]["reason"], "non_finite_toggle")
+            self.assertEqual(diag["samples"][0]["full_name"], invalid_pin_name)
+            self.assertEqual(len(diag["valid_samples"]), 4)
+            self.assertEqual(diag["valid_samples"][0]["full_name"], "pin[000]")
+            self.assertEqual(diag["valid_samples"][3]["full_name"], "pin[003]")
+            self.assertEqual(diag["finite_extrema"]["min_toggle"], 0.0)
+            self.assertEqual(diag["finite_extrema"]["max_toggle"], 0.19)
+
+    def test_tcl_script_pin_activity_nested_diagnostics_for_nonfinite_leaf(self) -> None:
+        if shutil.which("tclsh") is None:
+            self.skipTest("tclsh is required for Tcl runtime regression")
+
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "load.tcl").write_text("", encoding="utf-8")
+
+            result = root / "activity_power.json"
+            leaf_specs = (
+                ("leaf_group_7/instance_a", "reducer", "nan nan nan nan"),
+                ("leaf_group_b/leaf_b", "other", "1.0 2.0 3.0 4.0"),
+                ("leaf_group_c/leaf_c", "other", "1.0 2.0 3.0 4.0"),
+            )
+            tcl_script = self._write_tcl_runtime_stub(
+                root=root,
+                result=result,
+                leaf_specs=leaf_specs,
+                leaf_pin_map={
+                    "leaf_group_7/instance_a": (
+                        "pin_query_error",
+                        "pin_malformed",
+                        "pin_nonfinite_toggle",
+                        "pin_negative_toggle",
+                        "pin_nonfinite_duty",
+                        "pin_duty_lt_zero",
+                        "pin_duty_gt_one",
+                        "pin_valid",
+                    )
+                },
+                pin_properties={
+                    "pin_query_error": {"activity": None, "direction": "internal"},
+                    "pin_malformed": {"activity": "0.5", "direction": "output"},
+                    "pin_nonfinite_toggle": {
+                        "activity": "nan 0.4 vcd",
+                        "direction": "output",
+                    },
+                    "pin_negative_toggle": {
+                        "activity": "-0.2 0.5 vcd",
+                        "direction": "output",
+                    },
+                    "pin_nonfinite_duty": {
+                        "activity": "0.2 nan vcd",
+                        "direction": "output",
+                    },
+                    "pin_duty_lt_zero": {
+                        "activity": "0.2 -0.1 vcd",
+                        "direction": "output",
+                    },
+                    "pin_duty_gt_one": {
+                        "activity": "0.2 1.2 vcd",
+                        "direction": "output",
+                    },
+                    "pin_valid": {
+                        "activity": "0.2 0.5 vcd",
+                        "direction": "output",
+                    },
+                },
+            )
+            tcl_script_path = root / "activity_power.tcl"
+            tcl_script_path.write_text(tcl_script, encoding="utf-8")
+            tcl = shutil.which("tclsh")
+            assert tcl is not None
+            completed = MODULE.subprocess.run(
+                [tcl, str(tcl_script_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                msg=f"tcl failed: stdout={completed.stdout} stderr={completed.stderr}",
+            )
+            self.assertFalse(completed.stderr.strip())
+
+            payload = json.loads(result.read_text(encoding="utf-8"))
+            diag = payload["non_finite_leaf_instance_power"]
+            self.assertEqual(diag["instance_count"], 1)
+            pin_diag = diag["pin_activity"]
+            self.assertEqual(pin_diag["inspected_pin_count"], 8)
+            self.assertEqual(pin_diag["malformed_activity_tuple_count"], 1)
+            self.assertEqual(pin_diag["query_error_count"], 1)
+            self.assertEqual(pin_diag["non_finite_toggle_count"], 1)
+            self.assertEqual(pin_diag["negative_toggle_count"], 1)
+            self.assertEqual(pin_diag["non_finite_duty_count"], 1)
+            self.assertEqual(pin_diag["duty_less_than_zero_count"], 1)
+            self.assertEqual(pin_diag["duty_greater_than_one_count"], 1)
+            self.assertEqual(pin_diag["valid_pin_count"], 1)
+            self.assertEqual(pin_diag["finite_extrema"]["min_toggle"], 0.2)
+            self.assertEqual(pin_diag["finite_extrema"]["max_toggle"], 0.2)
+            self.assertEqual(pin_diag["finite_extrema"]["min_duty"], 0.5)
+            self.assertEqual(pin_diag["finite_extrema"]["max_duty"], 0.5)
+            self.assertEqual(len(pin_diag["samples"]), 7)
+            self.assertEqual(len(pin_diag["valid_samples"]), 1)
+            sample_reasons = {sample["reason"] for sample in pin_diag["samples"]}
+            self.assertEqual(
+                sample_reasons,
+                {
+                    "query_error",
+                    "malformed_activity_tuple",
+                    "non_finite_toggle",
+                    "negative_toggle",
+                    "non_finite_duty",
+                    "duty_lt_zero",
+                    "duty_gt_one",
+                },
+            )
+            sample = pin_diag["samples"][0]
+            self.assertIn("instance", sample)
+            self.assertIn("ref", sample)
+            self.assertIn("pin", sample)
+            self.assertIn("direction", sample)
+            self.assertIn("activity", sample)
+            valid_sample = pin_diag["valid_samples"][0]
+            self.assertEqual(
+                set(valid_sample),
+                {"instance", "ref", "pin", "direction", "activity", "reason"},
+            )
 
     def test_tcl_script_ref_name_buckets_are_sorted_and_bounded(self) -> None:
         if shutil.which("tclsh") is None:
@@ -1395,6 +1735,85 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertTrue(phase["trace_coverage_gate_pass"])
             self.assertFalse(phase["direct_vcd_annotation_pin_gate_pass"])
             self.assertFalse(phase["annotation_gate_pass"])
+
+    def test_build_report_gates_unchanged_when_activity_value_diagnostics_present(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, manifest_path = self._fixture(root)
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = self._with_structural_macro_transfer(
+                {
+                    "total_w": 1.5,
+                    "internal_w": 0.7,
+                    "switching_w": 0.5,
+                    "leakage_w": 0.3,
+                    "sdc_clock_period_ns": 8.0,
+                    "annotatable_pin_count": 1000,
+                    "leaf_annotatable_pin_count": 1000,
+                    "leaf_trace_backed_pin_count": 400,
+                    "vcd_annotated_pin_count": 400,
+                    "direct_annotatable_pin_count": 1000,
+                    "direct_vcd_pin_count": 400,
+                    "macro_trace_active_pin_count": 64,
+                    "macro_annotatable_pin_count": 1000,
+                    "activity_value_diagnostics": {
+                        "queried_pin_count": 2,
+                        "malformed_activity_tuple_count": 1,
+                        "query_error_count": 1,
+                        "samples": [
+                            {
+                                "full_name": "pin_a",
+                                "toggle": 0.1,
+                                "duty": 0.2,
+                                "origin": "vcd",
+                                "reason": "query_error",
+                            }
+                        ],
+                    },
+                },
+                assignment_count=1,
+            )
+            power_with_diag = dict(power)
+            power_with_diag["activity_value_diagnostics"] = dict(power_with_diag["activity_value_diagnostics"])
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                report_without_diag = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.25,
+                    min_vcd_pins=400,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
+                    timeout_seconds=10,
+                )
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power_with_diag):
+                report_with_diag = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.25,
+                    min_vcd_pins=400,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
+                    timeout_seconds=10,
+                )
+            self.assertEqual(report_without_diag["promotion_gate_pass"], report_with_diag["promotion_gate_pass"])
+            self.assertTrue(report_with_diag["promotion_gate_pass"])
+            for index, phase_without_diag in enumerate(report_without_diag["phases"]):
+                phase_with_diag = report_with_diag["phases"][index]
+                self.assertEqual(
+                    phase_without_diag["phase_gate_pass"],
+                    phase_with_diag["phase_gate_pass"],
+                )
+                self.assertEqual(
+                    phase_without_diag["structural_macro_activity_gate_pass"],
+                    phase_with_diag["structural_macro_activity_gate_pass"],
+                )
 
     def test_build_report_preserves_non_finite_power_diagnostics(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:


### PR DESCRIPTION
## Summary
- add bounded post-route pin activity validity diagnostics after structural macro annotation
- correlate non-finite leaf-instance power with exact input/output pin activities
- report invalid toggle/duty categories, origin counts, finite extrema, and bounded invalid/valid samples
- preserve strict numeric and promotion gates without substituting values

## Motivation
Compact v10 proved the FakeRAM activity path but finalize still produced 4,521 non-finite reducer cells and nonsensical finite subtotals. This distinguishes invalid propagated activity from library/power-table failures.

## Verification
- `PYTHONPATH=. python3 -m pytest -q tests/test_postroute_vcd_power.py tests/test_attention_decode_score_multivalue_cluster_activity_power.py tests/test_attention_decode_score_multivalue_gqa_group_activity_power.py` (47 passed)
- `python3 -m py_compile npu/synth/run_postroute_vcd_power.py`
- `git diff --check`