### PR TITLE
Compact multivalue integrated-service evidence

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/design_brief.md
@@ -31,7 +31,7 @@ composition work.
   - no HBM closure
   - no total-token energy claim
 - output discipline:
-  - compact repo-portable JSON/Markdown only
+  - compact repo-portable JSON/Markdown only, with deduplicated shared artifact identities and a pretty-printed JSON gate of `<=100000` bytes / `<=2500` lines
   - no full stdout traces
   - no intermediate tensors
   - identify the largest nominal round-robin case only as a representative

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_gate.md
@@ -2,7 +2,7 @@
 
 ## Proposal
 - `proposal_id`: `prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
-- `item_id`: `l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
+- `item_id`: `l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1`
 
 ## Required Inputs
 - merged/materialized dependency:
@@ -10,8 +10,8 @@
 - proposal implementation merged onto `origin/master`
 
 ## Expected Outputs
-- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_integrated_service__l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.json`
-- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_integrated_service__l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.md`
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_integrated_service__l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json`
+- `runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_integrated_service__l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.md`
 
 ## Dispatch Contract
 - abstraction layer:
@@ -23,5 +23,6 @@
 
 ## Gate Condition
 - The run must remain evidence-only and must not claim NoC/HBM/physical/token-energy closure.
+- The run must supersede PR #1436's original `..._v1` item only on artifact compactness: the functional gates remain valid history, but the committed JSON must deduplicate shared artifact identities, omit preload/manifest payload repeats, and stay within `<=100000` pretty-printed bytes / `<=2500` lines.
 - Any singled-out case must be labeled as a representative scale point, not as
   an architectural or performance best.

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
   "source_commit": "7691291314ff3739164633f6e5f17a1b3eb15c84",
-  "source_commit_note": "Replace with the merge commit that contains this proposal and the integrated-service generator hook before dispatch. Do not dispatch from an unmerged local branch.",
+  "source_commit_note": "Replace with the merge commit that contains this proposal and the compact-report evaluator update before dispatch. Do not dispatch from an unmerged local branch. PR #1436's original v1 evidence passed its functional gates but is superseded before merge on noncompact artifact shape only.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
@@ -20,8 +20,35 @@
         "direction": "record_decode_score_multivalue_integrated_service_probe",
         "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, and explicit exclusions over the bounded 14-case matrix; any selected scale point is representative evidence, not an architectural or performance ranking."
       },
+      "status": "superseded_before_merge",
+      "superseded_by_item_id": "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+      "notes": "PR #1436 exercised the intended 14-case matrix and kept functional hash/protocol/count gates green, but the committed report repeated generated manifests and preload payloads, reaching 403110 bytes / 11271 lines. The evidence is still valid as functional history; it is superseded before merge only to enforce compact portable report shape."
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the integrated shared-score multivalue decode-service RTL probe across the same bounded 14-case scale/resource matrix through cluster_count 32, preserving all functional gates while emitting only compact deduplicated service evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_integrated_service",
+      "comparison_role": "frontier_validation",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "compact_report_shape_gate",
+        "supersedes_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_decode_score_multivalue_integrated_service_probe",
+        "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, and explicit exclusions over the same bounded 14-case matrix, while enforcing a deduplicated compact report size/shape gate of <=100000 pretty-printed JSON bytes and <=2500 lines; any selected scale point remains representative evidence, not an architectural or performance ranking."
+      },
       "status": "pending",
-      "notes": "The dependency item is already merged/materialized. This request is ready for normal control-plane dispatch only after the proposal implementation itself is merged."
+      "notes": "The dependency item is already merged/materialized. This replacement request is ready for normal control-plane dispatch only after the proposal implementation itself is merged."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/implementation_summary.md
@@ -6,6 +6,10 @@
 - Wired compact JSON/Markdown evidence outputs and result-consumer recognition.
 - Expanded the probe to the requested bounded 14-case matrix through
   `cluster_count=32`.
+- Recorded `l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1`
+  as superseded before merge: PR #1436 passed its functional gates, but its
+  committed JSON repeated generated-manifest and preload payloads. The clean
+  rerun target is `..._v1_r1`.
 
 ## Evidence Contract
 - JSON now retains:
@@ -16,6 +20,9 @@
   - router/service contention and occupancy maxima
   - explicit exclusions
   - proposal/dependency linkage
+- JSON now deduplicates shared preload/manifest/top identities at the report
+  level and enforces a pretty-printed compactness gate of `<=100000` bytes /
+  `<=2500` lines.
 - Markdown now summarizes the same evidence in a compact per-case table.
 - The largest nominal round-robin coverage point is labeled
   `selected_scale_point`; it is explicitly not an architectural or performance
@@ -24,9 +31,8 @@
 ## Local Validation
 - focused pytest coverage for:
   - probe defaults and linkage
-  - L2 task generation
-  - L2 result consumption
+  - compact report shape rejection
+  - full-matrix size regression with oversized synthetic manifests
 - passed `pytest -q tests/test_attention_decode_score_multivalue_integrated_service.py`
-- passed `PYTHONPATH=/workspaces/RTLGen-l2-score-service-v1/control_plane pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k "decode_score_multivalue_integrated_service or decode_score_multivalue_cluster_frontier"`
-- passed `PYTHONPATH=/workspaces/RTLGen-l2-score-service-v1/control_plane pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py -k "decode_score_multivalue_integrated_service or hbm_command_calibrated_service"`
-- passed `python3 scripts/validate_runs.py --skip_eval_queue`
+- passed `python3 -m py_compile npu/eval/probe_attention_decode_score_multivalue_integrated_service.py`
+- passed real 14-case `build_report()` probe on Friday, July 24, 2026 UTC with compact output size `67278` bytes / `1690` lines (`403110` bytes / `11271` lines in the superseded PR #1436 artifact)

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json
@@ -14,7 +14,7 @@
       "fixed-resource scaling at cluster_count 1/2/4/8/16/32 with identical p128, banks=4, queue depths=4, read_latency=2, round_robin, locality_burst_max=2",
       "scaled-resource p256 points at c8/b8, c16/b16, and c32/b32 with queue depths=4, read_latency=2, and round_robin/locality variants",
       "one queue-depth stress case and one read-latency stress case at c32",
-      "compact repo-portable JSON/Markdown evidence that reports completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention and occupancy, explicit exclusions, and proposal/dependency linkage",
+      "compact repo-portable JSON/Markdown evidence that reports completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention and occupancy, explicit exclusions, proposal/dependency linkage, and a deduplicated shared-artifact size/shape gate of <=100000 pretty-printed JSON bytes and <=2500 lines",
       "label the largest nominal round-robin coverage case only as a representative selected_scale_point, not as an architectural or performance best"
     ],
     "exclude": [
@@ -57,6 +57,33 @@
       "expected_result": {
         "direction": "record_decode_score_multivalue_integrated_service_probe",
         "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, and explicit exclusions over the bounded 14-case matrix; any selected scale point is representative evidence, not an architectural or performance ranking."
+      },
+      "status": "superseded_before_merge",
+      "superseded_by_item_id": "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+      "notes": "PR #1436 completed the functional 14-case probe and kept every hash/protocol/count gate green, but the committed JSON repeated generated manifests and preload payloads, expanding the artifact to 403110 bytes / 11271 lines. The evidence is not invalid; it is superseded before merge only on compactness/portability shape."
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the integrated shared-score multivalue decode-service RTL probe across the same bounded 14-case scale/resource matrix through cluster_count 32, preserving all functional gates while emitting only compact deduplicated service evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_integrated_service",
+      "comparison_role": "frontier_validation",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "compact_report_shape_gate",
+        "supersedes_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_decode_score_multivalue_integrated_service_probe",
+        "reason": "Retain exact Python/baseline/integrated hash, protocol, and count gates while recording completion cycles, service penalty cycles, shared-result blocking/arbitration, router/service contention, occupancy maxima, explicit exclusions, and a compact report shape gate that keeps deduplicated pretty-printed JSON at or below 100000 bytes and 2500 lines over the same bounded 14-case matrix; any selected scale point remains representative evidence, not an architectural or performance ranking."
       },
       "status": "pending"
     }

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/quality_gate.md
@@ -18,13 +18,13 @@ gates while exposing the service contention profile across the bounded matrix.
 - metric: exclusions
   - threshold: the evidence explicitly lists physical PPA, SRAM macro timing, HBM, and total-token energy as excluded claims
 - metric: compactness
-  - threshold: outputs remain repo-portable JSON/Markdown without full stdout or intermediate tensors
+  - threshold: outputs remain repo-portable JSON/Markdown without full stdout or intermediate tensors, use deduplicated shared artifact identities, and keep pretty-printed JSON at or below `100000` bytes / `2500` lines
 - metric: selection semantics
   - threshold: the largest nominal round-robin coverage point is reported only
     as `selected_scale_point`, with no architectural-best or performance-best claim
 
 ## Local Command
-- command: `python3 npu/eval/probe_attention_decode_score_multivalue_integrated_service.py --proposal-id prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1 --proposal-path docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json --depends-on-item-id l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1 --out /tmp/decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.json --out-md /tmp/decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.md`
+- command: `python3 npu/eval/probe_attention_decode_score_multivalue_integrated_service.py --proposal-id prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1 --proposal-path docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json --depends-on-item-id l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1 --out /tmp/decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json --out-md /tmp/decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.md`
 
 ## Result
 - status: ready_after_proposal_merge

--- a/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
@@ -32,6 +32,9 @@ REPORT_EXCLUSIONS = [
     "value_sram_macro_timing",
     "score_bank_macro_timing",
 ]
+COMPACT_REPORT_SHAPE = "deduplicated_shared_artifact_identities_v1"
+COMPACT_REPORT_MAX_BYTES = 100_000
+COMPACT_REPORT_MAX_LINES = 2_500
 
 DEFAULT_CASES: list[JsonDict] = [
     {
@@ -271,6 +274,87 @@ def _hash(value: object) -> str:
 
 def _sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _pretty_json_metrics(value: object) -> tuple[int, int]:
+    rendered = json.dumps(value, indent=2, sort_keys=True)
+    return len(rendered.encode()), len(rendered.splitlines())
+
+
+def _compact_dict(payload: JsonDict) -> JsonDict:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _register_generated_manifest(catalog: dict[str, JsonDict], kind: str, manifest: JsonDict) -> str:
+    manifest_sha256 = _hash(manifest)
+    artifact_id = f"{kind}_manifest_{manifest_sha256[:12]}"
+    if artifact_id not in catalog:
+        result_beats = manifest.get("result_beats_per_command")
+        if result_beats is None:
+            result_beats = (
+                manifest.get("submodule_manifests", {})
+                .get("multivalue_cluster", {})
+                .get("result_beats_per_command")
+            )
+        catalog[artifact_id] = _compact_dict(
+            {
+                "artifact_id": artifact_id,
+                "artifact_kind": f"{kind}_manifest",
+                "manifest_sha256": manifest_sha256,
+                "semantic_profile": manifest.get("semantic_profile"),
+                "cluster_count": manifest.get("cluster_count"),
+                "packet_w": manifest.get("packet_w"),
+                "banks": manifest.get("banks"),
+                "arb_mode": manifest.get("arb_mode"),
+                "shared_result_egress": manifest.get("shared_result_egress"),
+                "shared_result_egress_initiation_interval": manifest.get(
+                    "shared_result_egress_initiation_interval"
+                ),
+                "shared_result_egress_stall_semantics": manifest.get("shared_result_egress_stall_semantics"),
+                "response_metadata_guard": manifest.get("response_metadata_guard"),
+                "result_beats_per_command": result_beats,
+            }
+        )
+    return artifact_id
+
+
+def _register_generated_top(
+    catalog: dict[str, JsonDict],
+    kind: str,
+    top_sha256: str,
+    case: JsonDict,
+) -> str:
+    artifact_id = f"{kind}_top_{top_sha256[:12]}"
+    if artifact_id not in catalog:
+        catalog[artifact_id] = _compact_dict(
+            {
+                "artifact_id": artifact_id,
+                "artifact_kind": f"{kind}_top",
+                "sha256": top_sha256,
+                "cluster_count": int(case["cluster_count"]),
+                "packet_w": int(case["packet_w"]) if kind == "integrated" else None,
+                "banks": int(case["banks"]) if kind == "integrated" else None,
+                "arb_mode": str(case["arb_mode"]) if kind == "integrated" else None,
+            }
+        )
+    return artifact_id
+
+
+def _record_case_source_refs(
+    case: JsonDict,
+    baseline: JsonDict,
+    integrated: JsonDict,
+    shared_preload_identity: JsonDict,
+    manifest_catalog: dict[str, JsonDict],
+    top_catalog: dict[str, JsonDict],
+) -> JsonDict:
+    return {
+        "shared_preload": str(shared_preload_identity["artifact_id"]),
+        "baseline_manifest": _register_generated_manifest(manifest_catalog, "baseline", baseline["manifest"]),
+        "integrated_manifest": _register_generated_manifest(manifest_catalog, "integrated", integrated["manifest"]),
+        "baseline_top": _register_generated_top(top_catalog, "baseline", str(baseline["top_sha256"]), case),
+        "integrated_top": _register_generated_top(top_catalog, "integrated", str(integrated["top_sha256"]), case),
+    }
 
 
 def _git_head() -> str:
@@ -1327,7 +1411,7 @@ def _canonical_wide(rows: list[JsonDict]) -> list[JsonDict]:
     ]
 
 
-def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, preload_entries: list[JsonDict]) -> JsonDict:
+def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, source_refs: JsonDict) -> JsonDict:
     cluster_count = int(case["cluster_count"])
     values = _shared_value_matrices()
     expected_clusters = [_cluster_expected(cluster, values) for cluster in range(cluster_count)]
@@ -1351,23 +1435,11 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
     integrated_wide = _canonical_wide(integrated["wide_rows"])
     expected_wide_rows = _canonical_wide(expected_wide)
 
-    per_cluster_done = [
-        {
-            "cluster": cluster,
-            "baseline_cycle": int(baseline["done_rows"][cluster]["cycle"]),
-            "integrated_cycle": int(integrated["done_rows"][cluster]["cycle"]),
-            "accepted_count": int(integrated["done_rows"][cluster]["accepted"]),
-            "completed_count": int(integrated["done_rows"][cluster]["completed"]),
-        }
+    done_cluster_count = sum(
+        1
         for cluster in range(cluster_count)
-    ]
-    per_cluster_counters = [
-        {
-            "cluster": cluster,
-            **integrated["counter_rows"][cluster],
-        }
-        for cluster in range(cluster_count)
-    ]
+        if cluster in baseline["done_rows"] and cluster in integrated["done_rows"]
+    )
 
     counts_ok = (
         len(baseline_results) == 16 * cluster_count
@@ -1404,12 +1476,13 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
     )
     service_penalty_cycles = integrated["shared"]["completion_cycle"] - baseline["completion_cycle"]
     cycle_bound_ok = service_penalty_cycles >= 0
-    no_drop_duplicate_deadlock_timeout = counts_ok and len(per_cluster_done) == cluster_count
+    no_drop_duplicate_deadlock_timeout = counts_ok and done_cluster_count == cluster_count
     decision = "pass" if exact_match and no_protocol_errors and cycle_bound_ok and no_drop_duplicate_deadlock_timeout else "fail"
 
     return {
         "case_id": str(case["case_id"]),
         "decision": decision,
+        "source_refs": dict(source_refs),
         "config": {
             key: case[key]
             for key in (
@@ -1429,10 +1502,6 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
             "score_hash": _hash(baseline_scores),
             "final_hash": _hash(baseline_results),
             "hash_gate_ok": baseline_hash_gate_ok,
-            "score_matches_expected": baseline_scores == expected_score_rows,
-            "final_matches_expected": baseline_results == expected_result_rows,
-            "cluster_done": per_cluster_done,
-            "top_sha256": baseline["top_sha256"],
         },
         "integrated_service": {
             "completion_cycle": integrated["shared"]["completion_cycle"],
@@ -1446,9 +1515,7 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
             "no_protocol_errors": no_protocol_errors,
             "no_drop_duplicate_deadlock_timeout": no_drop_duplicate_deadlock_timeout,
             "cycle_bound_ok": cycle_bound_ok,
-            "cluster_done": per_cluster_done,
             "counters": {
-                "cluster_input": per_cluster_counters,
                 "request_injection_stall_cycles": integrated["shared"]["router_injection_stall_cycles"],
                 "arbitration_contention_cycles": integrated["shared"]["router_arbitration_contention_cycles"],
                 "bank_conflict_count": integrated["shared"]["service_bank_conflict_count"],
@@ -1480,7 +1547,6 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
                 "stall_semantics": integrated["manifest"]["shared_result_egress_stall_semantics"],
                 "back_to_back_fire_seen": integrated["shared"]["result_back_to_back_fire_seen"],
             },
-            "top_sha256": integrated["top_sha256"],
         },
         "gates": {
             "hash_gate_ok": baseline_hash_gate_ok and integrated_hash_gate_ok,
@@ -1492,14 +1558,6 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, pr
             "final_hash": _hash(expected_result_rows),
             "request_hash": _hash(expected_request_rows),
             "wide_response_matrix_hash": _hash(expected_wide_rows),
-        },
-        "preload": {
-            "entry_count": len(preload_entries),
-            "entries_hash": _hash(preload_entries),
-        },
-        "generated_manifests": {
-            "baseline": baseline["manifest"],
-            "integrated": integrated["manifest"],
         },
     }
 
@@ -1652,12 +1710,29 @@ def build_report(
 
     values = _shared_value_matrices()
     preload_entries = _preload_entries(values)
+    shared_preload_identity = {
+        "artifact_id": "shared_preload_v1",
+        "entry_count": len(preload_entries),
+        "entries_hash": _hash(preload_entries),
+        "payload_elided": True,
+        "source": "shared_value_matrices_v1",
+    }
+    manifest_catalog: dict[str, JsonDict] = {}
+    top_catalog: dict[str, JsonDict] = {}
     reports = []
     for case in cases:
         expected_clusters = [_cluster_expected(cluster, values) for cluster in range(int(case["cluster_count"]))]
         baseline = _run_baseline(case, expected_clusters, values)
         integrated = _run_integrated(case, values)
-        reports.append(_summarize_case(case, baseline, integrated, preload_entries))
+        source_refs = _record_case_source_refs(
+            case,
+            baseline,
+            integrated,
+            shared_preload_identity,
+            manifest_catalog,
+            top_catalog,
+        )
+        reports.append(_summarize_case(case, baseline, integrated, source_refs))
 
     decision = "pass" if all(case["decision"] == "pass" for case in reports) else "fail"
     result = {
@@ -1676,6 +1751,11 @@ def build_report(
             ),
         },
         "exclusions": REPORT_EXCLUSIONS,
+        "report_contract": {
+            "shape": COMPACT_REPORT_SHAPE,
+            "max_pretty_json_bytes": COMPACT_REPORT_MAX_BYTES,
+            "max_pretty_json_lines": COMPACT_REPORT_MAX_LINES,
+        },
         "source_identities": {
             "repo_commit": _git_head(),
             "tool_versions": {
@@ -1697,8 +1777,16 @@ def build_report(
                     "npu/sim/rtl/noc_value_matrix_reassembler.sv",
                 )
             ],
+            "generated_artifacts": {
+                "shared_preload": shared_preload_identity,
+                "generated_manifests": [
+                    manifest_catalog[key] for key in sorted(manifest_catalog)
+                ],
+                "generated_tops": [
+                    top_catalog[key] for key in sorted(top_catalog)
+                ],
+            },
         },
-        "preload_entries": preload_entries,
         "selected_scale_point": _selected_scale_point(reports),
         "summary": _report_summary(reports),
         "cases": reports,
@@ -1724,12 +1812,40 @@ def validate_report(payload: JsonDict) -> None:
         raise ValueError("unexpected report model")
     if payload.get("exclusions") != REPORT_EXCLUSIONS:
         raise ValueError(f"report exclusions must explicitly be {', '.join(REPORT_EXCLUSIONS)}")
+    contract = payload.get("report_contract")
+    if contract != {
+        "shape": COMPACT_REPORT_SHAPE,
+        "max_pretty_json_bytes": COMPACT_REPORT_MAX_BYTES,
+        "max_pretty_json_lines": COMPACT_REPORT_MAX_LINES,
+    }:
+        raise ValueError("report compactness contract mismatch")
     source = payload.get("source_identities")
     if not isinstance(source, dict) or not source.get("repo_commit"):
         raise ValueError("report lacks source identities")
-    preload_entries = payload.get("preload_entries")
-    if not isinstance(preload_entries, list) or len(preload_entries) != 48:
-        raise ValueError("report must include all 48 preload entries")
+    if "preload_entries" in payload:
+        raise ValueError("report must elide preload payloads from committed output")
+    generated_artifacts = source.get("generated_artifacts")
+    if not isinstance(generated_artifacts, dict):
+        raise ValueError("report lacks generated artifact identities")
+    shared_preload = generated_artifacts.get("shared_preload")
+    if not isinstance(shared_preload, dict):
+        raise ValueError("report lacks shared preload identity")
+    if int(shared_preload.get("entry_count", 0)) != 48 or shared_preload.get("payload_elided") is not True:
+        raise ValueError("shared preload identity is incomplete")
+    manifest_rows = generated_artifacts.get("generated_manifests")
+    if not isinstance(manifest_rows, list) or not manifest_rows:
+        raise ValueError("report lacks generated manifest identities")
+    for row in manifest_rows:
+        if not isinstance(row, dict):
+            raise ValueError("generated manifest identities must be objects")
+        result_beats = row.get("result_beats_per_command")
+        if not isinstance(result_beats, int) or result_beats <= 0:
+            raise ValueError("generated manifest identity lacks finite positive result_beats_per_command")
+        if result_beats != 16:
+            raise ValueError("unexpected result_beats_per_command for generated manifest identity")
+    top_rows = generated_artifacts.get("generated_tops")
+    if not isinstance(top_rows, list) or not top_rows:
+        raise ValueError("report lacks generated top identities")
     cases = payload.get("cases")
     if not isinstance(cases, list) or not cases:
         raise ValueError("report must contain cases")
@@ -1751,11 +1867,35 @@ def validate_report(payload: JsonDict) -> None:
     case_ids = {str(case.get("case_id")) for case in cases if isinstance(case, dict)}
     if str(selected_scale_point.get("case_id")) not in case_ids:
         raise ValueError("selected_scale_point does not reference a report case")
+    manifest_ids = {
+        str(row.get("artifact_id"))
+        for row in manifest_rows
+        if isinstance(row, dict) and row.get("artifact_id")
+    }
+    top_ids = {
+        str(row.get("artifact_id"))
+        for row in top_rows
+        if isinstance(row, dict) and row.get("artifact_id")
+    }
+    shared_preload_id = str(shared_preload.get("artifact_id"))
     for case in cases:
         if not isinstance(case, dict):
             raise ValueError("case rows must be objects")
         if case.get("decision") != "pass":
             raise ValueError(f"case failed: {case.get('case_id')}")
+        if "generated_manifests" in case or "preload" in case:
+            raise ValueError(f"non-compact case payload present for {case.get('case_id')}")
+        source_refs = case.get("source_refs")
+        if not isinstance(source_refs, dict):
+            raise ValueError(f"source_refs missing for {case.get('case_id')}")
+        if str(source_refs.get("shared_preload")) != shared_preload_id:
+            raise ValueError(f"shared preload reference mismatch for {case.get('case_id')}")
+        for ref_key in ("baseline_manifest", "integrated_manifest"):
+            if str(source_refs.get(ref_key)) not in manifest_ids:
+                raise ValueError(f"unknown manifest reference for {case.get('case_id')}")
+        for ref_key in ("baseline_top", "integrated_top"):
+            if str(source_refs.get(ref_key)) not in top_ids:
+                raise ValueError(f"unknown top reference for {case.get('case_id')}")
         baseline = case.get("baseline_no_stall")
         integrated = case.get("integrated_service")
         if not isinstance(baseline, dict) or not isinstance(integrated, dict):
@@ -1776,7 +1916,6 @@ def validate_report(payload: JsonDict) -> None:
         if not isinstance(counters, dict):
             raise ValueError(f"counters missing for {case.get('case_id')}")
         required_counter_keys = {
-            "cluster_input",
             "request_injection_stall_cycles",
             "arbitration_contention_cycles",
             "bank_conflict_count",
@@ -1796,11 +1935,19 @@ def validate_report(payload: JsonDict) -> None:
         gates = case.get("gates")
         if not isinstance(gates, dict) or not all(bool(gates.get(key)) for key in ("hash_gate_ok", "protocol_gate_ok", "count_gate_ok")):
             raise ValueError(f"gate status missing or failed for {case.get('case_id')}")
+    pretty_json_bytes, pretty_json_lines = _pretty_json_metrics(payload)
+    if pretty_json_bytes > COMPACT_REPORT_MAX_BYTES or pretty_json_lines > COMPACT_REPORT_MAX_LINES:
+        raise ValueError(
+            "report exceeds compact size gate "
+            f"({pretty_json_bytes} bytes / {pretty_json_lines} lines)"
+        )
 
 
 def _build_markdown(report: JsonDict) -> str:
     summary = dict(report["summary"])
     selected_scale_point = dict(report["selected_scale_point"])
+    contract = dict(report["report_contract"])
+    pretty_json_bytes, pretty_json_lines = _pretty_json_metrics(report)
     linkage = dict(report.get("source_links") or {})
     lines = [
         "# Attention Decode Score Multivalue Integrated Service Probe",
@@ -1817,6 +1964,11 @@ def _build_markdown(report: JsonDict) -> str:
         f"- selected_scale_point_role: `{selected_scale_point['selection_role']}`",
         f"- selected_scale_point_note: {selected_scale_point['selection_basis']}",
         f"- gates: `hash={summary['all_hash_gates_passed']}` `protocol={summary['all_protocol_gates_passed']}` `count={summary['all_count_gates_passed']}`",
+        f"- compact_report_shape: `{contract['shape']}`",
+        (
+            f"- compact_report_size: `{pretty_json_bytes} bytes / {pretty_json_lines} lines` "
+            f"(gate <= {contract['max_pretty_json_bytes']} bytes / {contract['max_pretty_json_lines']} lines)"
+        ),
         f"- exclusions: `{', '.join(report['exclusions'])}`",
     ]
     if linkage.get("proposal_id"):

--- a/tests/test_attention_decode_score_multivalue_integrated_service.py
+++ b/tests/test_attention_decode_score_multivalue_integrated_service.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from pathlib import Path
 import shutil
@@ -9,7 +10,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+import npu.eval.probe_attention_decode_score_multivalue_integrated_service as probe_module
 from npu.eval.probe_attention_decode_score_multivalue_integrated_service import (
+    COMPACT_REPORT_MAX_BYTES,
+    COMPACT_REPORT_MAX_LINES,
     DEFAULT_CASES,
     REPORT_EXCLUSIONS,
     _selected_scale_point,
@@ -278,6 +282,194 @@ def test_integrated_service_report_retains_linkage_and_summary() -> None:
     assert report["selected_scale_point"]["arch_id"] == "decode_score_multivalue_integrated_service"
     assert report["selected_scale_point"]["case_id"] == "linkage"
     assert "not a performance or architectural ranking" in report["selected_scale_point"]["selection_basis"]
+    assert report["report_contract"]["shape"] == "deduplicated_shared_artifact_identities_v1"
+    assert report["source_identities"]["generated_artifacts"]["shared_preload"]["entry_count"] == 48
+    case = report["cases"][0]
+    assert "generated_manifests" not in case
+    assert "preload" not in case
+    assert set(case["source_refs"]) == {
+        "shared_preload",
+        "baseline_manifest",
+        "integrated_manifest",
+        "baseline_top",
+        "integrated_top",
+    }
+
+
+def test_integrated_service_report_compact_size_gate_with_large_manifests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _baseline_manifest(case: dict) -> dict:
+        return {
+            "semantic_profile": "decode_m1x8_multivalue_cluster_equivalence_v1",
+            "cluster_count": int(case["cluster_count"]),
+            "result_beats_per_command": 16,
+            "debug_payload": "b" * 8192,
+        }
+
+    def _integrated_manifest(case: dict) -> dict:
+        return {
+            "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+            "cluster_count": int(case["cluster_count"]),
+            "packet_w": int(case["packet_w"]),
+            "banks": int(case["banks"]),
+            "arb_mode": str(case["arb_mode"]),
+            "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",
+            "shared_result_egress_initiation_interval": 1,
+            "shared_result_egress_stall_semantics": "stable_until_handshake",
+            "response_metadata_guard": "single_outstanding_per_cluster_v1",
+            "submodule_manifests": {
+                "multivalue_cluster": {
+                    "result_beats_per_command": 16,
+                }
+            },
+            "debug_payload": "i" * 8192,
+        }
+
+    def _fake_baseline(case: dict, expected_clusters: list[dict], values: list[list[list[list[int]]]]) -> dict:
+        del values
+        score_rows = [
+            {"cluster": cluster, "addr": addr, "row": rows}
+            for cluster, payload in enumerate(expected_clusters)
+            for addr, rows in enumerate(payload["score_rows"])
+        ]
+        results = [
+            {
+                **row,
+                "cycle": 80 + row["slice"],
+                "protocol_error": False,
+            }
+            for payload in expected_clusters
+            for row in payload["results"]
+        ]
+        cluster_count = int(case["cluster_count"])
+        done_rows = {
+            cluster: {
+                "cycle": 100 + cluster,
+                "accepted": 48,
+                "completed": 16,
+            }
+            for cluster in range(cluster_count)
+        }
+        top_sha256 = hashlib.sha256(f"baseline:{cluster_count}".encode()).hexdigest()
+        return {
+            "score_rows": score_rows,
+            "results": results,
+            "done_rows": done_rows,
+            "completion_cycle": 180 + cluster_count,
+            "protocol_error": False,
+            "manifest": _baseline_manifest(case),
+            "top_sha256": top_sha256,
+        }
+
+    def _fake_integrated(case: dict, values: list[list[list[list[int]]]]) -> dict:
+        cluster_count = int(case["cluster_count"])
+        expected_clusters = [
+            probe_module._cluster_expected(cluster, values)
+            for cluster in range(cluster_count)
+        ]
+        score_rows = [
+            {"cluster": cluster, "addr": addr, "row": rows}
+            for cluster, payload in enumerate(expected_clusters)
+            for addr, rows in enumerate(payload["score_rows"])
+        ]
+        request_rows = [
+            {
+                **row,
+                "cycle": 20 + row["tag"],
+            }
+            for payload in expected_clusters
+            for row in payload["request_records"]
+        ]
+        wide_rows = [
+            {
+                **row,
+                "cycle": 40 + row["tag"],
+                "protocol_error": False,
+            }
+            for payload in expected_clusters
+            for row in payload["response_records"]
+        ]
+        results = [
+            {
+                **row,
+                "cycle": 220 + row["slice"],
+                "protocol_error": False,
+            }
+            for payload in expected_clusters
+            for row in payload["results"]
+        ]
+        done_rows = {
+            cluster: {
+                "cycle": 240 + cluster,
+                "accepted": 48,
+                "completed": 16,
+            }
+            for cluster in range(cluster_count)
+        }
+        counter_rows = {
+            cluster: {
+                "input_stall_cycles": cluster,
+                "input_starvation_cycles": 0,
+                "result_egress_block_cycles": max(cluster_count - 1, 0),
+                "request_count": 48,
+                "wide_response_count": 48,
+            }
+            for cluster in range(cluster_count)
+        }
+        top_sha256 = hashlib.sha256(
+            f"integrated:{json.dumps(case, sort_keys=True)}".encode()
+        ).hexdigest()
+        return {
+            "score_rows": score_rows,
+            "request_rows": request_rows,
+            "wide_rows": wide_rows,
+            "results": results,
+            "done_rows": done_rows,
+            "counter_rows": counter_rows,
+            "shared": {
+                "completion_cycle": 260 + cluster_count,
+                "protocol_error": False,
+                "router_injection_stall_cycles": cluster_count,
+                "router_arbitration_contention_cycles": max(cluster_count - 1, 0),
+                "router_response_block_cycles": cluster_count // 2,
+                "router_req_current_occupancy": 0,
+                "router_req_max_occupancy": min(cluster_count, int(case["req_queue_depth"]) + 1),
+                "router_resp_current_occupancy": 0,
+                "router_resp_max_occupancy": min(cluster_count, int(case["resp_queue_depth"]) + 1),
+                "service_accepted_req_count": 48 * cluster_count,
+                "service_emitted_resp_count": 48 * cluster_count,
+                "service_bank_conflict_count": max(cluster_count - 1, 0),
+                "service_response_block_cycles": cluster_count // 2,
+                "service_req_current_occupancy": 0,
+                "service_req_max_occupancy": min(cluster_count, int(case["bank_queue_depth"]) + 1),
+                "service_resp_current_occupancy": 0,
+                "service_resp_max_occupancy": min(cluster_count, int(case["resp_queue_depth"]) + 1),
+                "result_arbitration_contention_cycles": max(cluster_count - 1, 0),
+                "result_egress_block_cycles": max(cluster_count - 1, 0),
+                "result_back_to_back_fire_seen": True,
+            },
+            "manifest": _integrated_manifest(case),
+            "top_sha256": top_sha256,
+        }
+
+    monkeypatch.setattr(probe_module, "_run_baseline", _fake_baseline)
+    monkeypatch.setattr(probe_module, "_run_integrated", _fake_integrated)
+
+    report = build_report()
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+
+    assert len(rendered.encode()) <= COMPACT_REPORT_MAX_BYTES
+    assert len(rendered.splitlines()) <= COMPACT_REPORT_MAX_LINES
+    assert "preload_entries" not in report
+    assert "debug_payload" not in rendered
+    assert all("generated_manifests" not in case for case in report["cases"])
+    assert all("preload" not in case for case in report["cases"])
+    assert report["source_identities"]["generated_artifacts"]["shared_preload"]["payload_elided"] is True
+    assert all(
+        row["result_beats_per_command"] == 16
+        for row in report["source_identities"]["generated_artifacts"]["generated_manifests"]
+    )
 
 
 def test_integrated_service_selected_scale_point_is_nominal_not_worst_penalty() -> None:
@@ -362,4 +554,19 @@ def test_integrated_service_validate_report_rejects_incomplete_evidence() -> Non
     broken = json.loads(json.dumps(report))
     broken["cases"][0]["integrated_service"]["shared_result_egress"]["back_to_back_fire_seen"] = False
     with pytest.raises(ValueError, match="back-to-back evidence"):
+        validate_report(broken)
+
+    broken = json.loads(json.dumps(report))
+    broken["preload_entries"] = []
+    with pytest.raises(ValueError, match="elide preload payloads"):
+        validate_report(broken)
+
+    broken = json.loads(json.dumps(report))
+    broken["source_identities"]["generated_artifacts"]["generated_manifests"][0]["result_beats_per_command"] = 0
+    with pytest.raises(ValueError, match="finite positive result_beats_per_command"):
+        validate_report(broken)
+
+    broken = json.loads(json.dumps(report))
+    broken["debug_payload"] = "x" * COMPACT_REPORT_MAX_BYTES
+    with pytest.raises(ValueError, match="compact size gate"):
         validate_report(broken)


### PR DESCRIPTION
## Summary
- replace repeated per-case manifests and preload payloads with content-addressed compact identities
- retain exact hash/protocol/count gates and all frontier-relevant service metrics
- enforce <=100 KB / <=2500-line report gates
- record PR #1436 evidence as functionally valid but superseded before merge and add r1 replacement item

## Measured size
- prior PR #1436: 403,110 bytes / 11,271 lines
- compact 14-case report: 67,278 bytes / 1,690 lines

## Validation
- 11 focused probe tests passed
- `scripts/validate_runs.py --skip_eval_queue` passed
- `git diff --check` passed

No evaluation is dispatched by this PR.