### PR TITLE
npu: anchor postroute power to sequential VCD state

### DIFF
--- a/npu/eval/extract_sequential_register_vcd_activity.py
+++ b/npu/eval/extract_sequential_register_vcd_activity.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Extract per-bit sequential-register activity from RTL VCD traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+_TARGET_SCOPE_PREFIX = "tb/dut"
+_VAR_RE = re.compile(r"^\$var\s+(\S+)\s+(\d+)\s+(\S+)\s+(.*?)\s+\$end$")
+_SCOPE_RE = re.compile(r"^\$scope\s+\S+\s+(\S+)\s+\$end$")
+_SCALAR_UPDATE_RE = re.compile(r"^([01xXzZ])(\S+)$")
+_VECTOR_UPDATE_RE = re.compile(r"^b([01xXzZ]+)\s+(\S+)$")
+
+
+@dataclass
+class _RegisterBitActivity:
+    full_name: str
+    last_value: str | None
+    last_tick: int
+    transition_count: float
+    high_ticks: int
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_float_bits(value: str, unit: str) -> float:
+    factors = {
+        "s": 1.0,
+        "ms": 1e-3,
+        "us": 1e-6,
+        "ns": 1e-9,
+        "ps": 1e-12,
+        "fs": 1e-15,
+    }
+    unit_key = unit.strip().lower()
+    if unit_key not in factors:
+        raise ValueError(f"unsupported timescale unit: {unit}")
+    try:
+        return float(value) * factors[unit_key]
+    except ValueError as exc:
+        raise ValueError(f"invalid timescale value: {value}") from exc
+
+
+def _parse_timescale(vcd_text: str) -> float:
+    match = re.search(r"\$timescale\b(.*?)\$end", vcd_text, flags=re.S | re.I)
+    if match is None:
+        raise ValueError("missing $timescale declaration")
+    body = " ".join(match.group(1).split())
+    range_match = re.fullmatch(r"([0-9]+)\s*([A-Za-z]+)\s*/\s*([0-9]+)\s*([A-Za-z]+)", body)
+    if range_match:
+        return _safe_float_bits(range_match.group(3), range_match.group(4))
+    direct_match = re.fullmatch(r"([0-9]+)\s*([A-Za-z]+)", body)
+    if direct_match:
+        return _safe_float_bits(direct_match.group(1), direct_match.group(2))
+    raise ValueError(f"unrecognized $timescale format: {body!r}")
+
+
+def _parse_range_indices(raw: str | None, width: int) -> list[int]:
+    if raw is None:
+        return list(range(width))
+    match = re.fullmatch(r"\[\s*([+-]?\d+)\s*:\s*([+-]?\d+)\s*\]", raw)
+    if match is None:
+        raise ValueError(f"malformed range expression: {raw!r}")
+    start = int(match.group(1))
+    end = int(match.group(2))
+    if width <= 0:
+        raise ValueError("signal width must be > 0")
+    step = -1 if start > end else 1
+    bit_indices = list(range(start, end + step, step))
+    if len(bit_indices) != width:
+        raise ValueError(
+            f"vector range has {len(bit_indices)} bits but declaration reports width {width}: [{start}:{end}]"
+        )
+    return bit_indices
+
+
+def _parse_var_name_and_range(raw: str) -> tuple[str, str | None]:
+    text = raw.strip()
+    if not text:
+        raise ValueError("malformed $var declaration: missing name")
+    if text.startswith("\\"):
+        pieces = text.split(None, 1)
+        name = pieces[0]
+        range_expr = pieces[1].strip() if len(pieces) == 2 else None
+        if range_expr is not None and not re.fullmatch(r"\[\s*[+-]?\d+\s*:\s*[+-]?\d+\s*\]", range_expr):
+            raise ValueError(f"malformed escaped $var declaration: {raw!r}")
+    else:
+        tokens = text.split()
+        if len(tokens) == 0:
+            raise ValueError(f"malformed $var declaration: {raw!r}")
+        if len(tokens) > 2:
+            raise ValueError(f"malformed $var declaration: {raw!r}")
+        name = tokens[0]
+        range_expr = tokens[1] if len(tokens) == 2 else None
+    return name.lstrip("\\"), range_expr
+
+
+def _normalize_scope_tail(scope_path: str) -> str:
+    if scope_path == _TARGET_SCOPE_PREFIX:
+        return ""
+    if not scope_path.startswith(f"{_TARGET_SCOPE_PREFIX}/"):
+        raise ValueError(f"signal declaration outside scope '{_TARGET_SCOPE_PREFIX}': {scope_path}")
+    return scope_path[len(_TARGET_SCOPE_PREFIX) + 1 :]
+
+
+def _sanitize_bit(value: str) -> str:
+    val = value.lower()
+    if val not in {"0", "1", "x", "z"}:
+        raise ValueError(f"unsupported logic value: {value!r}")
+    return val
+
+
+def _transition_delta(old: str, new: str) -> float:
+    if old == new:
+        return 0.0
+    if (old in {"0", "1"}) and (new in {"0", "1"}):
+        return 1.0
+    return 0.5
+
+
+def _normalize_vector_update(value: str, width: int) -> list[str]:
+    if len(value) > width:
+        raise ValueError(f"vector update has {len(value)} bits but declaration width is {width}")
+    bits = [_sanitize_bit(ch) for ch in value]
+    if len(bits) == width:
+        return bits
+    if len(bits) < width:
+        if set(bits) == {"x"}:
+            return ["x"] * width
+        if set(bits) == {"z"}:
+            return ["z"] * width
+        return ["0"] * (width - len(bits)) + bits
+    return bits
+
+
+def _value_to_tick_delta(value: str | None, tick_delta: int) -> int:
+    if tick_delta < 0:
+        raise ValueError("timestamps in VCD must be nondecreasing")
+    if tick_delta == 0 or value != "1":
+        return 0
+    return tick_delta
+
+
+def extract_sequential_register_vcd_activity(
+    vcd_path: Path,
+    *,
+    source_vcd_sha256: str,
+    scope: str = _TARGET_SCOPE_PREFIX,
+) -> JsonDict:
+    if scope != _TARGET_SCOPE_PREFIX:
+        raise ValueError(f"scope must be {_TARGET_SCOPE_PREFIX}")
+    if not source_vcd_sha256:
+        raise ValueError("source_vcd_sha256 is required")
+
+    vcd_text = vcd_path.read_text(encoding="utf-8", errors="replace")
+    actual_hash = _sha256_file(vcd_path)
+    if actual_hash != source_vcd_sha256.lower():
+        raise ValueError("source_vcd_sha256 does not match actual vcd content")
+
+    timescale_seconds = _parse_timescale(vcd_text)
+    if not math.isfinite(timescale_seconds) or timescale_seconds <= 0.0:
+        raise ValueError("timescale_seconds must be a positive finite value")
+
+    id_to_full_names: dict[str, tuple[str, ...]] = {}
+    full_name_specs: dict[str, tuple[str, int]] = {}
+    scope_stack: list[str] = []
+    lines = vcd_text.splitlines()
+
+    # Parse declarations.
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "$enddefinitions":
+            break
+        if stripped.startswith("$scope "):
+            scope_match = _SCOPE_RE.match(stripped)
+            if scope_match:
+                scope_stack.append(scope_match.group(1).strip())
+            continue
+        if stripped == "$upscope" or stripped == "$upscope $end":
+            if scope_stack:
+                scope_stack.pop()
+            continue
+        if not (stripped.startswith("$var ") and stripped.endswith("$end")):
+            continue
+
+        match = _VAR_RE.match(stripped)
+        if match is None:
+            continue
+        signal_type = match.group(1)
+        if signal_type != "reg":
+            continue
+        width = int(match.group(2))
+        var_id = match.group(3)
+        raw = match.group(4).strip()
+
+        if width <= 0:
+            raise ValueError(f"invalid width {width} for {var_id}")
+
+        scope_path = "/".join(scope_stack)
+        if scope_path != scope and not scope_path.startswith(f"{scope}/"):
+            continue
+
+        scope_tail = _normalize_scope_tail(scope_path)
+
+        name_raw, range_expr = _parse_var_name_and_range(raw)
+        if not name_raw:
+            raise ValueError(f"invalid symbol name in {stripped}")
+        bit_indices = _parse_range_indices(range_expr, width)
+
+        base_name = name_raw if not scope_tail else f"{scope_tail}/{name_raw}"
+        if width == 1:
+            full_names = (base_name,)
+        else:
+            if len(bit_indices) != width:
+                raise ValueError(
+                    f"{scope_path}/{name_raw}: expected {width} bits, got range mapping of {len(bit_indices)}"
+                )
+            full_names = tuple(f"{base_name}[{index}]" for index in bit_indices)
+
+        if var_id in id_to_full_names:
+            raise ValueError(f"duplicate declaration for id {var_id}")
+
+        for bit_index, full_name in enumerate(full_names):
+            existing = full_name_specs.get(full_name)
+            if existing is not None:
+                existing_id, existing_bit_index = existing
+                raise ValueError(
+                    f"duplicate declaration for {full_name} (first {existing_id}[{existing_bit_index}], now {var_id}[{bit_index}])"
+                )
+            full_name_specs[full_name] = (var_id, bit_index)
+
+        id_to_full_names[var_id] = full_names
+
+    if not id_to_full_names:
+        raise ValueError("no target reg declarations found")
+
+    # Replay value transitions and active sampling region.
+    active_start: int | None = None
+    active_end: int | None = None
+    current_time = 0
+    dumping = False
+    full_name_state: dict[str, str | None] = {
+        full_name: None for full_name in full_name_specs
+    }
+    pin_rows: dict[str, _RegisterBitActivity] = {}
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            current_time = int(stripped[1:])
+            continue
+        if stripped == "$dumpon":
+            if active_end is not None:
+                raise ValueError("found $dumpon after $dumpoff")
+            if dumping:
+                raise ValueError("found nested $dumpon without $dumpoff")
+            active_start = current_time
+            dumping = True
+            pin_rows = {
+                full_name: _RegisterBitActivity(
+                    full_name=full_name,
+                    last_value=value,
+                    last_tick=current_time,
+                    transition_count=0.0,
+                    high_ticks=0,
+                )
+                for full_name, value in full_name_state.items()
+            }
+            continue
+        if stripped == "$dumpoff":
+            if not dumping:
+                raise ValueError("found $dumpoff without active $dumpon")
+            active_end = current_time
+            dumping = False
+            break
+        if current_time is None:
+            continue
+
+        scalar_update = _SCALAR_UPDATE_RE.match(stripped)
+        if scalar_update is not None:
+            new_value = _sanitize_bit(scalar_update.group(1))
+            var_id = scalar_update.group(2)
+            if var_id not in id_to_full_names:
+                continue
+            target_full_names = id_to_full_names[var_id]
+            if len(target_full_names) != 1:
+                raise ValueError(f"scalar update received for vector declaration {var_id}")
+            full_name = target_full_names[0]
+            full_name_state[full_name] = new_value
+            if not dumping:
+                continue
+            row = pin_rows[full_name]
+            if row.last_value is not None:
+                row.transition_count += _transition_delta(row.last_value, new_value)
+            row.high_ticks += _value_to_tick_delta(row.last_value, current_time - row.last_tick)
+            row.last_value = new_value
+            row.last_tick = current_time
+            continue
+
+        vector_update = _VECTOR_UPDATE_RE.match(stripped)
+        if vector_update is not None:
+            bits = vector_update.group(1).lower()
+            var_id = vector_update.group(2)
+            if var_id not in id_to_full_names:
+                continue
+            target_full_names = id_to_full_names[var_id]
+            bit_values = _normalize_vector_update(bits, len(target_full_names))
+            if len(bit_values) != len(target_full_names):
+                raise ValueError(
+                    f"vector update width mismatch for {var_id}: expected {len(target_full_names)}, got {len(bit_values)}"
+                )
+            for index, full_name in enumerate(target_full_names):
+                new_value = bit_values[index]
+                full_name_state[full_name] = new_value
+                if not dumping:
+                    continue
+                row = pin_rows[full_name]
+                if row.last_value is not None:
+                    row.transition_count += _transition_delta(row.last_value, new_value)
+                row.high_ticks += _value_to_tick_delta(row.last_value, current_time - row.last_tick)
+                row.last_value = new_value
+                row.last_tick = current_time
+            continue
+
+    if active_start is None or active_end is None:
+        raise ValueError("missing active dumpon/dumpoff interval")
+    if active_end <= active_start:
+        raise ValueError("active_end_tick must be greater than active_start_tick")
+
+    duration = active_end - active_start
+    for row in pin_rows.values():
+        if row.last_value is not None:
+            row.high_ticks += _value_to_tick_delta(row.last_value, active_end - row.last_tick)
+
+    register_bits: list[dict[str, Any]] = []
+    for row in sorted(pin_rows.values(), key=lambda entry: entry.full_name):
+        duty = row.high_ticks / duration
+        density = row.transition_count / (duration * timescale_seconds)
+        if not math.isfinite(row.transition_count) or row.transition_count < 0.0:
+            raise ValueError(f"non-finite transition_count for {row.full_name}")
+        if not math.isfinite(duty) or duty < 0.0 or duty > 1.0:
+            raise ValueError(f"non-finite or out-of-range duty_cycle for {row.full_name}")
+        if not math.isfinite(density) or density < 0.0:
+            raise ValueError(f"non-finite or negative density_hz for {row.full_name}")
+        register_bits.append(
+            {
+                "full_name": row.full_name,
+                "density_hz": density,
+                "duty_cycle": duty,
+                "transition_count": row.transition_count,
+                "source": "vcd",
+            }
+        )
+
+    return {
+        "version": 1,
+        "model": "sequential_register_vcd_activity_v1",
+        "scope": scope,
+        "source_vcd": vcd_path.name,
+        "source_vcd_sha256": actual_hash,
+        "timescale_seconds": timescale_seconds,
+        "active_start_tick": active_start,
+        "active_end_tick": active_end,
+        "register_bits": register_bits,
+    }
+
+
+def write_sequential_register_vcd_activity(
+    vcd_path: Path, *, output_path: Path, **kwargs: Any
+) -> JsonDict:
+    payload = extract_sequential_register_vcd_activity(vcd_path, **kwargs)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+if __name__ == "__main__":
+    raise SystemExit("extractor is library-only")

--- a/npu/eval/generate_attention_decode_score_multivalue_cluster_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_cluster_activity.py
@@ -24,6 +24,9 @@ from npu.eval.probe_attention_decode_score_multivalue_cluster_equivalence import
     _vectors,
 )
 from npu.eval.extract_fakeram_vcd_activity import extract_fakeram_vcd_activity
+from npu.eval.extract_sequential_register_vcd_activity import (
+    extract_sequential_register_vcd_activity,
+)
 from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate  # noqa: E402
 
 JsonDict = dict[str, Any]
@@ -42,6 +45,8 @@ _COMMAND_SETUP_CYCLES = 1
 _REPLAY_CLEAR_CYCLES = _VALUE_SLICES
 _FINALIZE_DIVIDE_CYCLES_PER_DIM = 60
 _FINALIZE_RESULT_EMIT_CYCLES = _VALUE_SLICES
+_REDUCER_NUMERATOR_ACCUM_WORDS = 128
+_SCORE_TILE_ACCUM_WORDS = 8
 
 
 def _load(path: Path) -> JsonDict:
@@ -126,6 +131,14 @@ def _testbench(
     )
     phase_active = _phase_expr(phase)
     clock_half_period = clock_period_ns / 2.0
+    reducer_dumpvars = "\n".join(
+        f"    $dumpvars(0, dut.reducer.numerator_accum[{index}]);"
+        for index in range(_REDUCER_NUMERATOR_ACCUM_WORDS)
+    )
+    score_tile_dumpvars = "\n".join(
+        f"    $dumpvars(0, dut.score_tile.accum[{index}]);"
+        for index in range(_SCORE_TILE_ACCUM_WORDS)
+    )
     return f"""`timescale 1ns/1ps
 {_FAKERAM_MODEL}
 module tb;
@@ -246,6 +259,8 @@ module tb;
   initial begin
     $dumpfile("{vcd_path.as_posix()}");
     $dumpvars(0, dut);
+{reducer_dumpvars}
+{score_tile_dumpvars}
     $dumpoff;
 {beat_init}
 {value_init}
@@ -280,7 +295,7 @@ def _run_phase(
     clock_period_ns: float,
     score_multiplier: int,
     score_shift: int,
-) -> tuple[int, int, Path, Path]:
+) -> tuple[int, int, Path, Path, Path]:
     validated = _validate_request(config=config, block_count=block_count, head_dim=head_dim)
     with tempfile.TemporaryDirectory(prefix=f"decode-score-multivalue-{phase}-") as tmp_text:
         tmp = Path(tmp_text)
@@ -325,7 +340,22 @@ def _run_phase(
             scope="tb/dut",
         )
         sidecar_path.write_text(json.dumps(sidecar, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        return cycle_count, service_cycles, phase_out, sidecar_path
+        sequential_sidecar_path = out_dir / f"{phase}_sequential_register_vcd_activity_v1.json"
+        sequential_sidecar = extract_sequential_register_vcd_activity(
+            phase_out,
+            source_vcd_sha256=_sha256_file(phase_out),
+            scope="tb/dut",
+        )
+        sequential_sidecar_path.write_text(
+            json.dumps(sequential_sidecar, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return (
+            cycle_count,
+            service_cycles,
+            phase_out,
+            sidecar_path,
+            sequential_sidecar_path,
+        )
 
 
 def _score_fill_scaling(*, cycle_count: int, block_count: int) -> JsonDict:
@@ -392,7 +422,13 @@ def generate_phase_activity(
     phases: list[JsonDict] = []
     full_service_cycles = 0
     for phase in _PHASES:
-        cycle_count, service_cycles, vcd_path, macro_activity_path = _run_phase(
+        (
+            cycle_count,
+            service_cycles,
+            vcd_path,
+            macro_activity_path,
+            sequential_register_activity_path,
+        ) = _run_phase(
             config=config,
             phase=phase,
             out_dir=out_dir,
@@ -417,6 +453,8 @@ def generate_phase_activity(
             "vcd_sha256": _sha256_file(vcd_path),
             "macro_activity": macro_activity_path.name,
             "macro_activity_sha256": _sha256_file(macro_activity_path),
+            "sequential_register_activity": sequential_register_activity_path.name,
+            "sequential_register_activity_sha256": _sha256_file(sequential_register_activity_path),
             "requires_macro_activity": phase in {"score_fill", "replay_value"},
             "scaling": scaling,
         })

--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -23,6 +23,7 @@ from typing import Any
 JsonDict = dict[str, Any]
 ORFS_FLOW = Path(os.environ.get("ORFS_FLOW", "/orfs/flow"))
 _FAKERAM_ACTIVITY_MODEL = "fakeram_macro_pin_vcd_activity_v1"
+_SEQUENTIAL_REGISTER_ACTIVITY_MODEL = "sequential_register_vcd_activity_v1"
 _SAFE_PIN_NAME = re.compile(r"^[A-Za-z0-9_./:+\-\[\]]+$")
 
 
@@ -172,6 +173,112 @@ def _write_macro_activity_tcl_assignments(*, path: Path, rows: list[JsonDict]) -
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def _load_sequential_register_activity(
+    path: Path,
+    *,
+    vcd_sha256: str,
+    phase_vcd_basename: str,
+) -> list[JsonDict]:
+    raw = _load_json(path)
+    version = raw.get("version")
+    if not isinstance(version, int) or isinstance(version, bool) or version != 1:
+        raise ValueError(
+            f"sequential register activity version mismatch for {path}: expected 1, got {version!r}"
+        )
+    model = str(raw.get("model", "")).strip()
+    if not isinstance(raw.get("model"), str) or not model:
+        raise ValueError(f"sequential register activity missing model for {path}")
+    source = str(raw.get("source_vcd_sha256", "")).strip().lower()
+    source_vcd_value = raw.get("source_vcd")
+    if not isinstance(source_vcd_value, str):
+        source_vcd = ""
+    else:
+        source_vcd = source_vcd_value.strip()
+    if model != _SEQUENTIAL_REGISTER_ACTIVITY_MODEL:
+        raise ValueError(
+            f"sequential register activity model mismatch for {path}: "
+            f"expected {_SEQUENTIAL_REGISTER_ACTIVITY_MODEL}, got {model or 'missing'}"
+        )
+    if source != vcd_sha256:
+        raise ValueError(
+            f"sequential register activity hash mismatch for {path}: expected {vcd_sha256}, got {source or 'missing'}"
+        )
+    if not source_vcd:
+        raise ValueError(f"sequential register activity missing source_vcd for {path}")
+    if source_vcd != phase_vcd_basename:
+        raise ValueError(
+            f"sequential register activity source_vcd mismatch for {path}: expected {phase_vcd_basename}, got {source_vcd}"
+        )
+    scope_value = raw.get("scope")
+    if not isinstance(scope_value, str):
+        scope = ""
+    else:
+        scope = scope_value.strip()
+    if scope != "tb/dut":
+        raise ValueError(f"sequential register activity scope mismatch for {path}: got {scope or 'missing'}")
+    timescale_seconds = _must_be_positive_finite("timescale_seconds", raw.get("timescale_seconds"))
+    active_start_tick = _must_be_int("active_start_tick", raw.get("active_start_tick"))
+    active_end_tick = _must_be_int("active_end_tick", raw.get("active_end_tick"))
+    if active_end_tick <= active_start_tick:
+        raise ValueError(
+            f"sequential register activity active range invalid for {path}: active_end_tick must be > active_start_tick"
+        )
+    rows_raw = raw.get("register_bits")
+    if not isinstance(rows_raw, list) or not rows_raw:
+        raise ValueError(f"sequential register activity must contain non-empty register_bits[]: {path}")
+    seen: set[str] = set()
+    rows: list[JsonDict] = []
+    for index, row in enumerate(rows_raw):
+        if not isinstance(row, dict):
+            raise ValueError(f"{path}: sequential register activity row[{index}] must be an object")
+        full_name = _must_be_safe_pin_name(row.get("full_name"))
+        if full_name in seen:
+            raise ValueError(f"duplicate sequential register full_name '{full_name}' in {path}")
+        if full_name.startswith("tb/dut/"):
+            raise ValueError(
+                f"sequential register activity full_name '{full_name}' must omit scope prefix in {path}"
+            )
+        if full_name == "tb" or full_name == "dut":
+            raise ValueError(f"invalid sequential register full_name '{full_name}' in {path}")
+        seen.add(full_name)
+        source_value = str(row.get("source", "")).strip()
+        if source_value != "vcd":
+            raise ValueError(
+                f"unsupported sequential register activity source '{source_value or 'missing'}' in {path}"
+            )
+        rows.append(
+            {
+                "full_name": full_name,
+                "density_hz": _must_be_positive_finite("density_hz", row.get("density_hz")),
+                "duty_cycle": _must_be_duty_cycle(row.get("duty_cycle")),
+                "transition_count": _must_be_positive_finite(
+                    "transition_count", row.get("transition_count")
+                ),
+                "source": source_value,
+            }
+        )
+    return rows
+
+
+def _write_sequential_register_activity_tcl_assignments(
+    *,
+    path: Path,
+    rows: list[JsonDict],
+) -> None:
+    lines = ["set rtlgen_sequential_register_activity_assignments {"]
+    for row in sorted(rows, key=lambda item: item["full_name"]):
+        lines.append(
+            "  {{{full_name} {density} {duty} {transition}}}".format(
+                full_name=row["full_name"],
+                density=f"{row['density_hz']:.17g}",
+                duty=f"{row['duty_cycle']:.17g}",
+                transition=f"{row['transition_count']:.17g}",
+            )
+        )
+    lines.append("}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
     raw_phases = manifest.get("phases")
     if not isinstance(raw_phases, list) or not raw_phases:
@@ -226,6 +333,34 @@ def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
             vcd_sha256=actual_hash,
             phase_vcd_basename=vcd_basename,
         )
+        sequential_activity_value = str(
+            raw.get("sequential_register_activity", raw.get("sequential_register_activity_path", ""))
+        ).strip()
+        if not sequential_activity_value:
+            raise ValueError(f"phase {phase} is missing sequential_register_activity")
+        sequential_activity = Path(sequential_activity_value)
+        if not sequential_activity.is_absolute():
+            sequential_activity = (manifest_path.parent / sequential_activity).resolve()
+        if not sequential_activity.is_file():
+            raise FileNotFoundError(
+                f"phase sequential_register_activity sidecar does not exist: {sequential_activity}"
+            )
+        expected_sequential_activity_hash = str(
+            raw.get("sequential_register_activity_sha256", "")
+        ).strip().lower()
+        if not expected_sequential_activity_hash:
+            raise ValueError(f"phase {phase} requires sequential_register_activity_sha256")
+        sequential_activity_hash = _sha256(sequential_activity)
+        if expected_sequential_activity_hash != sequential_activity_hash:
+            raise ValueError(
+                f"phase {phase} sequential register activity hash mismatch: "
+                f"expected {expected_sequential_activity_hash}, got {sequential_activity_hash}"
+            )
+        sequential_activity_rows = _load_sequential_register_activity(
+            sequential_activity,
+            vcd_sha256=actual_hash,
+            phase_vcd_basename=vcd_basename,
+        )
         measured_cycles_raw = raw.get("measured_cycles")
         if measured_cycles_raw is None:
             raise ValueError(f"phase {phase} is missing measured_cycles")
@@ -253,6 +388,11 @@ def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
                 "macro_activity_sha256": macro_activity_hash,
                 "_macro_activity_rows": macro_activity_rows,
                 "macro_activity_assignment_count": len(macro_activity_rows),
+                "sequential_register_activity": sequential_activity_value,
+                "_resolved_sequential_register_activity": str(sequential_activity),
+                "sequential_register_activity_sha256": sequential_activity_hash,
+                "_sequential_register_activity_rows": sequential_activity_rows,
+                "sequential_register_activity_assignment_count": len(sequential_activity_rows),
                 "measured_cycles": measured_cycles,
                 "full_context_cycles": full_context_cycles,
                 "requires_macro_activity": bool(
@@ -344,6 +484,15 @@ proc rtlgen_append_leaf_instance_pin_sample {samples_var limit_var instance_full
   lappend samples [list $instance_full_name $ref_name $pin_full_name $pin_direction $activity $reason]
 }
 
+proc rtlgen_append_sequential_register_activity_sample {samples_var limit_var full_name register_full_name pin pin_duty pin_type kind reason} {
+  upvar 1 $samples_var samples
+  upvar 1 $limit_var sample_limit
+  if {[llength $samples] >= $sample_limit} {
+    return
+  }
+  lappend samples [list $full_name $register_full_name $pin $pin_duty $pin_type $kind $reason]
+}
+
 proc rtlgen_sorted_list {values} {
   if {[catch {lsort -dictionary $values} sorted]} {
     if {[catch {lsort $values} sorted]} {
@@ -371,7 +520,7 @@ proc rtlgen_apply_macro_pin_activities {assignments} {
     return $results
   }
   foreach assignment $assignments {
-    if {[llength $assignment] < 4} {
+    if {[llength $assignment] != 4} {
       lappend results [list {} 0]
       continue
     }
@@ -386,10 +535,6 @@ proc rtlgen_apply_macro_pin_activities {assignments} {
 }
 
 set power_corner [sta::cmd_corner]
-set totals [sta::design_power $power_corner]
-set design_power_category_names {total sequential combinational clock macro pad}
-set design_power_category_count [expr {[llength $totals] / 4}]
-set design_power_totals [lrange $totals 0 3]
 set all_design_pins_unsorted {}
 set macro_pin_transfer_query_error_count 0
 set macro_pin_transfer_structural_query_error_count 0
@@ -402,6 +547,28 @@ set macro_pin_transfer_structural_assignments {}
 set macro_pin_transfer_structural_assignment_rows_by_full_name {}
 set macro_pin_transfer_structural_unmatched_rows_by_full_name {}
 set macro_pin_transfer_structural_unmatched_full_names {}
+set sequential_register_activity_query_error_count 0
+set sequential_register_activity_apply_error_count 0
+set sequential_register_activity_assignment_count 0
+set sequential_register_activity_scanned_pin_count 0
+set sequential_register_activity_candidate_q_count 0
+set sequential_register_activity_candidate_qn_count 0
+set sequential_register_activity_matched_count 0
+set sequential_register_activity_applied_count 0
+set sequential_register_activity_unmatched_output_count 0
+set sequential_register_activity_unused_sidecar_rows {}
+set sequential_register_activity_unused_sidecar_row_count 0
+set sequential_register_activity_scan_sample_limit 16
+set sequential_register_activity_scan_samples {}
+set sequential_register_activity_assignments {}
+set sequential_register_activity_updates {}
+set sequential_register_activity_assignment_rows_by_full_name {}
+set sequential_register_activity_unmatched_rows_by_full_name {}
+set sequential_register_activity_assignment_rows_seen {}
+set sequential_register_activity_updates_by_pin {}
+set sequential_register_activity_pin_type_by_pin {}
+set sequential_register_activity_pin_register_by_pin {}
+set sequential_register_activity_pin_duty_by_pin {}
 if {[info exists ::env(RTLGEN_MACRO_ACTIVITY_TCL)] && $::env(RTLGEN_MACRO_ACTIVITY_TCL) ne ""} {
   if {[catch {source $::env(RTLGEN_MACRO_ACTIVITY_TCL)} structural_source_error]} {
     incr macro_pin_transfer_structural_query_error_count
@@ -410,6 +577,17 @@ if {[info exists ::env(RTLGEN_MACRO_ACTIVITY_TCL)] && $::env(RTLGEN_MACRO_ACTIVI
       set macro_pin_transfer_structural_assignments $rtlgen_macro_activity_assignments
     } else {
       incr macro_pin_transfer_structural_query_error_count
+    }
+  }
+}
+if {[info exists ::env(RTLGEN_SEQUENTIAL_REGISTER_ACTIVITY_TCL)] && $::env(RTLGEN_SEQUENTIAL_REGISTER_ACTIVITY_TCL) ne ""} {
+  if {[catch {source $::env(RTLGEN_SEQUENTIAL_REGISTER_ACTIVITY_TCL)} sequential_source_error]} {
+    incr sequential_register_activity_query_error_count
+  } else {
+    if {[info exists rtlgen_sequential_register_activity_assignments]} {
+      set sequential_register_activity_assignments $rtlgen_sequential_register_activity_assignments
+    } else {
+      incr sequential_register_activity_query_error_count
     }
   }
 }
@@ -423,12 +601,170 @@ foreach macro_pin_transfer_structural_row $macro_pin_transfer_structural_assignm
   dict set macro_pin_transfer_structural_assignment_rows_by_full_name $macro_pin_transfer_structural_full_name [list $macro_pin_transfer_structural_density $macro_pin_transfer_structural_duty $macro_pin_transfer_structural_transition_count]
   dict set macro_pin_transfer_structural_unmatched_rows_by_full_name $macro_pin_transfer_structural_full_name 1
 }
+set sequential_register_activity_assignment_count [llength $sequential_register_activity_assignments]
+foreach sequential_register_activity_row $sequential_register_activity_assignments {
+  if {[llength $sequential_register_activity_row] != 4} {
+    incr sequential_register_activity_query_error_count
+    continue
+  }
+  lassign \
+    $sequential_register_activity_row \
+    sequential_register_activity_full_name \
+    sequential_register_activity_density \
+    sequential_register_activity_duty \
+    sequential_register_activity_transition_count
+  dict set sequential_register_activity_assignment_rows_by_full_name \
+    $sequential_register_activity_full_name \
+    [list \
+      $sequential_register_activity_density \
+      $sequential_register_activity_duty \
+      $sequential_register_activity_transition_count]
+  dict set sequential_register_activity_unmatched_rows_by_full_name \
+    $sequential_register_activity_full_name 1
+}
 set macro_pin_transfer_structural_candidate_count $macro_pin_transfer_structural_assignment_count
 if {[catch {set all_design_pins_unsorted [get_pins -hierarchical *]}]} {
   incr macro_pin_transfer_query_error_count
   set all_design_pins_unsorted {}
 }
 set all_design_pins [rtlgen_sorted_list $all_design_pins_unsorted]
+set sequential_register_activity_scanned_pin_count [llength $all_design_pins]
+foreach sequential_register_activity_pin $all_design_pins {
+  if {[catch {set sequential_register_activity_pin_full_name [get_property $sequential_register_activity_pin full_name]}]} {
+    incr sequential_register_activity_query_error_count
+    continue
+  }
+  if {[catch {set sequential_register_activity_pin_is_hierarchical [get_property $sequential_register_activity_pin is_hierarchical]}]} {
+    incr sequential_register_activity_query_error_count
+    continue
+  }
+  if {$sequential_register_activity_pin_is_hierarchical} {
+    continue
+  }
+  if {[catch {set sequential_register_activity_pin_direction [get_property $sequential_register_activity_pin direction]}]} {
+    incr sequential_register_activity_query_error_count
+    continue
+  }
+  if {$sequential_register_activity_pin_direction ne "output"} {
+    continue
+  }
+  if {![regexp {^(.+)\$_DFF[^/]+/(Q|QN)$} $sequential_register_activity_pin_full_name \
+          -> sequential_register_activity_register_full_name sequential_register_activity_pin_type]} {
+    continue
+  }
+  if {$sequential_register_activity_pin_type eq "Q"} {
+    incr sequential_register_activity_candidate_q_count
+  } else {
+    incr sequential_register_activity_candidate_qn_count
+  }
+  if {![dict exists $sequential_register_activity_assignment_rows_by_full_name $sequential_register_activity_register_full_name]} {
+    incr sequential_register_activity_unmatched_output_count
+    rtlgen_append_sequential_register_activity_sample \
+      sequential_register_activity_scan_samples \
+      sequential_register_activity_scan_sample_limit \
+      $sequential_register_activity_pin_full_name \
+      $sequential_register_activity_register_full_name \
+      $sequential_register_activity_pin \
+      0.0 \
+      $sequential_register_activity_pin_type \
+      unmatched_output \
+      no_sequential_row
+    continue
+  }
+  lassign \
+    [dict get $sequential_register_activity_assignment_rows_by_full_name $sequential_register_activity_register_full_name] \
+    sequential_register_activity_density \
+    sequential_register_activity_duty \
+    sequential_register_activity_transition_count
+  if {$sequential_register_activity_pin_type eq "QN"} {
+    set sequential_register_activity_effective_duty [expr {1.0 - $sequential_register_activity_duty}]
+  } else {
+    set sequential_register_activity_effective_duty $sequential_register_activity_duty
+  }
+  lappend sequential_register_activity_updates \
+    [list \
+      $sequential_register_activity_pin_full_name \
+      $sequential_register_activity_pin \
+      $sequential_register_activity_density \
+      $sequential_register_activity_effective_duty]
+  dict set sequential_register_activity_pin_register_by_pin $sequential_register_activity_pin $sequential_register_activity_register_full_name
+  dict set sequential_register_activity_pin_type_by_pin $sequential_register_activity_pin $sequential_register_activity_pin_type
+  dict set sequential_register_activity_pin_duty_by_pin $sequential_register_activity_pin $sequential_register_activity_effective_duty
+  dict incr sequential_register_activity_assignment_rows_seen $sequential_register_activity_register_full_name
+  incr sequential_register_activity_matched_count
+}
+if {[llength $sequential_register_activity_updates] > 0} {
+  set sequential_register_activity_apply_results [rtlgen_apply_macro_pin_activities $sequential_register_activity_updates]
+  foreach sequential_register_activity_apply_result $sequential_register_activity_apply_results {
+    lassign $sequential_register_activity_apply_result \
+      sequential_register_activity_pin_full_name \
+      sequential_register_activity_pin_applied
+    if {$sequential_register_activity_pin_full_name eq ""} {
+      continue
+    }
+    if {$sequential_register_activity_pin_applied} {
+      incr sequential_register_activity_applied_count
+      rtlgen_append_sequential_register_activity_sample \
+        sequential_register_activity_scan_samples \
+        sequential_register_activity_scan_sample_limit \
+        $sequential_register_activity_pin_full_name \
+        [dict get $sequential_register_activity_pin_register_by_pin $sequential_register_activity_pin_full_name] \
+        $sequential_register_activity_pin_full_name \
+        [dict get $sequential_register_activity_pin_duty_by_pin $sequential_register_activity_pin_full_name] \
+        [dict get $sequential_register_activity_pin_type_by_pin $sequential_register_activity_pin_full_name] \
+        matched \
+        applied
+    } else {
+      incr sequential_register_activity_apply_error_count
+      rtlgen_append_sequential_register_activity_sample \
+        sequential_register_activity_scan_samples \
+        sequential_register_activity_scan_sample_limit \
+        $sequential_register_activity_pin_full_name \
+        [dict get $sequential_register_activity_pin_register_by_pin $sequential_register_activity_pin_full_name] \
+        $sequential_register_activity_pin_full_name \
+        [dict get $sequential_register_activity_pin_duty_by_pin $sequential_register_activity_pin_full_name] \
+        [dict get $sequential_register_activity_pin_type_by_pin $sequential_register_activity_pin_full_name] \
+        matched \
+        apply_error
+    }
+  }
+}
+if {[dict size $sequential_register_activity_assignment_rows_by_full_name] > 0} {
+  dict for {sequential_register_activity_unused_row _} \
+    $sequential_register_activity_assignment_rows_by_full_name {
+    if {[dict exists $sequential_register_activity_assignment_rows_seen $sequential_register_activity_unused_row]} {
+      continue
+    }
+    lappend sequential_register_activity_unused_sidecar_rows $sequential_register_activity_unused_row
+    incr sequential_register_activity_unused_sidecar_row_count
+    if {[llength $sequential_register_activity_scan_samples] < $sequential_register_activity_scan_sample_limit} {
+      lappend sequential_register_activity_scan_samples \
+        [list \
+          "" \
+          $sequential_register_activity_unused_row \
+          "" \
+          "" \
+          "" \
+          unused_sidecar_row \
+          no_unmatched_sidecar_row
+        ]
+    }
+  }
+}
+if {![info exists sequential_register_activity_scan_samples]} {
+  set sequential_register_activity_scan_samples {}
+}
+set sequential_register_activity_candidate_count \
+  [expr {$sequential_register_activity_candidate_q_count + $sequential_register_activity_candidate_qn_count}]
+set sequential_register_activity_coverage 0.0
+if {$sequential_register_activity_candidate_count > 0} {
+  set sequential_register_activity_coverage \
+    [expr {double($sequential_register_activity_matched_count) / double($sequential_register_activity_candidate_count)}]
+}
+set totals [sta::design_power $power_corner]
+set design_power_category_names {total sequential combinational clock macro pad}
+set design_power_category_count [expr {[llength $totals] / 4}]
+set design_power_totals [lrange $totals 0 3]
 set macro_pin_transfer_scanned_pin_count [llength $all_design_pins]
 set macro_pin_transfer_name_match_count 0
 set macro_pin_transfer_input_pin_count 0
@@ -693,6 +1029,9 @@ if {[llength $macro_pin_transfer_updates] > 0} {
   set macro_pin_transfer_record_full_names {}
   foreach macro_pin_transfer_apply_result $macro_pin_transfer_apply_results {
     lassign $macro_pin_transfer_apply_result pin_full_name applied
+    if {$pin_full_name eq ""} {
+      continue
+    }
     if {$applied} {
       if {![dict exists $macro_pin_transfer_candidate_source_by_full_name $pin_full_name]} {
         incr macro_pin_transfer_apply_error_count
@@ -1435,7 +1774,7 @@ foreach activity_value_diagnostic_valid_sample $activity_value_diagnostic_valid_
   } else {
     puts $fp "$activity_value_diagnostic_valid_sample_line"
   }
-}
+  }
 puts $fp "    \]"
 puts $fp "  }"
 puts $fp ","
@@ -1510,7 +1849,54 @@ foreach macro_pin_transfer_record $macro_pin_transfer_records {
     puts $fp "$macro_pin_transfer_record_line"
   }
 }
-  puts $fp "    \]"
+puts $fp "    \]"
+puts $fp "  }"
+puts $fp ","
+puts $fp "  \"sequential_register_activity\": {"
+puts $fp "    \"assignment_count\": $sequential_register_activity_assignment_count,"
+puts $fp "    \"scanned_pin_count\": $sequential_register_activity_scanned_pin_count,"
+puts $fp "    \"candidate_count\": $sequential_register_activity_candidate_count,"
+puts $fp "    \"q_candidate_count\": $sequential_register_activity_candidate_q_count,"
+puts $fp "    \"qn_candidate_count\": $sequential_register_activity_candidate_qn_count,"
+puts $fp "    \"matched_count\": $sequential_register_activity_matched_count,"
+puts $fp "    \"applied_count\": $sequential_register_activity_applied_count,"
+puts $fp "    \"query_error_count\": $sequential_register_activity_query_error_count,"
+puts $fp "    \"apply_error_count\": $sequential_register_activity_apply_error_count,"
+puts $fp "    \"unmatched_output_count\": $sequential_register_activity_unmatched_output_count,"
+puts $fp "    \"unused_sidecar_row_count\": $sequential_register_activity_unused_sidecar_row_count,"
+puts $fp "    \"coverage\": [rtlgen_json_number $sequential_register_activity_coverage],"
+puts $fp "    \"scan_samples\": \["
+set sequential_register_activity_sample_count [llength $sequential_register_activity_scan_samples]
+set sequential_register_activity_sample_index 0
+foreach sequential_register_activity_sample $sequential_register_activity_scan_samples {
+  lassign \
+    $sequential_register_activity_sample \
+    sequential_register_activity_sample_full_name \
+    sequential_register_activity_sample_register_full_name \
+    sequential_register_activity_sample_pin \
+    sequential_register_activity_sample_pin_duty \
+    sequential_register_activity_sample_pin_type \
+    sequential_register_activity_sample_kind \
+    sequential_register_activity_sample_reason
+  set escaped_sample_full_name \
+    [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $sequential_register_activity_sample_full_name]]
+  set escaped_sample_register_full_name \
+    [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $sequential_register_activity_sample_register_full_name]]
+  set escaped_sample_pin \
+    [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $sequential_register_activity_sample_pin]]
+  set escaped_sample_pin_type [rtlgen_json_escape $sequential_register_activity_sample_pin_type]
+  set escaped_sample_kind [rtlgen_json_escape $sequential_register_activity_sample_kind]
+  set escaped_sample_reason [rtlgen_json_escape $sequential_register_activity_sample_reason]
+  set sample_pin_duty_json [rtlgen_json_number $sequential_register_activity_sample_pin_duty]
+  incr sequential_register_activity_sample_index
+  set sequential_register_activity_sample_line "      {\"full_name\": \"$escaped_sample_full_name\", \"register_full_name\": \"$escaped_sample_register_full_name\", \"pin\": \"$escaped_sample_pin\", \"pin_duty\": $sample_pin_duty_json, \"pin_type\": \"$escaped_sample_pin_type\", \"kind\": \"$escaped_sample_kind\", \"reason\": \"$escaped_sample_reason\"}"
+  if {$sequential_register_activity_sample_index < $sequential_register_activity_sample_count} {
+    puts $fp "$sequential_register_activity_sample_line,"
+  } else {
+    puts $fp "$sequential_register_activity_sample_line"
+  }
+}
+puts $fp "    \]"
 puts $fp "  }"
 if {$has_nonfinite_design_total} {
   puts $fp ","
@@ -1663,6 +2049,7 @@ def _run_openroad_phase(
     vcd: Path,
     scope: str,
     macro_activity_tcl: Path | None = None,
+    sequential_register_activity_tcl: Path | None = None,
     tcl: Path,
     result: Path,
     timeout_seconds: int,
@@ -1681,6 +2068,11 @@ def _run_openroad_phase(
         "rtlgen_activity_power:\n"
         f"\t@RTLGEN_ACTIVITY_VCD='{vcd}' "
         +(f"RTLGEN_MACRO_ACTIVITY_TCL='{macro_activity_tcl}' " if macro_activity_tcl else "")
+        +(
+            f"RTLGEN_SEQUENTIAL_REGISTER_ACTIVITY_TCL='{sequential_register_activity_tcl}' "
+            if sequential_register_activity_tcl
+            else ""
+        )
         +
         f"RTLGEN_ACTIVITY_SCOPE='{scope}' "
         f"RTLGEN_ACTIVITY_RESULT='{result}' "
@@ -1753,6 +2145,7 @@ def build_report(
     design_config: Path,
     flow_variant: str,
     scope: str,
+    min_sequential_register_activity_coverage: float = 0.95,
     min_vcd_coverage: float,
     min_vcd_pins: int,
     min_macro_active_coverage: float,
@@ -1777,6 +2170,16 @@ def build_report(
                     path=phase_macro_activity_tcl,
                     rows=phase_macro_activity_rows,  # type: ignore[arg-type]
                 )
+            phase_sequential_activity_tcl: Path | None = None
+            phase_sequential_activity_rows = phase.get("_sequential_register_activity_rows")
+            if phase_sequential_activity_rows:
+                phase_sequential_activity_tcl = temp / (
+                    f"{phase['phase']}.sequential_register_activity.tcl"
+                )
+                _write_sequential_register_activity_tcl_assignments(
+                    path=phase_sequential_activity_tcl,
+                    rows=phase_sequential_activity_rows,  # type: ignore[arg-type]
+                )
             result = temp / f"{phase['phase']}.json"
             power = _run_openroad_phase(
                 design_config=design_config,
@@ -1784,6 +2187,7 @@ def build_report(
                 vcd=Path(str(phase["_resolved_vcd"])),
                 scope=scope,
                 macro_activity_tcl=phase_macro_activity_tcl,
+                sequential_register_activity_tcl=phase_sequential_activity_tcl,
                 tcl=tcl,
                 result=result,
                 timeout_seconds=timeout_seconds,
@@ -1834,6 +2238,44 @@ def build_report(
             macro_pin_transfer_structural_apply_error_count = int(
                 macro_pin_transfer.get("structural_apply_error_count", 0)
             )
+            sequential_register_activity = power.get("sequential_register_activity", {})
+            if not isinstance(sequential_register_activity, dict):
+                sequential_register_activity = {}
+            sequential_register_activity_assignment_count = int(
+                phase.get(
+                    "sequential_register_activity_assignment_count",
+                    sequential_register_activity.get("assignment_count", 0),
+                )
+            )
+            sequential_register_activity_candidate_count = int(
+                sequential_register_activity.get("candidate_count", 0)
+            )
+            if sequential_register_activity_candidate_count == 0:
+                sequential_register_activity_candidate_count = int(
+                    sequential_register_activity.get("q_candidate_count", 0)
+                    + sequential_register_activity.get("qn_candidate_count", 0)
+                )
+            sequential_register_activity_matched_count = int(
+                sequential_register_activity.get("matched_count", 0)
+            )
+            sequential_register_activity_applied_count = int(
+                sequential_register_activity.get("applied_count", 0)
+            )
+            sequential_register_activity_unused_sidecar_rows = int(
+                sequential_register_activity.get("unused_sidecar_row_count", 0)
+            )
+            sequential_register_activity_apply_error_count = int(
+                sequential_register_activity.get("apply_error_count", 0)
+            )
+            sequential_register_activity_query_error_count = int(
+                sequential_register_activity.get("query_error_count", 0)
+            )
+            sequential_register_activity_coverage = 0.0
+            if sequential_register_activity_candidate_count > 0:
+                sequential_register_activity_coverage = (
+                    sequential_register_activity_matched_count
+                    / sequential_register_activity_candidate_count
+                )
             trace_coverage = (
                 trace_backed / leaf_annotatable
                 if leaf_annotatable
@@ -1869,6 +2311,15 @@ def build_report(
             )
             if phase["requires_macro_activity"]:
                 macro_pass = macro_pass and macro_activity_assignment_count > 0
+            sequential_register_activity_gate_pass = (
+                sequential_register_activity_assignment_count > 0
+                and sequential_register_activity_applied_count
+                == sequential_register_activity_matched_count
+                and sequential_register_activity_apply_error_count == 0
+                and sequential_register_activity_query_error_count == 0
+                and sequential_register_activity_coverage
+                >= min_sequential_register_activity_coverage
+            )
             sdc_period_value = power.get("sdc_clock_period_ns")
             sdc_period_ns = (
                 float(sdc_period_value) if sdc_period_value is not None else 0.0
@@ -1898,10 +2349,16 @@ def build_report(
                     "macro_activity_gate_pass": macro_pass,
                     "macro_trace_active_coverage": macro_coverage,
                     "structural_macro_activity_gate_pass": structural_macro_gate,
+                    "sequential_register_activity_assignment_count": sequential_register_activity_assignment_count,
+                    "sequential_register_activity_coverage": sequential_register_activity_coverage,
+                    "sequential_register_activity_matched_count": sequential_register_activity_matched_count,
+                    "sequential_register_activity_applied_count": sequential_register_activity_applied_count,
+                    "sequential_register_activity_gate_pass": sequential_register_activity_gate_pass,
                     "clock_period_gate_pass": clock_period_pass,
                     "power_numeric_gate_pass": power_numeric_pass,
                     "phase_gate_pass": annotation_gate_pass
                     and macro_pass
+                    and sequential_register_activity_gate_pass
                     and structural_macro_gate
                     and clock_period_pass
                     and power_numeric_pass,
@@ -1921,6 +2378,7 @@ def build_report(
         "flow_variant": flow_variant,
         "orfs_design_config": _orfs_relative_path(design_config),
         "min_vcd_annotation_coverage": min_vcd_coverage,
+        "min_sequential_register_activity_coverage": min_sequential_register_activity_coverage,
         "min_vcd_annotated_pins": min_vcd_pins,
         "min_macro_trace_active_coverage": min_macro_active_coverage,
         "min_macro_trace_active_pins": min_macro_active_pins,
@@ -2010,6 +2468,11 @@ def main() -> int:
     parser.add_argument("--design-config", type=Path, required=True)
     parser.add_argument("--flow-variant", required=True)
     parser.add_argument("--scope", default="tb/dut")
+    parser.add_argument(
+        "--min-sequential-register-activity-coverage",
+        type=float,
+        default=0.95,
+    )
     parser.add_argument("--min-vcd-coverage", type=float, default=0.05)
     parser.add_argument("--min-vcd-pins", type=int, default=32)
     parser.add_argument("--min-macro-active-coverage", type=float, default=0.01)
@@ -2020,6 +2483,10 @@ def main() -> int:
     args = parser.parse_args()
     if not 0.0 < args.min_vcd_coverage <= 1.0:
         parser.error("--min-vcd-coverage must be in (0, 1]")
+    if not 0.0 < args.min_sequential_register_activity_coverage <= 1.0:
+        parser.error(
+            "--min-sequential-register-activity-coverage must be in (0, 1]"
+        )
     if args.min_vcd_pins <= 0:
         parser.error("--min-vcd-pins must be positive")
     if not 0.0 < args.min_macro_active_coverage <= 1.0:
@@ -2033,6 +2500,9 @@ def main() -> int:
         design_config=args.design_config,
         flow_variant=args.flow_variant,
         scope=args.scope,
+        min_sequential_register_activity_coverage=(
+            args.min_sequential_register_activity_coverage
+        ),
         min_vcd_coverage=args.min_vcd_coverage,
         min_vcd_pins=args.min_vcd_pins,
         min_macro_active_coverage=args.min_macro_active_coverage,

--- a/tests/test_attention_decode_score_multivalue_cluster_activity.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import math
 import shutil
 from pathlib import Path
 
@@ -58,6 +59,8 @@ def test_multivalue_cluster_activity_generates_phase_vcds_and_manifest(tmp_path:
         assert phase["measured_cycles"] > 0
         assert "macro_activity" in phase
         assert "macro_activity_sha256" in phase
+        assert "sequential_register_activity" in phase
+        assert "sequential_register_activity_sha256" in phase
         macro_activity_path = tmp_path / phase["macro_activity"]
         assert macro_activity_path.exists()
         sidecar_raw = macro_activity_path.read_bytes()
@@ -72,6 +75,60 @@ def test_multivalue_cluster_activity_generates_phase_vcds_and_manifest(tmp_path:
         assert macro["timescale_seconds"] > 0
         assert len(macro["pins"]) == 5096
         assert macro["pins"] == sorted(macro["pins"], key=lambda row: row["full_name"])
+
+        sequential_activity_path = tmp_path / phase["sequential_register_activity"]
+        assert sequential_activity_path.exists()
+        sequential_raw = sequential_activity_path.read_bytes()
+        assert phase["sequential_register_activity_sha256"] == hashlib.sha256(sequential_raw).hexdigest()
+        sequential = json.loads(sequential_raw)
+        assert sequential["version"] == 1
+        assert sequential["model"] == "sequential_register_vcd_activity_v1"
+        assert sequential["scope"] == "tb/dut"
+        assert sequential["source_vcd"] == phase["vcd"]
+        assert sequential["source_vcd_sha256"] == phase["vcd_sha256"]
+        assert sequential["active_start_tick"] < sequential["active_end_tick"]
+        assert sequential["timescale_seconds"] > 0
+        assert sequential["register_bits"]
+        assert sequential["register_bits"] == sorted(
+            sequential["register_bits"], key=lambda row: row["full_name"]
+        )
+        register_bits = sequential["register_bits"]
+        names = {row["full_name"] for row in register_bits}
+        numerator_accum_names = {
+            name for name in names if name.startswith("reducer/numerator_accum[")
+        }
+        score_accum_names = {name for name in names if name.startswith("score_tile/accum[")}
+        expected_numerator_accum_names = {
+            f"reducer/numerator_accum[{word}][{bit}]"
+            for word in range(128)
+            for bit in range(41)
+        }
+        expected_score_accum_names = {
+            f"score_tile/accum[{word}][{bit}]" for word in range(8) for bit in range(32)
+        }
+        assert len(numerator_accum_names) == 5_248
+        assert numerator_accum_names == expected_numerator_accum_names
+        assert len(score_accum_names) == 256
+        assert score_accum_names == expected_score_accum_names
+        assert {
+            "reducer/numerator_accum[0][0]",
+            "reducer/numerator_accum[0][40]",
+            "reducer/numerator_accum[127][0]",
+            "reducer/numerator_accum[127][40]",
+            "score_tile/accum[0][0]",
+            "score_tile/accum[0][31]",
+            "score_tile/accum[7][0]",
+            "score_tile/accum[7][31]",
+        } <= names
+        for row in register_bits:
+            assert not row["full_name"].startswith("tb/dut/")
+            assert row["source"] == "vcd"
+            assert math.isfinite(row["density_hz"])
+            assert row["density_hz"] >= 0.0
+            assert math.isfinite(row["duty_cycle"])
+            assert 0.0 <= row["duty_cycle"] <= 1.0
+            assert math.isfinite(row["transition_count"])
+            assert row["transition_count"] >= 0.0
 
     score_fill = phases["score_fill"]
     assert (score_fill["measured_cycles"] - 1) % manifest["block_count"] == 0

--- a/tests/test_extract_sequential_register_vcd_activity.py
+++ b/tests/test_extract_sequential_register_vcd_activity.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Tests for sequential-register VCD extractor."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from npu.eval.extract_sequential_register_vcd_activity import (
+    extract_sequential_register_vcd_activity,
+)
+
+
+def _write_vcd(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+
+
+def _mini_vcd() -> str:
+    return "\n".join(
+        [
+            "$date",
+            " Sequential register VCD",
+            "$end",
+            "$version",
+            "  test",
+            "$end",
+            "$timescale",
+            " 1ns/1ps",
+            "$end",
+            "$scope module tb $end",
+            "$scope module dut $end",
+            "$scope module reducer $end",
+            "$var reg 3 a \\numerator_accum[56] [2:0] $end",
+            "$upscope $end",
+            "$scope module score_tile $end",
+            "$var reg 2 b \\accum[3] [1:0] $end",
+            "$upscope $end",
+            "$upscope $end",
+            "$enddefinitions",
+            "#0",
+            "b000 a",
+            "b00 b",
+            "#10",
+            "$dumpon",
+            "#20",
+            "b010 a",
+            "b10 b",
+            "#30",
+            "b01 b",
+            "#35",
+            "$dumpoff",
+        ]
+    )
+
+
+def test_extract_sequential_register_activity_mini_vcd_semantics(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "mini.vcd"
+    _write_vcd(vcd_path, _mini_vcd())
+    payload = extract_sequential_register_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+        scope="tb/dut",
+    )
+
+    assert payload["version"] == 1
+    assert payload["model"] == "sequential_register_vcd_activity_v1"
+    assert payload["scope"] == "tb/dut"
+    assert payload["source_vcd"] == vcd_path.name
+    assert payload["timescale_seconds"] == 1e-12
+    assert payload["active_start_tick"] == 10
+    assert payload["active_end_tick"] == 35
+    assert payload["active_end_tick"] > payload["active_start_tick"]
+    assert len(payload["register_bits"]) == 5
+
+    rows = {row["full_name"]: row for row in payload["register_bits"]}
+    assert rows["reducer/numerator_accum[56][1]"]["transition_count"] == 1.0
+    assert rows["reducer/numerator_accum[56][1]"]["duty_cycle"] == pytest.approx(0.6)
+    assert rows["score_tile/accum[3][1]"]["transition_count"] == 2.0
+    assert rows["score_tile/accum[3][1]"]["duty_cycle"] == pytest.approx(0.4)
+    assert rows["score_tile/accum[3][0]"]["transition_count"] == 1.0
+    assert rows["score_tile/accum[3][0]"]["duty_cycle"] == pytest.approx(0.2)
+
+
+def test_extract_sequential_register_activity_rejects_bad_hash(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "mini.vcd"
+    _write_vcd(vcd_path, _mini_vcd())
+    with pytest.raises(ValueError, match="source_vcd_sha256 does not match"):
+        extract_sequential_register_vcd_activity(
+            vcd_path,
+            source_vcd_sha256=hashlib.sha256(b"wrong").hexdigest(),
+            scope="tb/dut",
+        )
+
+
+def test_extract_sequential_register_activity_rejects_missing_active_window(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "missing_active.vcd"
+    _write_vcd(
+        vcd_path,
+        "\n".join(
+            [
+                "$timescale",
+                "1ns/1ps",
+                "$end",
+                "$scope module tb $end",
+                "$scope module dut $end",
+                "$scope module reducer $end",
+                "$var reg 1 a signal $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$enddefinitions",
+                "#0",
+                "0a",
+            ]
+        ),
+    )
+    with pytest.raises(ValueError, match="missing active dumpon/dumpoff interval"):
+        extract_sequential_register_vcd_activity(
+            vcd_path,
+            source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+            scope="tb/dut",
+        )
+
+
+def test_extract_sequential_register_activity_rejects_malformed_range(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "bad_range.vcd"
+    _write_vcd(
+        vcd_path,
+        "\n".join(
+            [
+                "$timescale",
+                "1ns/1ps",
+                "$end",
+                "$scope module tb $end",
+                "$scope module dut $end",
+                "$scope module reducer $end",
+                "$var reg 2 a \\accum [1:0:0] $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$enddefinitions",
+                "#0",
+                "b00 a",
+                "#10",
+                "$dumpon",
+                "#20",
+                "b11 a",
+                "#30",
+                "$dumpoff",
+            ]
+        ),
+    )
+    with pytest.raises(ValueError, match="malformed"):
+        extract_sequential_register_vcd_activity(
+            vcd_path,
+            source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+            scope="tb/dut",
+        )
+
+
+def test_extract_sequential_register_activity_rejects_duplicate_declaration(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "duplicate.vcd"
+    _write_vcd(
+        vcd_path,
+        "\n".join(
+            [
+                "$timescale",
+                "1ns/1ps",
+                "$end",
+                "$scope module tb $end",
+                "$scope module dut $end",
+                "$scope module reducer $end",
+                "$var reg 1 b bit $end",
+                "$var reg 1 b other $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$enddefinitions",
+                "#0",
+                "0b",
+                "1b",
+                "#10",
+                "$dumpon",
+                "#20",
+                "0b",
+                "#25",
+                "$dumpoff",
+            ]
+        ),
+    )
+    with pytest.raises(ValueError, match="duplicate declaration"):
+        extract_sequential_register_vcd_activity(
+            vcd_path,
+            source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+            scope="tb/dut",
+        )
+
+
+def test_extract_sequential_register_activity_ignores_adjacent_scope(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "adjacent_scope.vcd"
+    _write_vcd(
+        vcd_path,
+        "\n".join(
+            [
+                "$timescale",
+                "1ns/1ps",
+                "$end",
+                "$scope module tb $end",
+                "$scope module dut_shadow $end",
+                "$var reg 1 outside ignored $end",
+                "$upscope $end",
+                "$scope module dut $end",
+                "$var reg 1 inside kept $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$enddefinitions",
+                "#0",
+                "0outside",
+                "0inside",
+                "#10",
+                "$dumpon",
+                "#20",
+                "1outside",
+                "1inside",
+                "#30",
+                "$dumpoff",
+            ]
+        ),
+    )
+
+    payload = extract_sequential_register_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+        scope="tb/dut",
+    )
+
+    assert [row["full_name"] for row in payload["register_bits"]] == ["kept"]

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -53,6 +53,45 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             sidecar.update(overrides)
         return sidecar
 
+    def _sequential_activity(
+        self,
+        *,
+        vcd: Path,
+        full_name: str = "reducer/result_value[0]",
+        duty_cycle: float = 0.5,
+        density_hz: float = 100.0,
+        transition_count: float = 10.0,
+        overrides: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        sidecar: dict[str, object] = {
+            "version": 1,
+            "model": MODULE._SEQUENTIAL_REGISTER_ACTIVITY_MODEL,
+            "source_vcd_sha256": MODULE._sha256(vcd),
+            "source_vcd": vcd.name,
+            "scope": "tb/dut",
+            "timescale_seconds": 1e-9,
+            "active_start_tick": 0,
+            "active_end_tick": 1000,
+            "register_bits": [
+                {
+                    "full_name": full_name,
+                    "density_hz": density_hz,
+                    "duty_cycle": duty_cycle,
+                    "transition_count": transition_count,
+                    "source": "vcd",
+                }
+            ],
+        }
+        if overrides is not None:
+            sidecar.update(overrides)
+        return sidecar
+
+    def _write_sequential_activity(self, root: Path, *, vcd: Path, full_name: str = "reducer/result_value[0]") -> Path:
+        sidecar = self._sequential_activity(vcd=vcd, full_name=full_name)
+        path = root / f"{full_name.replace('/', '_').replace('[','_').replace(']','_').replace(':','_')}.sequential_register_activity.json"
+        path.write_text(json.dumps(sidecar), encoding="utf-8")
+        return path
+
     def _write_macro_activity(self, root: Path, *, phase_name: str, vcd: Path) -> Path:
         sidecar = self._macro_activity(
             phase_name=phase_name,
@@ -74,6 +113,8 @@ class PostrouteVcdPowerTests(unittest.TestCase):
         pin_properties: dict[str, dict[str, object]] | None = None,
         leaf_pin_map: dict[str, tuple[str, ...]] | None = None,
         leaf_specs: tuple[tuple[str, str, str], ...] | None = None,
+        sequential_register_activity_tcl: Path | None = None,
+        emit_power_pin_activity_calls: bool = False,
     ) -> str:
         if leaf_specs is None:
             leaf_specs = (
@@ -91,8 +132,9 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             is_hierarchical = int(config.get("is_hierarchical", False))
             direction = str(config.get("direction", "output"))
             full_name = str(config.get("full_name", pin_name))
+            has_activity = "activity" in config
             activity = config.get("activity")
-            if activity is None:
+            if has_activity and activity is None:
                 pin_property_overrides.extend(
                     [
                         f"  if {{$obj eq {{{pin_name}}}}} {{",
@@ -100,13 +142,13 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                         f"    if {{$property eq \"direction\"}} {{ return \"{direction}\" }}",
                         f"    if {{$property eq \"full_name\"}} {{ return {{{full_name}}} }}",
                         "    if {$property eq \"activity\"} {",
-                        f"      error \"forced_activity_query_error {pin_name}\"",
+                        "      error \"simulated get_property activity query error\"",
                         "    }",
                         "    return {}",
                         "  }",
                     ]
                 )
-            else:
+            elif has_activity:
                 pin_property_overrides.extend(
                     [
                         f"  if {{$obj eq {{{pin_name}}}}} {{",
@@ -250,19 +292,19 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             "proc get_property {obj property} {",
             *pin_property_body,
             *pin_property_overrides,
+            "  if {$property eq \"is_hierarchical\"} {",
+            "    return 0",
+            "  }",
+            "  if {$property eq \"direction\"} {",
+            "    return \"output\"",
+            "  }",
+            "  if {$property eq \"activity\"} {",
+            "    return {0.25 0.5 vcd}",
+            "  }",
+            "  if {$property eq \"full_name\"} {",
+            "    return $obj",
+            "  }",
             "  if {[string match \"pin_*\" $obj]} {",
-            "    if {$property eq \"is_hierarchical\"} {",
-            "      return 0",
-            "    }",
-            "    if {$property eq \"direction\"} {",
-            "      return \"output\"",
-            "    }",
-            "    if {$property eq \"activity\"} {",
-            "      return {0.25 0.5 vcd}",
-            "    }",
-            "    if {$property eq \"full_name\"} {",
-            "      return $obj",
-            "    }",
             "    return {}",
             "  }",
             "  if {$property eq \"ref_name\"} {",
@@ -334,12 +376,40 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 if macro_activity_tcl is not None
                 else "set ::env(RTLGEN_MACRO_ACTIVITY_TCL) \"\""
             ),
+            (
+            f"set ::env(RTLGEN_SEQUENTIAL_REGISTER_ACTIVITY_TCL) \"{sequential_register_activity_tcl}\""
+                if sequential_register_activity_tcl is not None
+                else "set ::env(RTLGEN_SEQUENTIAL_REGISTER_ACTIVITY_TCL) \"\""
+            ),
             MODULE._tcl_script(),
+            *(
+                [
+                    "set ::power_pin_activity_call_count [llength $::sta::power_pin_activity_calls]",
+                    "puts \"POWER_PIN_ACTIVITY_CALL_COUNT=$::power_pin_activity_call_count\"",
+                    "foreach call $::sta::power_pin_activity_calls {",
+                    "  lassign $call call_pin call_density call_duty",
+                    "  puts \"POWER_PIN_ACTIVITY_CALL|$call_pin|$call_density|$call_duty\"",
+                    "}",
+                ]
+                if emit_power_pin_activity_calls
+                else []
+            ),
             "if {$::ref_name_query_count == 0} {",
             "  error \"assertion failed: expected at least one instance ref_name query\"",
             "}",
         ]
         return "\n".join(lines)
+
+    def _parse_power_pin_activity_calls(self, stdout: str) -> list[tuple[str, float, float]]:
+        calls: list[tuple[str, float, float]] = []
+        for line in stdout.splitlines():
+            if not line.startswith("POWER_PIN_ACTIVITY_CALL|"):
+                continue
+            _, pin, density, duty = line.split("|", 3)
+            if pin.startswith("{") and pin.endswith("}"):
+                pin = pin[1:-1]
+            calls.append((pin, float(density), float(duty)))
+        return calls
 
     def test_tcl_script_non_finite_samples_have_escaped_json_array_literals(self) -> None:
         if shutil.which("tclsh") is None:
@@ -870,6 +940,226 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(payload["macro_trace_backed_pin_count"], 1)
             self.assertEqual(payload["macro_trace_active_pin_count"], 1)
 
+    def test_tcl_script_maps_generic_dff_outputs_and_qn_inversion(self) -> None:
+        if shutil.which("tclsh") is None:
+            self.skipTest("tclsh is required for Tcl runtime regression")
+
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "load.tcl").write_text("", encoding="utf-8")
+            result = root / "activity_power.json"
+            sequential_activity_tcl = self._write_sequential_activity_tcl(
+                root=root,
+                assignments=(
+                    ("reducer/result_value[116]", 500.0, 0.25, 5.0),
+                    ("reducer/numerator_accum[56][24]", 300.0, 0.60, 3.0),
+                ),
+            )
+            q_pin = "reducer/numerator_accum[56][24]$_DFFE_PP_/Q"
+            qn_pin = "reducer/numerator_accum[56][24]$_DFFSR_X1_/QN"
+            second_pin = "reducer/result_value[116]$_DFFX1_/Q"
+            pin_properties = {
+                pin: {
+                    "full_name": pin,
+                    "direction": "output",
+                    "is_hierarchical": False,
+                }
+                for pin in (q_pin, qn_pin, second_pin)
+            }
+            tcl_script = self._write_tcl_runtime_stub(
+                root=root,
+                result=result,
+                all_pin_names=(q_pin, qn_pin, second_pin),
+                pin_properties=pin_properties,
+                sequential_register_activity_tcl=sequential_activity_tcl,
+                emit_power_pin_activity_calls=True,
+            )
+            self.assertIn(
+                "regexp {^(.+)\\$_DFF[^/]+/(Q|QN)$} $sequential_register_activity_pin_full_name",
+                tcl_script,
+            )
+            tcl_script_path = root / "activity_power.tcl"
+            tcl_script_path.write_text(tcl_script, encoding="utf-8")
+            tcl = shutil.which("tclsh")
+            assert tcl is not None
+            completed = MODULE.subprocess.run(
+                [tcl, str(tcl_script_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                msg=f"tcl failed: stdout={completed.stdout} stderr={completed.stderr}",
+            )
+            payload = json.loads(result.read_text(encoding="utf-8"))
+            power_pin_activity_calls = self._parse_power_pin_activity_calls(
+                completed.stdout
+            )
+            self.assertEqual(len(power_pin_activity_calls), 3)
+            calls_by_pin = {
+                pin: (density, duty)
+                for pin, density, duty in power_pin_activity_calls
+            }
+            self.assertEqual(calls_by_pin[q_pin][0], 300.0)
+            self.assertEqual(calls_by_pin[q_pin][1], 0.60)
+            self.assertEqual(calls_by_pin[second_pin][0], 500.0)
+            self.assertEqual(calls_by_pin[second_pin][1], 0.25)
+            self.assertEqual(calls_by_pin[qn_pin][0], 300.0)
+            self.assertEqual(calls_by_pin[qn_pin][1], 0.4)
+            self.assertEqual(calls_by_pin[qn_pin][0], calls_by_pin[q_pin][0])
+            sequential = payload["sequential_register_activity"]
+            self.assertEqual(sequential["q_candidate_count"], 2)
+            self.assertEqual(sequential["qn_candidate_count"], 1)
+            self.assertEqual(sequential["matched_count"], 3)
+            self.assertEqual(sequential["applied_count"], 3)
+            self.assertEqual(sequential["unmatched_output_count"], 0)
+            self.assertEqual(sequential["unused_sidecar_row_count"], 0)
+            qn_samples = [
+                sample
+                for sample in sequential["scan_samples"]
+                if sample["pin"] == qn_pin
+            ]
+            self.assertEqual(len(qn_samples), 1)
+            self.assertEqual(qn_samples[0]["pin_type"], "QN")
+            self.assertEqual(
+                qn_samples[0]["pin_duty"],
+                1.0 - 0.60,
+            )
+
+    def test_tcl_script_rejects_malformed_sequential_register_activity_updates(self) -> None:
+        if shutil.which("tclsh") is None:
+            self.skipTest("tclsh is required for Tcl runtime regression")
+
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "load.tcl").write_text("", encoding="utf-8")
+
+            result = root / "activity_power.json"
+            sequential_activity_tcl = root / "sequential_register_activity.tcl"
+            sequential_activity_tcl.write_text(
+                "set rtlgen_sequential_register_activity_assignments {\n"
+                "  {reducer/result_value[0] 400 0.20 1.0}\n"
+                "  {reducer/result_value[1] 300 0.30 2.0 3.0}\n"
+                "  {reducer/result_value[2] 200 0.40}\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            ok_q = "reducer/result_value[0]$_DFFX1_/Q"
+            bad3_q = "reducer/result_value[1]$_DFFX1_/Q"
+            bad5_q = "reducer/result_value[2]$_DFFX1_/Q"
+            pin_properties = {
+                pin: {
+                    "full_name": pin,
+                    "direction": "output",
+                    "is_hierarchical": False,
+                }
+                for pin in (ok_q, bad3_q, bad5_q)
+            }
+            tcl_script = self._write_tcl_runtime_stub(
+                root=root,
+                result=result,
+                all_pin_names=(ok_q, bad3_q, bad5_q),
+                pin_properties=pin_properties,
+                sequential_register_activity_tcl=sequential_activity_tcl,
+                emit_power_pin_activity_calls=True,
+            )
+            tcl_script_path = root / "activity_power.tcl"
+            tcl_script_path.write_text(tcl_script, encoding="utf-8")
+            tcl = shutil.which("tclsh")
+            assert tcl is not None
+            completed = MODULE.subprocess.run(
+                [tcl, str(tcl_script_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                msg=f"tcl failed: stdout={completed.stdout} stderr={completed.stderr}",
+            )
+            self.assertFalse(completed.stderr.strip())
+
+            payload = json.loads(result.read_text(encoding="utf-8"))
+            calls = self._parse_power_pin_activity_calls(completed.stdout)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][0], ok_q)
+            self.assertEqual(calls[0][1], 400.0)
+            self.assertEqual(calls[0][2], 0.20)
+
+            sequential = payload["sequential_register_activity"]
+            self.assertEqual(sequential["assignment_count"], 3)
+            self.assertEqual(sequential["query_error_count"], 2)
+            self.assertEqual(sequential["candidate_count"], 3)
+            self.assertEqual(sequential["matched_count"], 1)
+            self.assertEqual(sequential["applied_count"], 1)
+            self.assertEqual(sequential["unmatched_output_count"], 2)
+
+    def test_tcl_script_sequential_register_activity_scan_samples_are_bounded(self) -> None:
+        if shutil.which("tclsh") is None:
+            self.skipTest("tclsh is required for Tcl runtime regression")
+
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "load.tcl").write_text("", encoding="utf-8")
+            result = root / "activity_power.json"
+            assignments = tuple(
+                (f"reducer/result[{index}][0]", 100.0 + index, 0.4, 1.0)
+                for index in range(20)
+            )
+            sequential_activity_tcl = self._write_sequential_activity_tcl(
+                root=root,
+                assignments=assignments,
+            )
+            all_pins = [
+                f"reducer/result[{index}][0]$_DFFH{i % 3}_/Q"
+                for i, index in enumerate(range(20))
+            ]
+            pin_properties = {
+                pin: {
+                    "full_name": pin,
+                    "direction": "output",
+                    "is_hierarchical": False,
+                }
+                for pin in all_pins
+            }
+            tcl_script = self._write_tcl_runtime_stub(
+                root=root,
+                result=result,
+                all_pin_names=tuple(all_pins),
+                pin_properties=pin_properties,
+                sequential_register_activity_tcl=sequential_activity_tcl,
+            )
+            tcl_script_path = root / "activity_power.tcl"
+            tcl_script_path.write_text(tcl_script, encoding="utf-8")
+            tcl = shutil.which("tclsh")
+            assert tcl is not None
+            completed = MODULE.subprocess.run(
+                [tcl, str(tcl_script_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                msg=f"tcl failed: stdout={completed.stdout} stderr={completed.stderr}",
+            )
+            payload = json.loads(result.read_text(encoding="utf-8"))
+            sequential = payload["sequential_register_activity"]
+            self.assertEqual(sequential["candidate_count"], 20)
+            self.assertEqual(sequential["matched_count"], 20)
+            self.assertEqual(sequential["applied_count"], 20)
+            self.assertEqual(len(sequential["scan_samples"]), 16)
+
     def test_tcl_counts_after_design_power(self) -> None:
         script = MODULE._tcl_script()
         totals_index = script.find("set totals [sta::design_power")
@@ -1075,6 +1365,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 phase_name=name,
                 vcd=vcd,
             )
+            sequential_activity = self._write_sequential_activity(root=root, vcd=vcd, full_name=f"{name}/reducer/result_value[{measured}]")
             phases.append(
                 {
                     "phase": name,
@@ -1082,6 +1373,8 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                     "vcd_sha256": MODULE._sha256(vcd),
                     "macro_activity": macro_activity.name,
                     "macro_activity_sha256": MODULE._sha256(macro_activity),
+                    "sequential_register_activity": sequential_activity.name,
+                    "sequential_register_activity_sha256": MODULE._sha256(sequential_activity),
                     "measured_cycles": measured,
                     "full_context_cycles": full,
                 }
@@ -1105,7 +1398,37 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             "structural_query_error_count": 0,
             "structural_apply_error_count": 0,
         }
+        payload["sequential_register_activity"] = {
+            "assignment_count": assignment_count,
+            "scanned_pin_count": 0,
+            "candidate_count": assignment_count,
+            "q_candidate_count": assignment_count,
+            "qn_candidate_count": 0,
+            "matched_count": assignment_count,
+            "applied_count": assignment_count,
+            "query_error_count": 0,
+            "apply_error_count": 0,
+            "unmatched_output_count": 0,
+            "unused_sidecar_row_count": 0,
+            "coverage": 1.0,
+            "scan_samples": [],
+        }
         return payload
+
+    def _write_sequential_activity_tcl(
+        self,
+        root: Path,
+        assignments: tuple[tuple[str, float, float, float], ...],
+    ) -> Path:
+        path = root / "sequential_register_activity.tcl"
+        lines = ["set rtlgen_sequential_register_activity_assignments {"]
+        for full_name, density, duty_cycle, transition_count in assignments:
+            lines.append(
+                f"  {{{full_name} {density} {duty_cycle} {transition_count}}}"
+            )
+        lines.append("}")
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
 
     def _assert_no_full_pin_arrays_in_phase_payload(self, phase: dict[str, object]) -> None:
         self.assertNotIn("macro_activity_rows", phase)
@@ -1407,14 +1730,18 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 phase["macro_activity_assignment_count"], len(phase["_macro_activity_rows"])
             )
 
-    def test_build_report_fails_if_structural_macro_activity_incomplete(self) -> None:
+    def test_phase_rows_rejects_sequential_activity_hash_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:
             root = Path(temp_text)
             vcd = root / "trace.vcd"
-            vcd.write_text("$comment score_fill $end\n", encoding="utf-8")
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
             macro_activity = self._write_macro_activity(
                 root=root,
                 phase_name="score_fill",
+                vcd=vcd,
+            )
+            sequential_activity = self._write_sequential_activity(
+                root=root,
                 vcd=vcd,
             )
             manifest = {
@@ -1426,6 +1753,68 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                         "vcd_sha256": MODULE._sha256(vcd),
                         "macro_activity": macro_activity.name,
                         "macro_activity_sha256": MODULE._sha256(macro_activity),
+                        "sequential_register_activity": sequential_activity.name,
+                        "sequential_register_activity_sha256": "0" * 64,
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(
+                ValueError,
+                "sequential register activity hash mismatch",
+            ):
+                MODULE._phase_rows(manifest, manifest_path)
+
+    def test_load_sequential_register_activity_rejects_scope_prefix_in_full_name(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            sidecar = self._sequential_activity(
+                vcd=vcd,
+                full_name="tb/dut/reducer/result_value[0]",
+            )
+            path = root / "sequential_activity.json"
+            path.write_text(json.dumps(sidecar), encoding="utf-8")
+            with self.assertRaisesRegex(
+                ValueError,
+                "omit scope prefix",
+            ):
+                MODULE._load_sequential_register_activity(
+                    path,
+                    vcd_sha256=MODULE._sha256(vcd),
+                    phase_vcd_basename=vcd.name,
+                )
+
+    def test_build_report_fails_if_structural_macro_activity_incomplete(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$comment score_fill $end\n", encoding="utf-8")
+            macro_activity = self._write_macro_activity(
+                root=root,
+                phase_name="score_fill",
+                vcd=vcd,
+            )
+            sequential_activity = self._write_sequential_activity(
+                root=root,
+                vcd=vcd,
+                full_name="score_fill/reducer/result_value[0]",
+            )
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "score_fill",
+                        "vcd": vcd.name,
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": macro_activity.name,
+                        "macro_activity_sha256": MODULE._sha256(macro_activity),
+                        "sequential_register_activity": sequential_activity.name,
+                        "sequential_register_activity_sha256": MODULE._sha256(sequential_activity),
                         "measured_cycles": 20,
                         "full_context_cycles": 20,
                     }
@@ -1472,6 +1861,212 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertFalse(phase["structural_macro_activity_gate_pass"])
             self.assertFalse(phase["phase_gate_pass"])
             self.assertFalse(report["promotion_gate_pass"])
+
+    def test_build_report_fails_when_sequential_register_activity_coverage_below_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, manifest_path = self._fixture(root)
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = self._with_structural_macro_transfer(
+                {
+                    "total_w": 1.0,
+                    "internal_w": 0.5,
+                    "switching_w": 0.5,
+                    "leakage_w": 0.0,
+                    "sdc_clock_period_ns": 8.0,
+                    "annotatable_pin_count": 1000,
+                    "leaf_annotatable_pin_count": 1000,
+                    "leaf_trace_backed_pin_count": 1000,
+                    "vcd_annotated_pin_count": 1000,
+                    "macro_trace_active_pin_count": 64,
+                    "macro_annotatable_pin_count": 1000,
+                    "direct_annotatable_pin_count": 1000,
+                    "direct_vcd_pin_count": 1000,
+                },
+                assignment_count=1,
+            )
+            power["sequential_register_activity"]["candidate_count"] = 2
+            power["sequential_register_activity"]["matched_count"] = 1
+            power["sequential_register_activity"]["applied_count"] = 1
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                report = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.25,
+                    min_vcd_pins=32,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
+                    timeout_seconds=10,
+                )
+            self.assertFalse(report["promotion_gate_pass"])
+            for phase in report["phases"]:
+                self.assertFalse(phase["sequential_register_activity_gate_pass"])
+                self.assertLess(phase["sequential_register_activity_coverage"], 1.0)
+
+    def test_build_report_fails_when_sequential_register_activity_apply_count_mismatches_matched_count(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, manifest_path = self._fixture(root)
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = self._with_structural_macro_transfer(
+                {
+                    "total_w": 1.0,
+                    "internal_w": 0.5,
+                    "switching_w": 0.5,
+                    "leakage_w": 0.0,
+                    "sdc_clock_period_ns": 8.0,
+                    "annotatable_pin_count": 1000,
+                    "leaf_annotatable_pin_count": 1000,
+                    "leaf_trace_backed_pin_count": 1000,
+                    "vcd_annotated_pin_count": 1000,
+                    "macro_trace_active_pin_count": 64,
+                    "macro_annotatable_pin_count": 1000,
+                    "direct_annotatable_pin_count": 1000,
+                    "direct_vcd_pin_count": 1000,
+                },
+                assignment_count=1,
+            )
+            power["sequential_register_activity"]["candidate_count"] = 1
+            power["sequential_register_activity"]["matched_count"] = 1
+            power["sequential_register_activity"]["applied_count"] = 0
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                report = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.25,
+                    min_vcd_pins=32,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
+                    timeout_seconds=10,
+                )
+            self.assertFalse(report["promotion_gate_pass"])
+            for phase in report["phases"]:
+                self.assertFalse(phase["sequential_register_activity_gate_pass"])
+                self.assertEqual(phase["sequential_register_activity_matched_count"], 1)
+                self.assertEqual(phase["sequential_register_activity_applied_count"], 0)
+
+    def test_build_report_fails_when_sequential_register_activity_query_or_apply_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, manifest_path = self._fixture(root)
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = self._with_structural_macro_transfer(
+                {
+                    "total_w": 1.0,
+                    "internal_w": 0.5,
+                    "switching_w": 0.5,
+                    "leakage_w": 0.0,
+                    "sdc_clock_period_ns": 8.0,
+                    "annotatable_pin_count": 1000,
+                    "leaf_annotatable_pin_count": 1000,
+                    "leaf_trace_backed_pin_count": 1000,
+                    "vcd_annotated_pin_count": 1000,
+                    "macro_trace_active_pin_count": 64,
+                    "macro_annotatable_pin_count": 1000,
+                    "direct_annotatable_pin_count": 1000,
+                    "direct_vcd_pin_count": 1000,
+                },
+                assignment_count=1,
+            )
+            power["sequential_register_activity"]["query_error_count"] = 2
+            power["sequential_register_activity"]["apply_error_count"] = 1
+            power["sequential_register_activity"]["candidate_count"] = 1
+            power["sequential_register_activity"]["matched_count"] = 1
+            power["sequential_register_activity"]["applied_count"] = 1
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                report = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.25,
+                    min_vcd_pins=32,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
+                    timeout_seconds=10,
+                )
+            self.assertFalse(report["promotion_gate_pass"])
+            for phase in report["phases"]:
+                self.assertFalse(phase["sequential_register_activity_gate_pass"])
+                self.assertGreater(phase["sequential_register_activity_coverage"], 0.9)
+
+    def test_build_report_allows_unused_sequential_sidecar_rows_when_impact_is_diagnostic_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            manifest, manifest_path = self._fixture(root)
+            design_config = root / "config.mk"
+            design_config.write_text("", encoding="utf-8")
+            power = self._with_structural_macro_transfer(
+                {
+                    "total_w": 1.0,
+                    "internal_w": 0.5,
+                    "switching_w": 0.5,
+                    "leakage_w": 0.0,
+                    "sdc_clock_period_ns": 8.0,
+                    "annotatable_pin_count": 1000,
+                    "leaf_annotatable_pin_count": 1000,
+                    "leaf_trace_backed_pin_count": 1000,
+                    "vcd_annotated_pin_count": 1000,
+                    "macro_trace_active_pin_count": 64,
+                    "macro_annotatable_pin_count": 1000,
+                    "direct_annotatable_pin_count": 1000,
+                    "direct_vcd_pin_count": 1000,
+                },
+                assignment_count=1,
+            )
+            power["sequential_register_activity"]["candidate_count"] = 1
+            power["sequential_register_activity"]["matched_count"] = 1
+            power["sequential_register_activity"]["applied_count"] = 1
+            power["sequential_register_activity"]["unused_sidecar_row_count"] = 3
+            power["sequential_register_activity"]["scan_samples"] = [
+                {
+                    "full_name": "",
+                    "register_full_name": f"unused_row_{index}",
+                    "pin": "",
+                    "pin_duty": 0.0,
+                    "pin_type": "Q",
+                    "kind": "unused_sidecar_row",
+                    "reason": "unused_sidecar_row",
+                }
+                for index in range(2)
+            ]
+            with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
+                report = MODULE.build_report(
+                    manifest=manifest,
+                    manifest_path=manifest_path,
+                    design_config=design_config,
+                    flow_variant="activity_test",
+                    scope="tb/dut",
+                    min_vcd_coverage=0.25,
+                    min_vcd_pins=32,
+                    min_macro_active_coverage=0.05,
+                    min_macro_active_pins=8,
+                    timeout_seconds=10,
+                )
+            self.assertTrue(report["promotion_gate_pass"])
+            for phase in report["phases"]:
+                self._assert_no_full_pin_arrays_in_phase_payload(phase)
+                self.assertEqual(phase["sequential_register_activity_gate_pass"], True)
+                self.assertEqual(phase["power"]["sequential_register_activity"]["unused_sidecar_row_count"], 3)
+                self.assertLessEqual(
+                    len(phase["power"]["sequential_register_activity"]["scan_samples"]),
+                    16,
+                )
+                sample_reasons = {
+                    sample["reason"]
+                    for sample in phase["power"]["sequential_register_activity"]["scan_samples"]
+                }
+                self.assertEqual(sample_reasons, {"unused_sidecar_row"})
 
     def test_build_report_omits_pin_arrays_from_phase_output(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:
@@ -1639,6 +2234,13 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "macro_trace_active_pin_count": 10,
                 "macro_annotatable_pin_count": 1000,
             }
+            power = self._with_structural_macro_transfer(power, assignment_count=1)
+            power["macro_pin_transfer"]["structural_assignment_count"] = 0
+            power["macro_pin_transfer"]["structural_matched_count"] = 0
+            power["macro_pin_transfer"]["structural_applied_count"] = 0
+            power["macro_pin_transfer"]["structural_unmatched_count"] = 0
+            power["macro_pin_transfer"]["structural_query_error_count"] = 0
+            power["macro_pin_transfer"]["structural_apply_error_count"] = 0
             with mock.patch.object(MODULE, "_phase_rows", return_value=[{
                 "phase": "score_fill",
                 "vcd": "trace.vcd",
@@ -1647,6 +2249,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 "full_context_cycles": 20,
                 "requires_macro_activity": False,
                 "_resolved_vcd": str(vcd),
+                "macro_activity_assignment_count": 0,
             }]):
                 with mock.patch.object(MODULE, "_run_openroad_phase", return_value=power):
                     report = MODULE.build_report(


### PR DESCRIPTION
## What changed

- emit a hashed per-phase `sequential_register_vcd_activity_v1` sidecar from RTL simulation
- explicitly dump the unpacked reducer and score-tile accumulator arrays omitted by Icarus recursive VCD dumping
- map exact RTL register-bit activity to postroute Yosys DFF/DFFE/reset-cell `Q` and `QN` pins before OpenSTA propagates combinational activity
- gate evidence on sequential-output coverage, successful application, hashes, and provenance while keeping full sidecar rows evaluator-local

## Root cause

The finalize divider/reducer contains state feedback whose synthesized DFF outputs were not directly VCD annotated. OpenSTA's vectorless sequential fixed-point propagation diverged, producing out-of-range activity and 4,521 non-finite reducer cell powers even though macro activity and score/replay power were valid.

This change anchors sequential outputs to measured RTL VCD activity. It does not clamp invalid activity, substitute heuristic values, relax existing gates, or change functional RTL.

## Validation

- `PYTHONPATH=. pytest -q tests/test_extract_sequential_register_vcd_activity.py tests/test_extract_fakeram_vcd_activity.py tests/test_attention_decode_score_multivalue_cluster_activity.py tests/test_postroute_vcd_power.py`
- 56 passed
- generated all three representative phase traces locally: 10,817 register-bit rows per phase, including 5,248 reducer numerator bits and 256 score-tile accumulator bits
- `git diff --check`

The next evidence job must run on the remote evaluator against the merged postroute database and prove finite finalize power.
