### PR TITLE
npu: enforce binary FSM synthesis evidence

### DIFF
--- a/npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py
+++ b/npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import re
 from pathlib import Path
+from typing import cast
 
 EXPECTED_CLOCK_PERIOD = 8
 EXPECTED_TAG_PREFIX = "decode_score_multivalue_cluster_v1_8ns_binary_fsm"
@@ -18,6 +20,27 @@ EXPECTED_SYNTH_HIERARCHICAL = "1"
 EXPECTED_SYNTH_MEMORY_MAX_BITS = "65536"
 EXPECTED_SYNTH_ARGS = "-nofsm"
 EXPECTED_RESULT_PATH_TOKEN = "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv"
+DEFAULT_SYNTH_RESULTS_DIR = Path("/orfs/flow/results")
+
+EXPECTED_SIGNAL_INDICES = {
+    "state_q": {0, 1, 2},
+    "reducer.state": {0, 1, 2, 3},
+}
+
+_COMMENT_RE = re.compile(r"//.*?$|/\*.*?\*/", re.MULTILINE | re.DOTALL)
+_DECL_KEYWORD_RE = re.compile(r"\b(?:wire|reg|logic|output|input|inout|tri)\b")
+_DECL_ITEM_RE = re.compile(
+    r"""
+    ^
+    (?:(?:\[\s*(?P<msb>\d+)\s*:\s*(?P<lsb>\d+)\s*\])\s*)?
+    (?P<name>\\[^\s,;\[]+|[A-Za-z_][A-Za-z0-9_$./]*)
+    (?:\[\s*(?P<bit>\d+)\s*\]\s*)?
+    (?:$|,|\s)
+    """,
+    re.VERBOSE,
+)
+
+_SignalEvidence = dict[str, dict[str, set[int] | set[tuple[int, int]]]]
 
 
 def _parse_params_json(value: str) -> dict[str, object]:
@@ -40,6 +63,133 @@ def _to_str(value: object) -> str:
     return str(value or "").strip()
 
 
+def _strip_verilog_comments(text: str) -> str:
+    return _COMMENT_RE.sub("", text)
+
+
+def _normalize_verilog_identifier(identifier: str) -> str:
+    return identifier.replace("\\", "").replace("/", ".").replace("\t", " ").strip()
+
+
+def _iter_declaration_items(statement: str):
+    keyword_match = _DECL_KEYWORD_RE.search(statement)
+    if not keyword_match:
+        return
+
+    body = statement[keyword_match.end() :].strip()
+    if not body:
+        return
+
+    for item in body.split(","):
+        if not item:
+            continue
+        match = _DECL_ITEM_RE.match(item.strip())
+        if match is None:
+            continue
+        yield match
+
+
+def _load_netlist_signal_evidence(path: Path) -> _SignalEvidence:
+    evidence: _SignalEvidence = {
+        signal: {"packed": set(), "bits": set()}
+        for signal in EXPECTED_SIGNAL_INDICES
+    }
+    text = _strip_verilog_comments(path.read_text(encoding="utf-8"))
+    for statement in text.split(";"):
+        for match in _iter_declaration_items(statement):
+            name = _normalize_verilog_identifier(match.group("name"))
+            if name not in EXPECTED_SIGNAL_INDICES:
+                continue
+            signal_data = evidence[name]
+            msb = match.group("msb")
+            lsb = match.group("lsb")
+            bit = match.group("bit")
+            if msb is not None and lsb is not None:
+                packed = cast(set[tuple[int, int]], signal_data["packed"])
+                packed.add((int(msb), int(lsb)))
+            elif bit is not None:
+                bits = cast(set[int], signal_data["bits"])
+                bits.add(int(bit))
+
+    return evidence
+
+
+def _load_signal_indices_or_widths(
+    signal: str, signal_data: dict[str, set[int] | set[tuple[int, int]]]
+) -> set[int]:
+    expected_indices = EXPECTED_SIGNAL_INDICES[signal]
+    packed = signal_data["packed"]
+    bits = signal_data["bits"]
+    if not isinstance(packed, set) or not isinstance(bits, set):
+        raise TypeError(f"invalid internal evidence for {signal}")
+
+    if packed:
+        if len(packed) != 1:
+            raise ValueError(
+                f"invalid declaration for {signal}: multiple packed ranges present"
+            )
+        msb, lsb = next(iter(packed))
+        expected_width = len(expected_indices)
+        observed_width = abs(msb - lsb) + 1
+        low = min(msb, lsb)
+        high = max(msb, lsb)
+        if observed_width != expected_width or low != 0 or high != expected_width - 1:
+            raise ValueError(
+                f"invalid width for {signal}: packed range [{msb}:{lsb}] is "
+                f"incompatible with allowed indices {sorted(expected_indices)}"
+            )
+        return set(range(expected_width))
+
+    if not bits:
+        return set()
+
+    out_of_range = set(bits) - expected_indices
+    if out_of_range:
+        raise ValueError(
+            f"invalid width for {signal}: bit indices include out-of-range indices {sorted(out_of_range)}"
+        )
+    return set(bits)
+
+
+def _netlist_has_required_signal_widths(path: Path) -> None:
+    evidence = _load_netlist_signal_evidence(path)
+    for signal in EXPECTED_SIGNAL_INDICES:
+        expected_indices = EXPECTED_SIGNAL_INDICES[signal]
+        try:
+            observed = _load_signal_indices_or_widths(signal, evidence[signal])
+        except ValueError as exc:
+            raise ValueError(f"{exc} in {path}") from exc
+        if not observed:
+            raise ValueError(f"missing declaration for {signal} in {path}")
+        if observed != expected_indices:
+            missing = sorted(expected_indices - observed)
+            if missing:
+                raise ValueError(
+                    f"missing declaration for {signal} in {path}: missing indices {missing}"
+                )
+            extra = sorted(observed - expected_indices)
+            if extra:
+                raise ValueError(
+                    f"invalid width for {signal} in {path}: out-of-range indices {extra}"
+                )
+
+
+def _derive_synth_netlist_path(
+    *,
+    platform: str,
+    design: str,
+    flow_variant: str,
+    synth_results_dir: Path,
+) -> Path:
+    platform_dir = synth_results_dir / platform / design
+    return platform_dir / flow_variant / "1_synth.v"
+
+
+def _parse_critical_path(row: dict[str, str]) -> float:
+    value = float(row.get("critical_path_ns", "inf"))
+    return float(value)
+
+
 def _iter_metrics_rows(metrics_path: Path):
     with metrics_path.open(newline="", encoding="utf-8") as stream:
         reader = csv.DictReader(stream)
@@ -48,61 +198,93 @@ def _iter_metrics_rows(metrics_path: Path):
                 yield row
 
 
-def _parse_critical_path(row: dict[str, str]) -> float:
-    value = float(row.get("critical_path_ns", "inf"))
-    return float(value)
-
-
-def _row_matches_binary_fsm(row: dict[str, str]) -> bool:
-    if _to_str(row.get("status")).lower() != "ok":
-        return False
-
+def _candidate_binary_fsm_row(
+    row: dict[str, str],
+    *,
+    synth_results_dir: Path,
+) -> tuple[bool, str | None]:
     try:
         params = _parse_params_json(_to_str(row.get("params_json", "")))
     except Exception:
-        return False
+        return False, None
 
-    tag = _to_str(row.get("tag"))
-    if not tag.startswith(EXPECTED_TAG_PREFIX):
-        return False
+    if _to_str(row.get("status")).lower() != "ok":
+        return False, None
+    if not _to_str(row.get("tag")).startswith(EXPECTED_TAG_PREFIX):
+        return False, None
     if _to_str(params.get("FLOW_VARIANT")) != EXPECTED_FLOW_VARIANT:
-        return False
+        return False, None
     if _to_str(params.get("PLACE_DENSITY")) != EXPECTED_PLACE_DENSITY:
-        return False
+        return False, None
     if _to_str(params.get("SYNTH_HIERARCHICAL")) != EXPECTED_SYNTH_HIERARCHICAL:
-        return False
+        return False, None
     if _to_str(params.get("SYNTH_MEMORY_MAX_BITS")) != EXPECTED_SYNTH_MEMORY_MAX_BITS:
-        return False
+        return False, None
     if _to_str(params.get("SYNTH_ARGS")) != EXPECTED_SYNTH_ARGS:
-        return False
-
-    try:
-        clock_period = float(_to_str(params.get("CLOCK_PERIOD", "")))
-    except ValueError:
-        return False
-    if clock_period != float(EXPECTED_CLOCK_PERIOD):
-        return False
-
+        return False, None
     if _to_str(params.get("DIE_AREA")) != EXPECTED_DIE_AREA:
-        return False
+        return False, None
     if _to_str(params.get("CORE_AREA")) != EXPECTED_CORE_AREA:
-        return False
+        return False, None
     if _to_str(row.get("result_path")).find(EXPECTED_RESULT_PATH_TOKEN) == -1:
-        return False
+        return False, None
 
     try:
-        return _parse_critical_path(row) <= 8
+        if float(_to_str(params.get("CLOCK_PERIOD", ""))) != float(EXPECTED_CLOCK_PERIOD):
+            return False, None
+        if _parse_critical_path(row) > 8:
+            return False, None
     except Exception:
-        return False
+        return False, None
+
+    flow_variant = _to_str(params.get("FLOW_VARIANT"))
+    if not flow_variant:
+        return False, None
+
+    netlist_path = _derive_synth_netlist_path(
+        platform=_to_str(row.get("platform")),
+        design=_to_str(row.get("design")),
+        flow_variant=flow_variant,
+        synth_results_dir=synth_results_dir,
+    )
+    if not netlist_path.exists():
+        return False, f"missing exact netlist: {netlist_path}"
+
+    try:
+        _netlist_has_required_signal_widths(netlist_path)
+    except ValueError as exc:
+        return False, str(exc)
+    return True, None
 
 
-def validate_binary_fsm_metrics(*, metrics_path: Path) -> int:
+def validate_binary_fsm_metrics(
+    *,
+    metrics_path: Path,
+    synth_results_dir: Path = DEFAULT_SYNTH_RESULTS_DIR,
+) -> int:
     if not metrics_path.exists():
         raise ValueError(f"missing metrics.csv: {metrics_path}")
 
+    last_candidate_error: str | None = None
     for row in _iter_metrics_rows(metrics_path):
-        if _row_matches_binary_fsm(row):
+        matches, candidate_error = _candidate_binary_fsm_row(
+            row,
+            synth_results_dir=synth_results_dir,
+        )
+        if candidate_error is not None:
+            last_candidate_error = candidate_error
+        if matches:
             return 0
+
+    if last_candidate_error is not None:
+        raise ValueError(
+            "missing required 8ns exact-state binary-FSM decode-score multivalue-cluster row "
+            "(status=ok, TAG=decode_score_multivalue_cluster_v1_8ns_binary_fsm*, "
+            "FLOW_VARIANT=decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500, "
+            "DIE_AREA=0 0 2500 2500, CORE_AREA=50 50 2450 2450, SYNTH_ARGS=-nofsm, "
+            "PLACE_DENSITY=0.4, SYNTH_HIERARCHICAL=1, SYNTH_MEMORY_MAX_BITS=65536, "
+            "critical_path_ns<=8); details: " + last_candidate_error
+        )
 
     raise ValueError(
         "missing required 8ns exact-state binary-FSM decode-score multivalue-cluster row "
@@ -117,8 +299,17 @@ def validate_binary_fsm_metrics(*, metrics_path: Path) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--metrics-path", type=Path, required=True)
+    parser.add_argument(
+        "--synth-results-dir",
+        type=Path,
+        default=DEFAULT_SYNTH_RESULTS_DIR,
+        help="Optional override for ORFS results root (default: /orfs/flow/results)",
+    )
     args = parser.parse_args()
-    validate_binary_fsm_metrics(metrics_path=args.metrics_path)
+    validate_binary_fsm_metrics(
+        metrics_path=args.metrics_path,
+        synth_results_dir=args.synth_results_dir,
+    )
     return 0
 
 

--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -1420,6 +1420,36 @@ def copy_or_sanitize_macro_lef(src: Path, dst: Path) -> None:
     shutil.copy(src, dst)
 
 
+def _assert_synth_full_args_in_call_lines(text: str) -> None:
+    executable_call_re = re.compile(r"^\s*(?:synth|yosys_synth_with_fsm_capture)\b")
+    missing_args = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if executable_call_re.match(line) and "{*}$synth_full_args" not in line:
+            missing_args.append(f"line {line_no}: {line.strip()}")
+    if missing_args:
+        raise RuntimeError(
+            "Generated synth/wrapper calls missing {*}$synth_full_args: "
+            + "; ".join(missing_args)
+        )
+
+
+def _append_synth_full_args_to_base_synth_calls(text: str) -> str:
+    pattern = re.compile(r"(?m)^(\s*)synth(\b.*)$")
+
+    def _replace_call(match: re.Match[str]) -> str:
+        leading_ws = match.group(1)
+        args = match.group(2)
+        if "{*}$synth_full_args" in args:
+            return f"{leading_ws}synth{args}"
+        if args.strip():
+            return f"{leading_ws}synth{args} {{*}}$synth_full_args"
+        return f"{leading_ws}synth {{*}}$synth_full_args"
+
+    replaced = pattern.sub(_replace_call, text)
+    _assert_synth_full_args_in_call_lines(replaced)
+    return replaced
+
+
 def _inject_fsm_capture_into_synth_script(text: str) -> str:
     proc_block = """
 proc yosys_synth_with_fsm_capture {args} {
@@ -1456,22 +1486,20 @@ proc yosys_synth_with_fsm_capture {args} {
 
 """.lstrip()
 
-    if "yosys_synth_with_fsm_capture" in text:
-        return text
+    if "yosys_synth_with_fsm_capture" not in text:
+        lines = text.splitlines(keepends=True)
+        synth_re = re.compile(r"^\s*synth\b")
+        insert_index = len(lines)
+        for idx, line in enumerate(lines):
+            if synth_re.match(line):
+                insert_index = idx
+                break
 
-    lines = text.splitlines(keepends=True)
-    synth_re = re.compile(r"^\s*synth\b")
-    insert_index = len(lines)
-    for idx, line in enumerate(lines):
-        if synth_re.match(line):
-            insert_index = idx
-            break
+        if insert_index == len(lines):
+            raise RuntimeError("Failed to locate any synth invocation in synth.tcl")
 
-    if insert_index == len(lines):
-        raise RuntimeError("Failed to locate any synth invocation in synth.tcl")
-
-    lines.insert(insert_index, proc_block)
-    text = "".join(lines)
+        lines.insert(insert_index, proc_block)
+        text = "".join(lines)
 
     # Replace all textual `synth` invocations in the flow script, including
     # forms that already rely on pre-expanded arguments or custom top settings.
@@ -1479,11 +1507,18 @@ proc yosys_synth_with_fsm_capture {args} {
     pattern = re.compile(r"(?m)^(\s*)synth(\b.*)$")
 
     def _replace_call(match: re.Match[str]) -> str:
-        return f"{match.group(1)}yosys_synth_with_fsm_capture{match.group(2)}"
+        leading_ws = match.group(1)
+        args = match.group(2)
+        if "{*}$synth_full_args" in args:
+            return f"{leading_ws}yosys_synth_with_fsm_capture{args}"
+        if args.strip():
+            return f"{leading_ws}yosys_synth_with_fsm_capture{args} {{*}}$synth_full_args"
+        return f"{leading_ws}yosys_synth_with_fsm_capture {{*}}$synth_full_args"
 
     replaced = pattern.sub(_replace_call, text)
     if "yosys_synth_with_fsm_capture" not in replaced:
         raise RuntimeError("Failed to instrument synth calls in synth.tcl")
+    _assert_synth_full_args_in_call_lines(replaced)
     return replaced
 
 
@@ -1520,6 +1555,7 @@ def write_preserve_blackbox_synth_script(
         "}"
     )
     text = text.replace(setundef_marker, setundef_block, 1)
+    text = _append_synth_full_args_to_base_synth_calls(text)
 
     if instrument_fsm_capture:
         text = _inject_fsm_capture_into_synth_script(text)
@@ -2225,19 +2261,12 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
     synth_script_sha1 = ""
     if macro_manifest is not None:
         blackboxes = [str(x).strip() for x in macro_manifest.get("blackboxes", []) if str(x).strip()]
-    if blackboxes:
+    synth_args = str(sweep_params.get("SYNTH_ARGS", "")).strip()
+    if blackboxes or capture_cfg.get("enabled") or synth_args:
         synth_script_override = run_dir / "synth_preserve_blackbox.tcl"
         write_preserve_blackbox_synth_script(
             script_path=synth_script_override,
             instrument_fsm_capture=bool(capture_cfg["enabled"]),
-        )
-        synth_script_sha1 = sha1_file(synth_script_override)
-        make_cmd.append(f"SYNTH_SCRIPT={synth_script_override.resolve()}")
-    elif capture_cfg.get("enabled"):
-        synth_script_override = run_dir / "synth_preserve_blackbox.tcl"
-        write_preserve_blackbox_synth_script(
-            script_path=synth_script_override,
-            instrument_fsm_capture=True,
         )
         synth_script_sha1 = sha1_file(synth_script_override)
         make_cmd.append(f"SYNTH_SCRIPT={synth_script_override.resolve()}")

--- a/tests/test_check_attention_decode_score_multivalue_cluster_binary_fsm.py
+++ b/tests/test_check_attention_decode_score_multivalue_cluster_binary_fsm.py
@@ -16,6 +16,88 @@ EXPECTED_TAG = "decode_score_multivalue_cluster_v1_8ns_binary_fsm"
 EXPECTED_VARIANT = "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
 EXPECTED_SYNTH_ARGS = "-nofsm"
 
+VALID_PACKED_NETLIST_DECLARATIONS = """\
+module top;
+  wire [2:0] \\state_q ;
+  wire [3:0] \\reducer.state ;
+endmodule
+"""
+
+VALID_BITBLASTED_NETLIST_DECLARATIONS = """\
+module top;
+  wire \\state_q[0] ;
+  wire \\state_q[1] ;
+  wire \\state_q[2] ;
+  wire \\reducer.state[0] ;
+  wire \\reducer.state[1] ;
+  wire \\reducer.state[2] ;
+  wire \\reducer.state[3] ;
+endmodule
+"""
+
+INVALID_REDUCER_STATE = """\
+module top;
+  wire [2:0] \\state_q ;
+  wire [6:0] \\reducer.state ;
+endmodule
+"""
+
+INVALID_STATE_Q = """\
+module top;
+  wire [3:0] \\state_q ;
+  wire [3:0] \\reducer.state ;
+endmodule
+"""
+
+INVALID_REDUCER_STATE_BIT = """\
+module top;
+  wire \\state_q[0] ;
+  wire \\state_q[1] ;
+  wire \\state_q[2] ;
+  wire \\reducer.state[0] ;
+  wire \\reducer.state[1] ;
+  wire \\reducer.state[2] ;
+  wire \\reducer.state[3] ;
+  wire \\reducer.state[6] ;
+endmodule
+"""
+
+INVALID_STATE_Q_BIT = """\
+module top;
+  wire \\state_q[0] ;
+  wire \\state_q[1] ;
+  wire \\state_q[2] ;
+  wire \\state_q[3] ;
+  wire \\reducer.state[0] ;
+  wire \\reducer.state[1] ;
+  wire \\reducer.state[2] ;
+  wire \\reducer.state[3] ;
+endmodule
+"""
+
+
+def _synth_results_dir(root: Path) -> Path:
+    return root / "orfs" / "flow" / "results"
+
+
+def _write_netlist(
+    root: Path,
+    *,
+    platform: str = "nangate45",
+    design: str = "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv",
+    flow_variant: str = EXPECTED_VARIANT,
+    body: str = VALID_PACKED_NETLIST_DECLARATIONS,
+) -> Path:
+    netlist = (
+        _synth_results_dir(root)
+        / platform
+        / design
+        / flow_variant
+        / "1_synth.v"
+    )
+    netlist.parent.mkdir(parents=True, exist_ok=True)
+    netlist.write_text(body, encoding="utf-8")
+    return netlist
 
 
 def _repo_root() -> Path:
@@ -92,10 +174,17 @@ def _write_row(
     )
 
 
-def _run_checker(metrics_path: Path) -> subprocess.CompletedProcess[str]:
+def _run_checker(
+    metrics_path: Path,
+    *,
+    synth_results_dir: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
     script = _repo_root() / "npu" / "eval" / "check_attention_decode_score_multivalue_cluster_binary_fsm.py"
+    command = [sys.executable, str(script), "--metrics-path", str(metrics_path)]
+    if synth_results_dir is not None:
+        command.extend(["--synth-results-dir", str(synth_results_dir)])
     return subprocess.run(
-        [sys.executable, str(script), "--metrics-path", str(metrics_path)],
+        command,
         check=False,
         capture_output=True,
         text=True,
@@ -105,6 +194,7 @@ def _run_checker(metrics_path: Path) -> subprocess.CompletedProcess[str]:
 def test_check_attention_decode_score_multivalue_cluster_binary_fsm_passes_with_exact_8ns_row() -> None:
     with tempfile.TemporaryDirectory() as td:
         metrics = _metrics_path(Path(td))
+        _write_netlist(Path(td))
         _write_metrics(
             metrics,
             [
@@ -115,12 +205,13 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_passes_with_
                 )
             ],
         )
-        assert _run_checker(metrics).returncode == 0
+        assert _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td))).returncode == 0
 
 
 def test_check_attention_decode_score_multivalue_cluster_binary_fsm_passes_with_mode_suffixed_tag() -> None:
     with tempfile.TemporaryDirectory() as td:
         metrics = _metrics_path(Path(td))
+        _write_netlist(Path(td))
         _write_metrics(
             metrics,
             [
@@ -132,12 +223,13 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_passes_with_
                 )
             ],
         )
-        assert _run_checker(metrics).returncode == 0
+        assert _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td))).returncode == 0
 
 
 def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_old_bridge_flow() -> None:
     with tempfile.TemporaryDirectory() as td:
         metrics = _metrics_path(Path(td))
+        _write_netlist(Path(td))
         _write_metrics(
             metrics,
             [
@@ -149,7 +241,7 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_old_
                 )
             ],
         )
-        proc = _run_checker(metrics)
+        proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td)))
         assert proc.returncode != 0
         assert "missing required 8ns" in proc.stderr
 
@@ -157,6 +249,7 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_old_
 def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_missing_synth_args() -> None:
     with tempfile.TemporaryDirectory() as td:
         metrics = _metrics_path(Path(td))
+        _write_netlist(Path(td))
         _write_metrics(
             metrics,
             [
@@ -168,7 +261,7 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_miss
                 )
             ],
         )
-        proc = _run_checker(metrics)
+        proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td)))
         assert proc.returncode != 0
         assert "missing required 8ns" in proc.stderr
 
@@ -176,6 +269,7 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_miss
 def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_wrong_synth_args() -> None:
     with tempfile.TemporaryDirectory() as td:
         metrics = _metrics_path(Path(td))
+        _write_netlist(Path(td))
         _write_metrics(
             metrics,
             [
@@ -187,7 +281,7 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_wron
                 )
             ],
         )
-        proc = _run_checker(metrics)
+        proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td)))
         assert proc.returncode != 0
         assert "missing required 8ns" in proc.stderr
 
@@ -208,6 +302,7 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_miss
 ) -> None:
     with tempfile.TemporaryDirectory() as td:
         metrics = _metrics_path(Path(td))
+        _write_netlist(Path(td))
         _write_metrics(
             metrics,
             [
@@ -219,7 +314,7 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_miss
                 )
             ],
         )
-        proc = _run_checker(metrics)
+        proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td)))
         assert proc.returncode != 0
         assert "missing required 8ns" in proc.stderr
 
@@ -227,6 +322,7 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_miss
 def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_bad_status_or_timing() -> None:
     with tempfile.TemporaryDirectory() as td:
         metrics = _metrics_path(Path(td))
+        _write_netlist(Path(td))
         _write_metrics(
             metrics,
             [
@@ -242,6 +338,104 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_bad_
                 ),
             ],
         )
-        proc = _run_checker(metrics)
+        proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td)))
         assert proc.returncode != 0
         assert "missing required 8ns" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [VALID_PACKED_NETLIST_DECLARATIONS, VALID_BITBLASTED_NETLIST_DECLARATIONS],
+)
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_accepts_valid_signal_declarations(
+    declaration: str,
+) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        metrics = _metrics_path(root)
+        _write_netlist(root, body=declaration)
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                )
+            ],
+        )
+        assert _run_checker(metrics, synth_results_dir=_synth_results_dir(root)).returncode == 0
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [INVALID_REDUCER_STATE, INVALID_REDUCER_STATE_BIT],
+    ids=["reducer_state_packed", "reducer_state_bit"],
+)
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_reducer_state_oob(
+    declaration: str,
+) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        metrics = _metrics_path(root)
+        _write_netlist(root, body=declaration)
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                )
+            ],
+        )
+        proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(root))
+        assert proc.returncode != 0
+        assert "invalid width for reducer.state" in proc.stderr
+        assert "details" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [INVALID_STATE_Q, INVALID_STATE_Q_BIT],
+    ids=["state_q_packed", "state_q_bit"],
+)
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_state_q_oob(
+    declaration: str,
+) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        metrics = _metrics_path(root)
+        _write_netlist(root, body=declaration)
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                )
+            ],
+        )
+        proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(root))
+        assert proc.returncode != 0
+        assert "invalid width for state_q" in proc.stderr
+        assert "details" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_when_synth_netlist_is_missing() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        metrics = _metrics_path(Path(td))
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                )
+            ],
+        )
+        proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td)))
+        assert proc.returncode != 0
+        assert "missing exact netlist" in proc.stderr

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -1227,6 +1227,87 @@ class ModeCompareRegressionTest(unittest.TestCase):
                 metrics_rows[0]["failure_signature"],
             )
 
+    def test_run_single_applies_synth_args_through_generated_script_without_capture(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            design_dir = tmp / "demo_design"
+            verilog_dir = design_dir / "verilog"
+            verilog_dir.mkdir(parents=True, exist_ok=True)
+            (verilog_dir / "top.v").write_text(
+                "module npu_top(input clk, output done); assign done = clk; endmodule\n",
+                encoding="utf-8",
+            )
+
+            calls = []
+
+            def fake_run(cmd, *, cwd, check, env):
+                calls.append((list(cmd), dict(env)))
+                flow_variant = str(env.get("FLOW_VARIANT", "base")).strip() or "base"
+                out_dir = (
+                    tmp / "orfs" / "results" / "nangate45" / "demo_design" / flow_variant
+                )
+                out_dir.mkdir(parents=True, exist_ok=True)
+                (out_dir / "1_synth.v").write_text("// synth result\n", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0)
+
+            old_dest = self.run_block_sweep.DEST_BASE
+            old_src = self.run_block_sweep.SRC_BASE
+            old_report = self.run_block_sweep.REPORT_BASE
+            old_result = self.run_block_sweep.RESULT_BASE
+            old_log = self.run_block_sweep.LOG_BASE
+            old_run = self.run_block_sweep.subprocess.run
+            self.run_block_sweep.DEST_BASE = tmp / "orfs" / "designs"
+            self.run_block_sweep.SRC_BASE = self.run_block_sweep.DEST_BASE / "src"
+            self.run_block_sweep.REPORT_BASE = tmp / "orfs" / "reports"
+            self.run_block_sweep.RESULT_BASE = tmp / "orfs" / "results"
+            self.run_block_sweep.LOG_BASE = tmp / "orfs" / "logs"
+            self.run_block_sweep.subprocess.run = fake_run
+            try:
+                row = self.run_block_sweep.run_single(
+                    design_dir=design_dir,
+                    design_name="demo_design",
+                    platform="nangate45",
+                    top="npu_top",
+                    verilog_dir=verilog_dir,
+                    sdc_template=None,
+                    sweep_params={
+                        "TAG": "demo_synth_args",
+                        "FLOW_VARIANT": "demo_synth_args",
+                        "CLOCK_PERIOD": 10.0,
+                        "CORE_AREA": "0 0 100 100",
+                        "SYNTH_ARGS": "-nofsm",
+                    },
+                    out_root=tmp / "out",
+                    skip_existing=False,
+                    dry_run=False,
+                    force_copy=True,
+                    make_target="1_synth.v",
+                    macro_manifest=None,
+                )
+            finally:
+                self.run_block_sweep.DEST_BASE = old_dest
+                self.run_block_sweep.SRC_BASE = old_src
+                self.run_block_sweep.REPORT_BASE = old_report
+                self.run_block_sweep.RESULT_BASE = old_result
+                self.run_block_sweep.LOG_BASE = old_log
+                self.run_block_sweep.subprocess.run = old_run
+
+            self.assertEqual("ok", row["status"])
+            synth_cmds = [
+                cmd
+                for cmd, _ in calls
+                if any(token.startswith("SYNTH_SCRIPT=") for token in cmd)
+            ]
+            self.assertEqual(1, len(synth_cmds))
+            make_cmd = synth_cmds[0]
+            synth_script_token = next(
+                token for token in make_cmd if token.startswith("SYNTH_SCRIPT=")
+            )
+            synth_script_path = Path(synth_script_token.split("=", 1)[1])
+            synth_text = synth_script_path.read_text(encoding="utf-8")
+            self.assertIn("synth -run :fine {*}$synth_full_args", synth_text)
+            self.assertNotIn("proc yosys_synth_with_fsm_capture", synth_text)
+
     def test_synth_script_instruments_all_internal_synth_calls(self):
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
@@ -1240,17 +1321,36 @@ class ModeCompareRegressionTest(unittest.TestCase):
 
             self.assertIn("proc yosys_synth_with_fsm_capture", text)
             self.assertIn(
-                "yosys_synth_with_fsm_capture -run :fine", text,
+                "yosys_synth_with_fsm_capture -run :fine {*}$synth_full_args", text,
             )
             self.assertIn(
-                "yosys_synth_with_fsm_capture -flatten -run coarse:fine", text,
+                "yosys_synth_with_fsm_capture -flatten -run coarse:fine {*}$synth_full_args",
+                text,
             )
             self.assertIn(
-                "yosys_synth_with_fsm_capture -top $::env(DESIGN_NAME) -run fine:", text,
+                "yosys_synth_with_fsm_capture -top $::env(DESIGN_NAME) -run fine: {*}$synth_full_args",
+                text,
             )
             self.assertNotIn("synth -run :fine", text)
             self.assertNotIn("synth -flatten -run coarse:fine", text)
             self.assertNotIn("synth -top $::env(DESIGN_NAME) -run fine:", text)
+            for line in text.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("synth ") or stripped.startswith(
+                    "yosys_synth_with_fsm_capture "
+                ):
+                    self.assertIn("{*}$synth_full_args", line)
+
+    def test_synth_script_fails_when_generated_call_lacks_synth_full_args(self):
+        malformed = (
+            "synth -run :fine\n"
+            "yosys_synth_with_fsm_capture -run :fine\n"
+        )
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Generated synth/wrapper calls missing",
+        ):
+            self.run_block_sweep._inject_fsm_capture_into_synth_script(malformed)
 
 class SynthTargetMappingRegressionTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Summary
- propagate `SYNTH_ARGS` into every Yosys `synth` invocation in the generated hierarchical synthesis script
- generate the synthesis-script override whenever `SYNTH_ARGS` is set, even without FSM capture or blackboxes
- require the binary-FSM physical checker to validate the exact variant's evaluator-local `1_synth.v`
- accept packed or bit-blasted Yosys state declarations, while requiring exactly `state_q[2:0]` and `reducer.state[3:0]`

## Root cause
OpenROAD's hierarchical synthesis script performs an initial `synth -run :fine` without `$synth_full_args`. The run recorded `SYNTH_ARGS=-nofsm`, but FSM recoding had already occurred before later calls received the option. PR #1418 therefore reproduced the one-hot PPA exactly and its routed report exposed `reducer/state[6]`.

The old checker trusted parameter metadata and timing only. It did not verify the synthesized state representation.

## Behavior
Generated scripts now fail construction if any executable synth call omits `{*}$synth_full_args`. The binary-FSM checker also fails closed when the exact synthesized netlist is missing, uses a stale/base variant, omits required state bits, or contains out-of-range one-hot state bits.

PR #1418 remains closed and its work item is `SUPERSEDED`. A new retry ID will be queued only after this fix merges.

## Validation
- `python -m pytest -q tests/test_run_block_sweep_mode_compare.py tests/test_check_attention_decode_score_multivalue_cluster_binary_fsm.py tests/test_attention_decode_score_multivalue_cluster_activity_power.py`
- 65 passed
- `git diff --check`
