### PR TITLE
Add multivalue integrated service L2 campaign

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -776,6 +776,7 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
         "recommended_next_l1_points",
         "required_follow_on_ppa",
         "best",
+        "selected_scale_point",
         "sweep_summary",
         "assumptions",
         "next_step",
@@ -1199,7 +1200,7 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
 
     if model == "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1":
         summary_row = dict(evidence_payload.get("summary") or {})
-        best = dict(evidence_payload.get("best") or {})
+        selected_scale_point = dict(evidence_payload.get("selected_scale_point") or {})
         diagnosis = dict(evidence_payload.get("diagnosis") or {})
         outcome = str(diagnosis.get("decision") or "multivalue_integrated_service_probe_recorded")
         parts = [
@@ -1218,14 +1219,16 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             if key in summary_row:
                 parts.append(f"{key}={summary_row.get(key)}")
         for key in (
-            "selected_case_id",
-            "selected_case_service_penalty_cycles",
-            "selected_case_shared_result_egress_block_cycles",
-            "selected_case_router_arbitration_contention_cycles",
-            "selected_case_bank_conflict_count",
+            "selection_role",
+            "case_id",
+            "completion_cycle",
+            "service_penalty_cycles",
+            "shared_result_egress_block_cycles",
+            "router_arbitration_contention_cycles",
+            "bank_conflict_count",
         ):
-            if key in best:
-                parts.append(f"{key}={best.get(key)}")
+            if key in selected_scale_point:
+                parts.append(f"selected_scale_point_{key}={selected_scale_point.get(key)}")
         recommended_next = str(diagnosis.get("recommended_next_step", "")).strip()
         if recommended_next:
             parts.append(f"recommended_next_step={recommended_next}")

--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -667,6 +667,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "decode_score_local_cluster_frontier_report",
     ),
     (
+        "decode_score_multivalue_integrated_service_out",
+        "decode_score_multivalue_integrated_service_report",
+    ),
+    (
         "score_bank_proxy_equivalence_out",
         "score_bank_proxy_equivalence_report",
     ),
@@ -1190,6 +1194,41 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
         ):
             if key in source_best_dict:
                 parts.append(f"{key}={source_best_dict.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
+    if model == "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1":
+        summary_row = dict(evidence_payload.get("summary") or {})
+        best = dict(evidence_payload.get("best") or {})
+        diagnosis = dict(evidence_payload.get("diagnosis") or {})
+        outcome = str(diagnosis.get("decision") or "multivalue_integrated_service_probe_recorded")
+        parts = [
+            f"Decoder multivalue integrated-service evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "validated_case_count",
+            "max_cluster_count",
+            "max_completion_cycle",
+            "max_service_penalty_cycles",
+            "stress_case_id",
+            "all_hash_gates_passed",
+            "all_protocol_gates_passed",
+            "all_count_gates_passed",
+        ):
+            if key in summary_row:
+                parts.append(f"{key}={summary_row.get(key)}")
+        for key in (
+            "selected_case_id",
+            "selected_case_service_penalty_cycles",
+            "selected_case_shared_result_egress_block_cycles",
+            "selected_case_router_arbitration_contention_cycles",
+            "selected_case_bank_conflict_count",
+        ):
+            if key in best:
+                parts.append(f"{key}={best.get(key)}")
+        recommended_next = str(diagnosis.get("recommended_next_step", "")).strip()
+        if recommended_next:
+            parts.append(f"recommended_next_step={recommended_next}")
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."
 

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7225,6 +7225,56 @@ def _decoder_attention_decode_score_multivalue_cluster_frontier_evidence(
     }
 
 
+def _decoder_attention_decode_score_multivalue_integrated_service_evidence(
+    *,
+    item_id: str,
+    proposal_id: str | None = None,
+    proposal_path: str | None = None,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_decode_score_multivalue_integrated_service__{item_id}.json"
+    report = f"{base}/decoder_attention_decode_score_multivalue_integrated_service__{item_id}.md"
+    equivalence = (
+        f"{base}/decoder_attention_decode_score_multivalue_cluster_equivalence__"
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json"
+    )
+    proposal_args: list[str] = []
+    proposal_id_text = str(proposal_id or "").strip()
+    proposal_path_text = str(proposal_path or "").strip()
+    if proposal_id_text:
+        proposal_args.extend(["--proposal-id", proposal_id_text])
+    if proposal_path_text:
+        proposal_args.extend(["--proposal-path", proposal_path_text])
+    proposal_arg_text = " ".join(shlex.quote(arg) for arg in proposal_args)
+    return {
+        "inputs": {
+            "decode_score_multivalue_integrated_service_equivalence": equivalence,
+            "decode_score_multivalue_integrated_service_out": out,
+            "decode_score_multivalue_integrated_service_report": report,
+            "decode_score_multivalue_integrated_service_scope": (
+                "Run the integrated shared-score value-service RTL probe across a bounded 14-case matrix through "
+                "cluster_count 32. Retain exact Python/baseline/integrated hash, protocol, and count gates while "
+                "reporting completion cycles, service penalty cycles, shared-result blocking/arbitration, "
+                "router/service contention and occupancy, and explicit exclusions for physical PPA, SRAM macro "
+                "timing, HBM, and token energy."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_decode_score_multivalue_integrated_service",
+                "run": (
+                    "python3 npu/eval/probe_attention_decode_score_multivalue_integrated_service.py "
+                    f"--out {out} --out-md {report} "
+                    "--depends-on-item-id l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1 "
+                    f"{proposal_arg_text}".strip()
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_decode_score_multivalue_gqa_group_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     evidence_version = _gqa_evidence_version_for_consumer(item_id)
@@ -10884,6 +10934,7 @@ def _build_payload(
         "decoder_attention_decode_score_multivalue_gqa_folded_lane_equivalence",
         "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
         "decoder_attention_decode_score_multivalue_cluster_activity_power",
+        "decoder_attention_decode_score_multivalue_integrated_service",
         "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
         "decoder_attention_decode_score_tile_frontier",
         "decoder_attention_decode_score_local_cluster_frontier",
@@ -11143,6 +11194,12 @@ def _build_payload(
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_cluster_activity_power":
             decoder_evidence = _decoder_attention_decode_score_multivalue_cluster_activity_power_evidence(
                 item_id=item_id
+            )
+        elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_integrated_service":
+            decoder_evidence = _decoder_attention_decode_score_multivalue_integrated_service_evidence(
+                item_id=item_id,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_group_activity_power":
             decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence(

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -5991,19 +5991,24 @@ def test_consume_l2_result_decode_score_multivalue_integrated_service_uses_decod
                             "decision": "multivalue_integrated_service_probe_passed",
                             "recommended_next_step": "Use this as the merged on-chip service closure input only.",
                         },
-                        "best": {
+                        "selected_scale_point": {
+                            "selection_role": "representative_largest_nominal_scale_point",
+                            "selection_basis": (
+                                "Largest tested nominal scale point; coverage representative only, "
+                                "not a performance or architectural ranking."
+                            ),
                             "arch_id": "decode_score_multivalue_integrated_service",
                             "macro_mode": "rtl_probe",
                             "cluster_count": 32,
                             "bank_count": 32,
                             "packet_payload_bytes": 32,
-                            "total_cycles": 1200,
+                            "completion_cycle": 1200,
+                            "service_penalty_cycles": 48,
                             "dominant_tile_resource": "onchip_shared_service",
-                            "selected_case_id": "c32_p256_b32_rr",
-                            "selected_case_service_penalty_cycles": 48,
-                            "selected_case_shared_result_egress_block_cycles": 17,
-                            "selected_case_router_arbitration_contention_cycles": 21,
-                            "selected_case_bank_conflict_count": 9,
+                            "case_id": "c32_p256_b32_rr",
+                            "shared_result_egress_block_cycles": 17,
+                            "router_arbitration_contention_cycles": 21,
+                            "bank_conflict_count": 9,
                         },
                         "summary": {
                             "validated_case_count": 14,
@@ -6066,13 +6071,16 @@ def test_consume_l2_result_decode_score_multivalue_integrated_service_uses_decod
                     encoding="utf-8"
                 )
             )
-            assert result.recommended_arch_id == "decode_score_multivalue_integrated_service"
+            assert result.recommended_arch_id == "fp16_nm1_demo"
             assert decision_payload["proposal_assessment"]["outcome"] == (
                 "multivalue_integrated_service_probe_passed"
             )
-            assert decision_payload["recommendation"]["source"] == "decoder_evidence"
-            assert decision_payload["recommendation"]["cluster_count"] == 32
-            assert decision_payload["recommendation"]["bank_count"] == 32
+            assert decision_payload["recommendation"].get("source") != "decoder_evidence"
+            selected_scale_point = decision_payload["proposal_assessment"]["decoder_quality"][
+                "selected_scale_point"
+            ]
+            assert selected_scale_point["case_id"] == "c32_p256_b32_rr"
+            assert selected_scale_point["selection_role"] == "representative_largest_nominal_scale_point"
             assert (
                 decision_payload["source_refs"]["decoder_decode_score_multivalue_integrated_service_out"]
                 == evidence_rel

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -5942,6 +5942,147 @@ def test_consume_l2_result_hbm_command_calibrated_service_uses_decoder_evidence(
             )
 
 
+def test_consume_l2_result_decode_score_multivalue_integrated_service_uses_decoder_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+                        "kind": "architecture",
+                        "title": "Integrated shared-score multivalue service probe",
+                        "direct_comparison": {
+                            "primary_question": "Does the bounded integrated service matrix retain exact hashes and protocol/count gates?"
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_integrated_service__"
+                "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_integrated_service__"
+                "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "model": "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1",
+                        "decision": "pass",
+                        "diagnosis": {
+                            "decision": "multivalue_integrated_service_probe_passed",
+                            "recommended_next_step": "Use this as the merged on-chip service closure input only.",
+                        },
+                        "best": {
+                            "arch_id": "decode_score_multivalue_integrated_service",
+                            "macro_mode": "rtl_probe",
+                            "cluster_count": 32,
+                            "bank_count": 32,
+                            "packet_payload_bytes": 32,
+                            "total_cycles": 1200,
+                            "dominant_tile_resource": "onchip_shared_service",
+                            "selected_case_id": "c32_p256_b32_rr",
+                            "selected_case_service_penalty_cycles": 48,
+                            "selected_case_shared_result_egress_block_cycles": 17,
+                            "selected_case_router_arbitration_contention_cycles": 21,
+                            "selected_case_bank_conflict_count": 9,
+                        },
+                        "summary": {
+                            "validated_case_count": 14,
+                            "max_cluster_count": 32,
+                            "max_completion_cycle": 1200,
+                            "max_service_penalty_cycles": 48,
+                            "stress_case_id": "c32_p256_b32_q1_rr",
+                            "all_hash_gates_passed": True,
+                            "all_protocol_gates_passed": True,
+                            "all_count_gates_passed": True,
+                        },
+                        "remaining_abstractions": [
+                            "No physical PPA, SRAM macro timing, HBM, or total-token energy claim.",
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# integrated service probe\n")
+            item_id = _seed_campaign_work_item(
+                session,
+                repo_root,
+                item_id="l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+                campaign_dir_rel="runs/campaigns/npu/decode_score_multivalue_integrated_service_campaign",
+                summary_rows=(
+                    "scope,arch_id,macro_mode,objective_rank,latency_ms_mean,energy_mj_mean,critical_path_ns_mean,total_power_mw_mean,flow_elapsed_s_mean,throughput_infer_per_s_mean\n"
+                    "aggregate,fp16_nm1_demo,flat_nomacro,1,0.4,0.15,5.5,0.18,1000,1.0\n"
+                ),
+                proposal_path=(
+                    "docs/proposals/"
+                    "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1"
+                ),
+                comparison={"role": "frontier_validation"},
+            )
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            payload = copy.deepcopy(work_item.task_request.request_payload or {})
+            payload["developer_loop"]["evaluation"] = {
+                "mode": "frontier_detail",
+                "expected_direction": "record_decode_score_multivalue_integrated_service_probe",
+                "expected_reason": "Use the merged integrated-service probe before composition claims.",
+            }
+            payload["developer_loop"]["abstraction"] = {
+                "layer": "decoder_attention_decode_score_multivalue_integrated_service",
+            }
+            work_item.task_request.request_payload = payload
+            work_item.input_manifest = {
+                "decoder_contract": {
+                    "decode_score_multivalue_integrated_service_out": evidence_rel,
+                    "decode_score_multivalue_integrated_service_report": report_rel,
+                }
+            }
+            work_item.expected_outputs = [*(work_item.expected_outputs or []), evidence_rel, report_rel]
+            session.commit()
+
+            result = consume_l2_result(session, Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id))
+
+            decision_payload = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert result.recommended_arch_id == "decode_score_multivalue_integrated_service"
+            assert decision_payload["proposal_assessment"]["outcome"] == (
+                "multivalue_integrated_service_probe_passed"
+            )
+            assert decision_payload["recommendation"]["source"] == "decoder_evidence"
+            assert decision_payload["recommendation"]["cluster_count"] == 32
+            assert decision_payload["recommendation"]["bank_count"] == 32
+            assert (
+                decision_payload["source_refs"]["decoder_decode_score_multivalue_integrated_service_out"]
+                == evidence_rel
+            )
+            assert (
+                decision_payload["source_refs"]["decoder_decode_score_multivalue_integrated_service_report"]
+                == report_rel
+            )
+
+
 def test_consume_l2_result_measured_compute_energy_closure_uses_decoder_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8851,6 +8851,79 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_frontier
             )
 
 
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_integrated_service() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+                    proposal_id="prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_integrated_service",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:2]] == [
+                "probe_decode_score_multivalue_integrated_service",
+                "validate_runs",
+            ]
+            assert "probe_attention_decode_score_multivalue_integrated_service.py" in run
+            assert "--proposal-id prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1" in run
+            assert (
+                "--proposal-path "
+                "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json"
+            ) in run
+            assert (
+                "--depends-on-item-id "
+                "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+            ) in run
+            assert (
+                decoder_inputs["decode_score_multivalue_integrated_service_equivalence"].endswith(
+                    "decoder_attention_decode_score_multivalue_cluster_equivalence__"
+                    "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json"
+                )
+            )
+            assert "shared-result blocking/arbitration" in decoder_inputs[
+                "decode_score_multivalue_integrated_service_scope"
+            ]
+            assert "physical PPA" in decoder_inputs["decode_score_multivalue_integrated_service_scope"]
+            assert (
+                decoder_inputs["decode_score_multivalue_integrated_service_out"]
+                == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_integrated_service__"
+                "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.json"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_decode_score_multivalue_integrated_service__"
+                    "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.md"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
 def test_generate_l2_campaign_task_cluster_frontier_uses_cluster_activity_v1_dependency() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/README.md
@@ -1,0 +1,5 @@
+# Llama7B Multivalue Integrated Service Probe
+
+This proposal records the bounded L2 job that runs the integrated shared-score
+multivalue service RTL probe for the Llama7B decode-score cluster family and
+stores compact JSON/Markdown evidence only.

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/analysis_report.md
@@ -1,0 +1,17 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
+- `candidate_id`: `l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
+
+## Status
+- pending_evaluation
+- no remote run has been consumed yet in this proposal workspace
+
+## Planned Evaluation
+- consume the compact JSON/Markdown probe evidence after the merged control-plane
+  hook dispatches the bounded 14-case integrated-service matrix
+
+## Caveats
+- this proposal does not claim physical PPA, SRAM macro timing, HBM, or
+  total-token energy closure

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/design_brief.md
@@ -34,6 +34,8 @@ composition work.
   - compact repo-portable JSON/Markdown only
   - no full stdout traces
   - no intermediate tensors
+  - identify the largest nominal round-robin case only as a representative
+    `selected_scale_point`, never as an architectural or performance best
 
 ## Knowledge Inputs
 - `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json`

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/design_brief.md
@@ -1,0 +1,51 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
+- `title`: `Llama7B multivalue integrated service probe`
+
+## Problem
+The merged exact shared-score multivalue cluster equivalence result proves the
+arithmetic contract in isolation, but it does not expose shared-result blocking,
+router arbitration, bank conflicts, or occupancy behavior once the integrated
+on-chip value service is active.
+
+## Hypothesis
+A bounded integrated-service matrix through `cluster_count=32` can preserve the
+exact Python/baseline/integrated hash contract while surfacing the first
+service-level penalties that matter before later NoC or value-memory
+composition work.
+
+## Evaluation Scope
+- direct comparison set:
+  - merged exact shared-score multivalue cluster equivalence evidence
+  - fixed-resource scaling `c1/c2/c4/c8/c16/c32` at `p128/b4/q4/rl2/round_robin`
+  - scaled-resource `p256` points at `c8/b8`, `c16/b16`, and `c32/b32` with
+    round-robin and locality variants
+  - one queue-depth stress case and one read-latency stress case at `c32`
+- evaluation mode:
+  - `frontier_detail` probe/evidence only
+- excluded first-stage claims:
+  - no physical PPA
+  - no SRAM macro timing closure
+  - no HBM closure
+  - no total-token energy claim
+- output discipline:
+  - compact repo-portable JSON/Markdown only
+  - no full stdout traces
+  - no intermediate tensors
+
+## Knowledge Inputs
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json`
+- `npu/eval/probe_attention_decode_score_multivalue_integrated_service.py`
+- `control_plane/control_plane/services/l2_task_generator.py`
+
+## Candidate Direction
+Record the integrated shared-score service evidence as the next merged service
+closure input for later NoC/value-memory composition, while keeping physical
+and HBM claims explicitly out of scope.
+
+## Direction Gate
+- status: ready_after_proposal_merge
+- note: The dependency item is already merged/materialized. Dispatch only after
+  the proposal implementation itself is merged onto `origin/master`.

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_gate.md
@@ -23,3 +23,5 @@
 
 ## Gate Condition
 - The run must remain evidence-only and must not claim NoC/HBM/physical/token-energy closure.
+- Any singled-out case must be labeled as a representative scale point, not as
+  an architectural or performance best.

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,25 @@
+# Evaluation Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
+- `item_id`: `l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
+
+## Required Inputs
+- merged/materialized dependency:
+  - `l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1`
+- proposal implementation merged onto `origin/master`
+
+## Expected Outputs
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_integrated_service__l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.json`
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_integrated_service__l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.md`
+
+## Dispatch Contract
+- abstraction layer:
+  - `decoder_attention_decode_score_multivalue_integrated_service`
+- task type:
+  - `l2_campaign`
+- expected direction:
+  - `record_decode_score_multivalue_integrated_service_probe`
+
+## Gate Condition
+- The run must remain evidence-only and must not claim NoC/HBM/physical/token-energy closure.

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_requests.json
@@ -18,7 +18,7 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "record_decode_score_multivalue_integrated_service_probe",
-        "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, and explicit exclusions over the bounded 14-case matrix."
+        "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, and explicit exclusions over the bounded 14-case matrix; any selected scale point is representative evidence, not an architectural or performance ranking."
       },
       "status": "pending",
       "notes": "The dependency item is already merged/materialized. This request is ready for normal control-plane dispatch only after the proposal implementation itself is merged."

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+  "source_commit": "7691291314ff3739164633f6e5f17a1b3eb15c84",
+  "source_commit_note": "Replace with the merge commit that contains this proposal and the integrated-service generator hook before dispatch. Do not dispatch from an unmerged local branch.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the integrated shared-score multivalue decode-service RTL probe across the bounded scale/resource matrix through cluster_count 32 and record compact service evidence only.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_integrated_service",
+      "comparison_role": "frontier_validation",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_decode_score_multivalue_integrated_service_probe",
+        "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, and explicit exclusions over the bounded 14-case matrix."
+      },
+      "status": "pending",
+      "notes": "The dependency item is already merged/materialized. This request is ready for normal control-plane dispatch only after the proposal implementation itself is merged."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/implementation_summary.md
@@ -1,0 +1,29 @@
+# Implementation Summary
+
+## Scope
+- Added the `decoder_attention_decode_score_multivalue_integrated_service`
+  L2 abstraction hook to the control-plane task generator.
+- Wired compact JSON/Markdown evidence outputs and result-consumer recognition.
+- Expanded the probe to the requested bounded 14-case matrix through
+  `cluster_count=32`.
+
+## Evidence Contract
+- JSON now retains:
+  - exact Python/baseline/integrated hashes
+  - protocol/count gate booleans
+  - completion and service penalty cycles
+  - shared-result blocking/arbitration counters
+  - router/service contention and occupancy maxima
+  - explicit exclusions
+  - proposal/dependency linkage
+- Markdown now summarizes the same evidence in a compact per-case table.
+
+## Local Validation
+- focused pytest coverage for:
+  - probe defaults and linkage
+  - L2 task generation
+  - L2 result consumption
+- passed `pytest -q tests/test_attention_decode_score_multivalue_integrated_service.py`
+- passed `PYTHONPATH=/workspaces/RTLGen-l2-score-service-v1/control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "decode_score_multivalue_integrated_service or decode_score_multivalue_cluster_frontier"`
+- passed `PYTHONPATH=/workspaces/RTLGen-l2-score-service-v1/control_plane pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k "decode_score_multivalue_integrated_service or hbm_command_calibrated_service"`
+- passed `python3 scripts/validate_runs.py --skip_eval_queue`

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/implementation_summary.md
@@ -17,6 +17,9 @@
   - explicit exclusions
   - proposal/dependency linkage
 - Markdown now summarizes the same evidence in a compact per-case table.
+- The largest nominal round-robin coverage point is labeled
+  `selected_scale_point`; it is explicitly not an architectural or performance
+  ranking and is not consumed as a decoder recommendation.
 
 ## Local Validation
 - focused pytest coverage for:

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/promotion_decision.json
@@ -1,0 +1,11 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+  "decision": "iterate",
+  "reason": "Await the first merged remote evaluator run for the bounded integrated-service probe before making a promotion decision.",
+  "evidence_refs": [
+    "item:l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1"
+  ],
+  "next_action": "Dispatch the merged integrated-service probe and review the compact JSON/Markdown evidence.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/promotion_gate.md
@@ -1,0 +1,14 @@
+# Promotion Gate
+
+## Candidate
+- `candidate_id`: `l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
+
+## Conditions
+- the remote evaluator must produce the compact JSON/Markdown evidence files
+- all exact hash, protocol, and count gates must pass across the bounded matrix
+- the probe must keep physical PPA, SRAM macro timing, HBM, and token-energy
+  claims explicitly excluded
+
+## Decision Rule
+- promote only as service evidence for later composition work, not as a full
+  architecture closure result

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+  "result": "pending",
+  "summary": "No remote evaluator result has been consumed yet for this proposal.",
+  "follow_on_items": []
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json
@@ -14,7 +14,8 @@
       "fixed-resource scaling at cluster_count 1/2/4/8/16/32 with identical p128, banks=4, queue depths=4, read_latency=2, round_robin, locality_burst_max=2",
       "scaled-resource p256 points at c8/b8, c16/b16, and c32/b32 with queue depths=4, read_latency=2, and round_robin/locality variants",
       "one queue-depth stress case and one read-latency stress case at c32",
-      "compact repo-portable JSON/Markdown evidence that reports completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention and occupancy, explicit exclusions, and proposal/dependency linkage"
+      "compact repo-portable JSON/Markdown evidence that reports completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention and occupancy, explicit exclusions, and proposal/dependency linkage",
+      "label the largest nominal round-robin coverage case only as a representative selected_scale_point, not as an architectural or performance best"
     ],
     "exclude": [
       "do not claim physical PPA",
@@ -55,7 +56,7 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "record_decode_score_multivalue_integrated_service_probe",
-        "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, and explicit exclusions over the bounded 14-case matrix."
+        "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, and explicit exclusions over the bounded 14-case matrix; any selected scale point is representative evidence, not an architectural or performance ranking."
       },
       "status": "pending"
     }

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json
@@ -1,0 +1,80 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+  "created_utc": "2026-07-23T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B multivalue integrated service probe",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_integrated_service",
+  "hypothesis": "Once the exact shared-score multivalue cluster equivalence item is merged and materialized, a bounded integrated service probe through cluster_count 32 can preserve the exact Python/baseline/integrated hash contract while exposing the first realistic on-chip service penalties, shared-result blocking, router arbitration, bank contention, and occupancy limits without claiming NoC/HBM/physical closure.",
+  "direct_comparison": {
+    "primary_question": "Does the merged shared-score multivalue cluster retain exact result hashes and protocol/count gates once the integrated on-chip value service is exercised across a bounded scale/resource matrix through 32 clusters?",
+    "include": [
+      "depend on the merged exact shared-score multivalue cluster equivalence item and require merged/materialized inputs",
+      "fixed-resource scaling at cluster_count 1/2/4/8/16/32 with identical p128, banks=4, queue depths=4, read_latency=2, round_robin, locality_burst_max=2",
+      "scaled-resource p256 points at c8/b8, c16/b16, and c32/b32 with queue depths=4, read_latency=2, and round_robin/locality variants",
+      "one queue-depth stress case and one read-latency stress case at c32",
+      "compact repo-portable JSON/Markdown evidence that reports completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention and occupancy, explicit exclusions, and proposal/dependency linkage"
+    ],
+    "exclude": [
+      "do not claim physical PPA",
+      "do not claim SRAM macro timing closure",
+      "do not claim HBM service closure",
+      "do not claim total-token energy or token energy rankings",
+      "do not emit full stdout traces or intermediate tensors"
+    ],
+    "follow_on_broad_sweep": [
+      "If the integrated-service probe passes, consume it as the shared-score service evidence for later NoC/value-memory composition work.",
+      "If the probe exposes blocking hotspots, use the case summary to prioritize the next router/service composition abstraction before any physical or HBM claim."
+    ]
+  },
+  "expected_benefit": [
+    "turns the exact multivalue equivalence point into merged service-aware evidence",
+    "bounds integrated shared-result and banked-value contention through cluster_count 32 without expanding into full system closure",
+    "provides portable evidence that the control plane can dispatch and later consume without full logs"
+  ],
+  "risks": [
+    "the bounded case matrix may still miss a more pathological service regime outside the chosen queue and latency points",
+    "passing this probe does not close value-memory composition, NoC composition, HBM service, or physical PPA",
+    "the service probe may reveal scaling penalties that weaken the shared-score family before later composition work"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the integrated shared-score multivalue decode-service RTL probe across the bounded scale/resource matrix through cluster_count 32 and record compact service evidence only.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_integrated_service",
+      "comparison_role": "frontier_validation",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_decode_score_multivalue_integrated_service_probe",
+        "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, and explicit exclusions over the bounded 14-case matrix."
+      },
+      "status": "pending"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json",
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json",
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_attention_decode_score_multivalue_integrated_service.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "control_plane/control_plane/services/l2_result_consumer.py",
+    "tests/test_attention_decode_score_multivalue_integrated_service.py"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "NoC composition is still open beyond the bounded integrated service probe.",
+    "HBM service remains unclaimed.",
+    "Physical PPA and SRAM macro timing remain unclaimed.",
+    "Token-energy claims remain out of scope."
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/quality_gate.md
@@ -1,0 +1,28 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
+- `title`: `Llama7B multivalue integrated service probe`
+
+## Why This Gate Is Required
+The exact shared-score multivalue equivalence result is necessary but not
+sufficient for later composition work. This gate proves that the integrated
+shared-result/value-service path still preserves exact hashes and protocol/count
+gates while exposing the service contention profile across the bounded matrix.
+
+## Checks
+- metric: exact gates
+  - threshold: every case keeps Python/baseline/integrated hash, protocol, and count gates green
+- metric: service evidence
+  - threshold: every case reports completion cycle, service penalty cycle, shared-result arbitration/blocking, router/service contention, and occupancy maxima
+- metric: exclusions
+  - threshold: the evidence explicitly lists physical PPA, SRAM macro timing, HBM, and total-token energy as excluded claims
+- metric: compactness
+  - threshold: outputs remain repo-portable JSON/Markdown without full stdout or intermediate tensors
+
+## Local Command
+- command: `python3 npu/eval/probe_attention_decode_score_multivalue_integrated_service.py --proposal-id prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1 --proposal-path docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json --depends-on-item-id l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1 --out /tmp/decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.json --out-md /tmp/decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.md`
+
+## Result
+- status: ready_after_proposal_merge
+- note: the dependency item is already merged/materialized; only the proposal implementation merge remains before dispatch.

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/quality_gate.md
@@ -19,6 +19,9 @@ gates while exposing the service contention profile across the bounded matrix.
   - threshold: the evidence explicitly lists physical PPA, SRAM macro timing, HBM, and total-token energy as excluded claims
 - metric: compactness
   - threshold: outputs remain repo-portable JSON/Markdown without full stdout or intermediate tensors
+- metric: selection semantics
+  - threshold: the largest nominal round-robin coverage point is reported only
+    as `selected_scale_point`, with no architectural-best or performance-best claim
 
 ## Local Command
 - command: `python3 npu/eval/probe_attention_decode_score_multivalue_integrated_service.py --proposal-id prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1 --proposal-path docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json --depends-on-item-id l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1 --out /tmp/decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.json --out-md /tmp/decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.md`

--- a/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
@@ -1504,19 +1504,43 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
     }
 
 
-def _summary_best(reports: list[JsonDict]) -> JsonDict:
+def _selected_scale_point(reports: list[JsonDict]) -> JsonDict:
+    nominal = [
+        case
+        for case in reports
+        if int(case["config"]["req_queue_depth"]) == 4
+        and int(case["config"]["resp_queue_depth"]) == 4
+        and int(case["config"]["bank_queue_depth"]) == 4
+        and int(case["config"]["read_latency"]) == 2
+        and str(case["config"]["arb_mode"]) == "round_robin"
+    ]
+    selection_pool = nominal or reports
+    selection_role = (
+        "representative_largest_nominal_scale_point"
+        if nominal
+        else "representative_largest_available_scale_point"
+    )
+    selection_basis = (
+        "Largest tested cluster_count, then packet_w, then banks among q4/read_latency=2/round_robin "
+        "cases; coverage representative only, not a performance or architectural ranking."
+        if nominal
+        else "Largest tested cluster_count, then packet_w, then banks because no q4/read_latency=2/round_robin "
+        "case was provided; coverage representative only, not a performance or architectural ranking."
+    )
     selected = max(
-        reports,
+        selection_pool,
         key=lambda case: (
             int(case["config"]["cluster_count"]),
             int(case["config"]["packet_w"]),
-            int(case["integrated_service"]["service_penalty_cycles"]),
-            int(case["integrated_service"]["completion_cycle"]),
+            int(case["config"]["banks"]),
+            str(case["case_id"]),
         ),
     )
     config = dict(selected["config"])
     integrated = dict(selected["integrated_service"])
     return {
+        "selection_role": selection_role,
+        "selection_basis": selection_basis,
         "arch_id": "decode_score_multivalue_integrated_service",
         "macro_mode": "rtl_probe",
         "cluster_count": config["cluster_count"],
@@ -1524,13 +1548,13 @@ def _summary_best(reports: list[JsonDict]) -> JsonDict:
         "packet_payload_bytes": int(config["packet_w"]) // 8,
         "schedule_policy": "shared_score_value_service_probe",
         "bank_arbiter_policy": config["arb_mode"],
-        "total_cycles": integrated["completion_cycle"],
+        "completion_cycle": integrated["completion_cycle"],
+        "service_penalty_cycles": integrated["service_penalty_cycles"],
         "dominant_tile_resource": "onchip_shared_service",
-        "selected_case_id": selected["case_id"],
-        "selected_case_service_penalty_cycles": integrated["service_penalty_cycles"],
-        "selected_case_shared_result_egress_block_cycles": integrated["counters"]["shared_result"]["egress_block_cycles"],
-        "selected_case_router_arbitration_contention_cycles": integrated["counters"]["arbitration_contention_cycles"],
-        "selected_case_bank_conflict_count": integrated["counters"]["bank_conflict_count"],
+        "case_id": selected["case_id"],
+        "shared_result_egress_block_cycles": integrated["counters"]["shared_result"]["egress_block_cycles"],
+        "router_arbitration_contention_cycles": integrated["counters"]["arbitration_contention_cycles"],
+        "bank_conflict_count": integrated["counters"]["bank_conflict_count"],
     }
 
 
@@ -1675,7 +1699,7 @@ def build_report(
             ],
         },
         "preload_entries": preload_entries,
-        "best": _summary_best(reports),
+        "selected_scale_point": _selected_scale_point(reports),
         "summary": _report_summary(reports),
         "cases": reports,
     }
@@ -1714,6 +1738,19 @@ def validate_report(payload: JsonDict) -> None:
         raise ValueError("report must contain summary")
     if int(summary.get("validated_case_count", 0)) != len(cases):
         raise ValueError("summary validated_case_count mismatch")
+    selected_scale_point = payload.get("selected_scale_point")
+    if not isinstance(selected_scale_point, dict):
+        raise ValueError("report must contain selected_scale_point")
+    if selected_scale_point.get("selection_role") not in {
+        "representative_largest_nominal_scale_point",
+        "representative_largest_available_scale_point",
+    }:
+        raise ValueError("selected_scale_point lacks representative selection role")
+    if "not a performance or architectural ranking" not in str(selected_scale_point.get("selection_basis", "")):
+        raise ValueError("selected_scale_point must explicitly disclaim ranking")
+    case_ids = {str(case.get("case_id")) for case in cases if isinstance(case, dict)}
+    if str(selected_scale_point.get("case_id")) not in case_ids:
+        raise ValueError("selected_scale_point does not reference a report case")
     for case in cases:
         if not isinstance(case, dict):
             raise ValueError("case rows must be objects")
@@ -1763,6 +1800,7 @@ def validate_report(payload: JsonDict) -> None:
 
 def _build_markdown(report: JsonDict) -> str:
     summary = dict(report["summary"])
+    selected_scale_point = dict(report["selected_scale_point"])
     linkage = dict(report.get("source_links") or {})
     lines = [
         "# Attention Decode Score Multivalue Integrated Service Probe",
@@ -1775,6 +1813,9 @@ def _build_markdown(report: JsonDict) -> str:
         f"- max_completion_cycle: `{summary['max_completion_cycle']}`",
         f"- max_service_penalty_cycles: `{summary['max_service_penalty_cycles']}`",
         f"- stress_case_id: `{summary['stress_case_id']}`",
+        f"- selected_scale_point: `{selected_scale_point['case_id']}`",
+        f"- selected_scale_point_role: `{selected_scale_point['selection_role']}`",
+        f"- selected_scale_point_note: {selected_scale_point['selection_basis']}",
         f"- gates: `hash={summary['all_hash_gates_passed']}` `protocol={summary['all_protocol_gates_passed']}` `count={summary['all_count_gates_passed']}`",
         f"- exclusions: `{', '.join(report['exclusions'])}`",
     ]

--- a/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
@@ -26,8 +26,8 @@ from npu.sim.perf.attention_separated import unpack_signed
 JsonDict = dict[str, Any]
 
 REPORT_EXCLUSIONS = [
+    "physical_ppa",
     "hbm",
-    "array_pnr",
     "total_token_energy",
     "value_sram_macro_timing",
     "score_bank_macro_timing",
@@ -35,14 +35,14 @@ REPORT_EXCLUSIONS = [
 
 DEFAULT_CASES: list[JsonDict] = [
     {
-        "case_id": "c1_p128_b2_rr",
+        "case_id": "c1_p128_b4_rr",
         "cluster_count": 1,
         "packet_w": 128,
-        "banks": 2,
-        "req_queue_depth": 2,
-        "resp_queue_depth": 2,
-        "bank_queue_depth": 2,
-        "read_latency": 1,
+        "banks": 4,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
         "arb_mode": "round_robin",
         "locality_burst_max": 2,
     },
@@ -51,24 +51,156 @@ DEFAULT_CASES: list[JsonDict] = [
         "cluster_count": 2,
         "packet_w": 128,
         "banks": 4,
-        "req_queue_depth": 2,
-        "resp_queue_depth": 2,
-        "bank_queue_depth": 2,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
         "read_latency": 2,
         "arb_mode": "round_robin",
         "locality_burst_max": 2,
     },
     {
-        "case_id": "c4_p256_b8_locality",
+        "case_id": "c4_p128_b4_rr",
         "cluster_count": 4,
+        "packet_w": 128,
+        "banks": 4,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    },
+    {
+        "case_id": "c8_p128_b4_rr",
+        "cluster_count": 8,
+        "packet_w": 128,
+        "banks": 4,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    },
+    {
+        "case_id": "c16_p128_b4_rr",
+        "cluster_count": 16,
+        "packet_w": 128,
+        "banks": 4,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    },
+    {
+        "case_id": "c32_p128_b4_rr",
+        "cluster_count": 32,
+        "packet_w": 128,
+        "banks": 4,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    },
+    {
+        "case_id": "c8_p256_b8_rr",
+        "cluster_count": 8,
         "packet_w": 256,
         "banks": 8,
-        "req_queue_depth": 3,
-        "resp_queue_depth": 2,
-        "bank_queue_depth": 3,
-        "read_latency": 3,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    },
+    {
+        "case_id": "c8_p256_b8_locality",
+        "cluster_count": 8,
+        "packet_w": 256,
+        "banks": 8,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
         "arb_mode": "locality_first_bounded",
-        "locality_burst_max": 3,
+        "locality_burst_max": 4,
+    },
+    {
+        "case_id": "c16_p256_b16_rr",
+        "cluster_count": 16,
+        "packet_w": 256,
+        "banks": 16,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    },
+    {
+        "case_id": "c16_p256_b16_locality",
+        "cluster_count": 16,
+        "packet_w": 256,
+        "banks": 16,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "locality_first_bounded",
+        "locality_burst_max": 4,
+    },
+    {
+        "case_id": "c32_p256_b32_rr",
+        "cluster_count": 32,
+        "packet_w": 256,
+        "banks": 32,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    },
+    {
+        "case_id": "c32_p256_b32_locality",
+        "cluster_count": 32,
+        "packet_w": 256,
+        "banks": 32,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "locality_first_bounded",
+        "locality_burst_max": 4,
+    },
+    {
+        "case_id": "c32_p256_b32_q1_rr",
+        "cluster_count": 32,
+        "packet_w": 256,
+        "banks": 32,
+        "req_queue_depth": 1,
+        "resp_queue_depth": 1,
+        "bank_queue_depth": 1,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    },
+    {
+        "case_id": "c32_p256_b32_rl6_rr",
+        "cluster_count": 32,
+        "packet_w": 256,
+        "banks": 32,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 6,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
     },
 ]
 
@@ -1253,6 +1385,16 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
         and integrated_requests == expected_request_rows
         and integrated_wide == expected_wide_rows
     )
+    baseline_hash_gate_ok = (
+        _hash(baseline_scores) == _hash(expected_score_rows)
+        and _hash(baseline_results) == _hash(expected_result_rows)
+    )
+    integrated_hash_gate_ok = (
+        _hash(integrated_scores) == _hash(expected_score_rows)
+        and _hash(integrated_results) == _hash(expected_result_rows)
+        and _hash(integrated_requests) == _hash(expected_request_rows)
+        and _hash(integrated_wide) == _hash(expected_wide_rows)
+    )
     no_protocol_errors = (
         not baseline["protocol_error"]
         and not integrated["shared"]["protocol_error"]
@@ -1286,6 +1428,7 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
             "completion_cycle": baseline["completion_cycle"],
             "score_hash": _hash(baseline_scores),
             "final_hash": _hash(baseline_results),
+            "hash_gate_ok": baseline_hash_gate_ok,
             "score_matches_expected": baseline_scores == expected_score_rows,
             "final_matches_expected": baseline_results == expected_result_rows,
             "cluster_done": per_cluster_done,
@@ -1298,6 +1441,7 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
             "final_hash": _hash(integrated_results),
             "request_hash": _hash(integrated_requests),
             "wide_response_matrix_hash": _hash(integrated_wide),
+            "hash_gate_ok": integrated_hash_gate_ok,
             "exact_match": exact_match,
             "no_protocol_errors": no_protocol_errors,
             "no_drop_duplicate_deadlock_timeout": no_drop_duplicate_deadlock_timeout,
@@ -1338,6 +1482,11 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
             },
             "top_sha256": integrated["top_sha256"],
         },
+        "gates": {
+            "hash_gate_ok": baseline_hash_gate_ok and integrated_hash_gate_ok,
+            "protocol_gate_ok": no_protocol_errors,
+            "count_gate_ok": counts_ok,
+        },
         "expected_hashes": {
             "score_hash": _hash(expected_score_rows),
             "final_hash": _hash(expected_result_rows),
@@ -1352,6 +1501,74 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
             "baseline": baseline["manifest"],
             "integrated": integrated["manifest"],
         },
+    }
+
+
+def _summary_best(reports: list[JsonDict]) -> JsonDict:
+    selected = max(
+        reports,
+        key=lambda case: (
+            int(case["config"]["cluster_count"]),
+            int(case["config"]["packet_w"]),
+            int(case["integrated_service"]["service_penalty_cycles"]),
+            int(case["integrated_service"]["completion_cycle"]),
+        ),
+    )
+    config = dict(selected["config"])
+    integrated = dict(selected["integrated_service"])
+    return {
+        "arch_id": "decode_score_multivalue_integrated_service",
+        "macro_mode": "rtl_probe",
+        "cluster_count": config["cluster_count"],
+        "bank_count": config["banks"],
+        "packet_payload_bytes": int(config["packet_w"]) // 8,
+        "schedule_policy": "shared_score_value_service_probe",
+        "bank_arbiter_policy": config["arb_mode"],
+        "total_cycles": integrated["completion_cycle"],
+        "dominant_tile_resource": "onchip_shared_service",
+        "selected_case_id": selected["case_id"],
+        "selected_case_service_penalty_cycles": integrated["service_penalty_cycles"],
+        "selected_case_shared_result_egress_block_cycles": integrated["counters"]["shared_result"]["egress_block_cycles"],
+        "selected_case_router_arbitration_contention_cycles": integrated["counters"]["arbitration_contention_cycles"],
+        "selected_case_bank_conflict_count": integrated["counters"]["bank_conflict_count"],
+    }
+
+
+def _report_summary(reports: list[JsonDict]) -> JsonDict:
+    stress_case = max(
+        reports,
+        key=lambda case: (
+            int(case["integrated_service"]["service_penalty_cycles"]),
+            int(case["integrated_service"]["completion_cycle"]),
+            int(case["config"]["cluster_count"]),
+        ),
+    )
+    return {
+        "validated_case_count": len(reports),
+        "max_cluster_count": max(int(case["config"]["cluster_count"]) for case in reports),
+        "max_completion_cycle": max(int(case["integrated_service"]["completion_cycle"]) for case in reports),
+        "max_service_penalty_cycles": max(
+            int(case["integrated_service"]["service_penalty_cycles"]) for case in reports
+        ),
+        "max_router_arbitration_contention_cycles": max(
+            int(case["integrated_service"]["counters"]["arbitration_contention_cycles"]) for case in reports
+        ),
+        "max_shared_result_egress_block_cycles": max(
+            int(case["integrated_service"]["counters"]["shared_result"]["egress_block_cycles"]) for case in reports
+        ),
+        "max_bank_conflict_count": max(
+            int(case["integrated_service"]["counters"]["bank_conflict_count"]) for case in reports
+        ),
+        "max_router_req_occupancy": max(
+            int(case["integrated_service"]["counters"]["max_occupancy"]["router_req"]) for case in reports
+        ),
+        "max_service_req_occupancy": max(
+            int(case["integrated_service"]["counters"]["max_occupancy"]["service_req"]) for case in reports
+        ),
+        "stress_case_id": str(stress_case["case_id"]),
+        "all_hash_gates_passed": all(bool(case["gates"]["hash_gate_ok"]) for case in reports),
+        "all_protocol_gates_passed": all(bool(case["gates"]["protocol_gate_ok"]) for case in reports),
+        "all_count_gates_passed": all(bool(case["gates"]["count_gate_ok"]) for case in reports),
     }
 
 
@@ -1396,7 +1613,13 @@ def _validate_case(case: JsonDict) -> JsonDict:
     }
 
 
-def build_report(config: JsonDict | None = None) -> JsonDict:
+def build_report(
+    config: JsonDict | None = None,
+    *,
+    proposal_id: str | None = None,
+    proposal_path: str | None = None,
+    depends_on_item_ids: list[str] | None = None,
+) -> JsonDict:
     payload = config or {"cases": DEFAULT_CASES}
     case_rows = payload.get("cases")
     if not isinstance(case_rows, list) or not case_rows:
@@ -1415,8 +1638,19 @@ def build_report(config: JsonDict | None = None) -> JsonDict:
     decision = "pass" if all(case["decision"] == "pass" for case in reports) else "fail"
     result = {
         "version": 1,
-        "model": "attention_decode_score_multivalue_integrated_service_probe_v1",
+        "model": "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1",
         "decision": decision,
+        "diagnosis": {
+            "decision": (
+                "multivalue_integrated_service_probe_passed"
+                if decision == "pass"
+                else "multivalue_integrated_service_probe_failed"
+            ),
+            "recommended_next_step": (
+                "Use this merged/materialized integrated-service probe as the shared-score on-chip service "
+                "closure input before any NoC, HBM, physical PPA, SRAM macro timing, or token-energy claim."
+            ),
+        },
         "exclusions": REPORT_EXCLUSIONS,
         "source_identities": {
             "repo_commit": _git_head(),
@@ -1441,8 +1675,20 @@ def build_report(config: JsonDict | None = None) -> JsonDict:
             ],
         },
         "preload_entries": preload_entries,
+        "best": _summary_best(reports),
+        "summary": _report_summary(reports),
         "cases": reports,
     }
+    linkage: JsonDict = {}
+    if proposal_id:
+        linkage["proposal_id"] = str(proposal_id)
+    if proposal_path:
+        linkage["proposal_path"] = str(proposal_path)
+    depends = [str(item).strip() for item in (depends_on_item_ids or []) if str(item).strip()]
+    if depends:
+        linkage["depends_on_item_ids"] = depends
+    if linkage:
+        result["source_links"] = linkage
     validate_report(result)
     return result
 
@@ -1450,7 +1696,7 @@ def build_report(config: JsonDict | None = None) -> JsonDict:
 def validate_report(payload: JsonDict) -> None:
     if payload.get("version") != 1:
         raise ValueError("report version must be 1")
-    if payload.get("model") != "attention_decode_score_multivalue_integrated_service_probe_v1":
+    if payload.get("model") != "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1":
         raise ValueError("unexpected report model")
     if payload.get("exclusions") != REPORT_EXCLUSIONS:
         raise ValueError(f"report exclusions must explicitly be {', '.join(REPORT_EXCLUSIONS)}")
@@ -1463,6 +1709,11 @@ def validate_report(payload: JsonDict) -> None:
     cases = payload.get("cases")
     if not isinstance(cases, list) or not cases:
         raise ValueError("report must contain cases")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise ValueError("report must contain summary")
+    if int(summary.get("validated_case_count", 0)) != len(cases):
+        raise ValueError("summary validated_case_count mismatch")
     for case in cases:
         if not isinstance(case, dict):
             raise ValueError("case rows must be objects")
@@ -1505,6 +1756,82 @@ def validate_report(payload: JsonDict) -> None:
             raise ValueError(f"unexpected shared_result egress II for {case.get('case_id')}")
         if int(case.get("config", {}).get("cluster_count", 0)) > 1 and egress.get("back_to_back_fire_seen") is not True:
             raise ValueError(f"missing shared_result back-to-back evidence for {case.get('case_id')}")
+        gates = case.get("gates")
+        if not isinstance(gates, dict) or not all(bool(gates.get(key)) for key in ("hash_gate_ok", "protocol_gate_ok", "count_gate_ok")):
+            raise ValueError(f"gate status missing or failed for {case.get('case_id')}")
+
+
+def _build_markdown(report: JsonDict) -> str:
+    summary = dict(report["summary"])
+    linkage = dict(report.get("source_links") or {})
+    lines = [
+        "# Attention Decode Score Multivalue Integrated Service Probe",
+        "",
+        f"- decision: `{report['decision']}`",
+        f"- outcome: `{report['diagnosis']['decision']}`",
+        f"- repo commit: `{report['source_identities']['repo_commit']}`",
+        f"- cases: `{summary['validated_case_count']}`",
+        f"- max_cluster_count: `{summary['max_cluster_count']}`",
+        f"- max_completion_cycle: `{summary['max_completion_cycle']}`",
+        f"- max_service_penalty_cycles: `{summary['max_service_penalty_cycles']}`",
+        f"- stress_case_id: `{summary['stress_case_id']}`",
+        f"- gates: `hash={summary['all_hash_gates_passed']}` `protocol={summary['all_protocol_gates_passed']}` `count={summary['all_count_gates_passed']}`",
+        f"- exclusions: `{', '.join(report['exclusions'])}`",
+    ]
+    if linkage.get("proposal_id"):
+        lines.append(f"- proposal_id: `{linkage['proposal_id']}`")
+    if linkage.get("proposal_path"):
+        lines.append(f"- proposal_path: `{linkage['proposal_path']}`")
+    depends = linkage.get("depends_on_item_ids")
+    if isinstance(depends, list) and depends:
+        lines.append(f"- depends_on_item_ids: `{', '.join(str(item) for item in depends)}`")
+    lines.extend(
+        [
+            "",
+            "## Cases",
+            "",
+            "| case | cfg | done | penalty | gate | req stall | router arb | bank conflict | resp block r/s | shared arb/block | occ rreq/rresp/sreq/sresp |",
+            "| --- | --- | ---: | ---: | --- | ---: | ---: | ---: | --- | --- | --- |",
+        ]
+    )
+    for case in report["cases"]:
+        config = dict(case["config"])
+        integrated = dict(case["integrated_service"])
+        counters = dict(integrated["counters"])
+        occupancy = dict(counters["max_occupancy"])
+        shared = dict(counters["shared_result"])
+        response_block = dict(counters["response_block_cycles"])
+        gate = dict(case["gates"])
+        lines.append(
+            "| {case_id} | c{cluster}/p{packet}/b{banks}/{arb}/q{queue}/rl{latency} | {done} | {penalty} | "
+            "h:{hash_gate}/p:{protocol_gate}/c:{count_gate} | {req_stall} | {router_arb} | {bank_conflict} | "
+            "{router_block}/{service_block} | {shared_arb}/{shared_block} | {router_req}/{router_resp}/{service_req}/{service_resp} |".format(
+                case_id=case["case_id"],
+                cluster=config["cluster_count"],
+                packet=config["packet_w"],
+                banks=config["banks"],
+                arb=config["arb_mode"],
+                queue=config["req_queue_depth"],
+                latency=config["read_latency"],
+                done=integrated["completion_cycle"],
+                penalty=integrated["service_penalty_cycles"],
+                hash_gate="ok" if gate["hash_gate_ok"] else "fail",
+                protocol_gate="ok" if gate["protocol_gate_ok"] else "fail",
+                count_gate="ok" if gate["count_gate_ok"] else "fail",
+                req_stall=counters["request_injection_stall_cycles"],
+                router_arb=counters["arbitration_contention_cycles"],
+                bank_conflict=counters["bank_conflict_count"],
+                router_block=response_block["router"],
+                service_block=response_block["service"],
+                shared_arb=shared["arbitration_contention_cycles"],
+                shared_block=shared["egress_block_cycles"],
+                router_req=occupancy["router_req"],
+                router_resp=occupancy["router_resp"],
+                service_req=occupancy["service_req"],
+                service_resp=occupancy["service_resp"],
+            )
+        )
+    return "\n".join(lines) + "\n"
 
 
 def main() -> int:
@@ -1512,6 +1839,9 @@ def main() -> int:
     parser.add_argument("--config", type=Path)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path)
+    parser.add_argument("--proposal-id")
+    parser.add_argument("--proposal-path")
+    parser.add_argument("--depends-on-item-id", action="append", default=[])
     args = parser.parse_args()
     config = None
     if args.config is not None:
@@ -1519,18 +1849,17 @@ def main() -> int:
         if not isinstance(config_payload, dict):
             raise SystemExit("config must decode to a JSON object")
         config = config_payload
-    report = build_report(config)
+    report = build_report(
+        config,
+        proposal_id=str(args.proposal_id or "").strip() or None,
+        proposal_path=str(args.proposal_path or "").strip() or None,
+        depends_on_item_ids=[str(item).strip() for item in args.depends_on_item_id if str(item).strip()],
+    )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     if args.out_md is not None:
         args.out_md.parent.mkdir(parents=True, exist_ok=True)
-        args.out_md.write_text(
-            "# Attention Decode Score Multivalue Integrated Service Probe\n\n"
-            f"- decision: `{report['decision']}`\n"
-            f"- repo commit: `{report['source_identities']['repo_commit']}`\n"
-            f"- cases: `{len(report['cases'])}`\n",
-            encoding="utf-8",
-        )
+        args.out_md.write_text(_build_markdown(report), encoding="utf-8")
     return 0 if report["decision"] == "pass" else 1
 
 

--- a/tests/test_attention_decode_score_multivalue_integrated_service.py
+++ b/tests/test_attention_decode_score_multivalue_integrated_service.py
@@ -83,10 +83,27 @@ def test_multivalue_service_generator_manifest(tmp_path: Path) -> None:
 
 
 def test_integrated_service_default_cases_cover_requested_surface() -> None:
-    assert {row["cluster_count"] for row in DEFAULT_CASES} >= {1, 2, 4}
+    assert len(DEFAULT_CASES) == 14
+    assert {row["cluster_count"] for row in DEFAULT_CASES} >= {1, 2, 4, 8, 16, 32}
     assert {row["packet_w"] for row in DEFAULT_CASES} == {128, 256}
-    assert {row["banks"] for row in DEFAULT_CASES} >= {2, 4, 8}
+    assert {row["banks"] for row in DEFAULT_CASES} >= {4, 8, 16, 32}
     assert {row["arb_mode"] for row in DEFAULT_CASES} == {"round_robin", "locality_first_bounded"}
+    fixed_resource = {
+        row["case_id"]
+        for row in DEFAULT_CASES
+        if row["packet_w"] == 128 and row["banks"] == 4 and row["arb_mode"] == "round_robin"
+    }
+    assert fixed_resource == {
+        "c1_p128_b4_rr",
+        "c2_p128_b4_rr",
+        "c4_p128_b4_rr",
+        "c8_p128_b4_rr",
+        "c16_p128_b4_rr",
+        "c32_p128_b4_rr",
+    }
+    assert {"c32_p256_b32_q1_rr", "c32_p256_b32_rl6_rr"} <= {
+        row["case_id"] for row in DEFAULT_CASES
+    }
 
 
 @pytest.mark.parametrize("packet_w", [128, 256])
@@ -196,24 +213,24 @@ def test_integrated_service_fixed_resource_scaling_pair() -> None:
                     case_id="fixed_c1",
                     cluster_count=1,
                     packet_w=128,
-                    banks=2,
+                    banks=4,
                     arb_mode="round_robin",
                     locality_burst_max=2,
-                    req_queue_depth=2,
-                    resp_queue_depth=2,
-                    bank_queue_depth=2,
+                    req_queue_depth=4,
+                    resp_queue_depth=4,
+                    bank_queue_depth=4,
                     read_latency=2,
                 ),
                 _case(
                     case_id="fixed_c2",
                     cluster_count=2,
                     packet_w=128,
-                    banks=2,
+                    banks=4,
                     arb_mode="round_robin",
                     locality_burst_max=2,
-                    req_queue_depth=2,
-                    resp_queue_depth=2,
-                    bank_queue_depth=2,
+                    req_queue_depth=4,
+                    resp_queue_depth=4,
+                    bank_queue_depth=4,
                     read_latency=2,
                 ),
             ]
@@ -222,16 +239,42 @@ def test_integrated_service_fixed_resource_scaling_pair() -> None:
     c1, c2 = report["cases"]
     assert report["decision"] == "pass"
     assert c1["config"]["packet_w"] == c2["config"]["packet_w"] == 128
-    assert c1["config"]["banks"] == c2["config"]["banks"] == 2
-    assert c1["config"]["req_queue_depth"] == c2["config"]["req_queue_depth"] == 2
-    assert c1["config"]["resp_queue_depth"] == c2["config"]["resp_queue_depth"] == 2
-    assert c1["config"]["bank_queue_depth"] == c2["config"]["bank_queue_depth"] == 2
+    assert c1["config"]["banks"] == c2["config"]["banks"] == 4
+    assert c1["config"]["req_queue_depth"] == c2["config"]["req_queue_depth"] == 4
+    assert c1["config"]["resp_queue_depth"] == c2["config"]["resp_queue_depth"] == 4
+    assert c1["config"]["bank_queue_depth"] == c2["config"]["bank_queue_depth"] == 4
     assert c1["config"]["read_latency"] == c2["config"]["read_latency"] == 2
     assert c1["config"]["arb_mode"] == c2["config"]["arb_mode"] == "round_robin"
     assert c2["integrated_service"]["completion_cycle"] >= c1["integrated_service"]["completion_cycle"]
     assert c2["integrated_service"]["service_penalty_cycles"] >= c1["integrated_service"]["service_penalty_cycles"]
     assert c2["integrated_service"]["counters"]["shared_result"]["egress_block_cycles"] > 0
     assert c2["integrated_service"]["shared_result_egress"]["back_to_back_fire_seen"] is True
+
+
+def test_integrated_service_report_retains_linkage_and_summary() -> None:
+    if not _iverilog_available():
+        pytest.skip("iverilog/vvp unavailable")
+    report = build_report(
+        {"cases": [_case(case_id="linkage", cluster_count=2, packet_w=128, banks=4, arb_mode="round_robin")]},
+        proposal_id="prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+        proposal_path=(
+            "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json"
+        ),
+        depends_on_item_ids=["l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"],
+    )
+    assert report["model"] == "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1"
+    assert report["source_links"]["proposal_id"] == (
+        "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1"
+    )
+    assert report["source_links"]["proposal_path"].endswith("/proposal.json")
+    assert report["source_links"]["depends_on_item_ids"] == [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+    ]
+    assert report["summary"]["validated_case_count"] == 1
+    assert report["summary"]["all_hash_gates_passed"] is True
+    assert report["summary"]["all_protocol_gates_passed"] is True
+    assert report["summary"]["all_count_gates_passed"] is True
+    assert report["best"]["arch_id"] == "decode_score_multivalue_integrated_service"
 
 
 def test_integrated_service_validate_report_rejects_incomplete_evidence() -> None:

--- a/tests/test_attention_decode_score_multivalue_integrated_service.py
+++ b/tests/test_attention_decode_score_multivalue_integrated_service.py
@@ -12,6 +12,7 @@ if str(REPO_ROOT) not in sys.path:
 from npu.eval.probe_attention_decode_score_multivalue_integrated_service import (
     DEFAULT_CASES,
     REPORT_EXCLUSIONS,
+    _selected_scale_point,
     build_report,
     validate_report,
 )
@@ -274,7 +275,62 @@ def test_integrated_service_report_retains_linkage_and_summary() -> None:
     assert report["summary"]["all_hash_gates_passed"] is True
     assert report["summary"]["all_protocol_gates_passed"] is True
     assert report["summary"]["all_count_gates_passed"] is True
-    assert report["best"]["arch_id"] == "decode_score_multivalue_integrated_service"
+    assert report["selected_scale_point"]["arch_id"] == "decode_score_multivalue_integrated_service"
+    assert report["selected_scale_point"]["case_id"] == "linkage"
+    assert "not a performance or architectural ranking" in report["selected_scale_point"]["selection_basis"]
+
+
+def test_integrated_service_selected_scale_point_is_nominal_not_worst_penalty() -> None:
+    reports = [
+        {
+            "case_id": "c32_nominal_rr",
+            "config": {
+                "cluster_count": 32,
+                "packet_w": 256,
+                "banks": 32,
+                "req_queue_depth": 4,
+                "resp_queue_depth": 4,
+                "bank_queue_depth": 4,
+                "read_latency": 2,
+                "arb_mode": "round_robin",
+            },
+            "integrated_service": {
+                "completion_cycle": 100,
+                "service_penalty_cycles": 10,
+                "counters": {
+                    "shared_result": {"egress_block_cycles": 3},
+                    "arbitration_contention_cycles": 4,
+                    "bank_conflict_count": 5,
+                },
+            },
+        },
+        {
+            "case_id": "c32_stress_q1",
+            "config": {
+                "cluster_count": 32,
+                "packet_w": 256,
+                "banks": 32,
+                "req_queue_depth": 1,
+                "resp_queue_depth": 1,
+                "bank_queue_depth": 1,
+                "read_latency": 2,
+                "arb_mode": "round_robin",
+            },
+            "integrated_service": {
+                "completion_cycle": 900,
+                "service_penalty_cycles": 800,
+                "counters": {
+                    "shared_result": {"egress_block_cycles": 30},
+                    "arbitration_contention_cycles": 40,
+                    "bank_conflict_count": 50,
+                },
+            },
+        },
+    ]
+    selected = _selected_scale_point(reports)
+    assert selected["case_id"] == "c32_nominal_rr"
+    assert selected["service_penalty_cycles"] == 10
+    assert selected["selection_role"] == "representative_largest_nominal_scale_point"
 
 
 def test_integrated_service_validate_report_rejects_incomplete_evidence() -> None:


### PR DESCRIPTION
## Summary
- add a bounded 14-case integrated shared-score/value-service RTL campaign through 32 clusters
- retain exact Python, baseline RTL, and integrated RTL hash/protocol/count gates
- report finite service penalties, contention, blocking, and occupancy with explicit physical/HBM/energy exclusions
- wire dispatch, result consumption, and proposal linkage
- label the largest nominal point as coverage evidence only, not an architecture ranking

## Validation
- 352 focused tests passed
- `scripts/validate_runs.py --skip_eval_queue` passed
- `git diff --check` passed

No job is dispatched by this PR.