### PR TITLE
npu: make cluster state activity synthesis-exact

### DIFF
--- a/npu/eval/generate_attention_decode_score_multivalue_cluster_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_cluster_activity.py
@@ -46,6 +46,7 @@ _REPLAY_CLEAR_CYCLES = _VALUE_SLICES
 _FINALIZE_DIVIDE_CYCLES_PER_DIM = 60
 _FINALIZE_RESULT_EMIT_CYCLES = _VALUE_SLICES
 _REDUCER_NUMERATOR_ACCUM_WORDS = 128
+_REDUCER_BLOCK_WEIGHT_WORDS = 8
 _SCORE_TILE_ACCUM_WORDS = 8
 
 
@@ -131,9 +132,15 @@ def _testbench(
     )
     phase_active = _phase_expr(phase)
     clock_half_period = clock_period_ns / 2.0
+    # Explicitly dump only bit-accurate feedback and accumulation vectors.
+    # Do not add raw RTL FSM state vectors here; post-compile state encodings differ from RTL.
     reducer_dumpvars = "\n".join(
         f"    $dumpvars(0, dut.reducer.numerator_accum[{index}]);"
         for index in range(_REDUCER_NUMERATOR_ACCUM_WORDS)
+    )
+    block_weight_dumpvars = "\n".join(
+        f"    $dumpvars(0, dut.reducer.block_weight[{index}]);"
+        for index in range(_REDUCER_BLOCK_WEIGHT_WORDS)
     )
     score_tile_dumpvars = "\n".join(
         f"    $dumpvars(0, dut.score_tile.accum[{index}]);"
@@ -260,6 +267,7 @@ module tb;
     $dumpfile("{vcd_path.as_posix()}");
     $dumpvars(0, dut);
 {reducer_dumpvars}
+{block_weight_dumpvars}
 {score_tile_dumpvars}
     $dumpoff;
 {beat_init}

--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -32,6 +32,28 @@ RESULT_BASE = Path("/orfs/flow/results")
 LOG_BASE = Path("/orfs/flow/logs")
 SRC_BASE = DEST_BASE / "src"
 DEFAULT_FAILURE_SIGNATURE_MAX_LEN = 255
+FSM_ENCFILE_PARAM = "SYNTH_FSM_ENCFILE"
+FSM_ENCFILE_REQUIRED_PARAM = "SYNTH_FSM_ENCFILE_REQUIRED"
+FSM_ENCFILE_PATH_PARAM = "SYNTH_FSM_ENCFILE_PATH"
+FSM_ENCFILE_BASE_PARAM = "SYNTH_FSM_ENCFILE_BASE"
+DEFAULT_FSM_ENCFILE_NAME = "fsm_encoding.enc"
+
+
+def _empty_fsm_capture_payload() -> Dict[str, object]:
+    return {
+        "fsm_encfile_path": "",
+        "fsm_encfile_sha1": "",
+        "fsm_encfile_sha256": "",
+        "fsm_encoding_json": "",
+    }
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
 
 
 def sha1_file(path: Path) -> str:
@@ -40,6 +62,230 @@ def sha1_file(path: Path) -> str:
         for chunk in iter(lambda: f.read(8192), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def _relative_path_text(path_value: object) -> str:
+    txt = str(path_value or "").strip()
+    if not txt:
+        return ""
+    p = Path(txt)
+    if p.is_absolute():
+        try:
+            return str(p.relative_to(REPO_ROOT))
+        except ValueError:
+            return txt
+    return txt
+
+
+def normalize_fsm_encfile_path(raw_path: object, default_dir: Path) -> Path:
+    raw_txt = str(raw_path or "").strip()
+    if raw_txt:
+        user_path = Path(raw_txt)
+        return user_path if user_path.is_absolute() else (default_dir / user_path)
+    return default_dir / DEFAULT_FSM_ENCFILE_NAME
+
+
+def _invocation_encfile_path(
+    base_path: Path,
+    invocation_index: int,
+    invocation_total: int,
+) -> Path:
+    if invocation_total <= 1:
+        return base_path
+    if not base_path.suffix:
+        return base_path.with_name(f"{base_path.name}_{invocation_index + 1:02d}")
+    return base_path.with_name(
+        f"{base_path.stem}_{invocation_index + 1:02d}{base_path.suffix}"
+    )
+
+
+def _cleanup_fsm_capture_part_files(invocation_base: Path) -> None:
+    for stale in sorted(invocation_base.parent.glob(f"{invocation_base.name}.[0-9][0-9]")):
+        if stale.is_file():
+            stale.unlink()
+
+
+def _collect_fsm_capture_part_files(invocation_base: Path) -> List[Path]:
+    return sorted(
+        p
+        for p in invocation_base.parent.glob(f"{invocation_base.name}.[0-9][0-9]")
+        if re.fullmatch(rf"\A{re.escape(invocation_base.name)}\.\d{{2}}\Z", p.name)
+    )
+
+
+def parse_fsm_encoding_map(encfile: Path) -> List[Dict[str, object]]:
+    parsed: List[Dict[str, object]] = []
+    if not encfile.exists():
+        return parsed
+
+    current = None
+    try:
+        for raw_line in encfile.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith(".fsm"):
+                parts = line.split()
+                if len(parts) >= 3:
+                    current = {
+                        "module": parts[1],
+                        "state": parts[2],
+                        "maps": [],
+                    }
+                    parsed.append(current)
+                else:
+                    current = None
+                continue
+            if line.startswith(".map") and current is not None:
+                parts = line.split()
+                if len(parts) >= 3:
+                    current.setdefault("maps", []).append([parts[1], parts[2]])
+    except UnicodeDecodeError:
+        return []
+
+    normalized: List[Dict[str, object]] = []
+    for item in parsed:
+        maps = sorted({tuple(x) for x in item.get("maps", []) if len(x) >= 2})
+        normalized.append(
+            {
+                "module": str(item.get("module", "")).strip(),
+                "state": str(item.get("state", "")).strip(),
+                "maps": [[str(x[0]), str(x[1])] for x in maps],
+            }
+        )
+    normalized.sort(key=lambda item: (item["module"], item["state"]))
+    return normalized
+
+
+def merge_fsm_encoding_payloads(encfiles: List[Path]) -> List[Dict[str, object]]:
+    merged: Dict[tuple[str, str], Dict[str, str]] = {}
+    for encfile in encfiles:
+        for entry in parse_fsm_encoding_map(encfile):
+            module = str(entry.get("module", "")).strip()
+            state = str(entry.get("state", "")).strip()
+            key = (module, state)
+            state_maps = merged.setdefault(key, {})
+            maps = sorted(
+                tuple(str(value) for value in mapping)
+                for mapping in entry.get("maps", [])  # type: ignore[union-attr]
+                if len(mapping) == 2
+            )
+            for old_code, new_code in maps:
+                previous_new_code = state_maps.get(old_code)
+                if previous_new_code is not None and previous_new_code != new_code:
+                    raise ValueError(
+                        "Conflicting FSM encoding for "
+                        f"module={module!r} state={state!r} old_code={old_code!r}: "
+                        f"new_code={previous_new_code!r} versus {new_code!r}"
+                    )
+                state_maps[old_code] = new_code
+
+    payload: List[Dict[str, object]] = []
+    for (module, state), maps in sorted(merged.items(), key=lambda item: item[0]):
+        payload.append(
+            {
+                "module": module,
+                "state": state,
+                "maps": [[lhs, rhs] for lhs, rhs in sorted(maps.items())],
+            }
+        )
+    return payload
+
+
+def encode_fsm_encoding_map(encfile: Path) -> str:
+    payload = parse_fsm_encoding_map(encfile)
+    if not payload:
+        return ""
+    return json.dumps(
+        {
+            "version": 1,
+            "fsm_encodings": payload,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def write_fsm_encoding_map(entries: List[Dict[str, object]], destination: Path) -> None:
+    lines: List[str] = []
+    for entry in entries:
+        module = str(entry.get("module", "")).strip()
+        state = str(entry.get("state", "")).strip()
+        if not module and not state:
+            continue
+        lines.append(f".fsm {module} {state}")
+        for lhs, rhs in entry.get("maps", []):  # type: ignore[union-attr]
+            lhs_text = str(lhs).strip()
+            rhs_text = str(rhs).strip()
+            if lhs_text and rhs_text:
+                lines.append(f".map {lhs_text} {rhs_text}")
+    destination.write_text("\n".join(lines), encoding="utf-8")
+
+
+def fsm_capture_required(sweep_params: Dict[str, object], run_dir: Path) -> Dict[str, object]:
+    enabled = parse_boolish(sweep_params.get(FSM_ENCFILE_PARAM), default=False)
+    required = parse_boolish(sweep_params.get(FSM_ENCFILE_REQUIRED_PARAM), default=False)
+    if required:
+        enabled = True
+    return {
+        "enabled": bool(enabled),
+        "required": bool(required),
+        "path": normalize_fsm_encfile_path(
+            sweep_params.get(FSM_ENCFILE_PATH_PARAM),
+            run_dir,
+        ),
+    }
+
+
+def fsm_capture_payload(encfile: Path) -> Dict[str, object]:
+    if not encfile.exists():
+        return _empty_fsm_capture_payload()
+    return {
+        "fsm_encfile_path": _relative_path_text(encfile),
+        "fsm_encfile_sha1": sha1_file(encfile),
+        "fsm_encfile_sha256": sha256_file(encfile),
+        "fsm_encoding_json": encode_fsm_encoding_map(encfile),
+    }
+
+
+def fsm_capture_cache_matches(
+    cached_payload: Dict[str, object],
+    capture_cfg: Dict[str, object],
+    run_dir: Path,
+) -> bool:
+    if not bool(capture_cfg.get("required", False)):
+        return True
+    expected_path = Path(capture_cfg.get("path"))
+    cached_path_txt = str(cached_payload.get("fsm_encfile_path", "")).strip()
+    if not cached_path_txt:
+        return False
+    cached_path = Path(cached_path_txt)
+    if not cached_path.is_absolute():
+        cached_path = (REPO_ROOT / cached_path).resolve()
+    else:
+        try:
+            cached_path = cached_path.resolve()
+        except FileNotFoundError:
+            cached_path = cached_path
+
+    try:
+        expected_resolved = expected_path.resolve()
+    except FileNotFoundError:
+        expected_resolved = expected_path
+
+    if str(cached_path) != str(expected_resolved):
+        return False
+
+    if not cached_path.exists():
+        return False
+
+    if str(cached_payload.get("fsm_encfile_sha1", "")).strip() != sha1_file(cached_path):
+        return False
+    if str(cached_payload.get("fsm_encfile_sha256", "")).strip() != sha256_file(cached_path):
+        return False
+    if str(cached_payload.get("fsm_encoding_json", "")).strip() != encode_fsm_encoding_map(cached_path):
+        return False
+    return True
 
 
 def sha1_verilog_dir(verilog_dir: Path) -> str:
@@ -1173,8 +1419,79 @@ def copy_or_sanitize_macro_lef(src: Path, dst: Path) -> None:
     shutil.copy(src, dst)
 
 
-def write_preserve_blackbox_synth_script(script_path: Path):
-    base_synth = Path("/orfs/flow/scripts/synth.tcl")
+def _inject_fsm_capture_into_synth_script(text: str) -> str:
+    proc_block = """
+proc yosys_synth_with_fsm_capture {args} {
+  if {![env_var_exists_and_non_empty SYNTH_FSM_ENCFILE_BASE]} {
+    return [eval synth $args]
+  }
+
+  if {![info exists ::fsm_capture_index]} {
+    set ::fsm_capture_index 0
+  }
+  incr ::fsm_capture_index
+
+  set args_without_encfile {}
+  set skip_next 0
+  foreach arg $args {
+    if {$skip_next} {
+      set skip_next 0
+      continue
+    }
+    if {$arg eq "-encfile"} {
+      set skip_next 1
+      continue
+    }
+    if {[string match "-encfile=*" $arg]} {
+      continue
+    }
+    lappend args_without_encfile $arg
+  }
+
+  set encfile "$::env(SYNTH_FSM_ENCFILE_BASE).[format %02d $::fsm_capture_index]"
+  lappend args_without_encfile -encfile $encfile
+  return [eval synth {*}$args_without_encfile]
+}
+
+""".lstrip()
+
+    if "yosys_synth_with_fsm_capture" in text:
+        return text
+
+    lines = text.splitlines(keepends=True)
+    synth_re = re.compile(r"^\s*synth\b")
+    insert_index = len(lines)
+    for idx, line in enumerate(lines):
+        if synth_re.match(line):
+            insert_index = idx
+            break
+
+    if insert_index == len(lines):
+        raise RuntimeError("Failed to locate any synth invocation in synth.tcl")
+
+    lines.insert(insert_index, proc_block)
+    text = "".join(lines)
+
+    # Replace all textual `synth` invocations in the flow script, including
+    # forms that already rely on pre-expanded arguments or custom top settings.
+
+    pattern = re.compile(r"(?m)^(\s*)synth(\b.*)$")
+
+    def _replace_call(match: re.Match[str]) -> str:
+        return f"{match.group(1)}yosys_synth_with_fsm_capture{match.group(2)}"
+
+    replaced = pattern.sub(_replace_call, text)
+    if "yosys_synth_with_fsm_capture" not in replaced:
+        raise RuntimeError("Failed to instrument synth calls in synth.tcl")
+    return replaced
+
+
+def write_preserve_blackbox_synth_script(
+    script_path: Path,
+    synth_tcl: Optional[Path] = None,
+    instrument_fsm_capture: bool = False,
+):
+    base_synth = synth_tcl or Path("/orfs/flow/scripts/synth.tcl")
     if not base_synth.exists():
         raise FileNotFoundError(base_synth)
     text = base_synth.read_text(encoding="utf-8")
@@ -1202,6 +1519,9 @@ def write_preserve_blackbox_synth_script(script_path: Path):
         "}"
     )
     text = text.replace(setundef_marker, setundef_block, 1)
+
+    if instrument_fsm_capture:
+        text = _inject_fsm_capture_into_synth_script(text)
 
     script_path.write_text(text, encoding="utf-8")
 
@@ -1419,6 +1739,10 @@ def append_metrics(metrics_path: Path, row: Dict[str, object]):
         "failure_log_path",
         "synth_script_path",
         "synth_script_sha1",
+        "fsm_encfile_path",
+        "fsm_encfile_sha1",
+        "fsm_encfile_sha256",
+        "fsm_encoding_json",
     ]
 
     existing_rows: List[Dict[str, object]] = []
@@ -1496,6 +1820,8 @@ def write_flow_failure_result(
     mode_name: Optional[str],
     mode_use_macro: Optional[bool],
     compare_group: str,
+    failure_signature_override: Optional[str] = None,
+    fsm_capture_fields: Optional[Dict[str, object]] = None,
 ) -> Dict[str, object]:
     log_dir = resolve_flow_log_dir(platform, design_name, str(tag), flow_variant)
     failure_log_path = _infer_failure_log_path(
@@ -1512,6 +1838,8 @@ def write_flow_failure_result(
         command=failing_command,
         returncode=returncode,
     )
+    if failure_signature_override:
+        failure_signature = failure_signature_override
     flow_elapsed_seconds = sum_elapsed_seconds_in_log_dir(log_dir)
     payload = {
         "design": design_name,
@@ -1550,10 +1878,16 @@ def write_flow_failure_result(
             str(synth_script_override.resolve()) if synth_script_override is not None else ""
         ),
         "synth_script_sha1": synth_script_sha1,
+        "fsm_encfile_path": "",
+        "fsm_encfile_sha1": "",
+        "fsm_encfile_sha256": "",
+        "fsm_encoding_json": "",
         "mode_name": mode_name or "",
         "mode_use_macro": bool(mode_use_macro),
         "compare_group": compare_group,
     }
+    if fsm_capture_fields is not None:
+        payload.update(fsm_capture_fields)
     result_path.write_text(json.dumps(payload, indent=2))
     append_metrics(circuit_root / "metrics.csv", payload)
     print(
@@ -1603,19 +1937,6 @@ def _stdev_or_none(values: List[float]) -> Optional[float]:
     if len(values) < 2:
         return 0.0 if values else None
     return statistics.stdev(values)
-
-
-def _relative_path_text(path_value: object) -> str:
-    txt = str(path_value or "").strip()
-    if not txt:
-        return ""
-    p = Path(txt)
-    if p.is_absolute():
-        try:
-            return str(p.relative_to(REPO_ROOT))
-        except ValueError:
-            return txt
-    return txt
 
 
 def write_mode_compare_report(
@@ -1786,39 +2107,10 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
     work_root = circuit_root / "work"
     run_dir = work_root / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
+    capture_cfg = fsm_capture_required(sweep_params, run_dir)
+    fsm_capture = _empty_fsm_capture_payload()
 
     result_path = run_dir / "result.json"
-    if skip_existing and result_path.exists():
-        print(f"[INFO] Skipping existing run: {run_dir}")
-        try:
-            cached_payload = json.loads(result_path.read_text(encoding="utf-8"))
-            if not isinstance(cached_payload, dict):
-                raise ValueError("result.json payload is not an object")
-            if not str(cached_payload.get("design", "")).strip():
-                cached_payload["design"] = design_name
-            if not str(cached_payload.get("platform", "")).strip():
-                cached_payload["platform"] = platform
-            if not str(cached_payload.get("config_hash", "")).strip():
-                cached_payload["config_hash"] = config_hash
-            if not str(cached_payload.get("param_hash", "")).strip():
-                cached_payload["param_hash"] = run_id
-            if not str(cached_payload.get("tag", "")).strip():
-                cached_payload["tag"] = tag
-            if not str(cached_payload.get("work_result_json", "")).strip():
-                cached_payload["work_result_json"] = str(result_path)
-
-            append_metrics(circuit_root / "metrics.csv", cached_payload)
-            return cached_payload
-        except (json.JSONDecodeError, ValueError):
-            return {
-                "design": design_name,
-                "platform": platform,
-                "param_hash": run_id,
-                "tag": tag,
-                "status": "unknown",
-                "work_result_json": str(result_path),
-            }
-
     if dry_run:
         print(f"[DRY] {design_name} {platform} tag={tag} params={sweep_params}")
         return {
@@ -1841,7 +2133,49 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
             "mode_name": mode_name or "",
             "mode_use_macro": bool(mode_use_macro),
             "compare_group": compare_group,
+            **fsm_capture,
         }
+
+    if skip_existing and result_path.exists():
+        print(f"[INFO] Skipping existing run: {run_dir}")
+        try:
+            cached_payload = json.loads(result_path.read_text(encoding="utf-8"))
+            if not isinstance(cached_payload, dict):
+                raise ValueError("result.json payload is not an object")
+            if not str(cached_payload.get("design", "")).strip():
+                cached_payload["design"] = design_name
+            if not str(cached_payload.get("platform", "")).strip():
+                cached_payload["platform"] = platform
+            if not str(cached_payload.get("config_hash", "")).strip():
+                cached_payload["config_hash"] = config_hash
+            if not str(cached_payload.get("param_hash", "")).strip():
+                cached_payload["param_hash"] = run_id
+            if not str(cached_payload.get("tag", "")).strip():
+                cached_payload["tag"] = tag
+            if not str(cached_payload.get("work_result_json", "")).strip():
+                cached_payload["work_result_json"] = str(result_path)
+
+            if capture_cfg.get("required", False) and not fsm_capture_cache_matches(
+                cached_payload,
+                capture_cfg,
+                run_dir,
+            ):
+                print(
+                    "[INFO] Existing result has missing or mismatched required FSM "
+                    "encoding capture; rerunning"
+                )
+            else:
+                append_metrics(circuit_root / "metrics.csv", cached_payload)
+                return cached_payload
+        except (json.JSONDecodeError, ValueError):
+            return {
+                "design": design_name,
+                "platform": platform,
+                "param_hash": run_id,
+                "tag": tag,
+                "status": "unknown",
+                "work_result_json": str(result_path),
+            }
 
     validate_synth_keep_modules(
         verilog_dir=verilog_dir,
@@ -1892,7 +2226,18 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
         blackboxes = [str(x).strip() for x in macro_manifest.get("blackboxes", []) if str(x).strip()]
     if blackboxes:
         synth_script_override = run_dir / "synth_preserve_blackbox.tcl"
-        write_preserve_blackbox_synth_script(synth_script_override)
+        write_preserve_blackbox_synth_script(
+            script_path=synth_script_override,
+            instrument_fsm_capture=bool(capture_cfg["enabled"]),
+        )
+        synth_script_sha1 = sha1_file(synth_script_override)
+        make_cmd.append(f"SYNTH_SCRIPT={synth_script_override.resolve()}")
+    elif capture_cfg.get("enabled"):
+        synth_script_override = run_dir / "synth_preserve_blackbox.tcl"
+        write_preserve_blackbox_synth_script(
+            script_path=synth_script_override,
+            instrument_fsm_capture=True,
+        )
         synth_script_sha1 = sha1_file(synth_script_override)
         make_cmd.append(f"SYNTH_SCRIPT={synth_script_override.resolve()}")
 
@@ -1903,14 +2248,48 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
         and bool(macro_manifest.get("additional_libs"))
         and not is_synth_target(make_target)
     )
+    actual_make_target = resolve_make_target(make_target)
+    synth_invocation_total = 1 + (1 if use_macro_synth_workaround else 0)
+    capture_synth_files: List[Path] = []
+
+    def run_synth_invocation(
+        base_command: List[str],
+        invocation_target: Optional[str],
+        invocation_index: int,
+    ) -> List[str]:
+        invocation_cmd = list(base_command)
+        invocation_encfile: Optional[Path] = None
+        invocation_env = env.copy()
+        if capture_cfg.get("enabled", False):
+            invocation_encfile = _invocation_encfile_path(
+                Path(capture_cfg["path"]),
+                invocation_index,
+                synth_invocation_total,
+            )
+            _cleanup_fsm_capture_part_files(invocation_encfile)
+            invocation_env[FSM_ENCFILE_BASE_PARAM] = str(invocation_encfile)
+        if invocation_target is not None:
+            invocation_cmd.append(invocation_target)
+        print(f"[INFO] Running OpenROAD flow: {' '.join(invocation_cmd)}")
+        subprocess.run(invocation_cmd, cwd="/orfs/flow", check=True, env=invocation_env)
+        if invocation_encfile is not None:
+            capture_synth_files.extend(_collect_fsm_capture_part_files(invocation_encfile))
+        return invocation_cmd
+
     if use_macro_synth_workaround:
-        synth_cmd = list(make_cmd)
-        synth_cmd.extend(macro_synth_make_overrides(sweep_params))
-        synth_cmd.append("synth")
-        print(f"[INFO] Running OpenROAD flow: {' '.join(synth_cmd)}")
+        synth_cmd: List[str] = []
         try:
-            subprocess.run(synth_cmd, cwd="/orfs/flow", check=True, env=env)
+            pre_synth_cmd = list(make_cmd)
+            pre_synth_cmd.extend(macro_synth_make_overrides(sweep_params))
+            synth_cmd = run_synth_invocation(pre_synth_cmd, "synth", 0)
         except subprocess.CalledProcessError as exc:
+            failing_cmd = (
+                list(synth_cmd)
+                if synth_cmd
+                else list(exc.cmd)
+                if isinstance(exc.cmd, list)
+                else [str(exc.cmd)]
+            )
             return write_flow_failure_result(
                 circuit_root=circuit_root,
                 result_path=result_path,
@@ -1922,7 +2301,7 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
                 sweep_params=sweep_params,
                 flow_variant=flow_variant,
                 failing_stage="synth",
-                failing_command=synth_cmd,
+                failing_command=failing_cmd,
                 returncode=int(exc.returncode),
                 macro_manifest=macro_manifest,
                 macro_selection=macro_selection,
@@ -1940,13 +2319,18 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
             raise FileNotFoundError(f"Missing synthesized netlist: {synth_netlist}")
         make_cmd.append(f"SYNTH_NETLIST_FILES={synth_netlist}")
 
-    actual_make_target = resolve_make_target(make_target)
-    if actual_make_target:
-        make_cmd.append(actual_make_target)
-    print(f"[INFO] Running OpenROAD flow: {' '.join(make_cmd)}")
     try:
-        subprocess.run(make_cmd, cwd="/orfs/flow", check=True, env=env)
+        flow_cmd: List[str] = []
+        if actual_make_target:
+            flow_cmd = run_synth_invocation(
+                make_cmd,
+                actual_make_target,
+                1 if use_macro_synth_workaround else 0,
+            )
+        else:
+            flow_cmd = run_synth_invocation(make_cmd, None, 1 if use_macro_synth_workaround else 0)
     except subprocess.CalledProcessError as exc:
+        failing_cmd = list(flow_cmd) if flow_cmd else list(exc.cmd) if isinstance(exc.cmd, list) else [str(exc.cmd)]
         return write_flow_failure_result(
             circuit_root=circuit_root,
             result_path=result_path,
@@ -1958,7 +2342,7 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
             sweep_params=sweep_params,
             flow_variant=flow_variant,
             failing_stage=str(actual_make_target or "flow"),
-            failing_command=make_cmd,
+            failing_command=failing_cmd,
             returncode=int(exc.returncode),
             macro_manifest=macro_manifest,
             macro_selection=macro_selection,
@@ -1968,10 +2352,63 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
             mode_use_macro=mode_use_macro,
             compare_group=compare_group,
         )
+
+    if capture_cfg.get("enabled", False):
+        try:
+            merged_fsm_entries = merge_fsm_encoding_payloads(capture_synth_files)
+        except ValueError as exc:
+            return write_flow_failure_result(
+                circuit_root=circuit_root,
+                result_path=result_path,
+                design_name=design_name,
+                platform=platform,
+                config_hash=config_hash,
+                run_id=run_id,
+                tag=tag,
+                sweep_params=sweep_params,
+                flow_variant=flow_variant,
+                failing_stage="synth_fsm_encoding",
+                failing_command=["merge_fsm_encoding_payloads", str(exc)],
+                returncode=1,
+                macro_manifest=macro_manifest,
+                macro_selection=macro_selection,
+                synth_script_override=synth_script_override,
+                synth_script_sha1=synth_script_sha1,
+                mode_name=mode_name,
+                mode_use_macro=mode_use_macro,
+                compare_group=compare_group,
+                failure_signature_override="conflicting_fsm_encoding_capture",
+            )
+        merged_fsm_path = Path(capture_cfg["path"])
+        if merged_fsm_entries:
+            write_fsm_encoding_map(merged_fsm_entries, merged_fsm_path)
+            fsm_capture = fsm_capture_payload(merged_fsm_path)
+        elif capture_cfg.get("required", False):
+            return write_flow_failure_result(
+                circuit_root=circuit_root,
+                result_path=result_path,
+                design_name=design_name,
+                platform=platform,
+                config_hash=config_hash,
+                run_id=run_id,
+                tag=tag,
+                sweep_params=sweep_params,
+                flow_variant=flow_variant,
+                failing_stage="synth_fsm_encoding",
+                failing_command=["synth_fsm_encoding_missing"],
+                returncode=1,
+                macro_manifest=macro_manifest,
+                macro_selection=macro_selection,
+                synth_script_override=synth_script_override,
+                synth_script_sha1=synth_script_sha1,
+                mode_name=mode_name,
+                mode_use_macro=mode_use_macro,
+                compare_group=compare_group,
+                failure_signature_override="missing_required_fsm_encoding_capture",
+            )
+
     if should_generate_openroad_metadata(actual_make_target):
         metadata_cmd = list(make_cmd)
-        if actual_make_target:
-            metadata_cmd = metadata_cmd[:-1]
         metadata_cmd.append("metadata-generate")
         print(f"[INFO] Running OpenROAD metadata extraction: {' '.join(metadata_cmd)}")
         try:
@@ -2101,6 +2538,7 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
             str(synth_script_override.resolve()) if synth_script_override is not None else ""
         ),
         "synth_script_sha1": synth_script_sha1,
+        **fsm_capture,
         "mode_name": mode_name or "",
         "mode_use_macro": bool(mode_use_macro),
         "compare_group": compare_group,

--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -31,6 +31,7 @@ REPORT_BASE = Path("/orfs/flow/reports")
 RESULT_BASE = Path("/orfs/flow/results")
 LOG_BASE = Path("/orfs/flow/logs")
 SRC_BASE = DEST_BASE / "src"
+DEFAULT_SYNTH_SCRIPT = Path("/orfs/flow/scripts/synth.tcl")
 DEFAULT_FAILURE_SIGNATURE_MAX_LEN = 255
 FSM_ENCFILE_PARAM = "SYNTH_FSM_ENCFILE"
 FSM_ENCFILE_REQUIRED_PARAM = "SYNTH_FSM_ENCFILE_REQUIRED"
@@ -1491,7 +1492,7 @@ def write_preserve_blackbox_synth_script(
     synth_tcl: Optional[Path] = None,
     instrument_fsm_capture: bool = False,
 ):
-    base_synth = synth_tcl or Path("/orfs/flow/scripts/synth.tcl")
+    base_synth = synth_tcl if synth_tcl is not None else DEFAULT_SYNTH_SCRIPT
     if not base_synth.exists():
         raise FileNotFoundError(base_synth)
     text = base_synth.read_text(encoding="utf-8")

--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -514,6 +514,13 @@ proc rtlgen_compare_ref_name_bucket {left right} {
   return [string compare $left_name $right_name]
 }
 
+proc rtlgen_strip_array_index_suffix {full_name} {
+  if {[regexp {^(.*)\[[^\]]+\]$} $full_name -> base]} {
+    return $base
+  }
+  return $full_name
+}
+
 proc rtlgen_apply_macro_pin_activities {assignments} {
   set results {}
   if {[llength $assignments] == 0} {
@@ -564,11 +571,13 @@ set sequential_register_activity_assignments {}
 set sequential_register_activity_updates {}
 set sequential_register_activity_assignment_rows_by_full_name {}
 set sequential_register_activity_unmatched_rows_by_full_name {}
+set sequential_register_activity_unmatched_rows_by_prefix {}
 set sequential_register_activity_assignment_rows_seen {}
 set sequential_register_activity_updates_by_pin {}
 set sequential_register_activity_pin_type_by_pin {}
 set sequential_register_activity_pin_register_by_pin {}
 set sequential_register_activity_pin_duty_by_pin {}
+set sequential_register_activity_unused_rows_by_prefix {}
 if {[info exists ::env(RTLGEN_MACRO_ACTIVITY_TCL)] && $::env(RTLGEN_MACRO_ACTIVITY_TCL) ne ""} {
   if {[catch {source $::env(RTLGEN_MACRO_ACTIVITY_TCL)} structural_source_error]} {
     incr macro_pin_transfer_structural_query_error_count
@@ -659,6 +668,10 @@ foreach sequential_register_activity_pin $all_design_pins {
   }
   if {![dict exists $sequential_register_activity_assignment_rows_by_full_name $sequential_register_activity_register_full_name]} {
     incr sequential_register_activity_unmatched_output_count
+    set sequential_register_activity_unmatched_prefix \
+      [rtlgen_strip_array_index_suffix $sequential_register_activity_register_full_name]
+    dict incr sequential_register_activity_unmatched_rows_by_prefix \
+      $sequential_register_activity_unmatched_prefix
     rtlgen_append_sequential_register_activity_sample \
       sequential_register_activity_scan_samples \
       sequential_register_activity_scan_sample_limit \
@@ -737,6 +750,10 @@ if {[dict size $sequential_register_activity_assignment_rows_by_full_name] > 0} 
     }
     lappend sequential_register_activity_unused_sidecar_rows $sequential_register_activity_unused_row
     incr sequential_register_activity_unused_sidecar_row_count
+    set sequential_register_activity_unused_row_prefix \
+      [rtlgen_strip_array_index_suffix $sequential_register_activity_unused_row]
+    dict incr sequential_register_activity_unused_rows_by_prefix \
+      $sequential_register_activity_unused_row_prefix
     if {[llength $sequential_register_activity_scan_samples] < $sequential_register_activity_scan_sample_limit} {
       lappend sequential_register_activity_scan_samples \
         [list \
@@ -750,6 +767,26 @@ if {[dict size $sequential_register_activity_assignment_rows_by_full_name] > 0} 
         ]
     }
   }
+}
+set sequential_register_activity_unmatched_output_bucket_pairs {}
+if {[dict size $sequential_register_activity_unmatched_rows_by_prefix] > 0} {
+  dict for {sequential_register_activity_unmatched_prefix sequential_register_activity_unmatched_count} \
+    $sequential_register_activity_unmatched_rows_by_prefix {
+    lappend sequential_register_activity_unmatched_output_bucket_pairs \
+      [list $sequential_register_activity_unmatched_count $sequential_register_activity_unmatched_prefix]
+  }
+  set sequential_register_activity_unmatched_output_bucket_pairs \
+    [lsort -command rtlgen_compare_ref_name_bucket $sequential_register_activity_unmatched_output_bucket_pairs]
+}
+set sequential_register_activity_unused_sidecar_row_bucket_pairs {}
+if {[dict size $sequential_register_activity_unused_rows_by_prefix] > 0} {
+  dict for {sequential_register_activity_unused_row_prefix sequential_register_activity_unused_row_bucket_count} \
+    $sequential_register_activity_unused_rows_by_prefix {
+    lappend sequential_register_activity_unused_sidecar_row_bucket_pairs \
+      [list $sequential_register_activity_unused_row_bucket_count $sequential_register_activity_unused_row_prefix]
+  }
+  set sequential_register_activity_unused_sidecar_row_bucket_pairs \
+    [lsort -command rtlgen_compare_ref_name_bucket $sequential_register_activity_unused_sidecar_row_bucket_pairs]
 }
 if {![info exists sequential_register_activity_scan_samples]} {
   set sequential_register_activity_scan_samples {}
@@ -1864,6 +1901,49 @@ puts $fp "    \"query_error_count\": $sequential_register_activity_query_error_c
 puts $fp "    \"apply_error_count\": $sequential_register_activity_apply_error_count,"
 puts $fp "    \"unmatched_output_count\": $sequential_register_activity_unmatched_output_count,"
 puts $fp "    \"unused_sidecar_row_count\": $sequential_register_activity_unused_sidecar_row_count,"
+puts $fp "    \"unmatched_output_rows_by_prefix\": \["
+set sequential_register_activity_unmatched_output_bucket_count \
+  [llength $sequential_register_activity_unmatched_output_bucket_pairs]
+set sequential_register_activity_unmatched_output_bucket_index 0
+foreach sequential_register_activity_unmatched_output_bucket \
+  $sequential_register_activity_unmatched_output_bucket_pairs {
+  lassign $sequential_register_activity_unmatched_output_bucket sequential_register_activity_unmatched_output_count sequential_register_activity_unmatched_output_prefix
+  set escaped_unmatched_prefix \
+    [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $sequential_register_activity_unmatched_output_prefix]]
+  incr sequential_register_activity_unmatched_output_bucket_index
+  set sequential_register_activity_unmatched_output_bucket_line \
+    "      {\"register_prefix\": \"$escaped_unmatched_prefix\", \"count\": $sequential_register_activity_unmatched_output_count}"
+  if {$sequential_register_activity_unmatched_output_bucket_index < \
+      $sequential_register_activity_unmatched_output_bucket_count} {
+    puts $fp "$sequential_register_activity_unmatched_output_bucket_line,"
+  } else {
+    puts $fp "$sequential_register_activity_unmatched_output_bucket_line"
+  }
+}
+puts $fp "    \],"
+puts $fp "    \"unused_sidecar_rows_by_prefix\": \["
+set sequential_register_activity_unused_sidecar_row_bucket_count \
+  [llength $sequential_register_activity_unused_sidecar_row_bucket_pairs]
+set sequential_register_activity_unused_sidecar_row_bucket_index 0
+foreach sequential_register_activity_unused_sidecar_row_bucket \
+  $sequential_register_activity_unused_sidecar_row_bucket_pairs {
+  lassign \
+    $sequential_register_activity_unused_sidecar_row_bucket \
+    sequential_register_activity_unused_row_bucket_count \
+    sequential_register_activity_unused_sidecar_row_prefix
+  set escaped_unused_prefix \
+    [rtlgen_json_escape_array_literal_chars [rtlgen_json_escape $sequential_register_activity_unused_sidecar_row_prefix]]
+  incr sequential_register_activity_unused_sidecar_row_bucket_index
+  set sequential_register_activity_unused_sidecar_row_bucket_line \
+    "      {\"register_prefix\": \"$escaped_unused_prefix\", \"count\": $sequential_register_activity_unused_row_bucket_count}"
+  if {$sequential_register_activity_unused_sidecar_row_bucket_index < \
+      $sequential_register_activity_unused_sidecar_row_bucket_count} {
+    puts $fp "$sequential_register_activity_unused_sidecar_row_bucket_line,"
+  } else {
+    puts $fp "$sequential_register_activity_unused_sidecar_row_bucket_line"
+  }
+}
+puts $fp "    \],"
 puts $fp "    \"coverage\": [rtlgen_json_number $sequential_register_activity_coverage],"
 puts $fp "    \"scan_samples\": \["
 set sequential_register_activity_sample_count [llength $sequential_register_activity_scan_samples]

--- a/tests/test_attention_decode_score_multivalue_cluster_activity.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity.py
@@ -98,6 +98,7 @@ def test_multivalue_cluster_activity_generates_phase_vcds_and_manifest(tmp_path:
             name for name in names if name.startswith("reducer/numerator_accum[")
         }
         score_accum_names = {name for name in names if name.startswith("score_tile/accum[")}
+        block_weight_names = {name for name in names if name.startswith("reducer/block_weight[")}
         expected_numerator_accum_names = {
             f"reducer/numerator_accum[{word}][{bit}]"
             for word in range(128)
@@ -106,10 +107,17 @@ def test_multivalue_cluster_activity_generates_phase_vcds_and_manifest(tmp_path:
         expected_score_accum_names = {
             f"score_tile/accum[{word}][{bit}]" for word in range(8) for bit in range(32)
         }
+        expected_block_weight_names = {
+            f"reducer/block_weight[{word}][{bit}]"
+            for word in range(8)
+            for bit in range(16)
+        }
         assert len(numerator_accum_names) == 5_248
         assert numerator_accum_names == expected_numerator_accum_names
         assert len(score_accum_names) == 256
         assert score_accum_names == expected_score_accum_names
+        assert len(block_weight_names) == 128
+        assert block_weight_names == expected_block_weight_names
         assert {
             "reducer/numerator_accum[0][0]",
             "reducer/numerator_accum[0][40]",
@@ -119,6 +127,8 @@ def test_multivalue_cluster_activity_generates_phase_vcds_and_manifest(tmp_path:
             "score_tile/accum[0][31]",
             "score_tile/accum[7][0]",
             "score_tile/accum[7][31]",
+            "reducer/block_weight[0][0]",
+            "reducer/block_weight[0][15]",
         } <= names
         for row in register_bits:
             assert not row["full_name"].startswith("tb/dut/")

--- a/tests/test_extract_sequential_register_vcd_activity.py
+++ b/tests/test_extract_sequential_register_vcd_activity.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import math
 from pathlib import Path
 
 import pytest
@@ -55,6 +56,46 @@ def _mini_vcd() -> str:
     )
 
 
+def _block_weight_vcd() -> str:
+    lines: list[str] = [
+        "$date",
+        " Sequential register VCD for unpacked array",
+        "$end",
+        "$version",
+        "  test",
+        "$end",
+        "$timescale",
+        " 1ns/1ps",
+        "$end",
+        "$scope module tb $end",
+        "$scope module dut $end",
+        "$scope module reducer $end",
+    ]
+    lines.extend(
+        f"$var reg 16 {chr(97 + index)} \\block_weight[{index}] [15:0] $end"
+        for index in range(8)
+    )
+    lines.extend(
+        [
+            "$upscope $end",
+            "$upscope $end",
+            "$enddefinitions",
+            "#0",
+            *(f"b{'0' * 16} {chr(97 + index)}" for index in range(8)),
+            "#10",
+            "$dumpon",
+            "#20",
+            *(
+                f"b{format(index, '016b')} {chr(97 + index)}"
+                for index in range(8)
+            ),
+            "#35",
+            "$dumpoff",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def test_extract_sequential_register_activity_mini_vcd_semantics(tmp_path: Path) -> None:
     vcd_path = tmp_path / "mini.vcd"
     _write_vcd(vcd_path, _mini_vcd())
@@ -81,6 +122,27 @@ def test_extract_sequential_register_activity_mini_vcd_semantics(tmp_path: Path)
     assert rows["score_tile/accum[3][1]"]["duty_cycle"] == pytest.approx(0.4)
     assert rows["score_tile/accum[3][0]"]["transition_count"] == 1.0
     assert rows["score_tile/accum[3][0]"]["duty_cycle"] == pytest.approx(0.2)
+
+
+def test_extract_sequential_register_activity_includes_unpacked_array_bits(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "unpacked.vcd"
+    _write_vcd(vcd_path, _block_weight_vcd())
+    payload = extract_sequential_register_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+        scope="tb/dut",
+    )
+
+    rows = {row["full_name"]: row for row in payload["register_bits"]}
+    for index in range(8):
+        expected = {f"reducer/block_weight[{index}][{bit}]" for bit in range(16)}
+        assert set(expected).issubset(rows)
+        for bit in (0, 15):
+            assert rows[f"reducer/block_weight[{index}][{bit}]"]["source"] == "vcd"
+            assert math.isfinite(rows[f"reducer/block_weight[{index}][{bit}]"]["transition_count"])
+    assert len(payload["register_bits"]) == 128
+    assert payload["active_start_tick"] == 10
+    assert payload["active_end_tick"] == 35
 
 
 def test_extract_sequential_register_activity_rejects_bad_hash(tmp_path: Path) -> None:

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -1245,6 +1245,87 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(sequential["applied_count"], 20)
             self.assertEqual(len(sequential["scan_samples"]), 16)
 
+    def test_tcl_script_sequential_register_activity_bucketed_diagnostics(self) -> None:
+        if shutil.which("tclsh") is None:
+            self.skipTest("tclsh is required for Tcl runtime regression")
+
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            (scripts / "load.tcl").write_text("", encoding="utf-8")
+            result = root / "activity_power.json"
+            assignments = (
+                ("reducer/block_weight[0][0]", 100.0, 0.10, 1.0),
+                ("reducer/block_weight[2][0]", 100.0, 0.20, 1.0),
+                ("reducer/other_unused[0]", 100.0, 0.30, 1.0),
+                ("reducer/other_unused[1]", 100.0, 0.40, 1.0),
+            )
+            sequential_activity_tcl = self._write_sequential_activity_tcl(
+                root=root,
+                assignments=assignments,
+            )
+            all_pins = (
+                "reducer/block_weight[0][0]$_DFFX1_/Q",
+                "reducer/block_weight[0][1]$_DFFX1_/Q",
+                "reducer/block_weight[1][0]$_DFFX1_/Q",
+                "reducer/block_weight[1][1]$_DFFX1_/Q",
+                "reducer/state_feedback[0]$_DFFX1_/Q",
+            )
+            pin_properties = {
+                pin: {
+                    "full_name": pin,
+                    "direction": "output",
+                    "is_hierarchical": False,
+                }
+                for pin in all_pins
+            }
+            tcl_script = self._write_tcl_runtime_stub(
+                root=root,
+                result=result,
+                all_pin_names=all_pins,
+                pin_properties=pin_properties,
+                sequential_register_activity_tcl=sequential_activity_tcl,
+            )
+            tcl_script_path = root / "activity_power.tcl"
+            tcl_script_path.write_text(tcl_script, encoding="utf-8")
+            tcl = shutil.which("tclsh")
+            assert tcl is not None
+            completed = MODULE.subprocess.run(
+                [tcl, str(tcl_script_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                msg=f"tcl failed: stdout={completed.stdout} stderr={completed.stderr}",
+            )
+            payload = json.loads(result.read_text(encoding="utf-8"))
+            sequential = payload["sequential_register_activity"]
+            self.assertEqual(sequential["unmatched_output_count"], 4)
+            self.assertEqual(sequential["unused_sidecar_row_count"], 3)
+            self.assertEqual(
+                sequential["unmatched_output_rows_by_prefix"],
+                [
+                    {"register_prefix": "reducer/block_weight[1]", "count": 2},
+                    {"register_prefix": "reducer/block_weight[0]", "count": 1},
+                    {"register_prefix": "reducer/state_feedback", "count": 1},
+                ],
+            )
+            self.assertEqual(
+                sequential["unused_sidecar_rows_by_prefix"],
+                [
+                    {"register_prefix": "reducer/other_unused", "count": 2},
+                    {"register_prefix": "reducer/block_weight[2]", "count": 1},
+                ],
+            )
+            self.assertLessEqual(len(sequential["scan_samples"]), 16)
+            sample_reasons = {sample["reason"] for sample in sequential["scan_samples"]}
+            self.assertIn("no_sequential_row", sample_reasons)
+            self.assertIn("no_unmatched_sidecar_row", sample_reasons)
+
     def test_tcl_counts_after_design_power(self) -> None:
         script = MODULE._tcl_script()
         totals_index = script.find("set totals [sta::design_power")

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -4,6 +4,7 @@
 import csv
 import importlib.util
 import json
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -30,6 +31,25 @@ class ModeCompareRegressionTest(unittest.TestCase):
         cls.run_block_sweep = load_script_module(
             "run_block_sweep", "npu/synth/run_block_sweep.py"
         )
+
+    @staticmethod
+    def _collect_encfile_arg(cmd: list) -> str | None:
+        for token in cmd:
+            if not token.startswith("SYNTH_ARGS="):
+                continue
+            arg_text = token[len("SYNTH_ARGS=") :]
+            args = shlex.split(arg_text)
+            for i, arg in enumerate(args):
+                if arg == "-encfile" and i + 1 < len(args):
+                    return args[i + 1]
+            for i, arg in enumerate(args):
+                if arg.startswith("-encfile="):
+                    return arg.split("=", 1)[1]
+        return None
+
+    @staticmethod
+    def _collect_fsm_capture_base(env: dict[str, str]) -> str | None:
+        return env.get("SYNTH_FSM_ENCFILE_BASE")
 
     def test_parse_mode_compare_default(self):
         cfg = self.run_block_sweep.parse_mode_compare_config({"mode_compare": True})
@@ -366,6 +386,70 @@ class ModeCompareRegressionTest(unittest.TestCase):
             self.assertEqual("flow", payload["failure_stage"])
             self.assertEqual(17, payload["failure_returncode"])
 
+    def test_macro_pre_synth_failure_uses_exception_command(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done); assign done = clk; endmodule\n",
+                encoding="utf-8",
+            )
+            lib_path = tmp / "dummy.lib"
+            lib_path.write_text("library(dummy);\n", encoding="utf-8")
+            macro_manifest = {"additional_libs": [lib_path]}
+
+            old_dest = self.run_block_sweep.DEST_BASE
+            old_src = self.run_block_sweep.SRC_BASE
+            old_report = self.run_block_sweep.REPORT_BASE
+            old_result = self.run_block_sweep.RESULT_BASE
+            old_log = self.run_block_sweep.LOG_BASE
+            old_run = self.run_block_sweep.subprocess.run
+
+            def fake_run(cmd, *, cwd, check, env):
+                raise subprocess.CalledProcessError(returncode=23, cmd=cmd)
+
+            self.run_block_sweep.DEST_BASE = tmp / "orfs" / "designs"
+            self.run_block_sweep.SRC_BASE = self.run_block_sweep.DEST_BASE / "src"
+            self.run_block_sweep.REPORT_BASE = tmp / "orfs" / "reports"
+            self.run_block_sweep.RESULT_BASE = tmp / "orfs" / "results"
+            self.run_block_sweep.LOG_BASE = tmp / "orfs" / "logs"
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                row = self.run_block_sweep.run_single(
+                    design_dir=design_dir,
+                    design_name="demo_design",
+                    platform="nangate45",
+                    top="npu_top",
+                    verilog_dir=verilog_dir,
+                    sdc_template=None,
+                    sweep_params={
+                        "TAG": "demo_pre_synth_fail",
+                        "FLOW_VARIANT": "demo_pre_synth_fail",
+                        "CLOCK_PERIOD": 10.0,
+                        "CORE_AREA": "0 0 100 100",
+                    },
+                    out_root=tmp / "out",
+                    skip_existing=False,
+                    dry_run=False,
+                    force_copy=True,
+                    make_target=None,
+                    macro_manifest=macro_manifest,
+                )
+            finally:
+                self.run_block_sweep.DEST_BASE = old_dest
+                self.run_block_sweep.SRC_BASE = old_src
+                self.run_block_sweep.REPORT_BASE = old_report
+                self.run_block_sweep.RESULT_BASE = old_result
+                self.run_block_sweep.LOG_BASE = old_log
+                self.run_block_sweep.subprocess.run = old_run
+
+            self.assertEqual("flow_failed", row["status"])
+            self.assertEqual("synth", row["failure_stage"])
+            self.assertEqual(23, row["failure_returncode"])
+            self.assertIn("synth", row["failure_command"])
+
     def test_run_single_failure_infers_stage_and_signature_from_logs(self):
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
@@ -563,6 +647,565 @@ class ModeCompareRegressionTest(unittest.TestCase):
             self.assertEqual("new_cfg", rows[0]["config_hash"])
             self.assertEqual("flow_failed", rows[0]["status"])
             self.assertEqual("/orfs/flow/logs/new", rows[0]["result_path"])
+
+    def test_run_single_assigns_distinct_fsm_capture_base_per_synth_invocation(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done); assign done = clk; endmodule\n",
+                encoding="utf-8",
+            )
+            lib_path = tmp / "dummy.lib"
+            lib_path.write_text("library(dummy);\n", encoding="utf-8")
+            macro_manifest = {
+                "additional_libs": [lib_path],
+            }
+
+            calls = []
+
+            def fake_run(cmd, *, cwd, check, env):
+                calls.append((list(cmd), dict(env)))
+                flow_variant = str(env.get("FLOW_VARIANT", "base")).strip() or "base"
+                for variant in (flow_variant, "base"):
+                    synth_out = tmp / "orfs" / "results" / "nangate45" / "demo_design" / variant / "1_synth.v"
+                    synth_out.parent.mkdir(parents=True, exist_ok=True)
+                    synth_out.write_text("// synthesized\n", encoding="utf-8")
+                capture_base = self._collect_fsm_capture_base(env)
+                if capture_base:
+                    Path(f"{capture_base}.01").write_text(
+                        ".fsm npu_top top\n.map 0 1\n",
+                        encoding="utf-8",
+                    )
+                return subprocess.CompletedProcess(cmd, 0)
+
+            old_dest = self.run_block_sweep.DEST_BASE
+            old_src = self.run_block_sweep.SRC_BASE
+            old_report = self.run_block_sweep.REPORT_BASE
+            old_result = self.run_block_sweep.RESULT_BASE
+            old_log = self.run_block_sweep.LOG_BASE
+            old_run = self.run_block_sweep.subprocess.run
+            self.run_block_sweep.DEST_BASE = tmp / "orfs" / "designs"
+            self.run_block_sweep.SRC_BASE = self.run_block_sweep.DEST_BASE / "src"
+            self.run_block_sweep.REPORT_BASE = tmp / "orfs" / "reports"
+            self.run_block_sweep.RESULT_BASE = tmp / "orfs" / "results"
+            self.run_block_sweep.LOG_BASE = tmp / "orfs" / "logs"
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                row = self.run_block_sweep.run_single(
+                    design_dir=design_dir,
+                    design_name="demo_design",
+                    platform="nangate45",
+                    top="npu_top",
+                    verilog_dir=verilog_dir,
+                    sdc_template=None,
+                    sweep_params={
+                        "TAG": "demo_invocable",
+                        "FLOW_VARIANT": "demo_invocable",
+                        "CLOCK_PERIOD": 10.0,
+                        "CORE_AREA": "0 0 100 100",
+                        "SYNTH_FSM_ENCFILE": True,
+                        "SYNTH_FSM_ENCFILE_PATH": "fsm_encoding.enc",
+                    },
+                    out_root=tmp / "out",
+                    skip_existing=False,
+                    dry_run=False,
+                    force_copy=True,
+                    make_target=None,
+                    macro_manifest=macro_manifest,
+                )
+            finally:
+                self.run_block_sweep.DEST_BASE = old_dest
+                self.run_block_sweep.SRC_BASE = old_src
+                self.run_block_sweep.REPORT_BASE = old_report
+                self.run_block_sweep.RESULT_BASE = old_result
+                self.run_block_sweep.LOG_BASE = old_log
+                self.run_block_sweep.subprocess.run = old_run
+
+            capture_bases = [
+                Path(self._collect_fsm_capture_base(call_env))
+                for _, call_env in calls
+                if self._collect_fsm_capture_base(call_env) is not None
+            ]
+            self.assertEqual(2, len(capture_bases))
+            self.assertEqual(
+                {"fsm_encoding_01.enc", "fsm_encoding_02.enc"},
+                {p.name for p in capture_bases},
+            )
+            self.assertNotEqual(capture_bases[0], capture_bases[1])
+            self.assertIsNotNone(row["fsm_encfile_path"])
+            self.assertTrue(row["fsm_encfile_path"] != "")
+
+    def test_run_single_records_fsm_encoding_provenance(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done); assign done = clk; endmodule\n",
+                encoding="utf-8",
+            )
+
+            def fake_run(cmd, *, cwd, check, env):
+                capture_base = self._collect_fsm_capture_base(env)
+                if capture_base:
+                    Path(f"{capture_base}.01").write_text(
+                        ".fsm npu_top top_state\\n.map 0 1\\n",
+                        encoding="utf-8",
+                    )
+                return subprocess.CompletedProcess(cmd, 0)
+
+            old_dest = self.run_block_sweep.DEST_BASE
+            old_src = self.run_block_sweep.SRC_BASE
+            old_report = self.run_block_sweep.REPORT_BASE
+            old_result = self.run_block_sweep.RESULT_BASE
+            old_log = self.run_block_sweep.LOG_BASE
+            old_run = self.run_block_sweep.subprocess.run
+            self.run_block_sweep.DEST_BASE = tmp / "orfs" / "designs"
+            self.run_block_sweep.SRC_BASE = self.run_block_sweep.DEST_BASE / "src"
+            self.run_block_sweep.REPORT_BASE = tmp / "orfs" / "reports"
+            self.run_block_sweep.RESULT_BASE = tmp / "orfs" / "results"
+            self.run_block_sweep.LOG_BASE = tmp / "orfs" / "logs"
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                row = self.run_block_sweep.run_single(
+                    design_dir=design_dir,
+                    design_name="demo_design",
+                    platform="nangate45",
+                    top="npu_top",
+                    verilog_dir=verilog_dir,
+                    sdc_template=None,
+                    sweep_params={
+                        "TAG": "demo_capture",
+                        "FLOW_VARIANT": "demo_capture",
+                        "CLOCK_PERIOD": 10.0,
+                        "CORE_AREA": "0 0 100 100",
+                        "SYNTH_FSM_ENCFILE": True,
+                        "SYNTH_FSM_ENCFILE_PATH": "fsm_encoding.enc",
+                        "SYNTH_FSM_ENCFILE_REQUIRED": False,
+                    },
+                    out_root=tmp / "out",
+                    skip_existing=False,
+                    dry_run=False,
+                    force_copy=True,
+                    make_target="1_synth.v",
+                    macro_manifest=None,
+                )
+                payload = json.loads(Path(row["work_result_json"]).read_text(encoding="utf-8"))
+                metrics_rows = list(
+                    csv.DictReader(
+                        (tmp / "out" / "demo_design" / "metrics.csv").open(encoding="utf-8")
+                    )
+                )
+            finally:
+                self.run_block_sweep.DEST_BASE = old_dest
+                self.run_block_sweep.SRC_BASE = old_src
+                self.run_block_sweep.REPORT_BASE = old_report
+                self.run_block_sweep.RESULT_BASE = old_result
+                self.run_block_sweep.LOG_BASE = old_log
+                self.run_block_sweep.subprocess.run = old_run
+
+            self.assertIn("fsm_encoding_json", row)
+            self.assertTrue(row["fsm_encfile_path"])
+            self.assertTrue(row["fsm_encfile_sha1"])
+            self.assertTrue(row["fsm_encfile_sha256"])
+            self.assertTrue(row["fsm_encoding_json"])
+            self.assertEqual(payload["fsm_encfile_path"], row["fsm_encfile_path"])
+            encoded = json.loads(row["fsm_encoding_json"])
+            self.assertEqual(1, encoded["version"])
+            self.assertEqual("npu_top", encoded["fsm_encodings"][0]["module"])
+            self.assertIn("result_path", row)
+            self.assertEqual(row["fsm_encfile_sha1"], payload["fsm_encfile_sha1"])
+            self.assertEqual(row["fsm_encoding_json"], metrics_rows[0]["fsm_encoding_json"])
+
+    def test_run_single_fails_clearly_when_fsm_capture_required_but_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done); assign done = clk; endmodule\n",
+                encoding="utf-8",
+            )
+
+            def fake_run(cmd, *, cwd, check, env):
+                return subprocess.CompletedProcess(cmd, 0)
+
+            old_dest = self.run_block_sweep.DEST_BASE
+            old_src = self.run_block_sweep.SRC_BASE
+            old_report = self.run_block_sweep.REPORT_BASE
+            old_result = self.run_block_sweep.RESULT_BASE
+            old_log = self.run_block_sweep.LOG_BASE
+            old_run = self.run_block_sweep.subprocess.run
+            self.run_block_sweep.DEST_BASE = tmp / "orfs" / "designs"
+            self.run_block_sweep.SRC_BASE = self.run_block_sweep.DEST_BASE / "src"
+            self.run_block_sweep.REPORT_BASE = tmp / "orfs" / "reports"
+            self.run_block_sweep.RESULT_BASE = tmp / "orfs" / "results"
+            self.run_block_sweep.LOG_BASE = tmp / "orfs" / "logs"
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                row = self.run_block_sweep.run_single(
+                    design_dir=design_dir,
+                    design_name="demo_design",
+                    platform="nangate45",
+                    top="npu_top",
+                    verilog_dir=verilog_dir,
+                    sdc_template=None,
+                    sweep_params={
+                        "TAG": "demo_req_missing",
+                        "FLOW_VARIANT": "demo_req_missing",
+                        "CLOCK_PERIOD": 10.0,
+                        "CORE_AREA": "0 0 100 100",
+                        "SYNTH_FSM_ENCFILE_REQUIRED": True,
+                    },
+                    out_root=tmp / "out",
+                    skip_existing=False,
+                    dry_run=False,
+                    force_copy=True,
+                    make_target="1_synth.v",
+                    macro_manifest=None,
+                )
+            finally:
+                self.run_block_sweep.DEST_BASE = old_dest
+                self.run_block_sweep.SRC_BASE = old_src
+                self.run_block_sweep.REPORT_BASE = old_report
+                self.run_block_sweep.RESULT_BASE = old_result
+                self.run_block_sweep.LOG_BASE = old_log
+                self.run_block_sweep.subprocess.run = old_run
+
+            self.assertEqual("flow_failed", row["status"])
+            self.assertEqual("synth", row["failure_stage"])
+            self.assertEqual("missing_required_fsm_encoding_capture", row["failure_signature"])
+
+    def test_skip_existing_rejects_missing_required_capture_map(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done); assign done = clk; endmodule\n",
+                encoding="utf-8",
+            )
+
+            sweep_params = {
+                "TAG": "demo_skip",
+                "FLOW_VARIANT": "demo_skip",
+                "CLOCK_PERIOD": 10.0,
+                "CORE_AREA": "0 0 100 100",
+                "SYNTH_FSM_ENCFILE_REQUIRED": True,
+            }
+            run_id = self.run_block_sweep.make_run_id(sweep_params)
+            old_payload = {
+                "design": "demo_design",
+                "platform": "nangate45",
+                "config_hash": "cfg",
+                "param_hash": run_id,
+                "tag": "demo_skip",
+                "status": "ok",
+                "work_result_json": str(tmp / "out" / "demo_design" / "work" / run_id / "result.json"),
+            }
+            result_dir = tmp / "out" / "demo_design" / "work" / run_id
+            result_dir.mkdir(parents=True, exist_ok=True)
+            (result_dir / "result.json").write_text(
+                json.dumps(old_payload),
+                encoding="utf-8",
+            )
+
+            calls = []
+
+            def fake_run(cmd, *, cwd, check, env):
+                calls.append(list(cmd))
+                return subprocess.CompletedProcess(cmd, 0)
+
+            old_dest = self.run_block_sweep.DEST_BASE
+            old_src = self.run_block_sweep.SRC_BASE
+            old_report = self.run_block_sweep.REPORT_BASE
+            old_result = self.run_block_sweep.RESULT_BASE
+            old_log = self.run_block_sweep.LOG_BASE
+            old_run = self.run_block_sweep.subprocess.run
+            self.run_block_sweep.DEST_BASE = tmp / "orfs" / "designs"
+            self.run_block_sweep.SRC_BASE = self.run_block_sweep.DEST_BASE / "src"
+            self.run_block_sweep.REPORT_BASE = tmp / "orfs" / "reports"
+            self.run_block_sweep.RESULT_BASE = tmp / "orfs" / "results"
+            self.run_block_sweep.LOG_BASE = tmp / "orfs" / "logs"
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                row = self.run_block_sweep.run_single(
+                    design_dir=design_dir,
+                    design_name="demo_design",
+                    platform="nangate45",
+                    top="npu_top",
+                    verilog_dir=verilog_dir,
+                    sdc_template=None,
+                    sweep_params=sweep_params,
+                    out_root=tmp / "out",
+                    skip_existing=True,
+                    dry_run=False,
+                    force_copy=True,
+                    make_target="1_synth.v",
+                    macro_manifest=None,
+                )
+            finally:
+                self.run_block_sweep.DEST_BASE = old_dest
+                self.run_block_sweep.SRC_BASE = old_src
+                self.run_block_sweep.REPORT_BASE = old_report
+                self.run_block_sweep.RESULT_BASE = old_result
+                self.run_block_sweep.LOG_BASE = old_log
+                self.run_block_sweep.subprocess.run = old_run
+
+            self.assertEqual(1, len(calls))
+            self.assertNotEqual("ok", row["status"])
+
+    def test_run_single_merges_fsm_encodings_from_multiple_synth_invocations(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done); assign done = clk; endmodule\n",
+                encoding="utf-8",
+            )
+            lib_path = tmp / "dummy.lib"
+            lib_path.write_text("library(dummy);\n", encoding="utf-8")
+            macro_manifest = {
+                "additional_libs": [lib_path],
+            }
+
+            calls = []
+
+            def fake_run(cmd, *, cwd, check, env):
+                calls.append((list(cmd), dict(env)))
+                capture_base = self._collect_fsm_capture_base(env)
+                flow_variant = str(env.get("FLOW_VARIANT", "base")).strip() or "base"
+                for variant in (flow_variant, "base"):
+                    synth_out = tmp / "orfs" / "results" / "nangate45" / "demo_design" / variant / "1_synth.v"
+                    synth_out.parent.mkdir(parents=True, exist_ok=True)
+                    synth_out.write_text("// synthesized\n", encoding="utf-8")
+                if capture_base:
+                    if "_01" in str(capture_base):
+                        Path(f"{capture_base}.01").write_text(
+                            ".fsm npu_top reducer\n.map 1 2\n",
+                            encoding="utf-8",
+                        )
+                    else:
+                        Path(f"{capture_base}.01").write_text(
+                            ".fsm npu_top score_tile\n.map S T\n",
+                            encoding="utf-8",
+                        )
+                return subprocess.CompletedProcess(cmd, 0)
+
+            old_dest = self.run_block_sweep.DEST_BASE
+            old_src = self.run_block_sweep.SRC_BASE
+            old_report = self.run_block_sweep.REPORT_BASE
+            old_result = self.run_block_sweep.RESULT_BASE
+            old_log = self.run_block_sweep.LOG_BASE
+            old_run = self.run_block_sweep.subprocess.run
+            self.run_block_sweep.DEST_BASE = tmp / "orfs" / "designs"
+            self.run_block_sweep.SRC_BASE = self.run_block_sweep.DEST_BASE / "src"
+            self.run_block_sweep.REPORT_BASE = tmp / "orfs" / "reports"
+            self.run_block_sweep.RESULT_BASE = tmp / "orfs" / "results"
+            self.run_block_sweep.LOG_BASE = tmp / "orfs" / "logs"
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                row = self.run_block_sweep.run_single(
+                    design_dir=design_dir,
+                    design_name="demo_design",
+                    platform="nangate45",
+                    top="npu_top",
+                    verilog_dir=verilog_dir,
+                    sdc_template=None,
+                    sweep_params={
+                        "TAG": "demo_multi",
+                        "FLOW_VARIANT": "demo_multi",
+                        "CLOCK_PERIOD": 10.0,
+                        "CORE_AREA": "0 0 100 100",
+                        "SYNTH_FSM_ENCFILE": True,
+                        "SYNTH_FSM_ENCFILE_PATH": "fsm_encoding.enc",
+                    },
+                    out_root=tmp / "out",
+                    skip_existing=False,
+                    dry_run=False,
+                    force_copy=True,
+                    make_target=None,
+                    macro_manifest=macro_manifest,
+                )
+            finally:
+                self.run_block_sweep.DEST_BASE = old_dest
+                self.run_block_sweep.SRC_BASE = old_src
+                self.run_block_sweep.REPORT_BASE = old_report
+                self.run_block_sweep.RESULT_BASE = old_result
+                self.run_block_sweep.LOG_BASE = old_log
+                self.run_block_sweep.subprocess.run = old_run
+
+            synth_calls = [
+                call
+                for call in calls
+                if self._collect_fsm_capture_base(call[1]) is not None
+            ]
+            self.assertEqual(2, len(synth_calls))
+            encoded = json.loads(row["fsm_encoding_json"])
+            module_states = {
+                (entry.get("module"), entry.get("state"))
+                for entry in encoded.get("fsm_encodings", [])
+            }
+            self.assertIn(("npu_top", "reducer"), module_states)
+            self.assertIn(("npu_top", "score_tile"), module_states)
+
+    def test_merge_fsm_encodings_accepts_identical_duplicates(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            first = tmp / "first.enc"
+            second = tmp / "second.enc"
+            content = ".fsm npu_top score_tile\n.map 00 01\n"
+            first.write_text(content, encoding="utf-8")
+            second.write_text(content, encoding="utf-8")
+
+            merged = self.run_block_sweep.merge_fsm_encoding_payloads([first, second])
+
+            self.assertEqual(
+                [{"module": "npu_top", "state": "score_tile", "maps": [["00", "01"]]}],
+                merged,
+            )
+
+    def test_merge_fsm_encodings_rejects_conflicting_recodes(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            first = tmp / "first.enc"
+            second = tmp / "second.enc"
+            first.write_text(
+                ".fsm npu_top score_tile\n.map 00 01\n",
+                encoding="utf-8",
+            )
+            second.write_text(
+                ".fsm npu_top score_tile\n.map 00 10\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "Conflicting FSM encoding"):
+                self.run_block_sweep.merge_fsm_encoding_payloads([first, second])
+
+    def test_run_single_records_conflicting_fsm_encodings_as_flow_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done); assign done = clk; endmodule\n",
+                encoding="utf-8",
+            )
+
+            def fake_run(cmd, *, cwd, check, env):
+                capture_base = self._collect_fsm_capture_base(env)
+                if capture_base:
+                    Path(f"{capture_base}.01").write_text(
+                        ".fsm npu_top score_tile\n.map 00 01\n",
+                        encoding="utf-8",
+                    )
+                    Path(f"{capture_base}.02").write_text(
+                        ".fsm npu_top score_tile\n.map 00 10\n",
+                        encoding="utf-8",
+                    )
+                return subprocess.CompletedProcess(cmd, 0)
+
+            old_dest = self.run_block_sweep.DEST_BASE
+            old_src = self.run_block_sweep.SRC_BASE
+            old_report = self.run_block_sweep.REPORT_BASE
+            old_result = self.run_block_sweep.RESULT_BASE
+            old_log = self.run_block_sweep.LOG_BASE
+            old_run = self.run_block_sweep.subprocess.run
+            self.run_block_sweep.DEST_BASE = tmp / "orfs" / "designs"
+            self.run_block_sweep.SRC_BASE = self.run_block_sweep.DEST_BASE / "src"
+            self.run_block_sweep.REPORT_BASE = tmp / "orfs" / "reports"
+            self.run_block_sweep.RESULT_BASE = tmp / "orfs" / "results"
+            self.run_block_sweep.LOG_BASE = tmp / "orfs" / "logs"
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                row = self.run_block_sweep.run_single(
+                    design_dir=design_dir,
+                    design_name="demo_design",
+                    platform="nangate45",
+                    top="npu_top",
+                    verilog_dir=verilog_dir,
+                    sdc_template=None,
+                    sweep_params={
+                        "TAG": "demo_conflict",
+                        "FLOW_VARIANT": "demo_conflict",
+                        "CLOCK_PERIOD": 10.0,
+                        "CORE_AREA": "0 0 100 100",
+                        "SYNTH_FSM_ENCFILE": True,
+                    },
+                    out_root=tmp / "out",
+                    skip_existing=False,
+                    dry_run=False,
+                    force_copy=True,
+                    make_target="1_synth.v",
+                    macro_manifest=None,
+                )
+            finally:
+                self.run_block_sweep.DEST_BASE = old_dest
+                self.run_block_sweep.SRC_BASE = old_src
+                self.run_block_sweep.REPORT_BASE = old_report
+                self.run_block_sweep.RESULT_BASE = old_result
+                self.run_block_sweep.LOG_BASE = old_log
+                self.run_block_sweep.subprocess.run = old_run
+
+            self.assertEqual("flow_failed", row["status"])
+            self.assertEqual("synth", row["failure_stage"])
+            self.assertEqual(
+                "conflicting_fsm_encoding_capture",
+                row["failure_signature"],
+            )
+            self.assertIn("module='npu_top'", row["failure_command"])
+            result_payload = json.loads(
+                Path(row["work_result_json"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual("flow_failed", result_payload["status"])
+            metrics_rows = list(
+                csv.DictReader(
+                    (tmp / "out" / "demo_design" / "metrics.csv").open(
+                        encoding="utf-8"
+                    )
+                )
+            )
+            self.assertEqual(1, len(metrics_rows))
+            self.assertEqual("flow_failed", metrics_rows[0]["status"])
+            self.assertEqual(
+                "conflicting_fsm_encoding_capture",
+                metrics_rows[0]["failure_signature"],
+            )
+
+    def test_synth_script_instruments_all_internal_synth_calls(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            script_path = tmp / "synth_capture.tcl"
+            self.run_block_sweep.write_preserve_blackbox_synth_script(
+                script_path=script_path,
+                synth_tcl=Path("/orfs/flow/scripts/synth.tcl"),
+                instrument_fsm_capture=True,
+            )
+
+            text = script_path.read_text(encoding="utf-8")
+
+            self.assertIn("proc yosys_synth_with_fsm_capture", text)
+            self.assertIn(
+                "yosys_synth_with_fsm_capture -run :fine", text,
+            )
+            self.assertIn(
+                "yosys_synth_with_fsm_capture -flatten -run coarse:fine", text,
+            )
+            self.assertIn(
+                "yosys_synth_with_fsm_capture -top $::env(DESIGN_NAME) -run fine:", text,
+            )
+            self.assertNotIn("synth -run :fine", text)
+            self.assertNotIn("synth -flatten -run coarse:fine", text)
+            self.assertNotIn("synth -top $::env(DESIGN_NAME) -run fine:", text)
 
 class SynthTargetMappingRegressionTest(unittest.TestCase):
     @classmethod

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -31,6 +31,23 @@ class ModeCompareRegressionTest(unittest.TestCase):
         cls.run_block_sweep = load_script_module(
             "run_block_sweep", "npu/synth/run_block_sweep.py"
         )
+        cls.synth_fixture_dir = tempfile.TemporaryDirectory()
+        cls.synth_fixture_path = Path(cls.synth_fixture_dir.name) / "synth.tcl"
+        cls.synth_fixture_path.write_text(
+            "hierarchy -check -top $::env(DESIGN_NAME)\n"
+            "synth -run :fine\n"
+            "synth -flatten -run coarse:fine\n"
+            "synth -top $::env(DESIGN_NAME) -run fine:\n"
+            "setundef -zero\n",
+            encoding="utf-8",
+        )
+        cls.default_synth_script = cls.run_block_sweep.DEFAULT_SYNTH_SCRIPT
+        cls.run_block_sweep.DEFAULT_SYNTH_SCRIPT = cls.synth_fixture_path
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.run_block_sweep.DEFAULT_SYNTH_SCRIPT = cls.default_synth_script
+        cls.synth_fixture_dir.cleanup()
 
     @staticmethod
     def _collect_encfile_arg(cmd: list) -> str | None:
@@ -1187,7 +1204,6 @@ class ModeCompareRegressionTest(unittest.TestCase):
             script_path = tmp / "synth_capture.tcl"
             self.run_block_sweep.write_preserve_blackbox_synth_script(
                 script_path=script_path,
-                synth_tcl=Path("/orfs/flow/scripts/synth.tcl"),
                 instrument_fsm_capture=True,
             )
 


### PR DESCRIPTION
## Summary

- explicitly capture the reducer's unpacked `block_weight[0..7]` feedback registers in phase VCD sidecars
- report deterministic compact groups for unmatched routed DFF outputs and unused sidecar rows
- preserve every internal Yosys FSM recoding map across hierarchical synthesis invocations
- embed a deterministic FSM encoding payload and hashes in `result.json` and `metrics.csv`
- reject missing required or conflicting FSM encoding provenance explicitly

## Why

Activity-power v13 proved exact pin application but left 272 routed Q/QN outputs unmatched. Of those, 256 are the eight 16-bit block-weight registers; the remainder exposes Yosys one-hot FSM recoding, which cannot be treated as bitwise-equivalent to the RTL binary state vector. This patch captures the missing feedback state and makes synthesis encoding a measured, transportable contract rather than guessing aliases.

## Validation

- `85 passed` across activity generation, sidecar extraction, postroute power, and sweep-runner tests
- Tcl wrapper runtime sanity check confirms distinct `.01`, `.02` encfiles and removes stale `-encfile` arguments
- `git diff --check`

No activity clamping, substitution, threshold relaxation, functional RTL change, or physical-result revision is included.
