### PR TITLE
npu: add matched binary-FSM cluster PNR calibration

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1456,6 +1456,13 @@ def _is_multivalue_cluster_8ns_bridge_sweep(*, item_id: str, sweep_path: str) ->
     )
 
 
+def _is_multivalue_cluster_8ns_binary_fsm_sweep(*, item_id: str, sweep_path: str) -> bool:
+    return (
+        item_id == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+        and Path(sweep_path).name == "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json"
+    )
+
+
 def _is_gqa_lanes2_macro_hier_placement_sweep(*, item_id: str, sweep_path: str) -> bool:
     return (
         item_id == "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_macro_placement_v1"
@@ -1735,6 +1742,23 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             "name": "check_attention_decode_score_multivalue_cluster_8ns_bridge",
             "run": f"python3 npu/eval/check_attention_decode_score_multivalue_cluster_8ns_bridge.py "
             f"--metrics-path {targets[0].expected_metrics_path}",
+        }
+        inserted = False
+        for idx, command in enumerate(command_manifest):
+            if command.get("name") == "run_block_sweep":
+                command_manifest.insert(idx + 1, checker_command)
+                inserted = True
+                break
+        if not inserted:
+            command_manifest.append(checker_command)
+
+    if _is_multivalue_cluster_8ns_binary_fsm_sweep(item_id=item_id, sweep_path=sweep_path) and targets:
+        checker_command = {
+            "name": "check_attention_decode_score_multivalue_cluster_binary_fsm",
+            "run": (
+                "python3 npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py "
+                f"--metrics-path {targets[0].expected_metrics_path}"
+            ),
         }
         inserted = False
         for idx, command in enumerate(command_manifest):

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -905,6 +905,48 @@ def _write_attention_decode_score_multivalue_cluster_8ns_bridge_sweep(repo_root:
     return str(sweep_path.relative_to(repo_root))
 
 
+def _write_attention_decode_score_multivalue_cluster_binary_fsm_8ns_v3_sweep(repo_root: Path) -> str:
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "decode_score_multivalue_cluster_v1"
+        / "sweeps"
+        / "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "flow_params": {
+                    "TAG": ["decode_score_multivalue_cluster_v1_8ns_binary_fsm"],
+                    "FLOW_VARIANT": ["decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"],
+                    "CLOCK_PERIOD": [8],
+                    "SYNTH_HIERARCHICAL": [1],
+                    "SYNTH_MEMORY_MAX_BITS": [65536],
+                    "PLACE_DENSITY": [0.4],
+                    "SYNTH_ARGS": ["-nofsm"],
+                },
+                "mode_compare": {
+                    "modes": [
+                        {
+                            "name": "proxy_die_2500",
+                            "use_macro": True,
+                            "param_overrides": {
+                                "DIE_AREA": "0 0 2500 2500",
+                                "CORE_AREA": "50 50 2450 2450",
+                            },
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(sweep_path.relative_to(repo_root))
+
+
 def _write_example_attention_decode_score_multivalue_gqa_group_repo(
     repo_root: Path,
 ) -> tuple[str, str]:
@@ -2810,6 +2852,43 @@ def test_generate_l1_sweep_task_adds_bridge_checker_for_exact_8ns_multivalue_clu
             ]
             assert (
                 "python3 npu/eval/check_attention_decode_score_multivalue_cluster_8ns_bridge.py "
+                "--metrics-path runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv"
+                in [command["run"] for command in work_item.command_manifest]
+            )
+
+
+def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_exact_8ns_multivalue_cluster_item() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, _ = _write_example_attention_decode_score_multivalue_cluster_repo(repo_root)
+        sweep_path = _write_attention_decode_score_multivalue_cluster_binary_fsm_8ns_v3_sweep(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    item_id="l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_cluster",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert "check_attention_decode_score_multivalue_cluster_binary_fsm" in [
+                command["name"] for command in work_item.command_manifest
+            ]
+            assert (
+                "python3 npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py "
                 "--metrics-path runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv"
                 in [command["run"] for command in work_item.command_manifest]
             )

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
@@ -86,6 +86,28 @@
       "merge_commit": "7b01c7e452af6f658c566900fef0513f6ba2490b",
       "merged_utc": "2026-07-19T09:36:12.486715Z",
       "notes": "Merged via PR #1364 and merge 7b01c7e452af6f658c566900fef0513f6ba2490b at 2026-07-19T09:36:12.486715Z."
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact-state activity calibration path with the unique binary-FSM 8 ns sweep, matched to the v2 physical architecture and configuration.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_binary_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
+        "reason": "The v2 result remains the valid one-hot PPA baseline and is not invalidated. V3 is a matched physical architecture point with SYNTH_ARGS=-nofsm so routed FSM bits correspond to RTL state activity. PR #1413 / merge f281d6f7 enables complete block_weight capture, compact diagnostics, and FSM provenance; the forthcoming v3 sweep implementation is not yet merged."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "source_commit": "9a857c5cb5deb84ae5487d1b0c37500833bd7e1a"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
@@ -114,6 +114,29 @@
         "reason": "Collect the missing 8 ns Nangate45 evidence in 2.5 mm envelope while keeping current vectorless metrics as bounded frontier evidence."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact-state activity calibration path with the unique binary-FSM 8 ns sweep, matched to the v2 physical architecture and configuration.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_binary_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
+        "reason": "The v2 result remains the valid one-hot PPA baseline and is not invalidated. V3 is a matched physical architecture point with SYNTH_ARGS=-nofsm so routed FSM bits correspond to RTL state activity. PR #1413 / merge f281d6f7 enables complete block_weight capture, compact diagnostics, and FSM provenance; the forthcoming v3 sweep implementation is not yet merged."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "baseline_refs": [

--- a/npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py
+++ b/npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Validate exact-state decode-score multivalue-cluster rows for binary-FSM PNR."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+EXPECTED_CLOCK_PERIOD = 8
+EXPECTED_TAG_PREFIX = "decode_score_multivalue_cluster_v1_8ns_binary_fsm"
+EXPECTED_FLOW_VARIANT = "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+EXPECTED_DIE_AREA = "0 0 2500 2500"
+EXPECTED_CORE_AREA = "50 50 2450 2450"
+EXPECTED_PLACE_DENSITY = "0.4"
+EXPECTED_SYNTH_HIERARCHICAL = "1"
+EXPECTED_SYNTH_MEMORY_MAX_BITS = "65536"
+EXPECTED_SYNTH_ARGS = "-nofsm"
+EXPECTED_RESULT_PATH_TOKEN = "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv"
+
+
+def _parse_params_json(value: str) -> dict[str, object]:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("empty params_json")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+            parsed = json.loads(text[1:-1].replace('""', '"'))
+        else:
+            raise
+    if not isinstance(parsed, dict):
+        raise ValueError("params_json did not decode to a JSON object")
+    return parsed
+
+
+def _to_str(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _iter_metrics_rows(metrics_path: Path):
+    with metrics_path.open(newline="", encoding="utf-8") as stream:
+        reader = csv.DictReader(stream)
+        for row in reader:
+            if row is not None:
+                yield row
+
+
+def _parse_critical_path(row: dict[str, str]) -> float:
+    value = float(row.get("critical_path_ns", "inf"))
+    return float(value)
+
+
+def _row_matches_binary_fsm(row: dict[str, str]) -> bool:
+    if _to_str(row.get("status")).lower() != "ok":
+        return False
+
+    try:
+        params = _parse_params_json(_to_str(row.get("params_json", "")))
+    except Exception:
+        return False
+
+    tag = _to_str(row.get("tag"))
+    if not tag.startswith(EXPECTED_TAG_PREFIX):
+        return False
+    if _to_str(params.get("FLOW_VARIANT")) != EXPECTED_FLOW_VARIANT:
+        return False
+    if _to_str(params.get("PLACE_DENSITY")) != EXPECTED_PLACE_DENSITY:
+        return False
+    if _to_str(params.get("SYNTH_HIERARCHICAL")) != EXPECTED_SYNTH_HIERARCHICAL:
+        return False
+    if _to_str(params.get("SYNTH_MEMORY_MAX_BITS")) != EXPECTED_SYNTH_MEMORY_MAX_BITS:
+        return False
+    if _to_str(params.get("SYNTH_ARGS")) != EXPECTED_SYNTH_ARGS:
+        return False
+
+    try:
+        clock_period = float(_to_str(params.get("CLOCK_PERIOD", "")))
+    except ValueError:
+        return False
+    if clock_period != float(EXPECTED_CLOCK_PERIOD):
+        return False
+
+    if _to_str(params.get("DIE_AREA")) != EXPECTED_DIE_AREA:
+        return False
+    if _to_str(params.get("CORE_AREA")) != EXPECTED_CORE_AREA:
+        return False
+    if _to_str(row.get("result_path")).find(EXPECTED_RESULT_PATH_TOKEN) == -1:
+        return False
+
+    try:
+        return _parse_critical_path(row) <= 8
+    except Exception:
+        return False
+
+
+def validate_binary_fsm_metrics(*, metrics_path: Path) -> int:
+    if not metrics_path.exists():
+        raise ValueError(f"missing metrics.csv: {metrics_path}")
+
+    for row in _iter_metrics_rows(metrics_path):
+        if _row_matches_binary_fsm(row):
+            return 0
+
+    raise ValueError(
+        "missing required 8ns exact-state binary-FSM decode-score multivalue-cluster row "
+        "(status=ok, TAG=decode_score_multivalue_cluster_v1_8ns_binary_fsm*, "
+        "FLOW_VARIANT=decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500, "
+        "DIE_AREA=0 0 2500 2500, CORE_AREA=50 50 2450 2450, SYNTH_ARGS=-nofsm, "
+        "PLACE_DENSITY=0.4, SYNTH_HIERARCHICAL=1, SYNTH_MEMORY_MAX_BITS=65536, "
+        "critical_path_ns<=8)"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metrics-path", type=Path, required=True)
+    args = parser.parse_args()
+    validate_binary_fsm_metrics(metrics_path=args.metrics_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json
+++ b/runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json
@@ -1,0 +1,38 @@
+{
+  "tag_prefix": "decode_score_multivalue_cluster_v1_8ns_binary_fsm",
+  "flow_params": {
+    "TAG": [
+      "decode_score_multivalue_cluster_v1_8ns_binary_fsm"
+    ],
+    "FLOW_VARIANT": [
+      "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+    ],
+    "CLOCK_PERIOD": [
+      8
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_ARGS": [
+      "-nofsm"
+    ]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "proxy_die_2500",
+        "use_macro": true,
+        "param_overrides": {
+          "DIE_AREA": "0 0 2500 2500",
+          "CORE_AREA": "50 50 2450 2450"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_check_attention_decode_score_multivalue_cluster_binary_fsm.py
+++ b/tests/test_check_attention_decode_score_multivalue_cluster_binary_fsm.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+EXPECTED_TAG = "decode_score_multivalue_cluster_v1_8ns_binary_fsm"
+EXPECTED_VARIANT = "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+EXPECTED_SYNTH_ARGS = "-nofsm"
+
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _metrics_path(root: Path) -> Path:
+    design_dir = root / "runs" / "designs" / "npu_blocks" / "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv"
+    return design_dir / "metrics.csv"
+
+
+def _write_metrics(metrics_path: Path, rows: list[tuple]) -> None:
+    header = [
+        "design",
+        "platform",
+        "config_hash",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "total_power_mw",
+        "params_json",
+        "result_path",
+    ]
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    with metrics_path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def _write_row(
+    *,
+    status: str,
+    critical_path_ns: float,
+    result_path: str,
+    tag: str = EXPECTED_TAG,
+    flow_variant: str = EXPECTED_VARIANT,
+    synth_args: str | None = EXPECTED_SYNTH_ARGS,
+    clock_period: float = 8,
+    die_area: str = "0 0 2500 2500",
+    core_area: str = "50 50 2450 2450",
+    place_density: object | None = 0.4,
+    synth_hierarchical: object | None = 1,
+    synth_memory_max_bits: object | None = 65536,
+) -> tuple[str, ...]:
+    params = {
+        "FLOW_VARIANT": flow_variant,
+        "CLOCK_PERIOD": clock_period,
+        "DIE_AREA": die_area,
+        "CORE_AREA": core_area,
+    }
+    if place_density is not None:
+        params["PLACE_DENSITY"] = place_density
+    if synth_hierarchical is not None:
+        params["SYNTH_HIERARCHICAL"] = synth_hierarchical
+    if synth_memory_max_bits is not None:
+        params["SYNTH_MEMORY_MAX_BITS"] = synth_memory_max_bits
+    if synth_args is not None:
+        params["SYNTH_ARGS"] = synth_args
+    return (
+        "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv",
+        "nangate45",
+        "cfg",
+        "param8",
+        tag,
+        status,
+        f"{critical_path_ns}",
+        "0.2",
+        "0.5",
+        json.dumps(params),
+        result_path,
+    )
+
+
+def _run_checker(metrics_path: Path) -> subprocess.CompletedProcess[str]:
+    script = _repo_root() / "npu" / "eval" / "check_attention_decode_score_multivalue_cluster_binary_fsm.py"
+    return subprocess.run(
+        [sys.executable, str(script), "--metrics-path", str(metrics_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_passes_with_exact_8ns_row() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                )
+            ],
+        )
+        assert _run_checker(metrics).returncode == 0
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_passes_with_mode_suffixed_tag() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                    tag=f"{EXPECTED_TAG}_proxy_die_2500",
+                )
+            ],
+        )
+        assert _run_checker(metrics).returncode == 0
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_old_bridge_flow() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                    flow_variant="decode_score_multivalue_cluster_v1_8ns_bridge_proxy_die_2500",
+                )
+            ],
+        )
+        proc = _run_checker(metrics)
+        assert proc.returncode != 0
+        assert "missing required 8ns" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_missing_synth_args() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                    synth_args=None,
+                )
+            ],
+        )
+        proc = _run_checker(metrics)
+        assert proc.returncode != 0
+        assert "missing required 8ns" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_wrong_synth_args() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                    synth_args="-nofsm -D DEBUG",
+                )
+            ],
+        )
+        proc = _run_checker(metrics)
+        assert proc.returncode != 0
+        assert "missing required 8ns" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "architecture_params",
+    [
+        {"place_density": None},
+        {"place_density": 0.41},
+        {"synth_hierarchical": None},
+        {"synth_hierarchical": 0},
+        {"synth_memory_max_bits": None},
+        {"synth_memory_max_bits": 32768},
+    ],
+)
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_missing_or_wrong_architecture_params(
+    architecture_params: dict[str, object | None],
+) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                    **architecture_params,
+                )
+            ],
+        )
+        proc = _run_checker(metrics)
+        assert proc.returncode != 0
+        assert "missing required 8ns" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_bad_status_or_timing() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="flow_failed",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+                _write_row(
+                    status="ok",
+                    critical_path_ns=8.2,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                ),
+            ],
+        )
+        proc = _run_checker(metrics)
+        assert proc.returncode != 0
+        assert "missing required 8ns" in proc.stderr


### PR DESCRIPTION
## Summary

- add a unique 8 ns cluster PNR sweep with `SYNTH_ARGS=-nofsm`
- reject reused one-hot or mismatched physical rows with a strict result checker
- register the exact L1 command in the control-plane generator
- schedule the calibration without invalidating the existing v2 one-hot PPA baseline

## Why

The previous routed activity run exposed a semantic mismatch between RTL binary FSM bits and synthesized one-hot state bits. This point preserves binary FSM state through synthesis so routed registers can be matched exactly to the verified RTL activity trace. It also measures the PPA cost of that encoding choice before the next finite post-route power run.

## Validation

- `13 passed` for the new checker and sweep-tag tests
- `46 passed` for `test_l1_task_generator.py`
- `git diff --check`
- JSON parsed with `jq`