### PR TITLE
control_plane: bind downstream recosts to strict power evidence

### DIFF
--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8329,6 +8329,55 @@ def test_cluster_activity_power_item_for_consumer_prefers_requested_version_for_
     )
 
 
+def test_cluster_activity_power_item_for_consumer_selects_v14_for_cluster_frontier() -> None:
+    assert (
+        _cluster_activity_power_item_for_consumer(
+            item_id="l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
+            depends_on_item_ids=[
+                "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14",
+            ],
+        )
+        == "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+    )
+
+
+def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v14() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1"
+    )
+    activity_item_ids = {
+        f"l2_decoder_attention_decode_score_multivalue_gqa8_folded_lanes{lanes}_activity_power_llama7b_v1"
+        for lanes in (1, 2, 4)
+    }
+    required_dependency = (
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+    )
+
+    for manifest_name, items_key in (
+        ("proposal.json", "required_evaluations"),
+        ("evaluation_requests.json", "requested_items"),
+    ):
+        manifest = json.loads((proposal_dir / manifest_name).read_text(encoding="utf-8"))
+        activity_items = {
+            item["item_id"]: item
+            for item in manifest[items_key]
+            if item["item_id"] in activity_item_ids
+        }
+        assert set(activity_items) == activity_item_ids
+        assert all(
+            required_dependency in item["depends_on_item_ids"]
+            for item in activity_items.values()
+        )
+        assert all(
+            "llama7b_v13" not in dependency
+            for item in activity_items.values()
+            for dependency in item["depends_on_item_ids"]
+        )
+
+
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activity_power() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/developer_agent_loop.md
+++ b/docs/developer_agent_loop.md
@@ -290,6 +290,15 @@ Ordering rule:
 - do not treat "baseline run finished" as sufficient when the comparison
   exporter reads baseline evidence from repo paths
 
+Retry identity rule:
+- a retry item suffix does not by itself force a new physical run
+- when correcting synthesis or flow semantics, use a fresh immutable sweep
+  parameter identity and prove its expanded `FLOW_VARIANT`/run ID differs from
+  the invalid attempt before dispatch
+- checkers must bind to the exact new physical artifact path and must not fall
+  back to an older or `base` result
+- supersede an unrun retry if `--skip_existing` could reuse invalid evidence
+
 ### Stage 7. Remote Evaluation
 
 Evaluator daemon:

--- a/docs/developer_agent_orchestration.md
+++ b/docs/developer_agent_orchestration.md
@@ -243,6 +243,30 @@ After proposal metadata is committed, always rerun generation with
 Before assigning or submitting queue items, verify `command_manifest` contains the
 expected generated commands for the committed proposal state.
 
+### Retry Freshness Rule
+
+A new work-item suffix such as `_r2` changes control-plane identity, but does
+not change `run_block_sweep` parameter identity. When a retry must exercise a
+code or synthesis-semantics fix, do not reuse sweep parameters with
+`--skip_existing`: the evaluator may accept the prior `metrics.csv` row and
+physical output without rerunning synthesis.
+
+Before dispatching such a retry:
+
+- preserve the old sweep and result as history
+- create a new immutable sweep/`FLOW_VARIANT` (or another intentional physical
+  parameter change) so `make_run_id` and the parameter hash differ
+- add a regression proving the new mode-expanded variant and run ID differ from
+  the invalid attempt
+- make the result checker require the exact new variant's physical artifacts,
+  with no fallback to `base` or an older variant
+- generate with `--no-auto-dispatch`, then inspect the required source SHA,
+  sweep path, and command manifest before assigning the remote evaluator
+
+If reuse risk is discovered after queue generation but before assignment,
+supersede the unrun item and create a fresh immutable retry. Do not patch the
+queued manifest or overwrite the historical result.
+
 Recommended file:
 ```text
 docs/proposals/<proposal_id>/evaluation_requests.json

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
   "source_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
-  "source_commit_note": "Queue this evidence-only remote frontier recost only after the corrected local-cluster frontier v2 and the shared-score multivalue activity-power v13 rerun (PR #1410, commit db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd).",
+  "source_commit_note": "Keep this evidence-only frontier recost pending until strict shared-score multivalue activity-power v14 is merged and its evidence is materialized. Activity-power v13 is invalid and must not be consumed; this request does not claim that v14 evidence exists.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
@@ -13,13 +13,13 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "recast_shared_score_multivalue_cluster_frontier",
-        "reason": "Frontier ranking must charge exact full-head cycles, measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
+        "reason": "Keep this frontier pending until strict activity-power v14 is merged and materialized; only then may ranking charge exact full-head cycles, valid measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
       },
       "status": "pending_implementation_merge"
     }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
@@ -57,13 +57,13 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "recast_shared_score_multivalue_cluster_frontier",
-        "reason": "Frontier ranking must charge exact full-head cycles, measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
+        "reason": "Keep this frontier pending until strict activity-power v14 is merged and materialized; only then may ranking charge exact full-head cycles, valid measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
       },
       "status": "pending_implementation_merge"
     }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1",
   "source_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
-  "source_commit_note": "Queue group jobs only after the GQA8 group generator, audit, design target, guard, and handlers are merged; folded-lane activity tasks should consume the shared-score activity-power v13 rerun from PR #1410 (commit db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd).",
+  "source_commit_note": "Keep folded-lane activity tasks pending until strict shared-score activity-power v14 is merged and its evidence is materialized. Activity-power v13 is invalid and must not be consumed; this request does not claim that v14 evidence exists.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
@@ -201,13 +201,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes1_direct_activity_energy",
-        "reason": "The minimum-area point needs routed, phase-accounted energy with all eight waves charged."
+        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the minimum-area point then needs routed, phase-accounted energy with all eight waves charged."
       },
       "status": "pending_implementation_merge"
     },
@@ -221,13 +221,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes2_direct_activity_energy",
-        "reason": "The first lane-parallel midpoint needs routed energy rather than linear scaling from one lane."
+        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the first lane-parallel midpoint then needs routed energy rather than linear scaling from one lane."
       },
       "status": "pending_implementation_merge"
     },
@@ -241,13 +241,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes4_direct_activity_energy",
-        "reason": "The near-parallel point needs routed energy before it can trade area for latency."
+        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the near-parallel point then needs routed energy before it can trade area for latency."
       },
       "status": "pending_implementation_merge"
     },

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -222,13 +222,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes1_direct_activity_energy",
-        "reason": "The minimum-area point needs direct phase-accounted energy rather than vectorless power."
+        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the minimum-area point then needs direct phase-accounted energy rather than vectorless power."
       },
       "status": "pending_control_plane_merge"
     },
@@ -242,13 +242,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes2_direct_activity_energy",
-        "reason": "The midpoint needs direct routed energy instead of linear lane scaling."
+        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the midpoint then needs direct routed energy instead of linear lane scaling."
       },
       "status": "pending_control_plane_merge"
     },
@@ -262,13 +262,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v13"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes4_direct_activity_energy",
-        "reason": "The near-parallel point needs direct routed energy before trading area for latency."
+        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the near-parallel point then needs direct routed energy before trading area for latency."
       },
       "status": "pending_control_plane_merge"
     },


### PR DESCRIPTION
## Summary
- rebind the shared-score cluster frontier from invalid activity-power v13 to strict v14
- rebind folded GQA lanes 1/2/4 activity jobs from v13 to v14
- keep all consumers pending until v14 is merged and materialized
- document the retry-freshness rule for `--skip_existing`

## Why
The v13 activity result is invalid because routed FSM/state activity was not mapped completely. No frontier or GQA energy ranking may consume it. The consumers now select v14 by dependency ID and make no claim that v14 evidence already exists.

The developer-agent procedure now also records the failure mode found before `_r2` dispatch: changing only a work-item retry suffix does not change the physical parameter hash, so `--skip_existing` can reuse invalid evidence. Corrective physical retries must use a fresh immutable sweep identity and exact artifact checker.

## Validation
- all four updated proposal/request JSON files parse
- focused dependency-selection tests: 3 passed
- `git diff --check`
