### PR TITLE
control_plane: schedule corrected binary FSM retry

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -37,7 +37,7 @@ _CLUSTER_ACTIVITY_POWER_V14_FLOW_VARIANT = (
 )
 _CLUSTER_ACTIVITY_POWER_V14_SYNTH_ARGS = "-nofsm"
 _CLUSTER_ACTIVITY_POWER_V14_PNR_ITEM = (
-    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
+    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
 )
 _CLUSTER_ACTIVITY_POWER_V14_MIN_SEQUENTIAL_REGISTER_ACTIVITY_COVERAGE = 1.0
 

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -2894,7 +2894,7 @@ def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_exact_8ns_multivalue
             )
 
 
-def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_retry_8ns_multivalue_cluster_item() -> None:
+def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_retry_8ns_multivalue_cluster_item_r2() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
         repo_root.mkdir()
@@ -2913,7 +2913,7 @@ def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_retry_8ns_multivalue
                     config_paths=[config_path],
                     platform="nangate45",
                     out_root="runs/designs/npu_blocks",
-                    item_id="l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1",
+                    item_id="l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
                     requested_by="@tester",
                     source_commit=source_commit,
                     abstraction_layer="decoder_attention_decode_score_multivalue_cluster",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8282,7 +8282,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
             assert (
                 "--source-pnr-item-id "
-                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
+                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
                 in run
             )
             assert (
@@ -8294,7 +8294,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_source_pnr_item_id"]
-                == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
+                == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_min_sequential_register_activity_coverage"]

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
@@ -1,7 +1,7 @@
 # Evaluation Gate
 
 1. Queue v14 only after merged
-   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1` and
+   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2` and
    `l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1`
    evidence is available.
 2. Run the activity-power audit on the remote evaluator with evaluator-local

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "PR #1413 merged complete block_weight VCD/FSM provenance, PR #1414 merged the binary-FSM PNR point, and PR #1415 merged strict v14 row selection and 100% routed-state coverage. V14 now requires the v3_r1 retry row; neither this retry implementation nor its result is claimed merged here.",
+  "source_commit_note": "PR #1413 merged complete block_weight VCD/FSM provenance, PR #1414 merged the binary-FSM PNR point, and PR #1415 merged strict v14 row selection and 100% routed-state coverage. V14 now requires the v3_r2 retry row; neither this retry implementation nor its result is claimed merged here.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -449,7 +449,7 @@
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
@@ -465,7 +465,7 @@
         "reason": "Rerun preserves all existing direct-VCD, macro, clock, numeric, artifact, applied==matched, and zero query/apply-error gates; strengthens DFF-output coverage to 1.0; and forbids clamping, substitution, heuristic activity, or other gate relaxation. It selects only decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500 with SYNTH_ARGS=-nofsm."
       },
       "status": "pending_implementation_merge",
-      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
     }
   ],
   "source_commit": "b968b50997ff980dd0a367ff0fe7c98d4f89b7fb"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -400,11 +400,12 @@
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
       "revision": {
         "reason": "exact_binary_fsm_postroute_activity_mapping",
         "invalidates_item_ids": [

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1",
-  "source_commit_note": "PR #1414 merged the binary-FSM PNR point and PR #1415 merged its strict activity consumer. The base v3 physical flow completed, but mode expansion duplicated the proxy suffix and the strict checker rejected the malformed row. Queue v3_r1 only after this retry implementation merges; no r1 result is claimed here.",
+  "source_commit_note": "PR #1414 merged the binary-FSM PNR point and PR #1415 merged its strict activity consumer. The base v3 physical flow completed, but remained one-hot due a missing argument in the first hierarchical `synth -run :fine` call. r1 stabilized the mode suffix expansion and kept SYNTH_ARGS=-nofsm; PR #1419 / merge 0d5317a1 propagates SYNTH_ARGS to every synth call and validates exact `1_synth.v` width checks. Queue v3_r2 only after this retry implementation merges; r1 is retained as superseded history.",
   "architecture_revision": {
     "reason": "shared_score_multivalue_cluster_replaces_repeated_score_fill_bound",
     "invalidates_item_ids": [
@@ -108,7 +108,33 @@
       ],
       "expected_result": {
         "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
-        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. The base v3 physical flow completed, but its row is non-promotable because mode expansion duplicated the proxy suffix and the strict checker rejected it. v3_r1 corrects base FLOW_VARIANT handling and keeps SYNTH_ARGS=-nofsm so routed FSM bits correspond to RTL state activity. PR #1413 / merge f281d6f7 enables complete block_weight capture, compact diagnostics, and FSM provenance; the r1 implementation is not yet merged."
+        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. The base v3 flow completed, but remained one-hot because OpenROAD's initial hierarchical `synth -run :fine` omitted `SYNTH_ARGS`. R1 stabilized mode expansion so `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500` is emitted as a single suffix and kept `SYNTH_ARGS=-nofsm`, yet still remained non-promotable for routed-state width mismatch. PR #1419 / merge 0d5317a1 propagates args to every synth invocation and validates exact `1_synth.v` state widths."
+      },
+      "status": "superseded"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact-state activity calibration path with the unique binary-FSM 8 ns sweep, matched to the v2 physical architecture and configuration.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_binary_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
+      ],
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
+        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. R2 validates the same mode expansion fix as r1 while enforcing PR #1419 / merge 0d5317a1 behavior: `SYNTH_ARGS` is propagated to every `synth` call and exact `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500` `1_synth.v` state widths are validated against RTL widths."
       },
       "status": "pending_implementation_merge"
     }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
@@ -137,7 +137,33 @@
       ],
       "expected_result": {
         "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
-        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. The base v3 physical flow completed, but its row is non-promotable because mode expansion duplicated the proxy suffix and the strict checker rejected it. v3_r1 corrects base FLOW_VARIANT handling and keeps SYNTH_ARGS=-nofsm so routed FSM bits correspond to RTL state activity. PR #1413 / merge f281d6f7 enables complete block_weight capture, compact diagnostics, and FSM provenance; the r1 implementation is not yet merged."
+        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. The base v3 flow completed, but remained one-hot because OpenROAD's initial hierarchical `synth -run :fine` omitted `SYNTH_ARGS`. R1 stabilized mode expansion so `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500` is emitted as a single suffix and kept `SYNTH_ARGS=-nofsm`, yet still remained non-promotable for routed-state width mismatch. PR #1419 / merge 0d5317a1 propagates args to every synth call and validates exact `1_synth.v` state widths."
+      },
+      "status": "superseded"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact-state activity calibration path with the unique binary-FSM 8 ns sweep, matched to the v2 physical architecture and configuration.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_binary_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r1"
+      ],
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
+        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. R2 validates the same mode expansion fix as r1 while enforcing PR #1419 / merge 0d5317a1 behavior: `SYNTH_ARGS` is propagated to every `synth` call and exact `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500` `1_synth.v` state widths are validated against RTL widths."
       },
       "status": "pending_implementation_merge"
     }


### PR DESCRIPTION
## Summary
- retain the base v3 failure and `_r1` one-hot result as non-promotable history
- add `_r2` as the active binary-FSM 8 ns physical retry
- rebind strict activity-power v14 to `_r2`
- verify retry IDs still receive the binary-FSM checker

## Why
PR #1419 fixed the independent cause exposed by `_r1`: OpenROAD's first hierarchical `synth -run :fine` omitted `SYNTH_ARGS`, so the run recorded `-nofsm` while still producing one-hot `reducer/state[6]`. The merged fix propagates args to every synth call and validates exact `1_synth.v` state widths.

`_r2` is a new immutable work item so neither failed nor superseded evidence is rewritten.

## Validation
- JSON parsing for all four updated proposal/request files
- focused L1/L2 generator tests: 3 passed
- `git diff --check`
