### PR TITLE
Add targeted binary activity-power v15

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -31,15 +31,59 @@ class Layer2TaskGenerationError(RuntimeError):
 _RETRY_SUFFIX_RE = re.compile(r"_r\d+$")
 _VERSION_SUFFIX_RE = re.compile(r"_v(\d+)$")
 _GQA_FOLDED_ACTIVITY_LANES_RE = re.compile(r"_gqa8_folded_lanes(1|2|4|8)_activity_power_")
-_CLUSTER_ACTIVITY_POWER_STRICT_REVISION = 14
-_CLUSTER_ACTIVITY_POWER_V14_FLOW_VARIANT = (
-    "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500"
-)
-_CLUSTER_ACTIVITY_POWER_V14_SYNTH_ARGS = "-nofsm"
-_CLUSTER_ACTIVITY_POWER_V14_PNR_ITEM = (
-    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3"
-)
-_CLUSTER_ACTIVITY_POWER_V14_MIN_SEQUENTIAL_REGISTER_ACTIVITY_COVERAGE = 1.0
+
+
+@dataclass(frozen=True)
+class _ClusterActivityPowerStrictProfile:
+    config_path: str
+    flow_variant: str
+    synth_args: str
+    source_pnr_item_id: str
+    min_sequential_register_activity_coverage: float
+    binary_fsm_diagnostic_path: str | None = None
+    binary_fsm_profile: str | None = None
+
+
+_CLUSTER_ACTIVITY_POWER_STRICT_PROFILES = {
+    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14": (
+        _ClusterActivityPowerStrictProfile(
+            config_path=(
+                "runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+            ),
+            flow_variant="decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500",
+            synth_args="-nofsm",
+            source_pnr_item_id=(
+                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3"
+            ),
+            min_sequential_register_activity_coverage=1.0,
+        )
+    ),
+    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15": (
+        _ClusterActivityPowerStrictProfile(
+            config_path=(
+                "runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+                "config_targeted_binary_fsm.json"
+            ),
+            flow_variant=(
+                "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+            ),
+            synth_args="",
+            source_pnr_item_id=(
+                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_"
+                "targeted_binary_fsm_8ns_v1"
+            ),
+            min_sequential_register_activity_coverage=1.0,
+            binary_fsm_diagnostic_path=(
+                "runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+                "targeted_binary_fsm_diagnostic.json"
+            ),
+            binary_fsm_profile="targeted_binary",
+        )
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -104,18 +148,15 @@ def _gqa_evidence_version_for_consumer(item_id: str) -> str:
     return "v2" if revision >= 2 else "v1"
 
 
-def _cluster_activity_power_revision(item_id: str) -> int:
-    match = _VERSION_SUFFIX_RE.search(_retry_base(item_id))
-    return int(match.group(1)) if match else 1
-
-
 def _gqa_group_equivalence_item_for_consumer(item_id: str) -> str:
     version = _gqa_evidence_version_for_consumer(item_id)
     return f"l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_{version}"
 
 
-def _cluster_activity_power_requires_strict_selection(item_id: str) -> bool:
-    return _cluster_activity_power_revision(item_id) >= _CLUSTER_ACTIVITY_POWER_STRICT_REVISION
+def _cluster_activity_power_strict_profile(
+    item_id: str,
+) -> _ClusterActivityPowerStrictProfile | None:
+    return _CLUSTER_ACTIVITY_POWER_STRICT_PROFILES.get(_retry_base(item_id))
 
 
 def _cluster_activity_power_item_for_consumer(
@@ -6886,8 +6927,8 @@ def _decoder_attention_decode_score_multivalue_gqa_array_equivalence_evidence(
 
 def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
-    require_exact_row = _cluster_activity_power_requires_strict_selection(item_id)
-    config = (
+    strict_profile = _cluster_activity_power_strict_profile(item_id)
+    config = strict_profile.config_path if strict_profile is not None else (
         "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
         "config.json"
     )
@@ -6906,16 +6947,18 @@ def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*
     activity_dir = "/tmp/rtlgen_multivalue_cluster_activity"
     out = f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__{item_id}.json"
     report = f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__{item_id}.md"
-    required_flow_variant = (
-        _CLUSTER_ACTIVITY_POWER_V14_FLOW_VARIANT if require_exact_row else None
-    )
-    required_synth_args = _CLUSTER_ACTIVITY_POWER_V14_SYNTH_ARGS if require_exact_row else None
-    source_pnr_item_id = _CLUSTER_ACTIVITY_POWER_V14_PNR_ITEM if require_exact_row else None
+    required_flow_variant = strict_profile.flow_variant if strict_profile is not None else None
+    required_synth_args = strict_profile.synth_args if strict_profile is not None else None
+    source_pnr_item_id = strict_profile.source_pnr_item_id if strict_profile is not None else None
     min_seq_register_activity_coverage = (
-        _CLUSTER_ACTIVITY_POWER_V14_MIN_SEQUENTIAL_REGISTER_ACTIVITY_COVERAGE
-        if require_exact_row
+        strict_profile.min_sequential_register_activity_coverage
+        if strict_profile is not None
         else None
     )
+    binary_fsm_diagnostic_path = (
+        strict_profile.binary_fsm_diagnostic_path if strict_profile is not None else None
+    )
+    binary_fsm_profile = strict_profile.binary_fsm_profile if strict_profile is not None else None
     command_args: list[str] = []
     if required_flow_variant is not None:
         command_args.append(f"--required-flow-variant {required_flow_variant}")
@@ -6927,6 +6970,10 @@ def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*
         command_args.append(
             f"--min-sequential-register-activity-coverage {min_seq_register_activity_coverage}"
         )
+    if binary_fsm_diagnostic_path is not None:
+        command_args.append(f"--binary-fsm-diagnostic {binary_fsm_diagnostic_path}")
+    if binary_fsm_profile is not None:
+        command_args.append(f"--required-binary-fsm-profile {binary_fsm_profile}")
     command_args_text = (" ".join(command_args) + " ") if command_args else ""
     inputs = {
         "decode_score_multivalue_cluster_config": config,
@@ -6958,6 +7005,12 @@ def _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(*
         inputs["decode_score_multivalue_cluster_min_sequential_register_activity_coverage"] = (
             min_seq_register_activity_coverage
         )
+    if binary_fsm_diagnostic_path is not None:
+        inputs["decode_score_multivalue_cluster_binary_fsm_diagnostic"] = (
+            binary_fsm_diagnostic_path
+        )
+    if binary_fsm_profile is not None:
+        inputs["decode_score_multivalue_cluster_required_binary_fsm_profile"] = binary_fsm_profile
     return {
         "inputs": inputs,
         "commands": [

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8302,6 +8302,77 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
 
 
+def test_generate_l2_campaign_task_adds_targeted_cluster_activity_power_v15_for_retries() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            for item_id in (
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15",
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15_r1",
+            ):
+                result = generate_l2_campaign_task(
+                    session,
+                    Layer2CampaignGenerateRequest(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        item_id=item_id,
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        abstraction_layer="decoder_attention_decode_score_multivalue_cluster_activity_power",
+                        evaluation_mode="frontier_detail",
+                        run_physical=False,
+                    ),
+                )
+
+                work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+                run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+                decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+                assert (
+                    "--config runs/designs/npu_blocks/"
+                    "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+                    "config_targeted_binary_fsm.json"
+                    in run
+                )
+                assert (
+                    "--required-flow-variant "
+                    "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+                    in run
+                )
+                assert "--required-synth-args=" in run
+                assert "--required-synth-args=-nofsm" not in run
+                assert "--required-binary-fsm-profile targeted_binary" in run
+                assert (
+                    "--binary-fsm-diagnostic runs/designs/npu_blocks/"
+                    "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+                    "targeted_binary_fsm_diagnostic.json"
+                    in run
+                )
+                assert "--min-sequential-register-activity-coverage 1.0" in run
+                assert (
+                    "--source-pnr-item-id "
+                    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_"
+                    "targeted_binary_fsm_8ns_v1"
+                    in run
+                )
+                assert decoder_inputs["decode_score_multivalue_cluster_required_synth_args"] == ""
+                assert (
+                    decoder_inputs["decode_score_multivalue_cluster_required_binary_fsm_profile"]
+                    == "targeted_binary"
+                )
+                assert (
+                    decoder_inputs["decode_score_multivalue_cluster_source_pnr_item_id"]
+                    == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_"
+                    "targeted_binary_fsm_8ns_v1"
+                )
+
+
 def test_cluster_activity_power_item_for_consumer_prefers_requested_version_for_unknown_depends_on() -> None:
     assert (
         _cluster_activity_power_item_for_consumer(
@@ -8329,20 +8400,45 @@ def test_cluster_activity_power_item_for_consumer_prefers_requested_version_for_
     )
 
 
-def test_cluster_activity_power_item_for_consumer_selects_v14_for_cluster_frontier() -> None:
+def test_cluster_activity_power_item_for_consumer_selects_v15_for_cluster_frontier() -> None:
     assert (
         _cluster_activity_power_item_for_consumer(
             item_id="l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
             depends_on_item_ids=[
                 "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14",
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15",
             ],
         )
-        == "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        == "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
     )
 
 
-def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v14() -> None:
+def test_cluster_frontier_request_manifests_require_cluster_activity_power_v15() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1"
+    )
+    required_dependency = (
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
+    )
+
+    for manifest_name, items_key in (
+        ("proposal.json", "required_evaluations"),
+        ("evaluation_requests.json", "requested_items"),
+    ):
+        manifest = json.loads((proposal_dir / manifest_name).read_text(encoding="utf-8"))
+        frontier = next(
+            item
+            for item in manifest[items_key]
+            if item["item_id"]
+            == "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1"
+        )
+        assert required_dependency in frontier["depends_on_item_ids"]
+        assert all("llama7b_v14" not in item for item in frontier["depends_on_item_ids"])
+
+
+def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v15() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (
         repo_root
@@ -8353,7 +8449,7 @@ def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v1
         for lanes in (1, 2, 4)
     }
     required_dependency = (
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
     )
 
     for manifest_name, items_key in (
@@ -8373,6 +8469,11 @@ def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v1
         )
         assert all(
             "llama7b_v13" not in dependency
+            for item in activity_items.values()
+            for dependency in item["depends_on_item_ids"]
+        )
+        assert all(
+            "llama7b_v14" not in dependency
             for item in activity_items.values()
             for dependency in item["depends_on_item_ids"]
         )

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_gate.md
@@ -1,7 +1,7 @@
 # Evaluation Gate
 
-1. Queue v14 only after merged
-   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3` and
+1. Queue v15 only after merged, promotion-valid
+   `l1_decoder_attention_decode_score_multivalue_cluster_pnr_targeted_binary_fsm_8ns_v1` and
    `l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1`
    evidence is available.
 2. Run the activity-power audit on the remote evaluator with evaluator-local
@@ -12,11 +12,13 @@
    silicon-current claim is allowed from LEF/LIB proxy views.
 5. Treat vectorless OpenROAD power as structural diagnostics only. It cannot
    substitute for activity-backed power or token-energy claims.
-6. Select only
-   `decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500` with
-   `SYNTH_ARGS=-nofsm`; the one-hot v2 row remains a PPA baseline but is invalid
-   for bit-exact RTL-to-routed FSM activity transfer.
+6. Select only `config_targeted_binary_fsm.json` with
+   `decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500`,
+   empty/default `SYNTH_ARGS`, and the exact promotion-valid `targeted_binary`
+   checker diagnostic bound to the selected metrics hashes. The v14 `-nofsm`
+   row and prior one-hot rows are invalid for this consumer.
 7. Require 100% routed sequential Q/QN coverage, applied assignments equal to
    matched assignments, zero query/apply errors, and finite positive power for
    every phase. Preserve the merged 10 ns and one-hot 8 ns rows as prior PPA
-   evidence rather than reusing them for v14 power.
+   evidence rather than reusing them for v15 power. Reject vectorless,
+   stale-row, baseline, or fallback substitutions.

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "PR #1413 merged complete block_weight VCD/FSM provenance, PR #1414 merged the binary-FSM PNR point, and PR #1415 merged strict v14 row selection and 100% routed-state coverage. v3_r2 was superseded because it reused the same sweep hash. V14 now depends on `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3`; neither this retry implementation nor its result is claimed merged here.",
+  "source_commit_note": "Merge 5e9a1024 adds the targeted-binary L1 candidate and strict diagnostic profile, but no targeted PPA result is claimed here. v14 was never launched and is superseded before dispatch. Keep v15 pending until `l1_decoder_attention_decode_score_multivalue_cluster_pnr_targeted_binary_fsm_8ns_v1` passes and is merged/materialized; this proposal change does not generate or dispatch a control-plane item.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -464,8 +464,37 @@
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
         "reason": "Rerun preserves all existing direct-VCD, macro, clock, numeric, artifact, applied==matched, and zero query/apply-error gates; strengthens DFF-output coverage to 1.0; and forbids clamping, substitution, heuristic activity, or other gate relaxation. It selects only decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500 with SYNTH_ARGS=-nofsm."
       },
-      "status": "pending_implementation_merge",
-      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3"
+      "status": "superseded_before_dispatch",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3",
+      "retracted_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15",
+      "retraction_reason": "replace_global_nofsm_candidate_with_targeted_binary_fsm_candidate",
+      "notes": "v14 was never generated or dispatched and must not be reused for the targeted-binary consumer."
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15",
+      "task_type": "l2_campaign",
+      "objective": "Measure shared-score multivalue-cluster activity-backed power only after the targeted-binary 8ns PNR item passes, using config_targeted_binary_fsm.json, decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500, normal empty SYNTH_ARGS, and the promotion-valid targeted_binary diagnostic. Preserve exact merged equivalence linkage, direct routed sequential activity, 100% sequential coverage, and finite power for every required phase.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_targeted_binary_fsm_8ns_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "targeted_binary_fsm_postroute_activity_mapping",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "v15 accepts only the exact targeted config and flow, empty/default SYNTH_ARGS, a promotion-valid targeted_binary checker diagnostic bound to the selected metrics hashes, direct routed phase VCD power, 100% sequential coverage with complete applied/matched assignments, and finite positive required-phase power. Vectorless, v14, stale-row, baseline, and fallback evidence remain non-promotable."
+      },
+      "status": "pending_targeted_ppa_merge",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_targeted_binary_fsm_8ns_v1"
     }
   ],
   "source_commit": "b968b50997ff980dd0a367ff0fe7c98d4f89b7fb"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -416,11 +416,41 @@
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
         "reason": "v14 preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, strengthens DFF-output coverage to 1.0, requires applied==matched and zero query/apply errors, and keeps all sidecar rows evaluator-local while forbidding clamping, substitution, heuristic activity, and other gate relaxation. It selects only decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500 with SYNTH_ARGS=-nofsm."
       },
-      "status": "pending_implementation_merge"
+      "status": "superseded_before_dispatch",
+      "retracted_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15",
+      "retraction_reason": "replace_global_nofsm_candidate_with_targeted_binary_fsm_candidate",
+      "notes": "v14 was never launched. It remains immutable history for the global -nofsm candidate and must not be reused as targeted-binary evidence."
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15",
+      "task_type": "l2_campaign",
+      "objective": "Measure shared-score multivalue-cluster activity-backed power only after the targeted-binary 8ns PNR item passes, using config_targeted_binary_fsm.json, decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500, normal empty SYNTH_ARGS, and the promotion-valid targeted_binary diagnostic. Preserve exact merged equivalence linkage, direct routed sequential activity, 100% sequential coverage, and finite power for every required phase.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
+      "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_targeted_binary_fsm_8ns_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_targeted_binary_fsm_8ns_v1",
+      "revision": {
+        "reason": "targeted_binary_fsm_postroute_activity_mapping",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
+        "reason": "v15 accepts only the exact targeted config and flow, empty/default SYNTH_ARGS, a promotion-valid targeted_binary checker diagnostic bound to the selected metrics hashes, direct routed phase VCD power, 100% sequential coverage with complete applied/matched assignments, and finite positive required-phase power. Vectorless, v14, stale-row, baseline, and fallback evidence remain non-promotable."
+      },
+      "status": "pending_targeted_ppa_merge"
     }
   ],
   "baseline_refs": [
     "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json",
+    "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config_targeted_binary_fsm.json",
     "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv",
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json",
     "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
   "source_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
-  "source_commit_note": "Keep this evidence-only frontier recost pending until strict shared-score multivalue activity-power v14 is merged and its evidence is materialized. Activity-power v13 is invalid and must not be consumed; this request does not claim that v14 evidence exists.",
+  "source_commit_note": "Keep this evidence-only frontier recost pending until targeted-binary strict activity-power v15 is merged and its evidence is materialized. Activity-power v13 is invalid and v14 was superseded before dispatch; this request does not claim that v15 evidence exists.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
@@ -13,13 +13,13 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "recast_shared_score_multivalue_cluster_frontier",
-        "reason": "Keep this frontier pending until strict activity-power v14 is merged and materialized; only then may ranking charge exact full-head cycles, valid measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
+        "reason": "Keep this frontier pending until targeted-binary strict activity-power v15 is merged and materialized; only then may ranking charge exact full-head cycles, valid measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
       },
       "status": "pending_implementation_merge"
     }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
@@ -57,13 +57,13 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "recast_shared_score_multivalue_cluster_frontier",
-        "reason": "Keep this frontier pending until strict activity-power v14 is merged and materialized; only then may ranking charge exact full-head cycles, valid measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
+        "reason": "Keep this frontier pending until targeted-binary strict activity-power v15 is merged and materialized; only then may ranking charge exact full-head cycles, valid measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
       },
       "status": "pending_implementation_merge"
     }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1",
   "source_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
-  "source_commit_note": "Keep folded-lane activity tasks pending until strict shared-score activity-power v14 is merged and its evidence is materialized. Activity-power v13 is invalid and must not be consumed; this request does not claim that v14 evidence exists.",
+  "source_commit_note": "Keep folded-lane activity tasks pending until targeted-binary strict shared-score activity-power v15 is merged and its evidence is materialized. Activity-power v13 is invalid and v14 was superseded before dispatch; this request does not claim that v15 evidence exists.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_gqa8_group_equivalence_llama7b_v1",
@@ -201,13 +201,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes1_direct_activity_energy",
-        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the minimum-area point then needs routed, phase-accounted energy with all eight waves charged."
+        "reason": "Keep this activity item pending until targeted-binary strict cluster activity-power v15 is merged and materialized; the minimum-area point then needs routed, phase-accounted energy with all eight waves charged."
       },
       "status": "pending_implementation_merge"
     },
@@ -221,13 +221,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes2_direct_activity_energy",
-        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the first lane-parallel midpoint then needs routed energy rather than linear scaling from one lane."
+        "reason": "Keep this activity item pending until targeted-binary strict cluster activity-power v15 is merged and materialized; the first lane-parallel midpoint then needs routed energy rather than linear scaling from one lane."
       },
       "status": "pending_implementation_merge"
     },
@@ -241,13 +241,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes4_direct_activity_energy",
-        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the near-parallel point then needs routed energy before it can trade area for latency."
+        "reason": "Keep this activity item pending until targeted-binary strict cluster activity-power v15 is merged and materialized; the near-parallel point then needs routed energy before it can trade area for latency."
       },
       "status": "pending_implementation_merge"
     },

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_gqa8_group_llama7b_v1/proposal.json
@@ -222,13 +222,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes1_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes1_direct_activity_energy",
-        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the minimum-area point then needs direct phase-accounted energy rather than vectorless power."
+        "reason": "Keep this activity item pending until targeted-binary strict cluster activity-power v15 is merged and materialized; the minimum-area point then needs direct phase-accounted energy rather than vectorless power."
       },
       "status": "pending_control_plane_merge"
     },
@@ -242,13 +242,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes2_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes2_direct_activity_energy",
-        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the midpoint then needs direct routed energy instead of linear lane scaling."
+        "reason": "Keep this activity item pending until targeted-binary strict cluster activity-power v15 is merged and materialized; the midpoint then needs direct routed energy instead of linear lane scaling."
       },
       "status": "pending_control_plane_merge"
     },
@@ -262,13 +262,13 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_gqa8_folded_lane_equivalence_llama7b_v1",
         "l1_decoder_attention_decode_score_multivalue_gqa8_folded_lanes4_pnr_v1",
-        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v14"
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v15"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "measure_folded_lanes4_direct_activity_energy",
-        "reason": "Keep this activity item pending until strict cluster activity-power v14 is merged and materialized; the near-parallel point then needs direct routed energy before trading area for latency."
+        "reason": "Keep this activity item pending until targeted-binary strict cluster activity-power v15 is merged and materialized; the near-parallel point then needs direct routed energy before trading area for latency."
       },
       "status": "pending_control_plane_merge"
     },

--- a/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
@@ -24,6 +24,19 @@ _MAX_FAILURE_DETAIL_BYTES = 4096
 _ABSOLUTE_PATH_RE = re.compile(r"/[^\s\"'`<>|&(){}\[\]]+")
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _EVALUATOR_LOCAL_PATH_PLACEHOLDER = "<evaluator-local-path>"
+_TARGETED_BINARY_FSM_PROFILE = "targeted_binary"
+_TARGETED_BINARY_FSM_CHECKER = "attention_decode_score_multivalue_cluster_targeted_binary_fsm_v1"
+_TARGETED_BINARY_FSM_FLOW_VARIANT = (
+    "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+)
+_TARGETED_BINARY_FSM_CONFIG = (
+    "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+    "config_targeted_binary_fsm.json"
+)
+_TARGETED_BINARY_FSM_PNR_ITEM = (
+    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_targeted_binary_fsm_8ns_v1"
+)
+_POWER_COMPONENTS = ("internal_w", "switching_w", "leakage_w", "total_w")
 
 
 def _redact_path(path: str) -> str:
@@ -91,7 +104,7 @@ def _metric_provenance(row: JsonDict, metrics_csv: Path) -> JsonDict:
         "params_json",
     )
     return {
-        "metrics_csv": str(metrics_csv),
+        "metrics_csv": _redact_path(str(metrics_csv)),
         **{field: row[field] for field in fields if str(row.get(field, "")).strip()},
     }
 
@@ -104,7 +117,9 @@ def _feasible_metrics(
     required_synth_args: str | None = None,
 ) -> list[JsonDict]:
     normalized_required_flow_variant = str(required_flow_variant or "").strip() or None
-    normalized_required_synth_args = str(required_synth_args or "").strip() or None
+    normalized_required_synth_args = (
+        None if required_synth_args is None else str(required_synth_args).strip()
+    )
 
     with metrics_csv.open(newline="", encoding="utf-8") as handle:
         raw_rows = [dict(row) for row in csv.DictReader(handle)]
@@ -142,7 +157,7 @@ def _feasible_metrics(
             if normalized_required_flow_variant is not None:
                 details.append(f"FLOW_VARIANT={normalized_required_flow_variant}")
             if normalized_required_synth_args is not None:
-                details.append(f"SYNTH_ARGS={normalized_required_synth_args}")
+                details.append(f"SYNTH_ARGS={normalized_required_synth_args or '<empty/default>'}")
             raise ValueError(
                 f"no status=ok timing-feasible rows in {metrics_csv} matching "
                 f"{', '.join(details)} at {clock_period_ns:g} ns"
@@ -158,6 +173,147 @@ def _feasible_metrics(
             float(row.get("critical_path_ns") or math.inf),
         ),
     )
+
+
+def _validate_targeted_binary_fsm_diagnostic(
+    path: Path,
+    *,
+    required_profile: str,
+    required_flow_variant: str | None,
+    required_synth_args: str | None,
+) -> JsonDict:
+    if required_profile != _TARGETED_BINARY_FSM_PROFILE:
+        raise ValueError(f"unsupported binary-FSM diagnostic profile: {required_profile}")
+    if required_flow_variant != _TARGETED_BINARY_FSM_FLOW_VARIANT:
+        raise ValueError("targeted binary-FSM diagnostic requires the exact targeted FLOW_VARIANT")
+    if required_synth_args != "":
+        raise ValueError("targeted binary-FSM diagnostic requires empty/default SYNTH_ARGS")
+
+    diagnostic = _load(path)
+    selected = diagnostic.get("selected_exact_row")
+    if not isinstance(selected, dict):
+        raise ValueError("binary-FSM diagnostic has no selected exact row")
+    checks = {
+        "profile": diagnostic.get("profile") == _TARGETED_BINARY_FSM_PROFILE,
+        "checker": diagnostic.get("checker") == _TARGETED_BINARY_FSM_CHECKER,
+        "expected_flow_variant": (
+            diagnostic.get("expected_flow_variant") == _TARGETED_BINARY_FSM_FLOW_VARIANT
+        ),
+        "promotion_valid": diagnostic.get("promotion_valid") is True,
+        "width_valid": diagnostic.get("width_valid") is True,
+        "selected_status": selected.get("status") == "ok",
+        "selected_flow_variant": (
+            selected.get("flow_variant") == _TARGETED_BINARY_FSM_FLOW_VARIANT
+        ),
+        "selected_synth_args": str(selected.get("synth_args") or "").strip() == "",
+        "selected_param_hash": bool(str(selected.get("param_hash") or "").strip()),
+        "selected_config_hash": bool(str(selected.get("config_hash") or "").strip()),
+    }
+    failed = [name for name, passed in checks.items() if not passed]
+    if failed:
+        raise ValueError(
+            "targeted binary-FSM diagnostic failed strict validation: " + ", ".join(failed)
+        )
+    logical_netlist = str(diagnostic.get("expected_logical_netlist_path") or "").strip()
+    if not logical_netlist or Path(logical_netlist).is_absolute():
+        raise ValueError("binary-FSM diagnostic netlist path must be nonempty and repo-portable")
+    return diagnostic
+
+
+def _validate_binary_fsm_metric_identity(diagnostic: JsonDict, metric: JsonDict) -> None:
+    selected = diagnostic.get("selected_exact_row")
+    if not isinstance(selected, dict):
+        raise TypeError("validated binary-FSM diagnostic selected row is not an object")
+    if str(metric.get("param_hash") or "").strip() != str(
+        selected.get("param_hash") or ""
+    ).strip() or str(metric.get("config_hash") or "").strip() != str(
+        selected.get("config_hash") or ""
+    ).strip():
+        raise ValueError("binary-FSM diagnostic does not match the selected PPA metrics row")
+
+
+def _validate_targeted_config(path: Path, payload: JsonDict) -> None:
+    normalized = path.as_posix()
+    if normalized != _TARGETED_BINARY_FSM_CONFIG and not normalized.endswith(
+        "/" + _TARGETED_BINARY_FSM_CONFIG
+    ):
+        raise ValueError("targeted activity power requires exact config_targeted_binary_fsm.json")
+    cluster = payload.get("attention_decode_score_multivalue_cluster")
+    if not isinstance(cluster, dict) or cluster.get("fsm_encoding") != "binary":
+        raise ValueError("targeted activity config must require binary FSM encoding")
+
+
+def _validate_strict_activity_power(
+    activity_power: JsonDict,
+    *,
+    activity_manifest: JsonDict,
+    flow_variant: str,
+    clock_period_ns: float,
+) -> None:
+    expected_phases = {
+        str(phase.get("phase", phase.get("name", ""))).strip()
+        for phase in activity_manifest.get("phases", [])
+        if isinstance(phase, dict)
+    }
+    phases = activity_power.get("phases")
+    if not expected_phases or not isinstance(phases, list):
+        raise ValueError("strict activity power requires every declared phase")
+    observed_phases = {
+        str(phase.get("phase", phase.get("name", ""))).strip()
+        for phase in phases
+        if isinstance(phase, dict)
+    }
+    if observed_phases != expected_phases or len(phases) != len(expected_phases):
+        raise ValueError("strict activity power phase set does not match the activity manifest")
+    if activity_power.get("model") != "postroute_phase_vcd_power_v1":
+        raise ValueError("strict activity power requires direct routed VCD power")
+    if activity_power.get("status") != "activity_backed":
+        raise ValueError("strict activity power status is not activity_backed")
+    if activity_power.get("promotion_gate_pass") is not True:
+        raise ValueError("strict activity power promotion gate did not pass")
+    if activity_power.get("flow_variant") != flow_variant:
+        raise ValueError("strict activity power FLOW_VARIANT does not match the selected PPA row")
+    if float(activity_power.get("clock_period_ns") or 0.0) != clock_period_ns:
+        raise ValueError("strict activity power clock does not match the selected PPA row")
+    if float(activity_power.get("min_sequential_register_activity_coverage") or 0.0) != 1.0:
+        raise ValueError("strict activity power did not require 100% sequential coverage")
+
+    for phase in phases:
+        if not isinstance(phase, dict):
+            raise ValueError("strict activity power phase is not an object")
+        phase_name = str(phase.get("phase", phase.get("name", ""))).strip()
+        if not all(
+            phase.get(gate) is True
+            for gate in (
+                "direct_vcd_annotation_pin_gate_pass",
+                "trace_coverage_gate_pass",
+                "annotation_gate_pass",
+                "sequential_register_activity_gate_pass",
+                "clock_period_gate_pass",
+                "power_numeric_gate_pass",
+                "phase_gate_pass",
+            )
+        ):
+            raise ValueError(f"strict activity gates failed for phase {phase_name}")
+        if float(phase.get("sequential_register_activity_coverage") or 0.0) != 1.0:
+            raise ValueError(f"sequential coverage is below 100% for phase {phase_name}")
+        assignments = int(phase.get("sequential_register_activity_assignment_count") or 0)
+        matched = int(phase.get("sequential_register_activity_matched_count") or 0)
+        applied = int(phase.get("sequential_register_activity_applied_count") or 0)
+        if assignments <= 0 or assignments != matched or matched != applied:
+            raise ValueError(f"sequential activity mapping is incomplete for phase {phase_name}")
+        power = phase.get("power")
+        if not isinstance(power, dict):
+            raise ValueError(f"missing routed power for phase {phase_name}")
+        for component in _POWER_COMPONENTS:
+            value = power.get(component)
+            if value is None or not math.isfinite(float(value)) or float(value) < 0.0:
+                raise ValueError(f"non-finite {component} for phase {phase_name}")
+        if float(power["total_w"]) <= 0.0:
+            raise ValueError(f"non-positive total_w for phase {phase_name}")
+    energy = activity_power.get("full_context_energy_j")
+    if energy is None or not math.isfinite(float(energy)) or float(energy) <= 0.0:
+        raise ValueError("strict activity power requires finite positive full-context energy")
 
 
 def _sanitized_failure(exc: Exception) -> JsonDict:
@@ -225,12 +381,34 @@ def build_report(
     required_flow_variant: str | None = None,
     required_synth_args: str | None = None,
     source_pnr_item_id: str | None = None,
+    binary_fsm_diagnostic: Path | None = None,
+    required_binary_fsm_profile: str | None = None,
 ) -> JsonDict:
     if not (0.0 < min_sequential_register_activity_coverage <= 1.0):
         raise ValueError("min_sequential_register_activity_coverage must be in (0, 1]")
     equivalence = _load(equivalence_json)
     if not equivalence.get("equivalence_pass"):
         raise ValueError("multivalue-cluster end-to-end equivalence did not pass")
+    if (binary_fsm_diagnostic is None) != (required_binary_fsm_profile is None):
+        raise ValueError(
+            "binary_fsm_diagnostic and required_binary_fsm_profile must be provided together"
+        )
+    binary_diagnostic = None
+    if binary_fsm_diagnostic is not None and required_binary_fsm_profile is not None:
+        if min_sequential_register_activity_coverage != 1.0:
+            raise ValueError("targeted activity power requires 100% sequential coverage")
+        if source_pnr_item_id != _TARGETED_BINARY_FSM_PNR_ITEM:
+            raise ValueError("targeted activity power requires the exact targeted-binary PNR item")
+        config_payload = _load(config)
+        _validate_targeted_config(config, config_payload)
+        binary_diagnostic = _validate_targeted_binary_fsm_diagnostic(
+            binary_fsm_diagnostic,
+            required_profile=required_binary_fsm_profile,
+            required_flow_variant=required_flow_variant,
+            required_synth_args=required_synth_args,
+        )
+    else:
+        config_payload = _load(config)
     activity_dir.mkdir(parents=True, exist_ok=True)
     for name in (
         "score_fill.vcd",
@@ -242,7 +420,7 @@ def build_report(
         if path.is_file():
             path.unlink()
     activity_manifest = generate_phase_activity(
-        _load(config),
+        config_payload,
         activity_dir,
         block_count=3,
         head_dim=128,
@@ -260,6 +438,8 @@ def build_report(
     ):
         params = _params(metric)
         flow_variant = str(params["FLOW_VARIANT"])
+        if binary_diagnostic is not None:
+            _validate_binary_fsm_metric_identity(binary_diagnostic, metric)
         candidate: JsonDict = {
             "candidate_id": f"multivalue_cluster_activity_{flow_variant}",
             "flow_variant": flow_variant,
@@ -279,6 +459,13 @@ def build_report(
                 min_macro_active_pins=16,
                 timeout_seconds=1800,
             )
+            if required_binary_fsm_profile is not None:
+                _validate_strict_activity_power(
+                    activity_power,
+                    activity_manifest=activity_manifest,
+                    flow_variant=flow_variant,
+                    clock_period_ns=clock_period_ns,
+                )
             candidate["activity_power"] = activity_power
             candidate["status"] = (
                 "activity_backed" if activity_power.get("promotion_gate_pass") else "rejected_gate"
@@ -297,6 +484,20 @@ def build_report(
                 float(row["ppa_metric"]["instance_area_um2"]),
                 float(row["ppa_metric"]["critical_path_ns"]),
             ),
+        )
+    selection_contract: JsonDict = {
+        "required_flow_variant": str(required_flow_variant or "").strip() or None,
+        "required_synth_args": (
+            None if required_synth_args is None else str(required_synth_args).strip()
+        ),
+        "min_sequential_register_activity_coverage": min_sequential_register_activity_coverage,
+    }
+    if required_binary_fsm_profile is not None and binary_fsm_diagnostic is not None:
+        selection_contract.update(
+            {
+                "required_binary_fsm_profile": required_binary_fsm_profile,
+                "binary_fsm_diagnostic": _redact_path(str(binary_fsm_diagnostic)),
+            }
         )
     return {
         "version": 1,
@@ -339,11 +540,7 @@ def build_report(
                 "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
             ]
         ),
-        "selection_contract": {
-            "required_flow_variant": str(required_flow_variant or "").strip() or None,
-            "required_synth_args": str(required_synth_args or "").strip() or None,
-            "min_sequential_register_activity_coverage": min_sequential_register_activity_coverage,
-        },
+        "selection_contract": selection_contract,
         "remaining_abstractions": [
             "FakeRAM area and power use Nangate45 proxy LEF/Liberty views, not SRAM compiler signoff.",
             "Value-memory, NoC, HBM/DRAM, command-distribution, and clock-tree composition outside the cluster are not included.",
@@ -375,6 +572,8 @@ def main() -> int:
         default=None,
         help="Optional source PNR work-item ID for source_dependencies tracking",
     )
+    parser.add_argument("--binary-fsm-diagnostic", type=Path, default=None)
+    parser.add_argument("--required-binary-fsm-profile", default=None)
     parser.add_argument(
         "--min-sequential-register-activity-coverage",
         type=float,
@@ -394,6 +593,8 @@ def main() -> int:
         required_flow_variant=args.required_flow_variant,
         required_synth_args=args.required_synth_args,
         source_pnr_item_id=args.source_pnr_item_id,
+        binary_fsm_diagnostic=args.binary_fsm_diagnostic,
+        required_binary_fsm_profile=args.required_binary_fsm_profile,
         min_sequential_register_activity_coverage=args.min_sequential_register_activity_coverage,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_cluster_activity_power.py
@@ -36,6 +36,17 @@ _TARGETED_BINARY_FSM_CONFIG = (
 _TARGETED_BINARY_FSM_PNR_ITEM = (
     "l1_decoder_attention_decode_score_multivalue_cluster_pnr_targeted_binary_fsm_8ns_v1"
 )
+_TARGETED_BINARY_FSM_DESIGN = "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv"
+_TARGETED_BINARY_FSM_PLATFORM = "nangate45"
+_TARGETED_BINARY_FSM_TAG_PREFIX = "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm"
+_TARGETED_BINARY_FSM_NETLIST = (
+    "results/nangate45/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+    "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500/1_synth.v"
+)
+_TARGETED_BINARY_FSM_SIGNAL_INDICES = {
+    "state_q": [0, 1, 2],
+    "reducer.state": [0, 1, 2, 3],
+}
 _POWER_COMPONENTS = ("internal_w", "switching_w", "leakage_w", "total_w")
 
 
@@ -194,41 +205,136 @@ def _validate_targeted_binary_fsm_diagnostic(
     if not isinstance(selected, dict):
         raise ValueError("binary-FSM diagnostic has no selected exact row")
     checks = {
+        "version": type(diagnostic.get("version")) is int and diagnostic.get("version") == 1,
         "profile": diagnostic.get("profile") == _TARGETED_BINARY_FSM_PROFILE,
         "checker": diagnostic.get("checker") == _TARGETED_BINARY_FSM_CHECKER,
         "expected_flow_variant": (
             diagnostic.get("expected_flow_variant") == _TARGETED_BINARY_FSM_FLOW_VARIANT
         ),
+        "netlist_exists": diagnostic.get("netlist_exists") is True,
+        "expected_logical_netlist_path": (
+            diagnostic.get("expected_logical_netlist_path") == _TARGETED_BINARY_FSM_NETLIST
+        ),
         "promotion_valid": diagnostic.get("promotion_valid") is True,
         "width_valid": diagnostic.get("width_valid") is True,
+        "selected_design": selected.get("design") == _TARGETED_BINARY_FSM_DESIGN,
+        "selected_platform": selected.get("platform") == _TARGETED_BINARY_FSM_PLATFORM,
+        "selected_tag": str(selected.get("tag") or "").startswith(
+            _TARGETED_BINARY_FSM_TAG_PREFIX
+        ),
         "selected_status": selected.get("status") == "ok",
         "selected_flow_variant": (
             selected.get("flow_variant") == _TARGETED_BINARY_FSM_FLOW_VARIANT
         ),
         "selected_synth_args": str(selected.get("synth_args") or "").strip() == "",
+        "selected_die_area": selected.get("die_area") == "0 0 2500 2500",
+        "selected_core_area": selected.get("core_area") == "50 50 2450 2450",
+        "selected_place_density": str(selected.get("place_density") or "").strip() == "0.4",
+        "selected_synth_hierarchical": (
+            str(selected.get("synth_hierarchical") or "").strip() == "1"
+        ),
+        "selected_synth_memory_max_bits": (
+            str(selected.get("synth_memory_max_bits") or "").strip() == "65536"
+        ),
+        "selected_failure_stage": not str(selected.get("failure_stage") or "").strip(),
+        "selected_failure_returncode": selected.get("failure_returncode") in (None, ""),
+        "selected_failure_signature": not str(
+            selected.get("failure_signature") or ""
+        ).strip(),
         "selected_param_hash": bool(str(selected.get("param_hash") or "").strip()),
         "selected_config_hash": bool(str(selected.get("config_hash") or "").strip()),
     }
+    try:
+        clock_period_ns = float(selected.get("clock_period_ns"))
+        critical_path_ns = float(selected.get("critical_path_ns"))
+    except (TypeError, ValueError):
+        clock_period_ns = math.nan
+        critical_path_ns = math.nan
+    checks["selected_clock_period_ns"] = (
+        math.isfinite(clock_period_ns) and clock_period_ns == 8.0
+    )
+    checks["selected_critical_path_ns"] = (
+        math.isfinite(critical_path_ns) and critical_path_ns <= 8.0
+    )
     failed = [name for name, passed in checks.items() if not passed]
     if failed:
         raise ValueError(
             "targeted binary-FSM diagnostic failed strict validation: " + ", ".join(failed)
         )
-    logical_netlist = str(diagnostic.get("expected_logical_netlist_path") or "").strip()
-    if not logical_netlist or Path(logical_netlist).is_absolute():
-        raise ValueError("binary-FSM diagnostic netlist path must be nonempty and repo-portable")
+    _validate_targeted_binary_fsm_signals(diagnostic.get("signals"))
     return diagnostic
+
+
+def _validate_targeted_binary_fsm_signals(value: object) -> None:
+    if not isinstance(value, dict) or set(value) != set(_TARGETED_BINARY_FSM_SIGNAL_INDICES):
+        raise ValueError("targeted binary-FSM diagnostic has an invalid signals object")
+    for signal, expected_indices in _TARGETED_BINARY_FSM_SIGNAL_INDICES.items():
+        evidence = value.get(signal)
+        if not isinstance(evidence, dict):
+            raise ValueError(f"targeted binary-FSM diagnostic has no evidence for {signal}")
+        if evidence.get("expected_bit_indices") != expected_indices:
+            raise ValueError(f"targeted binary-FSM diagnostic has wrong expected indices for {signal}")
+        packed = evidence.get("observed_packed_ranges")
+        bits = evidence.get("observed_bit_indices")
+        if not isinstance(packed, list) or not isinstance(bits, list):
+            raise ValueError(f"targeted binary-FSM diagnostic has malformed evidence for {signal}")
+        if bool(packed) == bool(bits):
+            raise ValueError(
+                f"targeted binary-FSM diagnostic must use exactly one observed representation for {signal}"
+            )
+        if packed:
+            if len(packed) != 1 or not isinstance(packed[0], dict):
+                raise ValueError(f"targeted binary-FSM diagnostic has invalid packed range for {signal}")
+            msb = packed[0].get("msb")
+            lsb = packed[0].get("lsb")
+            if (
+                not isinstance(msb, int)
+                or isinstance(msb, bool)
+                or not isinstance(lsb, int)
+                or isinstance(lsb, bool)
+            ):
+                raise ValueError(f"targeted binary-FSM diagnostic has invalid packed range for {signal}")
+            observed_indices = list(range(min(msb, lsb), max(msb, lsb) + 1))
+        else:
+            if any(not isinstance(bit, int) or isinstance(bit, bool) for bit in bits):
+                raise ValueError(f"targeted binary-FSM diagnostic has invalid bit indices for {signal}")
+            observed_indices = sorted(bits)
+        if observed_indices != expected_indices or len(observed_indices) != len(expected_indices):
+            raise ValueError(f"targeted binary-FSM diagnostic has wrong observed indices for {signal}")
 
 
 def _validate_binary_fsm_metric_identity(diagnostic: JsonDict, metric: JsonDict) -> None:
     selected = diagnostic.get("selected_exact_row")
     if not isinstance(selected, dict):
         raise TypeError("validated binary-FSM diagnostic selected row is not an object")
-    if str(metric.get("param_hash") or "").strip() != str(
-        selected.get("param_hash") or ""
-    ).strip() or str(metric.get("config_hash") or "").strip() != str(
-        selected.get("config_hash") or ""
-    ).strip():
+    identity_matches = (
+        str(metric.get("param_hash") or "").strip()
+        == str(selected.get("param_hash") or "").strip()
+        and str(metric.get("config_hash") or "").strip()
+        == str(selected.get("config_hash") or "").strip()
+        and str(metric.get("design") or "").strip()
+        == str(selected.get("design") or "").strip()
+        and str(metric.get("platform") or "").strip()
+        == str(selected.get("platform") or "").strip()
+    )
+    try:
+        metric_critical_path = float(metric.get("critical_path_ns"))
+        selected_critical_path = float(selected.get("critical_path_ns"))
+    except (TypeError, ValueError):
+        identity_matches = False
+        metric_critical_path = math.nan
+        selected_critical_path = math.nan
+    critical_path_matches = (
+        math.isfinite(metric_critical_path)
+        and math.isfinite(selected_critical_path)
+        and math.isclose(
+            metric_critical_path,
+            selected_critical_path,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        )
+    )
+    if not identity_matches or not critical_path_matches:
         raise ValueError("binary-FSM diagnostic does not match the selected PPA metrics row")
 
 

--- a/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
@@ -15,6 +15,7 @@ def _write_metrics(path: Path) -> None:
     fields = [
         "design",
         "platform",
+        "config_hash",
         "param_hash",
         "tag",
         "status",
@@ -74,6 +75,7 @@ def _write_metrics_rows(path: Path, rows: list[dict[str, str]]) -> None:
     fields = [
         "design",
         "platform",
+        "config_hash",
         "param_hash",
         "tag",
         "status",
@@ -242,6 +244,268 @@ def test_feasible_metrics_accepts_exact_binary_row_with_strict_contract(tmp_path
     assert [audit._params(row)["FLOW_VARIANT"] for row in rows] == [
         "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v3_proxy_die_2500",
     ]
+
+
+def test_feasible_metrics_rejects_v14_nofsm_and_base_fallback_for_targeted_contract(
+    tmp_path: Path,
+) -> None:
+    metrics = tmp_path / "metrics.csv"
+    targeted = "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+    rows = []
+    for param_hash, flow_variant, synth_args in (
+        ("targeted-nofsm", targeted, "-nofsm"),
+        (
+            "v14",
+            "decode_score_multivalue_cluster_v1_8ns_binary_fsm_v4_proxy_die_2500",
+            "",
+        ),
+        ("base", "decode_score_multivalue_cluster_v1_8ns_proxy_die_2500", ""),
+    ):
+        rows.append(
+            {
+                "design": "cluster",
+                "platform": "nangate45",
+                "config_hash": "config-targeted",
+                "param_hash": param_hash,
+                "tag": param_hash,
+                "status": "ok",
+                "critical_path_ns": "7.1",
+                "die_area": "6250000",
+                "instance_area_um2": "3000000",
+                "params_json": json.dumps(
+                    {
+                        "CLOCK_PERIOD": 8,
+                        "FLOW_VARIANT": flow_variant,
+                        "SYNTH_ARGS": synth_args,
+                    }
+                ),
+            }
+        )
+    _write_metrics_rows(metrics, rows)
+
+    try:
+        audit._feasible_metrics(
+            metrics,
+            8.0,
+            required_flow_variant=targeted,
+            required_synth_args="",
+        )
+    except ValueError as exc:
+        assert "SYNTH_ARGS=<empty/default>" in str(exc)
+    else:
+        raise AssertionError("v14, -nofsm, or base fallback row was accepted")
+
+
+def _targeted_diagnostic(*, param_hash: str = "targeted-param") -> dict[str, object]:
+    flow_variant = (
+        "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+    )
+    return {
+        "version": 1,
+        "checker": "attention_decode_score_multivalue_cluster_targeted_binary_fsm_v1",
+        "profile": "targeted_binary",
+        "expected_flow_variant": flow_variant,
+        "selected_exact_row": {
+            "status": "ok",
+            "flow_variant": flow_variant,
+            "synth_args": "",
+            "config_hash": "targeted-config",
+            "param_hash": param_hash,
+        },
+        "expected_logical_netlist_path": f"results/nangate45/cluster/{flow_variant}/1_synth.v",
+        "width_valid": True,
+        "promotion_valid": True,
+    }
+
+
+def _strict_activity_power(manifest: dict[str, object]) -> dict[str, object]:
+    flow_variant = (
+        "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+    )
+    phases = []
+    for phase in manifest["phases"]:
+        phase_name = phase["phase"]
+        phases.append(
+            {
+                "phase": phase_name,
+                "direct_vcd_annotation_pin_gate_pass": True,
+                "trace_coverage_gate_pass": True,
+                "annotation_gate_pass": True,
+                "sequential_register_activity_gate_pass": True,
+                "clock_period_gate_pass": True,
+                "power_numeric_gate_pass": True,
+                "phase_gate_pass": True,
+                "sequential_register_activity_coverage": 1.0,
+                "sequential_register_activity_assignment_count": 16,
+                "sequential_register_activity_matched_count": 16,
+                "sequential_register_activity_applied_count": 16,
+                "power": {
+                    "internal_w": 0.1,
+                    "switching_w": 0.1,
+                    "leakage_w": 0.01,
+                    "total_w": 0.21,
+                },
+            }
+        )
+    return {
+        "model": "postroute_phase_vcd_power_v1",
+        "status": "activity_backed",
+        "promotion_gate_pass": True,
+        "flow_variant": flow_variant,
+        "clock_period_ns": 8.0,
+        "min_sequential_register_activity_coverage": 1.0,
+        "full_context_energy_j": 0.001,
+        "phases": phases,
+    }
+
+
+def test_build_report_accepts_only_matching_targeted_diagnostic_and_strict_power(
+    tmp_path: Path,
+) -> None:
+    flow_variant = (
+        "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+    )
+    config = (
+        tmp_path
+        / "runs/designs/npu_blocks/"
+        "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+        "config_targeted_binary_fsm.json"
+    )
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps(
+            {
+                "attention_decode_score_multivalue_cluster": {
+                    "fsm_encoding": "binary",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics_rows(
+        metrics,
+        [
+            {
+                "design": "cluster",
+                "platform": "nangate45",
+                "config_hash": "targeted-config",
+                "param_hash": "targeted-param",
+                "tag": "targeted",
+                "status": "ok",
+                "critical_path_ns": "7.1",
+                "die_area": "6250000",
+                "instance_area_um2": "3000000",
+                "params_json": json.dumps(
+                    {
+                        "CLOCK_PERIOD": 8,
+                        "FLOW_VARIANT": flow_variant,
+                        "SYNTH_ARGS": "",
+                    }
+                ),
+            }
+        ],
+    )
+    equivalence = tmp_path / "equivalence.json"
+    equivalence.write_text(json.dumps({"equivalence_pass": True}), encoding="utf-8")
+    diagnostic = tmp_path / "targeted_binary_fsm_diagnostic.json"
+    diagnostic.write_text(json.dumps(_targeted_diagnostic()), encoding="utf-8")
+    manifest = {
+        "clock_period_ns": 8.0,
+        "block_count": 3,
+        "representative_full_transaction_cycles": 8334,
+        "phase_partition_cycle_sum": 8334,
+        "phases": [
+            {"phase": "score_fill"},
+            {"phase": "replay_value"},
+            {"phase": "finalize_result"},
+        ],
+    }
+    power = _strict_activity_power(manifest)
+
+    with mock.patch.object(audit, "generate_phase_activity", return_value=manifest), mock.patch.object(
+        audit, "build_power_report", return_value=power
+    ):
+        payload = audit.build_report(
+            config=config,
+            cluster_metrics_csv=metrics,
+            equivalence_json=equivalence,
+            orfs_design_config=tmp_path / "config.mk",
+            clock_period_ns=8.0,
+            activity_dir=tmp_path / "activity",
+            min_sequential_register_activity_coverage=1.0,
+            required_flow_variant=flow_variant,
+            required_synth_args="",
+            source_pnr_item_id=(
+                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_"
+                "targeted_binary_fsm_8ns_v1"
+            ),
+            binary_fsm_diagnostic=diagnostic,
+            required_binary_fsm_profile="targeted_binary",
+        )
+
+    assert payload["promotion_gate_pass"] is True
+    assert payload["selection_contract"]["required_synth_args"] == ""
+    assert payload["selection_contract"]["required_binary_fsm_profile"] == "targeted_binary"
+    assert payload["source_dependencies"][0].endswith("targeted_binary_fsm_8ns_v1")
+    assert str(tmp_path) not in json.dumps(payload)
+
+
+def test_strict_activity_power_rejects_nonfinite_required_phase() -> None:
+    manifest = {"phases": [{"phase": "score_fill"}]}
+    power = _strict_activity_power(manifest)
+    power["phases"][0]["power"]["total_w"] = float("nan")
+    try:
+        audit._validate_strict_activity_power(
+            power,
+            activity_manifest=manifest,
+            flow_variant=power["flow_variant"],
+            clock_period_ns=8.0,
+        )
+    except ValueError as exc:
+        assert "non-finite total_w" in str(exc)
+    else:
+        raise AssertionError("non-finite required phase power was accepted")
+
+
+def test_targeted_diagnostic_rejects_v14_profile_and_stale_row(tmp_path: Path) -> None:
+    diagnostic_path = tmp_path / "targeted_binary_fsm_diagnostic.json"
+    diagnostic = _targeted_diagnostic()
+    diagnostic["profile"] = "v4_nofsm"
+    diagnostic_path.write_text(json.dumps(diagnostic), encoding="utf-8")
+    try:
+        audit._validate_targeted_binary_fsm_diagnostic(
+            diagnostic_path,
+            required_profile="targeted_binary",
+            required_flow_variant=(
+                "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+            ),
+            required_synth_args="",
+        )
+    except ValueError as exc:
+        assert "profile" in str(exc)
+    else:
+        raise AssertionError("v14 checker profile was accepted")
+
+    diagnostic = _targeted_diagnostic(param_hash="stale-param")
+    diagnostic_path.write_text(json.dumps(diagnostic), encoding="utf-8")
+    validated = audit._validate_targeted_binary_fsm_diagnostic(
+        diagnostic_path,
+        required_profile="targeted_binary",
+        required_flow_variant=(
+            "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+        ),
+        required_synth_args="",
+    )
+    try:
+        audit._validate_binary_fsm_metric_identity(
+            validated,
+            {"config_hash": "targeted-config", "param_hash": "current-param"},
+        )
+    except ValueError as exc:
+        assert "does not match the selected PPA metrics row" in str(exc)
+    else:
+        raise AssertionError("stale diagnostic row was accepted")
 
 
 def test_build_report_records_strict_selection_contract_and_pnr_dependency(tmp_path: Path) -> None:

--- a/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_activity_power.py
@@ -306,15 +306,46 @@ def _targeted_diagnostic(*, param_hash: str = "targeted-param") -> dict[str, obj
         "profile": "targeted_binary",
         "expected_flow_variant": flow_variant,
         "selected_exact_row": {
+            "design": "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv",
+            "platform": "nangate45",
+            "tag": "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_targeted",
             "status": "ok",
             "flow_variant": flow_variant,
+            "clock_period_ns": 8.0,
+            "critical_path_ns": 7.1,
+            "die_area": "0 0 2500 2500",
+            "core_area": "50 50 2450 2450",
+            "place_density": "0.4",
+            "synth_hierarchical": "1",
+            "synth_memory_max_bits": "65536",
             "synth_args": "",
+            "failure_stage": None,
+            "failure_returncode": None,
+            "failure_signature": None,
             "config_hash": "targeted-config",
             "param_hash": param_hash,
         },
-        "expected_logical_netlist_path": f"results/nangate45/cluster/{flow_variant}/1_synth.v",
+        "expected_logical_netlist_path": (
+            "results/nangate45/"
+            "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+            f"{flow_variant}/1_synth.v"
+        ),
+        "netlist_exists": True,
+        "signals": {
+            "state_q": {
+                "expected_bit_indices": [0, 1, 2],
+                "observed_packed_ranges": [{"msb": 2, "lsb": 0}],
+                "observed_bit_indices": [],
+            },
+            "reducer.state": {
+                "expected_bit_indices": [0, 1, 2, 3],
+                "observed_packed_ranges": [],
+                "observed_bit_indices": [0, 1, 2, 3],
+            },
+        },
         "width_valid": True,
         "promotion_valid": True,
+        "promotion_reasons": [],
     }
 
 
@@ -387,7 +418,7 @@ def test_build_report_accepts_only_matching_targeted_diagnostic_and_strict_power
         metrics,
         [
             {
-                "design": "cluster",
+                "design": "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv",
                 "platform": "nangate45",
                 "config_hash": "targeted-config",
                 "param_hash": "targeted-param",
@@ -500,12 +531,154 @@ def test_targeted_diagnostic_rejects_v14_profile_and_stale_row(tmp_path: Path) -
     try:
         audit._validate_binary_fsm_metric_identity(
             validated,
-            {"config_hash": "targeted-config", "param_hash": "current-param"},
+            {
+                "design": "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv",
+                "platform": "nangate45",
+                "config_hash": "targeted-config",
+                "param_hash": "current-param",
+                "critical_path_ns": "7.1",
+            },
         )
     except ValueError as exc:
         assert "does not match the selected PPA metrics row" in str(exc)
     else:
         raise AssertionError("stale diagnostic row was accepted")
+
+
+def test_targeted_diagnostic_rejects_wrong_netlist_and_signal_evidence(tmp_path: Path) -> None:
+    diagnostic_path = tmp_path / "targeted_binary_fsm_diagnostic.json"
+    mutations = (
+        ("version", lambda payload: payload.__setitem__("version", 2)),
+        ("netlist existence", lambda payload: payload.__setitem__("netlist_exists", False)),
+        (
+            "netlist path",
+            lambda payload: payload.__setitem__(
+                "expected_logical_netlist_path", "results/nangate45/wrong/1_synth.v"
+            ),
+        ),
+        (
+            "state expected indices",
+            lambda payload: payload["signals"]["state_q"].__setitem__(
+                "expected_bit_indices", [0, 1, 3]
+            ),
+        ),
+        (
+            "state packed range",
+            lambda payload: payload["signals"]["state_q"].__setitem__(
+                "observed_packed_ranges", [{"msb": 3, "lsb": 0}]
+            ),
+        ),
+        (
+            "reducer bit indices",
+            lambda payload: payload["signals"]["reducer.state"].__setitem__(
+                "observed_bit_indices", [0, 1, 2, 4]
+            ),
+        ),
+        (
+            "inconsistent representations",
+            lambda payload: payload["signals"]["state_q"].__setitem__(
+                "observed_bit_indices", [0, 1, 2]
+            ),
+        ),
+        (
+            "missing signal",
+            lambda payload: payload["signals"].pop("reducer.state"),
+        ),
+        (
+            "extra signal",
+            lambda payload: payload["signals"].__setitem__(
+                "other.state", payload["signals"]["state_q"]
+            ),
+        ),
+    )
+
+    for label, mutate in mutations:
+        diagnostic = json.loads(json.dumps(_targeted_diagnostic()))
+        mutate(diagnostic)
+        assert diagnostic["width_valid"] is True
+        assert diagnostic["promotion_valid"] is True
+        diagnostic_path.write_text(json.dumps(diagnostic), encoding="utf-8")
+        try:
+            audit._validate_targeted_binary_fsm_diagnostic(
+                diagnostic_path,
+                required_profile="targeted_binary",
+                required_flow_variant=(
+                    "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+                ),
+                required_synth_args="",
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"invalid targeted diagnostic {label} was accepted")
+
+
+def test_targeted_diagnostic_rejects_wrong_physical_identity(tmp_path: Path) -> None:
+    diagnostic_path = tmp_path / "targeted_binary_fsm_diagnostic.json"
+    mutations = (
+        ("design", "design", "wrong_design"),
+        ("platform", "platform", "sky130hd"),
+        ("tag", "tag", "wrong_tag"),
+        ("clock", "clock_period_ns", 10.0),
+        ("critical path limit", "critical_path_ns", 8.000001),
+        ("critical path finiteness", "critical_path_ns", "nan"),
+        ("die area", "die_area", "0 0 2600 2600"),
+        ("core area", "core_area", "50 50 2550 2550"),
+        ("place density", "place_density", "0.45"),
+        ("hierarchy", "synth_hierarchical", "0"),
+        ("memory limit", "synth_memory_max_bits", "32768"),
+        ("synth args", "synth_args", "-nofsm"),
+        ("failure stage", "failure_stage", "globalplace"),
+        ("failure return code", "failure_returncode", 1),
+        ("failure signature", "failure_signature", "RSZ-1008"),
+    )
+
+    for label, field, value in mutations:
+        diagnostic = json.loads(json.dumps(_targeted_diagnostic()))
+        diagnostic["selected_exact_row"][field] = value
+        assert diagnostic["width_valid"] is True
+        assert diagnostic["promotion_valid"] is True
+        diagnostic_path.write_text(json.dumps(diagnostic), encoding="utf-8")
+        try:
+            audit._validate_targeted_binary_fsm_diagnostic(
+                diagnostic_path,
+                required_profile="targeted_binary",
+                required_flow_variant=(
+                    "decode_score_multivalue_cluster_v1_8ns_targeted_binary_fsm_v1_proxy_die_2500"
+                ),
+                required_synth_args="",
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"invalid selected-row {label} was accepted")
+
+
+def test_metric_identity_rejects_same_hashes_with_wrong_design_platform_or_timing() -> None:
+    diagnostic = _targeted_diagnostic()
+    metric = {
+        "design": "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv",
+        "platform": "nangate45",
+        "config_hash": "targeted-config",
+        "param_hash": "targeted-param",
+        "critical_path_ns": "7.1",
+    }
+    audit._validate_binary_fsm_metric_identity(diagnostic, metric)
+
+    for field, value in (
+        ("design", "wrong_design"),
+        ("platform", "sky130hd"),
+        ("critical_path_ns", "7.1000000001"),
+        ("critical_path_ns", "nan"),
+    ):
+        mismatched = dict(metric)
+        mismatched[field] = value
+        try:
+            audit._validate_binary_fsm_metric_identity(diagnostic, mismatched)
+        except ValueError as exc:
+            assert "does not match the selected PPA metrics row" in str(exc)
+        else:
+            raise AssertionError(f"same-hash metric with wrong {field} was accepted")
 
 
 def test_build_report_records_strict_selection_contract_and_pnr_dependency(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add immutable activity-power v15 bound to the targeted-binary config, flow, empty SYNTH_ARGS, checker diagnostic, and targeted L1 PNR dependency
- enforce exact diagnostic/metrics identity, direct routed sequential activity, 100% sequential coverage, and finite required-phase power
- mark unlaunched v14 superseded and rebind only the pending frontier and folded-GQA consumers to v15

## Validation
- `PYTHONPATH=. pytest -q tests/test_attention_decode_score_multivalue_cluster_activity_power.py` (15 passed)
- `PYTHONPATH=control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py` (227 passed)
- `python3 scripts/validate_runs.py`
- JSON validation for all changed proposal manifests
- `git diff --check`

## Merge Gate
**Do not merge this PR until `l1_decoder_attention_decode_score_multivalue_cluster_pnr_targeted_binary_fsm_8ns_v1` passes targeted PPA and its promotion-valid `targeted_binary` diagnostic is merged/materialized.**

This PR prepares definitions only. It does not generate or dispatch a control-plane item.