### PR TITLE
Fix multivalue cluster frontier promotion checks

### DIFF
--- a/npu/eval/audit_attention_decode_score_multivalue_cluster_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_cluster_frontier.py
@@ -12,6 +12,11 @@ from typing import Any
 
 JsonDict = dict[str, Any]
 
+_EXPECTED_ACTIVITY_MODEL = "decoder_attention_decode_score_multivalue_cluster_activity_power_v1"
+_EXPECTED_ACTIVITY_DECISION = "activity_backed_cluster_power_measured"
+_EXPECTED_EQUIVALENCE_DECISION = "decode_score_multivalue_cluster_equivalence_pass"
+_EXPECTED_PRECISION_STATUS = "unchanged_integer_contract_from_merged_multivalue_equivalence"
+
 
 def _load(path: Path) -> JsonDict:
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -52,6 +57,65 @@ def _nonnegative(value: Any, label: str) -> float:
     return result
 
 
+def _positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be a positive integer")
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a positive integer") from exc
+    if not math.isfinite(numeric) or numeric <= 0 or not numeric.is_integer():
+        raise ValueError(f"{label} must be a positive integer")
+    return int(numeric)
+
+
+def _nonnegative_int(value: Any, label: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be a nonnegative integer")
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a nonnegative integer") from exc
+    if not math.isfinite(numeric) or numeric < 0 or not numeric.is_integer():
+        raise ValueError(f"{label} must be a nonnegative integer")
+    return int(numeric)
+
+
+def _validated_activity_best(activity_report: JsonDict) -> JsonDict:
+    if activity_report.get("model") != _EXPECTED_ACTIVITY_MODEL:
+        raise ValueError("activity-power report has an unexpected model")
+    if activity_report.get("decision") != _EXPECTED_ACTIVITY_DECISION:
+        raise ValueError("activity-power report has an unexpected decision")
+    if activity_report.get("promotion_gate_pass") is not True:
+        raise ValueError("activity-power promotion gate did not pass")
+    best = activity_report.get("best")
+    if not isinstance(best, dict) or not isinstance(best.get("ppa_metric"), dict) or not isinstance(
+        best.get("activity_power"), dict
+    ):
+        raise ValueError("activity-power report lacks a promoted best candidate")
+    candidate_id = best.get("candidate_id")
+    if not isinstance(candidate_id, str) or not candidate_id.strip():
+        raise ValueError("activity-power best candidate lacks an identity")
+    if activity_report.get("best_candidate_id") != candidate_id:
+        raise ValueError("activity-power best candidate identity does not match")
+    if best.get("status") != "activity_backed":
+        raise ValueError("activity-power best candidate is not activity-backed")
+    if best["activity_power"].get("promotion_gate_pass") is not True:
+        raise ValueError("activity-power best candidate promotion gate did not pass")
+    if activity_report.get("precision_status") != _EXPECTED_PRECISION_STATUS:
+        raise ValueError("activity-power report has an unexpected precision status")
+    equivalence = activity_report.get("equivalence")
+    if not isinstance(equivalence, dict) or equivalence.get("equivalence_pass") is not True:
+        raise ValueError("activity-power equivalence did not pass")
+    if equivalence.get("decision") != _EXPECTED_EQUIVALENCE_DECISION:
+        raise ValueError("activity-power equivalence has an unexpected decision")
+    for field in ("score_tensor_hash", "final_tensor_hash"):
+        value = equivalence.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"activity-power equivalence lacks {field}")
+    return best
+
+
 def _activity_energy(activity: JsonDict) -> JsonDict:
     phases = activity.get("phases")
     if not isinstance(phases, list) or not phases:
@@ -62,7 +126,7 @@ def _activity_energy(activity: JsonDict) -> JsonDict:
     for phase in phases:
         if not isinstance(phase, dict):
             raise ValueError("activity phase is not an object")
-        cycles = int(phase["full_context_cycles"])
+        cycles = _positive_int(phase["full_context_cycles"], "phase full-context cycles")
         clock_ns = _positive(phase["clock_period_ns"], "phase clock")
         power = phase.get("power")
         if not isinstance(power, dict):
@@ -76,12 +140,12 @@ def _activity_energy(activity: JsonDict) -> JsonDict:
     recorded = _positive(activity["full_context_energy_j"], "full-context energy")
     if not math.isclose(total_j, recorded, rel_tol=1.0e-6, abs_tol=1.0e-15):
         raise ValueError("phase energy does not match recorded full-context energy")
-    if phase_cycles != int(activity["full_context_cycles"]):
+    if phase_cycles != _positive_int(activity["full_context_cycles"], "full-context cycles"):
         raise ValueError("phase cycles do not match full-context cycles")
     return {
         "dynamic_j_per_head_command": dynamic_j,
-        "leakage_j_per_head_command": leakage_j,
-        "total_j_per_head_command": total_j,
+        "service_window_leakage_j_per_head_command": leakage_j,
+        "modeled_service_j_per_head_command": total_j,
     }
 
 
@@ -95,44 +159,59 @@ def _row(
     energy: JsonDict,
     dense_tile: JsonDict,
 ) -> JsonDict:
-    heads = int(schedule["attention_heads"])
-    layers = int(schedule["layers"])
-    hidden = int(schedule["hidden_size"])
-    kv_heads = int(schedule["kv_heads"])
+    heads = _positive_int(schedule["attention_heads"], "attention heads")
+    layers = _positive_int(schedule["layers"], "layers")
+    hidden = _positive_int(schedule["hidden_size"], "hidden size")
+    kv_heads = _positive_int(schedule["kv_heads"], "KV heads")
     head_dim = hidden // heads
     if cluster_count < 1 or cluster_count > heads:
         raise ValueError(f"cluster count must be in [1, {heads}]")
     cluster_area_um2 = _positive(cluster_metric["instance_area_um2"], "cluster area")
     dense_area_um2 = _positive(dense_tile["area_um2"], "dense QKV tile area")
     dense_macs = _positive(dense_tile["effective_macs_per_cycle"], "dense QKV MAC/cycle")
-    budget_um2 = _positive(schedule["compute_budget_um2"], "compute budget")
+    budget_um2 = _positive(schedule["compute_budget_um2"], "logic compute budget")
+    logic_area_used_um2 = _nonnegative(schedule["logic_area_used_um2"], "logic area used")
+    compute_area_um2 = _nonnegative(schedule["compute_area_um2"], "compute area")
+    noncompute_logic_um2 = logic_area_used_um2 - compute_area_um2
+    if noncompute_logic_um2 < 0:
+        raise ValueError("retained noncompute logic area must be nonnegative")
+    available_compute_um2 = budget_um2 - noncompute_logic_um2
     cluster_total_um2 = cluster_count * cluster_area_um2
     qkv_useful_limit = hidden // 8 + 2 * kv_heads * head_dim // 8
     dense_count = min(
         qkv_useful_limit,
-        max(0, math.floor((budget_um2 - cluster_total_um2) / dense_area_um2)),
+        max(0, math.floor((available_compute_um2 - cluster_total_um2) / dense_area_um2)),
     )
-    area_fit = dense_count > 0 and cluster_total_um2 + dense_count * dense_area_um2 <= budget_um2
+    area_fit = (
+        dense_count > 0
+        and noncompute_logic_um2 + cluster_total_um2 + dense_count * dense_area_um2 <= budget_um2
+    )
     qkv_work = hidden**2 + 2 * hidden * kv_heads * head_dim
     qkv_cycles = math.ceil(qkv_work / (dense_count * dense_macs)) if dense_count else None
     waves = math.ceil(heads / cluster_count)
     attention_cycles = waves * command_cycles
-    fixed_cycles = int(schedule.get("command_dispatch_cycles", 0)) + int(
-        schedule.get("kv_write_cycles", 0)
+    fixed_cycles = _nonnegative_int(
+        schedule.get("command_dispatch_cycles", 0), "command dispatch cycles"
+    ) + _nonnegative_int(
+        schedule.get("kv_write_cycles", 0), "KV write cycles"
     )
     layer_cycles = qkv_cycles + attention_cycles + fixed_cycles if qkv_cycles is not None else None
-    clock_ns = max(_positive(schedule["clock_ns"], "schedule clock"), activity_clock_ns)
+    schedule_clock_ns = _positive(schedule["clock_ns"], "schedule clock")
+    if schedule_clock_ns > activity_clock_ns:
+        raise ValueError("schedule clock is slower than the measured activity clock")
+    clock_ns = activity_clock_ns
     total_cycles = layer_cycles * layers if layer_cycles is not None else None
     latency_us = total_cycles * clock_ns / 1000.0 if total_cycles is not None else None
-    noncompute_logic = float(schedule["logic_area_used_um2"]) - float(schedule["compute_area_um2"])
-    logic_area_um2 = noncompute_logic + cluster_total_um2 + dense_count * dense_area_um2
+    logic_area_um2 = noncompute_logic_um2 + cluster_total_um2 + dense_count * dense_area_um2
     sram_area_um2 = float(schedule.get("measured_shared_sram_used_area_um2", 0.0)) + float(
         schedule.get("measured_tile_local_sram_area_um2", 0.0)
     )
     active_commands_per_token = heads * layers
     deployed_command_slots = cluster_count * waves * layers
     dynamic_j = active_commands_per_token * float(energy["dynamic_j_per_head_command"])
-    leakage_j = deployed_command_slots * float(energy["leakage_j_per_head_command"])
+    leakage_j = deployed_command_slots * float(
+        energy["service_window_leakage_j_per_head_command"]
+    )
     component_energy_j = dynamic_j + leakage_j
     return {
         "candidate_id": f"decode_score_multivalue_cluster_c{cluster_count}",
@@ -151,8 +230,16 @@ def _row(
         "token_throughput_per_s": round(1.0e6 / latency_us, 12) if latency_us else None,
         "cluster_area_mm2": round(cluster_total_um2 / 1.0e6, 9),
         "dense_qkv_area_mm2": round(dense_count * dense_area_um2 / 1.0e6, 9),
+        "retained_noncompute_logic_area_mm2": round(noncompute_logic_um2 / 1.0e6, 9),
         "compute_budget_slack_mm2": round(
-            (budget_um2 - cluster_total_um2 - dense_count * dense_area_um2) / 1.0e6, 9
+            (
+                budget_um2
+                - noncompute_logic_um2
+                - cluster_total_um2
+                - dense_count * dense_area_um2
+            )
+            / 1.0e6,
+            9,
         ),
         "logic_area_mm2": round(logic_area_um2 / 1.0e6, 9),
         "embodied_logic_plus_shared_sram_area_mm2": round(
@@ -163,9 +250,12 @@ def _row(
             _positive(cluster_metric["critical_path_ns"], "cluster path") <= clock_ns
         ),
         "attention_cluster_dynamic_energy_mj_per_token": dynamic_j * 1.0e3,
-        "attention_cluster_leakage_energy_mj_per_token": leakage_j * 1.0e3,
-        "attention_cluster_energy_mj_per_token": component_energy_j * 1.0e3,
-        "energy_status": "activity_backed_attention_cluster_only_total_token_energy_incomplete",
+        "attention_cluster_service_window_leakage_energy_mj_per_token": leakage_j * 1.0e3,
+        "attention_cluster_modeled_service_energy_mj_per_token": component_energy_j * 1.0e3,
+        "energy_status": (
+            "activity_backed_attention_cluster_service_windows_only_"
+            "total_token_energy_incomplete"
+        ),
     }
 
 
@@ -178,14 +268,14 @@ def _pareto(rows: list[JsonDict]) -> list[JsonDict]:
             and float(other["latency_us"]) <= float(row["latency_us"])
             and float(other["embodied_logic_plus_shared_sram_area_mm2"])
             <= float(row["embodied_logic_plus_shared_sram_area_mm2"])
-            and float(other["attention_cluster_energy_mj_per_token"])
-            <= float(row["attention_cluster_energy_mj_per_token"])
+            and float(other["attention_cluster_modeled_service_energy_mj_per_token"])
+            <= float(row["attention_cluster_modeled_service_energy_mj_per_token"])
             and (
                 float(other["latency_us"]) < float(row["latency_us"])
                 or float(other["embodied_logic_plus_shared_sram_area_mm2"])
                 < float(row["embodied_logic_plus_shared_sram_area_mm2"])
-                or float(other["attention_cluster_energy_mj_per_token"])
-                < float(row["attention_cluster_energy_mj_per_token"])
+                or float(other["attention_cluster_modeled_service_energy_mj_per_token"])
+                < float(row["attention_cluster_modeled_service_energy_mj_per_token"])
             )
             for other in feasible
         )
@@ -199,21 +289,28 @@ def build_report(
 ) -> JsonDict:
     prior = _load(prior_frontier_json)
     activity_report = _load(activity_power_json)
-    if not activity_report.get("promotion_gate_pass"):
-        raise ValueError("activity-power promotion gate did not pass")
-    best = activity_report.get("best")
-    if not isinstance(best, dict) or not isinstance(best.get("ppa_metric"), dict) or not isinstance(
-        best.get("activity_power"), dict
-    ):
-        raise ValueError("activity-power report lacks a promoted best candidate")
+    best = _validated_activity_best(activity_report)
     schedule, schedule_source = _source_schedule(prior, prior_frontier_json)
-    if int(schedule["hidden_size"]) != 4096 or int(schedule["attention_heads"]) != 32:
+    hidden = _positive_int(schedule["hidden_size"], "hidden size")
+    heads = _positive_int(schedule["attention_heads"], "attention heads")
+    _positive_int(schedule["sequence_length"], "sequence length")
+    _positive_int(schedule["layers"], "layers")
+    _positive_int(schedule["kv_heads"], "KV heads")
+    if hidden != 4096 or heads != 32:
         raise ValueError("frontier is not the expected Llama7B 4096D/32-head schedule")
+    validated_cluster_counts = [
+        _positive_int(count, "cluster count") for count in cluster_counts
+    ]
+    for count in validated_cluster_counts:
+        if count > heads:
+            raise ValueError(f"cluster count must be in [1, {heads}]")
+        if heads % count != 0:
+            raise ValueError(f"cluster count {count} does not divide {heads} heads")
     dense_tile = prior.get("dense_qkv_tile")
     if not isinstance(dense_tile, dict):
         raise ValueError("prior frontier lacks measured dense_qkv_tile evidence")
     activity = best["activity_power"]
-    command_cycles = int(activity["full_context_cycles"])
+    command_cycles = _positive_int(activity["full_context_cycles"], "full-context cycles")
     activity_clock_ns = _positive(
         activity.get(
             "clock_period_ns",
@@ -238,7 +335,7 @@ def build_report(
             energy=energy,
             dense_tile=dense_tile,
         )
-        for count in cluster_counts
+        for count in validated_cluster_counts
     ]
     pareto_rows = _pareto(rows)
     if not pareto_rows:
@@ -274,11 +371,11 @@ def build_report(
         },
         "dense_qkv_tile": dense_tile,
         "precision": {
-            "status": activity_report.get("precision_status"),
-            "equivalence_pass": equivalence.get("equivalence_pass"),
-            "decision": equivalence.get("decision"),
-            "score_tensor_hash": equivalence.get("score_tensor_hash"),
-            "final_tensor_hash": equivalence.get("final_tensor_hash"),
+            "status": _EXPECTED_PRECISION_STATUS,
+            "equivalence_pass": True,
+            "decision": _EXPECTED_EQUIVALENCE_DECISION,
+            "score_tensor_hash": str(equivalence["score_tensor_hash"]).strip(),
+            "final_tensor_hash": str(equivalence["final_tensor_hash"]).strip(),
             "quality_change": "none_exact_integer_semantics_preserved",
         },
         "rows": rows,
@@ -299,7 +396,8 @@ def build_report(
             "Score multiplier and shift derivation remain external to the cluster boundary.",
             (
                 "Total token energy is incomplete; only activity-backed attention-cluster "
-                "energy is reported."
+                "dynamic energy and service-window leakage are reported. Leakage outside "
+                "the modeled cluster service windows is not included."
             ),
             (
                 "Sequence sharding and cross-cluster head reduction are not implemented, "
@@ -317,12 +415,19 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
         f"- decision: `{payload['decision']}`",
         f"- best measured-component throughput: `{best['token_throughput_per_s']}` token/s",
         f"- best measured-component area: `{best['embodied_logic_plus_shared_sram_area_mm2']}` mm2",
-        f"- attention-cluster energy: `{best['attention_cluster_energy_mj_per_token']}` mJ/token",
+        (
+            "- attention-cluster modeled-service energy: "
+            f"`{best['attention_cluster_modeled_service_energy_mj_per_token']}` mJ/token"
+        ),
+        (
+            "- attention-cluster service-window leakage: "
+            f"`{best['attention_cluster_service_window_leakage_energy_mj_per_token']}` mJ/token"
+        ),
         "- total-token energy: `incomplete`",
         "",
         (
             "| candidate | clusters | waves/layer | QKV tiles | latency us | token/s | "
-            "area mm2 | cluster mJ/token |"
+            "area mm2 | modeled service mJ/token |"
         ),
         "|---|---:|---:|---:|---:|---:|---:|---:|",
     ]
@@ -332,7 +437,7 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
             f"{row['cluster_waves_per_layer']} | {row['dense_qkv_tile_count']} | "
             f"{row['latency_us']} | {row['token_throughput_per_s']} | "
             f"{row['embodied_logic_plus_shared_sram_area_mm2']} | "
-            f"{row['attention_cluster_energy_mj_per_token']} |"
+            f"{row['attention_cluster_modeled_service_energy_mj_per_token']} |"
         )
     lines.extend(["", "## Remaining Abstractions", ""])
     lines.extend(f"- {item}" for item in payload["remaining_abstractions"])

--- a/tests/test_attention_decode_score_multivalue_cluster_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_frontier.py
@@ -63,19 +63,24 @@ def _inputs(tmp_path: Path) -> tuple[Path, Path]:
     activity = _write(
         tmp_path / "activity.json",
         {
+            "model": "decoder_attention_decode_score_multivalue_cluster_activity_power_v1",
+            "decision": "activity_backed_cluster_power_measured",
             "promotion_gate_pass": True,
-            "precision_status": "exact",
+            "precision_status": "unchanged_integer_contract_from_merged_multivalue_equivalence",
             "equivalence": {
                 "equivalence_pass": True,
-                "decision": "pass",
+                "decision": "decode_score_multivalue_cluster_equivalence_pass",
                 "score_tensor_hash": "score",
                 "final_tensor_hash": "final",
             },
+            "best_candidate_id": "cluster",
             "best": {
                 "candidate_id": "cluster",
                 "flow_variant": "v1",
+                "status": "activity_backed",
                 "ppa_metric": {"instance_area_um2": "2000000", "critical_path_ns": "7.5"},
                 "activity_power": {
+                    "promotion_gate_pass": True,
                     "clock_period_ns": 8.0,
                     "full_context_cycles": 300,
                     "full_context_energy_j": energy,
@@ -106,9 +111,12 @@ def test_recost_uses_full_head_commands_activity_energy_and_linked_schedule(tmp_
     assert rows[1]["attention_cluster_dynamic_energy_mj_per_token"] == pytest.approx(
         rows[32]["attention_cluster_dynamic_energy_mj_per_token"]
     )
-    assert rows[1]["attention_cluster_leakage_energy_mj_per_token"] == pytest.approx(
-        rows[32]["attention_cluster_leakage_energy_mj_per_token"]
+    assert rows[1]["attention_cluster_service_window_leakage_energy_mj_per_token"] == pytest.approx(
+        rows[32]["attention_cluster_service_window_leakage_energy_mj_per_token"]
     )
+    assert "attention_cluster_leakage_energy_mj_per_token" not in rows[32]
+    assert "service_windows_only" in rows[32]["energy_status"]
+    assert report["precision"]["decision"] == "decode_score_multivalue_cluster_equivalence_pass"
     assert report["precision"]["final_tensor_hash"] == "final"
     assert report["promotion_status"].endswith("full_architecture_promotion_blocked")
 
@@ -124,3 +132,130 @@ def test_recost_rejects_unpromoted_activity_and_unsupported_cluster_count(tmp_pa
     _, activity = _inputs(tmp_path)
     with pytest.raises(ValueError, match="cluster count"):
         build_report(prior_frontier_json=prior, activity_power_json=activity, cluster_counts=[64])
+
+
+def test_recost_reserves_retained_noncompute_logic_from_compute_budget(tmp_path: Path) -> None:
+    prior, activity = _inputs(tmp_path)
+    prior_payload = json.loads(prior.read_text(encoding="utf-8"))
+    source = Path(prior_payload["inputs"]["prior_frontier_json"])
+    source_payload = json.loads(source.read_text(encoding="utf-8"))
+    source_payload["source_schedule"].update(
+        {
+            "compute_budget_um2": 10_000_000,
+            "logic_area_used_um2": 4_000_000,
+            "compute_area_um2": 1_000_000,
+        }
+    )
+    source.write_text(json.dumps(source_payload), encoding="utf-8")
+    prior_payload["dense_qkv_tile"]["area_um2"] = 1_000_000
+    prior.write_text(json.dumps(prior_payload), encoding="utf-8")
+
+    report = build_report(
+        prior_frontier_json=prior,
+        activity_power_json=activity,
+        cluster_counts=[1],
+    )
+
+    row = report["rows"][0]
+    assert row["retained_noncompute_logic_area_mm2"] == 3.0
+    assert row["dense_qkv_tile_count"] == 5
+    assert row["compute_budget_slack_mm2"] == 0.0
+    assert row["logic_area_mm2"] == 10.0
+    assert row["compute_budget_area_fit"] is True
+
+
+@pytest.mark.parametrize(
+    ("field_path", "bad_value", "message"),
+    [
+        (("model",), "wrong-model", "unexpected model"),
+        (("decision",), "wrong-decision", "unexpected decision"),
+        (("best_candidate_id",), "other", "identity does not match"),
+        (("best", "status"), "rejected_gate", "not activity-backed"),
+        (
+            ("best", "activity_power", "promotion_gate_pass"),
+            False,
+            "best candidate promotion gate",
+        ),
+        (("precision_status",), "exact", "unexpected precision status"),
+        (("equivalence", "equivalence_pass"), False, "equivalence did not pass"),
+        (("equivalence", "decision"), "wrong", "equivalence has an unexpected decision"),
+        (("equivalence", "score_tensor_hash"), "", "lacks score_tensor_hash"),
+        (("equivalence", "final_tensor_hash"), "  ", "lacks final_tensor_hash"),
+    ],
+)
+def test_recost_rejects_invalid_activity_promotion_contract(
+    tmp_path: Path,
+    field_path: tuple[str, ...],
+    bad_value: object,
+    message: str,
+) -> None:
+    prior, activity = _inputs(tmp_path)
+    payload = json.loads(activity.read_text(encoding="utf-8"))
+    target = payload
+    for field in field_path[:-1]:
+        target = target[field]
+    target[field_path[-1]] = bad_value
+    activity.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        build_report(
+            prior_frontier_json=prior,
+            activity_power_json=activity,
+            cluster_counts=[1],
+        )
+
+
+def test_recost_rejects_schedule_clock_slower_than_activity_clock(tmp_path: Path) -> None:
+    prior, activity = _inputs(tmp_path)
+    prior_payload = json.loads(prior.read_text(encoding="utf-8"))
+    source = Path(prior_payload["inputs"]["prior_frontier_json"])
+    source_payload = json.loads(source.read_text(encoding="utf-8"))
+    source_payload["source_schedule"]["clock_ns"] = 9.0
+    source.write_text(json.dumps(source_payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="schedule clock is slower"):
+        build_report(
+            prior_frontier_json=prior,
+            activity_power_json=activity,
+            cluster_counts=[1],
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_path", "bad_value"),
+    [
+        (("best", "activity_power", "full_context_cycles"), 0),
+        (("best", "activity_power", "full_context_cycles"), 300.5),
+        (("best", "activity_power", "phases", 0, "full_context_cycles"), 0),
+        (("best", "activity_power", "phases", 0, "full_context_cycles"), 200.5),
+    ],
+)
+def test_recost_rejects_nonpositive_or_fractional_activity_cycles(
+    tmp_path: Path,
+    field_path: tuple[object, ...],
+    bad_value: object,
+) -> None:
+    prior, activity = _inputs(tmp_path)
+    payload = json.loads(activity.read_text(encoding="utf-8"))
+    target = payload
+    for field in field_path[:-1]:
+        target = target[field]
+    target[field_path[-1]] = bad_value
+    activity.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        build_report(
+            prior_frontier_json=prior,
+            activity_power_json=activity,
+            cluster_counts=[1],
+        )
+
+
+def test_recost_rejects_nondivisor_cluster_count(tmp_path: Path) -> None:
+    prior, activity = _inputs(tmp_path)
+    with pytest.raises(ValueError, match="does not divide 32 heads"):
+        build_report(
+            prior_frontier_json=prior,
+            activity_power_json=activity,
+            cluster_counts=[3],
+        )


### PR DESCRIPTION
## Summary

- reserve retained noncompute logic before sizing dense QKV capacity and calculating area fit/slack
- fail closed on the activity report model, decision, selected candidate, nested promotion gate, equivalence result, and tensor hashes
- reject slower schedule clocks, invalid cycle counts, and non-divisor cluster counts without an explicit idle policy
- scope leakage and composed energy naming to modeled cluster service windows

## Root cause

The frontier recost trusted a shallow top-level promotion bit, allowed cycle truncation and clock substitution, and treated the total logic budget as fully available to compute. That could promote rows using invalid activity evidence or overstated dense-tile capacity.

## Validation

- `PYTHONPATH=. pytest -q tests/test_attention_decode_score_multivalue_cluster_frontier.py` (`20 passed in 0.06s`)
- `python3 -m py_compile npu/eval/audit_attention_decode_score_multivalue_cluster_frontier.py tests/test_attention_decode_score_multivalue_cluster_frontier.py`
- `git diff --check`

No evaluation jobs were dispatched.