### PR TITLE
control_plane: propose cluster activity power v13

### DIFF
--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "Queue v12 sequential-activity divergence rerun after PR #1407 / commit fcaf03969708eee85a3e53fbbafad8c3a5d6ec47. This rerun keeps all quality/equivalence/annotation/macro/numeric/artifact/promotion gates unchanged while exact VCD-backed postroute sequential-output mapping replaces vectorless sequential fixed-point propagation and sidecars remain evaluator-local.",
+  "source_commit_note": "Queue v13 sequential-activity rerun after PR #1410 / commit db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd. PR #1409 was closed because activity_power.tcl line 325 failed before phase power (`key ...$_DFFE_PP_/Q not known in dictionary`) from opaque pin-handle/full_name key mismatch. v13 preserves existing v12 gates, thresholds, sidecar format, and does not change activity, RTL, or physical design.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -398,11 +398,45 @@
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
         "reason": "v12 preserves the existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, requires >=0.95 DFF-output coverage, applied==matched, and zero query/apply errors, keeps sidecar rows evaluator-local, and forbids clamping, substitution, heuristic activity, and gate relaxation."
       },
-      "status": "merged",
+      "status": "retracted",
       "merged_pr_number": 1407,
       "merge_commit": "fcaf03969708eee85a3e53fbbafad8c3a5d6ec47",
+      "retracted_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13",
+      "retraction_reason": "postroute_sequential_activity_pin_handle_key_mismatch",
+      "notes": "PR #1409 was closed; activity_power.tcl failed before phase power at line 325 (`key ...$_DFFE_PP_/Q not known in dictionary`) because metadata dictionaries were keyed by opaque pin handles while lookup used stable full_name.",
+      "revision_of_decision": "iterate"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power after PR #1410 / commit db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd. v12 was invalid because PR #1409 evidence failed at activity_power.tcl line 325 (`key ...$_DFFE_PP_/Q not known in dictionary`) and used fragile metadata keying; v13 keeps all v12 gates and coverage unchanged while fixing opaque-handle/full_name matching and strengthening handle-based tests.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "prior_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+      ],
+      "revision": {
+        "reason": "postroute_sequential_activity_pin_handle_key_mismatch",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "v13 preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, requires >=0.95 DFF-output coverage, applied==matched, and zero query/apply errors, keeps sidecar rows evaluator-local, and forbids clamping, substitution, heuristic activity, and gate relaxation while making no activity threshold, functional RTL, or physical-design changes."
+      },
+      "status": "merged",
+      "merged_pr_number": 1410,
+      "merge_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
       "revision_of_decision": "iterate"
     }
   ],
-  "source_commit": "fcaf03969708eee85a3e53fbbafad8c3a5d6ec47"
+  "source_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd"
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -356,9 +356,39 @@
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
         "reason": "v12 preserves all existing quality, equivalence, direct-VCD, macro, clock, numeric, and artifact gates, and now requires >=0.95 DFF-output coverage, applied==matched, and zero query/apply errors; it keeps sidecar rows evaluator-local and forbids clamping, substitution, heuristic activity, and gate relaxation."
       },
-      "status": "merged",
+      "status": "retracted",
       "merged_pr_number": 1407,
-      "merge_commit": "fcaf03969708eee85a3e53fbbafad8c3a5d6ec47"
+      "merge_commit": "fcaf03969708eee85a3e53fbbafad8c3a5d6ec47",
+      "retracted_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13",
+      "retraction_reason": "postroute_sequential_activity_pin_handle_key_mismatch",
+      "notes": "PR #1409 was closed and evidence invalid; activity_power.tcl failed before phase power at line 325 (`key ...$_DFFE_PP_/Q not known in dictionary`) because metadata dictionaries were keyed by opaque pin handles but read by stable full_name."
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power after PR #1410 / commit db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd. v12 was invalid because PR #1409 evidence failed at activity_power.tcl line 325 (`key ...$_DFFE_PP_/Q not known in dictionary`) while keyed by opaque pin handles; v13 fixes handle/full_name keying and strengthens tests for opaque handle and stable full_name behavior.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "postroute_sequential_activity_pin_handle_key_mismatch",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "v13 preserves all existing quality, equivalence, direct-VCD, macro, clock, numeric, and artifact gates, keeps the same DFF coverage and gate requirements from v12 including >=0.95 DFF-output coverage, applied==matched, and zero query/apply errors, keeps sidecar rows evaluator-local, and forbids clamping, substitution, heuristic activity, and gate relaxation; no activity thresholds, functional RTL, or physical design changes were made."
+      },
+      "status": "merged",
+      "merged_pr_number": 1410,
+      "merge_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd"
     }
   ],
   "baseline_refs": [

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,7 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
-  "source_commit_note": "Queue this evidence-only remote frontier recost only after the corrected local-cluster frontier v2 and the shared-score multivalue activity-power v12 rerun (PR #1407, commit fcaf03969708eee85a3e53fbbafad8c3a5d6ec47).",
+  "source_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
+  "source_commit_note": "Queue this evidence-only remote frontier recost only after the corrected local-cluster frontier v2 and the shared-score multivalue activity-power v13 rerun (PR #1410, commit db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd).",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
@@ -12,7 +13,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
@@ -57,7 +57,7 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,7 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1",
-  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged; folded-lane activity tasks should consume the shared-score activity-power v12 rerun from PR #1407 (commit fcaf03969708eee85a3e53fbbafad8c3a5d6ec47).",
+  "source_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
+  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged; folded-lane activity tasks should consume the shared-score activity-power v13 rerun from PR #1410 (commit db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd).",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
@@ -200,7 +201,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -220,7 +221,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -240,7 +241,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -222,7 +222,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -242,7 +242,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -262,7 +262,7 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v12"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,


### PR DESCRIPTION
## Summary

- retract invalid cluster activity-power v12 evidence after the OpenSTA pin-key failure
- propose v13 against the merged opaque-handle/full-name fix from PR #1410
- rewire cluster-frontier and GQA8-group dependencies from v12 to v13

## Validation

- `jq -e` on all six changed proposal files
- `239 passed` in focused task-generator and proposal-finalizer tests

## Evaluation contract

This revision changes no RTL, physical configuration, activity threshold, sidecar format, or promotion gate. It preserves the v12 exact sequential-register activity requirements and reruns them with corrected OpenSTA pin metadata keying.
