### PR TITLE
Add finite NoC and banked value service primitives

### DIFF
--- a/npu/sim/rtl/Makefile
+++ b/npu/sim/rtl/Makefile
@@ -22,6 +22,7 @@ TB_AXI=npu/sim/rtl/tb_axi_lite_mmio.sv
 TB_AXI_MULTI=npu/sim/rtl/tb_axi_lite_multi.sv
 NOC_FIFO=npu/sim/rtl/noc_ready_valid_fifo.sv
 NOC_ROUTER=npu/sim/rtl/noc_ready_valid_router.sv
+NOC_REASSEMBLER=npu/sim/rtl/noc_value_matrix_reassembler.sv
 VALUE_SERVICE=npu/sim/rtl/banked_value_memory_service.sv
 TB_NOC_ROUTER=npu/sim/rtl/tb_noc_ready_valid_router.sv
 TB_VALUE_SERVICE=npu/sim/rtl/tb_banked_value_memory_service.sv
@@ -100,11 +101,11 @@ run-noc-router-local-256:
 	$(VVP) $(OUT_NOC_ROUTER)
 
 run-value-service-128:
-	$(IVERILOG) $(IVERILOGFLAGS) -P tb_banked_value_memory_service.PACKET_W=128 -s tb_banked_value_memory_service -o $(OUT_VALUE_SERVICE) $(NOC_FIFO) $(NOC_ROUTER) $(VALUE_SERVICE) $(TB_VALUE_SERVICE)
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_banked_value_memory_service.PACKET_W=128 -s tb_banked_value_memory_service -o $(OUT_VALUE_SERVICE) $(NOC_FIFO) $(NOC_ROUTER) $(NOC_REASSEMBLER) $(VALUE_SERVICE) $(TB_VALUE_SERVICE)
 	$(VVP) $(OUT_VALUE_SERVICE)
 
 run-value-service-256:
-	$(IVERILOG) $(IVERILOGFLAGS) -P tb_banked_value_memory_service.PACKET_W=256 -s tb_banked_value_memory_service -o $(OUT_VALUE_SERVICE) $(NOC_FIFO) $(NOC_ROUTER) $(VALUE_SERVICE) $(TB_VALUE_SERVICE)
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_banked_value_memory_service.PACKET_W=256 -s tb_banked_value_memory_service -o $(OUT_VALUE_SERVICE) $(NOC_FIFO) $(NOC_ROUTER) $(NOC_REASSEMBLER) $(VALUE_SERVICE) $(TB_VALUE_SERVICE)
 	$(VVP) $(OUT_VALUE_SERVICE)
 
 status:

--- a/npu/sim/rtl/Makefile
+++ b/npu/sim/rtl/Makefile
@@ -20,8 +20,15 @@ MODEL=npu/sim/rtl/axi_mem_model.sv
 TB=npu/sim/rtl/tb_npu_shell.sv
 TB_AXI=npu/sim/rtl/tb_axi_lite_mmio.sv
 TB_AXI_MULTI=npu/sim/rtl/tb_axi_lite_multi.sv
+NOC_FIFO=npu/sim/rtl/noc_ready_valid_fifo.sv
+NOC_ROUTER=npu/sim/rtl/noc_ready_valid_router.sv
+VALUE_SERVICE=npu/sim/rtl/banked_value_memory_service.sv
+TB_NOC_ROUTER=npu/sim/rtl/tb_noc_ready_valid_router.sv
+TB_VALUE_SERVICE=npu/sim/rtl/tb_banked_value_memory_service.sv
+OUT_NOC_ROUTER=build_noc_router.vvp
+OUT_VALUE_SERVICE=build_value_service.vvp
 
-.PHONY: gen gen-arch build run run-axi run-axi-multi run-arch run-axi-arch run-axi-multi-arch run-arch-sram run-axi-arch-sram run-axi-multi-arch-sram run-arch-event run-axi-arch-event run-axi-multi-arch-event status clean
+.PHONY: gen gen-arch build run run-axi run-axi-multi run-arch run-axi-arch run-axi-multi-arch run-arch-sram run-axi-arch-sram run-axi-multi-arch-sram run-arch-event run-axi-arch-event run-axi-multi-arch-event run-noc-router-rr-128 run-noc-router-local-128 run-noc-router-local-256 run-value-service-128 run-value-service-256 status clean
 
 gen:
 	python3 npu/rtlgen/gen.py --config $(CONFIG) --out npu/rtlgen/out
@@ -79,6 +86,26 @@ run-axi-multi-arch-sram: gen-arch
 run-axi-multi-arch-event: gen-arch
 	$(IVERILOG) $(IVERILOGFLAGS) -s tb_axi_lite_multi -o $(OUT_AXI_MULTI) $(RTL) $(RTL_AXI) $(TB_AXI_MULTI) $(ROUTER) $(MODEL) $(SRAM_MODELS)
 	$(VVP) $(OUT_AXI_MULTI) +event_test=1
+
+run-noc-router-rr-128:
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_noc_ready_valid_router.PACKET_W=128 -P tb_noc_ready_valid_router.ARB_MODE=0 -s tb_noc_ready_valid_router -o $(OUT_NOC_ROUTER) $(NOC_FIFO) $(NOC_ROUTER) $(TB_NOC_ROUTER)
+	$(VVP) $(OUT_NOC_ROUTER)
+
+run-noc-router-local-128:
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_noc_ready_valid_router.PACKET_W=128 -P tb_noc_ready_valid_router.ARB_MODE=1 -s tb_noc_ready_valid_router -o $(OUT_NOC_ROUTER) $(NOC_FIFO) $(NOC_ROUTER) $(TB_NOC_ROUTER)
+	$(VVP) $(OUT_NOC_ROUTER)
+
+run-noc-router-local-256:
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_noc_ready_valid_router.PACKET_W=256 -P tb_noc_ready_valid_router.ARB_MODE=1 -s tb_noc_ready_valid_router -o $(OUT_NOC_ROUTER) $(NOC_FIFO) $(NOC_ROUTER) $(TB_NOC_ROUTER)
+	$(VVP) $(OUT_NOC_ROUTER)
+
+run-value-service-128:
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_banked_value_memory_service.PACKET_W=128 -s tb_banked_value_memory_service -o $(OUT_VALUE_SERVICE) $(NOC_FIFO) $(NOC_ROUTER) $(VALUE_SERVICE) $(TB_VALUE_SERVICE)
+	$(VVP) $(OUT_VALUE_SERVICE)
+
+run-value-service-256:
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_banked_value_memory_service.PACKET_W=256 -s tb_banked_value_memory_service -o $(OUT_VALUE_SERVICE) $(NOC_FIFO) $(NOC_ROUTER) $(VALUE_SERVICE) $(TB_VALUE_SERVICE)
+	$(VVP) $(OUT_VALUE_SERVICE)
 
 status:
 	python3 npu/docs/update_status.py

--- a/npu/sim/rtl/Makefile
+++ b/npu/sim/rtl/Makefile
@@ -26,10 +26,14 @@ NOC_REASSEMBLER=npu/sim/rtl/noc_value_matrix_reassembler.sv
 VALUE_SERVICE=npu/sim/rtl/banked_value_memory_service.sv
 TB_NOC_ROUTER=npu/sim/rtl/tb_noc_ready_valid_router.sv
 TB_VALUE_SERVICE=npu/sim/rtl/tb_banked_value_memory_service.sv
+TB_VALUE_SERVICE_PARALLEL=npu/sim/rtl/tb_banked_value_memory_service_parallel.sv
+TB_REASSEMBLER=npu/sim/rtl/tb_noc_value_matrix_reassembler.sv
 OUT_NOC_ROUTER=build_noc_router.vvp
 OUT_VALUE_SERVICE=build_value_service.vvp
+OUT_VALUE_SERVICE_PARALLEL=build_value_service_parallel.vvp
+OUT_REASSEMBLER=build_reassembler.vvp
 
-.PHONY: gen gen-arch build run run-axi run-axi-multi run-arch run-axi-arch run-axi-multi-arch run-arch-sram run-axi-arch-sram run-axi-multi-arch-sram run-arch-event run-axi-arch-event run-axi-multi-arch-event run-noc-router-rr-128 run-noc-router-local-128 run-noc-router-local-256 run-value-service-128 run-value-service-256 status clean
+.PHONY: gen gen-arch build run run-axi run-axi-multi run-arch run-axi-arch run-axi-multi-arch run-arch-sram run-axi-arch-sram run-axi-multi-arch-sram run-arch-event run-axi-arch-event run-axi-multi-arch-event run-noc-router-rr-128 run-noc-router-local-128 run-noc-router-local-256 run-value-service-128 run-value-service-256 run-value-service-parallel-128 run-value-service-parallel-256 run-reassembler-128 run-reassembler-256 status clean
 
 gen:
 	python3 npu/rtlgen/gen.py --config $(CONFIG) --out npu/rtlgen/out
@@ -107,6 +111,22 @@ run-value-service-128:
 run-value-service-256:
 	$(IVERILOG) $(IVERILOGFLAGS) -P tb_banked_value_memory_service.PACKET_W=256 -s tb_banked_value_memory_service -o $(OUT_VALUE_SERVICE) $(NOC_FIFO) $(NOC_ROUTER) $(NOC_REASSEMBLER) $(VALUE_SERVICE) $(TB_VALUE_SERVICE)
 	$(VVP) $(OUT_VALUE_SERVICE)
+
+run-value-service-parallel-128:
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_banked_value_memory_service_parallel.PACKET_W=128 -s tb_banked_value_memory_service_parallel -o $(OUT_VALUE_SERVICE_PARALLEL) $(NOC_FIFO) $(NOC_ROUTER) $(NOC_REASSEMBLER) $(VALUE_SERVICE) $(TB_VALUE_SERVICE_PARALLEL)
+	$(VVP) $(OUT_VALUE_SERVICE_PARALLEL)
+
+run-value-service-parallel-256:
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_banked_value_memory_service_parallel.PACKET_W=256 -s tb_banked_value_memory_service_parallel -o $(OUT_VALUE_SERVICE_PARALLEL) $(NOC_FIFO) $(NOC_ROUTER) $(NOC_REASSEMBLER) $(VALUE_SERVICE) $(TB_VALUE_SERVICE_PARALLEL)
+	$(VVP) $(OUT_VALUE_SERVICE_PARALLEL)
+
+run-reassembler-128:
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_noc_value_matrix_reassembler.PACKET_W=128 -s tb_noc_value_matrix_reassembler -o $(OUT_REASSEMBLER) $(NOC_REASSEMBLER) $(TB_REASSEMBLER)
+	$(VVP) $(OUT_REASSEMBLER)
+
+run-reassembler-256:
+	$(IVERILOG) $(IVERILOGFLAGS) -P tb_noc_value_matrix_reassembler.PACKET_W=256 -s tb_noc_value_matrix_reassembler -o $(OUT_REASSEMBLER) $(NOC_REASSEMBLER) $(TB_REASSEMBLER)
+	$(VVP) $(OUT_REASSEMBLER)
 
 status:
 	python3 npu/docs/update_status.py

--- a/npu/sim/rtl/banked_value_memory_service.sv
+++ b/npu/sim/rtl/banked_value_memory_service.sv
@@ -87,6 +87,8 @@ module banked_value_memory_service #(
   reg [BANKS-1:0] bank_ready_fragment_r;
   reg [BANK_PTR_W-1:0] resp_rr_cursor;
   reg [BANK_PTR_W-1:0] resp_grant_bank_r;
+  reg resp_lock_valid_r;
+  reg [BANK_PTR_W-1:0] resp_lock_bank_r;
   reg any_ready_response_r;
   reg [REQ_OCC_W-1:0] req_occupancy_sum_r;
   reg [RESP_OCC_W-1:0] resp_occupancy_sum_r;
@@ -239,15 +241,20 @@ module banked_value_memory_service #(
 
     any_ready_response_r = 1'b0;
     resp_grant_bank_r = resp_rr_cursor;
-    for (scan_i = 0; scan_i < BANKS; scan_i = scan_i + 1) begin
-      scan_bank_int = resp_rr_cursor + scan_i;
-      if (scan_bank_int >= BANKS) begin
-        scan_bank_int = scan_bank_int - BANKS;
-      end
-      scan_bank = scan_bank_int[BANK_PTR_W-1:0];
-      if (!any_ready_response_r && bank_ready_fragment_r[scan_bank]) begin
-        any_ready_response_r = 1'b1;
-        resp_grant_bank_r = scan_bank;
+    if (resp_lock_valid_r) begin
+      any_ready_response_r = bank_ready_fragment_r[resp_lock_bank_r];
+      resp_grant_bank_r = resp_lock_bank_r;
+    end else begin
+      for (scan_i = 0; scan_i < BANKS; scan_i = scan_i + 1) begin
+        scan_bank_int = resp_rr_cursor + scan_i;
+        if (scan_bank_int >= BANKS) begin
+          scan_bank_int = scan_bank_int - BANKS;
+        end
+        scan_bank = scan_bank_int[BANK_PTR_W-1:0];
+        if (!any_ready_response_r && bank_ready_fragment_r[scan_bank]) begin
+          any_ready_response_r = 1'b1;
+          resp_grant_bank_r = scan_bank;
+        end
       end
     end
   end
@@ -307,6 +314,8 @@ module banked_value_memory_service #(
         bank_latency[seq_bank_i] <= {LAT_W{1'b0}};
       end
       resp_rr_cursor <= {BANK_PTR_W{1'b0}};
+      resp_lock_valid_r <= 1'b0;
+      resp_lock_bank_r <= {BANK_PTR_W{1'b0}};
       accepted_req_count <= {COUNTER_W{1'b0}};
       emitted_resp_count <= {COUNTER_W{1'b0}};
       bank_conflict_count <= {COUNTER_W{1'b0}};
@@ -366,15 +375,19 @@ module banked_value_memory_service #(
         if (resp_last) begin
           bank_busy[resp_grant_bank_r] <= 1'b0;
           active_fragment[resp_grant_bank_r] <= {FRAG_IDX_W{1'b0}};
+          resp_lock_valid_r <= 1'b0;
+          resp_lock_bank_r <= {BANK_PTR_W{1'b0}};
           emitted_resp_count <= emitted_resp_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
+          if (resp_grant_bank_r == (BANKS - 1)) begin
+            resp_rr_cursor <= {BANK_PTR_W{1'b0}};
+          end else begin
+            resp_rr_cursor <= resp_grant_bank_r + {{(BANK_PTR_W-1){1'b0}}, 1'b1};
+          end
         end else begin
           active_fragment[resp_grant_bank_r] <=
             active_fragment[resp_grant_bank_r] + {{(FRAG_IDX_W-1){1'b0}}, 1'b1};
-        end
-        if (resp_grant_bank_r == (BANKS - 1)) begin
-          resp_rr_cursor <= {BANK_PTR_W{1'b0}};
-        end else begin
-          resp_rr_cursor <= resp_grant_bank_r + {{(BANK_PTR_W-1){1'b0}}, 1'b1};
+          resp_lock_valid_r <= 1'b1;
+          resp_lock_bank_r <= resp_grant_bank_r;
         end
       end
 

--- a/npu/sim/rtl/banked_value_memory_service.sv
+++ b/npu/sim/rtl/banked_value_memory_service.sv
@@ -1,31 +1,48 @@
 `timescale 1ns/1ps
 
-// Banked read-only value-memory service with per-bank request queues,
-// configurable read latency, and sliced 512-bit responses over a narrower
-// packet transport.
+// Banked value-memory service. Requests are keyed by address and semantic
+// value_slice. Responses preserve the request metadata and return a segmented
+// 512-bit matrix with fragment index/last sideband.
 module banked_value_memory_service #(
   parameter integer PACKET_W = 128,
+  parameter integer VALUE_W = 512,
+  parameter integer FRAG_IDX_W = ((VALUE_W / PACKET_W) <= 1) ? 1 : $clog2(VALUE_W / PACKET_W),
   parameter integer SOURCE_W = 2,
   parameter integer TAG_W = 8,
   parameter integer ADDR_W = 12,
-  parameter integer SLICE_W = 3,
-  parameter integer VALUE_W = 512,
+  parameter integer VALUE_SLICE_W = 4,
+  parameter integer STORE_DEPTH = 16,
   parameter integer BANKS = 4,
   parameter integer BANK_QUEUE_DEPTH = 2,
-  parameter integer RESP_QUEUE_DEPTH = 2,
   parameter integer READ_LATENCY = 2,
-  parameter integer COUNTER_W = 32
+  parameter integer COUNTER_W = 32,
+  parameter integer INIT_FROM_GENERATOR = 0
 ) (
   input wire clk,
   input wire rst_n,
 
+  input wire preload_valid,
+  output wire preload_ready,
+  input wire [ADDR_W-1:0] preload_addr,
+  input wire [VALUE_SLICE_W-1:0] preload_value_slice,
+  input wire [VALUE_W-1:0] preload_matrix,
+
   input wire req_valid,
   output wire req_ready,
-  input wire [PACKET_W-1:0] req_packet,
+  input wire [SOURCE_W-1:0] req_source,
+  input wire [TAG_W-1:0] req_tag,
+  input wire [ADDR_W-1:0] req_addr,
+  input wire [VALUE_SLICE_W-1:0] req_value_slice,
 
   output wire resp_valid,
   input wire resp_ready,
-  output wire [PACKET_W-1:0] resp_packet,
+  output wire [SOURCE_W-1:0] resp_source,
+  output wire [TAG_W-1:0] resp_tag,
+  output wire [ADDR_W-1:0] resp_addr,
+  output wire [VALUE_SLICE_W-1:0] resp_value_slice,
+  output wire [FRAG_IDX_W-1:0] resp_fragment_idx,
+  output wire resp_last,
+  output wire [PACKET_W-1:0] resp_data,
 
   output reg [COUNTER_W-1:0] accepted_req_count,
   output reg [COUNTER_W-1:0] emitted_resp_count,
@@ -36,229 +53,259 @@ module banked_value_memory_service #(
   output wire [COUNTER_W-1:0] resp_current_occupancy,
   output reg [COUNTER_W-1:0] resp_max_occupancy
 );
+  localparam integer FRAGMENTS = VALUE_W / PACKET_W;
+  localparam integer VALUE_SLICE_COUNT = (1 << VALUE_SLICE_W);
+  localparam integer STORE_ENTRY_COUNT = STORE_DEPTH * VALUE_SLICE_COUNT;
   localparam integer BANK_SEL_W = (BANKS <= 1) ? 1 : $clog2(BANKS);
   localparam integer BANK_PTR_W = (BANKS <= 1) ? 1 : $clog2(BANKS);
   localparam integer BANK_COUNT_W = (BANK_QUEUE_DEPTH <= 1) ? 1 : $clog2(BANK_QUEUE_DEPTH + 1);
-  localparam integer RESP_COUNT_W = (RESP_QUEUE_DEPTH <= 1) ? 1 : $clog2(RESP_QUEUE_DEPTH + 1);
-  localparam integer LAT_W = (READ_LATENCY <= 1) ? 1 : $clog2(READ_LATENCY);
-  localparam integer SRC_LSB = 0;
-  localparam integer TAG_LSB = SRC_LSB + SOURCE_W;
-  localparam integer ADDR_LSB = TAG_LSB + TAG_W;
-  localparam integer SLICE_LSB = ADDR_LSB + ADDR_W;
-  localparam integer PAYLOAD_LSB = SLICE_LSB + SLICE_W;
-  localparam integer PAYLOAD_W = PACKET_W - PAYLOAD_LSB;
+  localparam integer LAT_W = (READ_LATENCY <= 1) ? 1 : $clog2(READ_LATENCY + 1);
+  localparam integer REQ_META_W = SOURCE_W + TAG_W + ADDR_W + VALUE_SLICE_W;
   localparam integer REQ_OCC_W = $clog2((BANKS * (BANK_QUEUE_DEPTH + 1)) + BANKS + 1);
+  localparam integer RESP_OCC_W = $clog2(BANKS + 1);
+  localparam integer REQ_SRC_LSB = 0;
+  localparam integer REQ_TAG_LSB = REQ_SRC_LSB + SOURCE_W;
+  localparam integer REQ_ADDR_LSB = REQ_TAG_LSB + TAG_W;
+  localparam integer REQ_SLICE_LSB = REQ_ADDR_LSB + ADDR_W;
 
-  wire [BANKS-1:0] bank_fifo_in_ready;
   wire [BANKS-1:0] bank_fifo_in_valid;
+  wire [BANKS-1:0] bank_fifo_in_ready;
   wire [BANKS-1:0] bank_fifo_out_valid;
   wire [BANKS-1:0] bank_fifo_out_ready;
-  wire [PACKET_W-1:0] bank_fifo_out_packet [0:BANKS-1];
-  wire [BANK_COUNT_W-1:0] bank_fifo_occupancy [0:BANKS-1];
-  wire [PACKET_W-1:0] resp_fifo_out_packet;
-  wire [RESP_COUNT_W-1:0] resp_fifo_occupancy;
-  wire resp_fifo_in_ready;
-  wire resp_fifo_out_valid;
+  wire [BANKS-1:0] bank_launch_fire;
+  wire [BANKS*REQ_META_W-1:0] bank_fifo_out_bus;
+  wire [BANKS*BANK_COUNT_W-1:0] bank_fifo_occupancy_bus;
 
-  reg [PACKET_W-1:0] active_packet [0:BANKS-1];
-  reg [BANKS-1:0] bank_active;
-  reg [LAT_W-1:0] bank_latency_left [0:BANKS-1];
-  reg [BANKS-1:0] bank_launch;
-  reg [BANKS-1:0] bank_resp_ready_mask;
-  reg resp_fifo_in_valid;
-  reg [PACKET_W-1:0] resp_fifo_in_packet;
+  reg [BANKS-1:0] bank_busy;
+  reg [SOURCE_W-1:0] active_source [0:BANKS-1];
+  reg [TAG_W-1:0] active_tag [0:BANKS-1];
+  reg [ADDR_W-1:0] active_addr [0:BANKS-1];
+  reg [VALUE_SLICE_W-1:0] active_slice [0:BANKS-1];
+  reg [VALUE_W-1:0] active_matrix [0:BANKS-1];
+  reg [FRAG_IDX_W-1:0] active_fragment [0:BANKS-1];
+  reg [LAT_W-1:0] bank_latency [0:BANKS-1];
+  reg [BANKS-1:0] bank_ready_fragment_r;
   reg [BANK_PTR_W-1:0] resp_rr_cursor;
-  reg [BANK_PTR_W-1:0] resp_grant_bank;
-  reg any_ready_response;
-  reg [BANK_SEL_W-1:0] target_bank;
-  reg bank_conflicted;
-  reg [REQ_OCC_W-1:0] req_occupancy_sum;
+  reg [BANK_PTR_W-1:0] resp_grant_bank_r;
+  reg any_ready_response_r;
+  reg [REQ_OCC_W-1:0] req_occupancy_sum_r;
+  reg [RESP_OCC_W-1:0] resp_occupancy_sum_r;
 
-  integer bank_i;
+  reg [VALUE_W-1:0] value_mem [0:STORE_ENTRY_COUNT-1];
+
+  integer occ_bank_i;
+  integer seq_bank_i;
   integer scan_i;
   integer scan_bank_int;
+  integer init_addr;
+  integer init_slice;
   reg [BANK_PTR_W-1:0] scan_bank;
 
-  function [SOURCE_W-1:0] packet_source;
-    input [PACKET_W-1:0] packet;
+  function [REQ_META_W-1:0] pack_req;
+    input [SOURCE_W-1:0] source;
+    input [TAG_W-1:0] tag;
+    input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
     begin
-      packet_source = packet[SRC_LSB +: SOURCE_W];
+      pack_req = {REQ_META_W{1'b0}};
+      pack_req[REQ_SRC_LSB +: SOURCE_W] = source;
+      pack_req[REQ_TAG_LSB +: TAG_W] = tag;
+      pack_req[REQ_ADDR_LSB +: ADDR_W] = addr;
+      pack_req[REQ_SLICE_LSB +: VALUE_SLICE_W] = value_slice;
     end
   endfunction
 
-  function [TAG_W-1:0] packet_tag;
-    input [PACKET_W-1:0] packet;
+  function [SOURCE_W-1:0] meta_source;
+    input [REQ_META_W-1:0] meta;
     begin
-      packet_tag = packet[TAG_LSB +: TAG_W];
+      meta_source = meta[REQ_SRC_LSB +: SOURCE_W];
     end
   endfunction
 
-  function [ADDR_W-1:0] packet_addr;
-    input [PACKET_W-1:0] packet;
+  function [TAG_W-1:0] meta_tag;
+    input [REQ_META_W-1:0] meta;
     begin
-      packet_addr = packet[ADDR_LSB +: ADDR_W];
+      meta_tag = meta[REQ_TAG_LSB +: TAG_W];
     end
   endfunction
 
-  function [SLICE_W-1:0] packet_slice;
-    input [PACKET_W-1:0] packet;
+  function [ADDR_W-1:0] meta_addr;
+    input [REQ_META_W-1:0] meta;
     begin
-      packet_slice = packet[SLICE_LSB +: SLICE_W];
+      meta_addr = meta[REQ_ADDR_LSB +: ADDR_W];
     end
   endfunction
 
-  function [BANK_SEL_W-1:0] packet_bank;
-    input [PACKET_W-1:0] packet;
+  function [VALUE_SLICE_W-1:0] meta_slice;
+    input [REQ_META_W-1:0] meta;
+    begin
+      meta_slice = meta[REQ_SLICE_LSB +: VALUE_SLICE_W];
+    end
+  endfunction
+
+  function [BANK_SEL_W-1:0] bank_from_addr;
+    input [ADDR_W-1:0] addr;
     integer bank_int;
     begin
-      bank_int = packet_addr(packet) % BANKS;
-      packet_bank = bank_int[BANK_SEL_W-1:0];
+      bank_int = addr % BANKS;
+      bank_from_addr = bank_int[BANK_SEL_W-1:0];
     end
   endfunction
 
-  function [VALUE_W-1:0] make_value_line;
+  function integer store_index;
     input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
+    begin
+      store_index = (addr * VALUE_SLICE_COUNT) + value_slice;
+    end
+  endfunction
+
+  function [VALUE_W-1:0] generated_matrix;
+    input integer addr;
+    input integer value_slice;
     integer word_i;
     reg [63:0] word_value;
     begin
-      make_value_line = {VALUE_W{1'b0}};
+      generated_matrix = {VALUE_W{1'b0}};
       for (word_i = 0; word_i < (VALUE_W / 64); word_i = word_i + 1) begin
-        word_value = {16'hd000 + word_i[15:0], 16'h4100 + addr[15:0], 16'h2200 + word_i[15:0], addr[15:0] ^ (word_i * 16'h0011)};
-        make_value_line[(word_i * 64) +: 64] = word_value;
+        word_value = {8'hd0 + value_slice[7:0], 8'h40 + word_i[7:0],
+                      addr[15:0], value_slice[15:0], word_i[15:0]};
+        generated_matrix[(word_i * 64) +: 64] = word_value;
       end
     end
   endfunction
 
-  function [PAYLOAD_W-1:0] extract_slice;
-    input [VALUE_W-1:0] line;
-    input [SLICE_W-1:0] slice;
-    integer bit_i;
-    integer line_bit;
-    begin
-      extract_slice = {PAYLOAD_W{1'b0}};
-      for (bit_i = 0; bit_i < PAYLOAD_W; bit_i = bit_i + 1) begin
-        line_bit = (slice * PAYLOAD_W) + bit_i;
-        if (line_bit < VALUE_W) begin
-          extract_slice[bit_i] = line[line_bit];
-        end
-      end
-    end
-  endfunction
+  wire preload_fire = preload_valid && preload_ready;
+  wire req_fire = req_valid && req_ready;
+  wire resp_fire = resp_valid && resp_ready;
 
-  function [PACKET_W-1:0] build_response_packet;
-    input [PACKET_W-1:0] request_packet;
-    reg [VALUE_W-1:0] line;
-    reg [PAYLOAD_W-1:0] payload;
-    begin
-      line = make_value_line(packet_addr(request_packet));
-      payload = extract_slice(line, packet_slice(request_packet));
-      build_response_packet = request_packet;
-      build_response_packet[PAYLOAD_LSB +: PAYLOAD_W] = payload;
-    end
-  endfunction
+  assign preload_ready = 1'b1;
+  assign req_ready = bank_fifo_in_ready[bank_from_addr(req_addr)];
+  assign resp_valid = any_ready_response_r;
+  assign resp_source = active_source[resp_grant_bank_r];
+  assign resp_tag = active_tag[resp_grant_bank_r];
+  assign resp_addr = active_addr[resp_grant_bank_r];
+  assign resp_value_slice = active_slice[resp_grant_bank_r];
+  assign resp_fragment_idx = active_fragment[resp_grant_bank_r];
+  assign resp_last = any_ready_response_r &&
+                     (active_fragment[resp_grant_bank_r] == (FRAGMENTS - 1));
+  assign resp_data = any_ready_response_r ?
+    active_matrix[resp_grant_bank_r][(active_fragment[resp_grant_bank_r] * PACKET_W) +: PACKET_W] :
+    {PACKET_W{1'b0}};
+  assign req_current_occupancy = {{(COUNTER_W-REQ_OCC_W){1'b0}}, req_occupancy_sum_r};
+  assign resp_current_occupancy = {{(COUNTER_W-RESP_OCC_W){1'b0}}, resp_occupancy_sum_r};
 
   genvar bank_gi;
   generate
     for (bank_gi = 0; bank_gi < BANKS; bank_gi = bank_gi + 1) begin : gen_bank_fifo
       noc_ready_valid_fifo #(
-        .WIDTH(PACKET_W),
+        .WIDTH(REQ_META_W),
         .DEPTH(BANK_QUEUE_DEPTH)
       ) u_bank_fifo (
         .clk(clk),
         .rst_n(rst_n),
         .in_valid(bank_fifo_in_valid[bank_gi]),
         .in_ready(bank_fifo_in_ready[bank_gi]),
-        .in_data(req_packet),
+        .in_data(pack_req(req_source, req_tag, req_addr, req_value_slice)),
         .out_valid(bank_fifo_out_valid[bank_gi]),
-        .out_ready(bank_launch[bank_gi]),
-        .out_data(bank_fifo_out_packet[bank_gi]),
-        .occupancy(bank_fifo_occupancy[bank_gi]),
+        .out_ready(bank_fifo_out_ready[bank_gi]),
+        .out_data(bank_fifo_out_bus[(bank_gi * REQ_META_W) +: REQ_META_W]),
+        .occupancy(bank_fifo_occupancy_bus[(bank_gi * BANK_COUNT_W) +: BANK_COUNT_W]),
         .max_occupancy()
       );
-      assign bank_fifo_out_ready[bank_gi] = bank_launch[bank_gi];
-    end
-  endgenerate
 
-  noc_ready_valid_fifo #(
-    .WIDTH(PACKET_W),
-    .DEPTH(RESP_QUEUE_DEPTH)
-  ) u_resp_fifo (
-    .clk(clk),
-    .rst_n(rst_n),
-    .in_valid(resp_fifo_in_valid),
-    .in_ready(resp_fifo_in_ready),
-    .in_data(resp_fifo_in_packet),
-    .out_valid(resp_fifo_out_valid),
-    .out_ready(resp_ready),
-    .out_data(resp_fifo_out_packet),
-    .occupancy(resp_fifo_occupancy),
-    .max_occupancy()
-  );
-
-  assign resp_valid = resp_fifo_out_valid;
-  assign resp_packet = resp_fifo_out_packet;
-  assign resp_current_occupancy = {{(COUNTER_W-RESP_COUNT_W){1'b0}}, resp_fifo_occupancy};
-
-  always @(*) begin
-    target_bank = packet_bank(req_packet);
-  end
-
-  assign req_ready = bank_fifo_in_ready[target_bank];
-
-  generate
-    for (bank_gi = 0; bank_gi < BANKS; bank_gi = bank_gi + 1) begin : gen_bank_inputs
-      assign bank_fifo_in_valid[bank_gi] = req_valid && (target_bank == bank_gi[BANK_SEL_W-1:0]);
+      assign bank_fifo_in_valid[bank_gi] =
+        req_valid && (bank_from_addr(req_addr) == bank_gi[BANK_SEL_W-1:0]);
+      assign bank_fifo_out_ready[bank_gi] = !bank_busy[bank_gi] && bank_fifo_out_valid[bank_gi];
+      assign bank_launch_fire[bank_gi] = bank_fifo_out_valid[bank_gi] && bank_fifo_out_ready[bank_gi];
     end
   endgenerate
 
   always @(*) begin
-    bank_conflicted = 1'b0;
-    if (req_valid && req_ready) begin
-      if (bank_active[target_bank] || (bank_fifo_occupancy[target_bank] != {BANK_COUNT_W{1'b0}})) begin
-        bank_conflicted = 1'b1;
+    req_occupancy_sum_r = {REQ_OCC_W{1'b0}};
+    resp_occupancy_sum_r = {RESP_OCC_W{1'b0}};
+    for (occ_bank_i = 0; occ_bank_i < BANKS; occ_bank_i = occ_bank_i + 1) begin
+      req_occupancy_sum_r = req_occupancy_sum_r +
+        bank_fifo_occupancy_bus[(occ_bank_i * BANK_COUNT_W) +: BANK_COUNT_W];
+      if (bank_busy[occ_bank_i]) begin
+        req_occupancy_sum_r = req_occupancy_sum_r + {{(REQ_OCC_W-1){1'b0}}, 1'b1};
+      end
+      bank_ready_fragment_r[occ_bank_i] =
+        bank_busy[occ_bank_i] && (bank_latency[occ_bank_i] == {LAT_W{1'b0}});
+      if (bank_ready_fragment_r[occ_bank_i]) begin
+        resp_occupancy_sum_r = resp_occupancy_sum_r + {{(RESP_OCC_W-1){1'b0}}, 1'b1};
       end
     end
-  end
 
-  always @(*) begin
-    req_occupancy_sum = {REQ_OCC_W{1'b0}};
-    for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
-      req_occupancy_sum = req_occupancy_sum + bank_fifo_occupancy[bank_i];
-      if (bank_active[bank_i]) begin
-        req_occupancy_sum = req_occupancy_sum + {{(REQ_OCC_W-1){1'b0}}, 1'b1};
-      end
-    end
-  end
-
-  assign req_current_occupancy = {{(COUNTER_W-REQ_OCC_W){1'b0}}, req_occupancy_sum};
-
-  always @(*) begin
-    for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
-      bank_launch[bank_i] = !bank_active[bank_i] && bank_fifo_out_valid[bank_i];
-      bank_resp_ready_mask[bank_i] = bank_active[bank_i] && (bank_latency_left[bank_i] == {LAT_W{1'b0}});
-    end
-
-    any_ready_response = 1'b0;
-    resp_grant_bank = resp_rr_cursor;
+    any_ready_response_r = 1'b0;
+    resp_grant_bank_r = resp_rr_cursor;
     for (scan_i = 0; scan_i < BANKS; scan_i = scan_i + 1) begin
       scan_bank_int = resp_rr_cursor + scan_i;
       if (scan_bank_int >= BANKS) begin
         scan_bank_int = scan_bank_int - BANKS;
       end
       scan_bank = scan_bank_int[BANK_PTR_W-1:0];
-      if (!any_ready_response && bank_resp_ready_mask[scan_bank]) begin
-        any_ready_response = 1'b1;
-        resp_grant_bank = scan_bank;
+      if (!any_ready_response_r && bank_ready_fragment_r[scan_bank]) begin
+        any_ready_response_r = 1'b1;
+        resp_grant_bank_r = scan_bank;
       end
     end
-
-    resp_fifo_in_valid = any_ready_response && resp_fifo_in_ready;
-    resp_fifo_in_packet = any_ready_response ? build_response_packet(active_packet[resp_grant_bank]) : {PACKET_W{1'b0}};
   end
 
+  integer init_i;
+  initial begin
+    if ((PACKET_W != 128) && (PACKET_W != 256)) begin
+      $error("banked_value_memory_service PACKET_W must be 128 or 256, got %0d", PACKET_W);
+      $finish(1);
+    end
+    if (VALUE_W != 512) begin
+      $error("banked_value_memory_service VALUE_W must be 512, got %0d", VALUE_W);
+      $finish(1);
+    end
+    if ((VALUE_W % PACKET_W) != 0) begin
+      $error("banked_value_memory_service VALUE_W must be an integer multiple of PACKET_W");
+      $finish(1);
+    end
+    if (VALUE_SLICE_W != 4) begin
+      $error("banked_value_memory_service VALUE_SLICE_W must be 4, got %0d", VALUE_SLICE_W);
+      $finish(1);
+    end
+    if ((1 << FRAG_IDX_W) < FRAGMENTS) begin
+      $error("banked_value_memory_service FRAG_IDX_W is too small for %0d fragments", FRAGMENTS);
+      $finish(1);
+    end
+    if ((STORE_DEPTH <= 0) || (BANKS <= 0)) begin
+      $error("banked_value_memory_service STORE_DEPTH and BANKS must be positive");
+      $finish(1);
+    end
+    if (STORE_DEPTH > (1 << ADDR_W)) begin
+      $error("banked_value_memory_service STORE_DEPTH exceeds ADDR_W encoding");
+      $finish(1);
+    end
+    for (init_i = 0; init_i < STORE_ENTRY_COUNT; init_i = init_i + 1) begin
+      if (INIT_FROM_GENERATOR != 0) begin
+        init_addr = init_i / VALUE_SLICE_COUNT;
+        init_slice = init_i % VALUE_SLICE_COUNT;
+        value_mem[init_i] = generated_matrix(init_addr, init_slice);
+      end else begin
+        value_mem[init_i] = {VALUE_W{1'b0}};
+      end
+    end
+  end
+
+  integer preload_idx;
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
-      bank_active <= {BANKS{1'b0}};
+      bank_busy <= {BANKS{1'b0}};
+      for (seq_bank_i = 0; seq_bank_i < BANKS; seq_bank_i = seq_bank_i + 1) begin
+        active_source[seq_bank_i] <= {SOURCE_W{1'b0}};
+        active_tag[seq_bank_i] <= {TAG_W{1'b0}};
+        active_addr[seq_bank_i] <= {ADDR_W{1'b0}};
+        active_slice[seq_bank_i] <= {VALUE_SLICE_W{1'b0}};
+        active_matrix[seq_bank_i] <= {VALUE_W{1'b0}};
+        active_fragment[seq_bank_i] <= {FRAG_IDX_W{1'b0}};
+        bank_latency[seq_bank_i] <= {LAT_W{1'b0}};
+      end
       resp_rr_cursor <= {BANK_PTR_W{1'b0}};
       accepted_req_count <= {COUNTER_W{1'b0}};
       emitted_resp_count <= {COUNTER_W{1'b0}};
@@ -266,46 +313,69 @@ module banked_value_memory_service #(
       response_block_cycles <= {COUNTER_W{1'b0}};
       req_max_occupancy <= {COUNTER_W{1'b0}};
       resp_max_occupancy <= {COUNTER_W{1'b0}};
-      for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
-        active_packet[bank_i] <= {PACKET_W{1'b0}};
-        bank_latency_left[bank_i] <= {LAT_W{1'b0}};
-      end
     end else begin
-      if (req_valid && req_ready) begin
+      if (preload_fire && (preload_addr < STORE_DEPTH[ADDR_W-1:0])) begin
+        preload_idx = store_index(preload_addr, preload_value_slice);
+        value_mem[preload_idx] <= preload_matrix;
+      end
+
+      if (req_fire) begin
         accepted_req_count <= accepted_req_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
-        if (bank_conflicted) begin
+        if (bank_busy[bank_from_addr(req_addr)] ||
+            (bank_fifo_occupancy_bus[(bank_from_addr(req_addr) * BANK_COUNT_W) +: BANK_COUNT_W] != {BANK_COUNT_W{1'b0}})) begin
           bank_conflict_count <= bank_conflict_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
         end
       end
 
-      for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
-        if (bank_launch[bank_i]) begin
-          bank_active[bank_i] <= 1'b1;
-          active_packet[bank_i] <= bank_fifo_out_packet[bank_i];
-          if (READ_LATENCY <= 1) begin
-            bank_latency_left[bank_i] <= {LAT_W{1'b0}};
+      for (seq_bank_i = 0; seq_bank_i < BANKS; seq_bank_i = seq_bank_i + 1) begin
+        if (bank_launch_fire[seq_bank_i]) begin
+          bank_busy[seq_bank_i] <= 1'b1;
+          active_source[seq_bank_i] <=
+            meta_source(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]);
+          active_tag[seq_bank_i] <=
+            meta_tag(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]);
+          active_addr[seq_bank_i] <=
+            meta_addr(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]);
+          active_slice[seq_bank_i] <=
+            meta_slice(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]);
+          active_fragment[seq_bank_i] <= {FRAG_IDX_W{1'b0}};
+          if (READ_LATENCY == 0) begin
+            bank_latency[seq_bank_i] <= {LAT_W{1'b0}};
           end else begin
-            bank_latency_left[bank_i] <= READ_LATENCY - 1;
+            bank_latency[seq_bank_i] <= READ_LATENCY[LAT_W-1:0];
           end
-        end else if (bank_active[bank_i] && (bank_latency_left[bank_i] != {LAT_W{1'b0}})) begin
-          bank_latency_left[bank_i] <= bank_latency_left[bank_i] - {{(LAT_W-1){1'b0}}, 1'b1};
+          if (meta_addr(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]) <
+              STORE_DEPTH[ADDR_W-1:0]) begin
+            active_matrix[seq_bank_i] <=
+              value_mem[store_index(
+                meta_addr(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]),
+                meta_slice(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]))];
+          end else begin
+            active_matrix[seq_bank_i] <= {VALUE_W{1'b0}};
+          end
+        end else if (bank_busy[seq_bank_i] && (bank_latency[seq_bank_i] != {LAT_W{1'b0}})) begin
+          bank_latency[seq_bank_i] <=
+            bank_latency[seq_bank_i] - {{(LAT_W-1){1'b0}}, 1'b1};
         end
       end
 
-      if (any_ready_response && !resp_fifo_in_ready) begin
+      if (resp_valid && !resp_ready) begin
         response_block_cycles <= response_block_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
       end
-      if (resp_fifo_in_valid) begin
-        bank_active[resp_grant_bank] <= 1'b0;
-        if (resp_grant_bank == (BANKS - 1)) begin
+      if (resp_fire) begin
+        if (resp_last) begin
+          bank_busy[resp_grant_bank_r] <= 1'b0;
+          active_fragment[resp_grant_bank_r] <= {FRAG_IDX_W{1'b0}};
+          emitted_resp_count <= emitted_resp_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
+        end else begin
+          active_fragment[resp_grant_bank_r] <=
+            active_fragment[resp_grant_bank_r] + {{(FRAG_IDX_W-1){1'b0}}, 1'b1};
+        end
+        if (resp_grant_bank_r == (BANKS - 1)) begin
           resp_rr_cursor <= {BANK_PTR_W{1'b0}};
         end else begin
-          resp_rr_cursor <= resp_grant_bank + {{(BANK_PTR_W-1){1'b0}}, 1'b1};
+          resp_rr_cursor <= resp_grant_bank_r + {{(BANK_PTR_W-1){1'b0}}, 1'b1};
         end
-      end
-
-      if (resp_valid && resp_ready) begin
-        emitted_resp_count <= emitted_resp_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
       end
 
       if (req_current_occupancy > req_max_occupancy) begin

--- a/npu/sim/rtl/banked_value_memory_service.sv
+++ b/npu/sim/rtl/banked_value_memory_service.sv
@@ -1,0 +1,319 @@
+`timescale 1ns/1ps
+
+// Banked read-only value-memory service with per-bank request queues,
+// configurable read latency, and sliced 512-bit responses over a narrower
+// packet transport.
+module banked_value_memory_service #(
+  parameter integer PACKET_W = 128,
+  parameter integer SOURCE_W = 2,
+  parameter integer TAG_W = 8,
+  parameter integer ADDR_W = 12,
+  parameter integer SLICE_W = 3,
+  parameter integer VALUE_W = 512,
+  parameter integer BANKS = 4,
+  parameter integer BANK_QUEUE_DEPTH = 2,
+  parameter integer RESP_QUEUE_DEPTH = 2,
+  parameter integer READ_LATENCY = 2,
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire req_valid,
+  output wire req_ready,
+  input wire [PACKET_W-1:0] req_packet,
+
+  output wire resp_valid,
+  input wire resp_ready,
+  output wire [PACKET_W-1:0] resp_packet,
+
+  output reg [COUNTER_W-1:0] accepted_req_count,
+  output reg [COUNTER_W-1:0] emitted_resp_count,
+  output reg [COUNTER_W-1:0] bank_conflict_count,
+  output reg [COUNTER_W-1:0] response_block_cycles,
+  output wire [COUNTER_W-1:0] req_current_occupancy,
+  output reg [COUNTER_W-1:0] req_max_occupancy,
+  output wire [COUNTER_W-1:0] resp_current_occupancy,
+  output reg [COUNTER_W-1:0] resp_max_occupancy
+);
+  localparam integer BANK_SEL_W = (BANKS <= 1) ? 1 : $clog2(BANKS);
+  localparam integer BANK_PTR_W = (BANKS <= 1) ? 1 : $clog2(BANKS);
+  localparam integer BANK_COUNT_W = (BANK_QUEUE_DEPTH <= 1) ? 1 : $clog2(BANK_QUEUE_DEPTH + 1);
+  localparam integer RESP_COUNT_W = (RESP_QUEUE_DEPTH <= 1) ? 1 : $clog2(RESP_QUEUE_DEPTH + 1);
+  localparam integer LAT_W = (READ_LATENCY <= 1) ? 1 : $clog2(READ_LATENCY);
+  localparam integer SRC_LSB = 0;
+  localparam integer TAG_LSB = SRC_LSB + SOURCE_W;
+  localparam integer ADDR_LSB = TAG_LSB + TAG_W;
+  localparam integer SLICE_LSB = ADDR_LSB + ADDR_W;
+  localparam integer PAYLOAD_LSB = SLICE_LSB + SLICE_W;
+  localparam integer PAYLOAD_W = PACKET_W - PAYLOAD_LSB;
+  localparam integer REQ_OCC_W = $clog2((BANKS * (BANK_QUEUE_DEPTH + 1)) + BANKS + 1);
+
+  wire [BANKS-1:0] bank_fifo_in_ready;
+  wire [BANKS-1:0] bank_fifo_in_valid;
+  wire [BANKS-1:0] bank_fifo_out_valid;
+  wire [BANKS-1:0] bank_fifo_out_ready;
+  wire [PACKET_W-1:0] bank_fifo_out_packet [0:BANKS-1];
+  wire [BANK_COUNT_W-1:0] bank_fifo_occupancy [0:BANKS-1];
+  wire [PACKET_W-1:0] resp_fifo_out_packet;
+  wire [RESP_COUNT_W-1:0] resp_fifo_occupancy;
+  wire resp_fifo_in_ready;
+  wire resp_fifo_out_valid;
+
+  reg [PACKET_W-1:0] active_packet [0:BANKS-1];
+  reg [BANKS-1:0] bank_active;
+  reg [LAT_W-1:0] bank_latency_left [0:BANKS-1];
+  reg [BANKS-1:0] bank_launch;
+  reg [BANKS-1:0] bank_resp_ready_mask;
+  reg resp_fifo_in_valid;
+  reg [PACKET_W-1:0] resp_fifo_in_packet;
+  reg [BANK_PTR_W-1:0] resp_rr_cursor;
+  reg [BANK_PTR_W-1:0] resp_grant_bank;
+  reg any_ready_response;
+  reg [BANK_SEL_W-1:0] target_bank;
+  reg bank_conflicted;
+  reg [REQ_OCC_W-1:0] req_occupancy_sum;
+
+  integer bank_i;
+  integer scan_i;
+  integer scan_bank_int;
+  reg [BANK_PTR_W-1:0] scan_bank;
+
+  function [SOURCE_W-1:0] packet_source;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_source = packet[SRC_LSB +: SOURCE_W];
+    end
+  endfunction
+
+  function [TAG_W-1:0] packet_tag;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_tag = packet[TAG_LSB +: TAG_W];
+    end
+  endfunction
+
+  function [ADDR_W-1:0] packet_addr;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_addr = packet[ADDR_LSB +: ADDR_W];
+    end
+  endfunction
+
+  function [SLICE_W-1:0] packet_slice;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_slice = packet[SLICE_LSB +: SLICE_W];
+    end
+  endfunction
+
+  function [BANK_SEL_W-1:0] packet_bank;
+    input [PACKET_W-1:0] packet;
+    integer bank_int;
+    begin
+      bank_int = packet_addr(packet) % BANKS;
+      packet_bank = bank_int[BANK_SEL_W-1:0];
+    end
+  endfunction
+
+  function [VALUE_W-1:0] make_value_line;
+    input [ADDR_W-1:0] addr;
+    integer word_i;
+    reg [63:0] word_value;
+    begin
+      make_value_line = {VALUE_W{1'b0}};
+      for (word_i = 0; word_i < (VALUE_W / 64); word_i = word_i + 1) begin
+        word_value = {16'hd000 + word_i[15:0], 16'h4100 + addr[15:0], 16'h2200 + word_i[15:0], addr[15:0] ^ (word_i * 16'h0011)};
+        make_value_line[(word_i * 64) +: 64] = word_value;
+      end
+    end
+  endfunction
+
+  function [PAYLOAD_W-1:0] extract_slice;
+    input [VALUE_W-1:0] line;
+    input [SLICE_W-1:0] slice;
+    integer bit_i;
+    integer line_bit;
+    begin
+      extract_slice = {PAYLOAD_W{1'b0}};
+      for (bit_i = 0; bit_i < PAYLOAD_W; bit_i = bit_i + 1) begin
+        line_bit = (slice * PAYLOAD_W) + bit_i;
+        if (line_bit < VALUE_W) begin
+          extract_slice[bit_i] = line[line_bit];
+        end
+      end
+    end
+  endfunction
+
+  function [PACKET_W-1:0] build_response_packet;
+    input [PACKET_W-1:0] request_packet;
+    reg [VALUE_W-1:0] line;
+    reg [PAYLOAD_W-1:0] payload;
+    begin
+      line = make_value_line(packet_addr(request_packet));
+      payload = extract_slice(line, packet_slice(request_packet));
+      build_response_packet = request_packet;
+      build_response_packet[PAYLOAD_LSB +: PAYLOAD_W] = payload;
+    end
+  endfunction
+
+  genvar bank_gi;
+  generate
+    for (bank_gi = 0; bank_gi < BANKS; bank_gi = bank_gi + 1) begin : gen_bank_fifo
+      noc_ready_valid_fifo #(
+        .WIDTH(PACKET_W),
+        .DEPTH(BANK_QUEUE_DEPTH)
+      ) u_bank_fifo (
+        .clk(clk),
+        .rst_n(rst_n),
+        .in_valid(bank_fifo_in_valid[bank_gi]),
+        .in_ready(bank_fifo_in_ready[bank_gi]),
+        .in_data(req_packet),
+        .out_valid(bank_fifo_out_valid[bank_gi]),
+        .out_ready(bank_launch[bank_gi]),
+        .out_data(bank_fifo_out_packet[bank_gi]),
+        .occupancy(bank_fifo_occupancy[bank_gi]),
+        .max_occupancy()
+      );
+      assign bank_fifo_out_ready[bank_gi] = bank_launch[bank_gi];
+    end
+  endgenerate
+
+  noc_ready_valid_fifo #(
+    .WIDTH(PACKET_W),
+    .DEPTH(RESP_QUEUE_DEPTH)
+  ) u_resp_fifo (
+    .clk(clk),
+    .rst_n(rst_n),
+    .in_valid(resp_fifo_in_valid),
+    .in_ready(resp_fifo_in_ready),
+    .in_data(resp_fifo_in_packet),
+    .out_valid(resp_fifo_out_valid),
+    .out_ready(resp_ready),
+    .out_data(resp_fifo_out_packet),
+    .occupancy(resp_fifo_occupancy),
+    .max_occupancy()
+  );
+
+  assign resp_valid = resp_fifo_out_valid;
+  assign resp_packet = resp_fifo_out_packet;
+  assign resp_current_occupancy = {{(COUNTER_W-RESP_COUNT_W){1'b0}}, resp_fifo_occupancy};
+
+  always @(*) begin
+    target_bank = packet_bank(req_packet);
+  end
+
+  assign req_ready = bank_fifo_in_ready[target_bank];
+
+  generate
+    for (bank_gi = 0; bank_gi < BANKS; bank_gi = bank_gi + 1) begin : gen_bank_inputs
+      assign bank_fifo_in_valid[bank_gi] = req_valid && (target_bank == bank_gi[BANK_SEL_W-1:0]);
+    end
+  endgenerate
+
+  always @(*) begin
+    bank_conflicted = 1'b0;
+    if (req_valid && req_ready) begin
+      if (bank_active[target_bank] || (bank_fifo_occupancy[target_bank] != {BANK_COUNT_W{1'b0}})) begin
+        bank_conflicted = 1'b1;
+      end
+    end
+  end
+
+  always @(*) begin
+    req_occupancy_sum = {REQ_OCC_W{1'b0}};
+    for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
+      req_occupancy_sum = req_occupancy_sum + bank_fifo_occupancy[bank_i];
+      if (bank_active[bank_i]) begin
+        req_occupancy_sum = req_occupancy_sum + {{(REQ_OCC_W-1){1'b0}}, 1'b1};
+      end
+    end
+  end
+
+  assign req_current_occupancy = {{(COUNTER_W-REQ_OCC_W){1'b0}}, req_occupancy_sum};
+
+  always @(*) begin
+    for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
+      bank_launch[bank_i] = !bank_active[bank_i] && bank_fifo_out_valid[bank_i];
+      bank_resp_ready_mask[bank_i] = bank_active[bank_i] && (bank_latency_left[bank_i] == {LAT_W{1'b0}});
+    end
+
+    any_ready_response = 1'b0;
+    resp_grant_bank = resp_rr_cursor;
+    for (scan_i = 0; scan_i < BANKS; scan_i = scan_i + 1) begin
+      scan_bank_int = resp_rr_cursor + scan_i;
+      if (scan_bank_int >= BANKS) begin
+        scan_bank_int = scan_bank_int - BANKS;
+      end
+      scan_bank = scan_bank_int[BANK_PTR_W-1:0];
+      if (!any_ready_response && bank_resp_ready_mask[scan_bank]) begin
+        any_ready_response = 1'b1;
+        resp_grant_bank = scan_bank;
+      end
+    end
+
+    resp_fifo_in_valid = any_ready_response && resp_fifo_in_ready;
+    resp_fifo_in_packet = any_ready_response ? build_response_packet(active_packet[resp_grant_bank]) : {PACKET_W{1'b0}};
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      bank_active <= {BANKS{1'b0}};
+      resp_rr_cursor <= {BANK_PTR_W{1'b0}};
+      accepted_req_count <= {COUNTER_W{1'b0}};
+      emitted_resp_count <= {COUNTER_W{1'b0}};
+      bank_conflict_count <= {COUNTER_W{1'b0}};
+      response_block_cycles <= {COUNTER_W{1'b0}};
+      req_max_occupancy <= {COUNTER_W{1'b0}};
+      resp_max_occupancy <= {COUNTER_W{1'b0}};
+      for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
+        active_packet[bank_i] <= {PACKET_W{1'b0}};
+        bank_latency_left[bank_i] <= {LAT_W{1'b0}};
+      end
+    end else begin
+      if (req_valid && req_ready) begin
+        accepted_req_count <= accepted_req_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
+        if (bank_conflicted) begin
+          bank_conflict_count <= bank_conflict_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
+        end
+      end
+
+      for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
+        if (bank_launch[bank_i]) begin
+          bank_active[bank_i] <= 1'b1;
+          active_packet[bank_i] <= bank_fifo_out_packet[bank_i];
+          if (READ_LATENCY <= 1) begin
+            bank_latency_left[bank_i] <= {LAT_W{1'b0}};
+          end else begin
+            bank_latency_left[bank_i] <= READ_LATENCY - 1;
+          end
+        end else if (bank_active[bank_i] && (bank_latency_left[bank_i] != {LAT_W{1'b0}})) begin
+          bank_latency_left[bank_i] <= bank_latency_left[bank_i] - {{(LAT_W-1){1'b0}}, 1'b1};
+        end
+      end
+
+      if (any_ready_response && !resp_fifo_in_ready) begin
+        response_block_cycles <= response_block_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
+      end
+      if (resp_fifo_in_valid) begin
+        bank_active[resp_grant_bank] <= 1'b0;
+        if (resp_grant_bank == (BANKS - 1)) begin
+          resp_rr_cursor <= {BANK_PTR_W{1'b0}};
+        end else begin
+          resp_rr_cursor <= resp_grant_bank + {{(BANK_PTR_W-1){1'b0}}, 1'b1};
+        end
+      end
+
+      if (resp_valid && resp_ready) begin
+        emitted_resp_count <= emitted_resp_count + {{(COUNTER_W-1){1'b0}}, 1'b1};
+      end
+
+      if (req_current_occupancy > req_max_occupancy) begin
+        req_max_occupancy <= req_current_occupancy;
+      end
+      if (resp_current_occupancy > resp_max_occupancy) begin
+        resp_max_occupancy <= resp_current_occupancy;
+      end
+    end
+  end
+endmodule

--- a/npu/sim/rtl/noc_ready_valid_fifo.sv
+++ b/npu/sim/rtl/noc_ready_valid_fifo.sv
@@ -1,0 +1,76 @@
+`timescale 1ns/1ps
+
+module noc_ready_valid_fifo #(
+  parameter integer WIDTH = 128,
+  parameter integer DEPTH = 4,
+  parameter integer COUNT_W = (DEPTH <= 1) ? 1 : $clog2(DEPTH + 1)
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire in_valid,
+  output wire in_ready,
+  input wire [WIDTH-1:0] in_data,
+
+  output wire out_valid,
+  input wire out_ready,
+  output wire [WIDTH-1:0] out_data,
+
+  output wire [COUNT_W-1:0] occupancy,
+  output reg [COUNT_W-1:0] max_occupancy
+);
+  localparam [COUNT_W-1:0] DEPTH_VALUE = DEPTH;
+
+  reg [WIDTH-1:0] mem [0:DEPTH-1];
+  reg [COUNT_W-1:0] count;
+  integer slot_i;
+
+  wire out_valid_int = (count != {COUNT_W{1'b0}});
+  wire out_fire = out_valid_int && out_ready;
+  wire in_ready_int = (count < DEPTH_VALUE) || out_fire;
+  wire in_fire = in_valid && in_ready_int;
+
+  assign in_ready = in_ready_int;
+  assign out_valid = out_valid_int;
+  assign out_data = mem[0];
+  assign occupancy = count;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      count <= {COUNT_W{1'b0}};
+      max_occupancy <= {COUNT_W{1'b0}};
+    end else begin
+      case ({in_fire, out_fire})
+        2'b10: begin
+          mem[count] <= in_data;
+          count <= count + {{(COUNT_W-1){1'b0}}, 1'b1};
+          if ((count + {{(COUNT_W-1){1'b0}}, 1'b1}) > max_occupancy) begin
+            max_occupancy <= count + {{(COUNT_W-1){1'b0}}, 1'b1};
+          end
+        end
+        2'b01: begin
+          for (slot_i = 0; slot_i < (DEPTH - 1); slot_i = slot_i + 1) begin
+            if ((slot_i + 1) < count) begin
+              mem[slot_i] <= mem[slot_i + 1];
+            end
+          end
+          count <= count - {{(COUNT_W-1){1'b0}}, 1'b1};
+        end
+        2'b11: begin
+          for (slot_i = 0; slot_i < (DEPTH - 1); slot_i = slot_i + 1) begin
+            if ((slot_i + 1) < count) begin
+              mem[slot_i] <= mem[slot_i + 1];
+            end
+          end
+          if (count == {{(COUNT_W-1){1'b0}}, 1'b1}) begin
+            mem[0] <= in_data;
+          end else begin
+            mem[count - {{(COUNT_W-1){1'b0}}, 1'b1}] <= in_data;
+          end
+        end
+        default: begin
+        end
+      endcase
+    end
+  end
+endmodule

--- a/npu/sim/rtl/noc_ready_valid_router.sv
+++ b/npu/sim/rtl/noc_ready_valid_router.sv
@@ -25,7 +25,6 @@ module noc_ready_valid_router #(
 
   input wire [SOURCES-1:0] src_req_valid,
   output wire [SOURCES-1:0] src_req_ready,
-  input wire [SOURCES*SOURCE_W-1:0] src_req_source,
   input wire [SOURCES*TAG_W-1:0] src_req_tag,
   input wire [SOURCES*ADDR_W-1:0] src_req_addr,
   input wire [SOURCES*VALUE_SLICE_W-1:0] src_req_value_slice,

--- a/npu/sim/rtl/noc_ready_valid_router.sv
+++ b/npu/sim/rtl/noc_ready_valid_router.sv
@@ -1,19 +1,23 @@
 `timescale 1ns/1ps
 
-// Multi-source ready/valid transport with request arbitration and response
-// demultiplexing. The request path supports deterministic round-robin and
-// locality-first selection based on the address-derived bank index.
+// Multi-source ready/valid transport for metadata requests and segmented
+// matrix responses. Requests preserve source/tag/address/value_slice. The
+// response path adds fragment index and last metadata for a segmented 512-bit
+// matrix return.
 module noc_ready_valid_router #(
   parameter integer PACKET_W = 128,
+  parameter integer VALUE_W = 512,
+  parameter integer FRAG_IDX_W = ((VALUE_W / PACKET_W) <= 1) ? 1 : $clog2(VALUE_W / PACKET_W),
   parameter integer SOURCES = 4,
   parameter integer SOURCE_W = 2,
   parameter integer TAG_W = 8,
   parameter integer ADDR_W = 12,
-  parameter integer SLICE_W = 3,
+  parameter integer VALUE_SLICE_W = 4,
   parameter integer BANKS = 4,
   parameter integer REQ_QUEUE_DEPTH = 2,
   parameter integer RESP_QUEUE_DEPTH = 2,
   parameter integer ARB_MODE = 0,
+  parameter integer LOCALITY_BURST_MAX = 2,
   parameter integer COUNTER_W = 32
 ) (
   input wire clk,
@@ -21,19 +25,37 @@ module noc_ready_valid_router #(
 
   input wire [SOURCES-1:0] src_req_valid,
   output wire [SOURCES-1:0] src_req_ready,
-  input wire [SOURCES*PACKET_W-1:0] src_req_packet,
+  input wire [SOURCES*SOURCE_W-1:0] src_req_source,
+  input wire [SOURCES*TAG_W-1:0] src_req_tag,
+  input wire [SOURCES*ADDR_W-1:0] src_req_addr,
+  input wire [SOURCES*VALUE_SLICE_W-1:0] src_req_value_slice,
 
   output wire [SOURCES-1:0] src_resp_valid,
   input wire [SOURCES-1:0] src_resp_ready,
-  output wire [SOURCES*PACKET_W-1:0] src_resp_packet,
+  output wire [SOURCES*SOURCE_W-1:0] src_resp_source,
+  output wire [SOURCES*TAG_W-1:0] src_resp_tag,
+  output wire [SOURCES*ADDR_W-1:0] src_resp_addr,
+  output wire [SOURCES*VALUE_SLICE_W-1:0] src_resp_value_slice,
+  output wire [SOURCES*FRAG_IDX_W-1:0] src_resp_fragment_idx,
+  output wire [SOURCES-1:0] src_resp_last,
+  output wire [SOURCES*PACKET_W-1:0] src_resp_data,
 
   output wire req_valid,
   input wire req_ready,
-  output wire [PACKET_W-1:0] req_packet,
+  output wire [SOURCE_W-1:0] req_source,
+  output wire [TAG_W-1:0] req_tag,
+  output wire [ADDR_W-1:0] req_addr,
+  output wire [VALUE_SLICE_W-1:0] req_value_slice,
 
   input wire resp_valid,
   output wire resp_ready,
-  input wire [PACKET_W-1:0] resp_packet,
+  input wire [SOURCE_W-1:0] resp_source,
+  input wire [TAG_W-1:0] resp_tag,
+  input wire [ADDR_W-1:0] resp_addr,
+  input wire [VALUE_SLICE_W-1:0] resp_value_slice,
+  input wire [FRAG_IDX_W-1:0] resp_fragment_idx,
+  input wire resp_last,
+  input wire [PACKET_W-1:0] resp_data,
 
   output reg [COUNTER_W-1:0] injection_stall_cycles,
   output reg [COUNTER_W-1:0] arbitration_contention_cycles,
@@ -43,98 +65,223 @@ module noc_ready_valid_router #(
   output wire [COUNTER_W-1:0] resp_current_occupancy,
   output reg [COUNTER_W-1:0] resp_max_occupancy
 );
+  localparam integer FRAGMENTS = VALUE_W / PACKET_W;
+  localparam integer REQ_META_W = SOURCE_W + TAG_W + ADDR_W + VALUE_SLICE_W;
+  localparam integer RESP_META_W = SOURCE_W + TAG_W + ADDR_W + VALUE_SLICE_W + FRAG_IDX_W + 1 + PACKET_W;
   localparam integer REQ_COUNT_W = (REQ_QUEUE_DEPTH <= 1) ? 1 : $clog2(REQ_QUEUE_DEPTH + 1);
   localparam integer RESP_COUNT_W = (RESP_QUEUE_DEPTH <= 1) ? 1 : $clog2(RESP_QUEUE_DEPTH + 1);
   localparam integer SOURCE_PTR_W = (SOURCES <= 1) ? 1 : $clog2(SOURCES);
   localparam integer BANK_SEL_W = (BANKS <= 1) ? 1 : $clog2(BANKS);
-  localparam integer SRC_LSB = 0;
-  localparam integer TAG_LSB = SRC_LSB + SOURCE_W;
-  localparam integer ADDR_LSB = TAG_LSB + TAG_W;
-  localparam integer SLICE_LSB = ADDR_LSB + ADDR_W;
-  localparam integer PAYLOAD_LSB = SLICE_LSB + SLICE_W;
   localparam integer REQ_OCC_W = $clog2((SOURCES * (REQ_QUEUE_DEPTH + 1)) + 1);
   localparam integer RESP_OCC_W = $clog2((SOURCES * (RESP_QUEUE_DEPTH + 1)) + 1);
+  localparam integer LOCALITY_BURST_W = (LOCALITY_BURST_MAX <= 1) ? 1 : $clog2(LOCALITY_BURST_MAX + 1);
+  localparam integer REQ_SRC_LSB = 0;
+  localparam integer REQ_TAG_LSB = REQ_SRC_LSB + SOURCE_W;
+  localparam integer REQ_ADDR_LSB = REQ_TAG_LSB + TAG_W;
+  localparam integer REQ_SLICE_LSB = REQ_ADDR_LSB + ADDR_W;
+  localparam integer RESP_SRC_LSB = 0;
+  localparam integer RESP_TAG_LSB = RESP_SRC_LSB + SOURCE_W;
+  localparam integer RESP_ADDR_LSB = RESP_TAG_LSB + TAG_W;
+  localparam integer RESP_SLICE_LSB = RESP_ADDR_LSB + ADDR_W;
+  localparam integer RESP_FRAG_LSB = RESP_SLICE_LSB + VALUE_SLICE_W;
+  localparam integer RESP_LAST_LSB = RESP_FRAG_LSB + FRAG_IDX_W;
+  localparam integer RESP_DATA_LSB = RESP_LAST_LSB + 1;
 
   wire [SOURCES-1:0] req_fifo_out_valid;
-  wire [SOURCES-1:0] src_req_ready_int;
-  wire [SOURCES*PACKET_W-1:0] req_fifo_out_packet_bus;
+  wire [SOURCES-1:0] req_fifo_out_ready;
+  wire [SOURCES*REQ_META_W-1:0] req_fifo_out_bus;
   wire [SOURCES*REQ_COUNT_W-1:0] req_fifo_occupancy_bus;
 
   wire [SOURCES-1:0] resp_fifo_out_valid;
+  wire [SOURCES*RESP_META_W-1:0] resp_fifo_out_bus;
+  wire [SOURCES*RESP_COUNT_W-1:0] resp_fifo_occupancy_bus;
   wire [SOURCES-1:0] resp_fifo_in_valid;
   wire [SOURCES-1:0] resp_fifo_in_ready;
-  wire [SOURCES*PACKET_W-1:0] resp_fifo_out_packet_bus;
-  wire [SOURCES*RESP_COUNT_W-1:0] resp_fifo_occupancy_bus;
+  wire [RESP_META_W-1:0] resp_bus;
 
+  reg grant_valid_r;
+  reg [SOURCE_PTR_W-1:0] grant_idx_r;
+  reg [REQ_META_W-1:0] grant_req_r;
+  reg [SOURCES-1:0] req_fifo_out_ready_r;
   reg [SOURCE_PTR_W-1:0] rr_cursor;
   reg [BANK_SEL_W-1:0] preferred_bank;
-
-  reg grant_valid;
-  reg [SOURCE_PTR_W-1:0] grant_idx;
-  reg [PACKET_W-1:0] grant_packet;
-  reg [SOURCES-1:0] req_fifo_out_ready_int;
-  reg [SOURCE_PTR_W-1:0] resp_target_idx;
-  reg resp_target_valid;
-  reg any_injection_stall;
-  reg arbitration_contended;
-  reg [REQ_OCC_W-1:0] req_occupancy_sum;
-  reg [RESP_OCC_W-1:0] resp_occupancy_sum;
+  reg [LOCALITY_BURST_W-1:0] locality_burst_count;
+  reg [REQ_OCC_W-1:0] req_occupancy_sum_r;
+  reg [RESP_OCC_W-1:0] resp_occupancy_sum_r;
+  reg any_injection_stall_r;
+  reg arbitration_contended_r;
+  reg [SOURCE_PTR_W-1:0] resp_target_idx_r;
+  reg resp_target_valid_r;
 
   integer src_i;
   integer scan_i;
   integer scan_src_int;
   integer req_ready_count;
-  integer resp_ready_count;
-  reg [SOURCE_PTR_W-1:0] scan_src;
-  reg locality_hit;
   reg fallback_hit;
-  reg [SOURCE_PTR_W-1:0] locality_idx;
-  reg [PACKET_W-1:0] locality_packet;
+  reg locality_hit;
+  reg alternate_hit;
   reg [SOURCE_PTR_W-1:0] fallback_idx;
-  reg [PACKET_W-1:0] fallback_packet;
+  reg [SOURCE_PTR_W-1:0] locality_idx;
+  reg [SOURCE_PTR_W-1:0] alternate_idx;
+  reg [REQ_META_W-1:0] fallback_req;
+  reg [REQ_META_W-1:0] locality_req;
+  reg [REQ_META_W-1:0] alternate_req;
+  reg [SOURCE_PTR_W-1:0] scan_src;
 
-  function [SOURCE_W-1:0] packet_source;
-    input [PACKET_W-1:0] packet;
+  function [REQ_META_W-1:0] pack_req;
+    input [SOURCE_W-1:0] source;
+    input [TAG_W-1:0] tag;
+    input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
     begin
-      packet_source = packet[SRC_LSB +: SOURCE_W];
+      pack_req = {REQ_META_W{1'b0}};
+      pack_req[REQ_SRC_LSB +: SOURCE_W] = source;
+      pack_req[REQ_TAG_LSB +: TAG_W] = tag;
+      pack_req[REQ_ADDR_LSB +: ADDR_W] = addr;
+      pack_req[REQ_SLICE_LSB +: VALUE_SLICE_W] = value_slice;
     end
   endfunction
 
-  function [ADDR_W-1:0] packet_addr;
-    input [PACKET_W-1:0] packet;
+  function [RESP_META_W-1:0] pack_resp;
+    input [SOURCE_W-1:0] source;
+    input [TAG_W-1:0] tag;
+    input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
+    input [FRAG_IDX_W-1:0] fragment_idx;
+    input last;
+    input [PACKET_W-1:0] data;
     begin
-      packet_addr = packet[ADDR_LSB +: ADDR_W];
+      pack_resp = {RESP_META_W{1'b0}};
+      pack_resp[RESP_SRC_LSB +: SOURCE_W] = source;
+      pack_resp[RESP_TAG_LSB +: TAG_W] = tag;
+      pack_resp[RESP_ADDR_LSB +: ADDR_W] = addr;
+      pack_resp[RESP_SLICE_LSB +: VALUE_SLICE_W] = value_slice;
+      pack_resp[RESP_FRAG_LSB +: FRAG_IDX_W] = fragment_idx;
+      pack_resp[RESP_LAST_LSB] = last;
+      pack_resp[RESP_DATA_LSB +: PACKET_W] = data;
     end
   endfunction
 
-  function [BANK_SEL_W-1:0] packet_bank;
-    input [PACKET_W-1:0] packet;
+  function [SOURCE_W-1:0] req_source_from_meta;
+    input [REQ_META_W-1:0] meta;
+    begin
+      req_source_from_meta = meta[REQ_SRC_LSB +: SOURCE_W];
+    end
+  endfunction
+
+  function [TAG_W-1:0] req_tag_from_meta;
+    input [REQ_META_W-1:0] meta;
+    begin
+      req_tag_from_meta = meta[REQ_TAG_LSB +: TAG_W];
+    end
+  endfunction
+
+  function [ADDR_W-1:0] req_addr_from_meta;
+    input [REQ_META_W-1:0] meta;
+    begin
+      req_addr_from_meta = meta[REQ_ADDR_LSB +: ADDR_W];
+    end
+  endfunction
+
+  function [VALUE_SLICE_W-1:0] req_slice_from_meta;
+    input [REQ_META_W-1:0] meta;
+    begin
+      req_slice_from_meta = meta[REQ_SLICE_LSB +: VALUE_SLICE_W];
+    end
+  endfunction
+
+  function [BANK_SEL_W-1:0] req_bank_from_meta;
+    input [REQ_META_W-1:0] meta;
     integer bank_int;
     begin
-      bank_int = packet_addr(packet) % BANKS;
-      packet_bank = bank_int[BANK_SEL_W-1:0];
+      bank_int = req_addr_from_meta(meta) % BANKS;
+      req_bank_from_meta = bank_int[BANK_SEL_W-1:0];
     end
   endfunction
+
+  function [SOURCE_W-1:0] resp_source_from_meta;
+    input [RESP_META_W-1:0] meta;
+    begin
+      resp_source_from_meta = meta[RESP_SRC_LSB +: SOURCE_W];
+    end
+  endfunction
+
+  function [TAG_W-1:0] resp_tag_from_meta;
+    input [RESP_META_W-1:0] meta;
+    begin
+      resp_tag_from_meta = meta[RESP_TAG_LSB +: TAG_W];
+    end
+  endfunction
+
+  function [ADDR_W-1:0] resp_addr_from_meta;
+    input [RESP_META_W-1:0] meta;
+    begin
+      resp_addr_from_meta = meta[RESP_ADDR_LSB +: ADDR_W];
+    end
+  endfunction
+
+  function [VALUE_SLICE_W-1:0] resp_slice_from_meta;
+    input [RESP_META_W-1:0] meta;
+    begin
+      resp_slice_from_meta = meta[RESP_SLICE_LSB +: VALUE_SLICE_W];
+    end
+  endfunction
+
+  function [FRAG_IDX_W-1:0] resp_fragment_from_meta;
+    input [RESP_META_W-1:0] meta;
+    begin
+      resp_fragment_from_meta = meta[RESP_FRAG_LSB +: FRAG_IDX_W];
+    end
+  endfunction
+
+  function resp_last_from_meta;
+    input [RESP_META_W-1:0] meta;
+    begin
+      resp_last_from_meta = meta[RESP_LAST_LSB];
+    end
+  endfunction
+
+  function [PACKET_W-1:0] resp_data_from_meta;
+    input [RESP_META_W-1:0] meta;
+    begin
+      resp_data_from_meta = meta[RESP_DATA_LSB +: PACKET_W];
+    end
+  endfunction
+
+  wire req_fire = req_valid && req_ready;
+  wire resp_fire = resp_valid && resp_ready;
+
+  assign req_valid = grant_valid_r;
+  assign req_source = req_source_from_meta(grant_req_r);
+  assign req_tag = req_tag_from_meta(grant_req_r);
+  assign req_addr = req_addr_from_meta(grant_req_r);
+  assign req_value_slice = req_slice_from_meta(grant_req_r);
+  assign resp_bus = pack_resp(resp_source, resp_tag, resp_addr, resp_value_slice,
+                              resp_fragment_idx, resp_last, resp_data);
+  assign req_current_occupancy = {{(COUNTER_W-REQ_OCC_W){1'b0}}, req_occupancy_sum_r};
+  assign resp_current_occupancy = {{(COUNTER_W-RESP_OCC_W){1'b0}}, resp_occupancy_sum_r};
 
   genvar req_gi;
   generate
     for (req_gi = 0; req_gi < SOURCES; req_gi = req_gi + 1) begin : gen_req_fifo
       noc_ready_valid_fifo #(
-        .WIDTH(PACKET_W),
+        .WIDTH(REQ_META_W),
         .DEPTH(REQ_QUEUE_DEPTH)
       ) u_req_fifo (
         .clk(clk),
         .rst_n(rst_n),
         .in_valid(src_req_valid[req_gi]),
-        .in_ready(src_req_ready_int[req_gi]),
-        .in_data(src_req_packet[(req_gi * PACKET_W) +: PACKET_W]),
+        .in_ready(src_req_ready[req_gi]),
+        .in_data(pack_req(src_req_source[(req_gi * SOURCE_W) +: SOURCE_W],
+                          src_req_tag[(req_gi * TAG_W) +: TAG_W],
+                          src_req_addr[(req_gi * ADDR_W) +: ADDR_W],
+                          src_req_value_slice[(req_gi * VALUE_SLICE_W) +: VALUE_SLICE_W])),
         .out_valid(req_fifo_out_valid[req_gi]),
-        .out_ready(req_fifo_out_ready_int[req_gi]),
-        .out_data(req_fifo_out_packet_bus[(req_gi * PACKET_W) +: PACKET_W]),
+        .out_ready(req_fifo_out_ready_r[req_gi]),
+        .out_data(req_fifo_out_bus[(req_gi * REQ_META_W) +: REQ_META_W]),
         .occupancy(req_fifo_occupancy_bus[(req_gi * REQ_COUNT_W) +: REQ_COUNT_W]),
         .max_occupancy()
       );
-      assign src_req_ready[req_gi] = src_req_ready_int[req_gi];
     end
   endgenerate
 
@@ -142,50 +289,75 @@ module noc_ready_valid_router #(
   generate
     for (resp_gi = 0; resp_gi < SOURCES; resp_gi = resp_gi + 1) begin : gen_resp_fifo
       noc_ready_valid_fifo #(
-        .WIDTH(PACKET_W),
+        .WIDTH(RESP_META_W),
         .DEPTH(RESP_QUEUE_DEPTH)
       ) u_resp_fifo (
         .clk(clk),
         .rst_n(rst_n),
         .in_valid(resp_fifo_in_valid[resp_gi]),
         .in_ready(resp_fifo_in_ready[resp_gi]),
-        .in_data(resp_packet),
-        .out_valid(resp_fifo_out_valid[resp_gi]),
+        .in_data(resp_bus),
+        .out_valid(src_resp_valid[resp_gi]),
         .out_ready(src_resp_ready[resp_gi]),
-        .out_data(resp_fifo_out_packet_bus[(resp_gi * PACKET_W) +: PACKET_W]),
+        .out_data(resp_fifo_out_bus[(resp_gi * RESP_META_W) +: RESP_META_W]),
         .occupancy(resp_fifo_occupancy_bus[(resp_gi * RESP_COUNT_W) +: RESP_COUNT_W]),
         .max_occupancy()
       );
-      assign src_resp_valid[resp_gi] = resp_fifo_out_valid[resp_gi];
-      assign src_resp_packet[(resp_gi * PACKET_W) +: PACKET_W] = resp_fifo_out_packet_bus[(resp_gi * PACKET_W) +: PACKET_W];
+
+      assign src_resp_source[(resp_gi * SOURCE_W) +: SOURCE_W] =
+        resp_source_from_meta(resp_fifo_out_bus[(resp_gi * RESP_META_W) +: RESP_META_W]);
+      assign src_resp_tag[(resp_gi * TAG_W) +: TAG_W] =
+        resp_tag_from_meta(resp_fifo_out_bus[(resp_gi * RESP_META_W) +: RESP_META_W]);
+      assign src_resp_addr[(resp_gi * ADDR_W) +: ADDR_W] =
+        resp_addr_from_meta(resp_fifo_out_bus[(resp_gi * RESP_META_W) +: RESP_META_W]);
+      assign src_resp_value_slice[(resp_gi * VALUE_SLICE_W) +: VALUE_SLICE_W] =
+        resp_slice_from_meta(resp_fifo_out_bus[(resp_gi * RESP_META_W) +: RESP_META_W]);
+      assign src_resp_fragment_idx[(resp_gi * FRAG_IDX_W) +: FRAG_IDX_W] =
+        resp_fragment_from_meta(resp_fifo_out_bus[(resp_gi * RESP_META_W) +: RESP_META_W]);
+      assign src_resp_last[resp_gi] =
+        resp_last_from_meta(resp_fifo_out_bus[(resp_gi * RESP_META_W) +: RESP_META_W]);
+      assign src_resp_data[(resp_gi * PACKET_W) +: PACKET_W] =
+        resp_data_from_meta(resp_fifo_out_bus[(resp_gi * RESP_META_W) +: RESP_META_W]);
+
+      assign resp_fifo_in_valid[resp_gi] =
+        resp_valid && resp_target_valid_r && (resp_target_idx_r == resp_gi[SOURCE_PTR_W-1:0]);
     end
   endgenerate
 
   always @(*) begin
-    grant_valid = 1'b0;
-    grant_idx = {SOURCE_PTR_W{1'b0}};
-    grant_packet = {PACKET_W{1'b0}};
-    locality_hit = 1'b0;
-    fallback_hit = 1'b0;
-    locality_idx = {SOURCE_PTR_W{1'b0}};
-    locality_packet = {PACKET_W{1'b0}};
-    fallback_idx = {SOURCE_PTR_W{1'b0}};
-    fallback_packet = {PACKET_W{1'b0}};
-    req_fifo_out_ready_int = {SOURCES{1'b0}};
+    grant_valid_r = 1'b0;
+    grant_idx_r = {SOURCE_PTR_W{1'b0}};
+    grant_req_r = {REQ_META_W{1'b0}};
+    req_fifo_out_ready_r = {SOURCES{1'b0}};
+    req_occupancy_sum_r = {REQ_OCC_W{1'b0}};
+    resp_occupancy_sum_r = {RESP_OCC_W{1'b0}};
+    any_injection_stall_r = 1'b0;
+    arbitration_contended_r = 1'b0;
     req_ready_count = 0;
-    req_occupancy_sum = {REQ_OCC_W{1'b0}};
-    any_injection_stall = 1'b0;
+    fallback_hit = 1'b0;
+    locality_hit = 1'b0;
+    alternate_hit = 1'b0;
+    fallback_idx = {SOURCE_PTR_W{1'b0}};
+    locality_idx = {SOURCE_PTR_W{1'b0}};
+    alternate_idx = {SOURCE_PTR_W{1'b0}};
+    fallback_req = {REQ_META_W{1'b0}};
+    locality_req = {REQ_META_W{1'b0}};
+    alternate_req = {REQ_META_W{1'b0}};
 
     for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-      req_occupancy_sum = req_occupancy_sum + req_fifo_occupancy_bus[(src_i * REQ_COUNT_W) +: REQ_COUNT_W];
-      if (src_req_valid[src_i] && !src_req_ready_int[src_i]) begin
-        any_injection_stall = 1'b0;
-        any_injection_stall = 1'b1;
+      req_occupancy_sum_r = req_occupancy_sum_r +
+        req_fifo_occupancy_bus[(src_i * REQ_COUNT_W) +: REQ_COUNT_W];
+      resp_occupancy_sum_r = resp_occupancy_sum_r +
+        resp_fifo_occupancy_bus[(src_i * RESP_COUNT_W) +: RESP_COUNT_W];
+      if (src_req_valid[src_i] && !src_req_ready[src_i]) begin
+        any_injection_stall_r = 1'b1;
       end
       if (req_fifo_out_valid[src_i]) begin
         req_ready_count = req_ready_count + 1;
       end
     end
+
+    arbitration_contended_r = (req_ready_count > 1);
 
     for (scan_i = 0; scan_i < SOURCES; scan_i = scan_i + 1) begin
       scan_src_int = rr_cursor + scan_i;
@@ -193,95 +365,142 @@ module noc_ready_valid_router #(
         scan_src_int = scan_src_int - SOURCES;
       end
       scan_src = scan_src_int[SOURCE_PTR_W-1:0];
-      if (!fallback_hit && req_fifo_out_valid[scan_src]) begin
-        fallback_hit = 1'b1;
-        fallback_idx = scan_src;
-        fallback_packet = req_fifo_out_packet_bus[(scan_src * PACKET_W) +: PACKET_W];
-      end
-      if (!locality_hit && req_fifo_out_valid[scan_src] &&
-          (packet_bank(req_fifo_out_packet_bus[(scan_src * PACKET_W) +: PACKET_W]) == preferred_bank)) begin
-        locality_hit = 1'b1;
-        locality_idx = scan_src;
-        locality_packet = req_fifo_out_packet_bus[(scan_src * PACKET_W) +: PACKET_W];
+      if (req_fifo_out_valid[scan_src]) begin
+        if (!fallback_hit) begin
+          fallback_hit = 1'b1;
+          fallback_idx = scan_src;
+          fallback_req = req_fifo_out_bus[(scan_src * REQ_META_W) +: REQ_META_W];
+        end
+        if ((req_bank_from_meta(req_fifo_out_bus[(scan_src * REQ_META_W) +: REQ_META_W]) == preferred_bank) &&
+            !locality_hit) begin
+          locality_hit = 1'b1;
+          locality_idx = scan_src;
+          locality_req = req_fifo_out_bus[(scan_src * REQ_META_W) +: REQ_META_W];
+        end
+        if ((req_bank_from_meta(req_fifo_out_bus[(scan_src * REQ_META_W) +: REQ_META_W]) != preferred_bank) &&
+            !alternate_hit) begin
+          alternate_hit = 1'b1;
+          alternate_idx = scan_src;
+          alternate_req = req_fifo_out_bus[(scan_src * REQ_META_W) +: REQ_META_W];
+        end
       end
     end
 
-    if (ARB_MODE != 0 && locality_hit) begin
-      grant_valid = 1'b1;
-      grant_idx = locality_idx;
-      grant_packet = locality_packet;
-    end else if (fallback_hit) begin
-      grant_valid = 1'b1;
-      grant_idx = fallback_idx;
-      grant_packet = fallback_packet;
+    if (ARB_MODE == 0) begin
+      if (fallback_hit) begin
+        grant_valid_r = 1'b1;
+        grant_idx_r = fallback_idx;
+        grant_req_r = fallback_req;
+      end
+    end else begin
+      if (locality_hit && (!alternate_hit || (locality_burst_count < LOCALITY_BURST_MAX))) begin
+        grant_valid_r = 1'b1;
+        grant_idx_r = locality_idx;
+        grant_req_r = locality_req;
+      end else if (alternate_hit) begin
+        grant_valid_r = 1'b1;
+        grant_idx_r = alternate_idx;
+        grant_req_r = alternate_req;
+      end else if (locality_hit) begin
+        grant_valid_r = 1'b1;
+        grant_idx_r = locality_idx;
+        grant_req_r = locality_req;
+      end else if (fallback_hit) begin
+        grant_valid_r = 1'b1;
+        grant_idx_r = fallback_idx;
+        grant_req_r = fallback_req;
+      end
     end
 
-    if (grant_valid && req_ready) begin
-      req_fifo_out_ready_int[grant_idx] = 1'b1;
+    if (req_fire) begin
+      req_fifo_out_ready_r[grant_idx_r] = 1'b1;
     end
   end
 
-  assign req_valid = grant_valid;
-  assign req_packet = grant_packet;
-  assign req_current_occupancy = {{(COUNTER_W-REQ_OCC_W){1'b0}}, req_occupancy_sum};
-
   always @(*) begin
-    resp_target_idx = {SOURCE_PTR_W{1'b0}};
-    resp_target_valid = 1'b0;
-    resp_ready_count = 0;
-    resp_occupancy_sum = {RESP_OCC_W{1'b0}};
-
+    resp_target_valid_r = 1'b0;
+    resp_target_idx_r = {SOURCE_PTR_W{1'b0}};
     for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-      resp_occupancy_sum = resp_occupancy_sum + resp_fifo_occupancy_bus[(src_i * RESP_COUNT_W) +: RESP_COUNT_W];
-      if (resp_valid && (packet_source(resp_packet) == src_i[SOURCE_W-1:0])) begin
-        resp_target_idx = src_i[SOURCE_PTR_W-1:0];
-        resp_target_valid = 1'b1;
-      end
-      if (resp_fifo_out_valid[src_i]) begin
-        resp_ready_count = resp_ready_count + 1;
+      if (!resp_target_valid_r && (resp_source == src_i[SOURCE_W-1:0])) begin
+        resp_target_valid_r = 1'b1;
+        resp_target_idx_r = src_i[SOURCE_PTR_W-1:0];
       end
     end
   end
 
-  generate
-    for (resp_gi = 0; resp_gi < SOURCES; resp_gi = resp_gi + 1) begin : gen_resp_demux
-      assign resp_fifo_in_valid[resp_gi] =
-        resp_valid && resp_target_valid && (resp_target_idx == resp_gi[SOURCE_PTR_W-1:0]);
+  assign resp_ready = resp_target_valid_r && resp_fifo_in_ready[resp_target_idx_r];
+
+  integer init_src;
+  integer init_bank;
+  initial begin
+    if ((PACKET_W != 128) && (PACKET_W != 256)) begin
+      $error("noc_ready_valid_router PACKET_W must be 128 or 256, got %0d", PACKET_W);
+      $finish(1);
     end
-  endgenerate
-
-  assign resp_ready = resp_target_valid ? resp_fifo_in_ready[resp_target_idx] : 1'b0;
-  assign resp_current_occupancy = {{(COUNTER_W-RESP_OCC_W){1'b0}}, resp_occupancy_sum};
-
-  always @(*) begin
-    arbitration_contended = (req_ready_count > 1);
+    if (VALUE_W != 512) begin
+      $error("noc_ready_valid_router VALUE_W must be 512, got %0d", VALUE_W);
+      $finish(1);
+    end
+    if ((VALUE_W % PACKET_W) != 0) begin
+      $error("noc_ready_valid_router VALUE_W must be an integer multiple of PACKET_W");
+      $finish(1);
+    end
+    if (VALUE_SLICE_W != 4) begin
+      $error("noc_ready_valid_router VALUE_SLICE_W must be 4, got %0d", VALUE_SLICE_W);
+      $finish(1);
+    end
+    if ((1 << FRAG_IDX_W) < FRAGMENTS) begin
+      $error("noc_ready_valid_router FRAG_IDX_W is too small for %0d fragments", FRAGMENTS);
+      $finish(1);
+    end
+    if ((SOURCES <= 0) || (BANKS <= 0)) begin
+      $error("noc_ready_valid_router SOURCES and BANKS must be positive");
+      $finish(1);
+    end
+    if (SOURCES > (1 << SOURCE_W)) begin
+      $error("noc_ready_valid_router SOURCE_W is too small for SOURCES");
+      $finish(1);
+    end
+    if (LOCALITY_BURST_MAX <= 0) begin
+      $error("noc_ready_valid_router LOCALITY_BURST_MAX must be positive");
+      $finish(1);
+    end
   end
 
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
       rr_cursor <= {SOURCE_PTR_W{1'b0}};
       preferred_bank <= {BANK_SEL_W{1'b0}};
+      locality_burst_count <= {LOCALITY_BURST_W{1'b0}};
       injection_stall_cycles <= {COUNTER_W{1'b0}};
       arbitration_contention_cycles <= {COUNTER_W{1'b0}};
       response_block_cycles <= {COUNTER_W{1'b0}};
       req_max_occupancy <= {COUNTER_W{1'b0}};
       resp_max_occupancy <= {COUNTER_W{1'b0}};
     end else begin
-      if (any_injection_stall) begin
+      if (any_injection_stall_r) begin
         injection_stall_cycles <= injection_stall_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
       end
-      if (grant_valid && arbitration_contended) begin
+      if (grant_valid_r && arbitration_contended_r) begin
         arbitration_contention_cycles <= arbitration_contention_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
       end
       if (resp_valid && !resp_ready) begin
         response_block_cycles <= response_block_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
       end
-      if (grant_valid && req_ready) begin
-        preferred_bank <= packet_bank(grant_packet);
-        if (grant_idx == (SOURCES - 1)) begin
+      if (req_fire) begin
+        if (grant_idx_r == (SOURCES - 1)) begin
           rr_cursor <= {SOURCE_PTR_W{1'b0}};
         end else begin
-          rr_cursor <= grant_idx + {{(SOURCE_PTR_W-1){1'b0}}, 1'b1};
+          rr_cursor <= grant_idx_r + {{(SOURCE_PTR_W-1){1'b0}}, 1'b1};
+        end
+
+        if (req_bank_from_meta(grant_req_r) == preferred_bank) begin
+          if (locality_burst_count < LOCALITY_BURST_MAX[LOCALITY_BURST_W-1:0]) begin
+            locality_burst_count <= locality_burst_count + {{(LOCALITY_BURST_W-1){1'b0}}, 1'b1};
+          end
+        end else begin
+          preferred_bank <= req_bank_from_meta(grant_req_r);
+          locality_burst_count <= {{(LOCALITY_BURST_W-1){1'b0}}, 1'b1};
         end
       end
       if (req_current_occupancy > req_max_occupancy) begin

--- a/npu/sim/rtl/noc_ready_valid_router.sv
+++ b/npu/sim/rtl/noc_ready_valid_router.sv
@@ -272,7 +272,7 @@ module noc_ready_valid_router #(
         .rst_n(rst_n),
         .in_valid(src_req_valid[req_gi]),
         .in_ready(src_req_ready[req_gi]),
-        .in_data(pack_req(src_req_source[(req_gi * SOURCE_W) +: SOURCE_W],
+        .in_data(pack_req(req_gi[SOURCE_W-1:0],
                           src_req_tag[(req_gi * TAG_W) +: TAG_W],
                           src_req_addr[(req_gi * ADDR_W) +: ADDR_W],
                           src_req_value_slice[(req_gi * VALUE_SLICE_W) +: VALUE_SLICE_W])),

--- a/npu/sim/rtl/noc_ready_valid_router.sv
+++ b/npu/sim/rtl/noc_ready_valid_router.sv
@@ -1,0 +1,295 @@
+`timescale 1ns/1ps
+
+// Multi-source ready/valid transport with request arbitration and response
+// demultiplexing. The request path supports deterministic round-robin and
+// locality-first selection based on the address-derived bank index.
+module noc_ready_valid_router #(
+  parameter integer PACKET_W = 128,
+  parameter integer SOURCES = 4,
+  parameter integer SOURCE_W = 2,
+  parameter integer TAG_W = 8,
+  parameter integer ADDR_W = 12,
+  parameter integer SLICE_W = 3,
+  parameter integer BANKS = 4,
+  parameter integer REQ_QUEUE_DEPTH = 2,
+  parameter integer RESP_QUEUE_DEPTH = 2,
+  parameter integer ARB_MODE = 0,
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire [SOURCES-1:0] src_req_valid,
+  output wire [SOURCES-1:0] src_req_ready,
+  input wire [SOURCES*PACKET_W-1:0] src_req_packet,
+
+  output wire [SOURCES-1:0] src_resp_valid,
+  input wire [SOURCES-1:0] src_resp_ready,
+  output wire [SOURCES*PACKET_W-1:0] src_resp_packet,
+
+  output wire req_valid,
+  input wire req_ready,
+  output wire [PACKET_W-1:0] req_packet,
+
+  input wire resp_valid,
+  output wire resp_ready,
+  input wire [PACKET_W-1:0] resp_packet,
+
+  output reg [COUNTER_W-1:0] injection_stall_cycles,
+  output reg [COUNTER_W-1:0] arbitration_contention_cycles,
+  output reg [COUNTER_W-1:0] response_block_cycles,
+  output wire [COUNTER_W-1:0] req_current_occupancy,
+  output reg [COUNTER_W-1:0] req_max_occupancy,
+  output wire [COUNTER_W-1:0] resp_current_occupancy,
+  output reg [COUNTER_W-1:0] resp_max_occupancy
+);
+  localparam integer REQ_COUNT_W = (REQ_QUEUE_DEPTH <= 1) ? 1 : $clog2(REQ_QUEUE_DEPTH + 1);
+  localparam integer RESP_COUNT_W = (RESP_QUEUE_DEPTH <= 1) ? 1 : $clog2(RESP_QUEUE_DEPTH + 1);
+  localparam integer SOURCE_PTR_W = (SOURCES <= 1) ? 1 : $clog2(SOURCES);
+  localparam integer BANK_SEL_W = (BANKS <= 1) ? 1 : $clog2(BANKS);
+  localparam integer SRC_LSB = 0;
+  localparam integer TAG_LSB = SRC_LSB + SOURCE_W;
+  localparam integer ADDR_LSB = TAG_LSB + TAG_W;
+  localparam integer SLICE_LSB = ADDR_LSB + ADDR_W;
+  localparam integer PAYLOAD_LSB = SLICE_LSB + SLICE_W;
+  localparam integer REQ_OCC_W = $clog2((SOURCES * (REQ_QUEUE_DEPTH + 1)) + 1);
+  localparam integer RESP_OCC_W = $clog2((SOURCES * (RESP_QUEUE_DEPTH + 1)) + 1);
+
+  wire [SOURCES-1:0] req_fifo_out_valid;
+  wire [SOURCES-1:0] src_req_ready_int;
+  wire [SOURCES*PACKET_W-1:0] req_fifo_out_packet_bus;
+  wire [SOURCES*REQ_COUNT_W-1:0] req_fifo_occupancy_bus;
+
+  wire [SOURCES-1:0] resp_fifo_out_valid;
+  wire [SOURCES-1:0] resp_fifo_in_valid;
+  wire [SOURCES-1:0] resp_fifo_in_ready;
+  wire [SOURCES*PACKET_W-1:0] resp_fifo_out_packet_bus;
+  wire [SOURCES*RESP_COUNT_W-1:0] resp_fifo_occupancy_bus;
+
+  reg [SOURCE_PTR_W-1:0] rr_cursor;
+  reg [BANK_SEL_W-1:0] preferred_bank;
+
+  reg grant_valid;
+  reg [SOURCE_PTR_W-1:0] grant_idx;
+  reg [PACKET_W-1:0] grant_packet;
+  reg [SOURCES-1:0] req_fifo_out_ready_int;
+  reg [SOURCE_PTR_W-1:0] resp_target_idx;
+  reg resp_target_valid;
+  reg any_injection_stall;
+  reg arbitration_contended;
+  reg [REQ_OCC_W-1:0] req_occupancy_sum;
+  reg [RESP_OCC_W-1:0] resp_occupancy_sum;
+
+  integer src_i;
+  integer scan_i;
+  integer scan_src_int;
+  integer req_ready_count;
+  integer resp_ready_count;
+  reg [SOURCE_PTR_W-1:0] scan_src;
+  reg locality_hit;
+  reg fallback_hit;
+  reg [SOURCE_PTR_W-1:0] locality_idx;
+  reg [PACKET_W-1:0] locality_packet;
+  reg [SOURCE_PTR_W-1:0] fallback_idx;
+  reg [PACKET_W-1:0] fallback_packet;
+
+  function [SOURCE_W-1:0] packet_source;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_source = packet[SRC_LSB +: SOURCE_W];
+    end
+  endfunction
+
+  function [ADDR_W-1:0] packet_addr;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_addr = packet[ADDR_LSB +: ADDR_W];
+    end
+  endfunction
+
+  function [BANK_SEL_W-1:0] packet_bank;
+    input [PACKET_W-1:0] packet;
+    integer bank_int;
+    begin
+      bank_int = packet_addr(packet) % BANKS;
+      packet_bank = bank_int[BANK_SEL_W-1:0];
+    end
+  endfunction
+
+  genvar req_gi;
+  generate
+    for (req_gi = 0; req_gi < SOURCES; req_gi = req_gi + 1) begin : gen_req_fifo
+      noc_ready_valid_fifo #(
+        .WIDTH(PACKET_W),
+        .DEPTH(REQ_QUEUE_DEPTH)
+      ) u_req_fifo (
+        .clk(clk),
+        .rst_n(rst_n),
+        .in_valid(src_req_valid[req_gi]),
+        .in_ready(src_req_ready_int[req_gi]),
+        .in_data(src_req_packet[(req_gi * PACKET_W) +: PACKET_W]),
+        .out_valid(req_fifo_out_valid[req_gi]),
+        .out_ready(req_fifo_out_ready_int[req_gi]),
+        .out_data(req_fifo_out_packet_bus[(req_gi * PACKET_W) +: PACKET_W]),
+        .occupancy(req_fifo_occupancy_bus[(req_gi * REQ_COUNT_W) +: REQ_COUNT_W]),
+        .max_occupancy()
+      );
+      assign src_req_ready[req_gi] = src_req_ready_int[req_gi];
+    end
+  endgenerate
+
+  genvar resp_gi;
+  generate
+    for (resp_gi = 0; resp_gi < SOURCES; resp_gi = resp_gi + 1) begin : gen_resp_fifo
+      noc_ready_valid_fifo #(
+        .WIDTH(PACKET_W),
+        .DEPTH(RESP_QUEUE_DEPTH)
+      ) u_resp_fifo (
+        .clk(clk),
+        .rst_n(rst_n),
+        .in_valid(resp_fifo_in_valid[resp_gi]),
+        .in_ready(resp_fifo_in_ready[resp_gi]),
+        .in_data(resp_packet),
+        .out_valid(resp_fifo_out_valid[resp_gi]),
+        .out_ready(src_resp_ready[resp_gi]),
+        .out_data(resp_fifo_out_packet_bus[(resp_gi * PACKET_W) +: PACKET_W]),
+        .occupancy(resp_fifo_occupancy_bus[(resp_gi * RESP_COUNT_W) +: RESP_COUNT_W]),
+        .max_occupancy()
+      );
+      assign src_resp_valid[resp_gi] = resp_fifo_out_valid[resp_gi];
+      assign src_resp_packet[(resp_gi * PACKET_W) +: PACKET_W] = resp_fifo_out_packet_bus[(resp_gi * PACKET_W) +: PACKET_W];
+    end
+  endgenerate
+
+  always @(*) begin
+    grant_valid = 1'b0;
+    grant_idx = {SOURCE_PTR_W{1'b0}};
+    grant_packet = {PACKET_W{1'b0}};
+    locality_hit = 1'b0;
+    fallback_hit = 1'b0;
+    locality_idx = {SOURCE_PTR_W{1'b0}};
+    locality_packet = {PACKET_W{1'b0}};
+    fallback_idx = {SOURCE_PTR_W{1'b0}};
+    fallback_packet = {PACKET_W{1'b0}};
+    req_fifo_out_ready_int = {SOURCES{1'b0}};
+    req_ready_count = 0;
+    req_occupancy_sum = {REQ_OCC_W{1'b0}};
+    any_injection_stall = 1'b0;
+
+    for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+      req_occupancy_sum = req_occupancy_sum + req_fifo_occupancy_bus[(src_i * REQ_COUNT_W) +: REQ_COUNT_W];
+      if (src_req_valid[src_i] && !src_req_ready_int[src_i]) begin
+        any_injection_stall = 1'b0;
+        any_injection_stall = 1'b1;
+      end
+      if (req_fifo_out_valid[src_i]) begin
+        req_ready_count = req_ready_count + 1;
+      end
+    end
+
+    for (scan_i = 0; scan_i < SOURCES; scan_i = scan_i + 1) begin
+      scan_src_int = rr_cursor + scan_i;
+      if (scan_src_int >= SOURCES) begin
+        scan_src_int = scan_src_int - SOURCES;
+      end
+      scan_src = scan_src_int[SOURCE_PTR_W-1:0];
+      if (!fallback_hit && req_fifo_out_valid[scan_src]) begin
+        fallback_hit = 1'b1;
+        fallback_idx = scan_src;
+        fallback_packet = req_fifo_out_packet_bus[(scan_src * PACKET_W) +: PACKET_W];
+      end
+      if (!locality_hit && req_fifo_out_valid[scan_src] &&
+          (packet_bank(req_fifo_out_packet_bus[(scan_src * PACKET_W) +: PACKET_W]) == preferred_bank)) begin
+        locality_hit = 1'b1;
+        locality_idx = scan_src;
+        locality_packet = req_fifo_out_packet_bus[(scan_src * PACKET_W) +: PACKET_W];
+      end
+    end
+
+    if (ARB_MODE != 0 && locality_hit) begin
+      grant_valid = 1'b1;
+      grant_idx = locality_idx;
+      grant_packet = locality_packet;
+    end else if (fallback_hit) begin
+      grant_valid = 1'b1;
+      grant_idx = fallback_idx;
+      grant_packet = fallback_packet;
+    end
+
+    if (grant_valid && req_ready) begin
+      req_fifo_out_ready_int[grant_idx] = 1'b1;
+    end
+  end
+
+  assign req_valid = grant_valid;
+  assign req_packet = grant_packet;
+  assign req_current_occupancy = {{(COUNTER_W-REQ_OCC_W){1'b0}}, req_occupancy_sum};
+
+  always @(*) begin
+    resp_target_idx = {SOURCE_PTR_W{1'b0}};
+    resp_target_valid = 1'b0;
+    resp_ready_count = 0;
+    resp_occupancy_sum = {RESP_OCC_W{1'b0}};
+
+    for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+      resp_occupancy_sum = resp_occupancy_sum + resp_fifo_occupancy_bus[(src_i * RESP_COUNT_W) +: RESP_COUNT_W];
+      if (resp_valid && (packet_source(resp_packet) == src_i[SOURCE_W-1:0])) begin
+        resp_target_idx = src_i[SOURCE_PTR_W-1:0];
+        resp_target_valid = 1'b1;
+      end
+      if (resp_fifo_out_valid[src_i]) begin
+        resp_ready_count = resp_ready_count + 1;
+      end
+    end
+  end
+
+  generate
+    for (resp_gi = 0; resp_gi < SOURCES; resp_gi = resp_gi + 1) begin : gen_resp_demux
+      assign resp_fifo_in_valid[resp_gi] =
+        resp_valid && resp_target_valid && (resp_target_idx == resp_gi[SOURCE_PTR_W-1:0]);
+    end
+  endgenerate
+
+  assign resp_ready = resp_target_valid ? resp_fifo_in_ready[resp_target_idx] : 1'b0;
+  assign resp_current_occupancy = {{(COUNTER_W-RESP_OCC_W){1'b0}}, resp_occupancy_sum};
+
+  always @(*) begin
+    arbitration_contended = (req_ready_count > 1);
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      rr_cursor <= {SOURCE_PTR_W{1'b0}};
+      preferred_bank <= {BANK_SEL_W{1'b0}};
+      injection_stall_cycles <= {COUNTER_W{1'b0}};
+      arbitration_contention_cycles <= {COUNTER_W{1'b0}};
+      response_block_cycles <= {COUNTER_W{1'b0}};
+      req_max_occupancy <= {COUNTER_W{1'b0}};
+      resp_max_occupancy <= {COUNTER_W{1'b0}};
+    end else begin
+      if (any_injection_stall) begin
+        injection_stall_cycles <= injection_stall_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
+      end
+      if (grant_valid && arbitration_contended) begin
+        arbitration_contention_cycles <= arbitration_contention_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
+      end
+      if (resp_valid && !resp_ready) begin
+        response_block_cycles <= response_block_cycles + {{(COUNTER_W-1){1'b0}}, 1'b1};
+      end
+      if (grant_valid && req_ready) begin
+        preferred_bank <= packet_bank(grant_packet);
+        if (grant_idx == (SOURCES - 1)) begin
+          rr_cursor <= {SOURCE_PTR_W{1'b0}};
+        end else begin
+          rr_cursor <= grant_idx + {{(SOURCE_PTR_W-1){1'b0}}, 1'b1};
+        end
+      end
+      if (req_current_occupancy > req_max_occupancy) begin
+        req_max_occupancy <= req_current_occupancy;
+      end
+      if (resp_current_occupancy > resp_max_occupancy) begin
+        resp_max_occupancy <= resp_current_occupancy;
+      end
+    end
+  end
+endmodule

--- a/npu/sim/rtl/noc_value_matrix_reassembler.sv
+++ b/npu/sim/rtl/noc_value_matrix_reassembler.sv
@@ -30,17 +30,23 @@ module noc_value_matrix_reassembler #(
   output wire [TAG_W-1:0] wide_tag,
   output wire [ADDR_W-1:0] wide_addr,
   output wire [VALUE_SLICE_W-1:0] wide_value_slice,
-  output wire [VALUE_W-1:0] wide_matrix
+  output wire [VALUE_W-1:0] wide_matrix,
+  output reg protocol_error
 ) ;
   localparam integer FRAGMENTS = VALUE_W / PACKET_W;
 
   reg collecting;
+  reg [FRAG_IDX_W-1:0] expected_fragment_r;
   reg wide_valid_r;
   reg [SOURCE_W-1:0] wide_source_r;
   reg [TAG_W-1:0] wide_tag_r;
   reg [ADDR_W-1:0] wide_addr_r;
   reg [VALUE_SLICE_W-1:0] wide_value_slice_r;
   reg [VALUE_W-1:0] wide_matrix_r;
+  reg metadata_match;
+  reg fragment_in_order;
+  reg last_consistent;
+  reg segment_valid_r;
 
   wire seg_fire = seg_valid && seg_ready;
   wire wide_fire = wide_valid && wide_ready;
@@ -79,28 +85,57 @@ module noc_value_matrix_reassembler #(
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
       collecting <= 1'b0;
+      expected_fragment_r <= {{(FRAG_IDX_W-1){1'b0}}, 1'b1};
       wide_valid_r <= 1'b0;
       wide_source_r <= {SOURCE_W{1'b0}};
       wide_tag_r <= {TAG_W{1'b0}};
       wide_addr_r <= {ADDR_W{1'b0}};
       wide_value_slice_r <= {VALUE_SLICE_W{1'b0}};
       wide_matrix_r <= {VALUE_W{1'b0}};
+      protocol_error <= 1'b0;
     end else begin
       if (wide_fire) begin
         wide_valid_r <= 1'b0;
       end
 
       if (seg_fire) begin
+        metadata_match = !collecting ||
+                         ((seg_source == wide_source_r) &&
+                          (seg_tag == wide_tag_r) &&
+                          (seg_addr == wide_addr_r) &&
+                          (seg_value_slice == wide_value_slice_r));
+        fragment_in_order = collecting ?
+          (seg_fragment_idx == expected_fragment_r) :
+          (seg_fragment_idx == {FRAG_IDX_W{1'b0}});
+        last_consistent = seg_last ?
+          (seg_fragment_idx == (FRAGMENTS - 1)) :
+          (seg_fragment_idx != (FRAGMENTS - 1));
+        segment_valid_r = metadata_match && fragment_in_order && last_consistent;
+
         if (!collecting) begin
           wide_source_r <= seg_source;
           wide_tag_r <= seg_tag;
           wide_addr_r <= seg_addr;
           wide_value_slice_r <= seg_value_slice;
-          collecting <= !seg_last;
         end
-        wide_matrix_r[(seg_fragment_idx * PACKET_W) +: PACKET_W] <= seg_data;
-        if (seg_last) begin
-          wide_valid_r <= 1'b1;
+
+        if (!segment_valid_r) begin
+          protocol_error <= 1'b1;
+          collecting <= 1'b0;
+          expected_fragment_r <= {{(FRAG_IDX_W-1){1'b0}}, 1'b1};
+        end else begin
+          wide_matrix_r[(seg_fragment_idx * PACKET_W) +: PACKET_W] <= seg_data;
+          if (seg_last) begin
+            wide_valid_r <= 1'b1;
+            collecting <= 1'b0;
+            expected_fragment_r <= {{(FRAG_IDX_W-1){1'b0}}, 1'b1};
+          end else begin
+            collecting <= 1'b1;
+            expected_fragment_r <= seg_fragment_idx + {{(FRAG_IDX_W-1){1'b0}}, 1'b1};
+          end
+        end
+
+        if (!segment_valid_r) begin
           collecting <= 1'b0;
         end
       end

--- a/npu/sim/rtl/noc_value_matrix_reassembler.sv
+++ b/npu/sim/rtl/noc_value_matrix_reassembler.sv
@@ -1,0 +1,109 @@
+`timescale 1ns/1ps
+
+// Reassembles segmented 512-bit matrix responses back into a single wide
+// ready/valid response at a source endpoint.
+module noc_value_matrix_reassembler #(
+  parameter integer PACKET_W = 128,
+  parameter integer VALUE_W = 512,
+  parameter integer FRAG_IDX_W = ((VALUE_W / PACKET_W) <= 1) ? 1 : $clog2(VALUE_W / PACKET_W),
+  parameter integer SOURCE_W = 2,
+  parameter integer TAG_W = 8,
+  parameter integer ADDR_W = 12,
+  parameter integer VALUE_SLICE_W = 4
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire seg_valid,
+  output wire seg_ready,
+  input wire [SOURCE_W-1:0] seg_source,
+  input wire [TAG_W-1:0] seg_tag,
+  input wire [ADDR_W-1:0] seg_addr,
+  input wire [VALUE_SLICE_W-1:0] seg_value_slice,
+  input wire [FRAG_IDX_W-1:0] seg_fragment_idx,
+  input wire seg_last,
+  input wire [PACKET_W-1:0] seg_data,
+
+  output wire wide_valid,
+  input wire wide_ready,
+  output wire [SOURCE_W-1:0] wide_source,
+  output wire [TAG_W-1:0] wide_tag,
+  output wire [ADDR_W-1:0] wide_addr,
+  output wire [VALUE_SLICE_W-1:0] wide_value_slice,
+  output wire [VALUE_W-1:0] wide_matrix
+) ;
+  localparam integer FRAGMENTS = VALUE_W / PACKET_W;
+
+  reg collecting;
+  reg wide_valid_r;
+  reg [SOURCE_W-1:0] wide_source_r;
+  reg [TAG_W-1:0] wide_tag_r;
+  reg [ADDR_W-1:0] wide_addr_r;
+  reg [VALUE_SLICE_W-1:0] wide_value_slice_r;
+  reg [VALUE_W-1:0] wide_matrix_r;
+
+  wire seg_fire = seg_valid && seg_ready;
+  wire wide_fire = wide_valid && wide_ready;
+
+  assign seg_ready = !wide_valid_r;
+  assign wide_valid = wide_valid_r;
+  assign wide_source = wide_source_r;
+  assign wide_tag = wide_tag_r;
+  assign wide_addr = wide_addr_r;
+  assign wide_value_slice = wide_value_slice_r;
+  assign wide_matrix = wide_matrix_r;
+
+  initial begin
+    if ((PACKET_W != 128) && (PACKET_W != 256)) begin
+      $error("noc_value_matrix_reassembler PACKET_W must be 128 or 256, got %0d", PACKET_W);
+      $finish(1);
+    end
+    if (VALUE_W != 512) begin
+      $error("noc_value_matrix_reassembler VALUE_W must be 512, got %0d", VALUE_W);
+      $finish(1);
+    end
+    if ((VALUE_W % PACKET_W) != 0) begin
+      $error("noc_value_matrix_reassembler VALUE_W must be an integer multiple of PACKET_W");
+      $finish(1);
+    end
+    if ((1 << FRAG_IDX_W) < FRAGMENTS) begin
+      $error("noc_value_matrix_reassembler FRAG_IDX_W is too small for %0d fragments", FRAGMENTS);
+      $finish(1);
+    end
+    if (VALUE_SLICE_W != 4) begin
+      $error("noc_value_matrix_reassembler VALUE_SLICE_W must be 4, got %0d", VALUE_SLICE_W);
+      $finish(1);
+    end
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      collecting <= 1'b0;
+      wide_valid_r <= 1'b0;
+      wide_source_r <= {SOURCE_W{1'b0}};
+      wide_tag_r <= {TAG_W{1'b0}};
+      wide_addr_r <= {ADDR_W{1'b0}};
+      wide_value_slice_r <= {VALUE_SLICE_W{1'b0}};
+      wide_matrix_r <= {VALUE_W{1'b0}};
+    end else begin
+      if (wide_fire) begin
+        wide_valid_r <= 1'b0;
+      end
+
+      if (seg_fire) begin
+        if (!collecting) begin
+          wide_source_r <= seg_source;
+          wide_tag_r <= seg_tag;
+          wide_addr_r <= seg_addr;
+          wide_value_slice_r <= seg_value_slice;
+          collecting <= !seg_last;
+        end
+        wide_matrix_r[(seg_fragment_idx * PACKET_W) +: PACKET_W] <= seg_data;
+        if (seg_last) begin
+          wide_valid_r <= 1'b1;
+          collecting <= 1'b0;
+        end
+      end
+    end
+  end
+endmodule

--- a/npu/sim/rtl/tb_banked_value_memory_service.sv
+++ b/npu/sim/rtl/tb_banked_value_memory_service.sv
@@ -25,7 +25,6 @@ module tb_banked_value_memory_service;
 
   reg [SOURCES-1:0] src_req_valid;
   wire [SOURCES-1:0] src_req_ready;
-  reg [SOURCES*SOURCE_W-1:0] src_req_source;
   reg [SOURCES*TAG_W-1:0] src_req_tag;
   reg [SOURCES*ADDR_W-1:0] src_req_addr;
   reg [SOURCES*VALUE_SLICE_W-1:0] src_req_value_slice;
@@ -107,7 +106,6 @@ module tb_banked_value_memory_service;
     .rst_n(rst_n),
     .src_req_valid(src_req_valid),
     .src_req_ready(src_req_ready),
-    .src_req_source(src_req_source),
     .src_req_tag(src_req_tag),
     .src_req_addr(src_req_addr),
     .src_req_value_slice(src_req_value_slice),
@@ -261,7 +259,6 @@ module tb_banked_value_memory_service;
     input [VALUE_SLICE_W-1:0] value_slice;
     begin
       src_req_valid[src] = 1'b1;
-      src_req_source[(src * SOURCE_W) +: SOURCE_W] = src[SOURCE_W-1:0];
       src_req_tag[(src * TAG_W) +: TAG_W] = tag;
       src_req_addr[(src * ADDR_W) +: ADDR_W] = addr;
       src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = value_slice;
@@ -272,7 +269,6 @@ module tb_banked_value_memory_service;
     input integer src;
     begin
       src_req_valid[src] = 1'b0;
-      src_req_source[(src * SOURCE_W) +: SOURCE_W] = {SOURCE_W{1'b0}};
       src_req_tag[(src * TAG_W) +: TAG_W] = {TAG_W{1'b0}};
       src_req_addr[(src * ADDR_W) +: ADDR_W] = {ADDR_W{1'b0}};
       src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = {VALUE_SLICE_W{1'b0}};
@@ -329,7 +325,6 @@ module tb_banked_value_memory_service;
     preload_value_slice = {VALUE_SLICE_W{1'b0}};
     preload_matrix = {VALUE_W{1'b0}};
     src_req_valid = {SOURCES{1'b0}};
-    src_req_source = {(SOURCES * SOURCE_W){1'b0}};
     src_req_tag = {(SOURCES * TAG_W){1'b0}};
     src_req_addr = {(SOURCES * ADDR_W){1'b0}};
     src_req_value_slice = {(SOURCES * VALUE_SLICE_W){1'b0}};

--- a/npu/sim/rtl/tb_banked_value_memory_service.sv
+++ b/npu/sim/rtl/tb_banked_value_memory_service.sv
@@ -3,37 +3,59 @@
 module tb_banked_value_memory_service;
   parameter integer PACKET_W = 128;
   localparam integer CLK_PERIOD = 10;
+  localparam integer VALUE_W = 512;
   localparam integer SOURCES = 4;
   localparam integer SOURCE_W = 2;
   localparam integer TAG_W = 8;
   localparam integer ADDR_W = 12;
-  localparam integer SLICE_W = 3;
-  localparam integer VALUE_W = 512;
+  localparam integer VALUE_SLICE_W = 4;
   localparam integer BANKS = 2;
-  localparam integer ARB_MODE = 1;
-  localparam integer SRC_LSB = 0;
-  localparam integer TAG_LSB = SRC_LSB + SOURCE_W;
-  localparam integer ADDR_LSB = TAG_LSB + TAG_W;
-  localparam integer SLICE_LSB = ADDR_LSB + ADDR_W;
-  localparam integer PAYLOAD_LSB = SLICE_LSB + SLICE_W;
-  localparam integer PAYLOAD_W = PACKET_W - PAYLOAD_LSB;
+  localparam integer STORE_DEPTH = 8;
+  localparam integer FRAGMENTS = VALUE_W / PACKET_W;
+  localparam integer FRAG_IDX_W = (FRAGMENTS <= 1) ? 1 : $clog2(FRAGMENTS);
 
   reg clk;
   reg rst_n;
 
+  reg preload_valid;
+  wire preload_ready;
+  reg [ADDR_W-1:0] preload_addr;
+  reg [VALUE_SLICE_W-1:0] preload_value_slice;
+  reg [VALUE_W-1:0] preload_matrix;
+
   reg [SOURCES-1:0] src_req_valid;
   wire [SOURCES-1:0] src_req_ready;
-  reg [SOURCES*PACKET_W-1:0] src_req_packet;
+  reg [SOURCES*SOURCE_W-1:0] src_req_source;
+  reg [SOURCES*TAG_W-1:0] src_req_tag;
+  reg [SOURCES*ADDR_W-1:0] src_req_addr;
+  reg [SOURCES*VALUE_SLICE_W-1:0] src_req_value_slice;
+
   wire [SOURCES-1:0] src_resp_valid;
-  reg [SOURCES-1:0] src_resp_ready;
-  wire [SOURCES*PACKET_W-1:0] src_resp_packet;
+  wire [SOURCES*SOURCE_W-1:0] src_resp_source;
+  wire [SOURCES*TAG_W-1:0] src_resp_tag;
+  wire [SOURCES*ADDR_W-1:0] src_resp_addr;
+  wire [SOURCES*VALUE_SLICE_W-1:0] src_resp_value_slice;
+  wire [SOURCES*FRAG_IDX_W-1:0] src_resp_fragment_idx;
+  wire [SOURCES-1:0] src_resp_last;
+  wire [SOURCES*PACKET_W-1:0] src_resp_data;
+  wire [SOURCES-1:0] src_resp_ready;
+  wire [SOURCES-1:0] reasm_seg_ready;
 
   wire req_valid;
   wire req_ready;
-  wire [PACKET_W-1:0] req_packet;
+  wire [SOURCE_W-1:0] req_source;
+  wire [TAG_W-1:0] req_tag;
+  wire [ADDR_W-1:0] req_addr;
+  wire [VALUE_SLICE_W-1:0] req_value_slice;
   wire resp_valid;
   wire resp_ready;
-  wire [PACKET_W-1:0] resp_packet;
+  wire [SOURCE_W-1:0] resp_source;
+  wire [TAG_W-1:0] resp_tag;
+  wire [ADDR_W-1:0] resp_addr;
+  wire [VALUE_SLICE_W-1:0] resp_value_slice;
+  wire [FRAG_IDX_W-1:0] resp_fragment_idx;
+  wire resp_last;
+  wire [PACKET_W-1:0] resp_data;
 
   wire [31:0] router_injection_stall_cycles;
   wire [31:0] router_arbitration_contention_cycles;
@@ -47,43 +69,71 @@ module tb_banked_value_memory_service;
   wire [31:0] service_req_max_occupancy;
   wire [31:0] service_resp_max_occupancy;
 
-  reg [PACKET_W-1:0] source_packets [0:SOURCES-1][0:2];
-  integer sent_count [0:SOURCES-1];
-  integer expected_count [0:SOURCES-1];
-  integer received_count [0:SOURCES-1];
-  integer seen_tag [0:SOURCES-1][0:7];
-  integer cycle_count;
-  integer total_expected;
-  integer total_received;
+  wire [SOURCES-1:0] wide_resp_valid;
+  reg [SOURCES-1:0] wide_resp_ready;
+  reg [SOURCES-1:0] seg_accept_enable;
+  wire [SOURCES*SOURCE_W-1:0] wide_resp_source;
+  wire [SOURCES*TAG_W-1:0] wide_resp_tag;
+  wire [SOURCES*ADDR_W-1:0] wide_resp_addr;
+  wire [SOURCES*VALUE_SLICE_W-1:0] wide_resp_value_slice;
+  wire [SOURCES*VALUE_W-1:0] wide_resp_matrix;
+
+  reg [VALUE_W-1:0] expected_matrix [0:SOURCES-1];
+  reg [TAG_W-1:0] expected_tag [0:SOURCES-1];
+  reg [ADDR_W-1:0] expected_addr [0:SOURCES-1];
+  reg [VALUE_SLICE_W-1:0] expected_slice [0:SOURCES-1];
+  integer seen_wide [0:SOURCES-1];
+  integer total_seen;
   integer src_i;
-  integer slot_i;
+
+  assign src_resp_ready = reasm_seg_ready & seg_accept_enable;
 
   noc_ready_valid_router #(
     .PACKET_W(PACKET_W),
+    .VALUE_W(VALUE_W),
     .SOURCES(SOURCES),
     .SOURCE_W(SOURCE_W),
     .TAG_W(TAG_W),
     .ADDR_W(ADDR_W),
-    .SLICE_W(SLICE_W),
+    .VALUE_SLICE_W(VALUE_SLICE_W),
     .BANKS(BANKS),
-    .REQ_QUEUE_DEPTH(2),
-    .RESP_QUEUE_DEPTH(2),
-    .ARB_MODE(ARB_MODE)
+    .REQ_QUEUE_DEPTH(1),
+    .RESP_QUEUE_DEPTH(1),
+    .ARB_MODE(1),
+    .LOCALITY_BURST_MAX(2)
   ) u_router (
     .clk(clk),
     .rst_n(rst_n),
     .src_req_valid(src_req_valid),
     .src_req_ready(src_req_ready),
-    .src_req_packet(src_req_packet),
+    .src_req_source(src_req_source),
+    .src_req_tag(src_req_tag),
+    .src_req_addr(src_req_addr),
+    .src_req_value_slice(src_req_value_slice),
     .src_resp_valid(src_resp_valid),
     .src_resp_ready(src_resp_ready),
-    .src_resp_packet(src_resp_packet),
+    .src_resp_source(src_resp_source),
+    .src_resp_tag(src_resp_tag),
+    .src_resp_addr(src_resp_addr),
+    .src_resp_value_slice(src_resp_value_slice),
+    .src_resp_fragment_idx(src_resp_fragment_idx),
+    .src_resp_last(src_resp_last),
+    .src_resp_data(src_resp_data),
     .req_valid(req_valid),
     .req_ready(req_ready),
-    .req_packet(req_packet),
+    .req_source(req_source),
+    .req_tag(req_tag),
+    .req_addr(req_addr),
+    .req_value_slice(req_value_slice),
     .resp_valid(resp_valid),
     .resp_ready(resp_ready),
-    .resp_packet(resp_packet),
+    .resp_source(resp_source),
+    .resp_tag(resp_tag),
+    .resp_addr(resp_addr),
+    .resp_value_slice(resp_value_slice),
+    .resp_fragment_idx(resp_fragment_idx),
+    .resp_last(resp_last),
+    .resp_data(resp_data),
     .injection_stall_cycles(router_injection_stall_cycles),
     .arbitration_contention_cycles(router_arbitration_contention_cycles),
     .response_block_cycles(router_response_block_cycles),
@@ -95,24 +145,38 @@ module tb_banked_value_memory_service;
 
   banked_value_memory_service #(
     .PACKET_W(PACKET_W),
+    .VALUE_W(VALUE_W),
     .SOURCE_W(SOURCE_W),
     .TAG_W(TAG_W),
     .ADDR_W(ADDR_W),
-    .SLICE_W(SLICE_W),
-    .VALUE_W(VALUE_W),
+    .VALUE_SLICE_W(VALUE_SLICE_W),
+    .STORE_DEPTH(STORE_DEPTH),
     .BANKS(BANKS),
-    .BANK_QUEUE_DEPTH(2),
-    .RESP_QUEUE_DEPTH(1),
-    .READ_LATENCY(3)
+    .BANK_QUEUE_DEPTH(1),
+    .READ_LATENCY(2)
   ) u_service (
     .clk(clk),
     .rst_n(rst_n),
+    .preload_valid(preload_valid),
+    .preload_ready(preload_ready),
+    .preload_addr(preload_addr),
+    .preload_value_slice(preload_value_slice),
+    .preload_matrix(preload_matrix),
     .req_valid(req_valid),
     .req_ready(req_ready),
-    .req_packet(req_packet),
+    .req_source(req_source),
+    .req_tag(req_tag),
+    .req_addr(req_addr),
+    .req_value_slice(req_value_slice),
     .resp_valid(resp_valid),
     .resp_ready(resp_ready),
-    .resp_packet(resp_packet),
+    .resp_source(resp_source),
+    .resp_tag(resp_tag),
+    .resp_addr(resp_addr),
+    .resp_value_slice(resp_value_slice),
+    .resp_fragment_idx(resp_fragment_idx),
+    .resp_last(resp_last),
+    .resp_data(resp_data),
     .accepted_req_count(service_accepted_req_count),
     .emitted_resp_count(service_emitted_resp_count),
     .bank_conflict_count(service_bank_conflict_count),
@@ -123,195 +187,211 @@ module tb_banked_value_memory_service;
     .resp_max_occupancy(service_resp_max_occupancy)
   );
 
+  genvar reasm_gi;
+  generate
+    for (reasm_gi = 0; reasm_gi < SOURCES; reasm_gi = reasm_gi + 1) begin : gen_reassembler
+      noc_value_matrix_reassembler #(
+        .PACKET_W(PACKET_W),
+        .VALUE_W(VALUE_W),
+        .SOURCE_W(SOURCE_W),
+        .TAG_W(TAG_W),
+        .ADDR_W(ADDR_W),
+        .VALUE_SLICE_W(VALUE_SLICE_W)
+      ) u_reassembler (
+        .clk(clk),
+        .rst_n(rst_n),
+        .seg_valid(src_resp_valid[reasm_gi]),
+        .seg_ready(reasm_seg_ready[reasm_gi]),
+        .seg_source(src_resp_source[(reasm_gi * SOURCE_W) +: SOURCE_W]),
+        .seg_tag(src_resp_tag[(reasm_gi * TAG_W) +: TAG_W]),
+        .seg_addr(src_resp_addr[(reasm_gi * ADDR_W) +: ADDR_W]),
+        .seg_value_slice(src_resp_value_slice[(reasm_gi * VALUE_SLICE_W) +: VALUE_SLICE_W]),
+        .seg_fragment_idx(src_resp_fragment_idx[(reasm_gi * FRAG_IDX_W) +: FRAG_IDX_W]),
+        .seg_last(src_resp_last[reasm_gi]),
+        .seg_data(src_resp_data[(reasm_gi * PACKET_W) +: PACKET_W]),
+        .wide_valid(wide_resp_valid[reasm_gi]),
+        .wide_ready(wide_resp_ready[reasm_gi]),
+        .wide_source(wide_resp_source[(reasm_gi * SOURCE_W) +: SOURCE_W]),
+        .wide_tag(wide_resp_tag[(reasm_gi * TAG_W) +: TAG_W]),
+        .wide_addr(wide_resp_addr[(reasm_gi * ADDR_W) +: ADDR_W]),
+        .wide_value_slice(wide_resp_value_slice[(reasm_gi * VALUE_SLICE_W) +: VALUE_SLICE_W]),
+        .wide_matrix(wide_resp_matrix[(reasm_gi * VALUE_W) +: VALUE_W])
+      );
+    end
+  endgenerate
+
   initial clk = 1'b0;
   always #(CLK_PERIOD/2) clk = ~clk;
 
-  function [PACKET_W-1:0] pack_packet;
-    input [SOURCE_W-1:0] src;
-    input [TAG_W-1:0] tag;
-    input [ADDR_W-1:0] addr;
-    input [SLICE_W-1:0] slice;
-    begin
-      pack_packet = {PACKET_W{1'b0}};
-      pack_packet[SRC_LSB +: SOURCE_W] = src;
-      pack_packet[TAG_LSB +: TAG_W] = tag;
-      pack_packet[ADDR_LSB +: ADDR_W] = addr;
-      pack_packet[SLICE_LSB +: SLICE_W] = slice;
-    end
-  endfunction
-
-  function [TAG_W-1:0] packet_tag;
-    input [PACKET_W-1:0] packet;
-    begin
-      packet_tag = packet[TAG_LSB +: TAG_W];
-    end
-  endfunction
-
-  function [ADDR_W-1:0] packet_addr;
-    input [PACKET_W-1:0] packet;
-    begin
-      packet_addr = packet[ADDR_LSB +: ADDR_W];
-    end
-  endfunction
-
-  function [SLICE_W-1:0] packet_slice;
-    input [PACKET_W-1:0] packet;
-    begin
-      packet_slice = packet[SLICE_LSB +: SLICE_W];
-    end
-  endfunction
-
-  function [PAYLOAD_W-1:0] packet_payload;
-    input [PACKET_W-1:0] packet;
-    begin
-      packet_payload = packet[PAYLOAD_LSB +: PAYLOAD_W];
-    end
-  endfunction
-
-  function [VALUE_W-1:0] make_value_line;
-    input [ADDR_W-1:0] addr;
-    integer word_i;
+  function [VALUE_W-1:0] build_matrix;
+    input [15:0] matrix_id;
+    integer wi;
     reg [63:0] word_value;
     begin
-      make_value_line = {VALUE_W{1'b0}};
-      for (word_i = 0; word_i < (VALUE_W / 64); word_i = word_i + 1) begin
-        word_value = {16'hd000 + word_i[15:0], 16'h4100 + addr[15:0], 16'h2200 + word_i[15:0], addr[15:0] ^ (word_i * 16'h0011)};
-        make_value_line[(word_i * 64) +: 64] = word_value;
+      build_matrix = {VALUE_W{1'b0}};
+      for (wi = 0; wi < (VALUE_W / 64); wi = wi + 1) begin
+        word_value = {matrix_id, wi[15:0], matrix_id ^ wi[15:0], 16'h9000 + wi[15:0]};
+        build_matrix[(wi * 64) +: 64] = word_value;
       end
     end
   endfunction
 
-  function [PAYLOAD_W-1:0] expected_payload;
+  task automatic preload_entry;
     input [ADDR_W-1:0] addr;
-    input [SLICE_W-1:0] slice;
-    integer bit_i;
-    integer line_bit;
-    reg [VALUE_W-1:0] line;
+    input [VALUE_SLICE_W-1:0] value_slice;
+    input [VALUE_W-1:0] matrix;
     begin
-      line = make_value_line(addr);
-      expected_payload = {PAYLOAD_W{1'b0}};
-      for (bit_i = 0; bit_i < PAYLOAD_W; bit_i = bit_i + 1) begin
-        line_bit = (slice * PAYLOAD_W) + bit_i;
-        if (line_bit < VALUE_W) begin
-          expected_payload[bit_i] = line[line_bit];
-        end
-      end
-    end
-  endfunction
-
-  task automatic check_response;
-    input integer src;
-    input [PACKET_W-1:0] packet;
-    integer req_i;
-    begin
-      for (req_i = 0; req_i < received_count[src]; req_i = req_i + 1) begin
-        if (seen_tag[src][req_i] == packet_tag(packet)) begin
-          $display("ERROR: duplicate response source=%0d tag=%0h", src, packet_tag(packet));
-          $finish(1);
-        end
-      end
-      if (packet_payload(packet) !== expected_payload(packet_addr(packet), packet_slice(packet))) begin
-        $display("ERROR: payload mismatch source=%0d tag=%0h addr=%0h slice=%0d",
-                 src, packet_tag(packet), packet_addr(packet), packet_slice(packet));
-        $finish(1);
-      end
-      seen_tag[src][received_count[src]] = packet_tag(packet);
-      received_count[src] = received_count[src] + 1;
-      total_received = total_received + 1;
+      @(negedge clk);
+      preload_addr = addr;
+      preload_value_slice = value_slice;
+      preload_matrix = matrix;
+      preload_valid = 1'b1;
+      @(posedge clk);
+      @(negedge clk);
+      preload_valid = 1'b0;
     end
   endtask
 
-  always @(*) begin
-    src_req_valid = {SOURCES{1'b0}};
-    src_req_packet = {(SOURCES * PACKET_W){1'b0}};
-    for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-      if (sent_count[src_i] < expected_count[src_i]) begin
-        src_req_valid[src_i] = 1'b1;
-        src_req_packet[(src_i * PACKET_W) +: PACKET_W] = source_packets[src_i][sent_count[src_i]];
-      end
+  task automatic set_request;
+    input integer src;
+    input [TAG_W-1:0] tag;
+    input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
+    begin
+      src_req_valid[src] = 1'b1;
+      src_req_source[(src * SOURCE_W) +: SOURCE_W] = src[SOURCE_W-1:0];
+      src_req_tag[(src * TAG_W) +: TAG_W] = tag;
+      src_req_addr[(src * ADDR_W) +: ADDR_W] = addr;
+      src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = value_slice;
     end
-  end
+  endtask
+
+  task automatic clear_request;
+    input integer src;
+    begin
+      src_req_valid[src] = 1'b0;
+      src_req_source[(src * SOURCE_W) +: SOURCE_W] = {SOURCE_W{1'b0}};
+      src_req_tag[(src * TAG_W) +: TAG_W] = {TAG_W{1'b0}};
+      src_req_addr[(src * ADDR_W) +: ADDR_W] = {ADDR_W{1'b0}};
+      src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = {VALUE_SLICE_W{1'b0}};
+    end
+  endtask
 
   always @(posedge clk) begin
     if (!rst_n) begin
-      cycle_count <= 0;
       for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-        sent_count[src_i] <= 0;
+        seen_wide[src_i] <= 0;
       end
+      total_seen <= 0;
     end else begin
-      cycle_count <= cycle_count + 1;
-      if (cycle_count < 24) begin
-        src_resp_ready <= {SOURCES{1'b0}};
-      end else begin
-        src_resp_ready[0] <= 1'b1;
-        src_resp_ready[1] <= 1'b1;
-        src_resp_ready[2] <= (cycle_count[1] == 1'b0);
-        src_resp_ready[3] <= 1'b1;
-      end
+      wide_resp_ready[0] <= 1'b1;
+      wide_resp_ready[1] <= 1'b1;
+      wide_resp_ready[2] <= (seen_wide[0] != 0);
+      wide_resp_ready[3] <= 1'b1;
+
       for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-        if (src_req_valid[src_i] && src_req_ready[src_i]) begin
-          sent_count[src_i] <= sent_count[src_i] + 1;
-        end
-        if (src_resp_valid[src_i] && src_resp_ready[src_i]) begin
-          check_response(src_i, src_resp_packet[(src_i * PACKET_W) +: PACKET_W]);
+        if (wide_resp_valid[src_i] && wide_resp_ready[src_i]) begin
+          if (seen_wide[src_i] != 0) begin
+            $display("ERROR: duplicate wide response source=%0d", src_i);
+            $finish(1);
+          end
+          if (wide_resp_source[(src_i * SOURCE_W) +: SOURCE_W] !== src_i[SOURCE_W-1:0]) begin
+            $display("ERROR: source metadata mismatch source=%0d got=%0d",
+                     src_i, wide_resp_source[(src_i * SOURCE_W) +: SOURCE_W]);
+            $finish(1);
+          end
+          if (wide_resp_tag[(src_i * TAG_W) +: TAG_W] !== expected_tag[src_i] ||
+              wide_resp_addr[(src_i * ADDR_W) +: ADDR_W] !== expected_addr[src_i] ||
+              wide_resp_value_slice[(src_i * VALUE_SLICE_W) +: VALUE_SLICE_W] !== expected_slice[src_i]) begin
+            $display("ERROR: response metadata mismatch source=%0d tag=%0h addr=%0h slice=%0d",
+                     src_i,
+                     wide_resp_tag[(src_i * TAG_W) +: TAG_W],
+                     wide_resp_addr[(src_i * ADDR_W) +: ADDR_W],
+                     wide_resp_value_slice[(src_i * VALUE_SLICE_W) +: VALUE_SLICE_W]);
+            $finish(1);
+          end
+          if (wide_resp_matrix[(src_i * VALUE_W) +: VALUE_W] !== expected_matrix[src_i]) begin
+            $display("ERROR: reconstructed matrix mismatch source=%0d", src_i);
+            $finish(1);
+          end
+          seen_wide[src_i] <= 1;
+          total_seen <= total_seen + 1;
         end
       end
     end
   end
 
   initial begin
+    preload_valid = 1'b0;
+    preload_addr = {ADDR_W{1'b0}};
+    preload_value_slice = {VALUE_SLICE_W{1'b0}};
+    preload_matrix = {VALUE_W{1'b0}};
+    src_req_valid = {SOURCES{1'b0}};
+    src_req_source = {(SOURCES * SOURCE_W){1'b0}};
+    src_req_tag = {(SOURCES * TAG_W){1'b0}};
+    src_req_addr = {(SOURCES * ADDR_W){1'b0}};
+    src_req_value_slice = {(SOURCES * VALUE_SLICE_W){1'b0}};
+    wide_resp_ready = {SOURCES{1'b0}};
+    seg_accept_enable = {SOURCES{1'b1}};
+    seg_accept_enable[3] = 1'b0;
     rst_n = 1'b0;
-    src_resp_ready = {SOURCES{1'b0}};
-    cycle_count = 0;
-    total_expected = 12;
-    total_received = 0;
-
-    source_packets[0][0] = pack_packet(0, 8'h10, 12'd0, 0);
-    source_packets[0][1] = pack_packet(0, 8'h11, 12'd2, 1);
-    source_packets[0][2] = pack_packet(0, 8'h12, 12'd4, 2);
-    source_packets[1][0] = pack_packet(1, 8'h20, 12'd0, 1);
-    source_packets[1][1] = pack_packet(1, 8'h21, 12'd2, 2);
-    source_packets[1][2] = pack_packet(1, 8'h22, 12'd4, 3);
-    source_packets[2][0] = pack_packet(2, 8'h30, 12'd1, 0);
-    source_packets[2][1] = pack_packet(2, 8'h31, 12'd3, 1);
-    source_packets[2][2] = pack_packet(2, 8'h32, 12'd5, 2);
-    source_packets[3][0] = pack_packet(3, 8'h40, 12'd1, 3);
-    source_packets[3][1] = pack_packet(3, 8'h41, 12'd3, 0);
-    source_packets[3][2] = pack_packet(3, 8'h42, 12'd5, 1);
-
+    total_seen = 0;
     for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-      expected_count[src_i] = 3;
-      sent_count[src_i] = 0;
-      received_count[src_i] = 0;
-      for (slot_i = 0; slot_i < 8; slot_i = slot_i + 1) begin
-        seen_tag[src_i][slot_i] = -1;
-      end
+      seen_wide[src_i] = 0;
     end
+
+    expected_matrix[0] = build_matrix(16'h0101);
+    expected_matrix[1] = build_matrix(16'h0202);
+    expected_matrix[2] = build_matrix(16'h0303);
+    expected_matrix[3] = build_matrix(16'h0404);
+    expected_tag[0] = 8'h10;
+    expected_tag[1] = 8'h20;
+    expected_tag[2] = 8'h30;
+    expected_tag[3] = 8'h40;
+    expected_addr[0] = 12'd0;
+    expected_addr[1] = 12'd0;
+    expected_addr[2] = 12'd1;
+    expected_addr[3] = 12'd3;
+    expected_slice[0] = 4'h1;
+    expected_slice[1] = 4'h2;
+    expected_slice[2] = 4'h3;
+    expected_slice[3] = 4'h4;
 
     #(CLK_PERIOD * 4);
     rst_n = 1'b1;
-    wait (total_received == total_expected);
+
+    preload_entry(12'd0, 4'h1, expected_matrix[0]);
+    preload_entry(12'd0, 4'h2, expected_matrix[1]);
+    preload_entry(12'd1, 4'h3, expected_matrix[2]);
+    preload_entry(12'd3, 4'h4, expected_matrix[3]);
+
+    @(negedge clk);
+    set_request(0, 8'h10, 12'd0, 4'h1);
+    set_request(1, 8'h20, 12'd0, 4'h2);
+    set_request(2, 8'h30, 12'd1, 4'h3);
+    set_request(3, 8'h40, 12'd3, 4'h4);
+    @(posedge clk);
+    @(negedge clk);
+    clear_request(0);
+    clear_request(1);
+    clear_request(2);
+    clear_request(3);
+
+    wait (total_seen == SOURCES);
     repeat (4) @(posedge clk);
 
-    for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-      if (received_count[src_i] != expected_count[src_i]) begin
-        $display("ERROR: missing responses source=%0d got=%0d expected=%0d",
-                 src_i, received_count[src_i], expected_count[src_i]);
-        $finish(1);
-      end
-    end
-    if (service_accepted_req_count != total_expected || service_emitted_resp_count != total_expected) begin
-      $display("ERROR: service count mismatch req=%0d resp=%0d expected=%0d",
-               service_accepted_req_count, service_emitted_resp_count, total_expected);
+    if (service_accepted_req_count != SOURCES || service_emitted_resp_count != SOURCES) begin
+      $display("ERROR: service request/response counts mismatch req=%0d resp=%0d expected=%0d",
+               service_accepted_req_count, service_emitted_resp_count, SOURCES);
       $finish(1);
     end
     if (service_bank_conflict_count == 0) begin
-      $display("ERROR: expected bank conflict counter activity");
+      $display("ERROR: expected service bank conflicts");
       $finish(1);
     end
-    if (router_injection_stall_cycles == 0 || router_arbitration_contention_cycles == 0) begin
-      $display("ERROR: expected router counters to move stall=%0d contention=%0d",
-               router_injection_stall_cycles, router_arbitration_contention_cycles);
+    if (router_arbitration_contention_cycles == 0) begin
+      $display("ERROR: expected router contention counter to move contention=%0d",
+               router_arbitration_contention_cycles);
       $finish(1);
     end
     if (router_response_block_cycles == 0 || service_response_block_cycles == 0) begin
@@ -330,7 +410,14 @@ module tb_banked_value_memory_service;
   end
 
   initial begin
-    repeat (800) @(posedge clk);
+    wait (rst_n);
+    wait (src_resp_valid[3]);
+    repeat (4) @(posedge clk);
+    seg_accept_enable[3] = 1'b1;
+  end
+
+  initial begin
+    repeat (1200) @(posedge clk);
     $display("ERROR: tb_banked_value_memory_service timeout");
     $finish(1);
   end

--- a/npu/sim/rtl/tb_banked_value_memory_service.sv
+++ b/npu/sim/rtl/tb_banked_value_memory_service.sv
@@ -1,0 +1,337 @@
+`timescale 1ns/1ps
+
+module tb_banked_value_memory_service;
+  parameter integer PACKET_W = 128;
+  localparam integer CLK_PERIOD = 10;
+  localparam integer SOURCES = 4;
+  localparam integer SOURCE_W = 2;
+  localparam integer TAG_W = 8;
+  localparam integer ADDR_W = 12;
+  localparam integer SLICE_W = 3;
+  localparam integer VALUE_W = 512;
+  localparam integer BANKS = 2;
+  localparam integer ARB_MODE = 1;
+  localparam integer SRC_LSB = 0;
+  localparam integer TAG_LSB = SRC_LSB + SOURCE_W;
+  localparam integer ADDR_LSB = TAG_LSB + TAG_W;
+  localparam integer SLICE_LSB = ADDR_LSB + ADDR_W;
+  localparam integer PAYLOAD_LSB = SLICE_LSB + SLICE_W;
+  localparam integer PAYLOAD_W = PACKET_W - PAYLOAD_LSB;
+
+  reg clk;
+  reg rst_n;
+
+  reg [SOURCES-1:0] src_req_valid;
+  wire [SOURCES-1:0] src_req_ready;
+  reg [SOURCES*PACKET_W-1:0] src_req_packet;
+  wire [SOURCES-1:0] src_resp_valid;
+  reg [SOURCES-1:0] src_resp_ready;
+  wire [SOURCES*PACKET_W-1:0] src_resp_packet;
+
+  wire req_valid;
+  wire req_ready;
+  wire [PACKET_W-1:0] req_packet;
+  wire resp_valid;
+  wire resp_ready;
+  wire [PACKET_W-1:0] resp_packet;
+
+  wire [31:0] router_injection_stall_cycles;
+  wire [31:0] router_arbitration_contention_cycles;
+  wire [31:0] router_response_block_cycles;
+  wire [31:0] router_req_max_occupancy;
+  wire [31:0] router_resp_max_occupancy;
+  wire [31:0] service_accepted_req_count;
+  wire [31:0] service_emitted_resp_count;
+  wire [31:0] service_bank_conflict_count;
+  wire [31:0] service_response_block_cycles;
+  wire [31:0] service_req_max_occupancy;
+  wire [31:0] service_resp_max_occupancy;
+
+  reg [PACKET_W-1:0] source_packets [0:SOURCES-1][0:2];
+  integer sent_count [0:SOURCES-1];
+  integer expected_count [0:SOURCES-1];
+  integer received_count [0:SOURCES-1];
+  integer seen_tag [0:SOURCES-1][0:7];
+  integer cycle_count;
+  integer total_expected;
+  integer total_received;
+  integer src_i;
+  integer slot_i;
+
+  noc_ready_valid_router #(
+    .PACKET_W(PACKET_W),
+    .SOURCES(SOURCES),
+    .SOURCE_W(SOURCE_W),
+    .TAG_W(TAG_W),
+    .ADDR_W(ADDR_W),
+    .SLICE_W(SLICE_W),
+    .BANKS(BANKS),
+    .REQ_QUEUE_DEPTH(2),
+    .RESP_QUEUE_DEPTH(2),
+    .ARB_MODE(ARB_MODE)
+  ) u_router (
+    .clk(clk),
+    .rst_n(rst_n),
+    .src_req_valid(src_req_valid),
+    .src_req_ready(src_req_ready),
+    .src_req_packet(src_req_packet),
+    .src_resp_valid(src_resp_valid),
+    .src_resp_ready(src_resp_ready),
+    .src_resp_packet(src_resp_packet),
+    .req_valid(req_valid),
+    .req_ready(req_ready),
+    .req_packet(req_packet),
+    .resp_valid(resp_valid),
+    .resp_ready(resp_ready),
+    .resp_packet(resp_packet),
+    .injection_stall_cycles(router_injection_stall_cycles),
+    .arbitration_contention_cycles(router_arbitration_contention_cycles),
+    .response_block_cycles(router_response_block_cycles),
+    .req_current_occupancy(),
+    .req_max_occupancy(router_req_max_occupancy),
+    .resp_current_occupancy(),
+    .resp_max_occupancy(router_resp_max_occupancy)
+  );
+
+  banked_value_memory_service #(
+    .PACKET_W(PACKET_W),
+    .SOURCE_W(SOURCE_W),
+    .TAG_W(TAG_W),
+    .ADDR_W(ADDR_W),
+    .SLICE_W(SLICE_W),
+    .VALUE_W(VALUE_W),
+    .BANKS(BANKS),
+    .BANK_QUEUE_DEPTH(2),
+    .RESP_QUEUE_DEPTH(1),
+    .READ_LATENCY(3)
+  ) u_service (
+    .clk(clk),
+    .rst_n(rst_n),
+    .req_valid(req_valid),
+    .req_ready(req_ready),
+    .req_packet(req_packet),
+    .resp_valid(resp_valid),
+    .resp_ready(resp_ready),
+    .resp_packet(resp_packet),
+    .accepted_req_count(service_accepted_req_count),
+    .emitted_resp_count(service_emitted_resp_count),
+    .bank_conflict_count(service_bank_conflict_count),
+    .response_block_cycles(service_response_block_cycles),
+    .req_current_occupancy(),
+    .req_max_occupancy(service_req_max_occupancy),
+    .resp_current_occupancy(),
+    .resp_max_occupancy(service_resp_max_occupancy)
+  );
+
+  initial clk = 1'b0;
+  always #(CLK_PERIOD/2) clk = ~clk;
+
+  function [PACKET_W-1:0] pack_packet;
+    input [SOURCE_W-1:0] src;
+    input [TAG_W-1:0] tag;
+    input [ADDR_W-1:0] addr;
+    input [SLICE_W-1:0] slice;
+    begin
+      pack_packet = {PACKET_W{1'b0}};
+      pack_packet[SRC_LSB +: SOURCE_W] = src;
+      pack_packet[TAG_LSB +: TAG_W] = tag;
+      pack_packet[ADDR_LSB +: ADDR_W] = addr;
+      pack_packet[SLICE_LSB +: SLICE_W] = slice;
+    end
+  endfunction
+
+  function [TAG_W-1:0] packet_tag;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_tag = packet[TAG_LSB +: TAG_W];
+    end
+  endfunction
+
+  function [ADDR_W-1:0] packet_addr;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_addr = packet[ADDR_LSB +: ADDR_W];
+    end
+  endfunction
+
+  function [SLICE_W-1:0] packet_slice;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_slice = packet[SLICE_LSB +: SLICE_W];
+    end
+  endfunction
+
+  function [PAYLOAD_W-1:0] packet_payload;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_payload = packet[PAYLOAD_LSB +: PAYLOAD_W];
+    end
+  endfunction
+
+  function [VALUE_W-1:0] make_value_line;
+    input [ADDR_W-1:0] addr;
+    integer word_i;
+    reg [63:0] word_value;
+    begin
+      make_value_line = {VALUE_W{1'b0}};
+      for (word_i = 0; word_i < (VALUE_W / 64); word_i = word_i + 1) begin
+        word_value = {16'hd000 + word_i[15:0], 16'h4100 + addr[15:0], 16'h2200 + word_i[15:0], addr[15:0] ^ (word_i * 16'h0011)};
+        make_value_line[(word_i * 64) +: 64] = word_value;
+      end
+    end
+  endfunction
+
+  function [PAYLOAD_W-1:0] expected_payload;
+    input [ADDR_W-1:0] addr;
+    input [SLICE_W-1:0] slice;
+    integer bit_i;
+    integer line_bit;
+    reg [VALUE_W-1:0] line;
+    begin
+      line = make_value_line(addr);
+      expected_payload = {PAYLOAD_W{1'b0}};
+      for (bit_i = 0; bit_i < PAYLOAD_W; bit_i = bit_i + 1) begin
+        line_bit = (slice * PAYLOAD_W) + bit_i;
+        if (line_bit < VALUE_W) begin
+          expected_payload[bit_i] = line[line_bit];
+        end
+      end
+    end
+  endfunction
+
+  task automatic check_response;
+    input integer src;
+    input [PACKET_W-1:0] packet;
+    integer req_i;
+    begin
+      for (req_i = 0; req_i < received_count[src]; req_i = req_i + 1) begin
+        if (seen_tag[src][req_i] == packet_tag(packet)) begin
+          $display("ERROR: duplicate response source=%0d tag=%0h", src, packet_tag(packet));
+          $finish(1);
+        end
+      end
+      if (packet_payload(packet) !== expected_payload(packet_addr(packet), packet_slice(packet))) begin
+        $display("ERROR: payload mismatch source=%0d tag=%0h addr=%0h slice=%0d",
+                 src, packet_tag(packet), packet_addr(packet), packet_slice(packet));
+        $finish(1);
+      end
+      seen_tag[src][received_count[src]] = packet_tag(packet);
+      received_count[src] = received_count[src] + 1;
+      total_received = total_received + 1;
+    end
+  endtask
+
+  always @(*) begin
+    src_req_valid = {SOURCES{1'b0}};
+    src_req_packet = {(SOURCES * PACKET_W){1'b0}};
+    for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+      if (sent_count[src_i] < expected_count[src_i]) begin
+        src_req_valid[src_i] = 1'b1;
+        src_req_packet[(src_i * PACKET_W) +: PACKET_W] = source_packets[src_i][sent_count[src_i]];
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle_count <= 0;
+      for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+        sent_count[src_i] <= 0;
+      end
+    end else begin
+      cycle_count <= cycle_count + 1;
+      if (cycle_count < 24) begin
+        src_resp_ready <= {SOURCES{1'b0}};
+      end else begin
+        src_resp_ready[0] <= 1'b1;
+        src_resp_ready[1] <= 1'b1;
+        src_resp_ready[2] <= (cycle_count[1] == 1'b0);
+        src_resp_ready[3] <= 1'b1;
+      end
+      for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+        if (src_req_valid[src_i] && src_req_ready[src_i]) begin
+          sent_count[src_i] <= sent_count[src_i] + 1;
+        end
+        if (src_resp_valid[src_i] && src_resp_ready[src_i]) begin
+          check_response(src_i, src_resp_packet[(src_i * PACKET_W) +: PACKET_W]);
+        end
+      end
+    end
+  end
+
+  initial begin
+    rst_n = 1'b0;
+    src_resp_ready = {SOURCES{1'b0}};
+    cycle_count = 0;
+    total_expected = 12;
+    total_received = 0;
+
+    source_packets[0][0] = pack_packet(0, 8'h10, 12'd0, 0);
+    source_packets[0][1] = pack_packet(0, 8'h11, 12'd2, 1);
+    source_packets[0][2] = pack_packet(0, 8'h12, 12'd4, 2);
+    source_packets[1][0] = pack_packet(1, 8'h20, 12'd0, 1);
+    source_packets[1][1] = pack_packet(1, 8'h21, 12'd2, 2);
+    source_packets[1][2] = pack_packet(1, 8'h22, 12'd4, 3);
+    source_packets[2][0] = pack_packet(2, 8'h30, 12'd1, 0);
+    source_packets[2][1] = pack_packet(2, 8'h31, 12'd3, 1);
+    source_packets[2][2] = pack_packet(2, 8'h32, 12'd5, 2);
+    source_packets[3][0] = pack_packet(3, 8'h40, 12'd1, 3);
+    source_packets[3][1] = pack_packet(3, 8'h41, 12'd3, 0);
+    source_packets[3][2] = pack_packet(3, 8'h42, 12'd5, 1);
+
+    for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+      expected_count[src_i] = 3;
+      sent_count[src_i] = 0;
+      received_count[src_i] = 0;
+      for (slot_i = 0; slot_i < 8; slot_i = slot_i + 1) begin
+        seen_tag[src_i][slot_i] = -1;
+      end
+    end
+
+    #(CLK_PERIOD * 4);
+    rst_n = 1'b1;
+    wait (total_received == total_expected);
+    repeat (4) @(posedge clk);
+
+    for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+      if (received_count[src_i] != expected_count[src_i]) begin
+        $display("ERROR: missing responses source=%0d got=%0d expected=%0d",
+                 src_i, received_count[src_i], expected_count[src_i]);
+        $finish(1);
+      end
+    end
+    if (service_accepted_req_count != total_expected || service_emitted_resp_count != total_expected) begin
+      $display("ERROR: service count mismatch req=%0d resp=%0d expected=%0d",
+               service_accepted_req_count, service_emitted_resp_count, total_expected);
+      $finish(1);
+    end
+    if (service_bank_conflict_count == 0) begin
+      $display("ERROR: expected bank conflict counter activity");
+      $finish(1);
+    end
+    if (router_injection_stall_cycles == 0 || router_arbitration_contention_cycles == 0) begin
+      $display("ERROR: expected router counters to move stall=%0d contention=%0d",
+               router_injection_stall_cycles, router_arbitration_contention_cycles);
+      $finish(1);
+    end
+    if (router_response_block_cycles == 0 || service_response_block_cycles == 0) begin
+      $display("ERROR: expected response blocking counters router=%0d service=%0d",
+               router_response_block_cycles, service_response_block_cycles);
+      $finish(1);
+    end
+    if (router_req_max_occupancy == 0 || router_resp_max_occupancy == 0 ||
+        service_req_max_occupancy == 0 || service_resp_max_occupancy == 0) begin
+      $display("ERROR: expected occupancy counters to rise");
+      $finish(1);
+    end
+
+    $display("PASS: tb_banked_value_memory_service packet_w=%0d", PACKET_W);
+    $finish(0);
+  end
+
+  initial begin
+    repeat (800) @(posedge clk);
+    $display("ERROR: tb_banked_value_memory_service timeout");
+    $finish(1);
+  end
+endmodule

--- a/npu/sim/rtl/tb_banked_value_memory_service_parallel.sv
+++ b/npu/sim/rtl/tb_banked_value_memory_service_parallel.sv
@@ -25,7 +25,6 @@ module tb_banked_value_memory_service_parallel;
 
   reg [SOURCES-1:0] src_req_valid;
   wire [SOURCES-1:0] src_req_ready;
-  reg [SOURCES*SOURCE_W-1:0] src_req_source;
   reg [SOURCES*TAG_W-1:0] src_req_tag;
   reg [SOURCES*ADDR_W-1:0] src_req_addr;
   reg [SOURCES*VALUE_SLICE_W-1:0] src_req_value_slice;
@@ -103,7 +102,6 @@ module tb_banked_value_memory_service_parallel;
     .rst_n(rst_n),
     .src_req_valid(src_req_valid),
     .src_req_ready(src_req_ready),
-    .src_req_source(src_req_source),
     .src_req_tag(src_req_tag),
     .src_req_addr(src_req_addr),
     .src_req_value_slice(src_req_value_slice),
@@ -258,7 +256,6 @@ module tb_banked_value_memory_service_parallel;
     begin
       @(negedge clk);
       src_req_valid[src] = 1'b1;
-      src_req_source[(src * SOURCE_W) +: SOURCE_W] = {SOURCE_W{1'b1}};
       src_req_tag[(src * TAG_W) +: TAG_W] = tag;
       src_req_addr[(src * ADDR_W) +: ADDR_W] = addr;
       src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = value_slice;
@@ -269,7 +266,6 @@ module tb_banked_value_memory_service_parallel;
       @(posedge clk);
       @(negedge clk);
       src_req_valid[src] = 1'b0;
-      src_req_source[(src * SOURCE_W) +: SOURCE_W] = {SOURCE_W{1'b0}};
       src_req_tag[(src * TAG_W) +: TAG_W] = {TAG_W{1'b0}};
       src_req_addr[(src * ADDR_W) +: ADDR_W] = {ADDR_W{1'b0}};
       src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = {VALUE_SLICE_W{1'b0}};
@@ -324,7 +320,6 @@ module tb_banked_value_memory_service_parallel;
     preload_value_slice = {VALUE_SLICE_W{1'b0}};
     preload_matrix = {VALUE_W{1'b0}};
     src_req_valid = {SOURCES{1'b0}};
-    src_req_source = {(SOURCES * SOURCE_W){1'b0}};
     src_req_tag = {(SOURCES * TAG_W){1'b0}};
     src_req_addr = {(SOURCES * ADDR_W){1'b0}};
     src_req_value_slice = {(SOURCES * VALUE_SLICE_W){1'b0}};

--- a/npu/sim/rtl/tb_banked_value_memory_service_parallel.sv
+++ b/npu/sim/rtl/tb_banked_value_memory_service_parallel.sv
@@ -1,11 +1,11 @@
 `timescale 1ns/1ps
 
-module tb_banked_value_memory_service;
+module tb_banked_value_memory_service_parallel;
   parameter integer PACKET_W = 128;
   localparam integer CLK_PERIOD = 10;
   localparam integer VALUE_W = 512;
-  localparam integer SOURCES = 4;
-  localparam integer SOURCE_W = 2;
+  localparam integer SOURCES = 2;
+  localparam integer SOURCE_W = 1;
   localparam integer TAG_W = 8;
   localparam integer ADDR_W = 12;
   localparam integer VALUE_SLICE_W = 4;
@@ -58,17 +58,9 @@ module tb_banked_value_memory_service;
   wire resp_last;
   wire [PACKET_W-1:0] resp_data;
 
-  wire [31:0] router_injection_stall_cycles;
-  wire [31:0] router_arbitration_contention_cycles;
-  wire [31:0] router_response_block_cycles;
-  wire [31:0] router_req_max_occupancy;
-  wire [31:0] router_resp_max_occupancy;
   wire [31:0] service_accepted_req_count;
   wire [31:0] service_emitted_resp_count;
-  wire [31:0] service_bank_conflict_count;
   wire [31:0] service_response_block_cycles;
-  wire [31:0] service_req_max_occupancy;
-  wire [31:0] service_resp_max_occupancy;
 
   wire [SOURCES-1:0] wide_resp_valid;
   reg [SOURCES-1:0] wide_resp_ready;
@@ -79,12 +71,16 @@ module tb_banked_value_memory_service;
   wire [SOURCES*VALUE_SLICE_W-1:0] wide_resp_value_slice;
   wire [SOURCES*VALUE_W-1:0] wide_resp_matrix;
 
-  reg [VALUE_W-1:0] expected_matrix [0:SOURCES-1];
-  reg [TAG_W-1:0] expected_tag [0:SOURCES-1];
-  reg [ADDR_W-1:0] expected_addr [0:SOURCES-1];
-  reg [VALUE_SLICE_W-1:0] expected_slice [0:SOURCES-1];
-  integer seen_wide [0:SOURCES-1];
-  integer total_seen;
+  reg [VALUE_W-1:0] expected_matrix [0:1];
+  reg [TAG_W-1:0] expected_tag [0:1];
+  reg [ADDR_W-1:0] expected_addr [0:1];
+  reg [VALUE_SLICE_W-1:0] expected_slice [0:1];
+  reg [TAG_W-1:0] expected_group_tag [0:1];
+  reg [TAG_W-1:0] observed_seg_tag [0:(2 * FRAGMENTS) - 1];
+  reg [FRAG_IDX_W-1:0] observed_seg_frag [0:(2 * FRAGMENTS) - 1];
+  integer observed_seg_count;
+  integer observed_wide_count;
+  integer wide_release_done;
   integer src_i;
 
   assign src_resp_ready = reasm_seg_ready & seg_accept_enable;
@@ -135,13 +131,13 @@ module tb_banked_value_memory_service;
     .resp_fragment_idx(resp_fragment_idx),
     .resp_last(resp_last),
     .resp_data(resp_data),
-    .injection_stall_cycles(router_injection_stall_cycles),
-    .arbitration_contention_cycles(router_arbitration_contention_cycles),
-    .response_block_cycles(router_response_block_cycles),
+    .injection_stall_cycles(),
+    .arbitration_contention_cycles(),
+    .response_block_cycles(),
     .req_current_occupancy(),
-    .req_max_occupancy(router_req_max_occupancy),
+    .req_max_occupancy(),
     .resp_current_occupancy(),
-    .resp_max_occupancy(router_resp_max_occupancy)
+    .resp_max_occupancy()
   );
 
   banked_value_memory_service #(
@@ -154,7 +150,7 @@ module tb_banked_value_memory_service;
     .STORE_DEPTH(STORE_DEPTH),
     .BANKS(BANKS),
     .BANK_QUEUE_DEPTH(1),
-    .READ_LATENCY(2)
+    .READ_LATENCY(1)
   ) u_service (
     .clk(clk),
     .rst_n(rst_n),
@@ -180,12 +176,12 @@ module tb_banked_value_memory_service;
     .resp_data(resp_data),
     .accepted_req_count(service_accepted_req_count),
     .emitted_resp_count(service_emitted_resp_count),
-    .bank_conflict_count(service_bank_conflict_count),
+    .bank_conflict_count(),
     .response_block_cycles(service_response_block_cycles),
     .req_current_occupancy(),
-    .req_max_occupancy(service_req_max_occupancy),
+    .req_max_occupancy(),
     .resp_current_occupancy(),
-    .resp_max_occupancy(service_resp_max_occupancy)
+    .resp_max_occupancy()
   );
 
   genvar reasm_gi;
@@ -232,7 +228,7 @@ module tb_banked_value_memory_service;
     begin
       build_matrix = {VALUE_W{1'b0}};
       for (wi = 0; wi < (VALUE_W / 64); wi = wi + 1) begin
-        word_value = {matrix_id, wi[15:0], matrix_id ^ wi[15:0], 16'h9000 + wi[15:0]};
+        word_value = {matrix_id, wi[15:0], matrix_id ^ wi[15:0], 16'h7000 + wi[15:0]};
         build_matrix[(wi * 64) +: 64] = word_value;
       end
     end
@@ -254,23 +250,24 @@ module tb_banked_value_memory_service;
     end
   endtask
 
-  task automatic set_request;
+  task automatic pulse_request;
     input integer src;
     input [TAG_W-1:0] tag;
     input [ADDR_W-1:0] addr;
     input [VALUE_SLICE_W-1:0] value_slice;
     begin
+      @(negedge clk);
       src_req_valid[src] = 1'b1;
-      src_req_source[(src * SOURCE_W) +: SOURCE_W] = src[SOURCE_W-1:0];
+      src_req_source[(src * SOURCE_W) +: SOURCE_W] = {SOURCE_W{1'b1}};
       src_req_tag[(src * TAG_W) +: TAG_W] = tag;
       src_req_addr[(src * ADDR_W) +: ADDR_W] = addr;
       src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = value_slice;
-    end
-  endtask
-
-  task automatic clear_request;
-    input integer src;
-    begin
+      while (!src_req_ready[src]) begin
+        @(posedge clk);
+        @(negedge clk);
+      end
+      @(posedge clk);
+      @(negedge clk);
       src_req_valid[src] = 1'b0;
       src_req_source[(src * SOURCE_W) +: SOURCE_W] = {SOURCE_W{1'b0}};
       src_req_tag[(src * TAG_W) +: TAG_W] = {TAG_W{1'b0}};
@@ -280,45 +277,43 @@ module tb_banked_value_memory_service;
   endtask
 
   always @(posedge clk) begin
-    if (!rst_n) begin
-      for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-        seen_wide[src_i] <= 0;
-      end
-      total_seen <= 0;
+      if (!rst_n) begin
+      observed_seg_count <= 0;
+      observed_wide_count <= 0;
+      wide_release_done <= 0;
     end else begin
-      wide_resp_ready[0] <= 1'b1;
       wide_resp_ready[1] <= 1'b1;
-      wide_resp_ready[2] <= (seen_wide[0] != 0);
-      wide_resp_ready[3] <= 1'b1;
 
-      for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-        if (wide_resp_valid[src_i] && wide_resp_ready[src_i]) begin
-          if (seen_wide[src_i] != 0) begin
-            $display("ERROR: duplicate wide response source=%0d", src_i);
-            $finish(1);
-          end
-          if (wide_resp_source[(src_i * SOURCE_W) +: SOURCE_W] !== src_i[SOURCE_W-1:0]) begin
-            $display("ERROR: source metadata mismatch source=%0d got=%0d",
-                     src_i, wide_resp_source[(src_i * SOURCE_W) +: SOURCE_W]);
-            $finish(1);
-          end
-          if (wide_resp_tag[(src_i * TAG_W) +: TAG_W] !== expected_tag[src_i] ||
-              wide_resp_addr[(src_i * ADDR_W) +: ADDR_W] !== expected_addr[src_i] ||
-              wide_resp_value_slice[(src_i * VALUE_SLICE_W) +: VALUE_SLICE_W] !== expected_slice[src_i]) begin
-            $display("ERROR: response metadata mismatch source=%0d tag=%0h addr=%0h slice=%0d",
-                     src_i,
-                     wide_resp_tag[(src_i * TAG_W) +: TAG_W],
-                     wide_resp_addr[(src_i * ADDR_W) +: ADDR_W],
-                     wide_resp_value_slice[(src_i * VALUE_SLICE_W) +: VALUE_SLICE_W]);
-            $finish(1);
-          end
-          if (wide_resp_matrix[(src_i * VALUE_W) +: VALUE_W] !== expected_matrix[src_i]) begin
-            $display("ERROR: reconstructed matrix mismatch source=%0d", src_i);
-            $finish(1);
-          end
-          seen_wide[src_i] <= 1;
-          total_seen <= total_seen + 1;
+      if (src_resp_valid[0] && src_resp_ready[0]) begin
+        observed_seg_tag[observed_seg_count] <= src_resp_tag[0 +: TAG_W];
+        observed_seg_frag[observed_seg_count] <= src_resp_fragment_idx[0 +: FRAG_IDX_W];
+        observed_seg_count <= observed_seg_count + 1;
+      end
+
+      if (wide_resp_valid[0] && wide_resp_ready[0]) begin
+        if (observed_wide_count >= 2) begin
+          $display("ERROR: unexpected extra wide response");
+          $finish(1);
         end
+        if (wide_resp_source[0 +: SOURCE_W] !== {SOURCE_W{1'b0}} ||
+            wide_resp_tag[0 +: TAG_W] !== expected_tag[observed_wide_count] ||
+            wide_resp_addr[0 +: ADDR_W] !== expected_addr[observed_wide_count] ||
+            wide_resp_value_slice[0 +: VALUE_SLICE_W] !== expected_slice[observed_wide_count] ||
+            wide_resp_matrix[0 +: VALUE_W] !== expected_matrix[observed_wide_count]) begin
+          $display("ERROR: wide response mismatch index=%0d", observed_wide_count);
+          $finish(1);
+        end
+        observed_wide_count <= observed_wide_count + 1;
+      end
+
+      if (wide_resp_valid[0] && !wide_release_done && (service_accepted_req_count == 2)) begin
+        wide_release_done <= 1;
+        fork
+          begin
+            repeat (2) @(posedge clk);
+            wide_resp_ready[0] <= 1'b1;
+          end
+        join_none
       end
     end
   end
@@ -336,82 +331,80 @@ module tb_banked_value_memory_service;
     wide_resp_ready = {SOURCES{1'b0}};
     seg_accept_enable = {SOURCES{1'b1}};
     rst_n = 1'b0;
-    total_seen = 0;
-    for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
-      seen_wide[src_i] = 0;
-    end
+    observed_seg_count = 0;
+    observed_wide_count = 0;
+    wide_release_done = 0;
 
-    expected_matrix[0] = build_matrix(16'h0101);
-    expected_matrix[1] = build_matrix(16'h0202);
-    expected_matrix[2] = build_matrix(16'h0303);
-    expected_matrix[3] = build_matrix(16'h0404);
-    expected_tag[0] = 8'h10;
-    expected_tag[1] = 8'h20;
-    expected_tag[2] = 8'h30;
-    expected_tag[3] = 8'h40;
+    expected_matrix[0] = build_matrix(16'h1111);
+    expected_matrix[1] = build_matrix(16'h2222);
+    expected_tag[0] = 8'h11;
+    expected_tag[1] = 8'h22;
     expected_addr[0] = 12'd0;
-    expected_addr[1] = 12'd0;
-    expected_addr[2] = 12'd1;
-    expected_addr[3] = 12'd3;
+    expected_addr[1] = 12'd1;
     expected_slice[0] = 4'h1;
     expected_slice[1] = 4'h2;
-    expected_slice[2] = 4'h3;
-    expected_slice[3] = 4'h4;
+    expected_group_tag[0] = expected_tag[0];
+    expected_group_tag[1] = expected_tag[1];
 
     #(CLK_PERIOD * 4);
     rst_n = 1'b1;
 
-    preload_entry(12'd0, 4'h1, expected_matrix[0]);
-    preload_entry(12'd0, 4'h2, expected_matrix[1]);
-    preload_entry(12'd1, 4'h3, expected_matrix[2]);
-    preload_entry(12'd3, 4'h4, expected_matrix[3]);
+    preload_entry(expected_addr[0], expected_slice[0], expected_matrix[0]);
+    preload_entry(expected_addr[1], expected_slice[1], expected_matrix[1]);
 
-    @(negedge clk);
-    set_request(0, 8'h10, 12'd0, 4'h1);
-    set_request(1, 8'h20, 12'd0, 4'h2);
-    set_request(2, 8'h30, 12'd1, 4'h3);
-    set_request(3, 8'h40, 12'd3, 4'h4);
-    @(posedge clk);
-    @(negedge clk);
-    clear_request(0);
-    clear_request(1);
-    clear_request(2);
-    clear_request(3);
+    fork
+      pulse_request(0, expected_tag[0], expected_addr[0], expected_slice[0]);
+      begin
+        wait (service_accepted_req_count >= 1);
+        pulse_request(0, expected_tag[1], expected_addr[1], expected_slice[1]);
+      end
+    join
 
-    wait (total_seen == SOURCES);
-    repeat (4) @(posedge clk);
+    wait (service_accepted_req_count == 2);
+    wait (observed_wide_count == 2);
+    repeat (2) @(posedge clk);
 
-    if (service_accepted_req_count != SOURCES || service_emitted_resp_count != SOURCES) begin
-      $display("ERROR: service request/response counts mismatch req=%0d resp=%0d expected=%0d",
-               service_accepted_req_count, service_emitted_resp_count, SOURCES);
-      $finish(1);
-    end
-    if (service_bank_conflict_count == 0) begin
-      $display("ERROR: expected service bank conflicts");
-      $finish(1);
-    end
-    if (router_arbitration_contention_cycles == 0) begin
-      $display("ERROR: expected router contention counter to move contention=%0d",
-               router_arbitration_contention_cycles);
-      $finish(1);
-    end
-    if (router_req_max_occupancy == 0 || router_resp_max_occupancy == 0 ||
-        service_req_max_occupancy == 0 || service_resp_max_occupancy == 0) begin
-      $display("ERROR: expected occupancy counters to rise");
-      $finish(1);
-    end
     if (reasm_protocol_error != {SOURCES{1'b0}}) begin
-      $display("ERROR: protocol_error asserted during valid traffic flags=%b",
+      $display("ERROR: protocol_error asserted during valid same-source traffic flags=%b",
                reasm_protocol_error);
       $finish(1);
     end
+    if (service_emitted_resp_count != 2 || service_response_block_cycles == 0) begin
+      $display("ERROR: expected two packets and response backpressure resp=%0d block=%0d",
+               service_emitted_resp_count, service_response_block_cycles);
+      $finish(1);
+    end
+    if ((observed_seg_tag[0] == observed_seg_tag[FRAGMENTS]) ||
+        ((observed_seg_tag[0] != expected_tag[0]) && (observed_seg_tag[0] != expected_tag[1])) ||
+        ((observed_seg_tag[FRAGMENTS] != expected_tag[0]) && (observed_seg_tag[FRAGMENTS] != expected_tag[1]))) begin
+      $display("ERROR: expected two distinct packet groups got tags=%0h,%0h",
+               observed_seg_tag[0], observed_seg_tag[FRAGMENTS]);
+      $finish(1);
+    end
+    for (src_i = 0; src_i < FRAGMENTS; src_i = src_i + 1) begin
+      if (observed_seg_tag[src_i] !== observed_seg_tag[0] ||
+          observed_seg_frag[src_i] !== src_i[FRAG_IDX_W-1:0]) begin
+        $display("ERROR: first packet segment order mismatch idx=%0d tag=%0h frag=%0d",
+                 src_i, observed_seg_tag[src_i], observed_seg_frag[src_i]);
+        $finish(1);
+      end
+      if (observed_seg_tag[src_i + FRAGMENTS] !== observed_seg_tag[FRAGMENTS] ||
+          observed_seg_frag[src_i + FRAGMENTS] !== src_i[FRAG_IDX_W-1:0]) begin
+        $display("ERROR: second packet segment order mismatch idx=%0d tag=%0h frag=%0d",
+                 src_i + FRAGMENTS,
+                 observed_seg_tag[src_i + FRAGMENTS],
+                 observed_seg_frag[src_i + FRAGMENTS]);
+        $finish(1);
+      end
+    end
 
-    $display("PASS: tb_banked_value_memory_service packet_w=%0d", PACKET_W);
+    $display("PASS: tb_banked_value_memory_service_parallel packet_w=%0d", PACKET_W);
     $finish(0);
   end
+
   initial begin
     repeat (1200) @(posedge clk);
-    $display("ERROR: tb_banked_value_memory_service timeout");
+    $display("ERROR: tb_banked_value_memory_service_parallel timeout");
     $finish(1);
   end
 endmodule

--- a/npu/sim/rtl/tb_noc_ready_valid_router.sv
+++ b/npu/sim/rtl/tb_noc_ready_valid_router.sv
@@ -22,7 +22,6 @@ module tb_noc_ready_valid_router;
 
   reg [SOURCES-1:0] src_req_valid;
   wire [SOURCES-1:0] src_req_ready;
-  reg [SOURCES*SOURCE_W-1:0] src_req_source;
   reg [SOURCES*TAG_W-1:0] src_req_tag;
   reg [SOURCES*ADDR_W-1:0] src_req_addr;
   reg [SOURCES*VALUE_SLICE_W-1:0] src_req_value_slice;
@@ -90,7 +89,6 @@ module tb_noc_ready_valid_router;
     .rst_n(rst_n),
     .src_req_valid(src_req_valid),
     .src_req_ready(src_req_ready),
-    .src_req_source(src_req_source),
     .src_req_tag(src_req_tag),
     .src_req_addr(src_req_addr),
     .src_req_value_slice(src_req_value_slice),
@@ -137,7 +135,6 @@ module tb_noc_ready_valid_router;
     input [VALUE_SLICE_W-1:0] value_slice;
     begin
       src_req_valid[src] = 1'b1;
-      src_req_source[(src * SOURCE_W) +: SOURCE_W] = src[SOURCE_W-1:0];
       src_req_tag[(src * TAG_W) +: TAG_W] = tag;
       src_req_addr[(src * ADDR_W) +: ADDR_W] = addr;
       src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = value_slice;
@@ -148,7 +145,6 @@ module tb_noc_ready_valid_router;
     input integer src;
     begin
       src_req_valid[src] = 1'b0;
-      src_req_source[(src * SOURCE_W) +: SOURCE_W] = {SOURCE_W{1'b0}};
       src_req_tag[(src * TAG_W) +: TAG_W] = {TAG_W{1'b0}};
       src_req_addr[(src * ADDR_W) +: ADDR_W] = {ADDR_W{1'b0}};
       src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = {VALUE_SLICE_W{1'b0}};
@@ -227,7 +223,6 @@ module tb_noc_ready_valid_router;
 
   initial begin
     src_req_valid = {SOURCES{1'b0}};
-    src_req_source = {(SOURCES * SOURCE_W){1'b0}};
     src_req_tag = {(SOURCES * TAG_W){1'b0}};
     src_req_addr = {(SOURCES * ADDR_W){1'b0}};
     src_req_value_slice = {(SOURCES * VALUE_SLICE_W){1'b0}};
@@ -254,7 +249,6 @@ module tb_noc_ready_valid_router;
 
     @(negedge clk);
     set_request(0, 8'h01, 12'd0, 4'h0);
-    src_req_source[0 +: SOURCE_W] = 2'd2;
     repeat (3) @(posedge clk);
     @(negedge clk);
     clear_request(0);

--- a/npu/sim/rtl/tb_noc_ready_valid_router.sv
+++ b/npu/sim/rtl/tb_noc_ready_valid_router.sv
@@ -61,6 +61,7 @@ module tb_noc_ready_valid_router;
   wire [31:0] resp_max_occupancy;
 
   integer observed_req_tags [0:15];
+  integer observed_req_sources [0:15];
   integer observed_req_count;
   integer fairness_grants_to_source1;
   integer fairness_total_grants;
@@ -206,6 +207,7 @@ module tb_noc_ready_valid_router;
 
       if (req_valid && req_ready) begin
         observed_req_tags[observed_req_count] <= req_tag;
+        observed_req_sources[observed_req_count] <= req_source;
         observed_req_count <= observed_req_count + 1;
         if ((ARB_MODE == 1) && (fairness_total_grants < 6)) begin
           fairness_total_grants <= fairness_total_grants + 1;
@@ -252,11 +254,16 @@ module tb_noc_ready_valid_router;
 
     @(negedge clk);
     set_request(0, 8'h01, 12'd0, 4'h0);
+    src_req_source[0 +: SOURCE_W] = 2'd2;
     repeat (3) @(posedge clk);
     @(negedge clk);
     clear_request(0);
     req_ready = 1'b1;
     wait (observed_req_count >= 1);
+    if (observed_req_sources[0] !== 0) begin
+      $display("ERROR: request source spoofed through ingress got=%0d", observed_req_sources[0]);
+      $finish(1);
+    end
     observed_req_count = 0;
     req_ready = 1'b0;
 

--- a/npu/sim/rtl/tb_noc_ready_valid_router.sv
+++ b/npu/sim/rtl/tb_noc_ready_valid_router.sv
@@ -1,0 +1,265 @@
+`timescale 1ns/1ps
+
+module tb_noc_ready_valid_router;
+  parameter integer PACKET_W = 128;
+  parameter integer ARB_MODE = 0;
+  localparam integer CLK_PERIOD = 10;
+  localparam integer SOURCES = 3;
+  localparam integer SOURCE_W = 2;
+  localparam integer TAG_W = 8;
+  localparam integer ADDR_W = 12;
+  localparam integer SLICE_W = 3;
+  localparam integer BANKS = 2;
+  localparam integer REQ_QUEUE_DEPTH = 1;
+  localparam integer RESP_QUEUE_DEPTH = 1;
+  localparam integer SRC_LSB = 0;
+  localparam integer TAG_LSB = SRC_LSB + SOURCE_W;
+  localparam integer ADDR_LSB = TAG_LSB + TAG_W;
+  localparam integer SLICE_LSB = ADDR_LSB + ADDR_W;
+  localparam integer PAYLOAD_LSB = SLICE_LSB + SLICE_W;
+  localparam integer PAYLOAD_W = PACKET_W - PAYLOAD_LSB;
+
+  reg clk;
+  reg rst_n;
+
+  reg [SOURCES-1:0] src_req_valid;
+  wire [SOURCES-1:0] src_req_ready;
+  reg [SOURCES*PACKET_W-1:0] src_req_packet;
+  wire [SOURCES-1:0] src_resp_valid;
+  reg [SOURCES-1:0] src_resp_ready;
+  wire [SOURCES*PACKET_W-1:0] src_resp_packet;
+
+  wire req_valid;
+  reg req_ready;
+  wire [PACKET_W-1:0] req_packet;
+
+  reg resp_valid;
+  wire resp_ready;
+  reg [PACKET_W-1:0] resp_packet;
+
+  wire [31:0] injection_stall_cycles;
+  wire [31:0] arbitration_contention_cycles;
+  wire [31:0] response_block_cycles;
+  wire [31:0] req_max_occupancy;
+  wire [31:0] resp_max_occupancy;
+
+  integer observed_reqs [0:3];
+  integer expected_req_order [0:2];
+  integer observed_req_count;
+  integer observed_resp_tags [0:SOURCES-1][0:1];
+  integer observed_resp_count [0:SOURCES-1];
+  integer cycle_count;
+  integer src_i;
+
+  noc_ready_valid_router #(
+    .PACKET_W(PACKET_W),
+    .SOURCES(SOURCES),
+    .SOURCE_W(SOURCE_W),
+    .TAG_W(TAG_W),
+    .ADDR_W(ADDR_W),
+    .SLICE_W(SLICE_W),
+    .BANKS(BANKS),
+    .REQ_QUEUE_DEPTH(REQ_QUEUE_DEPTH),
+    .RESP_QUEUE_DEPTH(RESP_QUEUE_DEPTH),
+    .ARB_MODE(ARB_MODE)
+  ) dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .src_req_valid(src_req_valid),
+    .src_req_ready(src_req_ready),
+    .src_req_packet(src_req_packet),
+    .src_resp_valid(src_resp_valid),
+    .src_resp_ready(src_resp_ready),
+    .src_resp_packet(src_resp_packet),
+    .req_valid(req_valid),
+    .req_ready(req_ready),
+    .req_packet(req_packet),
+    .resp_valid(resp_valid),
+    .resp_ready(resp_ready),
+    .resp_packet(resp_packet),
+    .injection_stall_cycles(injection_stall_cycles),
+    .arbitration_contention_cycles(arbitration_contention_cycles),
+    .response_block_cycles(response_block_cycles),
+    .req_current_occupancy(),
+    .req_max_occupancy(req_max_occupancy),
+    .resp_current_occupancy(),
+    .resp_max_occupancy(resp_max_occupancy)
+  );
+
+  initial clk = 1'b0;
+  always #(CLK_PERIOD/2) clk = ~clk;
+
+  function [PACKET_W-1:0] pack_packet;
+    input [SOURCE_W-1:0] src;
+    input [TAG_W-1:0] tag;
+    input [ADDR_W-1:0] addr;
+    input [SLICE_W-1:0] slice;
+    input [PAYLOAD_W-1:0] payload;
+    begin
+      pack_packet = {PACKET_W{1'b0}};
+      pack_packet[SRC_LSB +: SOURCE_W] = src;
+      pack_packet[TAG_LSB +: TAG_W] = tag;
+      pack_packet[ADDR_LSB +: ADDR_W] = addr;
+      pack_packet[SLICE_LSB +: SLICE_W] = slice;
+      pack_packet[PAYLOAD_LSB +: PAYLOAD_W] = payload;
+    end
+  endfunction
+
+  function [TAG_W-1:0] packet_tag;
+    input [PACKET_W-1:0] packet;
+    begin
+      packet_tag = packet[TAG_LSB +: TAG_W];
+    end
+  endfunction
+
+  task automatic set_source_packet;
+    input integer src;
+    input [PACKET_W-1:0] packet;
+    begin
+      src_req_packet[(src * PACKET_W) +: PACKET_W] = packet;
+      src_req_valid[src] = 1'b1;
+    end
+  endtask
+
+  task automatic clear_source;
+    input integer src;
+    begin
+      src_req_packet[(src * PACKET_W) +: PACKET_W] = {PACKET_W{1'b0}};
+      src_req_valid[src] = 1'b0;
+    end
+  endtask
+
+  task automatic send_response;
+    input [PACKET_W-1:0] packet;
+    begin : wait_handshake
+      resp_packet = packet;
+      resp_valid = 1'b1;
+      while (1) begin
+        @(posedge clk);
+        if (resp_valid && resp_ready) begin
+          @(negedge clk);
+          resp_valid = 1'b0;
+          resp_packet = {PACKET_W{1'b0}};
+          disable wait_handshake;
+        end
+      end
+    end
+  endtask
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      observed_req_count <= 0;
+      cycle_count <= 0;
+      for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+        observed_resp_count[src_i] <= 0;
+      end
+    end else begin
+      cycle_count <= cycle_count + 1;
+      if (req_valid && req_ready && observed_req_count < 4) begin
+        observed_reqs[observed_req_count] <= packet_tag(req_packet);
+        observed_req_count <= observed_req_count + 1;
+      end
+      for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+        if (src_resp_valid[src_i] && src_resp_ready[src_i]) begin
+          observed_resp_tags[src_i][observed_resp_count[src_i]] <= packet_tag(src_resp_packet[(src_i * PACKET_W) +: PACKET_W]);
+          observed_resp_count[src_i] <= observed_resp_count[src_i] + 1;
+        end
+      end
+    end
+  end
+
+  initial begin
+    src_req_valid = {SOURCES{1'b0}};
+    src_req_packet = {(SOURCES * PACKET_W){1'b0}};
+    src_resp_ready = {SOURCES{1'b0}};
+    req_ready = 1'b0;
+    resp_valid = 1'b0;
+    resp_packet = {PACKET_W{1'b0}};
+    rst_n = 1'b0;
+    observed_req_count = 0;
+    cycle_count = 0;
+    for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
+      observed_resp_count[src_i] = 0;
+    end
+
+    if (ARB_MODE == 0) begin
+      expected_req_order[0] = 8'h10;
+      expected_req_order[1] = 8'h20;
+      expected_req_order[2] = 8'h30;
+    end else begin
+      expected_req_order[0] = 8'h10;
+      expected_req_order[1] = 8'h30;
+      expected_req_order[2] = 8'h20;
+    end
+
+    #(CLK_PERIOD * 4);
+    rst_n = 1'b1;
+
+    @(negedge clk);
+    set_source_packet(0, pack_packet(0, 8'h10, 12'd0, 0, {PAYLOAD_W{1'b0}}));
+    set_source_packet(1, pack_packet(1, 8'h20, 12'd1, 0, {PAYLOAD_W{1'b0}}));
+    set_source_packet(2, pack_packet(2, 8'h30, 12'd0, 0, {PAYLOAD_W{1'b0}}));
+    wait (&src_req_ready);
+    @(posedge clk);
+    @(negedge clk);
+    clear_source(0);
+    clear_source(1);
+    clear_source(2);
+
+    @(negedge clk);
+    set_source_packet(0, pack_packet(0, 8'h11, 12'd2, 0, {PAYLOAD_W{1'b0}}));
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    clear_source(0);
+    req_ready = 1'b1;
+    wait (observed_req_count >= 3);
+
+    src_resp_ready = 3'b101;
+    send_response(pack_packet(1, 8'ha0, 12'd9, 0, {PAYLOAD_W{1'b1}}));
+    @(negedge clk);
+    resp_packet = pack_packet(1, 8'ha1, 12'd9, 0, {PAYLOAD_W{1'b0}});
+    resp_valid = 1'b1;
+    repeat (4) @(posedge clk);
+    @(negedge clk);
+    resp_valid = 1'b0;
+    resp_packet = {PACKET_W{1'b0}};
+    src_resp_ready[1] = 1'b1;
+    wait (observed_resp_count[1] == 1);
+    send_response(pack_packet(1, 8'ha1, 12'd9, 0, {PAYLOAD_W{1'b0}}));
+    send_response(pack_packet(0, 8'hb0, 12'd4, 0, {{(PAYLOAD_W-8){1'b0}}, 8'h55}));
+    wait (observed_resp_count[0] == 1 && observed_resp_count[1] == 2);
+    repeat (2) @(posedge clk);
+
+    for (src_i = 0; src_i < 3; src_i = src_i + 1) begin
+      if (observed_reqs[src_i] !== expected_req_order[src_i]) begin
+        $display("ERROR: request order mismatch index=%0d got=%0h expected=%0h",
+                 src_i, observed_reqs[src_i], expected_req_order[src_i]);
+        $finish(1);
+      end
+    end
+    if (observed_resp_tags[1][0] !== 8'ha0 || observed_resp_tags[1][1] !== 8'ha1 ||
+        observed_resp_tags[0][0] !== 8'hb0) begin
+      $display("ERROR: response routing mismatch");
+      $finish(1);
+    end
+    if (injection_stall_cycles == 0 || arbitration_contention_cycles == 0 || response_block_cycles == 0) begin
+      $display("ERROR: expected router counters to move stall=%0d contention=%0d response_block=%0d",
+               injection_stall_cycles, arbitration_contention_cycles, response_block_cycles);
+      $finish(1);
+    end
+    if (req_max_occupancy < 2 || resp_max_occupancy == 0) begin
+      $display("ERROR: expected occupancy counters to rise req=%0d resp=%0d",
+               req_max_occupancy, resp_max_occupancy);
+      $finish(1);
+    end
+
+    $display("PASS: tb_noc_ready_valid_router packet_w=%0d arb_mode=%0d", PACKET_W, ARB_MODE);
+    $finish(0);
+  end
+
+  initial begin
+    repeat (300) @(posedge clk);
+    $display("ERROR: tb_noc_ready_valid_router timeout");
+    $finish(1);
+  end
+endmodule

--- a/npu/sim/rtl/tb_noc_ready_valid_router.sv
+++ b/npu/sim/rtl/tb_noc_ready_valid_router.sv
@@ -4,38 +4,55 @@ module tb_noc_ready_valid_router;
   parameter integer PACKET_W = 128;
   parameter integer ARB_MODE = 0;
   localparam integer CLK_PERIOD = 10;
+  localparam integer VALUE_W = 512;
   localparam integer SOURCES = 3;
   localparam integer SOURCE_W = 2;
   localparam integer TAG_W = 8;
   localparam integer ADDR_W = 12;
-  localparam integer SLICE_W = 3;
+  localparam integer VALUE_SLICE_W = 4;
   localparam integer BANKS = 2;
   localparam integer REQ_QUEUE_DEPTH = 1;
   localparam integer RESP_QUEUE_DEPTH = 1;
-  localparam integer SRC_LSB = 0;
-  localparam integer TAG_LSB = SRC_LSB + SOURCE_W;
-  localparam integer ADDR_LSB = TAG_LSB + TAG_W;
-  localparam integer SLICE_LSB = ADDR_LSB + ADDR_W;
-  localparam integer PAYLOAD_LSB = SLICE_LSB + SLICE_W;
-  localparam integer PAYLOAD_W = PACKET_W - PAYLOAD_LSB;
+  localparam integer LOCALITY_BURST_MAX = 2;
+  localparam integer FRAGMENTS = VALUE_W / PACKET_W;
+  localparam integer FRAG_IDX_W = (FRAGMENTS <= 1) ? 1 : $clog2(FRAGMENTS);
 
   reg clk;
   reg rst_n;
 
   reg [SOURCES-1:0] src_req_valid;
   wire [SOURCES-1:0] src_req_ready;
-  reg [SOURCES*PACKET_W-1:0] src_req_packet;
+  reg [SOURCES*SOURCE_W-1:0] src_req_source;
+  reg [SOURCES*TAG_W-1:0] src_req_tag;
+  reg [SOURCES*ADDR_W-1:0] src_req_addr;
+  reg [SOURCES*VALUE_SLICE_W-1:0] src_req_value_slice;
+
   wire [SOURCES-1:0] src_resp_valid;
   reg [SOURCES-1:0] src_resp_ready;
-  wire [SOURCES*PACKET_W-1:0] src_resp_packet;
+  wire [SOURCES*SOURCE_W-1:0] src_resp_source;
+  wire [SOURCES*TAG_W-1:0] src_resp_tag;
+  wire [SOURCES*ADDR_W-1:0] src_resp_addr;
+  wire [SOURCES*VALUE_SLICE_W-1:0] src_resp_value_slice;
+  wire [SOURCES*FRAG_IDX_W-1:0] src_resp_fragment_idx;
+  wire [SOURCES-1:0] src_resp_last;
+  wire [SOURCES*PACKET_W-1:0] src_resp_data;
 
   wire req_valid;
   reg req_ready;
-  wire [PACKET_W-1:0] req_packet;
+  wire [SOURCE_W-1:0] req_source;
+  wire [TAG_W-1:0] req_tag;
+  wire [ADDR_W-1:0] req_addr;
+  wire [VALUE_SLICE_W-1:0] req_value_slice;
 
   reg resp_valid;
   wire resp_ready;
-  reg [PACKET_W-1:0] resp_packet;
+  reg [SOURCE_W-1:0] resp_source;
+  reg [TAG_W-1:0] resp_tag;
+  reg [ADDR_W-1:0] resp_addr;
+  reg [VALUE_SLICE_W-1:0] resp_value_slice;
+  reg [FRAG_IDX_W-1:0] resp_fragment_idx;
+  reg resp_last;
+  reg [PACKET_W-1:0] resp_data;
 
   wire [31:0] injection_stall_cycles;
   wire [31:0] arbitration_contention_cycles;
@@ -43,40 +60,63 @@ module tb_noc_ready_valid_router;
   wire [31:0] req_max_occupancy;
   wire [31:0] resp_max_occupancy;
 
-  integer observed_reqs [0:3];
-  integer expected_req_order [0:2];
+  integer observed_req_tags [0:15];
   integer observed_req_count;
-  integer observed_resp_tags [0:SOURCES-1][0:1];
+  integer fairness_grants_to_source1;
+  integer fairness_total_grants;
+  integer fairness_nonpreferred_gap;
+  integer fairness_max_gap;
+  integer observed_resp_tags [0:SOURCES-1][0:3];
+  integer observed_resp_frags [0:SOURCES-1][0:3];
   integer observed_resp_count [0:SOURCES-1];
-  integer cycle_count;
   integer src_i;
 
   noc_ready_valid_router #(
     .PACKET_W(PACKET_W),
+    .VALUE_W(VALUE_W),
     .SOURCES(SOURCES),
     .SOURCE_W(SOURCE_W),
     .TAG_W(TAG_W),
     .ADDR_W(ADDR_W),
-    .SLICE_W(SLICE_W),
+    .VALUE_SLICE_W(VALUE_SLICE_W),
     .BANKS(BANKS),
     .REQ_QUEUE_DEPTH(REQ_QUEUE_DEPTH),
     .RESP_QUEUE_DEPTH(RESP_QUEUE_DEPTH),
-    .ARB_MODE(ARB_MODE)
+    .ARB_MODE(ARB_MODE),
+    .LOCALITY_BURST_MAX(LOCALITY_BURST_MAX)
   ) dut (
     .clk(clk),
     .rst_n(rst_n),
     .src_req_valid(src_req_valid),
     .src_req_ready(src_req_ready),
-    .src_req_packet(src_req_packet),
+    .src_req_source(src_req_source),
+    .src_req_tag(src_req_tag),
+    .src_req_addr(src_req_addr),
+    .src_req_value_slice(src_req_value_slice),
     .src_resp_valid(src_resp_valid),
     .src_resp_ready(src_resp_ready),
-    .src_resp_packet(src_resp_packet),
+    .src_resp_source(src_resp_source),
+    .src_resp_tag(src_resp_tag),
+    .src_resp_addr(src_resp_addr),
+    .src_resp_value_slice(src_resp_value_slice),
+    .src_resp_fragment_idx(src_resp_fragment_idx),
+    .src_resp_last(src_resp_last),
+    .src_resp_data(src_resp_data),
     .req_valid(req_valid),
     .req_ready(req_ready),
-    .req_packet(req_packet),
+    .req_source(req_source),
+    .req_tag(req_tag),
+    .req_addr(req_addr),
+    .req_value_slice(req_value_slice),
     .resp_valid(resp_valid),
     .resp_ready(resp_ready),
-    .resp_packet(resp_packet),
+    .resp_source(resp_source),
+    .resp_tag(resp_tag),
+    .resp_addr(resp_addr),
+    .resp_value_slice(resp_value_slice),
+    .resp_fragment_idx(resp_fragment_idx),
+    .resp_last(resp_last),
+    .resp_data(resp_data),
     .injection_stall_cycles(injection_stall_cycles),
     .arbitration_contention_cycles(arbitration_contention_cycles),
     .response_block_cycles(response_block_cycles),
@@ -89,58 +129,55 @@ module tb_noc_ready_valid_router;
   initial clk = 1'b0;
   always #(CLK_PERIOD/2) clk = ~clk;
 
-  function [PACKET_W-1:0] pack_packet;
-    input [SOURCE_W-1:0] src;
+  task automatic set_request;
+    input integer src;
     input [TAG_W-1:0] tag;
     input [ADDR_W-1:0] addr;
-    input [SLICE_W-1:0] slice;
-    input [PAYLOAD_W-1:0] payload;
+    input [VALUE_SLICE_W-1:0] value_slice;
     begin
-      pack_packet = {PACKET_W{1'b0}};
-      pack_packet[SRC_LSB +: SOURCE_W] = src;
-      pack_packet[TAG_LSB +: TAG_W] = tag;
-      pack_packet[ADDR_LSB +: ADDR_W] = addr;
-      pack_packet[SLICE_LSB +: SLICE_W] = slice;
-      pack_packet[PAYLOAD_LSB +: PAYLOAD_W] = payload;
-    end
-  endfunction
-
-  function [TAG_W-1:0] packet_tag;
-    input [PACKET_W-1:0] packet;
-    begin
-      packet_tag = packet[TAG_LSB +: TAG_W];
-    end
-  endfunction
-
-  task automatic set_source_packet;
-    input integer src;
-    input [PACKET_W-1:0] packet;
-    begin
-      src_req_packet[(src * PACKET_W) +: PACKET_W] = packet;
       src_req_valid[src] = 1'b1;
+      src_req_source[(src * SOURCE_W) +: SOURCE_W] = src[SOURCE_W-1:0];
+      src_req_tag[(src * TAG_W) +: TAG_W] = tag;
+      src_req_addr[(src * ADDR_W) +: ADDR_W] = addr;
+      src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = value_slice;
     end
   endtask
 
-  task automatic clear_source;
+  task automatic clear_request;
     input integer src;
     begin
-      src_req_packet[(src * PACKET_W) +: PACKET_W] = {PACKET_W{1'b0}};
       src_req_valid[src] = 1'b0;
+      src_req_source[(src * SOURCE_W) +: SOURCE_W] = {SOURCE_W{1'b0}};
+      src_req_tag[(src * TAG_W) +: TAG_W] = {TAG_W{1'b0}};
+      src_req_addr[(src * ADDR_W) +: ADDR_W] = {ADDR_W{1'b0}};
+      src_req_value_slice[(src * VALUE_SLICE_W) +: VALUE_SLICE_W] = {VALUE_SLICE_W{1'b0}};
     end
   endtask
 
-  task automatic send_response;
-    input [PACKET_W-1:0] packet;
-    begin : wait_handshake
-      resp_packet = packet;
+  task automatic issue_response;
+    input [SOURCE_W-1:0] source;
+    input [TAG_W-1:0] tag;
+    input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
+    input [FRAG_IDX_W-1:0] fragment_idx;
+    input last;
+    input [PACKET_W-1:0] data;
+    begin : wait_fire
+      @(negedge clk);
+      resp_source = source;
+      resp_tag = tag;
+      resp_addr = addr;
+      resp_value_slice = value_slice;
+      resp_fragment_idx = fragment_idx;
+      resp_last = last;
+      resp_data = data;
       resp_valid = 1'b1;
       while (1) begin
         @(posedge clk);
         if (resp_valid && resp_ready) begin
           @(negedge clk);
           resp_valid = 1'b0;
-          resp_packet = {PACKET_W{1'b0}};
-          disable wait_handshake;
+          disable wait_fire;
         end
       end
     end
@@ -149,20 +186,38 @@ module tb_noc_ready_valid_router;
   always @(posedge clk) begin
     if (!rst_n) begin
       observed_req_count <= 0;
-      cycle_count <= 0;
+      fairness_grants_to_source1 <= 0;
+      fairness_total_grants <= 0;
+      fairness_nonpreferred_gap <= 0;
+      fairness_max_gap <= 0;
       for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
         observed_resp_count[src_i] <= 0;
       end
     end else begin
-      cycle_count <= cycle_count + 1;
-      if (req_valid && req_ready && observed_req_count < 4) begin
-        observed_reqs[observed_req_count] <= packet_tag(req_packet);
-        observed_req_count <= observed_req_count + 1;
-      end
       for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
         if (src_resp_valid[src_i] && src_resp_ready[src_i]) begin
-          observed_resp_tags[src_i][observed_resp_count[src_i]] <= packet_tag(src_resp_packet[(src_i * PACKET_W) +: PACKET_W]);
+          observed_resp_tags[src_i][observed_resp_count[src_i]] <=
+            src_resp_tag[(src_i * TAG_W) +: TAG_W];
+          observed_resp_frags[src_i][observed_resp_count[src_i]] <=
+            src_resp_fragment_idx[(src_i * FRAG_IDX_W) +: FRAG_IDX_W];
           observed_resp_count[src_i] <= observed_resp_count[src_i] + 1;
+        end
+      end
+
+      if (req_valid && req_ready) begin
+        observed_req_tags[observed_req_count] <= req_tag;
+        observed_req_count <= observed_req_count + 1;
+        if ((ARB_MODE == 1) && (fairness_total_grants < 6)) begin
+          fairness_total_grants <= fairness_total_grants + 1;
+          if (req_source == 1) begin
+            fairness_grants_to_source1 <= fairness_grants_to_source1 + 1;
+            fairness_nonpreferred_gap <= 0;
+          end else begin
+            fairness_nonpreferred_gap <= fairness_nonpreferred_gap + 1;
+            if ((fairness_nonpreferred_gap + 1) > fairness_max_gap) begin
+              fairness_max_gap <= fairness_nonpreferred_gap + 1;
+            end
+          end
         end
       end
     end
@@ -170,85 +225,125 @@ module tb_noc_ready_valid_router;
 
   initial begin
     src_req_valid = {SOURCES{1'b0}};
-    src_req_packet = {(SOURCES * PACKET_W){1'b0}};
+    src_req_source = {(SOURCES * SOURCE_W){1'b0}};
+    src_req_tag = {(SOURCES * TAG_W){1'b0}};
+    src_req_addr = {(SOURCES * ADDR_W){1'b0}};
+    src_req_value_slice = {(SOURCES * VALUE_SLICE_W){1'b0}};
     src_resp_ready = {SOURCES{1'b0}};
     req_ready = 1'b0;
     resp_valid = 1'b0;
-    resp_packet = {PACKET_W{1'b0}};
+    resp_source = {SOURCE_W{1'b0}};
+    resp_tag = {TAG_W{1'b0}};
+    resp_addr = {ADDR_W{1'b0}};
+    resp_value_slice = {VALUE_SLICE_W{1'b0}};
+    resp_fragment_idx = {FRAG_IDX_W{1'b0}};
+    resp_last = 1'b0;
+    resp_data = {PACKET_W{1'b0}};
     rst_n = 1'b0;
     observed_req_count = 0;
-    cycle_count = 0;
+    fairness_grants_to_source1 = 0;
+    fairness_total_grants = 0;
     for (src_i = 0; src_i < SOURCES; src_i = src_i + 1) begin
       observed_resp_count[src_i] = 0;
-    end
-
-    if (ARB_MODE == 0) begin
-      expected_req_order[0] = 8'h10;
-      expected_req_order[1] = 8'h20;
-      expected_req_order[2] = 8'h30;
-    end else begin
-      expected_req_order[0] = 8'h10;
-      expected_req_order[1] = 8'h30;
-      expected_req_order[2] = 8'h20;
     end
 
     #(CLK_PERIOD * 4);
     rst_n = 1'b1;
 
     @(negedge clk);
-    set_source_packet(0, pack_packet(0, 8'h10, 12'd0, 0, {PAYLOAD_W{1'b0}}));
-    set_source_packet(1, pack_packet(1, 8'h20, 12'd1, 0, {PAYLOAD_W{1'b0}}));
-    set_source_packet(2, pack_packet(2, 8'h30, 12'd0, 0, {PAYLOAD_W{1'b0}}));
-    wait (&src_req_ready);
-    @(posedge clk);
-    @(negedge clk);
-    clear_source(0);
-    clear_source(1);
-    clear_source(2);
-
-    @(negedge clk);
-    set_source_packet(0, pack_packet(0, 8'h11, 12'd2, 0, {PAYLOAD_W{1'b0}}));
+    set_request(0, 8'h01, 12'd0, 4'h0);
     repeat (3) @(posedge clk);
     @(negedge clk);
-    clear_source(0);
+    clear_request(0);
+    req_ready = 1'b1;
+    wait (observed_req_count >= 1);
+    observed_req_count = 0;
+    req_ready = 1'b0;
+
+    @(negedge clk);
+    set_request(0, 8'h10, 12'd0, 4'h1);
+    set_request(1, 8'h20, 12'd1, 4'h2);
+    set_request(2, 8'h30, 12'd0, 4'h3);
+    @(posedge clk);
+    @(negedge clk);
+    clear_request(0);
+    clear_request(1);
+    clear_request(2);
+    repeat (2) @(posedge clk);
     req_ready = 1'b1;
     wait (observed_req_count >= 3);
 
-    src_resp_ready = 3'b101;
-    send_response(pack_packet(1, 8'ha0, 12'd9, 0, {PAYLOAD_W{1'b1}}));
-    @(negedge clk);
-    resp_packet = pack_packet(1, 8'ha1, 12'd9, 0, {PAYLOAD_W{1'b0}});
-    resp_valid = 1'b1;
-    repeat (4) @(posedge clk);
-    @(negedge clk);
-    resp_valid = 1'b0;
-    resp_packet = {PACKET_W{1'b0}};
-    src_resp_ready[1] = 1'b1;
-    wait (observed_resp_count[1] == 1);
-    send_response(pack_packet(1, 8'ha1, 12'd9, 0, {PAYLOAD_W{1'b0}}));
-    send_response(pack_packet(0, 8'hb0, 12'd4, 0, {{(PAYLOAD_W-8){1'b0}}, 8'h55}));
-    wait (observed_resp_count[0] == 1 && observed_resp_count[1] == 2);
-    repeat (2) @(posedge clk);
-
-    for (src_i = 0; src_i < 3; src_i = src_i + 1) begin
-      if (observed_reqs[src_i] !== expected_req_order[src_i]) begin
-        $display("ERROR: request order mismatch index=%0d got=%0h expected=%0h",
-                 src_i, observed_reqs[src_i], expected_req_order[src_i]);
+    if (ARB_MODE == 0) begin
+      if (observed_req_tags[0] !== 8'h20 || observed_req_tags[1] !== 8'h30 || observed_req_tags[2] !== 8'h10) begin
+        $display("ERROR: RR order mismatch got=%0h,%0h,%0h",
+                 observed_req_tags[0], observed_req_tags[1], observed_req_tags[2]);
+        $finish(1);
+      end
+    end else begin
+      if (observed_req_tags[0] !== 8'h30 || observed_req_tags[1] !== 8'h20 || observed_req_tags[2] !== 8'h10) begin
+        $display("ERROR: locality-first order mismatch got=%0h,%0h,%0h",
+                 observed_req_tags[0], observed_req_tags[1], observed_req_tags[2]);
         $finish(1);
       end
     end
-    if (observed_resp_tags[1][0] !== 8'ha0 || observed_resp_tags[1][1] !== 8'ha1 ||
+
+    if (ARB_MODE == 1) begin
+      observed_req_count = 0;
+      fairness_total_grants = 0;
+      fairness_grants_to_source1 = 0;
+      fairness_nonpreferred_gap = 0;
+      fairness_max_gap = 0;
+      @(negedge clk);
+      set_request(0, 8'h40, 12'd0, 4'h4);
+      set_request(1, 8'h50, 12'd1, 4'h5);
+      set_request(2, 8'h60, 12'd0, 4'h6);
+      repeat (6) @(posedge clk);
+      @(negedge clk);
+      clear_request(0);
+      clear_request(1);
+      clear_request(2);
+      if (fairness_grants_to_source1 < 2) begin
+        $display("ERROR: locality-first fairness failed to sustain service for the nonpreferred bank");
+        $finish(1);
+      end
+      if (fairness_max_gap > LOCALITY_BURST_MAX) begin
+        $display("ERROR: locality-first fairness gap exceeded bound gap=%0d bound=%0d",
+                 fairness_max_gap, LOCALITY_BURST_MAX);
+        $finish(1);
+      end
+    end
+
+    src_resp_ready = 3'b101;
+    fork
+      begin
+        issue_response(1, 8'ha0, 12'd5, 4'h8, 0, 1'b0, {PACKET_W{1'b1}});
+        issue_response(1, 8'ha0, 12'd5, 4'h8, FRAGMENTS-1, 1'b1, {PACKET_W{1'b0}});
+      end
+      begin
+        repeat (5) @(posedge clk);
+        @(negedge clk);
+        src_resp_ready[1] = 1'b1;
+      end
+    join
+    issue_response(0, 8'hb0, 12'd9, 4'h9, 0, 1'b1, {{(PACKET_W-8){1'b0}}, 8'h55});
+    wait ((observed_resp_count[1] == 2) && (observed_resp_count[0] == 1));
+    repeat (2) @(posedge clk);
+
+    if (observed_resp_tags[1][0] !== 8'ha0 ||
+        observed_resp_frags[1][0] !== 0 ||
+        observed_resp_tags[1][1] !== 8'ha0 ||
+        observed_resp_frags[1][1] !== (FRAGMENTS - 1) ||
         observed_resp_tags[0][0] !== 8'hb0) begin
-      $display("ERROR: response routing mismatch");
+      $display("ERROR: response routing metadata mismatch");
       $finish(1);
     end
     if (injection_stall_cycles == 0 || arbitration_contention_cycles == 0 || response_block_cycles == 0) begin
-      $display("ERROR: expected router counters to move stall=%0d contention=%0d response_block=%0d",
+      $display("ERROR: expected router counters to move stall=%0d contention=%0d block=%0d",
                injection_stall_cycles, arbitration_contention_cycles, response_block_cycles);
       $finish(1);
     end
-    if (req_max_occupancy < 2 || resp_max_occupancy == 0) begin
-      $display("ERROR: expected occupancy counters to rise req=%0d resp=%0d",
+    if (req_max_occupancy == 0 || resp_max_occupancy == 0) begin
+      $display("ERROR: expected router occupancy counters to move req=%0d resp=%0d",
                req_max_occupancy, resp_max_occupancy);
       $finish(1);
     end
@@ -258,7 +353,7 @@ module tb_noc_ready_valid_router;
   end
 
   initial begin
-    repeat (300) @(posedge clk);
+    repeat (400) @(posedge clk);
     $display("ERROR: tb_noc_ready_valid_router timeout");
     $finish(1);
   end

--- a/npu/sim/rtl/tb_noc_value_matrix_reassembler.sv
+++ b/npu/sim/rtl/tb_noc_value_matrix_reassembler.sv
@@ -1,0 +1,178 @@
+`timescale 1ns/1ps
+
+module tb_noc_value_matrix_reassembler;
+  parameter integer PACKET_W = 128;
+  localparam integer CLK_PERIOD = 10;
+  localparam integer VALUE_W = 512;
+  localparam integer SOURCE_W = 2;
+  localparam integer TAG_W = 8;
+  localparam integer ADDR_W = 12;
+  localparam integer VALUE_SLICE_W = 4;
+  localparam integer FRAGMENTS = VALUE_W / PACKET_W;
+  localparam integer FRAG_IDX_W = (FRAGMENTS <= 1) ? 1 : $clog2(FRAGMENTS);
+
+  reg clk;
+  reg rst_n;
+  reg seg_valid;
+  wire seg_ready;
+  reg [SOURCE_W-1:0] seg_source;
+  reg [TAG_W-1:0] seg_tag;
+  reg [ADDR_W-1:0] seg_addr;
+  reg [VALUE_SLICE_W-1:0] seg_value_slice;
+  reg [FRAG_IDX_W-1:0] seg_fragment_idx;
+  reg seg_last;
+  reg [PACKET_W-1:0] seg_data;
+  wire wide_valid;
+  reg wide_ready;
+  wire [SOURCE_W-1:0] wide_source;
+  wire [TAG_W-1:0] wide_tag;
+  wire [ADDR_W-1:0] wide_addr;
+  wire [VALUE_SLICE_W-1:0] wide_value_slice;
+  wire [VALUE_W-1:0] wide_matrix;
+  wire protocol_error;
+
+  reg [VALUE_W-1:0] expected_matrix;
+  integer frag_i;
+
+  noc_value_matrix_reassembler #(
+    .PACKET_W(PACKET_W),
+    .VALUE_W(VALUE_W),
+    .SOURCE_W(SOURCE_W),
+    .TAG_W(TAG_W),
+    .ADDR_W(ADDR_W),
+    .VALUE_SLICE_W(VALUE_SLICE_W)
+  ) dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .seg_valid(seg_valid),
+    .seg_ready(seg_ready),
+    .seg_source(seg_source),
+    .seg_tag(seg_tag),
+    .seg_addr(seg_addr),
+    .seg_value_slice(seg_value_slice),
+    .seg_fragment_idx(seg_fragment_idx),
+    .seg_last(seg_last),
+    .seg_data(seg_data),
+    .wide_valid(wide_valid),
+    .wide_ready(wide_ready),
+    .wide_source(wide_source),
+    .wide_tag(wide_tag),
+    .wide_addr(wide_addr),
+    .wide_value_slice(wide_value_slice),
+    .wide_matrix(wide_matrix),
+    .protocol_error(protocol_error)
+  );
+
+  initial clk = 1'b0;
+  always #(CLK_PERIOD/2) clk = ~clk;
+
+  function [VALUE_W-1:0] build_matrix;
+    input [15:0] matrix_id;
+    integer wi;
+    reg [63:0] word_value;
+    begin
+      build_matrix = {VALUE_W{1'b0}};
+      for (wi = 0; wi < (VALUE_W / 64); wi = wi + 1) begin
+        word_value = {matrix_id, wi[15:0], matrix_id + wi[15:0], 16'h5000 + wi[15:0]};
+        build_matrix[(wi * 64) +: 64] = word_value;
+      end
+    end
+  endfunction
+
+  task automatic reset_dut;
+    begin
+      rst_n = 1'b0;
+      seg_valid = 1'b0;
+      seg_source = {SOURCE_W{1'b0}};
+      seg_tag = {TAG_W{1'b0}};
+      seg_addr = {ADDR_W{1'b0}};
+      seg_value_slice = {VALUE_SLICE_W{1'b0}};
+      seg_fragment_idx = {FRAG_IDX_W{1'b0}};
+      seg_last = 1'b0;
+      seg_data = {PACKET_W{1'b0}};
+      repeat (3) @(posedge clk);
+      rst_n = 1'b1;
+      @(posedge clk);
+    end
+  endtask
+
+  task automatic send_segment;
+    input [SOURCE_W-1:0] source;
+    input [TAG_W-1:0] tag;
+    input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
+    input [FRAG_IDX_W-1:0] fragment_idx;
+    input last;
+    input [PACKET_W-1:0] data;
+    begin
+      @(negedge clk);
+      seg_source = source;
+      seg_tag = tag;
+      seg_addr = addr;
+      seg_value_slice = value_slice;
+      seg_fragment_idx = fragment_idx;
+      seg_last = last;
+      seg_data = data;
+      seg_valid = 1'b1;
+      while (!seg_ready) begin
+        @(posedge clk);
+        @(negedge clk);
+      end
+      @(posedge clk);
+      @(negedge clk);
+      seg_valid = 1'b0;
+    end
+  endtask
+
+  initial begin
+    wide_ready = 1'b1;
+    expected_matrix = build_matrix(16'h3456);
+    reset_dut();
+
+    for (frag_i = 0; frag_i < FRAGMENTS; frag_i = frag_i + 1) begin
+      send_segment(2'd1, 8'h44, 12'h055, 4'h3, frag_i[FRAG_IDX_W-1:0],
+                   (frag_i == (FRAGMENTS - 1)),
+                   expected_matrix[(frag_i * PACKET_W) +: PACKET_W]);
+    end
+    wait (wide_valid);
+    @(posedge clk);
+    if (protocol_error !== 1'b0 ||
+        wide_source !== 2'd1 ||
+        wide_tag !== 8'h44 ||
+        wide_addr !== 12'h055 ||
+        wide_value_slice !== 4'h3 ||
+        wide_matrix !== expected_matrix) begin
+      $display("ERROR: valid reassembly failed");
+      $finish(1);
+    end
+
+    reset_dut();
+    send_segment(2'd2, 8'h66, 12'h077, 4'h5, {{(FRAG_IDX_W-1){1'b0}}, 1'b1}, 1'b0,
+                 {PACKET_W{1'b1}});
+    @(posedge clk);
+    if (protocol_error !== 1'b1) begin
+      $display("ERROR: expected protocol_error on out-of-order fragment");
+      $finish(1);
+    end
+
+    reset_dut();
+    send_segment(2'd0, 8'h80, 12'h088, 4'h6, {FRAG_IDX_W{1'b0}}, 1'b0, {PACKET_W{1'b0}});
+    send_segment(2'd0, 8'h81, 12'h088, 4'h6, {{(FRAG_IDX_W-1){1'b0}}, 1'b1},
+                 (FRAGMENTS == 2),
+                 {PACKET_W{1'b1}});
+    @(posedge clk);
+    if (protocol_error !== 1'b1) begin
+      $display("ERROR: expected protocol_error on metadata mismatch");
+      $finish(1);
+    end
+
+    $display("PASS: tb_noc_value_matrix_reassembler packet_w=%0d", PACKET_W);
+    $finish(0);
+  end
+
+  initial begin
+    repeat (400) @(posedge clk);
+    $display("ERROR: tb_noc_value_matrix_reassembler timeout");
+    $finish(1);
+  end
+endmodule


### PR DESCRIPTION
## Summary
- add 128/256-bit ready/valid request routing with finite per-source queues, round-robin or bounded locality-first arbitration, backpressure, and occupancy/stall counters
- add a preloadable banked value-memory service keyed by address and semantic 4-bit value slice
- segment each exact 512-bit value matrix into transport flits and reassemble it with metadata/order validation
- keep response packets atomic across banks, support multiple outstanding same-source requests, and derive source identity from the ingress lane

## Architectural scope
This closes reusable on-chip service primitives only. It does not yet claim integrated multivalue-cluster service latency, array PPA, HBM behavior, or total-token energy. A subsequent L2 wrapper/equivalence job must connect these primitives to the exact cluster and measure completion/stall cycles.

## Validation
Nine `iverilog`/`vvp` configurations pass:
- router round-robin 128
- router locality-first 128/256
- value service 128/256
- same-source parallel value service 128/256
- positive/negative reassembler protocol tests 128/256

The tests cover finite-queue backpressure, bounded locality fairness, distinct matrices at the same address/different semantic slices, exact 512-bit reconstruction, packet-atomic delivery, same-source requests to different banks, source routing, and sticky protocol errors on out-of-order or metadata-mismatched fragments.