### PR TITLE
control_plane: propose cluster activity power v12

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "Queue v11 diagnostic rerun after PR #1404 / commit 658232d3ae22a8360457130e174e6156a088157a. This rerun keeps all quality/equivalence/annotation/macro/numeric/artifact/promotion gates unchanged and replaces v10 with bounded final-diagnostics for non-finite reducer behavior.",
+  "source_commit_note": "Queue v12 sequential-activity divergence rerun after PR #1407 / commit fcaf03969708eee85a3e53fbbafad8c3a5d6ec47. This rerun keeps all quality/equivalence/annotation/macro/numeric/artifact/promotion gates unchanged while exact VCD-backed postroute sequential-output mapping replaces vectorless sequential fixed-point propagation and sidecars remain evaluator-local.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -362,13 +362,47 @@
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
         "reason": "v11 keeps structural assignment counts and scores unchanged, preserves score_fill/replay and existing gate set, and adds bounded global plus non-finite-cell pin toggle/duty/origin diagnostics to make finalize failure root-cause explicit without introducing substitutes or relaxed thresholds."
       },
-      "status": "merged",
+      "status": "retracted",
       "merged_pr_number": 1406,
       "merge_commit": "faea0cd81042da796696025befcc6d12b29a043b",
       "revision_of_decision": "iterate",
       "merged_utc": "2026-07-19T15:05:12.782027Z",
-      "notes": "Merged via PR #1406 and merge faea0cd81042da796696025befcc6d12b29a043b at 2026-07-19T15:05:12.782027Z."
+      "notes": "Merged via PR #1406 and merge faea0cd81042da796696025befcc6d12b29a043b at 2026-07-19T15:05:12.782027Z. V11 showed OpenSTA vectorless sequential fixed-point divergence in finalize: 4,521 non-finite reducer cells and 13,199 non-finite global toggles (with out-of-range/negative values), while score_fill/replay and 5,096 macro assignments passed.",
+      "retracted_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12",
+      "retraction_reason": "postroute_vectorless_sequential_activity_divergence",
+      "replacement_artifact": "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12.json"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power after PR #1407 / commit fcaf03969708eee85a3e53fbbafad8c3a5d6ec47. v11 diagnosed OpenSTA vectorless sequential fixed-point divergence: finalize had 4,521 non-finite reducer cells, and a global scan showed 13,199 non-finite toggles plus out-of-range/negative values while score_fill/replay and 5,096 macro assignments passed. v12 maps sequential bit activity onto post-route Yosys DFF/DFFE/reset Q/QN outputs before first design_power, adds hashed sequential_register_vcd_activity_v1 sidecars with explicit 128x41 reducer numerator and 8x32 score-tile accumulator states, and enforces strict DFF coverage/gating behavior.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "prior_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+      ],
+      "revision": {
+        "reason": "postroute_vectorless_sequential_activity_divergence",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "v12 preserves the existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, requires >=0.95 DFF-output coverage, applied==matched, and zero query/apply errors, keeps sidecar rows evaluator-local, and forbids clamping, substitution, heuristic activity, and gate relaxation."
+      },
+      "status": "merged",
+      "merged_pr_number": 1407,
+      "merge_commit": "fcaf03969708eee85a3e53fbbafad8c3a5d6ec47",
+      "revision_of_decision": "iterate"
     }
   ],
-  "source_commit": "658232d3ae22a8360457130e174e6156a088157a"
+  "source_commit": "fcaf03969708eee85a3e53fbbafad8c3a5d6ec47"
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -327,9 +327,38 @@
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
         "reason": "v11 preserves all existing quality/equivalence/annotation/macro/numeric/artifact/promotion gates and score_fill/replay checks, keeps per-phase structural counts and compact artifacts unchanged, and records bounded global and non-finite-cell pin toggle/duty/origin diagnostics to diagnose finalize non-finite behavior without substituting or relaxing any gate."
       },
-      "status": "merged",
+      "status": "retracted",
       "merged_pr_number": 1404,
-      "merge_commit": "658232d3ae22a8360457130e174e6156a088157a"
+      "merge_commit": "658232d3ae22a8360457130e174e6156a088157a",
+      "retracted_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12",
+      "retraction_reason": "postroute_vectorless_sequential_activity_divergence"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power after PR #1407 / commit fcaf03969708eee85a3e53fbbafad8c3a5d6ec47. v11 diagnosed OpenSTA vectorless sequential fixed-point divergence: finalize had 4,521 non-finite reducer cells, and a global audit reported 13,199 non-finite toggles plus out-of-range/negative values while score_fill/replay and 5,096 macro assignments passed. v12 maps exact sequential RTL bit activity to post-route Yosys DFF/DFFE/reset Q/QN outputs before first design_power, generates hashed sequential_register_vcd_activity_v1 sidecars, and explicitly includes 128x41 reducer numerator and 8x32 score-tile accumulator states.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "postroute_vectorless_sequential_activity_divergence",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "v12 preserves all existing quality, equivalence, direct-VCD, macro, clock, numeric, and artifact gates, and now requires >=0.95 DFF-output coverage, applied==matched, and zero query/apply errors; it keeps sidecar rows evaluator-local and forbids clamping, substitution, heuristic activity, and gate relaxation."
+      },
+      "status": "merged",
+      "merged_pr_number": 1407,
+      "merge_commit": "fcaf03969708eee85a3e53fbbafad8c3a5d6ec47"
     }
   ],
   "baseline_refs": [

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
-  "source_commit_note": "Queue this evidence-only remote frontier recost only after the corrected local-cluster frontier v2 and the shared-score multivalue activity-power v11 rerun (PR #1404, commit 658232d3ae22a8360457130e174e6156a088157a).",
+  "source_commit_note": "Queue this evidence-only remote frontier recost only after the corrected local-cluster frontier v2 and the shared-score multivalue activity-power v12 rerun (PR #1407, commit fcaf03969708eee85a3e53fbbafad8c3a5d6ec47).",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
@@ -12,7 +12,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
@@ -57,7 +57,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1",
-  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged; folded-lane activity tasks should consume the shared-score activity-power v11 rerun from PR #1404 (commit 658232d3ae22a8360457130e174e6156a088157a).",
+  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged; folded-lane activity tasks should consume the shared-score activity-power v12 rerun from PR #1407 (commit fcaf03969708eee85a3e53fbbafad8c3a5d6ec47).",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
@@ -200,7 +200,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -220,7 +220,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -240,7 +240,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -483,5 +483,5 @@
       "status": "pending_implementation_merge"
     }
   ],
-  "source_commit": "b0cc5abb01265029ede35d1076263b229e5ba622"
+  "source_commit": "fcaf03969708eee85a3e53fbbafad8c3a5d6ec47"
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -222,7 +222,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -242,7 +242,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -262,7 +262,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v11"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,


### PR DESCRIPTION
## Summary

- queue cluster activity-power v12 from merged sequential-state anchoring commit `fcaf0396`
- retract v11 after its diagnostics isolated vectorless sequential fixed-point divergence
- rewire blocked cluster-frontier and folded-GQA activity dependencies from v11 to v12

## V12 gate

V12 keeps all existing equivalence, direct-VCD, FakeRAM macro, clock, numeric, artifact, and promotion gates. It additionally requires exact hashed sequential sidecars, at least 95% postroute DFF-output coverage, `applied == matched`, and zero query/apply errors. It does not clamp activity, substitute power, use heuristic activity, or relax any prior gate.

## Validation

- all six JSON files parse with `jq -e .`
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py control_plane/control_plane/tests/test_proposal_finalizer.py`
- 239 passed
