### PR TITLE
npu: require exact binary-FSM cluster activity mapping

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -31,6 +31,15 @@ class Layer2TaskGenerationError(RuntimeError):
 _RETRY_SUFFIX_RE = re.compile(r"_r\d+$")
 _VERSION_SUFFIX_RE = re.compile(r"_v(\d+)$")
 _GQA_FOLDED_ACTIVITY_LANES_RE = re.compile(r"_gqa8_folded_lanes(1|2|4|8)_activity_power_")
+_CLUSTER_ACTIVITY_POWER_STRICT_REVISION = 14
+_CLUSTER_ACTIVITY_POWER_V14_FLOW_VARIANT = (
+    "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+)
+_CLUSTER_ACTIVITY_POWER_V14_SYNTH_ARGS = "-nofsm"
+_CLUSTER_ACTIVITY_POWER_V14_PNR_ITEM = (
+    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+)
+_CLUSTER_ACTIVITY_POWER_V14_MIN_SEQUENTIAL_REGISTER_ACTIVITY_COVERAGE = 1.0
 
 
 @dataclass(frozen=True)
@@ -95,9 +104,18 @@ def _gqa_evidence_version_for_consumer(item_id: str) -> str:
     return "v2" if revision >= 2 else "v1"
 
 
+def _cluster_activity_power_revision(item_id: str) -> int:
+    match = _VERSION_SUFFIX_RE.search(_retry_base(item_id))
+    return int(match.group(1)) if match else 1
+
+
 def _gqa_group_equivalence_item_for_consumer(item_id: str) -> str:
     version = _gqa_evidence_version_for_consumer(item_id)
     return f"l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_{version}"
+
+
+def _cluster_activity_power_requires_strict_selection(item_id: str) -> bool:
+    return _cluster_activity_power_revision(item_id) >= _CLUSTER_ACTIVITY_POWER_STRICT_REVISION
 
 
 def _cluster_activity_power_item_for_consumer(
@@ -6868,6 +6886,7 @@ def _decoder_attention_decode_score_multivalue_gqa_array_equivalence_evidence(
 
 def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    require_exact_row = _cluster_activity_power_requires_strict_selection(item_id)
     config = (
         "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
         "config.json"
@@ -6887,27 +6906,60 @@ def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*
     activity_dir = "/tmp/rtlgen_multivalue_cluster_activity"
     out = f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__{item_id}.json"
     report = f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__{item_id}.md"
+    required_flow_variant = (
+        _CLUSTER_ACTIVITY_POWER_V14_FLOW_VARIANT if require_exact_row else None
+    )
+    required_synth_args = _CLUSTER_ACTIVITY_POWER_V14_SYNTH_ARGS if require_exact_row else None
+    source_pnr_item_id = _CLUSTER_ACTIVITY_POWER_V14_PNR_ITEM if require_exact_row else None
+    min_seq_register_activity_coverage = (
+        _CLUSTER_ACTIVITY_POWER_V14_MIN_SEQUENTIAL_REGISTER_ACTIVITY_COVERAGE
+        if require_exact_row
+        else None
+    )
+    command_args: list[str] = []
+    if required_flow_variant is not None:
+        command_args.append(f"--required-flow-variant {required_flow_variant}")
+    if required_synth_args is not None:
+        command_args.append(f"--required-synth-args={required_synth_args}")
+    if source_pnr_item_id is not None:
+        command_args.append(f"--source-pnr-item-id {source_pnr_item_id}")
+    if min_seq_register_activity_coverage is not None:
+        command_args.append(
+            f"--min-sequential-register-activity-coverage {min_seq_register_activity_coverage}"
+        )
+    command_args_text = (" ".join(command_args) + " ") if command_args else ""
+    inputs = {
+        "decode_score_multivalue_cluster_config": config,
+        "decode_score_multivalue_cluster_pnr_metrics_csv": cluster_metrics_csv,
+        "decode_score_multivalue_cluster_equivalence_json": equivalence_json,
+        "decode_score_multivalue_cluster_orfs_design_config": orfs_design_config,
+        "decode_score_multivalue_cluster_activity_dir": activity_dir,
+        "decode_score_multivalue_cluster_activity_power_out": out,
+        "decode_score_multivalue_cluster_activity_power_report": report,
+        "decode_score_multivalue_cluster_activity_power_scope": (
+            "Audit the shared-score multivalue cluster with activity-backed power evidence after merged "
+            "equivalence and PNR. Keep VCD/ODB/SPEF evaluator-local, commit only repo-portable JSON/MD "
+            "artifacts, preserve the FakeRAM proxy qualification, and reject vectorless power as a "
+            "substitute for annotated power or token-energy claims."
+        ),
+        "decode_score_multivalue_cluster_activity_power_promotion_gate": (
+            "Promotion requires explicit annotation coverage, declared clock assumptions, macro activity "
+            "attribution, and finite power-gate accounting."
+        ),
+        "decode_score_multivalue_cluster_activity_power_local_only_artifacts": ["VCD", "ODB", "SPEF"],
+    }
+    if required_flow_variant is not None:
+        inputs["decode_score_multivalue_cluster_required_flow_variant"] = required_flow_variant
+    if required_synth_args is not None:
+        inputs["decode_score_multivalue_cluster_required_synth_args"] = required_synth_args
+    if source_pnr_item_id is not None:
+        inputs["decode_score_multivalue_cluster_source_pnr_item_id"] = source_pnr_item_id
+    if min_seq_register_activity_coverage is not None:
+        inputs["decode_score_multivalue_cluster_min_sequential_register_activity_coverage"] = (
+            min_seq_register_activity_coverage
+        )
     return {
-        "inputs": {
-            "decode_score_multivalue_cluster_config": config,
-            "decode_score_multivalue_cluster_pnr_metrics_csv": cluster_metrics_csv,
-            "decode_score_multivalue_cluster_equivalence_json": equivalence_json,
-            "decode_score_multivalue_cluster_orfs_design_config": orfs_design_config,
-            "decode_score_multivalue_cluster_activity_dir": activity_dir,
-            "decode_score_multivalue_cluster_activity_power_out": out,
-            "decode_score_multivalue_cluster_activity_power_report": report,
-            "decode_score_multivalue_cluster_activity_power_scope": (
-                "Audit the shared-score multivalue cluster with activity-backed power evidence after merged "
-                "equivalence and PNR. Keep VCD/ODB/SPEF evaluator-local, commit only repo-portable JSON/MD "
-                "artifacts, preserve the FakeRAM proxy qualification, and reject vectorless power as a "
-                "substitute for annotated power or token-energy claims."
-            ),
-            "decode_score_multivalue_cluster_activity_power_promotion_gate": (
-                "Promotion requires explicit annotation coverage, declared clock assumptions, macro activity "
-                "attribution, and finite power-gate accounting."
-            ),
-            "decode_score_multivalue_cluster_activity_power_local_only_artifacts": ["VCD", "ODB", "SPEF"],
-        },
+        "inputs": inputs,
         "commands": [
             {
                 "name": "audit_decode_score_multivalue_cluster_activity_power",
@@ -6919,6 +6971,7 @@ def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*
                     f"--orfs-design-config {orfs_design_config} "
                     "--clock-period-ns 8 "
                     f"--activity-dir {activity_dir} "
+                    f"{command_args_text}"
                     f"--out {out} "
                     f"--out-md {report}"
                 ),

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8244,6 +8244,64 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
 
 
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity_power_v14() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_cluster_activity_power",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert (
+                "--required-flow-variant "
+                "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500" in run
+            )
+            assert "--required-synth-args=-nofsm" in run
+            assert (
+                "--min-sequential-register-activity-coverage 1.0" in run
+            )
+            assert (
+                "--source-pnr-item-id "
+                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+                in run
+            )
+            assert (
+                decoder_inputs["decode_score_multivalue_cluster_required_flow_variant"]
+                == "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+            )
+            assert (
+                decoder_inputs["decode_score_multivalue_cluster_required_synth_args"] == "-nofsm"
+            )
+            assert (
+                decoder_inputs["decode_score_multivalue_cluster_source_pnr_item_id"]
+                == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+            )
+            assert (
+                decoder_inputs["decode_score_multivalue_cluster_min_sequential_register_activity_coverage"]
+                == 1.0
+            )
+
+
 def test_cluster_activity_power_item_for_consumer_prefers_requested_version_for_unknown_depends_on() -> None:
     assert (
         _cluster_activity_power_item_for_consumer(

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
@@ -1,7 +1,7 @@
 # Evaluation Gate
 
-1. Queue only after merged
-   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2` and
+1. Queue v14 only after merged
+   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3` and
    `l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1`
    evidence is available.
 2. Run the activity-power audit on the remote evaluator with evaluator-local
@@ -12,8 +12,11 @@
    silicon-current claim is allowed from LEF/LIB proxy views.
 5. Treat vectorless OpenROAD power as structural diagnostics only. It cannot
    substitute for activity-backed power or token-energy claims.
-
-6. Preserve the merged 10 ns Nangate45 row as prior evidence and append the new
-   8 ns proxy-die_2500 (2.5 mm die / 2.4 mm square core) bridge row from the
-   refreshed routed evaluator-local artifacts as the next data point for the same
-   design.
+6. Select only
+   `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500` with
+   `SYNTH_ARGS=-nofsm`; the one-hot v2 row remains a PPA baseline but is invalid
+   for bit-exact RTL-to-routed FSM activity transfer.
+7. Require 100% routed sequential Q/QN coverage, applied assignments equal to
+   matched assignments, zero query/apply errors, and finite positive power for
+   every phase. Preserve the merged 10 ns and one-hot 8 ns rows as prior PPA
+   evidence rather than reusing them for v14 power.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "Queue v13 sequential-activity rerun after PR #1410 / commit db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd. PR #1409 was closed because activity_power.tcl line 325 failed before phase power (`key ...$_DFFE_PP_/Q not known in dictionary`) from opaque pin-handle/full_name key mismatch. v13 preserves existing v12 gates, thresholds, sidecar format, and does not change activity, RTL, or physical design.",
+  "source_commit_note": "Queue v14 exact-binary-fsm postroute re-run after PR #1413 merge f281d6f7 (all block_weight VCD + complete FSM provenance) and PR #1414 merge 66a2b3a1 (matched binary-FSM PNR v3 with SYNTH_ARGS=-nofsm).",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -432,11 +432,41 @@
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
         "reason": "v13 preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, requires >=0.95 DFF-output coverage, applied==matched, and zero query/apply errors, keeps sidecar rows evaluator-local, and forbids clamping, substitution, heuristic activity, and gate relaxation while making no activity threshold, functional RTL, or physical-design changes."
       },
-      "status": "merged",
+      "status": "retracted",
       "merged_pr_number": 1410,
       "merge_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
-      "revision_of_decision": "iterate"
+      "revision_of_decision": "iterate",
+      "notes": "v13 was executed from commit 57633e77 and showed strong sequential coverage (14,922/15,194 Q/QN, 98.2098%, with zero query/apply errors; score_fill 0.249088972807 W and replay_value 0.226863563061 W were finite), but finalize reported 17,761 non-finite toggles, 26 non-finite duties, 7,502 affected leaf instances, and total_w=null. Of 272 unmatched outputs, 256 Q/QN outputs came from 128 block_weight registers omitted from VCD and the remaining 16 came from recoded FSM state, so the activity evidence is invalid.",
+      "retracted_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14",
+      "retraction_reason": "exact_binary_fsm_postroute_activity_mapping",
+      "retracted_utc": "2026-07-21T02:53:45Z"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power using only the binary-FSM matched 8ns PNR flow (decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500 with SYNTH_ARGS=-nofsm) plus merged equivalence; preserve every prior gate and strengthen routed sequential-output coverage from 95% to 100% so no recoded or omitted state can pass.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "exact_binary_fsm_postroute_activity_mapping",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "Rerun preserves all existing direct-VCD, macro, clock, numeric, artifact, applied==matched, and zero query/apply-error gates; strengthens DFF-output coverage to 1.0; and forbids clamping, substitution, heuristic activity, or other gate relaxation. It selects only decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500 with SYNTH_ARGS=-nofsm."
+      },
+      "status": "pending_implementation_merge",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
     }
   ],
-  "source_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd"
+  "source_commit": "66a2b3a10a64cb721880ff97282bf349a7b7d514"
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -386,9 +386,36 @@
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
         "reason": "v13 preserves all existing quality, equivalence, direct-VCD, macro, clock, numeric, and artifact gates, keeps the same DFF coverage and gate requirements from v12 including >=0.95 DFF-output coverage, applied==matched, and zero query/apply errors, keeps sidecar rows evaluator-local, and forbids clamping, substitution, heuristic activity, and gate relaxation; no activity thresholds, functional RTL, or physical design changes were made."
       },
-      "status": "merged",
+      "status": "retracted",
       "merged_pr_number": 1410,
-      "merge_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd"
+      "merge_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
+      "retracted_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14",
+      "retraction_reason": "exact_binary_fsm_postroute_activity_mapping"
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14",
+      "task_type": "l2_campaign",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power using only the binary-FSM matched 8ns PNR flow (decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500 with SYNTH_ARGS=-nofsm) plus merged equivalence; preserve every previous evidence gate and strengthen routed sequential-output coverage from 95% to 100%.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "exact_binary_fsm_postroute_activity_mapping",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "v14 preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, strengthens DFF-output coverage to 1.0, requires applied==matched and zero query/apply errors, and keeps all sidecar rows evaluator-local while forbidding clamping, substitution, heuristic activity, and other gate relaxation."
+      },
+      "status": "pending_implementation_merge"
     }
   ],
   "baseline_refs": [

--- a/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
@@ -96,7 +96,16 @@ def _metric_provenance(row: JsonDict, metrics_csv: Path) -> JsonDict:
     }
 
 
-def _feasible_metrics(metrics_csv: Path, clock_period_ns: float) -> list[JsonDict]:
+def _feasible_metrics(
+    metrics_csv: Path,
+    clock_period_ns: float,
+    *,
+    required_flow_variant: str | None = None,
+    required_synth_args: str | None = None,
+) -> list[JsonDict]:
+    normalized_required_flow_variant = str(required_flow_variant or "").strip() or None
+    normalized_required_synth_args = str(required_synth_args or "").strip() or None
+
     with metrics_csv.open(newline="", encoding="utf-8") as handle:
         raw_rows = [dict(row) for row in csv.DictReader(handle)]
     selected: dict[str, JsonDict] = {}
@@ -107,7 +116,18 @@ def _feasible_metrics(metrics_csv: Path, clock_period_ns: float) -> list[JsonDic
         row_clock = float(params.get("CLOCK_PERIOD", 0.0))
         critical_path = float(row.get("critical_path_ns") or math.inf)
         flow_variant = str(params.get("FLOW_VARIANT", "")).strip()
+        synth_args = str(params.get("SYNTH_ARGS", "")).strip()
         if not flow_variant or abs(row_clock - clock_period_ns) > 1e-9:
+            continue
+        if (
+            normalized_required_flow_variant is not None
+            and flow_variant != normalized_required_flow_variant
+        ):
+            continue
+        if (
+            normalized_required_synth_args is not None
+            and synth_args != normalized_required_synth_args
+        ):
             continue
         if not math.isfinite(critical_path) or critical_path > clock_period_ns:
             continue
@@ -117,6 +137,16 @@ def _feasible_metrics(metrics_csv: Path, clock_period_ns: float) -> list[JsonDic
         ):
             selected[flow_variant] = row
     if not selected:
+        if normalized_required_flow_variant is not None or normalized_required_synth_args is not None:
+            details = []
+            if normalized_required_flow_variant is not None:
+                details.append(f"FLOW_VARIANT={normalized_required_flow_variant}")
+            if normalized_required_synth_args is not None:
+                details.append(f"SYNTH_ARGS={normalized_required_synth_args}")
+            raise ValueError(
+                f"no status=ok timing-feasible rows in {metrics_csv} matching "
+                f"{', '.join(details)} at {clock_period_ns:g} ns"
+            )
         raise ValueError(
             f"no status=ok timing-feasible {clock_period_ns:g} ns rows in {metrics_csv}"
         )
@@ -191,7 +221,13 @@ def build_report(
     orfs_design_config: Path,
     clock_period_ns: float,
     activity_dir: Path,
+    min_sequential_register_activity_coverage: float = 0.95,
+    required_flow_variant: str | None = None,
+    required_synth_args: str | None = None,
+    source_pnr_item_id: str | None = None,
 ) -> JsonDict:
+    if not (0.0 < min_sequential_register_activity_coverage <= 1.0):
+        raise ValueError("min_sequential_register_activity_coverage must be in (0, 1]")
     equivalence = _load(equivalence_json)
     if not equivalence.get("equivalence_pass"):
         raise ValueError("multivalue-cluster end-to-end equivalence did not pass")
@@ -216,7 +252,12 @@ def build_report(
         activity_dir / "attention_decode_score_multivalue_cluster_activity_manifest.json"
     )
     rows: list[JsonDict] = []
-    for metric in _feasible_metrics(cluster_metrics_csv, clock_period_ns):
+    for metric in _feasible_metrics(
+        cluster_metrics_csv,
+        clock_period_ns,
+        required_flow_variant=required_flow_variant,
+        required_synth_args=required_synth_args,
+    ):
         params = _params(metric)
         flow_variant = str(params["FLOW_VARIANT"])
         candidate: JsonDict = {
@@ -233,6 +274,7 @@ def build_report(
                 scope="tb/dut",
                 min_vcd_coverage=0.05,
                 min_vcd_pins=32,
+                min_sequential_register_activity_coverage=min_sequential_register_activity_coverage,
                 min_macro_active_coverage=0.01,
                 min_macro_active_pins=16,
                 timeout_seconds=1800,
@@ -286,10 +328,22 @@ def build_report(
             "score_tensor_hash": equivalence.get("score_tensor_hash"),
             "final_tensor_hash": equivalence.get("final_tensor_hash"),
         },
-        "source_dependencies": [
-            "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
-            "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
-        ],
+        "source_dependencies": (
+            [
+                str(source_pnr_item_id).strip(),
+                "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+            ]
+            if str(source_pnr_item_id or "").strip()
+            else [
+                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+                "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+            ]
+        ),
+        "selection_contract": {
+            "required_flow_variant": str(required_flow_variant or "").strip() or None,
+            "required_synth_args": str(required_synth_args or "").strip() or None,
+            "min_sequential_register_activity_coverage": min_sequential_register_activity_coverage,
+        },
         "remaining_abstractions": [
             "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
             "Value-memory, NoC, HBM/DRAM, command-distribution, and clock-tree composition outside the cluster are not included.",
@@ -306,6 +360,26 @@ def main() -> int:
     parser.add_argument("--equivalence-json", type=Path, required=True)
     parser.add_argument("--orfs-design-config", type=Path, required=True)
     parser.add_argument("--clock-period-ns", type=float, default=8.0)
+    parser.add_argument(
+        "--required-flow-variant",
+        default=None,
+        help="Optional exact FLOW_VARIANT to require before candidate measurement",
+    )
+    parser.add_argument(
+        "--required-synth-args",
+        default=None,
+        help="Optional exact SYNTH_ARGS to require before candidate measurement",
+    )
+    parser.add_argument(
+        "--source-pnr-item-id",
+        default=None,
+        help="Optional source PNR work-item ID for source_dependencies tracking",
+    )
+    parser.add_argument(
+        "--min-sequential-register-activity-coverage",
+        type=float,
+        default=0.95,
+    )
     parser.add_argument("--activity-dir", type=Path, required=True)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
@@ -317,6 +391,10 @@ def main() -> int:
         orfs_design_config=args.orfs_design_config,
         clock_period_ns=args.clock_period_ns,
         activity_dir=args.activity_dir,
+        required_flow_variant=args.required_flow_variant,
+        required_synth_args=args.required_synth_args,
+        source_pnr_item_id=args.source_pnr_item_id,
+        min_sequential_register_activity_coverage=args.min_sequential_register_activity_coverage,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
@@ -70,11 +70,339 @@ def _write_metrics(path: Path) -> None:
         writer.writerows(rows)
 
 
+def _write_metrics_rows(path: Path, rows: list[dict[str, str]]) -> None:
+    fields = [
+        "design",
+        "platform",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "instance_area_um2",
+        "params_json",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
 def test_feasible_metrics_selects_exact_clock_and_timing(tmp_path: Path) -> None:
     metrics = tmp_path / "metrics.csv"
     _write_metrics(metrics)
     rows = audit._feasible_metrics(metrics, 8.0)
     assert [audit._params(row)["FLOW_VARIANT"] for row in rows] == ["cluster_die2500"]
+
+
+def test_feasible_metrics_excludes_non_matching_onehot_rows(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics_rows(
+        metrics,
+        [
+            {
+                "design": "cluster",
+                "platform": "nangate45",
+                "param_hash": "p1",
+                "tag": "onehot",
+                "status": "ok",
+                "critical_path_ns": "7.2",
+                "die_area": "6100000",
+                "instance_area_um2": "3000000",
+                "params_json": json.dumps(
+                    {
+                        "CLOCK_PERIOD": 8,
+                        "FLOW_VARIANT": "decode_score_multivalue_cluster_v1_8ns_onehot_fsm_v3_proxy_die_2500",
+                        "SYNTH_ARGS": "-nofsm",
+                    }
+                ),
+            },
+            {
+                "design": "cluster",
+                "platform": "nangate45",
+                "param_hash": "p2",
+                "tag": "binary",
+                "status": "ok",
+                "critical_path_ns": "7.4",
+                "die_area": "6000000",
+                "instance_area_um2": "3020000",
+                "params_json": json.dumps(
+                    {
+                        "CLOCK_PERIOD": 8,
+                        "FLOW_VARIANT": "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v2_proxy_die_2500",
+                        "SYNTH_ARGS": "-nofsm",
+                    }
+                ),
+            },
+        ],
+    )
+    try:
+        audit._feasible_metrics(
+            metrics,
+            8.0,
+            required_flow_variant=(
+                "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+            ),
+            required_synth_args="-nofsm",
+        )
+    except ValueError as exc:
+        assert "FLOW_VARIANT=decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500" in str(
+            exc
+        )
+    else:
+        raise AssertionError("one-hot row mismatch was not rejected")
+
+
+def test_feasible_metrics_rejects_wrong_synth_args(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics_rows(
+        metrics,
+        [
+            {
+                "design": "cluster",
+                "platform": "nangate45",
+                "param_hash": "p1",
+                "tag": "binary",
+                "status": "ok",
+                "critical_path_ns": "7.1",
+                "die_area": "6000000",
+                "instance_area_um2": "3000000",
+                "params_json": json.dumps(
+                    {
+                        "CLOCK_PERIOD": 8,
+                        "FLOW_VARIANT": "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+                        "SYNTH_ARGS": "-fsm",
+                    }
+                ),
+            },
+        ],
+    )
+    try:
+        audit._feasible_metrics(
+            metrics,
+            8.0,
+            required_flow_variant=(
+                "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+            ),
+            required_synth_args="-nofsm",
+        )
+    except ValueError as exc:
+        assert "SYNTH_ARGS=-nofsm" in str(exc)
+    else:
+        raise AssertionError("wrong synth args was not rejected")
+
+
+def test_feasible_metrics_accepts_exact_binary_row_with_strict_contract(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics_rows(
+        metrics,
+        [
+            {
+                "design": "cluster",
+                "platform": "nangate45",
+                "param_hash": "p1",
+                "tag": "binary",
+                "status": "ok",
+                "critical_path_ns": "7.1",
+                "die_area": "6000000",
+                "instance_area_um2": "3050000",
+                "params_json": json.dumps(
+                    {
+                        "CLOCK_PERIOD": 8,
+                        "FLOW_VARIANT": "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+                        "SYNTH_ARGS": "-nofsm",
+                    }
+                ),
+            },
+            {
+                "design": "cluster",
+                "platform": "nangate45",
+                "param_hash": "p2",
+                "tag": "other",
+                "status": "ok",
+                "critical_path_ns": "7.2",
+                "die_area": "6100000",
+                "instance_area_um2": "3060000",
+                "params_json": json.dumps(
+                    {
+                        "CLOCK_PERIOD": 8,
+                        "FLOW_VARIANT": "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v2_proxy_die_2500",
+                        "SYNTH_ARGS": "-nofsm",
+                    }
+                ),
+            },
+        ],
+    )
+    rows = audit._feasible_metrics(
+        metrics,
+        8.0,
+        required_flow_variant="decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+        required_synth_args="-nofsm",
+    )
+    assert [audit._params(row)["FLOW_VARIANT"] for row in rows] == [
+        "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+    ]
+
+
+def test_build_report_records_strict_selection_contract_and_pnr_dependency(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    config.write_text("{}", encoding="utf-8")
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics_rows(
+        metrics,
+        [
+            {
+                "design": "cluster",
+                "platform": "nangate45",
+                "param_hash": "p1",
+                "tag": "binary",
+                "status": "ok",
+                "critical_path_ns": "7.1",
+                "die_area": "6000000",
+                "instance_area_um2": "3000000",
+                "params_json": json.dumps(
+                    {
+                        "CLOCK_PERIOD": 8,
+                        "FLOW_VARIANT": "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+                        "SYNTH_ARGS": "-nofsm",
+                    }
+                ),
+            },
+        ],
+    )
+    manifest = {
+        "clock_period_ns": 8.0,
+        "block_count": 3,
+        "representative_full_transaction_cycles": 8334,
+        "phase_partition_cycle_sum": 8334,
+        "phases": [],
+    }
+    equivalence = tmp_path / "equivalence.json"
+    equivalence.write_text(
+        json.dumps(
+            {
+                "equivalence_pass": True,
+                "decision": "shared_score_multivalue_cluster_equivalent",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with mock.patch.object(audit, "generate_phase_activity", return_value=manifest), mock.patch.object(
+        audit, "build_power_report",
+        return_value={"promotion_gate_pass": True, "full_context_energy_j": 1.0},
+    ):
+        payload = audit.build_report(
+            config=config,
+            cluster_metrics_csv=metrics,
+            equivalence_json=equivalence,
+            orfs_design_config=tmp_path / "config.mk",
+            clock_period_ns=8.0,
+            activity_dir=tmp_path / "activity",
+            required_flow_variant="decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+            required_synth_args="-nofsm",
+            source_pnr_item_id="l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+        )
+    assert payload["selection_contract"] == {
+        "required_flow_variant": "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+        "required_synth_args": "-nofsm",
+        "min_sequential_register_activity_coverage": 0.95,
+    }
+    assert payload["source_dependencies"] == [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+    ]
+
+
+def test_build_report_keeps_legacy_source_dependencies_without_v14_source_pnr_id(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    config.write_text("{}", encoding="utf-8")
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics)
+    manifest = {
+        "clock_period_ns": 8.0,
+        "block_count": 3,
+        "representative_full_transaction_cycles": 8334,
+        "phase_partition_cycle_sum": 8334,
+        "phases": [],
+    }
+    equivalence = tmp_path / "equivalence.json"
+    equivalence.write_text(
+        json.dumps(
+            {
+                "equivalence_pass": True,
+                "decision": "shared_score_multivalue_cluster_equivalent",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with mock.patch.object(audit, "generate_phase_activity", return_value=manifest), mock.patch.object(
+        audit, "build_power_report",
+        return_value={"promotion_gate_pass": True, "full_context_energy_j": 1.0},
+    ):
+        payload = audit.build_report(
+            config=config,
+            cluster_metrics_csv=metrics,
+            equivalence_json=equivalence,
+            orfs_design_config=tmp_path / "config.mk",
+            clock_period_ns=8.0,
+            activity_dir=tmp_path / "activity",
+        )
+    assert payload["source_dependencies"] == [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+    ]
+    assert payload["selection_contract"] == {
+        "required_flow_variant": None,
+        "required_synth_args": None,
+        "min_sequential_register_activity_coverage": 0.95,
+    }
+
+
+def test_build_report_rejects_invalid_min_sequential_register_activity_coverage(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    config.write_text("{}", encoding="utf-8")
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics_rows(
+        metrics,
+        [
+            {
+                "design": "cluster",
+                "platform": "nangate45",
+                "param_hash": "p1",
+                "tag": "binary",
+                "status": "ok",
+                "critical_path_ns": "7.1",
+                "die_area": "6000000",
+                "instance_area_um2": "3000000",
+                "params_json": json.dumps(
+                    {
+                        "CLOCK_PERIOD": 8,
+                        "FLOW_VARIANT": "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+                        "SYNTH_ARGS": "-nofsm",
+                    }
+                ),
+            },
+        ],
+    )
+    equivalence = tmp_path / "equivalence.json"
+    equivalence.write_text(json.dumps({"equivalence_pass": True}), encoding="utf-8")
+    for coverage in (0.0, 1.1):
+        try:
+            audit.build_report(
+                config=config,
+                cluster_metrics_csv=metrics,
+                equivalence_json=equivalence,
+                orfs_design_config=tmp_path / "config.mk",
+                clock_period_ns=8.0,
+                activity_dir=tmp_path / "activity",
+                min_sequential_register_activity_coverage=coverage,
+            )
+        except ValueError as exc:
+            assert "min_sequential_register_activity_coverage must be in (0, 1]" in str(exc)
+        else:
+            raise AssertionError(
+                f"invalid min sequential register activity coverage {coverage} was accepted"
+            )
 
 
 def test_build_report_rejects_unproven_equivalence(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- select only the matched binary-FSM 8 ns PNR row for cluster activity power
- require exact `SYNTH_ARGS=-nofsm` provenance and record the source PNR item
- raise routed sequential Q/QN coverage from 95% to 100% for v14
- preserve legacy v1-v13 generator behavior
- retract invalid v13 evidence and schedule v14 after the binary-FSM PNR result

## Root cause

V13 annotated 14,922 of 15,194 routed Q/QN outputs, but 256 `block_weight` outputs were absent from the VCD and 16 state outputs had binary-to-one-hot semantic mismatch. Finalize consequently produced non-finite activity and `total_w=null`. A clock-compatible row alone is insufficient because the shared metrics file also contains the one-hot v2 physical point.

## Validation

- `234 passed` across the activity-power and L2 generator suites
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
- proposal JSON parsed with `jq`