### PR TITLE
Fix multivalue cluster guard config selection

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -867,7 +867,7 @@ def _read_config_target(
                     "name": "check_attention_decode_score_multivalue_cluster_guard",
                     "run": (
                         "python3 npu/eval/check_attention_decode_score_multivalue_cluster_guard.py "
-                        f"--design-dir {design_dir}"
+                        f"--design-dir {design_dir} --config {config_rel}"
                     ),
                 },
                 {

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -3005,6 +3005,11 @@ def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_clust
             ]
             assert "gen_attention_decode_score_multivalue_cluster.py" in work_item.command_manifest[0]["run"]
             assert "check_attention_decode_score_multivalue_cluster_guard.py" in work_item.command_manifest[1]["run"]
+            assert (
+                "--config runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config.json"
+                in work_item.command_manifest[1]["run"]
+            )
             assert "--top attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv" in work_item.command_manifest[2]["run"]
             assert (
                 "--macro_manifest runs/designs/npu_blocks/"
@@ -3212,7 +3217,7 @@ def test_generate_l1_sweep_task_adds_explicit_onehot_retry_profile_and_diagnosti
                     out_root="runs/designs/npu_blocks",
                     item_id=(
                         "l1_decoder_attention_decode_score_multivalue_cluster_pnr_"
-                        "explicit_onehot_fsm_8ns_v1"
+                        "explicit_onehot_fsm_8ns_v1_r1"
                     ),
                     requested_by="@tester",
                     source_commit=source_commit,
@@ -3227,6 +3232,16 @@ def test_generate_l1_sweep_task_adds_explicit_onehot_retry_profile_and_diagnosti
                 if command["name"] == "check_attention_decode_score_multivalue_cluster_explicit_onehot"
             ]
             assert len(checker_commands) == 1
+            assert (
+                "--config runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+                "config_explicit_onehot_fsm.json"
+                in next(
+                    command["run"]
+                    for command in work_item.command_manifest
+                    if command["name"] == "check_attention_decode_score_multivalue_cluster_guard"
+                )
+            )
             assert checker_commands[0]["run"].endswith(
                 "--diagnostic-out runs/designs/npu_blocks/"
                 "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
@@ -3288,7 +3303,7 @@ def test_binary_fsm_retry_profile_requires_exact_config_and_sweep() -> None:
 
     explicit_item_id = (
         "l1_decoder_attention_decode_score_multivalue_cluster_pnr_"
-        "explicit_onehot_fsm_8ns_v1"
+        "explicit_onehot_fsm_8ns_v1_r1"
     )
     explicit_config = (
         "runs/designs/npu_blocks/"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1",
-  "source_commit_note": "R3 used the fresh v4 identity but failed global placement with RSZ-1008 and is explicitly non-promotable. Issue #1416 must supply its diagnostic before any retained-state-width claim. Keep the targeted-binary candidate pending until this generator/config/sweep/checker implementation is merged; it preserves normal Yosys FSM optimization and does not claim physical or width evidence here.",
+  "source_commit_note": "R3 used the fresh v4 identity but failed global placement with RSZ-1008 and is explicitly non-promotable. The explicit-onehot v1 item never reached PPA: its generator used config_explicit_onehot_fsm.json, but the pre-PPA guard hardcoded design-dir/config.json and rejected the manifest fsm_encoding as a guard_config_selection_mismatch, so that evidence is non-physical. R1 keeps the same explicit-onehot config/sweep/baseline while requiring the selected config path and the strict exact-state diagnostic before any physical claim.",
   "architecture_revision": {
     "reason": "shared_score_multivalue_cluster_replaces_repeated_score_fill_bound",
     "invalidates_item_ids": [
@@ -215,6 +215,33 @@
       "expected_result": {
         "direction": "measure_shared_score_multivalue_cluster_explicit_onehot_fsm_ppa",
         "reason": "Use a fresh config and flow parameter hash with source-level explicit one-hot FSM state vectors, exact empty/default SYNTH_ARGS, exact-state diagnostic evidence bound to the selected metrics row and synthesized netlist, and no reliance on Yosys auto-recoding. Promotion still requires a successful 8 ns row with critical_path_ns<=8 and exact post-synthesis 7/11-bit state widths."
+      },
+      "status": "failed_before_pnr",
+      "status_reason": "Non-physical pre-PPA failure: guard_config_selection_mismatch. The generator used config_explicit_onehot_fsm.json, but check_attention_decode_score_multivalue_cluster_guard.py hardcoded design-dir/config.json, rejected manifest fsm_encoding=explicit_onehot against the baseline config, and produced no physical evidence."
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r1",
+      "task_type": "l1_sweep",
+      "objective": "Measure an 8 ns explicit-onehot FSM candidate that keeps the v2 physical architecture and uses source-level one-hot state vectors for the cluster controller and multivalue reducer, with guarded exact post-synthesis 7/11-bit state widths and empty/default SYNTH_ARGS.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_explicit_onehot_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config_explicit_onehot_fsm.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_explicit_onehot_fsm_v1.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1"
+      ],
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_explicit_onehot_fsm_ppa",
+        "reason": "Retry the same explicit-onehot config/sweep/baseline after the guard config-selection fix. Promotion still requires the selected config path to match the generated design, the strict explicit_onehot exact-state diagnostic bound to the measured row and synthesized netlist, a successful 8 ns row with critical_path_ns<=8, and exact post-synthesis 7/11-bit state widths."
       },
       "status": "pending_implementation_merge"
     }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
@@ -246,6 +246,33 @@
         "direction": "measure_shared_score_multivalue_cluster_explicit_onehot_fsm_ppa",
         "reason": "Use a fresh config and flow parameter hash with source-level explicit one-hot FSM state vectors, exact empty/default SYNTH_ARGS, exact-state diagnostic evidence bound to the selected metrics row and synthesized netlist, and no reliance on Yosys auto-recoding. Promotion still requires a successful 8 ns row with critical_path_ns<=8 and exact post-synthesis 7/11-bit state widths."
       },
+      "status": "failed_before_pnr",
+      "status_reason": "Non-physical pre-PPA failure: guard_config_selection_mismatch. The generator used config_explicit_onehot_fsm.json, but check_attention_decode_score_multivalue_cluster_guard.py hardcoded design-dir/config.json, rejected manifest fsm_encoding=explicit_onehot against the baseline config, and produced no physical evidence."
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r1",
+      "task_type": "l1_sweep",
+      "objective": "Measure an 8 ns explicit-onehot FSM candidate that keeps the v2 physical architecture and uses source-level one-hot state vectors for the cluster controller and multivalue reducer, with guarded exact post-synthesis 7/11-bit state widths and empty/default SYNTH_ARGS.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_explicit_onehot_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config_explicit_onehot_fsm.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_explicit_onehot_fsm_v1.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1"
+      ],
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_explicit_onehot_fsm_ppa",
+        "reason": "Retry the same explicit-onehot config/sweep/baseline after the guard config-selection fix. Promotion still requires the selected config path to match the generated design, the strict explicit_onehot exact-state diagnostic bound to the measured row and synthesized netlist, a successful 8 ns row with critical_path_ns<=8, and exact post-synthesis 7/11-bit state widths."
+      },
       "status": "pending_implementation_merge"
     }
   ],

--- a/npu/eval/check_attention_decode_score_multivalue_cluster_guard.py
+++ b/npu/eval/check_attention_decode_score_multivalue_cluster_guard.py
@@ -9,18 +9,51 @@ from pathlib import Path
 import re
 
 
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_selected_config(*, design_dir: Path, selected: Path | None) -> Path:
+    config_path = selected or (design_dir / "config.json")
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise SystemExit(f"missing config: {config_path}")
+    try:
+        relative_path = config_path.relative_to(design_dir)
+    except ValueError as exc:
+        raise SystemExit(f"selected config must live under design-dir: {config_path}") from exc
+    if len(relative_path.parts) != 1:
+        raise SystemExit(
+            f"selected config must be a direct child of design-dir, got: {relative_path.as_posix()}"
+        )
+    return config_path
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--design-dir", type=Path, required=True)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Config used to generate the design; defaults to <design-dir>/config.json",
+    )
     args = parser.parse_args()
     design_dir = args.design_dir.resolve()
-    config = json.loads((design_dir / "config.json").read_text(encoding="utf-8"))
+    config_path = _resolve_selected_config(design_dir=design_dir, selected=args.config)
+    config = _load_json(config_path)
     rtl_dir = design_dir / "verilog"
-    manifest = json.loads(
-        (rtl_dir / "attention_decode_score_multivalue_cluster_manifest.json").read_text(encoding="utf-8")
-    )
+    generated_config_path = rtl_dir / "config.json"
+    if not generated_config_path.exists():
+        raise SystemExit(f"missing generated config: {generated_config_path}")
+    generated_config = _load_json(generated_config_path)
+    manifest = _load_json(rtl_dir / "attention_decode_score_multivalue_cluster_manifest.json")
     rtl = (rtl_dir / "top.v").read_text(encoding="utf-8")
     errors: list[str] = []
+    if config != generated_config:
+        errors.append(
+            f"selected config {config_path} does not match generated config {generated_config_path}"
+        )
     expected_top = str(config.get("top_name") or "")
     if manifest.get("top_name") != expected_top:
         errors.append("manifest top_name does not match config")
@@ -80,6 +113,7 @@ def main() -> int:
         json.dumps(
             {
                 "design": expected_top,
+                "config": str(config_path),
                 "guard": "attention_decode_score_multivalue_cluster_v1",
                 "status": "ok",
             },

--- a/tests/test_attention_decode_score_multivalue_cluster.py
+++ b/tests/test_attention_decode_score_multivalue_cluster.py
@@ -29,6 +29,23 @@ def _config(*, scale_lanes: int = 1, fsm_encoding: str | None = None) -> dict:
     return config
 
 
+def _run_guard(design_dir: Path, *, config_path: Path | None = None) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        "npu/eval/check_attention_decode_score_multivalue_cluster_guard.py",
+        "--design-dir",
+        str(design_dir),
+    ]
+    if config_path is not None:
+        command.extend(["--config", str(config_path)])
+    return subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_multivalue_cluster_manifest_closes_full_head_boundary(tmp_path: Path) -> None:
     generate(_config(), tmp_path)
     manifest = json.loads(
@@ -129,17 +146,41 @@ def test_multivalue_cluster_guard_accepts_generated_design(tmp_path: Path) -> No
     config = _config()
     (design_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
     generate(config, design_dir / "verilog")
-    subprocess.run(
-        [
-            sys.executable,
-            "npu/eval/check_attention_decode_score_multivalue_cluster_guard.py",
-            "--design-dir",
-            str(design_dir),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
+    proc = _run_guard(design_dir)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_multivalue_cluster_guard_accepts_generated_design_with_selected_explicit_onehot_config(
+    tmp_path: Path,
+) -> None:
+    design_dir = tmp_path / "design"
+    design_dir.mkdir()
+    baseline_config = _config()
+    explicit_config = _config(fsm_encoding="explicit_onehot")
+    (design_dir / "config.json").write_text(json.dumps(baseline_config), encoding="utf-8")
+    explicit_config_path = design_dir / "config_explicit_onehot_fsm.json"
+    explicit_config_path.write_text(json.dumps(explicit_config), encoding="utf-8")
+    generate(explicit_config, design_dir / "verilog")
+
+    proc = _run_guard(design_dir, config_path=explicit_config_path)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_multivalue_cluster_guard_rejects_generated_design_when_default_config_mismatches_selected_rtl(
+    tmp_path: Path,
+) -> None:
+    design_dir = tmp_path / "design"
+    design_dir.mkdir()
+    (design_dir / "config.json").write_text(json.dumps(_config()), encoding="utf-8")
+    explicit_config = _config(fsm_encoding="explicit_onehot")
+    (design_dir / "config_explicit_onehot_fsm.json").write_text(
+        json.dumps(explicit_config), encoding="utf-8"
     )
+    generate(explicit_config, design_dir / "verilog")
+
+    proc = _run_guard(design_dir)
+    assert proc.returncode != 0
+    assert "does not match generated config" in proc.stderr
 
 
 @pytest.mark.parametrize("scale_lanes", [1, 8])


### PR DESCRIPTION
## Summary
- pass the exact generation config into the multivalue-cluster guard
- verify that selected config matches the generated config
- record v1 as a pre-PPA guard failure and define r1 as its replacement

## Validation
- 89 focused tests passed
- `scripts/validate_runs.py --skip_eval_queue` passed
- `git diff --check` passed

The failed v1 produced no physical evidence and must not be retried; r1 is the corrected evaluation item.