### PR TITLE
npu: fix binary-FSM PNR retry variant identity

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1458,7 +1458,7 @@ def _is_multivalue_cluster_8ns_bridge_sweep(*, item_id: str, sweep_path: str) ->
 
 def _is_multivalue_cluster_8ns_binary_fsm_sweep(*, item_id: str, sweep_path: str) -> bool:
     return (
-        item_id == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+        _retry_base(item_id) == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
         and Path(sweep_path).name == "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json"
     )
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -37,7 +37,7 @@ _CLUSTER_ACTIVITY_POWER_V14_FLOW_VARIANT = (
 )
 _CLUSTER_ACTIVITY_POWER_V14_SYNTH_ARGS = "-nofsm"
 _CLUSTER_ACTIVITY_POWER_V14_PNR_ITEM = (
-    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
 )
 _CLUSTER_ACTIVITY_POWER_V14_MIN_SEQUENTIAL_REGISTER_ACTIVITY_COVERAGE = 1.0
 

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -921,7 +921,7 @@ def _write_attention_decode_score_multivalue_cluster_binary_fsm_8ns_v3_sweep(rep
             {
                 "flow_params": {
                     "TAG": ["decode_score_multivalue_cluster_v1_8ns_binary_fsm"],
-                    "FLOW_VARIANT": ["decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"],
+                    "FLOW_VARIANT": ["decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3"],
                     "CLOCK_PERIOD": [8],
                     "SYNTH_HIERARCHICAL": [1],
                     "SYNTH_MEMORY_MAX_BITS": [65536],
@@ -2887,6 +2887,42 @@ def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_exact_8ns_multivalue
             assert "check_attention_decode_score_multivalue_cluster_binary_fsm" in [
                 command["name"] for command in work_item.command_manifest
             ]
+            assert (
+                "python3 npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py "
+                "--metrics-path runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv"
+                in [command["run"] for command in work_item.command_manifest]
+            )
+
+
+def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_retry_8ns_multivalue_cluster_item() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, _ = _write_example_attention_decode_score_multivalue_cluster_repo(repo_root)
+        sweep_path = _write_attention_decode_score_multivalue_cluster_binary_fsm_8ns_v3_sweep(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    item_id="l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_cluster",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            checker_command_names = [command["name"] for command in work_item.command_manifest]
+            assert checker_command_names.count("check_attention_decode_score_multivalue_cluster_binary_fsm") == 1
             assert (
                 "python3 npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py "
                 "--metrics-path runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8282,7 +8282,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
             assert (
                 "--source-pnr-item-id "
-                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
                 in run
             )
             assert (
@@ -8294,7 +8294,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_source_pnr_item_id"]
-                == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+                == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_min_sequential_register_activity_coverage"]

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
@@ -1,7 +1,7 @@
 # Evaluation Gate
 
 1. Queue v14 only after merged
-   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3` and
+   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1` and
    `l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1`
    evidence is available.
 2. Run the activity-power audit on the remote evaluator with evaluator-local

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "Queue v14 exact-binary-fsm postroute re-run after PR #1413 merge f281d6f7 (all block_weight VCD + complete FSM provenance) and PR #1414 merge 66a2b3a1 (matched binary-FSM PNR v3 with SYNTH_ARGS=-nofsm).",
+  "source_commit_note": "PR #1413 merged complete block_weight VCD/FSM provenance, PR #1414 merged the binary-FSM PNR point, and PR #1415 merged strict v14 row selection and 100% routed-state coverage. V14 now requires the v3_r1 retry row; neither this retry implementation nor its result is claimed merged here.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -449,7 +449,7 @@
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
@@ -465,8 +465,8 @@
         "reason": "Rerun preserves all existing direct-VCD, macro, clock, numeric, artifact, applied==matched, and zero query/apply-error gates; strengthens DFF-output coverage to 1.0; and forbids clamping, substitution, heuristic activity, or other gate relaxation. It selects only decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500 with SYNTH_ARGS=-nofsm."
       },
       "status": "pending_implementation_merge",
-      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
     }
   ],
-  "source_commit": "66a2b3a10a64cb721880ff97282bf349a7b7d514"
+  "source_commit": "b968b50997ff980dd0a367ff0fe7c98d4f89b7fb"
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -400,7 +400,7 @@
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1",
-  "source_commit_note": "Queue the shared-score multivalue cluster only after the local-cluster frontier revision is merged and the new multivalue generator/probe/config paths are present.",
+  "source_commit_note": "PR #1414 merged the binary-FSM PNR point and PR #1415 merged its strict activity consumer. The base v3 physical flow completed, but mode expansion duplicated the proxy suffix and the strict checker rejected the malformed row. Queue v3_r1 only after this retry implementation merges; no r1 result is claimed here.",
   "architecture_revision": {
     "reason": "shared_score_multivalue_cluster_replaces_repeated_score_fill_bound",
     "invalidates_item_ids": [
@@ -88,7 +88,7 @@
       "notes": "Merged via PR #1364 and merge 7b01c7e452af6f658c566900fef0513f6ba2490b at 2026-07-19T09:36:12.486715Z."
     },
     {
-      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1",
       "task_type": "l1_sweep",
       "objective": "Measure the exact-state activity calibration path with the unique binary-FSM 8 ns sweep, matched to the v2 physical architecture and configuration.",
       "evaluation_mode": "frontier_followup",
@@ -103,12 +103,15 @@
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+      ],
       "expected_result": {
         "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
-        "reason": "The v2 result remains the valid one-hot PPA baseline and is not invalidated. V3 is a matched physical architecture point with SYNTH_ARGS=-nofsm so routed FSM bits correspond to RTL state activity. PR #1413 / merge f281d6f7 enables complete block_weight capture, compact diagnostics, and FSM provenance; the forthcoming v3 sweep implementation is not yet merged."
+        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. The base v3 physical flow completed, but its row is non-promotable because mode expansion duplicated the proxy suffix and the strict checker rejected it. v3_r1 corrects base FLOW_VARIANT handling and keeps SYNTH_ARGS=-nofsm so routed FSM bits correspond to RTL state activity. PR #1413 / merge f281d6f7 enables complete block_weight capture, compact diagnostics, and FSM provenance; the r1 implementation is not yet merged."
       },
       "status": "pending_implementation_merge"
     }
   ],
-  "source_commit": "9a857c5cb5deb84ae5487d1b0c37500833bd7e1a"
+  "source_commit": "b968b50997ff980dd0a367ff0fe7c98d4f89b7fb"
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
@@ -116,7 +116,7 @@
       "status": "pending_implementation_merge"
     },
     {
-      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3",
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1",
       "task_type": "l1_sweep",
       "objective": "Measure the exact-state activity calibration path with the unique binary-FSM 8 ns sweep, matched to the v2 physical architecture and configuration.",
       "evaluation_mode": "frontier_followup",
@@ -132,9 +132,12 @@
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
+      ],
       "expected_result": {
         "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
-        "reason": "The v2 result remains the valid one-hot PPA baseline and is not invalidated. V3 is a matched physical architecture point with SYNTH_ARGS=-nofsm so routed FSM bits correspond to RTL state activity. PR #1413 / merge f281d6f7 enables complete block_weight capture, compact diagnostics, and FSM provenance; the forthcoming v3 sweep implementation is not yet merged."
+        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. The base v3 physical flow completed, but its row is non-promotable because mode expansion duplicated the proxy suffix and the strict checker rejected it. v3_r1 corrects base FLOW_VARIANT handling and keeps SYNTH_ARGS=-nofsm so routed FSM bits correspond to RTL state activity. PR #1413 / merge f281d6f7 enables complete block_weight capture, compact diagnostics, and FSM provenance; the r1 implementation is not yet merged."
       },
       "status": "pending_implementation_merge"
     }

--- a/runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json
+++ b/runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json
@@ -5,7 +5,7 @@
       "decode_score_multivalue_cluster_v1_8ns_binary_fsm"
     ],
     "FLOW_VARIANT": [
-      "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+      "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3"
     ],
     "CLOCK_PERIOD": [
       8

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -201,6 +201,35 @@ class ModeCompareRegressionTest(unittest.TestCase):
         self.assertEqual("seed_flat_nomacro", out2["tag_prefix"])
         self.assertEqual("flat_nomacro", out2["FLOW_VARIANT"])
 
+    def test_apply_mode_to_params_does_not_duplicate_binary_fsm_proxy_mode(self) -> None:
+        sweep_path = (
+            REPO_ROOT
+            / "runs"
+            / "campaigns"
+            / "npu"
+            / "decode_score_multivalue_cluster_v1"
+            / "sweeps"
+            / "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json"
+        )
+        sweep = json.loads(sweep_path.read_text(encoding="utf-8"))
+        mode_cfg = self.run_block_sweep.parse_mode_compare_config(sweep)
+        assert mode_cfg is not None
+        proxy_mode = next(
+            mode for mode in mode_cfg["modes"] if str(mode.get("slug", "")).strip() == "proxy_die_2500"
+        )
+        out = self.run_block_sweep.apply_mode_to_params(
+            {
+                "TAG": sweep["flow_params"]["TAG"][0],
+                "FLOW_VARIANT": sweep["flow_params"]["FLOW_VARIANT"][0],
+            },
+            proxy_mode,
+            str(sweep["tag_prefix"]),
+        )
+        self.assertEqual(
+            "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+            out["FLOW_VARIANT"],
+        )
+
     def test_apply_repeat_to_params_sets_flow_random_seed(self):
         out = self.run_block_sweep.apply_repeat_to_params(
             {"TAG": "tag_flat", "FLOW_VARIANT": "var_flat"},


### PR DESCRIPTION
## Summary

- remove the pre-appended mode suffix from the binary-FSM sweep base `FLOW_VARIANT`
- prove mode expansion yields the intended single-suffix physical variant
- retain the strict binary-FSM checker for `_r1` retry IDs
- bind the downstream v14 activity-power proof to the retry work item
- retain the failed base row as explicit non-promotable history

## Root cause

The base sweep encoded `_proxy_die_2500` and `mode_compare` appended the same mode slug again. OpenROAD succeeded, but the strict checker rejected the resulting `...proxy_die_2500_proxy_die_2500` row. The physical result was not promoted.

## Validation

- `326 passed` across L1/L2 generators, mode expansion, binary-FSM checker, and activity-power audit
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
- proposal and sweep JSON parsed with `jq`