### PR TITLE
control_plane: isolate corrected binary FSM retry

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1459,7 +1459,11 @@ def _is_multivalue_cluster_8ns_bridge_sweep(*, item_id: str, sweep_path: str) ->
 def _is_multivalue_cluster_8ns_binary_fsm_sweep(*, item_id: str, sweep_path: str) -> bool:
     return (
         _retry_base(item_id) == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3"
-        and Path(sweep_path).name == "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json"
+        and Path(sweep_path).name
+        in {
+            "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json",
+            "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v4.json",
+        }
     )
 
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -33,11 +33,11 @@ _VERSION_SUFFIX_RE = re.compile(r"_v(\d+)$")
 _GQA_FOLDED_ACTIVITY_LANES_RE = re.compile(r"_gqa8_folded_lanes(1|2|4|8)_activity_power_")
 _CLUSTER_ACTIVITY_POWER_STRICT_REVISION = 14
 _CLUSTER_ACTIVITY_POWER_V14_FLOW_VARIANT = (
-    "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+    "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500"
 )
 _CLUSTER_ACTIVITY_POWER_V14_SYNTH_ARGS = "-nofsm"
 _CLUSTER_ACTIVITY_POWER_V14_PNR_ITEM = (
-    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
+    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3"
 )
 _CLUSTER_ACTIVITY_POWER_V14_MIN_SEQUENTIAL_REGISTER_ACTIVITY_COVERAGE = 1.0
 

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -947,6 +947,48 @@ def _write_attention_decode_score_multivalue_cluster_binary_fsm_8ns_v3_sweep(rep
     return str(sweep_path.relative_to(repo_root))
 
 
+def _write_attention_decode_score_multivalue_cluster_binary_fsm_8ns_v4_sweep(repo_root: Path) -> str:
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "decode_score_multivalue_cluster_v1"
+        / "sweeps"
+        / "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v4.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "flow_params": {
+                    "TAG": ["decode_score_multivalue_cluster_v1_8ns_binary_fsm"],
+                    "FLOW_VARIANT": ["decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4"],
+                    "CLOCK_PERIOD": [8],
+                    "SYNTH_HIERARCHICAL": [1],
+                    "SYNTH_MEMORY_MAX_BITS": [65536],
+                    "PLACE_DENSITY": [0.4],
+                    "SYNTH_ARGS": ["-nofsm"],
+                },
+                "mode_compare": {
+                    "modes": [
+                        {
+                            "name": "proxy_die_2500",
+                            "use_macro": True,
+                            "param_overrides": {
+                                "DIE_AREA": "0 0 2500 2500",
+                                "CORE_AREA": "50 50 2450 2450",
+                            },
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(sweep_path.relative_to(repo_root))
+
+
 def _write_example_attention_decode_score_multivalue_gqa_group_repo(
     repo_root: Path,
 ) -> tuple[str, str]:
@@ -2894,12 +2936,12 @@ def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_exact_8ns_multivalue
             )
 
 
-def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_retry_8ns_multivalue_cluster_item_r2() -> None:
+def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_retry_8ns_multivalue_cluster_item_r3() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
         repo_root.mkdir()
         config_path, _ = _write_example_attention_decode_score_multivalue_cluster_repo(repo_root)
-        sweep_path = _write_attention_decode_score_multivalue_cluster_binary_fsm_8ns_v3_sweep(repo_root)
+        sweep_path = _write_attention_decode_score_multivalue_cluster_binary_fsm_8ns_v4_sweep(repo_root)
         source_commit = _init_git_repo(repo_root)
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         create_all(engine)
@@ -2913,7 +2955,7 @@ def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_retry_8ns_multivalue
                     config_paths=[config_path],
                     platform="nangate45",
                     out_root="runs/designs/npu_blocks",
-                    item_id="l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
+                    item_id="l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3",
                     requested_by="@tester",
                     source_commit=source_commit,
                     abstraction_layer="decoder_attention_decode_score_multivalue_cluster",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8274,7 +8274,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
 
             assert (
                 "--required-flow-variant "
-                "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500" in run
+                "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500" in run
             )
             assert "--required-synth-args=-nofsm" in run
             assert (
@@ -8282,19 +8282,19 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
             assert (
                 "--source-pnr-item-id "
-                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
+                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3"
                 in run
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_required_flow_variant"]
-                == "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+                == "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500"
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_required_synth_args"] == "-nofsm"
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_source_pnr_item_id"]
-                == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
+                == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3"
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_min_sequential_register_activity_coverage"]

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
@@ -1,7 +1,7 @@
 # Evaluation Gate
 
 1. Queue v14 only after merged
-   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2` and
+   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3` and
    `l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1`
    evidence is available.
 2. Run the activity-power audit on the remote evaluator with evaluator-local
@@ -13,7 +13,7 @@
 5. Treat vectorless OpenROAD power as structural diagnostics only. It cannot
    substitute for activity-backed power or token-energy claims.
 6. Select only
-   `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500` with
+   `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500` with
    `SYNTH_ARGS=-nofsm`; the one-hot v2 row remains a PPA baseline but is invalid
    for bit-exact RTL-to-routed FSM activity transfer.
 7. Require 100% routed sequential Q/QN coverage, applied assignments equal to

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "PR #1413 merged complete block_weight VCD/FSM provenance, PR #1414 merged the binary-FSM PNR point, and PR #1415 merged strict v14 row selection and 100% routed-state coverage. V14 now requires the v3_r2 retry row; neither this retry implementation nor its result is claimed merged here.",
+  "source_commit_note": "PR #1413 merged complete block_weight VCD/FSM provenance, PR #1414 merged the binary-FSM PNR point, and PR #1415 merged strict v14 row selection and 100% routed-state coverage. v3_r2 was superseded because it reused the same sweep hash. V14 now depends on `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3`; neither this retry implementation nor its result is claimed merged here.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -444,12 +444,12 @@
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14",
       "task_type": "l2_campaign",
-      "objective": "Rerun shared-score multivalue-cluster activity-backed power using only the binary-FSM matched 8ns PNR flow (decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500 with SYNTH_ARGS=-nofsm) plus merged equivalence; preserve every prior gate and strengthen routed sequential-output coverage from 95% to 100% so no recoded or omitted state can pass.",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power using only the binary-FSM matched 8ns PNR flow (decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500 with SYNTH_ARGS=-nofsm) plus merged equivalence; preserve every prior gate and strengthen routed sequential-output coverage from 95% to 100% so no recoded or omitted state can pass.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
@@ -462,10 +462,10 @@
       },
       "expected_result": {
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
-        "reason": "Rerun preserves all existing direct-VCD, macro, clock, numeric, artifact, applied==matched, and zero query/apply-error gates; strengthens DFF-output coverage to 1.0; and forbids clamping, substitution, heuristic activity, or other gate relaxation. It selects only decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500 with SYNTH_ARGS=-nofsm."
+        "reason": "Rerun preserves all existing direct-VCD, macro, clock, numeric, artifact, applied==matched, and zero query/apply-error gates; strengthens DFF-output coverage to 1.0; and forbids clamping, substitution, heuristic activity, or other gate relaxation. It selects only decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500 with SYNTH_ARGS=-nofsm."
       },
       "status": "pending_implementation_merge",
-      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3"
     }
   ],
   "source_commit": "b968b50997ff980dd0a367ff0fe7c98d4f89b7fb"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -395,17 +395,17 @@
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14",
       "task_type": "l2_campaign",
-      "objective": "Rerun shared-score multivalue-cluster activity-backed power using only the binary-FSM matched 8ns PNR flow (decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500 with SYNTH_ARGS=-nofsm) plus merged equivalence; preserve every previous evidence gate and strengthen routed sequential-output coverage from 95% to 100%.",
+      "objective": "Rerun shared-score multivalue-cluster activity-backed power using only the binary-FSM matched 8ns PNR flow (decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500 with SYNTH_ARGS=-nofsm) plus merged equivalence; preserve every previous evidence gate and strengthen routed sequential-output coverage from 95% to 100%.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
-      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3",
       "revision": {
         "reason": "exact_binary_fsm_postroute_activity_mapping",
         "invalidates_item_ids": [
@@ -414,7 +414,7 @@
       },
       "expected_result": {
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
-        "reason": "v14 preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, strengthens DFF-output coverage to 1.0, requires applied==matched and zero query/apply errors, and keeps all sidecar rows evaluator-local while forbidding clamping, substitution, heuristic activity, and other gate relaxation."
+        "reason": "v14 preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, strengthens DFF-output coverage to 1.0, requires applied==matched and zero query/apply errors, and keeps all sidecar rows evaluator-local while forbidding clamping, substitution, heuristic activity, and other gate relaxation. It selects only decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500 with SYNTH_ARGS=-nofsm."
       },
       "status": "pending_implementation_merge"
     }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1",
-  "source_commit_note": "PR #1414 merged the binary-FSM PNR point and PR #1415 merged its strict activity consumer. The base v3 physical flow completed, but remained one-hot due a missing argument in the first hierarchical `synth -run :fine` call. r1 stabilized the mode suffix expansion and kept SYNTH_ARGS=-nofsm; PR #1419 / merge 0d5317a1 propagates SYNTH_ARGS to every synth call and validates exact `1_synth.v` width checks. Queue v3_r2 only after this retry implementation merges; r1 is retained as superseded history.",
+  "source_commit_note": "PR #1414 merged the binary-FSM PNR point and PR #1415 merged its strict activity consumer. The base v3 physical flow completed, but remained one-hot due a missing argument in the first hierarchical `synth -run :fine` call. r1 stabilized the mode suffix expansion and kept SYNTH_ARGS=-nofsm; PR #1419 / merge 0d5317a1 propagates SYNTH_ARGS to every synth call and validates exact `1_synth.v` width checks. v3_r2 reused the same sweep hash and could not force a fresh recompute with `--skip_existing`; r3 introduces v4 and is active, with r1/r2 retained as superseded history.",
   "architecture_revision": {
     "reason": "shared_score_multivalue_cluster_replaces_repeated_score_fill_bound",
     "invalidates_item_ids": [
@@ -134,7 +134,33 @@
       ],
       "expected_result": {
         "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
-        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. R2 validates the same mode expansion fix as r1 while enforcing PR #1419 / merge 0d5317a1 behavior: `SYNTH_ARGS` is propagated to every `synth` call and exact `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500` `1_synth.v` state widths are validated against RTL widths."
+        "reason": "R2 was superseded before dispatch: it retained r1's v3 sweep parameter hash, so `--skip_existing` could reuse the old one-hot output instead of exercising PR #1419. No r2 physical result is claimed."
+      },
+      "status": "superseded"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact-state activity calibration path with the unique binary-FSM 8 ns sweep, matched to the v2 physical architecture and configuration.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_binary_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v4.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
+      ],
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
+        "reason": "The base v3 retry retained the old `FLOW_VARIANT` hash, which let `--skip_existing` reuse one-hot routed outputs. R3 switches to v4 (`decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500`) with the same strict activity-consumer behavior, producing a new parameter hash so a clean recompute is possible."
       },
       "status": "pending_implementation_merge"
     }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
@@ -163,7 +163,34 @@
       ],
       "expected_result": {
         "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
-        "reason": "V2 remains the valid one-hot PPA baseline and is not invalidated. R2 validates the same mode expansion fix as r1 while enforcing PR #1419 / merge 0d5317a1 behavior: `SYNTH_ARGS` is propagated to every `synth` call and exact `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500` `1_synth.v` state widths are validated against RTL widths."
+        "reason": "R2 was superseded before dispatch: it retained r1's v3 sweep parameter hash, so `--skip_existing` could reuse the old one-hot output instead of exercising PR #1419. No r2 physical result is claimed."
+      },
+      "status": "superseded",
+      "status_reason": "R2 reused r1's sweep parameter hash, so `--skip_existing` could not distinguish the intended corrected binary-FSM mapping from the old one-hot output."
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact-state activity calibration path with the unique binary-FSM 8 ns sweep, matched to the v2 physical architecture and configuration.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_binary_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v4.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r2"
+      ],
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_binary_fsm_ppa",
+        "reason": "V3_r2 was a retry but did not change the `FLOW_VARIANT` hash, so `--skip_existing` could reuse one-hot results. R3 uses a fresh v4 sweep path (`..._v4`), so the required exact-flow variant is `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500` and routed-state width validation is enforced against fresh `1_synth.v` netlists."
       },
       "status": "pending_implementation_merge"
     }

--- a/npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py
+++ b/npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py
@@ -12,7 +12,7 @@ from typing import cast
 
 EXPECTED_CLOCK_PERIOD = 8
 EXPECTED_TAG_PREFIX = "decode_score_multivalue_cluster_v1_8ns_binary_fsm"
-EXPECTED_FLOW_VARIANT = "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+EXPECTED_FLOW_VARIANT = "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500"
 EXPECTED_DIE_AREA = "0 0 2500 2500"
 EXPECTED_CORE_AREA = "50 50 2450 2450"
 EXPECTED_PLACE_DENSITY = "0.4"
@@ -280,7 +280,7 @@ def validate_binary_fsm_metrics(
         raise ValueError(
             "missing required 8ns exact-state binary-FSM decode-score multivalue-cluster row "
             "(status=ok, TAG=decode_score_multivalue_cluster_v1_8ns_binary_fsm*, "
-            "FLOW_VARIANT=decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500, "
+            f"FLOW_VARIANT={EXPECTED_FLOW_VARIANT}, "
             "DIE_AREA=0 0 2500 2500, CORE_AREA=50 50 2450 2450, SYNTH_ARGS=-nofsm, "
             "PLACE_DENSITY=0.4, SYNTH_HIERARCHICAL=1, SYNTH_MEMORY_MAX_BITS=65536, "
             "critical_path_ns<=8); details: " + last_candidate_error
@@ -289,7 +289,7 @@ def validate_binary_fsm_metrics(
     raise ValueError(
         "missing required 8ns exact-state binary-FSM decode-score multivalue-cluster row "
         "(status=ok, TAG=decode_score_multivalue_cluster_v1_8ns_binary_fsm*, "
-        "FLOW_VARIANT=decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500, "
+        f"FLOW_VARIANT={EXPECTED_FLOW_VARIANT}, "
         "DIE_AREA=0 0 2500 2500, CORE_AREA=50 50 2450 2450, SYNTH_ARGS=-nofsm, "
         "PLACE_DENSITY=0.4, SYNTH_HIERARCHICAL=1, SYNTH_MEMORY_MAX_BITS=65536, "
         "critical_path_ns<=8)"

--- a/runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v4.json
+++ b/runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v4.json
@@ -1,0 +1,38 @@
+{
+  "tag_prefix": "decode_score_multivalue_cluster_v1_8ns_binary_fsm",
+  "flow_params": {
+    "TAG": [
+      "decode_score_multivalue_cluster_v1_8ns_binary_fsm"
+    ],
+    "FLOW_VARIANT": [
+      "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4"
+    ],
+    "CLOCK_PERIOD": [
+      8
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_ARGS": [
+      "-nofsm"
+    ]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "proxy_die_2500",
+        "use_macro": true,
+        "param_overrides": {
+          "DIE_AREA": "0 0 2500 2500",
+          "CORE_AREA": "50 50 2450 2450"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_check_attention_decode_score_multivalue_cluster_binary_fsm.py
+++ b/tests/test_check_attention_decode_score_multivalue_cluster_binary_fsm.py
@@ -13,8 +13,9 @@ import pytest
 
 
 EXPECTED_TAG = "decode_score_multivalue_cluster_v1_8ns_binary_fsm"
-EXPECTED_VARIANT = "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
+EXPECTED_VARIANT = "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500"
 EXPECTED_SYNTH_ARGS = "-nofsm"
+STALE_VARIANT = "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500"
 
 VALID_PACKED_NETLIST_DECLARATIONS = """\
 module top;
@@ -244,6 +245,30 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_old_
         proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td)))
         assert proc.returncode != 0
         assert "missing required 8ns" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_stale_v3_exact_netlist_for_v4_checker() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        metrics = _metrics_path(root)
+        _write_netlist(root, flow_variant=STALE_VARIANT)
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.5,
+                    result_path="runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json",
+                    flow_variant=EXPECTED_VARIANT,
+                    tag=f"{EXPECTED_TAG}_proxy_die_2500",
+                    synth_args=EXPECTED_SYNTH_ARGS,
+                )
+            ],
+        )
+        proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(root))
+        assert proc.returncode != 0
+        assert "missing exact netlist" in proc.stderr
+        assert EXPECTED_VARIANT in proc.stderr
 
 
 def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_missing_synth_args() -> None:

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -230,6 +230,69 @@ class ModeCompareRegressionTest(unittest.TestCase):
             out["FLOW_VARIANT"],
         )
 
+    def test_apply_mode_to_params_distinguishes_v3_and_v4_binary_fsm_sweeps(self) -> None:
+        v3_sweep_path = (
+            REPO_ROOT
+            / "runs"
+            / "campaigns"
+            / "npu"
+            / "decode_score_multivalue_cluster_v1"
+            / "sweeps"
+            / "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v3.json"
+        )
+        v4_sweep_path = (
+            REPO_ROOT
+            / "runs"
+            / "campaigns"
+            / "npu"
+            / "decode_score_multivalue_cluster_v1"
+            / "sweeps"
+            / "nangate45_decode_score_multivalue_cluster_8ns_binary_fsm_v4.json"
+        )
+        v3_sweep = json.loads(v3_sweep_path.read_text(encoding="utf-8"))
+        v4_sweep = json.loads(v4_sweep_path.read_text(encoding="utf-8"))
+        v3_cfg = self.run_block_sweep.parse_mode_compare_config(v3_sweep)
+        v4_cfg = self.run_block_sweep.parse_mode_compare_config(v4_sweep)
+        assert v3_cfg is not None
+        assert v4_cfg is not None
+        v3_mode = next(
+            m for m in v3_cfg["modes"] if str(m.get("slug", "")).strip() == "proxy_die_2500"
+        )
+        v4_mode = next(
+            m for m in v4_cfg["modes"] if str(m.get("slug", "")).strip() == "proxy_die_2500"
+        )
+        v3_applied = self.run_block_sweep.apply_mode_to_params(
+            {
+                "TAG": v3_sweep["flow_params"]["TAG"][0],
+                "FLOW_VARIANT": v3_sweep["flow_params"]["FLOW_VARIANT"][0],
+            },
+            v3_mode,
+            str(v3_sweep["tag_prefix"]),
+        )
+        v4_applied = self.run_block_sweep.apply_mode_to_params(
+            {
+                "TAG": v4_sweep["flow_params"]["TAG"][0],
+                "FLOW_VARIANT": v4_sweep["flow_params"]["FLOW_VARIANT"][0],
+            },
+            v4_mode,
+            str(v4_sweep["tag_prefix"]),
+        )
+
+        self.assertEqual(
+            "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
+            v3_applied["FLOW_VARIANT"],
+        )
+        self.assertEqual(
+            "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500",
+            v4_applied["FLOW_VARIANT"],
+        )
+        self.assertEqual(1, v4_applied["FLOW_VARIANT"].count("_proxy_die_2500"))
+        self.assertNotEqual(
+            self.run_block_sweep.make_run_id(v3_applied),
+            self.run_block_sweep.make_run_id(v4_applied),
+        )
+        self.assertNotEqual(v3_applied["FLOW_VARIANT"], v4_applied["FLOW_VARIANT"])
+
     def test_apply_repeat_to_params_sets_flow_random_seed(self):
         out = self.run_block_sweep.apply_repeat_to_params(
             {"TAG": "tag_flat", "FLOW_VARIANT": "var_flat"},


### PR DESCRIPTION
## Summary
- add a v4 binary-FSM sweep variant with a fresh parameter/run hash
- supersede `_r2` before dispatch and schedule `_r3` against the v4 sweep
- require the exact v4 synthesized netlist in the binary-FSM checker
- rebind strict activity-power v14 to the eventual `_r3` PNR result

## Why
The `_r2` item was correctly withheld from the evaluator: it used the same v3 sweep parameters as `_r1`, while `run_block_sweep` uses `--skip_existing`. That could reuse the old one-hot physical output and fail to exercise PR #1419's corrected hierarchical `SYNTH_ARGS` propagation.

The v4 flow variant changes the parameter hash without modifying historical v3 evidence. `_r3` must perform a fresh synthesis and its checker rejects both stale v3 netlists and routed state widths beyond `state_q[2:0]` / `reducer.state[3:0]`.

## Validation
- JSON parse checks for the new sweep and all updated proposal/request files
- checker + mode-compare tests: 56 passed
- focused L1/L2 generator tests: 3 passed
- `git diff --check`
